### PR TITLE
chore(MeshTrace): improve openapi schema and validation

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -3883,13 +3883,14 @@ spec:
                           description: Datadog backend configuration.
                           properties:
                             splitService:
+                              default: false
                               description: 'Determines if datadog service name should
                                 be split based on traffic direction and destination.
                                 For example, with `splitService: true` and a `backend`
                                 service that communicates with a couple of databases,
                                 you would get service names like `backend_INBOUND`,
                                 `backend_OUTBOUND_db1`, and `backend_OUTBOUND_db2`
-                                in Datadog. Default: false'
+                                in Datadog.'
                               type: boolean
                             url:
                               description: Address of Datadog collector, only host
@@ -3920,18 +3921,19 @@ spec:
                           properties:
                             apiVersion:
                               default: httpJson
-                              description: 'Version of the API. values: httpJson,
-                                httpProto. Default: httpJson see https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L66'
+                              description: Version of the API. https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L66
                               enum:
                               - httpJson
                               - httpProto
                               type: string
                             sharedSpanContext:
-                              description: 'Determines whether client and server spans
-                                will share the same span context. Default: true. https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L63'
+                              default: true
+                              description: Determines whether client and server spans
+                                will share the same span context. https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L63
                               type: boolean
                             traceId128bit:
-                              description: 'Generate 128bit traces. Default: false'
+                              default: false
+                              description: Generate 128bit traces.
                               type: boolean
                             url:
                               description: Address of Zipkin collector.
@@ -3942,6 +3944,7 @@ spec:
                       required:
                       - type
                       type: object
+                    maxItems: 1
                     type: array
                   sampling:
                     description: Sampling configuration. Sampling is the process by
@@ -3952,34 +3955,36 @@ spec:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'Target percentage of requests that will be force
-                          traced if the ''x-client-trace-id'' header is set. Default:
-                          100% Mirror of client_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L127-L133
-                          Either int or decimal represented as string.'
+                        default: 100%
+                        description: Target percentage of requests that will be force
+                          traced if the 'x-client-trace-id' header is set. Mirror
+                          of client_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L127-L133
+                          Either int or decimal represented as string.
                         x-kubernetes-int-or-string: true
                       overall:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'Target percentage of requests will be traced
+                        default: 100%
+                        description: Target percentage of requests will be traced
                           after all other sampling checks have been applied (client,
                           force tracing, random sampling). This field functions as
                           an upper limit on the total configured sampling rate. For
                           instance, setting client_sampling to 100% but overall_sampling
                           to 1% will result in only 1% of client requests with the
-                          appropriate headers to be force traced. Default: 100% Mirror
-                          of overall_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L142-L150
-                          Either int or decimal represented as string.'
+                          appropriate headers to be force traced. Mirror of overall_sampling
+                          in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L142-L150
+                          Either int or decimal represented as string.
                         x-kubernetes-int-or-string: true
                       random:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'Target percentage of requests that will be randomly
+                        default: 100%
+                        description: Target percentage of requests that will be randomly
                           selected for trace generation, if not requested by the client
-                          or not forced. Default: 100% Mirror of random_sampling in
-                          Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L135-L140
-                          Either int or decimal represented as string.'
+                          or not forced. Mirror of random_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L135-L140
+                          Either int or decimal represented as string.
                         x-kubernetes-int-or-string: true
                     type: object
                   tags:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
@@ -3883,13 +3883,14 @@ spec:
                           description: Datadog backend configuration.
                           properties:
                             splitService:
+                              default: false
                               description: 'Determines if datadog service name should
                                 be split based on traffic direction and destination.
                                 For example, with `splitService: true` and a `backend`
                                 service that communicates with a couple of databases,
                                 you would get service names like `backend_INBOUND`,
                                 `backend_OUTBOUND_db1`, and `backend_OUTBOUND_db2`
-                                in Datadog. Default: false'
+                                in Datadog.'
                               type: boolean
                             url:
                               description: Address of Datadog collector, only host
@@ -3920,18 +3921,19 @@ spec:
                           properties:
                             apiVersion:
                               default: httpJson
-                              description: 'Version of the API. values: httpJson,
-                                httpProto. Default: httpJson see https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L66'
+                              description: Version of the API. https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L66
                               enum:
                               - httpJson
                               - httpProto
                               type: string
                             sharedSpanContext:
-                              description: 'Determines whether client and server spans
-                                will share the same span context. Default: true. https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L63'
+                              default: true
+                              description: Determines whether client and server spans
+                                will share the same span context. https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L63
                               type: boolean
                             traceId128bit:
-                              description: 'Generate 128bit traces. Default: false'
+                              default: false
+                              description: Generate 128bit traces.
                               type: boolean
                             url:
                               description: Address of Zipkin collector.
@@ -3942,6 +3944,7 @@ spec:
                       required:
                       - type
                       type: object
+                    maxItems: 1
                     type: array
                   sampling:
                     description: Sampling configuration. Sampling is the process by
