### PR TITLE
chore(kuma-cp): include stack traces on runtime errors

### DIFF
--- a/pkg/core/runtime/component/resilient.go
+++ b/pkg/core/runtime/component/resilient.go
@@ -33,7 +33,7 @@ func (r *resilientComponent) Start(stop <-chan struct{}) error {
 			defer func() {
 				if e := recover(); e != nil {
 					if err, ok := e.(error); ok {
-						errCh <- err
+						errCh <- errors.WithStack(err)
 					} else {
 						errCh <- errors.Errorf("%v", e)
 					}

--- a/pkg/util/watchdog/watchdog.go
+++ b/pkg/util/watchdog/watchdog.go
@@ -59,7 +59,7 @@ func (w *SimpleWatchdog) onTick(ctx context.Context) error {
 				var err error
 				switch typ := cause.(type) {
 				case error:
-					err = typ
+					err = errors.WithStack(typ)
 				default:
 					err = errors.Errorf("%v", cause)
 				}


### PR DESCRIPTION
Right now, runtime errors, like out of bounds accesses, aren't logged with a stack trace.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
