### PR TITLE
chore(MeshHTTPRoute): add precise hostname validation

### DIFF
--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation_test.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation_test.go
@@ -361,6 +361,161 @@ to:
                 tags:
                   version: v1
 `),
+		ErrorCases("invalid hostnames",
+			[]validators.Violation{
+				{
+					Field:   "spec.to[0].rules[0].default.filters[0].requestRedirect.hostname",
+					Message: "cannot be an IP address",
+				},
+				{
+					Field:   "spec.to[0].rules[0].default.filters[1].requestRedirect.hostname",
+					Message: "cannot be an IP address",
+				},
+				{
+					Field:   "spec.to[0].rules[0].default.filters[2].requestRedirect.hostname",
+					Message: "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')",
+				},
+				{
+					Field:   "spec.to[0].rules[0].default.filters[3].requestRedirect.hostname",
+					Message: "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')",
+				},
+				{
+					Field:   "spec.to[0].rules[0].default.filters[4].requestRedirect.hostname",
+					Message: "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')",
+				},
+				{
+					Field:   "spec.to[0].rules[0].default.filters[5].requestRedirect.hostname",
+					Message: "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')",
+				},
+				{
+					Field:   "spec.to[0].rules[0].default.filters[6].requestRedirect.hostname",
+					Message: "must be no more than 253 characters",
+				},
+				{
+					Field:   "spec.to[0].rules[0].default.filters[7].requestRedirect.hostname",
+					Message: "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')",
+				},
+				{
+					Field:   "spec.to[0].rules[0].default.filters[8].requestRedirect.hostname",
+					Message: "must be no more than 253 characters",
+				},
+				{
+					Field:   "spec.to[0].rules[0].default.filters[8].requestRedirect.hostname",
+					Message: "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')",
+				},
+				{
+					Field:   "spec.to[0].rules[0].default.filters[9].urlRewrite.hostname",
+					Message: "cannot be an IP address",
+				},
+				{
+					Field:   "spec.to[0].rules[0].default.filters[10].urlRewrite.hostname",
+					Message: "cannot be an IP address",
+				},
+				{
+					Field:   "spec.to[0].rules[0].default.filters[11].urlRewrite.hostname",
+					Message: "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')",
+				},
+				{
+					Field:   "spec.to[0].rules[0].default.filters[12].urlRewrite.hostname",
+					Message: "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')",
+				},
+				{
+					Field:   "spec.to[0].rules[0].default.filters[13].urlRewrite.hostname",
+					Message: "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')",
+				},
+				{
+					Field:   "spec.to[0].rules[0].default.filters[14].urlRewrite.hostname",
+					Message: "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')",
+				},
+				{
+					Field:   "spec.to[0].rules[0].default.filters[15].urlRewrite.hostname",
+					Message: "must be no more than 253 characters",
+				},
+				{
+					Field:   "spec.to[0].rules[0].default.filters[16].urlRewrite.hostname",
+					Message: "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')",
+				},
+				{
+					Field:   "spec.to[0].rules[0].default.filters[17].urlRewrite.hostname",
+					Message: "must be no more than 253 characters",
+				},
+				{
+					Field:   "spec.to[0].rules[0].default.filters[17].urlRewrite.hostname",
+					Message: "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')",
+				},
+			}, `
+type: MeshHTTPRoute
+mesh: mesh-1
+name: route-1
+targetRef:
+  kind: MeshService
+  name: frontend
+to:
+- targetRef:
+    kind: MeshService
+    name: frontend
+  rules:
+    - matches:
+      - path:
+          type: PathPrefix
+          value: /
+      default:
+        filters:
+          - type: RequestRedirect
+            requestRedirect:
+              hostname: 127.0.0.1
+          - type: RequestRedirect
+            requestRedirect:
+              hostname: 2001:db8:3333:4444:5555:6666:7777:8888
+          - type: RequestRedirect
+            requestRedirect:
+              hostname: a..bc
+          - type: RequestRedirect
+            requestRedirect:
+              hostname: ec2-35-160-210-253.us-west-2-.compute.amazonaws.com
+          - type: RequestRedirect
+            requestRedirect:
+              hostname: -ec2_35$160%210-253.us-west-2-.compute.amazonaws.com
+          - type: RequestRedirect
+            requestRedirect:
+              hostname: ec2-35-160-210-253.us-west-2-.compute.amazonaws.com.
+          - type: RequestRedirect
+            requestRedirect:
+              hostname: a23456789-a23456789-a234567890.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.com
+          - type: RequestRedirect
+            requestRedirect:
+              hostname: mx.foo.com.
+          - type: RequestRedirect
+            requestRedirect:
+              hostname: a23456789-a23456789-a234567890.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a2345678.com.
+          - type: URLRewrite
+            urlRewrite:
+              hostname: 127.0.0.1
+          - type: URLRewrite
+            urlRewrite:
+              hostname: 2001:db8:3333:4444:5555:6666:7777:8888
+          - type: URLRewrite
+            urlRewrite:
+              hostname: a..bc
+          - type: URLRewrite
+            urlRewrite:
+              hostname: ec2-35-160-210-253.us-west-2-.compute.amazonaws.com
+          - type: URLRewrite
+            urlRewrite:
+              hostname: -ec2_35$160%210-253.us-west-2-.compute.amazonaws.com
+          - type: URLRewrite
+            urlRewrite:
+              hostname: ec2-35-160-210-253.us-west-2-.compute.amazonaws.com.
+          - type: URLRewrite
+            urlRewrite:
+              hostname: a23456789-a23456789-a234567890.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.com
+          - type: URLRewrite
+            urlRewrite:
+              hostname: mx.foo.com.
+          - type: URLRewrite
+            urlRewrite:
+              hostname: a23456789-a23456789-a234567890.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a2345678.com.
+`),
 	)
 	DescribeValidCases(
 		api.NewMeshHTTPRouteResource,


### PR DESCRIPTION
Added validation for PreciseHostname used in RequestRedirect and URLRewrite filters

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - Closes https://github.com/kumahq/kuma/issues/8286
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Unit tests added and run locally
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - There is no need

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
