### PR TITLE
chore(MeshRetry): improve policy openapi schema and validation

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -3076,14 +3076,15 @@ spec:
                           properties:
                             backOff:
                               description: BackOff is a configuration of durations
-                                which will be used in exponential backoff strategy
+                                which will be used in an exponential backoff strategy
                                 between retries.
                               properties:
                                 baseInterval:
+                                  default: 25ms
                                   description: BaseInterval is an amount of time which
                                     should be taken between retries. Must be greater
                                     than zero. Values less than 1 ms are rounded up
-                                    to 1 ms. Default is 25ms.
+                                    to 1 ms.
                                   type: string
                                 maxInterval:
                                   description: MaxInterval is a maximal amount of
@@ -3093,13 +3094,16 @@ spec:
                               type: object
                             numRetries:
                               description: NumRetries is the number of attempts that
-                                will be made on failed (and retriable) requests.
+                                will be made on failed (and retriable) requests. If
+                                not set, the default value is 1.
                               format: int32
                               type: integer
                             perTryTimeout:
-                              description: PerTryTimeout is the amount of time after
-                                which retry attempt should timeout. Setting this timeout
-                                to 0 will disable it. Default is 15s.
+                              description: PerTryTimeout is the maximum amount of
+                                time each retry attempt can take before it times out.
+                                If not set, the global request timeout for the route
+                                will be used. Setting this value to 0 will disable
+                                the per-try timeout.
                               type: string
                             rateLimitedBackOff:
                               description: RateLimitedBackOff is a configuration of
@@ -3107,9 +3111,9 @@ spec:
                                 one of the headers configured.
                               properties:
                                 maxInterval:
+                                  default: 300s
                                   description: MaxInterval is a maximal amount of
-                                    time which will be taken between retries. Default
-                                    is 300 seconds.
+                                    time which will be taken between retries.
                                   type: string
                                 resetHeaders:
                                   description: ResetHeaders specifies the list of
@@ -3122,8 +3126,7 @@ spec:
                                   items:
                                     properties:
                                       format:
-                                        description: The format of the reset header,
-                                          either Seconds or UnixTimestamp.
+                                        description: The format of the reset header.
                                         enum:
                                         - Seconds
                                         - UnixTimestamp
@@ -3141,10 +3144,21 @@ spec:
                                   type: array
                               type: object
                             retryOn:
-                              description: 'RetryOn is a list of conditions which
-                                will cause a retry. Available values are: [Canceled,
-                                DeadlineExceeded, Internal, ResourceExhausted, Unavailable].'
+                              description: RetryOn is a list of conditions which will
+                                cause a retry.
+                              example:
+                              - Canceled
+                              - DeadlineExceeded
+                              - Internal
+                              - ResourceExhausted
+                              - Unavailable
                               items:
+                                enum:
+                                - Canceled
+                                - DeadlineExceeded
+                                - Internal
+                                - ResourceExhausted
+                                - Unavailable
                                 type: string
                               type: array
                           type: object
@@ -3155,13 +3169,14 @@ spec:
                             backOff:
                               description: BackOff is a configuration of durations
                                 which will be used in exponential backoff strategy
-                                between retries
+                                between retries.
                               properties:
                                 baseInterval:
+                                  default: 25ms
                                   description: BaseInterval is an amount of time which
                                     should be taken between retries. Must be greater
                                     than zero. Values less than 1 ms are rounded up
-                                    to 1 ms. Default is 25ms.
+                                    to 1 ms.
                                   type: string
                                 maxInterval:
                                   description: MaxInterval is a maximal amount of
@@ -3177,8 +3192,10 @@ spec:
                                 properties:
                                   predicate:
                                     description: Type is requested predicate mode.
-                                      Available values are OmitPreviousHosts, OmitHostsWithTags,
-                                      and OmitPreviousPriorities.
+                                    enum:
+                                    - OmitPreviousHosts
+                                    - OmitHostsWithTags
+                                    - OmitPreviousPriorities
                                     type: string
                                   tags:
                                     additionalProperties:
@@ -3188,10 +3205,10 @@ spec:
                                       if Type is OmitHostsWithTags
                                     type: object
                                   updateFrequency:
+                                    default: 2
                                     description: UpdateFrequency is how often the
                                       priority load should be updated based on previously
                                       attempted priorities. Used for OmitPreviousPriorities.
-                                      Default is 2 if not set.
                                     format: int32
                                     type: integer
                                 required:
@@ -3208,13 +3225,18 @@ spec:
                               type: integer
                             numRetries:
                               description: NumRetries is the number of attempts that
-                                will be made on failed (and retriable) requests
+                                will be made on failed (and retriable) requests.  If
+                                not set, the default value is 1.
                               format: int32
                               type: integer
                             perTryTimeout:
                               description: PerTryTimeout is the amount of time after
-                                which retry attempt should timeout. Setting this timeout
-                                to 0 will disable it. Default is 15s.
+                                which retry attempt should time out. If left unspecified,
+                                the global route timeout for the request will be used.
+                                Consequently, when using a 5xx based retry policy,
+                                a request that times out will not be retried as the
+                                total timeout budget would have been exhausted. Setting
+                                this timeout to 0 will disable it.
                               type: string
                             rateLimitedBackOff:
                               description: RateLimitedBackOff is a configuration of
@@ -3222,9 +3244,9 @@ spec:
                                 one of the headers configured.
                               properties:
                                 maxInterval:
+                                  default: 300s
                                   description: MaxInterval is a maximal amount of
-                                    time which will be taken between retries. Default
-                                    is 300 seconds.
+                                    time which will be taken between retries.
                                   type: string
                                 resetHeaders:
                                   description: ResetHeaders specifies the list of
@@ -3237,8 +3259,7 @@ spec:
                                   items:
                                     properties:
                                       format:
-                                        description: The format of the reset header,
-                                          either Seconds or UnixTimestamp.
+                                        description: The format of the reset header.
                                         enum:
                                         - Seconds
                                         - UnixTimestamp
@@ -3295,7 +3316,7 @@ spec:
                               description: RetriableResponseHeaders is an HTTP response
                                 headers that trigger a retry if present in the response.
                                 A retry will be triggered if any of the header matches
-                                match the upstream response headers.
+                                the upstream response headers.
                               items:
                                 description: HeaderMatch describes how to select an
                                   HTTP route by matching HTTP request headers.
@@ -3335,7 +3356,27 @@ spec:
                                 RefusedStream, Http3PostConnectFailure, HttpMethodConnect,
                                 HttpMethodDelete, HttpMethodGet, HttpMethodHead, HttpMethodOptions,
                                 HttpMethodPatch, HttpMethodPost, HttpMethodPut, HttpMethodTrace].
-                                Also, any HTTP status code (500, 503, etc).'
+                                Also, any HTTP status code (500, 503, etc.).'
+                              example:
+                              - 5XX
+                              - GatewayError
+                              - Reset
+                              - Retriable4xx
+                              - ConnectFailure
+                              - EnvoyRatelimited
+                              - RefusedStream
+                              - Http3PostConnectFailure
+                              - HttpMethodConnect
+                              - HttpMethodDelete
+                              - HttpMethodGet
+                              - HttpMethodHead
+                              - HttpMethodOptions
+                              - HttpMethodPatch
+                              - HttpMethodPost
+                              - HttpMethodPut
+                              - HttpMethodTrace
+                              - "500"
+                              - "503"
                               items:
                                 type: string
                               type: array

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
@@ -3076,14 +3076,15 @@ spec:
                           properties:
                             backOff:
                               description: BackOff is a configuration of durations
-                                which will be used in exponential backoff strategy
+                                which will be used in an exponential backoff strategy
                                 between retries.
                               properties:
                                 baseInterval:
+                                  default: 25ms
                                   description: BaseInterval is an amount of time which
                                     should be taken between retries. Must be greater
                                     than zero. Values less than 1 ms are rounded up
-                                    to 1 ms. Default is 25ms.
+                                    to 1 ms.
                                   type: string
                                 maxInterval:
                                   description: MaxInterval is a maximal amount of
@@ -3093,13 +3094,16 @@ spec:
                               type: object
                             numRetries:
                               description: NumRetries is the number of attempts that
-                                will be made on failed (and retriable) requests.
+                                will be made on failed (and retriable) requests. If
+                                not set, the default value is 1.
                               format: int32
                               type: integer
                             perTryTimeout:
-                              description: PerTryTimeout is the amount of time after
-                                which retry attempt should timeout. Setting this timeout
-                                to 0 will disable it. Default is 15s.
+                              description: PerTryTimeout is the maximum amount of
+                                time each retry attempt can take before it times out.
+                                If not set, the global request timeout for the route
+                                will be used. Setting this value to 0 will disable
+                                the per-try timeout.
                               type: string
                             rateLimitedBackOff:
                               description: RateLimitedBackOff is a configuration of
@@ -3107,9 +3111,9 @@ spec:
                                 one of the headers configured.
                               properties:
                                 maxInterval:
+                                  default: 300s
                                   description: MaxInterval is a maximal amount of
-                                    time which will be taken between retries. Default
-                                    is 300 seconds.
+                                    time which will be taken between retries.
                                   type: string
                                 resetHeaders:
                                   description: ResetHeaders specifies the list of
@@ -3122,8 +3126,7 @@ spec:
                                   items:
                                     properties:
                                       format:
-                                        description: The format of the reset header,
-                                          either Seconds or UnixTimestamp.
+                                        description: The format of the reset header.
                                         enum:
                                         - Seconds
                                         - UnixTimestamp
@@ -3141,10 +3144,21 @@ spec:
                                   type: array
                               type: object
                             retryOn:
-                              description: 'RetryOn is a list of conditions which
-                                will cause a retry. Available values are: [Canceled,
-                                DeadlineExceeded, Internal, ResourceExhausted, Unavailable].'
+                              description: RetryOn is a list of conditions which will
+                                cause a retry.
+                              example:
+                              - Canceled
+                              - DeadlineExceeded
+                              - Internal
+                              - ResourceExhausted
+                              - Unavailable
                               items:
+                                enum:
+                                - Canceled
+                                - DeadlineExceeded
+                                - Internal
+                                - ResourceExhausted
+                                - Unavailable
                                 type: string
                               type: array
                           type: object
