### PR TITLE
ci(actions): improve the GH Actions format to make it better for syncing to KM

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -1,7 +1,7 @@
 name: "build-test-distribute"
 on:
   push:
-    branches: ["master", "release-*", "!*-merge-master"]
+    branches: ["master", "release-*", "!*-merge-master", "sync-gh-actions-to-km"]
     tags: ["*"]
   pull_request_target:
     branches: ["master", "release-*"]
@@ -53,6 +53,7 @@ jobs:
           make dev/tools
       - name: "Check if should run on all arch/os combinations"
         if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix')
+        id: set-full-matrix-switches
         run: |
           echo 'ENABLED_GOARCHES=arm64 amd64' >> $GITHUB_ENV
           echo 'ENABLED_GOOSES=linux darwin' >> $GITHUB_ENV
@@ -123,6 +124,9 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: "Halt due to previous failures"
         if: ${{ contains(needs.*.result, 'failure')|| contains(needs.*.result, 'cancelled') }}
         run: |
@@ -131,6 +135,7 @@ jobs:
           # so we manually check it here. An example could be found here: https://github.com/kumahq/kuma/actions/runs/7044980149
       - name: "Check if should run on all arch/os combinations"
         if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix')
+        id: set-full-matrix-switches
         run: |
           echo 'ENABLED_GOARCHES=arm64 amd64' >> $GITHUB_ENV
           echo 'ENABLED_GOOSES=linux darwin' >> $GITHUB_ENV
@@ -143,9 +148,6 @@ jobs:
       - name: Install dependencies for cross builds
         run: |
           sudo apt-get update; sudo apt-get install -y qemu-user-static binfmt-support
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
@@ -187,21 +189,26 @@ jobs:
       test_e2e: ${{ steps.generate-matrix.outputs.test_e2e }}
       test_e2e_env: ${{ steps.generate-matrix.outputs.test_e2e_env }}
     steps:
+      - name: Inject matrix hook
+        id: matrix-hook
+        run: echo 'Nothing to inject'
+      - name: "Check if should run on all arch/os combinations"
+        if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix')
+        id: set-full-matrix-switches
+        run: |
+          echo 'RUN_FULL_MATRIX=true' >> $GITHUB_ENV
       - name: Install jq
         run: |
           sudo apt-get install -y jq
       - id: generate-matrix
         name: Generate matrix
         run: |-
-          BASE_MATRIX_SLOW=$(cat <<-END
-          {
+          BASE_MATRIX_ALL=$(cat <<-END
+          {"test_e2e": {
             "k8sVersion": ["kind", "kindIpv6", "${{ env.K8S_MIN_VERSION }}", "${{ env.K8S_MAX_VERSION }}"],
             "arch": ["amd64", "arm64"]
-          }
-          END
-          )
-          BASE_MATRIX_ENV=$(cat <<-END
-          {
+          },
+          "test_e2e_env": {
             "target": ["kubernetes", "universal", "multizone"],
             "k8sVersion": ["kind", "kindIpv6", "${{ env.K8S_MIN_VERSION }}", "${{ env.K8S_MAX_VERSION }}"],
             "arch": ["amd64", "arm64"],
@@ -219,15 +226,19 @@ jobs:
               {"legacyKDS": true, "k8sVersion": "${{ env.K8S_MAX_VERSION }}", "target": "multizone", "arch": "amd64", "cniNetworkPlugin": "flannel"},
               {"cniNetworkPlugin": "calico", "k8sVersion": "${{ env.K8S_MAX_VERSION }}", "target": "multizone", "arch": "amd64", "legacyKDS": false}
             ]
-          }
+          }}
           END
           )
 
-          MATRIX_SLOW=$(echo $BASE_MATRIX_SLOW | jq -rc)
-          MATRIX_ENV=$(echo $BASE_MATRIX_ENV | jq -rc)
+          BASE_HOOK="${{ steps.matrix-hook.output.hook }}"
+          if [[ "$BASE_HOOK" != "" ]]; then
+            BASE_MATRIX_ALL=$(echo $BASE_MATRIX_ALL | jq -rc "$BASE_HOOK")
+          fi
 