@@ -3952,34 +3955,36 @@ spec:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'Target percentage of requests that will be force
-                          traced if the ''x-client-trace-id'' header is set. Default:
-                          100% Mirror of client_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L127-L133
-                          Either int or decimal represented as string.'
+                        default: 100%
+                        description: Target percentage of requests that will be force
+                          traced if the 'x-client-trace-id' header is set. Mirror
+                          of client_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L127-L133
+                          Either int or decimal represented as string.
                         x-kubernetes-int-or-string: true
                       overall:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'Target percentage of requests will be traced
+                        default: 100%
+                        description: Target percentage of requests will be traced
                           after all other sampling checks have been applied (client,
                           force tracing, random sampling). This field functions as
                           an upper limit on the total configured sampling rate. For
                           instance, setting client_sampling to 100% but overall_sampling
                           to 1% will result in only 1% of client requests with the
-                          appropriate headers to be force traced. Default: 100% Mirror
-                          of overall_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L142-L150
-                          Either int or decimal represented as string.'
+                          appropriate headers to be force traced. Mirror of overall_sampling
+                          in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L142-L150
+                          Either int or decimal represented as string.
                         x-kubernetes-int-or-string: true
                       random:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'Target percentage of requests that will be randomly
+                        default: 100%
+                        description: Target percentage of requests that will be randomly
                           selected for trace generation, if not requested by the client
-                          or not forced. Default: 100% Mirror of random_sampling in
-                          Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L135-L140
-                          Either int or decimal represented as string.'
+                          or not forced. Mirror of random_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L135-L140
+                          Either int or decimal represented as string.
                         x-kubernetes-int-or-string: true
                     type: object
                   tags:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -4087,13 +4087,14 @@ spec:
                           description: Datadog backend configuration.
                           properties:
                             splitService:
+                              default: false
                               description: 'Determines if datadog service name should
                                 be split based on traffic direction and destination.
                                 For example, with `splitService: true` and a `backend`
                                 service that communicates with a couple of databases,
                                 you would get service names like `backend_INBOUND`,
                                 `backend_OUTBOUND_db1`, and `backend_OUTBOUND_db2`
-                                in Datadog. Default: false'
+                                in Datadog.'
                               type: boolean
                             url:
                               description: Address of Datadog collector, only host
@@ -4124,18 +4125,19 @@ spec:
                           properties:
                             apiVersion:
                               default: httpJson
-                              description: 'Version of the API. values: httpJson,
-                                httpProto. Default: httpJson see https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L66'
+                              description: Version of the API. https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L66
                               enum:
                               - httpJson
                               - httpProto
                               type: string
                             sharedSpanContext:
-                              description: 'Determines whether client and server spans
-                                will share the same span context. Default: true. https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L63'
+                              default: true
+                              description: Determines whether client and server spans
+                                will share the same span context. https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L63
                               type: boolean
                             traceId128bit:
-                              description: 'Generate 128bit traces. Default: false'
+                              default: false
+                              description: Generate 128bit traces.
                               type: boolean
                             url:
                               description: Address of Zipkin collector.
@@ -4146,6 +4148,7 @@ spec:
                       required:
                       - type
                       type: object
+                    maxItems: 1
                     type: array
                   sampling:
                     description: Sampling configuration. Sampling is the process by
@@ -4156,34 +4159,36 @@ spec:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'Target percentage of requests that will be force
-                          traced if the ''x-client-trace-id'' header is set. Default:
-                          100% Mirror of client_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L127-L133
-                          Either int or decimal represented as string.'
+                        default: 100%
+                        description: Target percentage of requests that will be force
+                          traced if the 'x-client-trace-id' header is set. Mirror
+                          of client_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L127-L133
+                          Either int or decimal represented as string.
                         x-kubernetes-int-or-string: true
                       overall:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'Target percentage of requests will be traced
+                        default: 100%
+                        description: Target percentage of requests will be traced
                           after all other sampling checks have been applied (client,
                           force tracing, random sampling). This field functions as
                           an upper limit on the total configured sampling rate. For
                           instance, setting client_sampling to 100% but overall_sampling
                           to 1% will result in only 1% of client requests with the
-                          appropriate headers to be force traced. Default: 100% Mirror
-                          of overall_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L142-L150
-                          Either int or decimal represented as string.'
+                          appropriate headers to be force traced. Mirror of overall_sampling
+                          in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L142-L150
+                          Either int or decimal represented as string.
                         x-kubernetes-int-or-string: true
                       random:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'Target percentage of requests that will be randomly
+                        default: 100%
+                        description: Target percentage of requests that will be randomly
                           selected for trace generation, if not requested by the client
-                          or not forced. Default: 100% Mirror of random_sampling in
-                          Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L135-L140
-                          Either int or decimal represented as string.'
+                          or not forced. Mirror of random_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L135-L140
+                          Either int or decimal represented as string.
                         x-kubernetes-int-or-string: true
                     type: object
                   tags:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -3903,13 +3903,14 @@ spec:
                           description: Datadog backend configuration.
                           properties:
                             splitService:
+                              default: false
                               description: 'Determines if datadog service name should
                                 be split based on traffic direction and destination.
                                 For example, with `splitService: true` and a `backend`
                                 service that communicates with a couple of databases,
                                 you would get service names like `backend_INBOUND`,
                                 `backend_OUTBOUND_db1`, and `backend_OUTBOUND_db2`