@@ -3155,13 +3169,14 @@ spec:
                             backOff:
                               description: BackOff is a configuration of durations
                                 which will be used in exponential backoff strategy
-                                between retries
+                                between retries.
                               properties:
                                 baseInterval:
+                                  default: 25ms
                                   description: BaseInterval is an amount of time which
                                     should be taken between retries. Must be greater
                                     than zero. Values less than 1 ms are rounded up
-                                    to 1 ms. Default is 25ms.
+                                    to 1 ms.
                                   type: string
                                 maxInterval:
                                   description: MaxInterval is a maximal amount of
@@ -3177,8 +3192,10 @@ spec:
                                 properties:
                                   predicate:
                                     description: Type is requested predicate mode.
-                                      Available values are OmitPreviousHosts, OmitHostsWithTags,
-                                      and OmitPreviousPriorities.
+                                    enum:
+                                    - OmitPreviousHosts
+                                    - OmitHostsWithTags
+                                    - OmitPreviousPriorities
                                     type: string
                                   tags:
                                     additionalProperties:
@@ -3188,10 +3205,10 @@ spec:
                                       if Type is OmitHostsWithTags
                                     type: object
                                   updateFrequency:
+                                    default: 2
                                     description: UpdateFrequency is how often the
                                       priority load should be updated based on previously
                                       attempted priorities. Used for OmitPreviousPriorities.
-                                      Default is 2 if not set.
                                     format: int32
                                     type: integer
                                 required:
@@ -3208,13 +3225,18 @@ spec:
                               type: integer
                             numRetries:
                               description: NumRetries is the number of attempts that
-                                will be made on failed (and retriable) requests
+                                will be made on failed (and retriable) requests.  If
+                                not set, the default value is 1.
                               format: int32
                               type: integer
                             perTryTimeout:
                               description: PerTryTimeout is the amount of time after
-                                which retry attempt should timeout. Setting this timeout
-                                to 0 will disable it. Default is 15s.
+                                which retry attempt should time out. If left unspecified,
+                                the global route timeout for the request will be used.
+                                Consequently, when using a 5xx based retry policy,
+                                a request that times out will not be retried as the
+                                total timeout budget would have been exhausted. Setting
+                                this timeout to 0 will disable it.
                               type: string
                             rateLimitedBackOff:
                               description: RateLimitedBackOff is a configuration of
@@ -3222,9 +3244,9 @@ spec:
                                 one of the headers configured.
                               properties:
                                 maxInterval:
+                                  default: 300s
                                   description: MaxInterval is a maximal amount of
-                                    time which will be taken between retries. Default
-                                    is 300 seconds.
+                                    time which will be taken between retries.
                                   type: string
                                 resetHeaders:
                                   description: ResetHeaders specifies the list of
@@ -3237,8 +3259,7 @@ spec:
                                   items:
                                     properties:
                                       format:
-                                        description: The format of the reset header,
-                                          either Seconds or UnixTimestamp.
+                                        description: The format of the reset header.
                                         enum:
                                         - Seconds
                                         - UnixTimestamp
@@ -3295,7 +3316,7 @@ spec:
                               description: RetriableResponseHeaders is an HTTP response
                                 headers that trigger a retry if present in the response.
                                 A retry will be triggered if any of the header matches
-                                match the upstream response headers.
+                                the upstream response headers.
                               items:
                                 description: HeaderMatch describes how to select an
                                   HTTP route by matching HTTP request headers.
@@ -3335,7 +3356,27 @@ spec:
                                 RefusedStream, Http3PostConnectFailure, HttpMethodConnect,
                                 HttpMethodDelete, HttpMethodGet, HttpMethodHead, HttpMethodOptions,
                                 HttpMethodPatch, HttpMethodPost, HttpMethodPut, HttpMethodTrace].
-                                Also, any HTTP status code (500, 503, etc).'
+                                Also, any HTTP status code (500, 503, etc.).'
+                              example:
+                              - 5XX
+                              - GatewayError
+                              - Reset
+                              - Retriable4xx
+                              - ConnectFailure
+                              - EnvoyRatelimited
+                              - RefusedStream
+                              - Http3PostConnectFailure
+                              - HttpMethodConnect
+                              - HttpMethodDelete
+                              - HttpMethodGet
+                              - HttpMethodHead
+                              - HttpMethodOptions
+                              - HttpMethodPatch
+                              - HttpMethodPost
+                              - HttpMethodPut
+                              - HttpMethodTrace
+                              - "500"
+                              - "503"
                               items:
                                 type: string
                               type: array

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -3280,14 +3280,15 @@ spec:
                           properties:
                             backOff:
                               description: BackOff is a configuration of durations
-                                which will be used in exponential backoff strategy
+                                which will be used in an exponential backoff strategy
                                 between retries.
                               properties:
                                 baseInterval:
+                                  default: 25ms
                                   description: BaseInterval is an amount of time which
                                     should be taken between retries. Must be greater
                                     than zero. Values less than 1 ms are rounded up
-                                    to 1 ms. Default is 25ms.
+                                    to 1 ms.
                                   type: string
                                 maxInterval:
                                   description: MaxInterval is a maximal amount of
@@ -3297,13 +3298,16 @@ spec:
                               type: object
                             numRetries:
                               description: NumRetries is the number of attempts that
-                                will be made on failed (and retriable) requests.
+                                will be made on failed (and retriable) requests. If
+                                not set, the default value is 1.
                               format: int32
                               type: integer
                             perTryTimeout:
-                              description: PerTryTimeout is the amount of time after
-                                which retry attempt should timeout. Setting this timeout
-                                to 0 will disable it. Default is 15s.
+                              description: PerTryTimeout is the maximum amount of
+                                time each retry attempt can take before it times out.
+                                If not set, the global request timeout for the route
+                                will be used. Setting this value to 0 will disable
+                                the per-try timeout.
                               type: string
                             rateLimitedBackOff:
                               description: RateLimitedBackOff is a configuration of
@@ -3311,9 +3315,9 @@ spec:
                                 one of the headers configured.
                               properties:
                                 maxInterval:
+                                  default: 300s
                                   description: MaxInterval is a maximal amount of
-                                    time which will be taken between retries. Default
-                                    is 300 seconds.
+                                    time which will be taken between retries.
                                   type: string
                                 resetHeaders:
                                   description: ResetHeaders specifies the list of
@@ -3326,8 +3330,7 @@ spec:
                                   items:
                                     properties:
                                       format:
-                                        description: The format of the reset header,
-                                          either Seconds or UnixTimestamp.
+                                        description: The format of the reset header.
                                         enum:
                                         - Seconds
                                         - UnixTimestamp
@@ -3345,10 +3348,21 @@ spec:
                                   type: array
                               type: object
                             retryOn:
-                              description: 'RetryOn is a list of conditions which
-                                will cause a retry. Available values are: [Canceled,
-                                DeadlineExceeded, Internal, ResourceExhausted, Unavailable].'
+                              description: RetryOn is a list of conditions which will
+                                cause a retry.
+                              example:
+                              - Canceled
+                              - DeadlineExceeded
+                              - Internal
+                              - ResourceExhausted
+                              - Unavailable
                               items:
+                                enum:
+                                - Canceled
+                                - DeadlineExceeded
+                                - Internal
+                                - ResourceExhausted
+                                - Unavailable
                                 type: string
                               type: array
                           type: object
@@ -3359,13 +3373,14 @@ spec:
                             backOff:
                               description: BackOff is a configuration of durations
                                 which will be used in exponential backoff strategy
-                                between retries
+                                between retries.
                               properties:
                                 baseInterval:
+                                  default: 25ms
                                   description: BaseInterval is an amount of time which
                                     should be taken between retries. Must be greater
                                     than zero. Values less than 1 ms are rounded up
-                                    to 1 ms. Default is 25ms.
+                                    to 1 ms.
                                   type: string
                                 maxInterval:
                                   description: MaxInterval is a maximal amount of
@@ -3381,8 +3396,10 @@ spec:
                                 properties:
                                   predicate:
                                     description: Type is requested predicate mode.
-                                      Available values are OmitPreviousHosts, OmitHostsWithTags,
-                                      and OmitPreviousPriorities.
+                                    enum:
+                                    - OmitPreviousHosts
+                                    - OmitHostsWithTags
+                                    - OmitPreviousPriorities
                                     type: string
                                   tags:
                                     additionalProperties:
@@ -3392,10 +3409,10 @@ spec:
                                       if Type is OmitHostsWithTags
                                     type: object
                                   updateFrequency:
+                                    default: 2
                                     description: UpdateFrequency is how often the
                                       priority load should be updated based on previously
                                       attempted priorities. Used for OmitPreviousPriorities.
-                                      Default is 2 if not set.
                                     format: int32
                                     type: integer
                                 required:
@@ -3412,13 +3429,18 @@ spec:
                               type: integer
                             numRetries:
                               description: NumRetries is the number of attempts that
-                                will be made on failed (and retriable) requests
+                                will be made on failed (and retriable) requests.  If
+                                not set, the default value is 1.
                               format: int32
                               type: integer
                             perTryTimeout:
                               description: PerTryTimeout is the amount of time after
-                                which retry attempt should timeout. Setting this timeout
-                                to 0 will disable it. Default is 15s.
+                                which retry attempt should time out. If left unspecified,
+                                the global route timeout for the request will be used.
+                                Consequently, when using a 5xx based retry policy,
+                                a request that times out will not be retried as the
+                                total timeout budget would have been exhausted. Setting
+                                this timeout to 0 will disable it.
                               type: string
                             rateLimitedBackOff:
                               description: RateLimitedBackOff is a configuration of
@@ -3426,9 +3448,9 @@ spec:
                                 one of the headers configured.
                               properties:
                                 maxInterval:
+                                  default: 300s
                                   description: MaxInterval is a maximal amount of
-                                    time which will be taken between retries. Default
-                                    is 300 seconds.
+                                    time which will be taken between retries.
                                   type: string
                                 resetHeaders:
                                   description: ResetHeaders specifies the list of
@@ -3441,8 +3463,7 @@ spec:
                                   items:
                                     properties:
                                       format:
-                                        description: The format of the reset header,
-                                          either Seconds or UnixTimestamp.
+                                        description: The format of the reset header.
                                         enum:
                                         - Seconds
                                         - UnixTimestamp
