### PR TITLE
chore(logging): add more context on errors from http servers

### DIFF
--- a/app/kuma-dp/pkg/dataplane/metrics/server.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/server.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/bakito/go-log-logr-adapter/adapter"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/expfmt"
 
@@ -137,6 +138,7 @@ func (s *Hijacker) Start(stop <-chan struct{}) error {
 	server := &http.Server{
 		ReadHeaderTimeout: time.Second,
 		Handler:           s,
+		ErrorLog:          adapter.ToStd(logger),
 	}
 
 	errCh := make(chan error)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/Nordix/simple-ipam v1.0.0
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
+	github.com/bakito/go-log-logr-adapter v0.0.2
 	github.com/cilium/ebpf v0.12.3
 	github.com/containernetworking/cni v1.1.2
 	github.com/containernetworking/plugins v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d h1:Byv0BzEl
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aws/aws-sdk-go v1.44.187 h1:D5CsRomPnlwDHJCanL2mtaLIcbhjiWxNh5j8zvaWdJA=
 github.com/aws/aws-sdk-go v1.44.187/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
+github.com/bakito/go-log-logr-adapter v0.0.2 h1:epK+VaMPkK7dK+Vs78xo0BABqN1lIXD3IXX1VUj4PcM=
+github.com/bakito/go-log-logr-adapter v0.0.2/go.mod h1:B2tvB31L1Sxpkfhpj13QkJEisDNNKcC9FoYU8KL87AA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=

--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bakito/go-log-logr-adapter/adapter"
 	"github.com/emicklei/go-restful/v3"
 	"github.com/pkg/errors"
 	http_prometheus "github.com/slok/go-http-metrics/metrics/prometheus"
@@ -348,6 +349,7 @@ func (a *ApiServer) startHttpServer(errChan chan error) *http.Server {
 		ReadHeaderTimeout: time.Second,
 		Addr:              net.JoinHostPort(a.config.HTTP.Interface, strconv.FormatUint(uint64(a.config.HTTP.Port), 10)),
 		Handler:           a.mux,
+		ErrorLog:          adapter.ToStd(log),
 	}
 
 	go func() {
@@ -390,6 +392,7 @@ func (a *ApiServer) startHttpsServer(errChan chan error) (*http.Server, error) {
 		Addr:              net.JoinHostPort(a.config.HTTPS.Interface, strconv.FormatUint(uint64(a.config.HTTPS.Port), 10)),
 		Handler:           a.mux,
 		TLSConfig:         tlsConfig,
+		ErrorLog:          adapter.ToStd(log),
 	}
 
 	go func() {

--- a/pkg/diagnostics/server.go
+++ b/pkg/diagnostics/server.go
@@ -8,6 +8,7 @@ import (
 	pprof "net/http/pprof"
 	"time"
 
+	"github.com/bakito/go-log-logr-adapter/adapter"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
@@ -51,7 +52,12 @@ func (s *diagnosticsServer) Start(stop <-chan struct{}) error {
 		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 	}
 
-	httpServer := &http.Server{Addr: fmt.Sprintf(":%d", s.config.ServerPort), Handler: mux, ReadHeaderTimeout: time.Second}
+	httpServer := &http.Server{
+		Addr:              fmt.Sprintf(":%d", s.config.ServerPort),
+		Handler:           mux,
+		ReadHeaderTimeout: time.Second,
+		ErrorLog:          adapter.ToStd(diagnosticsServerLog),
+	}
 
 	if s.config.TlsEnabled {
 		cert, err := tls.LoadX509KeyPair(s.config.TlsCertFile, s.config.TlsKeyFile)

--- a/pkg/dp-server/server/server.go
+++ b/pkg/dp-server/server/server.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bakito/go-log-logr-adapter/adapter"
 	http_prometheus "github.com/slok/go-http-metrics/metrics/prometheus"
 	"github.com/slok/go-http-metrics/middleware"
 	"github.com/slok/go-http-metrics/middleware/std"
@@ -88,6 +89,7 @@ func (d *DpServer) Start(stop <-chan struct{}) error {
 		Addr:              fmt.Sprintf(":%d", d.config.Port),
 		Handler:           http.HandlerFunc(d.handle),
 		TLSConfig:         tlsConfig,
+		ErrorLog:          adapter.ToStd(log),
 	}
 
 	errChan := make(chan error)

--- a/pkg/mads/server/server.go
+++ b/pkg/mads/server/server.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bakito/go-log-logr-adapter/adapter"
 	"github.com/emicklei/go-restful/v3"
 	"github.com/pkg/errors"
 	http_prometheus "github.com/slok/go-http-metrics/metrics/prometheus"
@@ -154,6 +155,7 @@ func (s *muxServer) Start(stop <-chan struct{}) error {
 	httpS := &http.Server{
 		ReadHeaderTimeout: time.Second,
 		Handler:           s.createHttpServicesHandler(),
+		ErrorLog:          adapter.ToStd(log),
 	}
 	errChanHttp := make(chan error)
 	go func() {


### PR DESCRIPTION
### Checklist prior to review

Logs like this
```
2023/12/05 10:49:11 http: TLS handshake error from 10.42.0.1:42848: EOF
2023-12-05T10:49:11.119Z	INFO	controllers.Pod	Dataplane updated	{"pod": {"name":"demo-app-gateway-747594bcb5-sv6db","namespace":"kuma-demo"}}
2023/12/05 10:49:11 http: TLS handshake error from 10.42.0.1:42896: EOF
```
are very annoying because we don't know which sever it is and those logs are not in common format. I found a way to enrich those logs so it looks like this

```
2023-12-05T12:09:21.885Z	INFO	dp-server	http: TLS handshake error from 10.42.0.8:38384: EOF
```

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