-                                in Datadog. Default: false'
+                                in Datadog.'
                               type: boolean
                             url:
                               description: Address of Datadog collector, only host
@@ -3940,18 +3941,19 @@ spec:
                           properties:
                             apiVersion:
                               default: httpJson
-                              description: 'Version of the API. values: httpJson,
-                                httpProto. Default: httpJson see https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L66'
+                              description: Version of the API. https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L66
                               enum:
                               - httpJson
                               - httpProto
                               type: string
                             sharedSpanContext:
-                              description: 'Determines whether client and server spans
-                                will share the same span context. Default: true. https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L63'
+                              default: true
+                              description: Determines whether client and server spans
+                                will share the same span context. https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L63
                               type: boolean
                             traceId128bit:
-                              description: 'Generate 128bit traces. Default: false'
+                              default: false
+                              description: Generate 128bit traces.
                               type: boolean
                             url:
                               description: Address of Zipkin collector.
@@ -3962,6 +3964,7 @@ spec:
                       required:
                       - type
                       type: object
+                    maxItems: 1
                     type: array
                   sampling:
                     description: Sampling configuration. Sampling is the process by
@@ -3972,34 +3975,36 @@ spec:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'Target percentage of requests that will be force
-                          traced if the ''x-client-trace-id'' header is set. Default:
-                          100% Mirror of client_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L127-L133
-                          Either int or decimal represented as string.'
+                        default: 100%
+                        description: Target percentage of requests that will be force
+                          traced if the 'x-client-trace-id' header is set. Mirror
+                          of client_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L127-L133
+                          Either int or decimal represented as string.
                         x-kubernetes-int-or-string: true
                       overall:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'Target percentage of requests will be traced
+                        default: 100%
+                        description: Target percentage of requests will be traced
                           after all other sampling checks have been applied (client,
                           force tracing, random sampling). This field functions as
                           an upper limit on the total configured sampling rate. For
                           instance, setting client_sampling to 100% but overall_sampling
                           to 1% will result in only 1% of client requests with the
-                          appropriate headers to be force traced. Default: 100% Mirror
-                          of overall_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L142-L150
-                          Either int or decimal represented as string.'
+                          appropriate headers to be force traced. Mirror of overall_sampling
+                          in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L142-L150
+                          Either int or decimal represented as string.
                         x-kubernetes-int-or-string: true
                       random:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'Target percentage of requests that will be randomly
+                        default: 100%
+                        description: Target percentage of requests that will be randomly
                           selected for trace generation, if not requested by the client
-                          or not forced. Default: 100% Mirror of random_sampling in
-                          Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L135-L140
-                          Either int or decimal represented as string.'
+                          or not forced. Mirror of random_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L135-L140
+                          Either int or decimal represented as string.
                         x-kubernetes-int-or-string: true
                     type: object
                   tags:

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -5198,13 +5198,14 @@ spec:
                           description: Datadog backend configuration.
                           properties:
                             splitService:
+                              default: false
                               description: 'Determines if datadog service name should
                                 be split based on traffic direction and destination.
                                 For example, with `splitService: true` and a `backend`
                                 service that communicates with a couple of databases,
                                 you would get service names like `backend_INBOUND`,
                                 `backend_OUTBOUND_db1`, and `backend_OUTBOUND_db2`
-                                in Datadog. Default: false'
+                                in Datadog.'
                               type: boolean
                             url:
                               description: Address of Datadog collector, only host
@@ -5235,18 +5236,19 @@ spec:
                           properties:
                             apiVersion:
                               default: httpJson
-                              description: 'Version of the API. values: httpJson,
-                                httpProto. Default: httpJson see https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L66'
+                              description: Version of the API. https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L66
                               enum:
                               - httpJson
                               - httpProto
                               type: string
                             sharedSpanContext:
-                              description: 'Determines whether client and server spans
-                                will share the same span context. Default: true. https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L63'
+                              default: true
+                              description: Determines whether client and server spans
+                                will share the same span context. https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L63
                               type: boolean
                             traceId128bit:
-                              description: 'Generate 128bit traces. Default: false'
+                              default: false
+                              description: Generate 128bit traces.
                               type: boolean
                             url:
                               description: Address of Zipkin collector.
@@ -5257,6 +5259,7 @@ spec:
                       required:
                       - type
                       type: object
+                    maxItems: 1
                     type: array
                   sampling:
                     description: Sampling configuration. Sampling is the process by
@@ -5267,34 +5270,36 @@ spec:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'Target percentage of requests that will be force
-                          traced if the ''x-client-trace-id'' header is set. Default:
-                          100% Mirror of client_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L127-L133
-                          Either int or decimal represented as string.'
+                        default: 100%
+                        description: Target percentage of requests that will be force
+                          traced if the 'x-client-trace-id' header is set. Mirror
+                          of client_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L127-L133
+                          Either int or decimal represented as string.
                         x-kubernetes-int-or-string: true
                       overall:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'Target percentage of requests will be traced