@@ -3499,7 +3520,7 @@ spec:
                               description: RetriableResponseHeaders is an HTTP response
                                 headers that trigger a retry if present in the response.
                                 A retry will be triggered if any of the header matches
-                                match the upstream response headers.
+                                the upstream response headers.
                               items:
                                 description: HeaderMatch describes how to select an
                                   HTTP route by matching HTTP request headers.
@@ -3539,7 +3560,27 @@ spec:
                                 RefusedStream, Http3PostConnectFailure, HttpMethodConnect,
                                 HttpMethodDelete, HttpMethodGet, HttpMethodHead, HttpMethodOptions,
                                 HttpMethodPatch, HttpMethodPost, HttpMethodPut, HttpMethodTrace].
-                                Also, any HTTP status code (500, 503, etc).'
+                                Also, any HTTP status code (500, 503, etc.).'
+                              example:
+                              - 5XX
+                              - GatewayError
+                              - Reset
+                              - Retriable4xx
+                              - ConnectFailure
+                              - EnvoyRatelimited
+                              - RefusedStream
+                              - Http3PostConnectFailure
+                              - HttpMethodConnect
+                              - HttpMethodDelete
+                              - HttpMethodGet
+                              - HttpMethodHead
+                              - HttpMethodOptions
+                              - HttpMethodPatch
+                              - HttpMethodPost
+                              - HttpMethodPut
+                              - HttpMethodTrace
+                              - "500"
+                              - "503"
                               items:
                                 type: string
                               type: array

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -3096,14 +3096,15 @@ spec:
                           properties:
                             backOff:
                               description: BackOff is a configuration of durations
-                                which will be used in exponential backoff strategy
+                                which will be used in an exponential backoff strategy
                                 between retries.
                               properties:
                                 baseInterval:
+                                  default: 25ms
                                   description: BaseInterval is an amount of time which
                                     should be taken between retries. Must be greater
                                     than zero. Values less than 1 ms are rounded up
-                                    to 1 ms. Default is 25ms.
+                                    to 1 ms.
                                   type: string
                                 maxInterval:
                                   description: MaxInterval is a maximal amount of
@@ -3113,13 +3114,16 @@ spec:
                               type: object
                             numRetries:
                               description: NumRetries is the number of attempts that
-                                will be made on failed (and retriable) requests.
+                                will be made on failed (and retriable) requests. If
+                                not set, the default value is 1.
                               format: int32
                               type: integer
                             perTryTimeout:
-                              description: PerTryTimeout is the amount of time after
-                                which retry attempt should timeout. Setting this timeout
-                                to 0 will disable it. Default is 15s.
+                              description: PerTryTimeout is the maximum amount of
+                                time each retry attempt can take before it times out.
+                                If not set, the global request timeout for the route
+                                will be used. Setting this value to 0 will disable
+                                the per-try timeout.
                               type: string
                             rateLimitedBackOff:
                               description: RateLimitedBackOff is a configuration of
@@ -3127,9 +3131,9 @@ spec:
                                 one of the headers configured.
                               properties:
                                 maxInterval:
+                                  default: 300s
                                   description: MaxInterval is a maximal amount of
-                                    time which will be taken between retries. Default
-                                    is 300 seconds.
+                                    time which will be taken between retries.
                                   type: string
                                 resetHeaders:
                                   description: ResetHeaders specifies the list of
@@ -3142,8 +3146,7 @@ spec:
                                   items:
                                     properties:
                                       format:
-                                        description: The format of the reset header,
-                                          either Seconds or UnixTimestamp.
+                                        description: The format of the reset header.
                                         enum:
                                         - Seconds
                                         - UnixTimestamp
@@ -3161,10 +3164,21 @@ spec:
                                   type: array
                               type: object
                             retryOn:
-                              description: 'RetryOn is a list of conditions which
-                                will cause a retry. Available values are: [Canceled,
-                                DeadlineExceeded, Internal, ResourceExhausted, Unavailable].'
+                              description: RetryOn is a list of conditions which will
+                                cause a retry.
+                              example:
+                              - Canceled
+                              - DeadlineExceeded
+                              - Internal
+                              - ResourceExhausted
+                              - Unavailable
                               items:
+                                enum:
+                                - Canceled
+                                - DeadlineExceeded
+                                - Internal
+                                - ResourceExhausted
+                                - Unavailable
                                 type: string
                               type: array
                           type: object
@@ -3175,13 +3189,14 @@ spec:
                             backOff:
                               description: BackOff is a configuration of durations
                                 which will be used in exponential backoff strategy
-                                between retries
+                                between retries.
                               properties:
                                 baseInterval:
+                                  default: 25ms
                                   description: BaseInterval is an amount of time which
                                     should be taken between retries. Must be greater
                                     than zero. Values less than 1 ms are rounded up
-                                    to 1 ms. Default is 25ms.
+                                    to 1 ms.
                                   type: string
                                 maxInterval:
                                   description: MaxInterval is a maximal amount of
@@ -3197,8 +3212,10 @@ spec:
                                 properties:
                                   predicate:
                                     description: Type is requested predicate mode.
-                                      Available values are OmitPreviousHosts, OmitHostsWithTags,
-                                      and OmitPreviousPriorities.
+                                    enum:
+                                    - OmitPreviousHosts
+                                    - OmitHostsWithTags
+                                    - OmitPreviousPriorities
                                     type: string
                                   tags:
                                     additionalProperties:
@@ -3208,10 +3225,10 @@ spec:
                                       if Type is OmitHostsWithTags
                                     type: object
                                   updateFrequency:
+                                    default: 2
                                     description: UpdateFrequency is how often the
                                       priority load should be updated based on previously
                                       attempted priorities. Used for OmitPreviousPriorities.
-                                      Default is 2 if not set.
                                     format: int32
                                     type: integer
                                 required:
@@ -3228,13 +3245,18 @@ spec:
                               type: integer
                             numRetries:
                               description: NumRetries is the number of attempts that
-                                will be made on failed (and retriable) requests
+                                will be made on failed (and retriable) requests.  If
+                                not set, the default value is 1.
                               format: int32
                               type: integer
                             perTryTimeout:
                               description: PerTryTimeout is the amount of time after
-                                which retry attempt should timeout. Setting this timeout
-                                to 0 will disable it. Default is 15s.
+                                which retry attempt should time out. If left unspecified,
+                                the global route timeout for the request will be used.
+                                Consequently, when using a 5xx based retry policy,
+                                a request that times out will not be retried as the
+                                total timeout budget would have been exhausted. Setting
+                                this timeout to 0 will disable it.
                               type: string
                             rateLimitedBackOff:
                               description: RateLimitedBackOff is a configuration of
@@ -3242,9 +3264,9 @@ spec:
                                 one of the headers configured.
                               properties:
                                 maxInterval:
+                                  default: 300s
                                   description: MaxInterval is a maximal amount of
-                                    time which will be taken between retries. Default
-                                    is 300 seconds.
+                                    time which will be taken between retries.
                                   type: string
                                 resetHeaders:
                                   description: ResetHeaders specifies the list of
@@ -3257,8 +3279,7 @@ spec:
                                   items:
                                     properties:
                                       format:
-                                        description: The format of the reset header,
-                                          either Seconds or UnixTimestamp.
+                                        description: The format of the reset header.
                                         enum:
                                         - Seconds
                                         - UnixTimestamp
@@ -3315,7 +3336,7 @@ spec:
                               description: RetriableResponseHeaders is an HTTP response
                                 headers that trigger a retry if present in the response.
                                 A retry will be triggered if any of the header matches
-                                match the upstream response headers.
+                                the upstream response headers.
                               items:
                                 description: HeaderMatch describes how to select an
                                   HTTP route by matching HTTP request headers.
@@ -3355,7 +3376,27 @@ spec:
                                 RefusedStream, Http3PostConnectFailure, HttpMethodConnect,
                                 HttpMethodDelete, HttpMethodGet, HttpMethodHead, HttpMethodOptions,
                                 HttpMethodPatch, HttpMethodPost, HttpMethodPut, HttpMethodTrace].
-                                Also, any HTTP status code (500, 503, etc).'
+                                Also, any HTTP status code (500, 503, etc.).'
+                              example:
+                              - 5XX
+                              - GatewayError
+                              - Reset
+                              - Retriable4xx
+                              - ConnectFailure
+                              - EnvoyRatelimited
+                              - RefusedStream
+                              - Http3PostConnectFailure
+                              - HttpMethodConnect
+                              - HttpMethodDelete
+                              - HttpMethodGet
+                              - HttpMethodHead
+                              - HttpMethodOptions
+                              - HttpMethodPatch
+                              - HttpMethodPost
+                              - HttpMethodPut
+                              - HttpMethodTrace
+                              - "500"
+                              - "503"
                               items:
                                 type: string
                               type: array

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -4391,14 +4391,15 @@ spec:
                           properties:
                             backOff:
                               description: BackOff is a configuration of durations
-                                which will be used in exponential backoff strategy
+                                which will be used in an exponential backoff strategy
                                 between retries.
                               properties:
                                 baseInterval:
+                                  default: 25ms
                                   description: BaseInterval is an amount of time which
                                     should be taken between retries. Must be greater
                                     than zero. Values less than 1 ms are rounded up
-                                    to 1 ms. Default is 25ms.
+                                    to 1 ms.
                                   type: string
                                 maxInterval:
                                   description: MaxInterval is a maximal amount of
@@ -4408,13 +4409,16 @@ spec:
                               type: object
                             numRetries:
                               description: NumRetries is the number of attempts that
-                                will be made on failed (and retriable) requests.
+                                will be made on failed (and retriable) requests. If
+                                not set, the default value is 1.
                               format: int32
                               type: integer
                             perTryTimeout:
-                              description: PerTryTimeout is the amount of time after
-                                which retry attempt should timeout. Setting this timeout
-                                to 0 will disable it. Default is 15s.
+                              description: PerTryTimeout is the maximum amount of
+                                time each retry attempt can take before it times out.
+                                If not set, the global request timeout for the route
+                                will be used. Setting this value to 0 will disable
+                                the per-try timeout.
                               type: string
                             rateLimitedBackOff:
                               description: RateLimitedBackOff is a configuration of
@@ -4422,9 +4426,9 @@ spec:
                                 one of the headers configured.
                               properties:
                                 maxInterval:
+                                  default: 300s
                                   description: MaxInterval is a maximal amount of
-                                    time which will be taken between retries. Default
-                                    is 300 seconds.
+                                    time which will be taken between retries.
                                   type: string
                                 resetHeaders:
                                   description: ResetHeaders specifies the list of
@@ -4437,8 +4441,7 @@ spec:
                                   items:
                                     properties:
                                       format:
-                                        description: The format of the reset header,
-                                          either Seconds or UnixTimestamp.
+                                        description: The format of the reset header.
                                         enum:
                                         - Seconds
                                         - UnixTimestamp
@@ -4456,10 +4459,21 @@ spec:
                                   type: array
                               type: object
                             retryOn:
-                              description: 'RetryOn is a list of conditions which
-                                will cause a retry. Available values are: [Canceled,
-                                DeadlineExceeded, Internal, ResourceExhausted, Unavailable].'
+                              description: RetryOn is a list of conditions which will
+                                cause a retry.
+                              example:
+                              - Canceled
+                              - DeadlineExceeded
+                              - Internal
+                              - ResourceExhausted
+                              - Unavailable
                               items:
+                                enum:
+                                - Canceled
+                                - DeadlineExceeded
+                                - Internal
+                                - ResourceExhausted
+                                - Unavailable
                                 type: string
                               type: array
                           type: object
@@ -4470,13 +4484,14 @@ spec:
                             backOff:
                               description: BackOff is a configuration of durations
                                 which will be used in exponential backoff strategy
-                                between retries
+                                between retries.
                               properties:
                                 baseInterval:
+                                  default: 25ms
                                   description: BaseInterval is an amount of time which
                                     should be taken between retries. Must be greater
                                     than zero. Values less than 1 ms are rounded up
-                                    to 1 ms. Default is 25ms.
+                                    to 1 ms.
                                   type: string
                                 maxInterval:
                                   description: MaxInterval is a maximal amount of
@@ -4492,8 +4507,10 @@ spec:
                                 properties:
                                   predicate:
                                     description: Type is requested predicate mode.
-                                      Available values are OmitPreviousHosts, OmitHostsWithTags,
-                                      and OmitPreviousPriorities.
+                                    enum:
+                                    - OmitPreviousHosts
+                                    - OmitHostsWithTags
+                                    - OmitPreviousPriorities
                                     type: string
                                   tags:
                                     additionalProperties:
@@ -4503,10 +4520,10 @@ spec:
                                       if Type is OmitHostsWithTags
                                     type: object
                                   updateFrequency:
+                                    default: 2
                                     description: UpdateFrequency is how often the
                                       priority load should be updated based on previously
                                       attempted priorities. Used for OmitPreviousPriorities.
-                                      Default is 2 if not set.
                                     format: int32
                                     type: integer
                                 required:
@@ -4523,13 +4540,18 @@ spec:
                               type: integer
                             numRetries:
                               description: NumRetries is the number of attempts that
-                                will be made on failed (and retriable) requests
+                                will be made on failed (and retriable) requests.  If
+                                not set, the default value is 1.
                               format: int32
                               type: integer
                             perTryTimeout:
                               description: PerTryTimeout is the amount of time after
-                                which retry attempt should timeout. Setting this timeout
-                                to 0 will disable it. Default is 15s.
+                                which retry attempt should time out. If left unspecified,
+                                the global route timeout for the request will be used.
+                                Consequently, when using a 5xx based retry policy,
+                                a request that times out will not be retried as the
+                                total timeout budget would have been exhausted. Setting
+                                this timeout to 0 will disable it.
                               type: string
                             rateLimitedBackOff:
                               description: RateLimitedBackOff is a configuration of
@@ -4537,9 +4559,9 @@ spec:
                                 one of the headers configured.
                               properties:
                                 maxInterval:
+                                  default: 300s
                                   description: MaxInterval is a maximal amount of
-                                    time which will be taken between retries. Default
-                                    is 300 seconds.
+                                    time which will be taken between retries.
                                   type: string
                                 resetHeaders:
                                   description: ResetHeaders specifies the list of
@@ -4552,8 +4574,7 @@ spec:
                                   items:
                                     properties:
                                       format:
-                                        description: The format of the reset header,
-                                          either Seconds or UnixTimestamp.
+                                        description: The format of the reset header.
                                         enum:
                                         - Seconds
                                         - UnixTimestamp
@@ -4610,7 +4631,7 @@ spec:
                               description: RetriableResponseHeaders is an HTTP response
                                 headers that trigger a retry if present in the response.
                                 A retry will be triggered if any of the header matches
-                                match the upstream response headers.
+                                the upstream response headers.
                               items:
                                 description: HeaderMatch describes how to select an
                                   HTTP route by matching HTTP request headers.
@@ -4650,7 +4671,27 @@ spec:
                                 RefusedStream, Http3PostConnectFailure, HttpMethodConnect,
                                 HttpMethodDelete, HttpMethodGet, HttpMethodHead, HttpMethodOptions,
                                 HttpMethodPatch, HttpMethodPost, HttpMethodPut, HttpMethodTrace].
-                                Also, any HTTP status code (500, 503, etc).'
+                                Also, any HTTP status code (500, 503, etc.).'
+                              example:
+                              - 5XX
+                              - GatewayError
+                              - Reset
+                              - Retriable4xx
+                              - ConnectFailure
+                              - EnvoyRatelimited
+                              - RefusedStream
+                              - Http3PostConnectFailure
+                              - HttpMethodConnect
+                              - HttpMethodDelete
+                              - HttpMethodGet
+                              - HttpMethodHead
+                              - HttpMethodOptions
+                              - HttpMethodPatch
+                              - HttpMethodPost
+                              - HttpMethodPut
+                              - HttpMethodTrace
+                              - "500"
+                              - "503"
                               items:
                                 type: string
                               type: array

--- a/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
@@ -4595,14 +4595,15 @@ spec:
                           properties:
                             backOff:
                               description: BackOff is a configuration of durations
-                                which will be used in exponential backoff strategy
+                                which will be used in an exponential backoff strategy
                                 between retries.
                               properties:
                                 baseInterval:
+                                  default: 25ms
                                   description: BaseInterval is an amount of time which
                                     should be taken between retries. Must be greater
                                     than zero. Values less than 1 ms are rounded up
-                                    to 1 ms. Default is 25ms.
+                                    to 1 ms.
                                   type: string
                                 maxInterval:
                                   description: MaxInterval is a maximal amount of
@@ -4612,13 +4613,16 @@ spec:
                               type: object
                             numRetries:
                               description: NumRetries is the number of attempts that
-                                will be made on failed (and retriable) requests.
+                                will be made on failed (and retriable) requests. If
+                                not set, the default value is 1.
                               format: int32
                               type: integer
                             perTryTimeout:
-                              description: PerTryTimeout is the amount of time after
-                                which retry attempt should timeout. Setting this timeout
-                                to 0 will disable it. Default is 15s.
+                              description: PerTryTimeout is the maximum amount of
+                                time each retry attempt can take before it times out.
+                                If not set, the global request timeout for the route
+                                will be used. Setting this value to 0 will disable
+                                the per-try timeout.
                               type: string
                             rateLimitedBackOff:
                               description: RateLimitedBackOff is a configuration of
@@ -4626,9 +4630,9 @@ spec:
                                 one of the headers configured.
                               properties:
                                 maxInterval:
+                                  default: 300s
                                   description: MaxInterval is a maximal amount of
-                                    time which will be taken between retries. Default
-                                    is 300 seconds.
+                                    time which will be taken between retries.
                                   type: string
                                 resetHeaders:
                                   description: ResetHeaders specifies the list of
@@ -4641,8 +4645,7 @@ spec:
                                   items:
                                     properties:
                                       format:
-                                        description: The format of the reset header,
-                                          either Seconds or UnixTimestamp.
+                                        description: The format of the reset header.
                                         enum:
                                         - Seconds
                                         - UnixTimestamp
@@ -4660,10 +4663,21 @@ spec:
                                   type: array
                               type: object
                             retryOn:
-                              description: 'RetryOn is a list of conditions which
-                                will cause a retry. Available values are: [Canceled,
-                                DeadlineExceeded, Internal, ResourceExhausted, Unavailable].'
+                              description: RetryOn is a list of conditions which will
+                                cause a retry.
+                              example:
+                              - Canceled
+                              - DeadlineExceeded
+                              - Internal
+                              - ResourceExhausted
+                              - Unavailable
                               items:
+                                enum:
+                                - Canceled
+                                - DeadlineExceeded
+                                - Internal
+                                - ResourceExhausted
+                                - Unavailable
                                 type: string
                               type: array
                           type: object
@@ -4674,13 +4688,14 @@ spec:
                             backOff:
                               description: BackOff is a configuration of durations
                                 which will be used in exponential backoff strategy
-                                between retries
+                                between retries.
                               properties:
                                 baseInterval:
+                                  default: 25ms
                                   description: BaseInterval is an amount of time which
                                     should be taken between retries. Must be greater
                                     than zero. Values less than 1 ms are rounded up
-                                    to 1 ms. Default is 25ms.
+                                    to 1 ms.
                                   type: string
                                 maxInterval:
                                   description: MaxInterval is a maximal amount of
@@ -4696,8 +4711,10 @@ spec:
                                 properties:
                                   predicate:
                                     description: Type is requested predicate mode.
-                                      Available values are OmitPreviousHosts, OmitHostsWithTags,
-                                      and OmitPreviousPriorities.
+                                    enum:
+                                    - OmitPreviousHosts
+                                    - OmitHostsWithTags
+                                    - OmitPreviousPriorities
                                     type: string
                                   tags:
                                     additionalProperties:
@@ -4707,10 +4724,10 @@ spec:
                                       if Type is OmitHostsWithTags
                                     type: object
                                   updateFrequency:
+                                    default: 2
                                     description: UpdateFrequency is how often the
                                       priority load should be updated based on previously
                                       attempted priorities. Used for OmitPreviousPriorities.
-                                      Default is 2 if not set.
                                     format: int32
                                     type: integer
                                 required:
@@ -4727,13 +4744,18 @@ spec:
                               type: integer
                             numRetries:
                               description: NumRetries is the number of attempts that
