### PR TITLE
feat(MeshAccessLog): select gateway listeners

### DIFF
--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
@@ -918,8 +918,8 @@ var _ = Describe("MeshAccessLog", func() {
 		}),
 	)
 	type gatewayTestCase struct {
-		routes  []*core_mesh.MeshGatewayRouteResource
-		toRules core_rules.ToRules
+		routes []*core_mesh.MeshGatewayRouteResource
+		rules  core_rules.GatewayRules
 	}
 	DescribeTable("should generate proper Envoy config for MeshGateway Dataplanes",
 		func(given gatewayTestCase) {
@@ -962,7 +962,7 @@ var _ = Describe("MeshAccessLog", func() {
 						WithMesh("default").
 						WithBuiltInGateway("gateway"),
 				).
-				WithPolicies(xds_builders.MatchedPolicies().WithToPolicy(api.MeshAccessLogType, given.toRules)).
+				WithPolicies(xds_builders.MatchedPolicies().WithGatewayPolicy(api.MeshAccessLogType, given.rules)).
 				Build()
 
 			for n, p := range core_plugins.Plugins().ProxyPlugins() {
@@ -991,16 +991,18 @@ var _ = Describe("MeshAccessLog", func() {
 					WithExactMatchHttpRoute("/", "backend", "other-service").
 					Build(),
 			},
-			toRules: core_rules.ToRules{
-				Rules: []*core_rules.Rule{
-					{
-						Subset: core_rules.Subset{},
-						Conf: api.Conf{
-							Backends: &[]api.Backend{{
-								File: &api.FileBackend{
-									Path: "/tmp/log",
-								},
-							}},
+			rules: core_rules.GatewayRules{
+				Rules: map[core_rules.InboundListener]core_rules.Rules{
+					{Address: "127.0.0.1", Port: 8080}: {
+						{
+							Subset: core_rules.Subset{},
+							Conf: api.Conf{
+								Backends: &[]api.Backend{{
+									File: &api.FileBackend{
+										Path: "/tmp/log",
+									},
+								}},
+							},
 						},
 					},
 				},


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- #8549
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
