### PR TITLE
feat(MeshLoadBalancingStrategy): select MeshGateway listeners

### DIFF
--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
@@ -1214,7 +1214,7 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 	type gatewayTestCase struct {
 		name        string
 		endpointMap *xds_builders.EndpointMapBuilder
-		toRules     core_rules.ToRules
+		rules       core_rules.GatewayRules
 	}
 	DescribeTable("should generate proper Envoy config for MeshGateways",
 		func(given gatewayTestCase) {
@@ -1243,7 +1243,7 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 						"k8s.io/region": "test",
 					})).
 				WithPolicies(
-					xds_builders.MatchedPolicies().WithToPolicy(v1alpha1.MeshLoadBalancingStrategyType, given.toRules),
+					xds_builders.MatchedPolicies().WithGatewayPolicy(v1alpha1.MeshLoadBalancingStrategyType, given.rules),
 				).
 				Build()
 			for n, p := range core_plugins.Plugins().ProxyPlugins() {
@@ -1280,31 +1280,33 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 					createEndpointBuilderWith("test-zone", "192.168.1.1", map[string]string{}),
 					createEndpointBuilderWith("test-zone-2", "192.168.1.2", map[string]string{}),
 				),
-			toRules: core_rules.ToRules{
-				Rules: []*core_rules.Rule{
-					{
-						Subset: core_rules.Subset{},
-						Conf: v1alpha1.Conf{
-							LoadBalancer: &v1alpha1.LoadBalancer{
-								Type: v1alpha1.RingHashType,
-								RingHash: &v1alpha1.RingHash{
-									MinRingSize:  pointer.To[uint32](100),
-									MaxRingSize:  pointer.To[uint32](1000),
-									HashFunction: pointer.To(v1alpha1.MurmurHash2Type),
-									HashPolicies: &[]v1alpha1.HashPolicy{
-										{
-											Type: v1alpha1.QueryParameterType,
-											QueryParameter: &v1alpha1.QueryParameter{
-												Name: "queryparam",
+			rules: core_rules.GatewayRules{
+				Rules: map[core_rules.InboundListener]core_rules.Rules{
+					{Address: "192.168.0.1", Port: 8080}: {
+						{
+							Subset: core_rules.Subset{},
+							Conf: v1alpha1.Conf{
+								LoadBalancer: &v1alpha1.LoadBalancer{
+									Type: v1alpha1.RingHashType,
+									RingHash: &v1alpha1.RingHash{
+										MinRingSize:  pointer.To[uint32](100),
+										MaxRingSize:  pointer.To[uint32](1000),
+										HashFunction: pointer.To(v1alpha1.MurmurHash2Type),
+										HashPolicies: &[]v1alpha1.HashPolicy{
+											{
+												Type: v1alpha1.QueryParameterType,
+												QueryParameter: &v1alpha1.QueryParameter{
+													Name: "queryparam",
+												},
+												Terminal: pointer.To(true),
 											},
-											Terminal: pointer.To(true),
-										},
-										{
-											Type: v1alpha1.ConnectionType,
-											Connection: &v1alpha1.Connection{
-												SourceIP: pointer.To(true),
+											{
+												Type: v1alpha1.ConnectionType,
+												Connection: &v1alpha1.Connection{
+													SourceIP: pointer.To(true),
+												},
+												Terminal: pointer.To(false),
 											},
-											Terminal: pointer.To(false),
 										},
 									},
 								},
@@ -1327,49 +1329,51 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 					createEndpointBuilderWith("zone-4", "192.168.1.7", map[string]string{}),
 					createEndpointBuilderWith("zone-5", "192.168.1.8", map[string]string{}),
 				),
-			toRules: core_rules.ToRules{
-				Rules: []*core_rules.Rule{
-					{
-						Subset: core_rules.Subset{},
-						Conf: v1alpha1.Conf{
-							LocalityAwareness: &v1alpha1.LocalityAwareness{
-								LocalZone: &v1alpha1.LocalZone{
-									AffinityTags: &[]v1alpha1.AffinityTag{
-										{
-											Key:    "k8s.io/node",
-											Weight: pointer.To[uint32](9000),
-										},
-										{
-											Key:    "k8s.io/az",
-											Weight: pointer.To[uint32](900),
-										},
-										{
-											Key:    "k8s.io/region",
-											Weight: pointer.To[uint32](90),
+			rules: core_rules.GatewayRules{
+				Rules: map[core_rules.InboundListener]core_rules.Rules{
+					{Address: "192.168.0.1", Port: 8080}: {
+						{
+							Subset: core_rules.Subset{},
+							Conf: v1alpha1.Conf{
+								LocalityAwareness: &v1alpha1.LocalityAwareness{
+									LocalZone: &v1alpha1.LocalZone{
+										AffinityTags: &[]v1alpha1.AffinityTag{
+											{
+												Key:    "k8s.io/node",
+												Weight: pointer.To[uint32](9000),
+											},
+											{
+												Key:    "k8s.io/az",
+												Weight: pointer.To[uint32](900),
+											},
+											{
+												Key:    "k8s.io/region",
+												Weight: pointer.To[uint32](90),
+											},
 										},
 									},
-								},
-								CrossZone: &v1alpha1.CrossZone{
-									Failover: []v1alpha1.Failover{
-										{
-											To: v1alpha1.ToZone{
-												Type:  v1alpha1.AnyExcept,
-												Zones: &[]string{"zone-3", "zone-4", "zone-5"},
+									CrossZone: &v1alpha1.CrossZone{
+										Failover: []v1alpha1.Failover{
+											{
+												To: v1alpha1.ToZone{
+													Type:  v1alpha1.AnyExcept,
+													Zones: &[]string{"zone-3", "zone-4", "zone-5"},
+												},
 											},
-										},
-										{
-											From: &v1alpha1.FromZone{
-												Zones: []string{"zone-1"},
+											{
+												From: &v1alpha1.FromZone{
+													Zones: []string{"zone-1"},
+												},
+												To: v1alpha1.ToZone{
+													Type:  v1alpha1.Only,
+													Zones: &[]string{"zone-3"},
+												},
 											},
-											To: v1alpha1.ToZone{
-												Type:  v1alpha1.Only,
-												Zones: &[]string{"zone-3"},
-											},
-										},
-										{
-											To: v1alpha1.ToZone{
-												Type:  v1alpha1.Only,
-												Zones: &[]string{"zone-4"},
+											{
+												To: v1alpha1.ToZone{
+													Type:  v1alpha1.Only,
+													Zones: &[]string{"zone-4"},
+												},
 											},
 										},
 									},


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- #8549 
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
