### PR TITLE
test(framework): try to fix flaky tests related to postgre db and k8s resource installation

### DIFF
--- a/pkg/test/store/postgres/test_container.go
+++ b/pkg/test/store/postgres/test_container.go
@@ -136,6 +136,8 @@ func (v *PostgresContainer) Config(dbOpts ...DbOption) (*pg_config.PostgresStore
 		return nil, err
 	}
 	var db *sql.DB
+
+	// make sure the server is reachable
 	Eventually(func() error {
 		var dbErr error
 		db, dbErr = postgres.ConnectToDb(*cfg)
@@ -151,6 +153,13 @@ func (v *PostgresContainer) Config(dbOpts ...DbOption) (*pg_config.PostgresStore
 				return nil, err
 			}
 			cfg.DbName = dbName
+
+			// make sure the database instance is reachable
+			Eventually(func() error {
+				var dbAccessErr error
+				_, dbAccessErr = postgres.ConnectToDb(*cfg)
+				return dbAccessErr
+			}, "10s", "100ms").Should(Succeed())
 		}
 	}
 	return cfg, nil

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -221,15 +221,20 @@ func WaitPodsAvailable(namespace, app string) InstallFunc {
 func WaitPodsAvailableWithLabel(namespace, labelKey, labelValue string) InstallFunc {
 	return func(c Cluster) error {
 		ck8s := c.(*K8sCluster)
-		pods, err := k8s.ListPodsE(c.GetTesting(), c.GetKubectlOptions(namespace),
+		testingT := c.GetTesting()
+		kubectlOptions := c.GetKubectlOptions(namespace)
+
+		pods, err := k8s.ListPodsE(testingT, kubectlOptions,
 			metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", labelKey, labelValue)})
 		if err != nil {
 			return err
 		}
+
+		var podError error
 		for _, p := range pods {
-			err := k8s.WaitUntilPodAvailableE(c.GetTesting(), c.GetKubectlOptions(namespace), p.GetName(), ck8s.defaultRetries, ck8s.defaultTimeout)
-			if err != nil {
-				return err
+			podError = k8s.WaitUntilPodAvailableE(testingT, kubectlOptions, p.GetName(), ck8s.defaultRetries, ck8s.defaultTimeout)
+			if podError != nil {
+				return printDetailedPodInfo(testingT, kubectlOptions, podError, p)
 			}
 		}
 		return nil


### PR DESCRIPTION
Try to fix flaky tests related to postgre db:
* Connect to the newly created database instance before test cases run

Trying to fix this flaky:
https://github.com/kumahq/kuma/actions/runs/7119978753/job/19386239557#step:6:3840

Print more useful information when timeout waiting for k8s Pod to be available:
* print Pod phase and conditions
* print Deployment and ReplicaSet conditions

Trying to help on this flaky:
https://github.com/kumahq/kuma/actions/runs/7116642948/job/19375940607#step:10:25037


### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - N/A
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - Confirmed
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - N/A
  - Don't forget `ci/` labels to run additional/fewer tests
    - Checked
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - No need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - No backport.

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
