### PR TITLE
feat(MeshTrace): select MeshGateway listeners

### DIFF
--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.golden.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.golden.yaml
@@ -1,4 +1,11 @@
-Rules:
+SingleItemRules:
+  127.0.0.1:8080:
+    Rules: null
+  127.0.0.1:8081:
+    Rules: null
+  127.0.0.1:8082:
+    Rules: null
+ToRules:
   127.0.0.1:8080:
   - Conf:
       backends:

--- a/pkg/plugins/policies/core/rules/rules.go
+++ b/pkg/plugins/policies/core/rules/rules.go
@@ -48,7 +48,7 @@ type ToRules struct {
 }
 
 type GatewayRules struct {
-	Rules map[InboundListener]Rules
+	ToRules map[InboundListener]Rules
 }
 
 type SingleItemRules struct {
@@ -269,7 +269,7 @@ func BuildGatewayRules(
 		}
 		rulesByInbound[inbound] = rules.Rules
 	}
-	return GatewayRules{Rules: rulesByInbound}, nil
+	return GatewayRules{ToRules: rulesByInbound}, nil
 }
 
 func buildToList(p core_model.Resource, httpRoutes []core_model.Resource) ([]core_model.PolicyItem, error) {

--- a/pkg/plugins/policies/core/rules/rules.go
+++ b/pkg/plugins/policies/core/rules/rules.go
@@ -48,7 +48,8 @@ type ToRules struct {
 }
 
 type GatewayRules struct {
-	ToRules map[InboundListener]Rules
+	ToRules         map[InboundListener]Rules
+	SingleItemRules map[InboundListener]SingleItemRules
 }
 
 type SingleItemRules struct {
@@ -261,6 +262,7 @@ func BuildGatewayRules(
 	matchedPoliciesByInbound map[InboundListener][]core_model.Resource,
 	httpRoutes []core_model.Resource,
 ) (GatewayRules, error) {
+	singleItemRules := map[InboundListener]SingleItemRules{}
 	rulesByInbound := map[InboundListener]Rules{}
 	for inbound, policies := range matchedPoliciesByInbound {
 		rules, err := BuildToRules(policies, httpRoutes)
@@ -268,8 +270,16 @@ func BuildGatewayRules(
 			return GatewayRules{}, err
 		}
 		rulesByInbound[inbound] = rules.Rules
+
+		singleItemRules[inbound], err = BuildSingleItemRules(policies)
+		if err != nil {
+			return GatewayRules{}, err
+		}
 	}
-	return GatewayRules{ToRules: rulesByInbound}, nil
+	return GatewayRules{
+		ToRules:         rulesByInbound,
+		SingleItemRules: singleItemRules,
+	}, nil
 }
 
 func buildToList(p core_model.Resource, httpRoutes []core_model.Resource) ([]core_model.PolicyItem, error) {

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin.go
@@ -186,7 +186,7 @@ func applyToGateway(
 			continue
 		}
 
-		listenerRules, ok := rules.Rules[rulesListener]
+		listenerRules, ok := rules.ToRules[rulesListener]
 		if !ok {
 			continue
 		}

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
@@ -992,7 +992,7 @@ var _ = Describe("MeshAccessLog", func() {
 					Build(),
 			},
 			rules: core_rules.GatewayRules{
-				Rules: map[core_rules.InboundListener]core_rules.Rules{
+				ToRules: map[core_rules.InboundListener]core_rules.Rules{
 					{Address: "127.0.0.1", Port: 8080}: {
 						{
 							Subset: core_rules.Subset{},

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin.go
@@ -113,7 +113,7 @@ func applyToGateways(
 	proxy *core_xds.Proxy,
 ) error {
 	for _, listenerInfo := range gateway.ExtractGatewayListeners(proxy) {
-		rules, ok := gatewayRules.Rules[core_rules.InboundListener{
+		rules, ok := gatewayRules.ToRules[core_rules.InboundListener{
 			Address: proxy.Dataplane.Spec.GetNetworking().Address,
 			Port:    listenerInfo.Listener.Port,
 		}]

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin_test.go
@@ -433,7 +433,7 @@ var _ = Describe("MeshCircuitBreaker", func() {
 		Entry("basic outbound cluster with connection limits", gatewayTestCase{
 			name: "basic",
 			rules: core_rules.GatewayRules{
-				Rules: map[core_rules.InboundListener]core_rules.Rules{
+				ToRules: map[core_rules.InboundListener]core_rules.Rules{
 					{Address: "192.168.0.1", Port: 8080}: {{
 						Subset: core_rules.Subset{core_rules.Tag{
 							Key:   mesh_proto.ServiceTag,

--- a/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin.go
@@ -103,7 +103,7 @@ func applyToGateways(
 		if !ok {
 			continue
 		}
-		rules, ok := rules.Rules[listenerKey]
+		rules, ok := rules.ToRules[listenerKey]
 		if !ok {
 			continue
 		}

--- a/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin_test.go
@@ -195,7 +195,7 @@ var _ = Describe("MeshFaultInjection", func() {
 	It("should generate proper Envoy config for MeshGateway Dataplanes", func() {
 		// given
 		rules := core_rules.GatewayRules{
-			Rules: map[core_rules.InboundListener]core_rules.Rules{
+			ToRules: map[core_rules.InboundListener]core_rules.Rules{
 				{Address: "192.168.0.1", Port: 8080}: {{
 					Subset: core_rules.Subset{},
 					Conf: api.Conf{

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin.go
@@ -67,7 +67,7 @@ func applyToGateways(
 	proxy *core_xds.Proxy,
 ) error {
 	for _, listenerInfo := range gateway_plugin.ExtractGatewayListeners(proxy) {
-		rules, ok := gatewayRules.Rules[core_rules.InboundListener{
+		rules, ok := gatewayRules.ToRules[core_rules.InboundListener{
 			Address: proxy.Dataplane.Spec.GetNetworking().Address,
 			Port:    listenerInfo.Listener.Port,
 		}]

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
@@ -275,7 +275,7 @@ var _ = Describe("MeshHealthCheck", func() {
 		Entry("basic outbound cluster with HTTP health check", gatewayTestCase{
 			name: "basic",
 			rules: core_rules.GatewayRules{
-				Rules: map[core_rules.InboundListener]core_rules.Rules{
+				ToRules: map[core_rules.InboundListener]core_rules.Rules{
 					{Address: "192.168.0.1", Port: 8080}: {
 						{
 							Subset: core_rules.Subset{},

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
@@ -182,7 +182,7 @@ func (p plugin) configureGateway(
 			continue
 		}
 
-		rules, ok := rules.Rules[inboundListener]
+		rules, ok := rules.ToRules[inboundListener]
 		if !ok {
 			continue
 		}

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
@@ -1281,7 +1281,7 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 					createEndpointBuilderWith("test-zone-2", "192.168.1.2", map[string]string{}),
 				),
 			rules: core_rules.GatewayRules{
-				Rules: map[core_rules.InboundListener]core_rules.Rules{
+				ToRules: map[core_rules.InboundListener]core_rules.Rules{
 					{Address: "192.168.0.1", Port: 8080}: {
 						{
 							Subset: core_rules.Subset{},
@@ -1330,7 +1330,7 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 					createEndpointBuilderWith("zone-5", "192.168.1.8", map[string]string{}),
 				),
 			rules: core_rules.GatewayRules{
-				Rules: map[core_rules.InboundListener]core_rules.Rules{
+				ToRules: map[core_rules.InboundListener]core_rules.Rules{
 					{Address: "192.168.0.1", Port: 8080}: {
 						{
 							Subset: core_rules.Subset{},

--- a/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
@@ -37,7 +37,7 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 	if !ok {
 		return nil
 	}
-	if len(policies.ToRules.Rules) == 0 && len(policies.FromRules.Rules) == 0 && len(policies.GatewayRules.Rules) == 0 {
+	if len(policies.ToRules.Rules) == 0 && len(policies.FromRules.Rules) == 0 && len(policies.GatewayRules.ToRules) == 0 {
 		return nil
 	}
 
@@ -169,7 +169,7 @@ func applyToGateway(
 	proxy *core_xds.Proxy,
 ) error {
 	for _, listenerInfo := range gateway_plugin.ExtractGatewayListeners(proxy) {
-		rules, ok := rules.Rules[core_rules.InboundListener{
+		rules, ok := rules.ToRules[core_rules.InboundListener{
 			Address: proxy.Dataplane.Spec.GetNetworking().Address,
 			Port:    listenerInfo.Listener.Port,
 		}]

--- a/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin_test.go
@@ -448,7 +448,7 @@ var _ = Describe("MeshTimeout", func() {
 		Expect(getResourceYaml(generatedResources.ListOf(envoy_resource.RouteType))).To(matchers.MatchGoldenYAML(filepath.Join("..", "testdata", fmt.Sprintf("%s.gateway.route.golden.yaml", name))))
 	}, Entry("basic", gatewayTestCase{
 		rules: core_rules.GatewayRules{
-			Rules: map[core_rules.InboundListener]core_rules.Rules{
+			ToRules: map[core_rules.InboundListener]core_rules.Rules{
 				{Address: "192.168.0.1", Port: 8080}: {
 					{
 						Subset: core_rules.MeshSubset(),
@@ -468,7 +468,7 @@ var _ = Describe("MeshTimeout", func() {
 		},
 	}), Entry("no-default-idle-timeout", gatewayTestCase{
 		rules: core_rules.GatewayRules{
-			Rules: map[core_rules.InboundListener]core_rules.Rules{
+			ToRules: map[core_rules.InboundListener]core_rules.Rules{
 				{Address: "192.168.0.1", Port: 8080}: {
 					{
 						Subset: core_rules.MeshSubset(),
@@ -494,7 +494,7 @@ var _ = Describe("MeshTimeout", func() {
 				Build(),
 		},
 		rules: core_rules.GatewayRules{
-			Rules: map[core_rules.InboundListener]core_rules.Rules{
+			ToRules: map[core_rules.InboundListener]core_rules.Rules{
 				{Address: "192.168.0.1", Port: 8080}: {
 					{
 						Subset: core_rules.MeshService("backend"),

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/simple-gateway.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/simple-gateway.listeners.golden.yaml
@@ -1,0 +1,68 @@
+address:
+  socketAddress:
+    address: 192.168.0.1
+    portValue: 8080
+enableReusePort: true
+filterChains:
+- filters:
+  - name: envoy.filters.network.http_connection_manager
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+      commonHttpProtocolOptions:
+        headersWithUnderscoresAction: REJECT_REQUEST
+        idleTimeout: 300s
+      http2ProtocolOptions:
+        allowConnect: true
+        initialConnectionWindowSize: 1048576
+        initialStreamWindowSize: 65536
+        maxConcurrentStreams: 100
+      httpFilters:
+      - name: envoy.filters.http.local_ratelimit
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+          statPrefix: rate_limit
+      - name: gzip-compress
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+          compressorLibrary:
+            name: gzip
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+          responseDirectionConfig:
+            disableOnEtagHeader: true
+      - name: envoy.filters.http.router
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          startChildSpan: true
+      mergeSlashes: true
+      normalizePath: true
+      pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
+      rds:
+        configSource:
+          ads: {}
+          resourceApiVersion: V3
+        routeConfigName: sample-gateway:HTTP:8080
+      requestHeadersTimeout: 0.500s
+      serverName: Kuma Gateway
+      statPrefix: sample-gateway
+      streamIdleTimeout: 5s
+      tracing:
+        provider:
+          name: envoy.tracers.zipkin
+          typedConfig:
+            '@type': type.googleapis.com/envoy.config.trace.v3.ZipkinConfig
+            collectorCluster: meshtrace:zipkin
+            collectorEndpoint: /api/v2/spans
+            collectorEndpointVersion: HTTP_JSON
+            collectorHostname: jaeger-collector.mesh-observability:9411
+            sharedSpanContext: true
+            splitSpansForRequest: true
+            traceId128bit: true
+      useRemoteAddress: true
+listenerFilters:
+- name: envoy.filters.listener.tls_inspector
+  typedConfig:
+    '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+name: sample-gateway:HTTP:8080
+perConnectionBufferLimitBytes: 32768
+trafficDirection: INBOUND


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- #8549 
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
