### PR TITLE
feat(MeshHealthCheck): select MeshGateway listeners

### DIFF
--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin.go
@@ -40,7 +40,7 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 		return err
 	}
 
-	if err := applyToGateways(policies.ToRules, clusters.Gateway, proxy); err != nil {
+	if err := applyToGateways(policies.GatewayRules, clusters.Gateway, proxy); err != nil {
 		return err
 	}
 
@@ -62,11 +62,18 @@ func applyToOutbounds(rules core_rules.ToRules, outboundClusters map[string]*env
 }
 
 func applyToGateways(
-	rules core_rules.ToRules,
+	gatewayRules core_rules.GatewayRules,
 	gatewayClusters map[string]*envoy_cluster.Cluster,
 	proxy *core_xds.Proxy,
 ) error {
 	for _, listenerInfo := range gateway_plugin.ExtractGatewayListeners(proxy) {
+		rules, ok := gatewayRules.Rules[core_rules.InboundListener{
+			Address: proxy.Dataplane.Spec.GetNetworking().Address,
+			Port:    listenerInfo.Listener.Port,
+		}]
+		if !ok {
+			continue
+		}
 		for _, hostInfo := range listenerInfo.HostInfos {
 			destinations := gateway_plugin.RouteDestinationsMutable(hostInfo.Entries)
 			for _, dest := range destinations {
@@ -83,7 +90,7 @@ func applyToGateways(
 
 				if err := configure(
 					proxy.Dataplane,
-					rules.Rules,
+					rules,
 					core_rules.MeshService(serviceName),
 					toProtocol(listenerInfo.Listener.Protocol),
 					cluster,
@@ -108,15 +115,13 @@ func configure(
 	protocol core_mesh.Protocol,
 	cluster *envoy_cluster.Cluster,
 ) error {
-	var conf api.Conf
-	if computed := rules.Compute(subset); computed != nil {
-		conf = computed.Conf.(api.Conf)
-	} else {
+	conf := core_rules.ComputeConf[api.Conf](rules, subset)
+	if conf == nil {
 		return nil
 	}
 
 	configurer := plugin_xds.Configurer{
-		Conf:     conf,
+		Conf:     *conf,
 		Protocol: protocol,
 		Tags:     dataplane.Spec.TagSet(),
 	}

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
@@ -232,8 +232,8 @@ var _ = Describe("MeshHealthCheck", func() {
 	)
 
 	type gatewayTestCase struct {
-		name    string
-		toRules core_rules.ToRules
+		name  string
+		rules core_rules.GatewayRules
 	}
 	DescribeTable("should generate proper Envoy config for MeshGateways",
 		func(given gatewayTestCase) {
@@ -249,7 +249,7 @@ var _ = Describe("MeshHealthCheck", func() {
 			xdsCtx := xds_samples.SampleContextWith(resources)
 			proxy := xds_builders.Proxy().
 				WithDataplane(samples.GatewayDataplaneBuilder()).
-				WithPolicies(xds_builders.MatchedPolicies().WithToPolicy(api.MeshHealthCheckType, given.toRules)).
+				WithPolicies(xds_builders.MatchedPolicies().WithGatewayPolicy(api.MeshHealthCheckType, given.rules)).
 				Build()
 			for n, p := range core_plugins.Plugins().ProxyPlugins() {
 				Expect(p.Apply(context.Background(), xdsCtx.Mesh, proxy)).To(Succeed(), n)
@@ -274,43 +274,45 @@ var _ = Describe("MeshHealthCheck", func() {
 		},
 		Entry("basic outbound cluster with HTTP health check", gatewayTestCase{
 			name: "basic",
-			toRules: core_rules.ToRules{
-				Rules: []*core_rules.Rule{
-					{
-						Subset: core_rules.Subset{},
-						Conf: api.Conf{
-							Interval:                     test.ParseDuration("10s"),
-							Timeout:                      test.ParseDuration("2s"),
-							UnhealthyThreshold:           pointer.To[int32](3),
-							HealthyThreshold:             pointer.To[int32](1),
-							InitialJitter:                test.ParseDuration("13s"),
-							IntervalJitter:               test.ParseDuration("15s"),
-							IntervalJitterPercent:        pointer.To[int32](10),
-							HealthyPanicThreshold:        pointer.To(intstr.FromString("62.9")),
-							FailTrafficOnPanic:           pointer.To(true),
-							EventLogPath:                 pointer.To("/tmp/log.txt"),
-							AlwaysLogHealthCheckFailures: pointer.To(false),
-							NoTrafficInterval:            test.ParseDuration("16s"),
-							Http: &api.HttpHealthCheck{
-								Disabled: pointer.To(false),
-								Path:     pointer.To("/health"),
-								RequestHeadersToAdd: &api.HeaderModifier{
-									Add: []api.HeaderKeyValue{
-										{
-											Name:  "x-some-header",
-											Value: "value",
+			rules: core_rules.GatewayRules{
+				Rules: map[core_rules.InboundListener]core_rules.Rules{
+					{Address: "192.168.0.1", Port: 8080}: {
+						{
+							Subset: core_rules.Subset{},
+							Conf: api.Conf{
+								Interval:                     test.ParseDuration("10s"),
+								Timeout:                      test.ParseDuration("2s"),
+								UnhealthyThreshold:           pointer.To[int32](3),
+								HealthyThreshold:             pointer.To[int32](1),
+								InitialJitter:                test.ParseDuration("13s"),
+								IntervalJitter:               test.ParseDuration("15s"),
+								IntervalJitterPercent:        pointer.To[int32](10),
+								HealthyPanicThreshold:        pointer.To(intstr.FromString("62.9")),
+								FailTrafficOnPanic:           pointer.To(true),
+								EventLogPath:                 pointer.To("/tmp/log.txt"),
+								AlwaysLogHealthCheckFailures: pointer.To(false),
+								NoTrafficInterval:            test.ParseDuration("16s"),
+								Http: &api.HttpHealthCheck{
+									Disabled: pointer.To(false),
+									Path:     pointer.To("/health"),
+									RequestHeadersToAdd: &api.HeaderModifier{
+										Add: []api.HeaderKeyValue{
+											{
+												Name:  "x-some-header",
+												Value: "value",
+											},
+										},
+										Set: []api.HeaderKeyValue{
+											{
+												Name:  "x-some-other-header",
+												Value: "value",
+											},
 										},
 									},
-									Set: []api.HeaderKeyValue{
-										{
-											Name:  "x-some-other-header",
-											Value: "value",
-										},
-									},
+									ExpectedStatuses: &[]int32{200, 201},
 								},
-								ExpectedStatuses: &[]int32{200, 201},
+								ReuseConnection: pointer.To(true),
 							},
-							ReuseConnection: pointer.To(true),
 						},
 					},
 				},


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- #8549 
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