-                                will be made on failed (and retriable) requests
+                                will be made on failed (and retriable) requests.  If
+                                not set, the default value is 1.
                               format: int32
                               type: integer
                             perTryTimeout:
                               description: PerTryTimeout is the amount of time after
-                                which retry attempt should timeout. Setting this timeout
-                                to 0 will disable it. Default is 15s.
+                                which retry attempt should time out. If left unspecified,
+                                the global route timeout for the request will be used.
+                                Consequently, when using a 5xx based retry policy,
+                                a request that times out will not be retried as the
+                                total timeout budget would have been exhausted. Setting
+                                this timeout to 0 will disable it.
                               type: string
                             rateLimitedBackOff:
                               description: RateLimitedBackOff is a configuration of
@@ -4741,9 +4763,9 @@ spec:
                                 one of the headers configured.
                               properties:
                                 maxInterval:
+                                  default: 300s
                                   description: MaxInterval is a maximal amount of
-                                    time which will be taken between retries. Default
-                                    is 300 seconds.
+                                    time which will be taken between retries.
                                   type: string
                                 resetHeaders:
                                   description: ResetHeaders specifies the list of
@@ -4756,8 +4778,7 @@ spec:
                                   items:
                                     properties:
                                       format:
-                                        description: The format of the reset header,
-                                          either Seconds or UnixTimestamp.
+                                        description: The format of the reset header.
                                         enum:
                                         - Seconds
                                         - UnixTimestamp
@@ -4814,7 +4835,7 @@ spec:
                               description: RetriableResponseHeaders is an HTTP response
                                 headers that trigger a retry if present in the response.
                                 A retry will be triggered if any of the header matches
-                                match the upstream response headers.
+                                the upstream response headers.
                               items:
                                 description: HeaderMatch describes how to select an
                                   HTTP route by matching HTTP request headers.
@@ -4854,7 +4875,27 @@ spec:
                                 RefusedStream, Http3PostConnectFailure, HttpMethodConnect,
                                 HttpMethodDelete, HttpMethodGet, HttpMethodHead, HttpMethodOptions,
                                 HttpMethodPatch, HttpMethodPost, HttpMethodPut, HttpMethodTrace].
-                                Also, any HTTP status code (500, 503, etc).'
+                                Also, any HTTP status code (500, 503, etc.).'
+                              example:
+                              - 5XX
+                              - GatewayError
+                              - Reset
+                              - Retriable4xx
+                              - ConnectFailure
+                              - EnvoyRatelimited
+                              - RefusedStream
+                              - Http3PostConnectFailure
+                              - HttpMethodConnect
+                              - HttpMethodDelete
+                              - HttpMethodGet
+                              - HttpMethodHead
+                              - HttpMethodOptions
+                              - HttpMethodPatch
+                              - HttpMethodPost
+                              - HttpMethodPut
+                              - HttpMethodTrace
+                              - "500"
+                              - "503"
                               items:
                                 type: string
                               type: array

--- a/deployments/charts/kuma/crds/kuma.io_meshretries.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshretries.yaml
@@ -87,14 +87,15 @@ spec:
                           properties:
                             backOff:
                               description: BackOff is a configuration of durations
-                                which will be used in exponential backoff strategy
+                                which will be used in an exponential backoff strategy
                                 between retries.
                               properties:
                                 baseInterval:
+                                  default: 25ms
                                   description: BaseInterval is an amount of time which
                                     should be taken between retries. Must be greater
                                     than zero. Values less than 1 ms are rounded up
-                                    to 1 ms. Default is 25ms.
+                                    to 1 ms.
                                   type: string
                                 maxInterval:
                                   description: MaxInterval is a maximal amount of
@@ -104,13 +105,16 @@ spec:
                               type: object
                             numRetries:
                               description: NumRetries is the number of attempts that
-                                will be made on failed (and retriable) requests.
+                                will be made on failed (and retriable) requests. If
+                                not set, the default value is 1.
                               format: int32
                               type: integer
                             perTryTimeout:
-                              description: PerTryTimeout is the amount of time after
-                                which retry attempt should timeout. Setting this timeout
-                                to 0 will disable it. Default is 15s.
+                              description: PerTryTimeout is the maximum amount of
+                                time each retry attempt can take before it times out.
+                                If not set, the global request timeout for the route
+                                will be used. Setting this value to 0 will disable
+                                the per-try timeout.
                               type: string
                             rateLimitedBackOff:
                               description: RateLimitedBackOff is a configuration of
@@ -118,9 +122,9 @@ spec:
                                 one of the headers configured.
                               properties:
                                 maxInterval:
+                                  default: 300s
                                   description: MaxInterval is a maximal amount of
-                                    time which will be taken between retries. Default
-                                    is 300 seconds.
+                                    time which will be taken between retries.
                                   type: string
                                 resetHeaders:
                                   description: ResetHeaders specifies the list of
@@ -133,8 +137,7 @@ spec:
                                   items:
                                     properties:
                                       format:
-                                        description: The format of the reset header,
-                                          either Seconds or UnixTimestamp.
+                                        description: The format of the reset header.
                                         enum:
                                         - Seconds
                                         - UnixTimestamp
@@ -152,10 +155,21 @@ spec:
                                   type: array
                               type: object
                             retryOn:
-                              description: 'RetryOn is a list of conditions which
-                                will cause a retry. Available values are: [Canceled,
-                                DeadlineExceeded, Internal, ResourceExhausted, Unavailable].'
+                              description: RetryOn is a list of conditions which will
+                                cause a retry.
+                              example:
+                              - Canceled
+                              - DeadlineExceeded
+                              - Internal
+                              - ResourceExhausted
+                              - Unavailable
                               items:
+                                enum:
+                                - Canceled
+                                - DeadlineExceeded
+                                - Internal
+                                - ResourceExhausted
+                                - Unavailable
                                 type: string
                               type: array
                           type: object
@@ -166,13 +180,14 @@ spec:
                             backOff:
                               description: BackOff is a configuration of durations
                                 which will be used in exponential backoff strategy
-                                between retries
+                                between retries.
                               properties:
                                 baseInterval:
+                                  default: 25ms
                                   description: BaseInterval is an amount of time which
                                     should be taken between retries. Must be greater
                                     than zero. Values less than 1 ms are rounded up
-                                    to 1 ms. Default is 25ms.
+                                    to 1 ms.
                                   type: string
                                 maxInterval:
                                   description: MaxInterval is a maximal amount of
@@ -188,8 +203,10 @@ spec:
                                 properties:
                                   predicate:
                                     description: Type is requested predicate mode.
-                                      Available values are OmitPreviousHosts, OmitHostsWithTags,
-                                      and OmitPreviousPriorities.
+                                    enum:
+                                    - OmitPreviousHosts
+                                    - OmitHostsWithTags
+                                    - OmitPreviousPriorities
                                     type: string
                                   tags:
                                     additionalProperties:
@@ -199,10 +216,10 @@ spec:
                                       if Type is OmitHostsWithTags
                                     type: object
                                   updateFrequency:
+                                    default: 2
                                     description: UpdateFrequency is how often the
                                       priority load should be updated based on previously
                                       attempted priorities. Used for OmitPreviousPriorities.
-                                      Default is 2 if not set.
                                     format: int32
                                     type: integer
                                 required:
@@ -219,13 +236,18 @@ spec:
                               type: integer
                             numRetries:
                               description: NumRetries is the number of attempts that
-                                will be made on failed (and retriable) requests
+                                will be made on failed (and retriable) requests.  If
+                                not set, the default value is 1.
                               format: int32
                               type: integer
                             perTryTimeout:
                               description: PerTryTimeout is the amount of time after
-                                which retry attempt should timeout. Setting this timeout
-                                to 0 will disable it. Default is 15s.
+                                which retry attempt should time out. If left unspecified,
+                                the global route timeout for the request will be used.
+                                Consequently, when using a 5xx based retry policy,
+                                a request that times out will not be retried as the
+                                total timeout budget would have been exhausted. Setting
+                                this timeout to 0 will disable it.
                               type: string
                             rateLimitedBackOff:
                               description: RateLimitedBackOff is a configuration of
@@ -233,9 +255,9 @@ spec:
                                 one of the headers configured.
                               properties:
                                 maxInterval:
+                                  default: 300s
                                   description: MaxInterval is a maximal amount of
-                                    time which will be taken between retries. Default
-                                    is 300 seconds.
+                                    time which will be taken between retries.
                                   type: string
                                 resetHeaders:
                                   description: ResetHeaders specifies the list of
@@ -248,8 +270,7 @@ spec:
                                   items:
                                     properties:
                                       format:
-                                        description: The format of the reset header,
-                                          either Seconds or UnixTimestamp.
+                                        description: The format of the reset header.
                                         enum:
                                         - Seconds
                                         - UnixTimestamp
@@ -306,7 +327,7 @@ spec:
                               description: RetriableResponseHeaders is an HTTP response
                                 headers that trigger a retry if present in the response.
                                 A retry will be triggered if any of the header matches
-                                match the upstream response headers.
+                                the upstream response headers.
                               items:
                                 description: HeaderMatch describes how to select an
                                   HTTP route by matching HTTP request headers.
@@ -346,7 +367,27 @@ spec:
                                 RefusedStream, Http3PostConnectFailure, HttpMethodConnect,
                                 HttpMethodDelete, HttpMethodGet, HttpMethodHead, HttpMethodOptions,
                                 HttpMethodPatch, HttpMethodPost, HttpMethodPut, HttpMethodTrace].
-                                Also, any HTTP status code (500, 503, etc).'
+                                Also, any HTTP status code (500, 503, etc.).'
+                              example:
+                              - 5XX
+                              - GatewayError
+                              - Reset
+                              - Retriable4xx
+                              - ConnectFailure
+                              - EnvoyRatelimited
+                              - RefusedStream
+                              - Http3PostConnectFailure
+                              - HttpMethodConnect
+                              - HttpMethodDelete
+                              - HttpMethodGet
+                              - HttpMethodHead
+                              - HttpMethodOptions
+                              - HttpMethodPatch
+                              - HttpMethodPost
+                              - HttpMethodPut
+                              - HttpMethodTrace
+                              - "500"
+                              - "503"
                               items:
                                 type: string
                               type: array

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -5251,15 +5251,16 @@ components:
                           backOff:
                             description: >-
                               BackOff is a configuration of durations which will
