### PR TITLE
test(MeshTCPRoute): improve and fix test cases

### DIFF
--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
@@ -213,7 +213,7 @@ var _ = Describe("MeshTCPRoute", func() {
 						WithPort(8005).
 						WithWeight(1).
 						WithTags(mesh_proto.ServiceTag, "backend", mesh_proto.ProtocolTag, core_mesh.ProtocolHTTP, "region", "us")).
-				AddEndpoint("other-service", xds_builders.Endpoint().
+				AddEndpoint("other-backend", xds_builders.Endpoint().
 					WithTarget("192.168.0.6").
 					WithPort(8006).
 					WithWeight(1).
@@ -228,6 +228,7 @@ var _ = Describe("MeshTCPRoute", func() {
 			rules := core_rules.ToRules{
 				Rules: core_rules.Rules{
 					{
+						Subset: core_rules.MeshService("backend"),
 						Conf: api.Rule{
 							Default: api.RuleConf{
 								BackendRefs: []common_api.BackendRef{
@@ -271,7 +272,11 @@ var _ = Describe("MeshTCPRoute", func() {
 					AddServiceProtocol("externalservice", core_mesh.ProtocolHTTP2).
 					Build(),
 				proxy: xds_builders.Proxy().
-					WithDataplane(samples.DataplaneWebBuilder()).
+					WithDataplane(
+						samples.DataplaneWebBuilder().
+							AddOutboundToService("other-backend").
+							AddOutboundToService("externalservice"),
+					).
 					WithRouting(
 						xds_builders.Routing().
 							WithOutboundTargets(outboundTargets).
@@ -297,6 +302,7 @@ var _ = Describe("MeshTCPRoute", func() {
 			rules := core_rules.ToRules{
 				Rules: core_rules.Rules{
 					{
+						Subset: core_rules.MeshService("backend"),
 						Conf: api.Rule{
 							Default: api.RuleConf{
 								BackendRefs: []common_api.BackendRef{
@@ -319,7 +325,10 @@ var _ = Describe("MeshTCPRoute", func() {
 					AddServiceProtocol("tcp-backend", core_mesh.ProtocolTCP).
 					Build(),
 				proxy: xds_builders.Proxy().
-					WithDataplane(samples.DataplaneWebBuilder()).
+					WithDataplane(
+						samples.DataplaneWebBuilder().
+							AddOutboundToService("tcp-backend"),
+					).
 					WithRouting(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
 					WithPolicies(xds_builders.MatchedPolicies().WithToPolicy(api.MeshTCPRouteType, rules)).
 					Build(),
@@ -346,6 +355,7 @@ var _ = Describe("MeshTCPRoute", func() {
 			tcpRules := core_rules.ToRules{
 				Rules: core_rules.Rules{
 					{
+						Subset: core_rules.MeshService("backend"),
 						Conf: api.Rule{
 							Default: api.RuleConf{
 								BackendRefs: []common_api.BackendRef{
@@ -365,6 +375,7 @@ var _ = Describe("MeshTCPRoute", func() {
 			httpRules := core_rules.ToRules{
 				Rules: core_rules.Rules{
 					{
+						Subset: core_rules.MeshService("backend"),
 						Conf: meshhttproute_api.PolicyDefault{
 							Rules: []meshhttproute_api.Rule{
 								{
@@ -398,7 +409,11 @@ var _ = Describe("MeshTCPRoute", func() {
 					AddServiceProtocol("http-backend", core_mesh.ProtocolHTTP).
 					Build(),
 				proxy: xds_builders.Proxy().
-					WithDataplane(samples.DataplaneWebBuilder()).
+					WithDataplane(
+						samples.DataplaneWebBuilder().
+							AddOutboundToService("tcp-backend").
+							AddOutboundToService("http-backend"),
+					).
 					WithRouting(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
 					WithPolicies(
 						xds_builders.MatchedPolicies().
@@ -429,6 +444,7 @@ var _ = Describe("MeshTCPRoute", func() {
 			tcpRules := core_rules.ToRules{
 				Rules: core_rules.Rules{
 					{
+						Subset: core_rules.MeshService("backend"),
 						Conf: api.Rule{
 							Default: api.RuleConf{
 								BackendRefs: []common_api.BackendRef{
@@ -448,6 +464,7 @@ var _ = Describe("MeshTCPRoute", func() {
 			httpRules := core_rules.ToRules{
 				Rules: core_rules.Rules{
 					{
+						Subset: core_rules.MeshService("backend"),
 						Conf: meshhttproute_api.PolicyDefault{
 							Rules: []meshhttproute_api.Rule{
 								{
@@ -481,7 +498,11 @@ var _ = Describe("MeshTCPRoute", func() {
 					AddServiceProtocol("http-backend", core_mesh.ProtocolHTTP).
 					Build(),
 				proxy: xds_builders.Proxy().
-					WithDataplane(samples.DataplaneWebBuilder()).
+					WithDataplane(
+						samples.DataplaneWebBuilder().
+							AddOutboundToService("tcp-backend").
+							AddOutboundToService("http-backend"),
+					).
 					WithRouting(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
 					WithPolicies(
 						xds_builders.MatchedPolicies().

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/split-traffic.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/split-traffic.endpoints.golden.yaml
@@ -43,3 +43,17 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
     clusterName: other-backend
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.0.6
+              portValue: 8006
+        loadBalancingWeight: 1
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              kuma.io/protocol: http
+            envoy.transport_socket_match:
+              kuma.io/protocol: http


### PR DESCRIPTION
* Fix service/endpoint inconsistency
* These confs need to have a `MeshService` subset since `kind: Mesh` isn't allowed with `MeshTCPRoute.spec.to[].targetRef`
  * This means I'm kind of guessing at the intention of the tests
* Outbounds were missing from the `Dataplanes`

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