+                        default: 100%
+                        description: Target percentage of requests will be traced
                           after all other sampling checks have been applied (client,
                           force tracing, random sampling). This field functions as
                           an upper limit on the total configured sampling rate. For
                           instance, setting client_sampling to 100% but overall_sampling
                           to 1% will result in only 1% of client requests with the
-                          appropriate headers to be force traced. Default: 100% Mirror
-                          of overall_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L142-L150
-                          Either int or decimal represented as string.'
+                          appropriate headers to be force traced. Mirror of overall_sampling
+                          in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L142-L150
+                          Either int or decimal represented as string.
                         x-kubernetes-int-or-string: true
                       random:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'Target percentage of requests that will be randomly
+                        default: 100%
+                        description: Target percentage of requests that will be randomly
                           selected for trace generation, if not requested by the client
-                          or not forced. Default: 100% Mirror of random_sampling in
-                          Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L135-L140
-                          Either int or decimal represented as string.'
+                          or not forced. Mirror of random_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L135-L140
+                          Either int or decimal represented as string.
                         x-kubernetes-int-or-string: true
                     type: object
                   tags:

--- a/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
@@ -5402,13 +5402,14 @@ spec:
                           description: Datadog backend configuration.
                           properties:
                             splitService:
+                              default: false
                               description: 'Determines if datadog service name should
                                 be split based on traffic direction and destination.
                                 For example, with `splitService: true` and a `backend`
                                 service that communicates with a couple of databases,
                                 you would get service names like `backend_INBOUND`,
                                 `backend_OUTBOUND_db1`, and `backend_OUTBOUND_db2`
-                                in Datadog. Default: false'
+                                in Datadog.'
                               type: boolean
                             url:
                               description: Address of Datadog collector, only host
@@ -5439,18 +5440,19 @@ spec:
                           properties:
                             apiVersion:
                               default: httpJson
-                              description: 'Version of the API. values: httpJson,
-                                httpProto. Default: httpJson see https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L66'
+                              description: Version of the API. https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L66
                               enum:
                               - httpJson
                               - httpProto
                               type: string
                             sharedSpanContext:
-                              description: 'Determines whether client and server spans
-                                will share the same span context. Default: true. https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L63'
+                              default: true
+                              description: Determines whether client and server spans
+                                will share the same span context. https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L63
                               type: boolean
                             traceId128bit:
-                              description: 'Generate 128bit traces. Default: false'
+                              default: false
+                              description: Generate 128bit traces.
                               type: boolean
                             url:
                               description: Address of Zipkin collector.
@@ -5461,6 +5463,7 @@ spec:
                       required:
                       - type
                       type: object
+                    maxItems: 1
                     type: array
                   sampling:
                     description: Sampling configuration. Sampling is the process by
@@ -5471,34 +5474,36 @@ spec:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'Target percentage of requests that will be force
-                          traced if the ''x-client-trace-id'' header is set. Default:
-                          100% Mirror of client_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L127-L133
-                          Either int or decimal represented as string.'
+                        default: 100%
+                        description: Target percentage of requests that will be force
+                          traced if the 'x-client-trace-id' header is set. Mirror
+                          of client_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L127-L133
+                          Either int or decimal represented as string.
                         x-kubernetes-int-or-string: true
                       overall:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'Target percentage of requests will be traced
+                        default: 100%
+                        description: Target percentage of requests will be traced
                           after all other sampling checks have been applied (client,
                           force tracing, random sampling). This field functions as
                           an upper limit on the total configured sampling rate. For
                           instance, setting client_sampling to 100% but overall_sampling
                           to 1% will result in only 1% of client requests with the
-                          appropriate headers to be force traced. Default: 100% Mirror
-                          of overall_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L142-L150
-                          Either int or decimal represented as string.'
+                          appropriate headers to be force traced. Mirror of overall_sampling
+                          in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L142-L150
+                          Either int or decimal represented as string.
                         x-kubernetes-int-or-string: true
                       random:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'Target percentage of requests that will be randomly
+                        default: 100%
+                        description: Target percentage of requests that will be randomly
                           selected for trace generation, if not requested by the client
-                          or not forced. Default: 100% Mirror of random_sampling in
-                          Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L135-L140
-                          Either int or decimal represented as string.'
+                          or not forced. Mirror of random_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L135-L140
+                          Either int or decimal represented as string.
                         x-kubernetes-int-or-string: true
                     type: object
                   tags:

--- a/deployments/charts/kuma/crds/kuma.io_meshtraces.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtraces.yaml
@@ -59,13 +59,14 @@ spec:
                           description: Datadog backend configuration.
                           properties:
                             splitService:
+                              default: false
                               description: 'Determines if datadog service name should
                                 be split based on traffic direction and destination.
                                 For example, with `splitService: true` and a `backend`
                                 service that communicates with a couple of databases,
                                 you would get service names like `backend_INBOUND`,
                                 `backend_OUTBOUND_db1`, and `backend_OUTBOUND_db2`
-                                in Datadog. Default: false'
+                                in Datadog.'
                               type: boolean
                             url:
                               description: Address of Datadog collector, only host