-                              be used in exponential backoff strategy between
+                              be used in an exponential backoff strategy between
                               retries.
                             properties:
                               baseInterval:
+                                default: 25ms
                                 description: >-
                                   BaseInterval is an amount of time which should
                                   be taken between retries. Must be greater than
                                   zero. Values less than 1 ms are rounded up to
-                                  1 ms. Default is 25ms.
+                                  1 ms.
                                 type: string
                               maxInterval:
                                 description: >-
@@ -5271,14 +5272,17 @@ components:
                           numRetries:
                             description: >-
                               NumRetries is the number of attempts that will be
-                              made on failed (and retriable) requests.
+                              made on failed (and retriable) requests. If not
+                              set, the default value is 1.
                             format: int32
                             type: integer
                           perTryTimeout:
                             description: >-
-                              PerTryTimeout is the amount of time after which
-                              retry attempt should timeout. Setting this timeout
-                              to 0 will disable it. Default is 15s.
+                              PerTryTimeout is the maximum amount of time each
+                              retry attempt can take before it times out. If not
+                              set, the global request timeout for the route will
+                              be used. Setting this value to 0 will disable the
+                              per-try timeout.
                             type: string
                           rateLimitedBackOff:
                             description: >-
@@ -5287,10 +5291,10 @@ components:
                               of the headers configured.
                             properties:
                               maxInterval:
+                                default: 300s
                                 description: >-
                                   MaxInterval is a maximal amount of time which
-                                  will be taken between retries. Default is 300
-                                  seconds.
+                                  will be taken between retries.
                                 type: string
                               resetHeaders:
                                 description: >-
@@ -5304,9 +5308,7 @@ components:
                                 items:
                                   properties:
                                     format:
-                                      description: >-
-                                        The format of the reset header, either
-                                        Seconds or UnixTimestamp.
+                                      description: The format of the reset header.
                                       enum:
                                         - Seconds
                                         - UnixTimestamp
@@ -5326,10 +5328,20 @@ components:
                           retryOn:
                             description: >-
                               RetryOn is a list of conditions which will cause a
-                              retry. Available values are: [Canceled,
-                              DeadlineExceeded, Internal, ResourceExhausted,
-                              Unavailable].
+                              retry.
+                            example:
+                              - Canceled
+                              - DeadlineExceeded
+                              - Internal
+                              - ResourceExhausted
+                              - Unavailable
                             items:
+                              enum:
+                                - Canceled
+                                - DeadlineExceeded
+                                - Internal
+                                - ResourceExhausted
+                                - Unavailable
                               type: string
                             type: array
                         type: object
@@ -5342,14 +5354,15 @@ components:
                             description: >-
                               BackOff is a configuration of durations which will
                               be used in exponential backoff strategy between
-                              retries
+                              retries.
                             properties:
                               baseInterval:
+                                default: 25ms
                                 description: >-
                                   BaseInterval is an amount of time which should
                                   be taken between retries. Must be greater than
                                   zero. Values less than 1 ms are rounded up to
-                                  1 ms. Default is 25ms.
+                                  1 ms.
                                 type: string
                               maxInterval:
                                 description: >-
@@ -5366,11 +5379,11 @@ components:
                             items:
                               properties:
                                 predicate:
-                                  description: >-
-                                    Type is requested predicate mode. Available
-                                    values are OmitPreviousHosts,
-                                    OmitHostsWithTags, and
-                                    OmitPreviousPriorities.
+                                  description: Type is requested predicate mode.
+                                  enum:
+                                    - OmitPreviousHosts
+                                    - OmitHostsWithTags
+                                    - OmitPreviousPriorities
                                   type: string
                                 tags:
                                   additionalProperties:
@@ -5381,12 +5394,12 @@ components:
                                     Type is OmitHostsWithTags
                                   type: object
                                 updateFrequency:
+                                  default: 2
                                   description: >-
                                     UpdateFrequency is how often the priority
                                     load should be updated based on previously
                                     attempted priorities. Used for
-                                    OmitPreviousPriorities. Default is 2 if not
-                                    set.
+                                    OmitPreviousPriorities.
                                   format: int32
                                   type: integer
                               required:
@@ -5405,14 +5418,20 @@ components:
                           numRetries:
                             description: >-
                               NumRetries is the number of attempts that will be
-                              made on failed (and retriable) requests
+                              made on failed (and retriable) requests.  If not
+                              set, the default value is 1.
                             format: int32
                             type: integer
                           perTryTimeout:
                             description: >-
                               PerTryTimeout is the amount of time after which
-                              retry attempt should timeout. Setting this timeout
-                              to 0 will disable it. Default is 15s.
+                              retry attempt should time out. If left
+                              unspecified, the global route timeout for the
+                              request will be used. Consequently, when using a
+                              5xx based retry policy, a request that times out
+                              will not be retried as the total timeout budget
+                              would have been exhausted. Setting this timeout to
+                              0 will disable it.
                             type: string
                           rateLimitedBackOff:
                             description: >-
@@ -5421,10 +5440,10 @@ components:
                               of the headers configured.
                             properties:
                               maxInterval:
+                                default: 300s
                                 description: >-
                                   MaxInterval is a maximal amount of time which
-                                  will be taken between retries. Default is 300
-                                  seconds.
+                                  will be taken between retries.
                                 type: string
                               resetHeaders:
                                 description: >-
@@ -5438,9 +5457,7 @@ components:
                                 items:
                                   properties:
                                     format:
-                                      description: >-
-                                        The format of the reset header, either
-                                        Seconds or UnixTimestamp.
+                                      description: The format of the reset header.
                                       enum:
                                         - Seconds
                                         - UnixTimestamp
@@ -5503,8 +5520,7 @@ components:
                               RetriableResponseHeaders is an HTTP response
                               headers that trigger a retry if present in the
                               response. A retry will be triggered if any of the
-                              header matches match the upstream response
-                              headers.
+                              header matches the upstream response headers.
                             items:
                               description: >-
                                 HeaderMatch describes how to select an HTTP
@@ -5551,7 +5567,27 @@ components:
                               HttpMethodDelete, HttpMethodGet, HttpMethodHead,
                               HttpMethodOptions, HttpMethodPatch,
                               HttpMethodPost, HttpMethodPut, HttpMethodTrace].
-                              Also, any HTTP status code (500, 503, etc).
+                              Also, any HTTP status code (500, 503, etc.).
+                            example:
+                              - 5XX
+                              - GatewayError
+                              - Reset
+                              - Retriable4xx
+                              - ConnectFailure
+                              - EnvoyRatelimited
+                              - RefusedStream
+                              - Http3PostConnectFailure
+                              - HttpMethodConnect
+                              - HttpMethodDelete
+                              - HttpMethodGet
+                              - HttpMethodHead
+                              - HttpMethodOptions
+                              - HttpMethodPatch
+                              - HttpMethodPost
+                              - HttpMethodPut
+                              - HttpMethodTrace
+                              - '500'
+                              - '503'
                             items:
                               type: string
                             type: array

--- a/docs/generated/raw/crds/kuma.io_meshretries.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshretries.yaml
@@ -87,14 +87,15 @@ spec:
                           properties:
                             backOff:
                               description: BackOff is a configuration of durations
-                                which will be used in exponential backoff strategy
+                                which will be used in an exponential backoff strategy
                                 between retries.
                               properties:
                                 baseInterval:
+                                  default: 25ms
                                   description: BaseInterval is an amount of time which
                                     should be taken between retries. Must be greater
                                     than zero. Values less than 1 ms are rounded up
-                                    to 1 ms. Default is 25ms.
+                                    to 1 ms.
                                   type: string
                                 maxInterval:
                                   description: MaxInterval is a maximal amount of
@@ -104,13 +105,16 @@ spec:
                               type: object
                             numRetries:
                               description: NumRetries is the number of attempts that
-                                will be made on failed (and retriable) requests.
+                                will be made on failed (and retriable) requests. If
+                                not set, the default value is 1.
                               format: int32
                               type: integer
                             perTryTimeout:
-                              description: PerTryTimeout is the amount of time after
-                                which retry attempt should timeout. Setting this timeout
-                                to 0 will disable it. Default is 15s.
+                              description: PerTryTimeout is the maximum amount of
+                                time each retry attempt can take before it times out.
+                                If not set, the global request timeout for the route
+                                will be used. Setting this value to 0 will disable
+                                the per-try timeout.
                               type: string
                             rateLimitedBackOff:
                               description: RateLimitedBackOff is a configuration of
@@ -118,9 +122,9 @@ spec:
                                 one of the headers configured.
                               properties:
                                 maxInterval:
+                                  default: 300s
                                   description: MaxInterval is a maximal amount of
-                                    time which will be taken between retries. Default
-                                    is 300 seconds.
+                                    time which will be taken between retries.
                                   type: string
                                 resetHeaders:
                                   description: ResetHeaders specifies the list of
@@ -133,8 +137,7 @@ spec:
                                   items:
                                     properties:
                                       format:
-                                        description: The format of the reset header,
-                                          either Seconds or UnixTimestamp.
+                                        description: The format of the reset header.
                                         enum:
                                         - Seconds
                                         - UnixTimestamp
@@ -152,10 +155,21 @@ spec:
                                   type: array
                               type: object
                             retryOn:
-                              description: 'RetryOn is a list of conditions which
-                                will cause a retry. Available values are: [Canceled,
-                                DeadlineExceeded, Internal, ResourceExhausted, Unavailable].'
+                              description: RetryOn is a list of conditions which will
+                                cause a retry.
+                              example:
+                              - Canceled
+                              - DeadlineExceeded
+                              - Internal
+                              - ResourceExhausted
+                              - Unavailable
                               items:
+                                enum:
+                                - Canceled
+                                - DeadlineExceeded
+                                - Internal
+                                - ResourceExhausted
+                                - Unavailable
                                 type: string
                               type: array
                           type: object
@@ -166,13 +180,14 @@ spec:
                             backOff:
                               description: BackOff is a configuration of durations
                                 which will be used in exponential backoff strategy
-                                between retries
+                                between retries.
                               properties:
                                 baseInterval:
+                                  default: 25ms
                                   description: BaseInterval is an amount of time which
                                     should be taken between retries. Must be greater
                                     than zero. Values less than 1 ms are rounded up
