### PR TITLE
Revert "chore(MeshTimeout): improve policy's openapi schema (#8532)"

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -3623,50 +3623,46 @@ spec:
                         of clients referenced in 'targetRef'
                       properties:
                         connectionTimeout:
-                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Cannot be set to "0".
+                            Default value is 5 seconds. Cannot be set to 0.
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
-                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Disabled by default.
                               type: string
                             maxStreamDuration:
-                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to "0s" will disable it.
+                                to 0 will disable it. Disabled by default.
                               type: string
                             requestTimeout:
-                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Default is 15s.
                               type: string
                             streamIdleTimeout:
-                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to "0s" will disable it.
+                                Setting this timeout to 0 will disable it. Default
+                                is 30m
                               type: string
                           type: object
                         idleTimeout:
-                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to "0s" will disable it. Be cautious when
-                            disabling it because it can lead to connection leaking.
+                            this timeout to 0 will disable it. Be cautious when disabling
+                            it because it can lead to connection leaking. Default
+                            value is 1h.
                           type: string
                       type: object
                     targetRef:
@@ -3706,7 +3702,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined in-place.
+                  virtual resource defined inplace.
                 properties:
                   kind:
                     description: Kind of the referenced resource
@@ -3743,50 +3739,46 @@ spec:
                         of destinations referenced in 'targetRef'
                       properties:
                         connectionTimeout:
-                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Cannot be set to "0".
+                            Default value is 5 seconds. Cannot be set to 0.
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
-                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Disabled by default.
                               type: string
                             maxStreamDuration:
-                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to "0s" will disable it.
+                                to 0 will disable it. Disabled by default.
                               type: string
                             requestTimeout:
-                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Default is 15s.
                               type: string
                             streamIdleTimeout:
-                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to "0s" will disable it.
+                                Setting this timeout to 0 will disable it. Default
+                                is 30m
                               type: string
                           type: object
                         idleTimeout:
-                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to "0s" will disable it. Be cautious when
-                            disabling it because it can lead to connection leaking.
+                            this timeout to 0 will disable it. Be cautious when disabling
+                            it because it can lead to connection leaking. Default
+                            value is 1h.
                           type: string
                       type: object
                     targetRef:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
@@ -3623,50 +3623,46 @@ spec:
                         of clients referenced in 'targetRef'
                       properties:
                         connectionTimeout:
-                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Cannot be set to "0".
+                            Default value is 5 seconds. Cannot be set to 0.
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
-                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Disabled by default.
                               type: string
                             maxStreamDuration:
-                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to "0s" will disable it.
+                                to 0 will disable it. Disabled by default.
                               type: string
                             requestTimeout:
-                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Default is 15s.
                               type: string
                             streamIdleTimeout:
-                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to "0s" will disable it.
+                                Setting this timeout to 0 will disable it. Default
+                                is 30m
                               type: string
                           type: object
                         idleTimeout:
-                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to "0s" will disable it. Be cautious when
-                            disabling it because it can lead to connection leaking.
+                            this timeout to 0 will disable it. Be cautious when disabling
+                            it because it can lead to connection leaking. Default
+                            value is 1h.
                           type: string
                       type: object
                     targetRef:
@@ -3706,7 +3702,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined in-place.
+                  virtual resource defined inplace.
                 properties:
                   kind:
                     description: Kind of the referenced resource
@@ -3743,50 +3739,46 @@ spec:
                         of destinations referenced in 'targetRef'
                       properties:
                         connectionTimeout:
-                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Cannot be set to "0".
+                            Default value is 5 seconds. Cannot be set to 0.
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
-                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Disabled by default.
                               type: string
                             maxStreamDuration:
-                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to "0s" will disable it.
+                                to 0 will disable it. Disabled by default.
                               type: string
                             requestTimeout:
-                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Default is 15s.
                               type: string
                             streamIdleTimeout:
-                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to "0s" will disable it.
+                                Setting this timeout to 0 will disable it. Default
+                                is 30m
                               type: string
                           type: object
                         idleTimeout:
-                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to "0s" will disable it. Be cautious when
-                            disabling it because it can lead to connection leaking.
+                            this timeout to 0 will disable it. Be cautious when disabling
+                            it because it can lead to connection leaking. Default
+                            value is 1h.
                           type: string
                       type: object
                     targetRef:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -3827,50 +3827,46 @@ spec:
                         of clients referenced in 'targetRef'
                       properties:
                         connectionTimeout:
-                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Cannot be set to "0".
+                            Default value is 5 seconds. Cannot be set to 0.
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
-                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Disabled by default.
                               type: string
                             maxStreamDuration:
-                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to "0s" will disable it.
+                                to 0 will disable it. Disabled by default.
                               type: string
                             requestTimeout:
-                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Default is 15s.
                               type: string
                             streamIdleTimeout:
-                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to "0s" will disable it.
+                                Setting this timeout to 0 will disable it. Default
+                                is 30m
                               type: string
                           type: object
                         idleTimeout:
-                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to "0s" will disable it. Be cautious when
-                            disabling it because it can lead to connection leaking.
+                            this timeout to 0 will disable it. Be cautious when disabling
+                            it because it can lead to connection leaking. Default
+                            value is 1h.
                           type: string
                       type: object
                     targetRef:
@@ -3910,7 +3906,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined in-place.
+                  virtual resource defined inplace.
                 properties:
                   kind:
                     description: Kind of the referenced resource
@@ -3947,50 +3943,46 @@ spec:
                         of destinations referenced in 'targetRef'
                       properties:
                         connectionTimeout:
-                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Cannot be set to "0".
+                            Default value is 5 seconds. Cannot be set to 0.
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
-                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Disabled by default.
                               type: string
                             maxStreamDuration:
-                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to "0s" will disable it.
+                                to 0 will disable it. Disabled by default.
                               type: string
                             requestTimeout:
-                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Default is 15s.
                               type: string
                             streamIdleTimeout:
-                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to "0s" will disable it.
+                                Setting this timeout to 0 will disable it. Default
+                                is 30m
                               type: string
                           type: object
                         idleTimeout:
-                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to "0s" will disable it. Be cautious when
-                            disabling it because it can lead to connection leaking.
+                            this timeout to 0 will disable it. Be cautious when disabling
+                            it because it can lead to connection leaking. Default
+                            value is 1h.
                           type: string
                       type: object
                     targetRef:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -3643,50 +3643,46 @@ spec:
                         of clients referenced in 'targetRef'
                       properties:
                         connectionTimeout:
-                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Cannot be set to "0".
+                            Default value is 5 seconds. Cannot be set to 0.
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
-                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Disabled by default.
                               type: string
                             maxStreamDuration:
-                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to "0s" will disable it.
+                                to 0 will disable it. Disabled by default.
                               type: string
                             requestTimeout:
-                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Default is 15s.
                               type: string
                             streamIdleTimeout:
-                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to "0s" will disable it.
+                                Setting this timeout to 0 will disable it. Default
+                                is 30m
                               type: string
                           type: object
                         idleTimeout:
-                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to "0s" will disable it. Be cautious when
-                            disabling it because it can lead to connection leaking.
+                            this timeout to 0 will disable it. Be cautious when disabling
+                            it because it can lead to connection leaking. Default
+                            value is 1h.
                           type: string
                       type: object
                     targetRef:
@@ -3726,7 +3722,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined in-place.
+                  virtual resource defined inplace.
                 properties:
                   kind:
                     description: Kind of the referenced resource
@@ -3763,50 +3759,46 @@ spec:
                         of destinations referenced in 'targetRef'
                       properties:
                         connectionTimeout:
-                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Cannot be set to "0".
+                            Default value is 5 seconds. Cannot be set to 0.
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
-                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Disabled by default.
                               type: string
                             maxStreamDuration:
-                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to "0s" will disable it.
+                                to 0 will disable it. Disabled by default.
                               type: string
                             requestTimeout:
-                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Default is 15s.
                               type: string
                             streamIdleTimeout:
-                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to "0s" will disable it.
+                                Setting this timeout to 0 will disable it. Default
+                                is 30m
                               type: string
                           type: object
                         idleTimeout:
-                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to "0s" will disable it. Be cautious when
-                            disabling it because it can lead to connection leaking.
+                            this timeout to 0 will disable it. Be cautious when disabling
+                            it because it can lead to connection leaking. Default
+                            value is 1h.
                           type: string
                       type: object
                     targetRef:

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -4938,50 +4938,46 @@ spec:
                         of clients referenced in 'targetRef'
                       properties:
                         connectionTimeout:
-                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Cannot be set to "0".
+                            Default value is 5 seconds. Cannot be set to 0.
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
-                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Disabled by default.
                               type: string
                             maxStreamDuration:
-                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to "0s" will disable it.
+                                to 0 will disable it. Disabled by default.
                               type: string
                             requestTimeout:
-                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Default is 15s.
                               type: string
                             streamIdleTimeout:
-                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to "0s" will disable it.
+                                Setting this timeout to 0 will disable it. Default
+                                is 30m
                               type: string
                           type: object
                         idleTimeout:
-                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to "0s" will disable it. Be cautious when
-                            disabling it because it can lead to connection leaking.
+                            this timeout to 0 will disable it. Be cautious when disabling
+                            it because it can lead to connection leaking. Default
+                            value is 1h.
                           type: string
                       type: object
                     targetRef:
@@ -5021,7 +5017,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined in-place.
+                  virtual resource defined inplace.
                 properties:
                   kind:
                     description: Kind of the referenced resource
@@ -5058,50 +5054,46 @@ spec:
                         of destinations referenced in 'targetRef'
                       properties:
                         connectionTimeout:
-                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Cannot be set to "0".
+                            Default value is 5 seconds. Cannot be set to 0.
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
-                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Disabled by default.
                               type: string
                             maxStreamDuration:
-                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to "0s" will disable it.
+                                to 0 will disable it. Disabled by default.
                               type: string
                             requestTimeout:
-                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Default is 15s.
                               type: string
                             streamIdleTimeout:
-                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to "0s" will disable it.
+                                Setting this timeout to 0 will disable it. Default
+                                is 30m
                               type: string
                           type: object
                         idleTimeout:
-                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to "0s" will disable it. Be cautious when
-                            disabling it because it can lead to connection leaking.
+                            this timeout to 0 will disable it. Be cautious when disabling
+                            it because it can lead to connection leaking. Default
+                            value is 1h.
                           type: string
                       type: object
                     targetRef:

--- a/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
@@ -5142,50 +5142,46 @@ spec:
                         of clients referenced in 'targetRef'
                       properties:
                         connectionTimeout:
-                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Cannot be set to "0".
+                            Default value is 5 seconds. Cannot be set to 0.
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
-                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Disabled by default.
                               type: string
                             maxStreamDuration:
-                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to "0s" will disable it.
+                                to 0 will disable it. Disabled by default.
                               type: string
                             requestTimeout:
-                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Default is 15s.
                               type: string
                             streamIdleTimeout:
-                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to "0s" will disable it.
+                                Setting this timeout to 0 will disable it. Default
+                                is 30m
                               type: string
                           type: object
                         idleTimeout:
-                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to "0s" will disable it. Be cautious when
-                            disabling it because it can lead to connection leaking.
+                            this timeout to 0 will disable it. Be cautious when disabling
+                            it because it can lead to connection leaking. Default
+                            value is 1h.
                           type: string
                       type: object
                     targetRef:
@@ -5225,7 +5221,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined in-place.
+                  virtual resource defined inplace.
                 properties:
                   kind:
                     description: Kind of the referenced resource
@@ -5262,50 +5258,46 @@ spec:
                         of destinations referenced in 'targetRef'
                       properties:
                         connectionTimeout:
-                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Cannot be set to "0".
+                            Default value is 5 seconds. Cannot be set to 0.
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
-                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Disabled by default.
                               type: string
                             maxStreamDuration:
-                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to "0s" will disable it.
+                                to 0 will disable it. Disabled by default.
                               type: string
                             requestTimeout:
-                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Default is 15s.
                               type: string
                             streamIdleTimeout:
-                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to "0s" will disable it.
+                                Setting this timeout to 0 will disable it. Default
+                                is 30m
                               type: string
                           type: object
                         idleTimeout:
-                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to "0s" will disable it. Be cautious when
-                            disabling it because it can lead to connection leaking.
+                            this timeout to 0 will disable it. Be cautious when disabling
+                            it because it can lead to connection leaking. Default
+                            value is 1h.
                           type: string
                       type: object
                     targetRef:

--- a/deployments/charts/kuma/crds/kuma.io_meshtimeouts.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtimeouts.yaml
@@ -52,50 +52,46 @@ spec:
                         of clients referenced in 'targetRef'
                       properties:
                         connectionTimeout:
-                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Cannot be set to "0".
+                            Default value is 5 seconds. Cannot be set to 0.
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
-                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Disabled by default.
                               type: string
                             maxStreamDuration:
-                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to "0s" will disable it.
+                                to 0 will disable it. Disabled by default.
                               type: string
                             requestTimeout:
-                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Default is 15s.
                               type: string
                             streamIdleTimeout:
-                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to "0s" will disable it.
+                                Setting this timeout to 0 will disable it. Default
+                                is 30m
                               type: string
                           type: object
                         idleTimeout:
-                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to "0s" will disable it. Be cautious when
-                            disabling it because it can lead to connection leaking.
+                            this timeout to 0 will disable it. Be cautious when disabling
+                            it because it can lead to connection leaking. Default
+                            value is 1h.
                           type: string
                       type: object
                     targetRef:
@@ -135,7 +131,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined in-place.
+                  virtual resource defined inplace.
                 properties:
                   kind:
                     description: Kind of the referenced resource
@@ -172,50 +168,46 @@ spec:
                         of destinations referenced in 'targetRef'
                       properties:
                         connectionTimeout:
-                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Cannot be set to "0".
+                            Default value is 5 seconds. Cannot be set to 0.
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
-                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Disabled by default.
                               type: string
                             maxStreamDuration:
-                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to "0s" will disable it.
+                                to 0 will disable it. Disabled by default.
                               type: string
                             requestTimeout:
-                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Default is 15s.
                               type: string
                             streamIdleTimeout:
-                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to "0s" will disable it.
+                                Setting this timeout to 0 will disable it. Default
+                                is 30m
                               type: string
                           type: object
                         idleTimeout:
-                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to "0s" will disable it. Be cautious when
-                            disabling it because it can lead to connection leaking.
+                            this timeout to 0 will disable it. Be cautious when disabling
+                            it because it can lead to connection leaking. Default
+                            value is 1h.
                           type: string
                       type: object
                     targetRef:

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -5722,56 +5722,52 @@ components:
                       clients referenced in 'targetRef'
                     properties:
                       connectionTimeout:
-                        default: 5s
                         description: >-
                           ConnectionTimeout specifies the amount of time proxy
                           will wait for an TCP connection to be established.
-                          Cannot be set to "0".
+                          Default value is 5 seconds. Cannot be set to 0.
                         type: string
                       http:
                         description: Http provides configuration for HTTP specific timeouts
                         properties:
                           maxConnectionDuration:
-                            default: 0s
                             description: >-
                               MaxConnectionDuration is the time after which a
                               connection will be drained and/or closed, starting
                               from when it was first established. Setting this
-                              timeout to "0s" will disable it.
+                              timeout to 0 will disable it. Disabled by default.
                             type: string
                           maxStreamDuration:
-                            default: 0s
                             description: >-
                               MaxStreamDuration is the maximum time that a
                               stream’s lifetime will span. Setting this timeout
-                              to "0s" will disable it.
+                              to 0 will disable it. Disabled by default.
                             type: string
                           requestTimeout:
-                            default: 15s
                             description: >-
                               RequestTimeout The amount of time that proxy will
                               wait for the entire request to be received. The
                               timer is activated when the request is initiated,
                               and is disarmed when the last byte of the request
                               is sent, OR when the response is initiated.
-                              Setting this timeout to "0s" will disable it.
+                              Setting this timeout to 0 will disable it. Default
+                              is 15s.
                             type: string
                           streamIdleTimeout:
-                            default: 30s
                             description: >-
                               StreamIdleTimeout is the amount of time that proxy
                               will allow a stream to exist with no activity.
-                              Setting this timeout to "0s" will disable it.
+                              Setting this timeout to 0 will disable it. Default
+                              is 30m
                             type: string
                         type: object
                       idleTimeout:
-                        default: 1h
                         description: >-
                           IdleTimeout is defined as the period in which there
                           are no bytes sent or received on connection Setting
-                          this timeout to "0s" will disable it. Be cautious when
+                          this timeout to 0 will disable it. Be cautious when
                           disabling it because it can lead to connection
-                          leaking.
+                          leaking. Default value is 1h.
                         type: string
                     type: object
                   targetRef:
@@ -5817,7 +5813,7 @@ components:
               description: >-
                 TargetRef is a reference to the resource the policy takes an
                 effect on. The resource could be either a real store object or
-                virtual resource defined in-place.
+                virtual resource defined inplace.
               properties:
                 kind:
                   description: Kind of the referenced resource
@@ -5860,56 +5856,52 @@ components:
                       destinations referenced in 'targetRef'
                     properties:
                       connectionTimeout:
-                        default: 5s
                         description: >-
                           ConnectionTimeout specifies the amount of time proxy
                           will wait for an TCP connection to be established.
-                          Cannot be set to "0".
+                          Default value is 5 seconds. Cannot be set to 0.
                         type: string
                       http:
                         description: Http provides configuration for HTTP specific timeouts
                         properties:
                           maxConnectionDuration:
-                            default: 0s
                             description: >-
                               MaxConnectionDuration is the time after which a
                               connection will be drained and/or closed, starting
                               from when it was first established. Setting this
-                              timeout to "0s" will disable it.
+                              timeout to 0 will disable it. Disabled by default.
                             type: string
                           maxStreamDuration:
-                            default: 0s
                             description: >-
                               MaxStreamDuration is the maximum time that a
                               stream’s lifetime will span. Setting this timeout
-                              to "0s" will disable it.
+                              to 0 will disable it. Disabled by default.
                             type: string
                           requestTimeout:
-                            default: 15s
                             description: >-
                               RequestTimeout The amount of time that proxy will
                               wait for the entire request to be received. The
                               timer is activated when the request is initiated,
                               and is disarmed when the last byte of the request
                               is sent, OR when the response is initiated.
-                              Setting this timeout to "0s" will disable it.
+                              Setting this timeout to 0 will disable it. Default
+                              is 15s.
                             type: string
                           streamIdleTimeout:
-                            default: 30s
                             description: >-
                               StreamIdleTimeout is the amount of time that proxy
                               will allow a stream to exist with no activity.
-                              Setting this timeout to "0s" will disable it.
+                              Setting this timeout to 0 will disable it. Default
+                              is 30m
                             type: string
                         type: object
                       idleTimeout:
-                        default: 1h
                         description: >-
                           IdleTimeout is defined as the period in which there
                           are no bytes sent or received on connection Setting
-                          this timeout to "0s" will disable it. Be cautious when
+                          this timeout to 0 will disable it. Be cautious when
                           disabling it because it can lead to connection
-                          leaking.
+                          leaking. Default value is 1h.
                         type: string
                     type: object
                   targetRef:

--- a/docs/generated/raw/crds/kuma.io_meshtimeouts.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshtimeouts.yaml
@@ -52,50 +52,46 @@ spec:
                         of clients referenced in 'targetRef'
                       properties:
                         connectionTimeout:
-                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Cannot be set to "0".
+                            Default value is 5 seconds. Cannot be set to 0.
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
-                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Disabled by default.
                               type: string
                             maxStreamDuration:
-                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to "0s" will disable it.
+                                to 0 will disable it. Disabled by default.
                               type: string
                             requestTimeout:
-                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Default is 15s.
                               type: string
                             streamIdleTimeout:
-                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to "0s" will disable it.
+                                Setting this timeout to 0 will disable it. Default
+                                is 30m
                               type: string
                           type: object
                         idleTimeout:
-                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to "0s" will disable it. Be cautious when
-                            disabling it because it can lead to connection leaking.
+                            this timeout to 0 will disable it. Be cautious when disabling
+                            it because it can lead to connection leaking. Default
+                            value is 1h.
                           type: string
                       type: object
                     targetRef:
@@ -135,7 +131,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined in-place.
+                  virtual resource defined inplace.
                 properties:
                   kind:
                     description: Kind of the referenced resource