@@ -96,18 +97,19 @@ spec:
                           properties:
                             apiVersion:
                               default: httpJson
-                              description: 'Version of the API. values: httpJson,
-                                httpProto. Default: httpJson see https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L66'
+                              description: Version of the API. https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L66
                               enum:
                               - httpJson
                               - httpProto
                               type: string
                             sharedSpanContext:
-                              description: 'Determines whether client and server spans
-                                will share the same span context. Default: true. https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L63'
+                              default: true
+                              description: Determines whether client and server spans
+                                will share the same span context. https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L63
                               type: boolean
                             traceId128bit:
-                              description: 'Generate 128bit traces. Default: false'
+                              default: false
+                              description: Generate 128bit traces.
                               type: boolean
                             url:
                               description: Address of Zipkin collector.
@@ -118,6 +120,7 @@ spec:
                       required:
                       - type
                       type: object
+                    maxItems: 1
                     type: array
                   sampling:
                     description: Sampling configuration. Sampling is the process by
@@ -128,34 +131,36 @@ spec:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'Target percentage of requests that will be force
-                          traced if the ''x-client-trace-id'' header is set. Default:
-                          100% Mirror of client_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L127-L133
-                          Either int or decimal represented as string.'
+                        default: 100%
+                        description: Target percentage of requests that will be force
+                          traced if the 'x-client-trace-id' header is set. Mirror
+                          of client_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L127-L133
+                          Either int or decimal represented as string.
                         x-kubernetes-int-or-string: true
                       overall:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'Target percentage of requests will be traced
+                        default: 100%
+                        description: Target percentage of requests will be traced
                           after all other sampling checks have been applied (client,
                           force tracing, random sampling). This field functions as
                           an upper limit on the total configured sampling rate. For
                           instance, setting client_sampling to 100% but overall_sampling
                           to 1% will result in only 1% of client requests with the
-                          appropriate headers to be force traced. Default: 100% Mirror
-                          of overall_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L142-L150
-                          Either int or decimal represented as string.'
+                          appropriate headers to be force traced. Mirror of overall_sampling
+                          in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L142-L150
+                          Either int or decimal represented as string.
                         x-kubernetes-int-or-string: true
                       random:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'Target percentage of requests that will be randomly
+                        default: 100%
+                        description: Target percentage of requests that will be randomly
                           selected for trace generation, if not requested by the client
-                          or not forced. Default: 100% Mirror of random_sampling in
-                          Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L135-L140
-                          Either int or decimal represented as string.'
+                          or not forced. Mirror of random_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L135-L140
+                          Either int or decimal represented as string.
                         x-kubernetes-int-or-string: true
                     type: object
                   tags:

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -6066,6 +6066,7 @@ components:
                         description: Datadog backend configuration.
                         properties:
                           splitService:
+                            default: false
                             description: >-
                               Determines if datadog service name should be split
                               based on traffic direction and destination. For
@@ -6073,7 +6074,7 @@ components:
                               service that communicates with a couple of
                               databases, you would get service names like
                               `backend_INBOUND`, `backend_OUTBOUND_db1`, and
-                              `backend_OUTBOUND_db2` in Datadog. Default: false
+                              `backend_OUTBOUND_db2` in Datadog.
                             type: boolean
                           url:
                             description: >-
@@ -6106,21 +6107,22 @@ components:
                           apiVersion:
                             default: httpJson
                             description: >-
-                              Version of the API. values: httpJson, httpProto.
-                              Default: httpJson see
+                              Version of the API.
                               https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L66
                             enum:
                               - httpJson
                               - httpProto
                             type: string
                           sharedSpanContext:
+                            default: true
                             description: >-
                               Determines whether client and server spans will
-                              share the same span context. Default: true.
+                              share the same span context.
                               https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L63
                             type: boolean
                           traceId128bit:
-                            description: 'Generate 128bit traces. Default: false'
+                            default: false
+                            description: Generate 128bit traces.
                             type: boolean
                           url:
                             description: Address of Zipkin collector.
@@ -6131,6 +6133,7 @@ components:
                     required:
                       - type
                     type: object
+                  maxItems: 1
                   type: array
                 sampling:
                   description: >-
@@ -6141,10 +6144,11 @@ components:
                       anyOf:
                         - type: integer
                         - type: string
+                      default: 100%
                       description: >-
                         Target percentage of requests that will be force traced
-                        if the 'x-client-trace-id' header is set. Default: 100%
-                        Mirror of client_sampling in Envoy
+                        if the 'x-client-trace-id' header is set. Mirror of
+                        client_sampling in Envoy
                         https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L127-L133
                         Either int or decimal represented as string.
                       x-kubernetes-int-or-string: true
@@ -6152,6 +6156,7 @@ components:
                       anyOf:
                         - type: integer
                         - type: string