-                                    to 1 ms. Default is 25ms.
+                                    to 1 ms.
                                   type: string
                                 maxInterval:
                                   description: MaxInterval is a maximal amount of
@@ -188,8 +203,10 @@ spec:
                                 properties:
                                   predicate:
                                     description: Type is requested predicate mode.
-                                      Available values are OmitPreviousHosts, OmitHostsWithTags,
-                                      and OmitPreviousPriorities.
+                                    enum:
+                                    - OmitPreviousHosts
+                                    - OmitHostsWithTags
+                                    - OmitPreviousPriorities
                                     type: string
                                   tags:
                                     additionalProperties:
@@ -199,10 +216,10 @@ spec:
                                       if Type is OmitHostsWithTags
                                     type: object
                                   updateFrequency:
+                                    default: 2
                                     description: UpdateFrequency is how often the
                                       priority load should be updated based on previously
                                       attempted priorities. Used for OmitPreviousPriorities.
-                                      Default is 2 if not set.
                                     format: int32
                                     type: integer
                                 required:
@@ -219,13 +236,18 @@ spec:
                               type: integer
                             numRetries:
                               description: NumRetries is the number of attempts that
-                                will be made on failed (and retriable) requests
+                                will be made on failed (and retriable) requests.  If
+                                not set, the default value is 1.
                               format: int32
                               type: integer
                             perTryTimeout:
                               description: PerTryTimeout is the amount of time after
-                                which retry attempt should timeout. Setting this timeout
-                                to 0 will disable it. Default is 15s.
+                                which retry attempt should time out. If left unspecified,
+                                the global route timeout for the request will be used.
+                                Consequently, when using a 5xx based retry policy,
+                                a request that times out will not be retried as the
+                                total timeout budget would have been exhausted. Setting
+                                this timeout to 0 will disable it.
                               type: string
                             rateLimitedBackOff:
                               description: RateLimitedBackOff is a configuration of
@@ -233,9 +255,9 @@ spec:
                                 one of the headers configured.
                               properties:
                                 maxInterval:
+                                  default: 300s
                                   description: MaxInterval is a maximal amount of
-                                    time which will be taken between retries. Default
-                                    is 300 seconds.
+                                    time which will be taken between retries.
                                   type: string
                                 resetHeaders:
                                   description: ResetHeaders specifies the list of
@@ -248,8 +270,7 @@ spec:
                                   items:
                                     properties:
                                       format:
-                                        description: The format of the reset header,
-                                          either Seconds or UnixTimestamp.
+                                        description: The format of the reset header.
                                         enum:
                                         - Seconds
                                         - UnixTimestamp
@@ -306,7 +327,7 @@ spec:
                               description: RetriableResponseHeaders is an HTTP response
                                 headers that trigger a retry if present in the response.
                                 A retry will be triggered if any of the header matches
-                                match the upstream response headers.
+                                the upstream response headers.
                               items:
                                 description: HeaderMatch describes how to select an
                                   HTTP route by matching HTTP request headers.
@@ -346,7 +367,27 @@ spec:
                                 RefusedStream, Http3PostConnectFailure, HttpMethodConnect,
                                 HttpMethodDelete, HttpMethodGet, HttpMethodHead, HttpMethodOptions,
                                 HttpMethodPatch, HttpMethodPost, HttpMethodPut, HttpMethodTrace].
-                                Also, any HTTP status code (500, 503, etc).'
+                                Also, any HTTP status code (500, 503, etc.).'
+                              example:
+                              - 5XX
+                              - GatewayError
+                              - Reset
+                              - Retriable4xx
+                              - ConnectFailure
+                              - EnvoyRatelimited
+                              - RefusedStream
+                              - Http3PostConnectFailure
+                              - HttpMethodConnect
+                              - HttpMethodDelete
+                              - HttpMethodGet
+                              - HttpMethodHead
+                              - HttpMethodOptions
+                              - HttpMethodPatch
+                              - HttpMethodPost
+                              - HttpMethodPut
+                              - HttpMethodTrace
+                              - "500"
+                              - "503"
                               items:
                                 type: string
                               type: array

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/schema.yaml
@@ -51,34 +51,36 @@ properties:
                   description: GRPC defines a configuration of retries for GRPC traffic
                   properties:
                     backOff:
-                      description: BackOff is a configuration of durations which will be used in exponential backoff strategy between retries.
+                      description: BackOff is a configuration of durations which will be used in an exponential backoff strategy between retries.
                       properties:
                         baseInterval:
-                          description: BaseInterval is an amount of time which should be taken between retries. Must be greater than zero. Values less than 1 ms are rounded up to 1 ms. Default is 25ms.
+                          default: 25ms
+                          description: BaseInterval is an amount of time which should be taken between retries. Must be greater than zero. Values less than 1 ms are rounded up to 1 ms.
                           type: string
                         maxInterval:
                           description: MaxInterval is a maximal amount of time which will be taken between retries. Default is 10 times the "BaseInterval".
                           type: string
                       type: object
                     numRetries:
-                      description: NumRetries is the number of attempts that will be made on failed (and retriable) requests.
+                      description: NumRetries is the number of attempts that will be made on failed (and retriable) requests. If not set, the default value is 1.
                       format: int32
                       type: integer
                     perTryTimeout:
-                      description: PerTryTimeout is the amount of time after which retry attempt should timeout. Setting this timeout to 0 will disable it. Default is 15s.
+                      description: PerTryTimeout is the maximum amount of time each retry attempt can take before it times out. If not set, the global request timeout for the route will be used. Setting this value to 0 will disable the per-try timeout.
                       type: string
                     rateLimitedBackOff:
                       description: RateLimitedBackOff is a configuration of backoff which will be used when the upstream returns one of the headers configured.
                       properties:
                         maxInterval:
-                          description: MaxInterval is a maximal amount of time which will be taken between retries. Default is 300 seconds.
+                          default: 300s
+                          description: MaxInterval is a maximal amount of time which will be taken between retries.
                           type: string
                         resetHeaders:
                           description: ResetHeaders specifies the list of headers (like Retry-After or X-RateLimit-Reset) to match against the response. Headers are tried in order, and matched case-insensitive. The first header to be parsed successfully is used. If no headers match the default exponential BackOff is used instead.
                           items:
                             properties:
                               format:
-                                description: The format of the reset header, either Seconds or UnixTimestamp.
+                                description: The format of the reset header.
                                 enum:
                                   - Seconds
                                   - UnixTimestamp
@@ -96,8 +98,20 @@ properties:
                           type: array
                       type: object
                     retryOn:
-                      description: 'RetryOn is a list of conditions which will cause a retry. Available values are: [Canceled, DeadlineExceeded, Internal, ResourceExhausted, Unavailable].'
+                      description: RetryOn is a list of conditions which will cause a retry.
+                      example:
+                        - Canceled
+                        - DeadlineExceeded
+                        - Internal
+                        - ResourceExhausted
+                        - Unavailable
                       items:
+                        enum:
+                          - Canceled
+                          - DeadlineExceeded
+                          - Internal
+                          - ResourceExhausted
+                          - Unavailable
                         type: string
                       type: array
                   type: object
@@ -105,10 +119,11 @@ properties:
                   description: HTTP defines a configuration of retries for HTTP traffic
                   properties:
                     backOff:
-                      description: BackOff is a configuration of durations which will be used in exponential backoff strategy between retries
+                      description: BackOff is a configuration of durations which will be used in exponential backoff strategy between retries.
                       properties:
                         baseInterval:
-                          description: BaseInterval is an amount of time which should be taken between retries. Must be greater than zero. Values less than 1 ms are rounded up to 1 ms. Default is 25ms.
+                          default: 25ms
+                          description: BaseInterval is an amount of time which should be taken between retries. Must be greater than zero. Values less than 1 ms are rounded up to 1 ms.
                           type: string
                         maxInterval:
                           description: MaxInterval is a maximal amount of time which will be taken between retries. Default is 10 times the "BaseInterval".
@@ -119,7 +134,11 @@ properties:
                       items:
                         properties:
                           predicate:
-                            description: Type is requested predicate mode. Available values are OmitPreviousHosts, OmitHostsWithTags, and OmitPreviousPriorities.
+                            description: Type is requested predicate mode.
+                            enum:
+                              - OmitPreviousHosts
+                              - OmitHostsWithTags
+                              - OmitPreviousPriorities
                             type: string
                           tags:
                             additionalProperties:
@@ -127,7 +146,8 @@ properties:
                             description: Tags is a map of metadata to match against for selecting the omitted hosts. Required if Type is OmitHostsWithTags
                             type: object
                           updateFrequency:
-                            description: UpdateFrequency is how often the priority load should be updated based on previously attempted priorities. Used for OmitPreviousPriorities. Default is 2 if not set.
+                            default: 2
+                            description: UpdateFrequency is how often the priority load should be updated based on previously attempted priorities. Used for OmitPreviousPriorities.
                             format: int32
                             type: integer
                         required:
@@ -139,24 +159,25 @@ properties:
                       format: int64
                       type: integer
                     numRetries:
-                      description: NumRetries is the number of attempts that will be made on failed (and retriable) requests
+                      description: NumRetries is the number of attempts that will be made on failed (and retriable) requests.  If not set, the default value is 1.
                       format: int32
                       type: integer
                     perTryTimeout:
-                      description: PerTryTimeout is the amount of time after which retry attempt should timeout. Setting this timeout to 0 will disable it. Default is 15s.
+                      description: PerTryTimeout is the amount of time after which retry attempt should time out. If left unspecified, the global route timeout for the request will be used. Consequently, when using a 5xx based retry policy, a request that times out will not be retried as the total timeout budget would have been exhausted. Setting this timeout to 0 will disable it.
                       type: string
                     rateLimitedBackOff:
                       description: RateLimitedBackOff is a configuration of backoff which will be used when the upstream returns one of the headers configured.
                       properties:
                         maxInterval:
-                          description: MaxInterval is a maximal amount of time which will be taken between retries. Default is 300 seconds.
+                          default: 300s
+                          description: MaxInterval is a maximal amount of time which will be taken between retries.
                           type: string
                         resetHeaders:
                           description: ResetHeaders specifies the list of headers (like Retry-After or X-RateLimit-Reset) to match against the response. Headers are tried in order, and matched case-insensitive. The first header to be parsed successfully is used. If no headers match the default exponential BackOff is used instead.
                           items:
                             properties:
                               format:
-                                description: The format of the reset header, either Seconds or UnixTimestamp.
+                                description: The format of the reset header.
                                 enum:
                                   - Seconds
                                   - UnixTimestamp
@@ -202,7 +223,7 @@ properties:
                         type: object
                       type: array
                     retriableResponseHeaders:
-                      description: RetriableResponseHeaders is an HTTP response headers that trigger a retry if present in the response. A retry will be triggered if any of the header matches match the upstream response headers.
+                      description: RetriableResponseHeaders is an HTTP response headers that trigger a retry if present in the response. A retry will be triggered if any of the header matches the upstream response headers.
                       items:
                         description: HeaderMatch describes how to select an HTTP route by matching HTTP request headers.
                         properties:
@@ -230,7 +251,27 @@ properties:
                         type: object
                       type: array
                     retryOn:
-                      description: 'RetryOn is a list of conditions which will cause a retry. Available values are: [5XX, GatewayError, Reset, Retriable4xx, ConnectFailure, EnvoyRatelimited, RefusedStream, Http3PostConnectFailure, HttpMethodConnect, HttpMethodDelete, HttpMethodGet, HttpMethodHead, HttpMethodOptions, HttpMethodPatch, HttpMethodPost, HttpMethodPut, HttpMethodTrace]. Also, any HTTP status code (500, 503, etc).'
+                      description: 'RetryOn is a list of conditions which will cause a retry. Available values are: [5XX, GatewayError, Reset, Retriable4xx, ConnectFailure, EnvoyRatelimited, RefusedStream, Http3PostConnectFailure, HttpMethodConnect, HttpMethodDelete, HttpMethodGet, HttpMethodHead, HttpMethodOptions, HttpMethodPatch, HttpMethodPost, HttpMethodPut, HttpMethodTrace]. Also, any HTTP status code (500, 503, etc.).'
+                      example:
+                        - 5XX
+                        - GatewayError
+                        - Reset
+                        - Retriable4xx
+                        - ConnectFailure
+                        - EnvoyRatelimited
+                        - RefusedStream
+                        - Http3PostConnectFailure
+                        - HttpMethodConnect
+                        - HttpMethodDelete
+                        - HttpMethodGet
+                        - HttpMethodHead
+                        - HttpMethodOptions
+                        - HttpMethodPatch
+                        - HttpMethodPost
+                        - HttpMethodPut
+                        - HttpMethodTrace
+                        - "500"
+                        - "503"
                       items:
                         type: string
                       type: array

--- a/pkg/plugins/policies/meshretry/k8s/crd/kuma.io_meshretries.yaml
+++ b/pkg/plugins/policies/meshretry/k8s/crd/kuma.io_meshretries.yaml
@@ -87,14 +87,15 @@ spec:
                           properties:
                             backOff:
                               description: BackOff is a configuration of durations
-                                which will be used in exponential backoff strategy
+                                which will be used in an exponential backoff strategy
                                 between retries.
                               properties:
                                 baseInterval:
+                                  default: 25ms
                                   description: BaseInterval is an amount of time which
                                     should be taken between retries. Must be greater
                                     than zero. Values less than 1 ms are rounded up
-                                    to 1 ms. Default is 25ms.
+                                    to 1 ms.
                                   type: string
                                 maxInterval:
                                   description: MaxInterval is a maximal amount of
@@ -104,13 +105,16 @@ spec:
                               type: object
                             numRetries:
                               description: NumRetries is the number of attempts that
-                                will be made on failed (and retriable) requests.
+                                will be made on failed (and retriable) requests. If
+                                not set, the default value is 1.
                               format: int32
                               type: integer
                             perTryTimeout:
-                              description: PerTryTimeout is the amount of time after
-                                which retry attempt should timeout. Setting this timeout
-                                to 0 will disable it. Default is 15s.
+                              description: PerTryTimeout is the maximum amount of
+                                time each retry attempt can take before it times out.
+                                If not set, the global request timeout for the route
+                                will be used. Setting this value to 0 will disable
+                                the per-try timeout.
                               type: string
                             rateLimitedBackOff:
                               description: RateLimitedBackOff is a configuration of
@@ -118,9 +122,9 @@ spec:
                                 one of the headers configured.
                               properties:
                                 maxInterval:
+                                  default: 300s
                                   description: MaxInterval is a maximal amount of
-                                    time which will be taken between retries. Default
-                                    is 300 seconds.
+                                    time which will be taken between retries.
                                   type: string
                                 resetHeaders:
                                   description: ResetHeaders specifies the list of
@@ -133,8 +137,7 @@ spec:
                                   items:
                                     properties:
                                       format:
-                                        description: The format of the reset header,
-                                          either Seconds or UnixTimestamp.
+                                        description: The format of the reset header.
                                         enum:
                                         - Seconds
                                         - UnixTimestamp
@@ -152,10 +155,21 @@ spec:
                                   type: array
                               type: object
                             retryOn:
-                              description: 'RetryOn is a list of conditions which
-                                will cause a retry. Available values are: [Canceled,
-                                DeadlineExceeded, Internal, ResourceExhausted, Unavailable].'
+                              description: RetryOn is a list of conditions which will
+                                cause a retry.
+                              example:
+                              - Canceled
+                              - DeadlineExceeded
+                              - Internal
+                              - ResourceExhausted
+                              - Unavailable
                               items:
+                                enum:
+                                - Canceled
+                                - DeadlineExceeded
+                                - Internal
+                                - ResourceExhausted
+                                - Unavailable
                                 type: string
                               type: array
                           type: object
@@ -166,13 +180,14 @@ spec:
                             backOff:
                               description: BackOff is a configuration of durations
                                 which will be used in exponential backoff strategy
-                                between retries
+                                between retries.
                               properties:
                                 baseInterval:
+                                  default: 25ms
                                   description: BaseInterval is an amount of time which
                                     should be taken between retries. Must be greater
                                     than zero. Values less than 1 ms are rounded up
-                                    to 1 ms. Default is 25ms.
+                                    to 1 ms.
                                   type: string
                                 maxInterval:
                                   description: MaxInterval is a maximal amount of
@@ -188,8 +203,10 @@ spec:
                                 properties:
                                   predicate:
                                     description: Type is requested predicate mode.
-                                      Available values are OmitPreviousHosts, OmitHostsWithTags,
-                                      and OmitPreviousPriorities.
+                                    enum:
+                                    - OmitPreviousHosts
+                                    - OmitHostsWithTags
+                                    - OmitPreviousPriorities
                                     type: string
                                   tags:
                                     additionalProperties:
@@ -199,10 +216,10 @@ spec:
                                       if Type is OmitHostsWithTags
                                     type: object
                                   updateFrequency:
+                                    default: 2
                                     description: UpdateFrequency is how often the
                                       priority load should be updated based on previously
                                       attempted priorities. Used for OmitPreviousPriorities.
-                                      Default is 2 if not set.
                                     format: int32
                                     type: integer
                                 required:
@@ -219,13 +236,18 @@ spec:
                               type: integer
                             numRetries:
                               description: NumRetries is the number of attempts that
-                                will be made on failed (and retriable) requests
+                                will be made on failed (and retriable) requests.  If
+                                not set, the default value is 1.
                               format: int32
                               type: integer
                             perTryTimeout:
                               description: PerTryTimeout is the amount of time after
-                                which retry attempt should timeout. Setting this timeout
-                                to 0 will disable it. Default is 15s.
+                                which retry attempt should time out. If left unspecified,
+                                the global route timeout for the request will be used.
+                                Consequently, when using a 5xx based retry policy,
+                                a request that times out will not be retried as the
+                                total timeout budget would have been exhausted. Setting
+                                this timeout to 0 will disable it.
                               type: string
                             rateLimitedBackOff:
                               description: RateLimitedBackOff is a configuration of
@@ -233,9 +255,9 @@ spec:
                                 one of the headers configured.
                               properties:
                                 maxInterval:
+                                  default: 300s
                                   description: MaxInterval is a maximal amount of
-                                    time which will be taken between retries. Default
-                                    is 300 seconds.
+                                    time which will be taken between retries.
                                   type: string
                                 resetHeaders:
                                   description: ResetHeaders specifies the list of
@@ -248,8 +270,7 @@ spec:
                                   items:
                                     properties:
                                       format:
-                                        description: The format of the reset header,
-                                          either Seconds or UnixTimestamp.
+                                        description: The format of the reset header.
                                         enum:
                                         - Seconds
                                         - UnixTimestamp
@@ -306,7 +327,7 @@ spec:
                               description: RetriableResponseHeaders is an HTTP response
                                 headers that trigger a retry if present in the response.
                                 A retry will be triggered if any of the header matches
-                                match the upstream response headers.
+                                the upstream response headers.
                               items:
                                 description: HeaderMatch describes how to select an
                                   HTTP route by matching HTTP request headers.
@@ -346,7 +367,27 @@ spec:
                                 RefusedStream, Http3PostConnectFailure, HttpMethodConnect,
                                 HttpMethodDelete, HttpMethodGet, HttpMethodHead, HttpMethodOptions,
                                 HttpMethodPatch, HttpMethodPost, HttpMethodPut, HttpMethodTrace].
-                                Also, any HTTP status code (500, 503, etc).'
+                                Also, any HTTP status code (500, 503, etc.).'
+                              example:
+                              - 5XX
+                              - GatewayError
+                              - Reset
+                              - Retriable4xx
+                              - ConnectFailure
+                              - EnvoyRatelimited
+                              - RefusedStream
+                              - Http3PostConnectFailure
+                              - HttpMethodConnect
+                              - HttpMethodDelete
+                              - HttpMethodGet
+                              - HttpMethodHead
+                              - HttpMethodOptions
+                              - HttpMethodPatch
+                              - HttpMethodPost
+                              - HttpMethodPut
+                              - HttpMethodTrace
+                              - "500"
+                              - "503"
                               items:
                                 type: string
                               type: array


### PR DESCRIPTION
Added examples and defaults to some fields + validation for enums where possible

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - Closes https://github.com/kumahq/kuma/issues/8259
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - No changes in tests
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - There is no need

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
