### PR TITLE
ci(actions): pin git SHA to the same value as GH Actions when running e2e tests on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -747,6 +747,9 @@ workflows:
         equal: ["", << pipeline.parameters.gh_action_build_artifact_name >>]
     jobs:
       - e2e_testing:
+          filters:
+            tags:
+              only: /.*/
           k8sVersion: << pipeline.parameters.e2e_param_k8s_version >>
           target: << pipeline.parameters.e2e_param_target >>
           arch: << pipeline.parameters.e2e_param_arch >>

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -162,10 +162,15 @@ jobs:
           BODY='{"parameters": { "e2e_param_k8s_version": "${{ inputs.k8sVersion }}", "e2e_param_arch": "${{ inputs.arch }}", "e2e_param_parallelism": ${{ inputs.parallelism }}, "e2e_param_target": "${{ inputs.target }}", "e2e_param_cni_network_plugin": "${{ inputs.cniNetworkPlugin }}", "e2e_param_legacy_kds": ${{ inputs.legacyKDS }}  } }'
           BODY=$(echo "$BODY" | jq -c ".parameters += { \"gh_action_build_artifact_name\": \"$BUILD_OUTPUT_ARTIFACT_NAME\", \"gh_action_runtime_token\": \"$ACTIONS_RUNTIME_TOKEN\", \"gh_action_artifact_list_url\": \"${ACTIONS_RUNTIME_URL}_apis/pipelines/workflows/${{ github.run_id }}/artifacts?api-version=6.0-preview\" }")
 
-          if [[ "${{ github.ref_type }}" == "tag" ]]; then
-            BODY=$(echo $BODY | jq -rc '.+= {"tag": "${{ github.ref_name }}"}')
+          REF_NAME=
+          # use pull/<number>/head if it's PR from a fork,
+          # otherwise, always use the current SHA to make sure all CircleCI e2e runnings are using the same commit SHA with this GH Action run
+          if [[ "${{ github.event_name }}" == "pull_request" ]] && [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+            REF_NAME=${REF_NAME#refs/}
+            BODY=$(echo $BODY | jq -rc ".+= {\"branch\": \"$REF_NAME\"}")
           else
-            BODY=$(echo $BODY | jq -rc '.+= {"branch": "${{ github.ref_name }}"}')
+            REF_NAME=${{ github.event.pull_request.head.sha || github.sha }}
+            BODY=$(echo $BODY | jq -rc ".+= {\"tag\": \"$REF_NAME\"}")
           fi
 
           CIRCLE_CI_API_PATH=https://circleci.com/api/v2/project/gh/${{ github.repository }}/pipeline


### PR DESCRIPTION
CircleCI failed to load downloaded artifacts if there are new commits pushed in the branch during an ongoing run.

This PR is to pin the SHA that CircleCI workflows run on.

It should fix failures like this: https://app.circleci.com/pipelines/gh/kumahq/kuma/26972/workflows/be3668af-9369-4cf2-81d4-39e61694606a/jobs/566681

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - N/A
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - Confirmed 
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - N/A
  - Don't forget `ci/` labels to run additional/fewer tests
    - Added
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - No need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) 
  - No need

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