-          RUN_FULL_MATRIX="${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') }}"
-          if [[ "$RUN_FULL_MATRIX" == "false" ]]; then
+          MATRIX_SLOW=$(echo $BASE_MATRIX_ALL | jq -rc ".test_e2e")
+          MATRIX_ENV=$(echo $BASE_MATRIX_ALL | jq -rc ".test_e2e_env")
+
+          if [[ "${RUN_FULL_MATRIX}" != "true" ]]; then
             echo "Skipping non priority e2e tests, because no label 'ci/run-full-matrix' was found on the pull request and not pushing on a releasable branch."
 
             MATRIX_SLOW=''  # target==""

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -159,7 +159,8 @@ jobs:
           fi
 
           BUILD_OUTPUT_ARTIFACT_NAME=build-output
-          BODY='{"parameters": { "e2e_param_k8s_version": "${{ inputs.k8sVersion }}", "e2e_param_arch": "${{ inputs.arch }}", "e2e_param_parallelism": ${{ inputs.parallelism }}, "e2e_param_target": "${{ inputs.target }}", "e2e_param_cni_network_plugin": "${{ inputs.cniNetworkPlugin }}", "e2e_param_legacy_kds": ${{ inputs.legacyKDS }}  } }'
+          BODY='{}'
+          BODY=$(echo "$BODY" | jq -c '.parameters += { "e2e_param_k8s_version": "${{ inputs.k8sVersion }}", "e2e_param_arch": "${{ inputs.arch }}", "e2e_param_parallelism": ${{ inputs.parallelism }}, "e2e_param_target": "${{ inputs.target }}", "e2e_param_cni_network_plugin": "${{ inputs.cniNetworkPlugin }}", "e2e_param_legacy_kds": ${{ inputs.legacyKDS }}  }')
           BODY=$(echo "$BODY" | jq -c ".parameters += { \"gh_action_build_artifact_name\": \"$BUILD_OUTPUT_ARTIFACT_NAME\", \"gh_action_runtime_token\": \"$ACTIONS_RUNTIME_TOKEN\", \"gh_action_artifact_list_url\": \"${ACTIONS_RUNTIME_URL}_apis/pipelines/workflows/${{ github.run_id }}/artifacts?api-version=6.0-preview\" }")
 
           REF_NAME=

--- a/mk/check.mk
+++ b/mk/check.mk
@@ -35,6 +35,11 @@ fmt/ci:
 	$(CI_TOOLS_BIN_DIR)/yq -i '.parameters.go_version.default = "$(GO_VERSION)" | .parameters.first_k8s_version.default = "$(K8S_MIN_VERSION)" | .parameters.last_k8s_version.default = "$(K8S_MAX_VERSION)"' .circleci/config.yml
 	$(CI_TOOLS_BIN_DIR)/yq -i '.env.K8S_MIN_VERSION = "$(K8S_MIN_VERSION)" | .env.K8S_MAX_VERSION = "$(K8S_MAX_VERSION)"' .github/workflows/"$(ACTION_PREFIX)"build-test-distribute.yaml
 	find .github/workflows -name '*ml' | xargs -n 1 $(CI_TOOLS_BIN_DIR)/yq -i '(.jobs.* | select(. | has("steps")) | .steps[] | select(.uses == "golangci/golangci-lint-action*") | .with.version) |= "$(GOLANGCI_LINT_VERSION)"'
+	@CHECKOUT_NOT_AT_ZERO=$$(cat .github/workflows/build-test-distribute.yaml  | $(CI_TOOLS_BIN_DIR)/yq '.jobs.*.steps[] | select(.uses | contains("actions/checkout@")) | path | .[-1]' | grep -v '0'); \
+	if [ ! -z "$$CHECKOUT_NOT_AT_ZERO" ]; then \
+		echo "Please make 'checkout' the first step in jobs of build-test-distribute.yaml." ; \
+		exit 1 ; \
+	fi
 
 .PHONY: helm-lint
 helm-lint:


### PR DESCRIPTION
Minor changes to the structure of the `.github/workflows/build-test-distbutions.yaml` to make it friendly for script manipulating.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - N/A
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - Confirmed
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Manual tested
  - Don't forget `ci/` labels to run additional/fewer tests
    - Added
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? 
  - No needed
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - No need

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
