### PR TITLE
feat(policy): support MeshGateway listener matching

### DIFF
--- a/pkg/core/xds/matched_policies.go
+++ b/pkg/core/xds/matched_policies.go
@@ -18,6 +18,7 @@ type TypedMatchingPolicies struct {
 	DataplanePolicies []core_model.Resource
 	FromRules         rules.FromRules
 	ToRules           rules.ToRules
+	GatewayRules      rules.GatewayRules
 	SingleItemRules   rules.SingleItemRules
 	Warnings          []string
 }

--- a/pkg/plugins/policies/core/matchers/dataplane.go
+++ b/pkg/plugins/policies/core/matchers/dataplane.go
@@ -76,6 +76,11 @@ func MatchedPolicies(rType core_model.ResourceType, dpp *core_mesh.DataplaneReso
 		warnings = append(warnings, fmt.Sprintf("couldn't create To rules: %s", err.Error()))
 	}
 
+	gr, err := core_rules.BuildGatewayRules(matchedPoliciesByInbound, resources.ListOrEmpty(meshhttproute_api.MeshHTTPRouteType).GetItems())
+	if err != nil {
+		warnings = append(warnings, fmt.Sprintf("couldn't create Gateway rules: %s", err.Error()))
+	}
+
 	sr, err := core_rules.BuildSingleItemRules(dpPolicies)
 	if err != nil {
 		warnings = append(warnings, fmt.Sprintf("couldn't create top level rules: %s", err.Error()))
@@ -86,6 +91,7 @@ func MatchedPolicies(rType core_model.ResourceType, dpp *core_mesh.DataplaneReso
 		DataplanePolicies: dpPolicies,
 		FromRules:         fr,
 		ToRules:           tr,
+		GatewayRules:      gr,
 		SingleItemRules:   sr,
 		Warnings:          warnings,
 	}, nil

--- a/pkg/plugins/policies/core/matchers/dataplane_test.go
+++ b/pkg/plugins/policies/core/matchers/dataplane_test.go
@@ -161,7 +161,7 @@ var _ = Describe("MatchedPolicies", func() {
 			policies, err := matchers.MatchedPolicies(meshaccesslog_api.MeshAccessLogType, dpp, resources)
 			Expect(err).ToNot(HaveOccurred())
 
-			bytes, err := yaml.Marshal(policies.FromRules)
+			bytes, err := yaml.Marshal(policies.GatewayRules)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(bytes).To(test_matchers.MatchGoldenYAML(given.goldenFile))
 		},

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.policies.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.policies.yaml
@@ -5,7 +5,7 @@ name: mesh
 spec:
  targetRef:
   kind: Mesh
- from:
+ to:
   - targetRef:
      kind: Mesh
     default:
@@ -23,7 +23,7 @@ spec:
   name: edge-gateway
   tags:
     listener: two
- from:
+ to:
   - targetRef:
      kind: Mesh
     default:
@@ -39,7 +39,7 @@ spec:
  targetRef:
   kind: MeshGateway
   name: gateway-1
- from:
+ to:
   - targetRef:
      kind: Mesh
     default:
@@ -57,7 +57,7 @@ spec:
   name: gateway-1
   tags:
     listener: one
- from:
+ to:
   - targetRef:
      kind: Mesh
     default:
@@ -75,7 +75,7 @@ spec:
   name: other-gateway
   tags:
     listener: three
- from:
+ to:
   - targetRef:
      kind: Mesh
     default:

--- a/pkg/plugins/policies/core/rules/rules.go
+++ b/pkg/plugins/policies/core/rules/rules.go
@@ -47,6 +47,10 @@ type ToRules struct {
 	Rules Rules
 }
 
+type GatewayRules struct {
+	Rules map[InboundListener]Rules
+}
+
 type SingleItemRules struct {
 	Rules Rules
 }
@@ -251,6 +255,21 @@ func BuildToRules(matchedPolicies []core_model.Resource, httpRoutes []core_model
 	}
 
 	return ToRules{Rules: rules}, nil
+}
+
+func BuildGatewayRules(
+	matchedPoliciesByInbound map[InboundListener][]core_model.Resource,
+	httpRoutes []core_model.Resource,
+) (GatewayRules, error) {
+	rulesByInbound := map[InboundListener]Rules{}
+	for inbound, policies := range matchedPoliciesByInbound {
+		rules, err := BuildToRules(policies, httpRoutes)
+		if err != nil {
+			return GatewayRules{}, err
+		}
+		rulesByInbound[inbound] = rules.Rules
+	}
+	return GatewayRules{Rules: rulesByInbound}, nil
 }
 
 func buildToList(p core_model.Resource, httpRoutes []core_model.Resource) ([]core_model.PolicyItem, error) {


### PR DESCRIPTION
At the moment we're actually using `ToRules` in policies which doesn't take into account the MeshGateway listener tags. We need a new entry indexed by listener, like `FromRules`, but for `to` policies.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- https://github.com/kumahq/kuma/issues/8549
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
