### PR TITLE
docs(MADR): add `to` to `MeshFaultInjection` for top level `MeshGateway`

### DIFF
--- a/docs/madr/decisions/019-fault-injection-policy.md
+++ b/docs/madr/decisions/019-fault-injection-policy.md
@@ -122,11 +122,16 @@ We'll use `x-kuma-tags` headers to select traffic from origin. `MeshHealthCheck`
 
 #### To level
 
-We can allow configuration to different destinations.
+The `to` level is only allowed for `spec.kind: MeshGateway` and only `to[].targetRef.kind: Mesh` is permitted. This is because fault injection is configured on a listener and `MeshGateway`'s have only one kind of listener.
+
 ```yaml
-from:
+spec:
+  targetRef:
+    kind: MeshGateway
+    name: edge
+to:
  - targetRef:
-     kind: Mesh|MeshSubset|MeshService|MeshServiceSubset
+     kind: Mesh
      name: ...
 ```
 


### PR DESCRIPTION
What do we think about this? This is basically to keep only `to` rules for `MeshGateway`.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- #5792 
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
