### PR TITLE
chore(MeshProxyPatch): handle multiple modification types in a single object

### DIFF
--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/validator.go
@@ -45,26 +45,43 @@ func validateTop(targetRef common_api.TargetRef) validators.ValidationError {
 func validateDefault(conf Conf) validators.ValidationError {
 	var verr validators.ValidationError
 	path := validators.RootedAt("appendModifications")
-	for i, modification := range conf.AppendModifications {
-		path := path.Index(i)
-		switch {
-		case modification.Cluster != nil:
-			verr.AddErrorAt(path, validateClusterMod(*modification.Cluster))
-		case modification.Listener != nil:
-			verr.AddErrorAt(path, validateListenerMod(*modification.Listener))
-		case modification.VirtualHost != nil:
-			verr.AddErrorAt(path, validateVirtualHostMod(*modification.VirtualHost))
-		case modification.NetworkFilter != nil:
-			verr.AddErrorAt(path, validateNetworkFilterMod(*modification.NetworkFilter))
-		case modification.HTTPFilter != nil:
-			verr.AddErrorAt(path, validateHTTPFilterMod(*modification.HTTPFilter))
-		default:
-			verr.AddViolationAt(path, "at least one modification has to be defined")
-		}
-	}
+
 	if len(conf.AppendModifications) == 0 {
 		verr.AddViolationAt(path, validators.MustNotBeEmpty)
 	}
+
+	for i, modification := range conf.AppendModifications {
+		path := path.Index(i)
+
+		if modification.Cluster == nil &&
+			modification.Listener == nil &&
+			modification.VirtualHost == nil &&
+			modification.NetworkFilter == nil &&
+			modification.HTTPFilter == nil {
+			verr.AddViolationAt(path, "at least one modification has to be defined")
+		}
+
+		if modification.Cluster != nil {
+			verr.AddErrorAt(path, validateClusterMod(*modification.Cluster))
+		}
+
+		if modification.Listener != nil {
+			verr.AddErrorAt(path, validateListenerMod(*modification.Listener))
+		}
+
+		if modification.VirtualHost != nil {
+			verr.AddErrorAt(path, validateVirtualHostMod(*modification.VirtualHost))
+		}
+
+		if modification.NetworkFilter != nil {
+			verr.AddErrorAt(path, validateNetworkFilterMod(*modification.NetworkFilter))
+		}
+
+		if modification.HTTPFilter != nil {
+			verr.AddErrorAt(path, validateHTTPFilterMod(*modification.HTTPFilter))
+		}
+	}
+
 	return verr
 }
 

--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/validator_test.go
@@ -295,45 +295,6 @@ default:
           '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           dynamicStats: false
     `),
-			Entry("multiple types in one modification", `
-targetRef:
-  kind: MeshGateway
-  name: gateway
-default:
-  appendModifications:
-  - cluster:
-      operation: Patch
-      jsonPatches:
-        - op: replace
-          path: /foo/bar
-          value: baz
-        - op: replace
-          path: /foo
-          value:
-            bar: baz
-    listener:
-      operation: Add
-      value: |
-        name: xyz
-        address:
-          socketAddress:
-            address: 192.168.0.1
-            portValue: 8080
-    networkFilter:
-      operation: AddFirst
-      value: |
-        name: envoy.filters.network.tcp_proxy
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: backend
-    httpFilter:
-      operation: AddFirst
-      value: |
-        name: envoy.filters.http.router
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-          dynamicStats: false
-    `),
 		)
 
 		type testCase struct {
@@ -653,6 +614,51 @@ default:
                 violations:
                 - field: spec.targetRef.kind
                   message: value is not supported`,
+			}),
+			Entry("multiple types in one modification", testCase{
+				inputYaml: `
+targetRef:
+  kind: MeshGateway
+  name: gateway
+default:
+  appendModifications:
+  - cluster:
+      operation: Patch
+      jsonPatches:
+        - op: replace
+          path: /foo/bar
+          value: baz
+        - op: replace
+          path: /foo
+          value:
+            bar: baz
+    listener:
+      operation: Add
+      value: |
+        name: xyz
+        address:
+          socketAddress:
+            address: 192.168.0.1
+            portValue: 8080
+    networkFilter:
+      operation: AddFirst
+      value: |
+        name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: backend
+    httpFilter:
+      operation: AddFirst
+      value: |
+        name: envoy.filters.http.router
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          dynamicStats: false
+`,
+				expected: `
+                violations:
+                - field: spec.default.appendModifications[0]
+                  message: exactly one modification can be defined at a time. Currently, 4 modifications are defined`,
 			}),
 		)
 	})

--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/validator_test.go
@@ -338,7 +338,7 @@ default:
 				expected: `
                 violations:
                 - field: spec.default.appendModifications[0]
-                  message: at least one modification has to be defined`,
+                  message: exactly one modification can be defined at a time. Currently, 0 modifications are defined`,
 			}),
 			Entry("invalid cluster modifications", testCase{
 				inputYaml: `

--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/validator_test.go
@@ -295,6 +295,45 @@ default:
           '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           dynamicStats: false
     `),
+			Entry("multiple types in one modification", `
+targetRef:
+  kind: MeshGateway
+  name: gateway
+default:
+  appendModifications:
+  - cluster:
+      operation: Patch
+      jsonPatches:
+        - op: replace
+          path: /foo/bar
+          value: baz
+        - op: replace
+          path: /foo
+          value:
+            bar: baz
+    listener:
+      operation: Add
+      value: |
+        name: xyz
+        address:
+          socketAddress:
+            address: 192.168.0.1
+            portValue: 8080
+    networkFilter:
+      operation: AddFirst
+      value: |
+        name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: backend
+    httpFilter:
+      operation: AddFirst
+      value: |
+        name: envoy.filters.http.router
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          dynamicStats: false
+    `),
 		)
 
 		type testCase struct {


### PR DESCRIPTION
Previously, the MeshProxyPatch policy only validated the first element in the provided modification object. This meant that if a modification object contained multiple types of modifications (e.g., cluster, listener and networkFilter), only the first type of modification would be applied, and the others would be silently ignored. To address this, I updated the validator to fail when multiple modification types to be specified within a single modification object.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - Closes https://github.com/kumahq/kuma/issues/8287
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Unit tests were updated
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - There is no need

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