+                      default: 100%
                       description: >-
                         Target percentage of requests will be traced after all
                         other sampling checks have been applied (client, force
@@ -6160,8 +6165,7 @@ components:
                         instance, setting client_sampling to 100% but
                         overall_sampling to 1% will result in only 1% of client
                         requests with the appropriate headers to be force
-                        traced. Default: 100% Mirror of overall_sampling in
-                        Envoy
+                        traced. Mirror of overall_sampling in Envoy
                         https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L142-L150
                         Either int or decimal represented as string.
                       x-kubernetes-int-or-string: true
@@ -6169,11 +6173,11 @@ components:
                       anyOf:
                         - type: integer
                         - type: string
+                      default: 100%
                       description: >-
                         Target percentage of requests that will be randomly
                         selected for trace generation, if not requested by the
-                        client or not forced. Default: 100% Mirror of
-                        random_sampling in Envoy
+                        client or not forced. Mirror of random_sampling in Envoy
                         https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L135-L140
                         Either int or decimal represented as string.
                       x-kubernetes-int-or-string: true

--- a/docs/generated/raw/crds/kuma.io_meshtraces.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshtraces.yaml
@@ -59,13 +59,14 @@ spec:
                           description: Datadog backend configuration.
                           properties:
                             splitService:
+                              default: false
                               description: 'Determines if datadog service name should
                                 be split based on traffic direction and destination.
                                 For example, with `splitService: true` and a `backend`
                                 service that communicates with a couple of databases,
                                 you would get service names like `backend_INBOUND`,
                                 `backend_OUTBOUND_db1`, and `backend_OUTBOUND_db2`
-                                in Datadog. Default: false'
+                                in Datadog.'
                               type: boolean
                             url:
                               description: Address of Datadog collector, only host
@@ -96,18 +97,19 @@ spec:
                           properties:
                             apiVersion:
                               default: httpJson
-                              description: 'Version of the API. values: httpJson,
-                                httpProto. Default: httpJson see https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L66'
+                              description: Version of the API. https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L66
                               enum:
                               - httpJson
                               - httpProto
                               type: string
                             sharedSpanContext:
-                              description: 'Determines whether client and server spans
-                                will share the same span context. Default: true. https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L63'
+                              default: true
+                              description: Determines whether client and server spans
+                                will share the same span context. https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L63
                               type: boolean
                             traceId128bit:
-                              description: 'Generate 128bit traces. Default: false'
+                              default: false
+                              description: Generate 128bit traces.
                               type: boolean
                             url:
                               description: Address of Zipkin collector.
@@ -118,6 +120,7 @@ spec:
                       required:
                       - type
                       type: object
+                    maxItems: 1
                     type: array
                   sampling:
                     description: Sampling configuration. Sampling is the process by
@@ -128,34 +131,36 @@ spec:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'Target percentage of requests that will be force
-                          traced if the ''x-client-trace-id'' header is set. Default:
-                          100% Mirror of client_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L127-L133
-                          Either int or decimal represented as string.'
+                        default: 100%
+                        description: Target percentage of requests that will be force
+                          traced if the 'x-client-trace-id' header is set. Mirror
+                          of client_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L127-L133
+                          Either int or decimal represented as string.
                         x-kubernetes-int-or-string: true
                       overall:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'Target percentage of requests will be traced
+                        default: 100%
+                        description: Target percentage of requests will be traced
                           after all other sampling checks have been applied (client,
                           force tracing, random sampling). This field functions as
                           an upper limit on the total configured sampling rate. For
                           instance, setting client_sampling to 100% but overall_sampling
                           to 1% will result in only 1% of client requests with the
-                          appropriate headers to be force traced. Default: 100% Mirror
-                          of overall_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L142-L150
-                          Either int or decimal represented as string.'
+                          appropriate headers to be force traced. Mirror of overall_sampling
+                          in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L142-L150
+                          Either int or decimal represented as string.
                         x-kubernetes-int-or-string: true
                       random:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'Target percentage of requests that will be randomly
+                        default: 100%
+                        description: Target percentage of requests that will be randomly
                           selected for trace generation, if not requested by the client
-                          or not forced. Default: 100% Mirror of random_sampling in
-                          Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L135-L140
-                          Either int or decimal represented as string.'
+                          or not forced. Mirror of random_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L135-L140
+                          Either int or decimal represented as string.
                         x-kubernetes-int-or-string: true
                     type: object
                   tags:

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/meshtrace.go
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/meshtrace.go
@@ -24,6 +24,7 @@ type Conf struct {
 	// representing that would be just one object. Unfortunately due to the
 	// reasons explained in MADR 009-tracing-policy this has to be a one element
 	// array for now.
+	// +kubebuilder:validation:MaxItems=1
 	Backends *[]Backend `json:"backends,omitempty"`
 	// Sampling configuration.
 	// Sampling is the process by which a decision is made on whether to
@@ -65,18 +66,20 @@ type OpenTelemetryBackend struct {
 // Zipkin tracing backend configuration.
 type ZipkinBackend struct {
 	// Address of Zipkin collector.
+	// +kubebuilder:examle="http://jaeger-collector:9411/api/v2/spans"
 	Url string `json:"url"`
-	// Generate 128bit traces. Default: false
+	// Generate 128bit traces.
+	// +kubebuilder:default=false
 	TraceId128Bit *bool `json:"traceId128bit,omitempty"`
-	// Version of the API. values: httpJson, httpProto. Default:
-	// httpJson see
+	// Version of the API.
 	// https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L66
 	// +kubebuilder:default="httpJson"
 	// +kubebuilder:validation:Enum=httpJson;httpProto
 	ApiVersion *string `json:"apiVersion,omitempty"`
 	// Determines whether client and server spans will share the same span
-	// context. Default: true.
+	// context.
 	// https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L63
+	// +kubebuilder:default=true
 	SharedSpanContext *bool `json:"sharedSpanContext,omitempty"`
 }
 
@@ -84,12 +87,14 @@ type ZipkinBackend struct {
 type DatadogBackend struct {
 	// Address of Datadog collector, only host and port are allowed (no paths,
 	// fragments etc.)
+	// +kubebuilder:examle="http://my-agent:8080"
 	Url string `json:"url"`
 	// Determines if datadog service name should be split based on traffic
 	// direction and destination. For example, with `splitService: true` and a
 	// `backend` service that communicates with a couple of databases, you would
 	// get service names like `backend_INBOUND`, `backend_OUTBOUND_db1`, and
-	// `backend_OUTBOUND_db2` in Datadog. Default: false
+	// `backend_OUTBOUND_db2` in Datadog.
+	// +kubebuilder:default=false
 	SplitService *bool `json:"splitService,omitempty"`
 }
 
@@ -100,22 +105,24 @@ type Sampling struct {
 	// random sampling). This field functions as an upper limit on the total
 	// configured sampling rate. For instance, setting client_sampling to 100%
 	// but overall_sampling to 1% will result in only 1% of client requests with
-	// the appropriate headers to be force traced. Default: 100% Mirror of
+	// the appropriate headers to be force traced. Mirror of
 	// overall_sampling in Envoy
 	// https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L142-L150
 	// Either int or decimal represented as string.
+	// +kubebuilder:default="100%"
 	Overall *intstr.IntOrString `json:"overall,omitempty"`
 	// Target percentage of requests that will be force traced if the
-	// 'x-client-trace-id' header is set. Default: 100% Mirror of
-	// client_sampling in Envoy
+	// 'x-client-trace-id' header is set. Mirror of client_sampling in Envoy
 	// https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L127-L133
 	// Either int or decimal represented as string.
+	// +kubebuilder:default="100%"
 	Client *intstr.IntOrString `json:"client,omitempty"`
 	// Target percentage of requests that will be randomly selected for trace
-	// generation, if not requested by the client or not forced. Default: 100%
+	// generation, if not requested by the client or not forced.
 	// Mirror of random_sampling in Envoy
 	// https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L135-L140
 	// Either int or decimal represented as string.
+	// +kubebuilder:default="100%"
 	Random *intstr.IntOrString `json:"random,omitempty"`
 }
 

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/schema.yaml
@@ -27,7 +27,8 @@ properties:
                   description: Datadog backend configuration.
                   properties:
                     splitService:
-                      description: 'Determines if datadog service name should be split based on traffic direction and destination. For example, with `splitService: true` and a `backend` service that communicates with a couple of databases, you would get service names like `backend_INBOUND`, `backend_OUTBOUND_db1`, and `backend_OUTBOUND_db2` in Datadog. Default: false'
+                      default: false
+                      description: 'Determines if datadog service name should be split based on traffic direction and destination. For example, with `splitService: true` and a `backend` service that communicates with a couple of databases, you would get service names like `backend_INBOUND`, `backend_OUTBOUND_db1`, and `backend_OUTBOUND_db2` in Datadog.'
                       type: boolean
                     url:
                       description: Address of Datadog collector, only host and port are allowed (no paths, fragments etc.)
@@ -57,16 +58,18 @@ properties:
                   properties:
                     apiVersion:
                       default: httpJson
-                      description: 'Version of the API. values: httpJson, httpProto. Default: httpJson see https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L66'
+                      description: Version of the API. https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L66
                       enum:
                         - httpJson
                         - httpProto
                       type: string
                     sharedSpanContext:
-                      description: 'Determines whether client and server spans will share the same span context. Default: true. https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L63'
+                      default: true
+                      description: Determines whether client and server spans will share the same span context. https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L63
                       type: boolean
                     traceId128bit:
-                      description: 'Generate 128bit traces. Default: false'
+                      default: false
+                      description: Generate 128bit traces.
                       type: boolean
                     url:
                       description: Address of Zipkin collector.
@@ -77,6 +80,7 @@ properties:
               required:
                 - type
               type: object
+            maxItems: 1
             type: array
           sampling:
             description: Sampling configuration. Sampling is the process by which a decision is made on whether to process/export a span or not.
@@ -85,19 +89,22 @@ properties:
                 anyOf:
                   - type: integer
                   - type: string
-                description: 'Target percentage of requests that will be force traced if the ''x-client-trace-id'' header is set. Default: 100% Mirror of client_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L127-L133 Either int or decimal represented as string.'
+                default: 100%
+                description: Target percentage of requests that will be force traced if the 'x-client-trace-id' header is set. Mirror of client_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L127-L133 Either int or decimal represented as string.
                 x-kubernetes-int-or-string: true
               overall:
                 anyOf:
                   - type: integer
                   - type: string
-                description: 'Target percentage of requests will be traced after all other sampling checks have been applied (client, force tracing, random sampling). This field functions as an upper limit on the total configured sampling rate. For instance, setting client_sampling to 100% but overall_sampling to 1% will result in only 1% of client requests with the appropriate headers to be force traced. Default: 100% Mirror of overall_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L142-L150 Either int or decimal represented as string.'
+                default: 100%
+                description: Target percentage of requests will be traced after all other sampling checks have been applied (client, force tracing, random sampling). This field functions as an upper limit on the total configured sampling rate. For instance, setting client_sampling to 100% but overall_sampling to 1% will result in only 1% of client requests with the appropriate headers to be force traced. Mirror of overall_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L142-L150 Either int or decimal represented as string.
                 x-kubernetes-int-or-string: true
               random:
                 anyOf:
                   - type: integer
                   - type: string
-                description: 'Target percentage of requests that will be randomly selected for trace generation, if not requested by the client or not forced. Default: 100% Mirror of random_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L135-L140 Either int or decimal represented as string.'
+                default: 100%
+                description: Target percentage of requests that will be randomly selected for trace generation, if not requested by the client or not forced. Mirror of random_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L135-L140 Either int or decimal represented as string.
                 x-kubernetes-int-or-string: true
             type: object
           tags:

--- a/pkg/plugins/policies/meshtrace/k8s/crd/kuma.io_meshtraces.yaml
+++ b/pkg/plugins/policies/meshtrace/k8s/crd/kuma.io_meshtraces.yaml
@@ -59,13 +59,14 @@ spec:
                           description: Datadog backend configuration.
                           properties:
                             splitService:
+                              default: false
                               description: 'Determines if datadog service name should
                                 be split based on traffic direction and destination.
                                 For example, with `splitService: true` and a `backend`
                                 service that communicates with a couple of databases,
                                 you would get service names like `backend_INBOUND`,
                                 `backend_OUTBOUND_db1`, and `backend_OUTBOUND_db2`
-                                in Datadog. Default: false'
+                                in Datadog.'
                               type: boolean
                             url:
                               description: Address of Datadog collector, only host
@@ -96,18 +97,19 @@ spec:
                           properties:
                             apiVersion:
                               default: httpJson
-                              description: 'Version of the API. values: httpJson,
-                                httpProto. Default: httpJson see https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L66'
+                              description: Version of the API. https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L66
                               enum:
                               - httpJson
                               - httpProto
                               type: string
                             sharedSpanContext:
-                              description: 'Determines whether client and server spans
-                                will share the same span context. Default: true. https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L63'
+                              default: true
+                              description: Determines whether client and server spans
+                                will share the same span context. https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L63
                               type: boolean
                             traceId128bit:
-                              description: 'Generate 128bit traces. Default: false'
+                              default: false
+                              description: Generate 128bit traces.
                               type: boolean
                             url:
                               description: Address of Zipkin collector.
@@ -118,6 +120,7 @@ spec:
                       required:
                       - type
                       type: object
+                    maxItems: 1
                     type: array
                   sampling:
                     description: Sampling configuration. Sampling is the process by
@@ -128,34 +131,36 @@ spec:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'Target percentage of requests that will be force
-                          traced if the ''x-client-trace-id'' header is set. Default:
-                          100% Mirror of client_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L127-L133
-                          Either int or decimal represented as string.'
+                        default: 100%
+                        description: Target percentage of requests that will be force
+                          traced if the 'x-client-trace-id' header is set. Mirror
+                          of client_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L127-L133
+                          Either int or decimal represented as string.
                         x-kubernetes-int-or-string: true
                       overall:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'Target percentage of requests will be traced
+                        default: 100%
+                        description: Target percentage of requests will be traced
                           after all other sampling checks have been applied (client,
                           force tracing, random sampling). This field functions as
                           an upper limit on the total configured sampling rate. For
                           instance, setting client_sampling to 100% but overall_sampling
                           to 1% will result in only 1% of client requests with the
-                          appropriate headers to be force traced. Default: 100% Mirror
-                          of overall_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L142-L150
-                          Either int or decimal represented as string.'
+                          appropriate headers to be force traced. Mirror of overall_sampling
+                          in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L142-L150
+                          Either int or decimal represented as string.
                         x-kubernetes-int-or-string: true
                       random:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'Target percentage of requests that will be randomly
+                        default: 100%
+                        description: Target percentage of requests that will be randomly
                           selected for trace generation, if not requested by the client
-                          or not forced. Default: 100% Mirror of random_sampling in
-                          Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L135-L140
-                          Either int or decimal represented as string.'
+                          or not forced. Mirror of random_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L135-L140
+                          Either int or decimal represented as string.
                         x-kubernetes-int-or-string: true
                     type: object
                   tags:


### PR DESCRIPTION
Added examples and defaults to some fields + added validation to make sure provided list of backends will have only 1 element.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - Closes https://github.com/kumahq/kuma/issues/8289
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - No changes in tests
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - There is no need

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