@@ -172,50 +168,46 @@ spec:
                         of destinations referenced in 'targetRef'
                       properties:
                         connectionTimeout:
-                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Cannot be set to "0".
+                            Default value is 5 seconds. Cannot be set to 0.
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
-                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Disabled by default.
                               type: string
                             maxStreamDuration:
-                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to "0s" will disable it.
+                                to 0 will disable it. Disabled by default.
                               type: string
                             requestTimeout:
-                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Default is 15s.
                               type: string
                             streamIdleTimeout:
-                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to "0s" will disable it.
+                                Setting this timeout to 0 will disable it. Default
+                                is 30m
                               type: string
                           type: object
                         idleTimeout:
-                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to "0s" will disable it. Be cautious when
-                            disabling it because it can lead to connection leaking.
+                            this timeout to 0 will disable it. Be cautious when disabling
+                            it because it can lead to connection leaking. Default
+                            value is 1h.
                           type: string
                       type: object
                     targetRef:

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/meshtimeout.go
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/meshtimeout.go
@@ -11,7 +11,7 @@ import (
 type MeshTimeout struct {
 	// TargetRef is a reference to the resource the policy takes an effect on.
 	// The resource could be either a real store object or virtual resource
-	// defined in-place.
+	// defined inplace.
 	TargetRef common_api.TargetRef `json:"targetRef"`
 	// To list makes a match between the consumed services and corresponding configurations
 	To []To `json:"to,omitempty"`
@@ -39,13 +39,11 @@ type From struct {
 
 type Conf struct {
 	// ConnectionTimeout specifies the amount of time proxy will wait for an TCP connection to be established.
-	// Cannot be set to "0".
-	// +kubebuilder:default="5s"
+	// Default value is 5 seconds. Cannot be set to 0.
 	ConnectionTimeout *k8s.Duration `json:"connectionTimeout,omitempty"`
 	// IdleTimeout is defined as the period in which there are no bytes sent or received on connection
-	// Setting this timeout to "0s" will disable it. Be cautious when disabling it because
-	// it can lead to connection leaking.
-	// +kubebuilder:default="1h"
+	// Setting this timeout to 0 will disable it. Be cautious when disabling it because
+	// it can lead to connection leaking. Default value is 1h.
 	IdleTimeout *k8s.Duration `json:"idleTimeout,omitempty"`
 	// Http provides configuration for HTTP specific timeouts
 	Http *Http `json:"http,omitempty"`
@@ -54,19 +52,17 @@ type Conf struct {
 type Http struct {
 	// RequestTimeout The amount of time that proxy will wait for the entire request to be received.
 	// The timer is activated when the request is initiated, and is disarmed when the last byte of the request is sent,
-	// OR when the response is initiated. Setting this timeout to "0s" will disable it.
-	// +kubebuilder:default="15s"
+	// OR when the response is initiated. Setting this timeout to 0 will disable it.
+	// Default is 15s.
 	RequestTimeout *k8s.Duration `json:"requestTimeout,omitempty"`
 	// StreamIdleTimeout is the amount of time that proxy will allow a stream to exist with no activity.
-	// Setting this timeout to "0s" will disable it.
-	// +kubebuilder:default="30s"
+	// Setting this timeout to 0 will disable it. Default is 30m
 	StreamIdleTimeout *k8s.Duration `json:"streamIdleTimeout,omitempty"`
 	// MaxStreamDuration is the maximum time that a stream’s lifetime will span.
-	// Setting this timeout to "0s" will disable it.
-	// +kubebuilder:default="0s"
+	// Setting this timeout to 0 will disable it. Disabled by default.
 	MaxStreamDuration *k8s.Duration `json:"maxStreamDuration,omitempty"`
 	// MaxConnectionDuration is the time after which a connection will be drained and/or closed,
-	// starting from when it was first established. Setting this timeout to "0s" will disable it.
-	// +kubebuilder:default="0s"
+	// starting from when it was first established. Setting this timeout to 0 will disable it.
+	// Disabled by default.
 	MaxConnectionDuration *k8s.Duration `json:"maxConnectionDuration,omitempty"`
 }

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/schema.yaml
@@ -23,32 +23,26 @@ properties:
               description: Default is a configuration specific to the group of clients referenced in 'targetRef'
               properties:
                 connectionTimeout:
-                  default: 5s
-                  description: ConnectionTimeout specifies the amount of time proxy will wait for an TCP connection to be established. Cannot be set to "0".
+                  description: ConnectionTimeout specifies the amount of time proxy will wait for an TCP connection to be established. Default value is 5 seconds. Cannot be set to 0.
                   type: string
                 http:
                   description: Http provides configuration for HTTP specific timeouts
                   properties:
                     maxConnectionDuration:
-                      default: 0s
-                      description: MaxConnectionDuration is the time after which a connection will be drained and/or closed, starting from when it was first established. Setting this timeout to "0s" will disable it.
+                      description: MaxConnectionDuration is the time after which a connection will be drained and/or closed, starting from when it was first established. Setting this timeout to 0 will disable it. Disabled by default.
                       type: string
                     maxStreamDuration:
-                      default: 0s
-                      description: MaxStreamDuration is the maximum time that a stream’s lifetime will span. Setting this timeout to "0s" will disable it.
+                      description: MaxStreamDuration is the maximum time that a stream’s lifetime will span. Setting this timeout to 0 will disable it. Disabled by default.
                       type: string
                     requestTimeout:
-                      default: 15s
-                      description: RequestTimeout The amount of time that proxy will wait for the entire request to be received. The timer is activated when the request is initiated, and is disarmed when the last byte of the request is sent, OR when the response is initiated. Setting this timeout to "0s" will disable it.
+                      description: RequestTimeout The amount of time that proxy will wait for the entire request to be received. The timer is activated when the request is initiated, and is disarmed when the last byte of the request is sent, OR when the response is initiated. Setting this timeout to 0 will disable it. Default is 15s.
                       type: string
                     streamIdleTimeout:
-                      default: 30s
-                      description: StreamIdleTimeout is the amount of time that proxy will allow a stream to exist with no activity. Setting this timeout to "0s" will disable it.
+                      description: StreamIdleTimeout is the amount of time that proxy will allow a stream to exist with no activity. Setting this timeout to 0 will disable it. Default is 30m
                       type: string
                   type: object
                 idleTimeout:
-                  default: 1h
-                  description: IdleTimeout is defined as the period in which there are no bytes sent or received on connection Setting this timeout to "0s" will disable it. Be cautious when disabling it because it can lead to connection leaking.
+                  description: IdleTimeout is defined as the period in which there are no bytes sent or received on connection Setting this timeout to 0 will disable it. Be cautious when disabling it because it can lead to connection leaking. Default value is 1h.
                   type: string
               type: object
             targetRef:
@@ -81,7 +75,7 @@ properties:
           type: object
         type: array
       targetRef:
-        description: TargetRef is a reference to the resource the policy takes an effect on. The resource could be either a real store object or virtual resource defined in-place.
+        description: TargetRef is a reference to the resource the policy takes an effect on. The resource could be either a real store object or virtual resource defined inplace.
         properties:
           kind:
             description: Kind of the referenced resource
@@ -113,32 +107,26 @@ properties:
               description: Default is a configuration specific to the group of destinations referenced in 'targetRef'
               properties:
                 connectionTimeout:
-                  default: 5s
-                  description: ConnectionTimeout specifies the amount of time proxy will wait for an TCP connection to be established. Cannot be set to "0".
+                  description: ConnectionTimeout specifies the amount of time proxy will wait for an TCP connection to be established. Default value is 5 seconds. Cannot be set to 0.
                   type: string
                 http:
                   description: Http provides configuration for HTTP specific timeouts
                   properties:
                     maxConnectionDuration:
-                      default: 0s
-                      description: MaxConnectionDuration is the time after which a connection will be drained and/or closed, starting from when it was first established. Setting this timeout to "0s" will disable it.
+                      description: MaxConnectionDuration is the time after which a connection will be drained and/or closed, starting from when it was first established. Setting this timeout to 0 will disable it. Disabled by default.
                       type: string
                     maxStreamDuration:
-                      default: 0s
-                      description: MaxStreamDuration is the maximum time that a stream’s lifetime will span. Setting this timeout to "0s" will disable it.
+                      description: MaxStreamDuration is the maximum time that a stream’s lifetime will span. Setting this timeout to 0 will disable it. Disabled by default.
                       type: string
                     requestTimeout:
-                      default: 15s
-                      description: RequestTimeout The amount of time that proxy will wait for the entire request to be received. The timer is activated when the request is initiated, and is disarmed when the last byte of the request is sent, OR when the response is initiated. Setting this timeout to "0s" will disable it.
+                      description: RequestTimeout The amount of time that proxy will wait for the entire request to be received. The timer is activated when the request is initiated, and is disarmed when the last byte of the request is sent, OR when the response is initiated. Setting this timeout to 0 will disable it. Default is 15s.
                       type: string
                     streamIdleTimeout:
-                      default: 30s
-                      description: StreamIdleTimeout is the amount of time that proxy will allow a stream to exist with no activity. Setting this timeout to "0s" will disable it.
+                      description: StreamIdleTimeout is the amount of time that proxy will allow a stream to exist with no activity. Setting this timeout to 0 will disable it. Default is 30m
                       type: string
                   type: object
                 idleTimeout:
-                  default: 1h
-                  description: IdleTimeout is defined as the period in which there are no bytes sent or received on connection Setting this timeout to "0s" will disable it. Be cautious when disabling it because it can lead to connection leaking.
+                  description: IdleTimeout is defined as the period in which there are no bytes sent or received on connection Setting this timeout to 0 will disable it. Be cautious when disabling it because it can lead to connection leaking. Default value is 1h.
                   type: string
               type: object
             targetRef:

--- a/pkg/plugins/policies/meshtimeout/k8s/crd/kuma.io_meshtimeouts.yaml
+++ b/pkg/plugins/policies/meshtimeout/k8s/crd/kuma.io_meshtimeouts.yaml
@@ -52,50 +52,46 @@ spec:
                         of clients referenced in 'targetRef'
                       properties:
                         connectionTimeout:
-                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Cannot be set to "0".
+                            Default value is 5 seconds. Cannot be set to 0.
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
-                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Disabled by default.
                               type: string
                             maxStreamDuration:
-                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to "0s" will disable it.
+                                to 0 will disable it. Disabled by default.
                               type: string
                             requestTimeout:
-                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Default is 15s.
                               type: string
                             streamIdleTimeout:
-                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to "0s" will disable it.
+                                Setting this timeout to 0 will disable it. Default
+                                is 30m
                               type: string
                           type: object
                         idleTimeout:
-                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to "0s" will disable it. Be cautious when
-                            disabling it because it can lead to connection leaking.
+                            this timeout to 0 will disable it. Be cautious when disabling
+                            it because it can lead to connection leaking. Default
+                            value is 1h.
                           type: string
                       type: object
                     targetRef:
@@ -135,7 +131,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined in-place.
+                  virtual resource defined inplace.
                 properties:
                   kind:
                     description: Kind of the referenced resource
@@ -172,50 +168,46 @@ spec:
                         of destinations referenced in 'targetRef'
                       properties:
                         connectionTimeout:
-                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Cannot be set to "0".
+                            Default value is 5 seconds. Cannot be set to 0.
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
-                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Disabled by default.
                               type: string
                             maxStreamDuration:
-                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to "0s" will disable it.
+                                to 0 will disable it. Disabled by default.
                               type: string
                             requestTimeout:
-                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to "0s" will disable it.
+                                this timeout to 0 will disable it. Default is 15s.
                               type: string
                             streamIdleTimeout:
-                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to "0s" will disable it.
+                                Setting this timeout to 0 will disable it. Default
+                                is 30m
                               type: string
                           type: object
                         idleTimeout:
-                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to "0s" will disable it. Be cautious when
-                            disabling it because it can lead to connection leaking.
+                            this timeout to 0 will disable it. Be cautious when disabling
+                            it because it can lead to connection leaking. Default
+                            value is 1h.
                           type: string
                       type: object
                     targetRef:


### PR DESCRIPTION
This reverts commit b81edc42482c77b1c20791a3804ffc4011fe7689.

Validation in current form doesn't allow to set the default values using `kubebuilder` annotations.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
