### PR TITLE
docs(MADR): document transition from TrafficRoute to Mesh*Route

### DIFF
--- a/docs/madr/decisions/036-route-transition.md
+++ b/docs/madr/decisions/036-route-transition.md
@@ -1,0 +1,63 @@
+# Moving to routes 2.0
+
+- Status: accepted
+
+## Context and Problem Statement
+
+This document is meant to make explicit how we will transition
+from `TrafficRoute` to `MeshTCPRoute` and `MeshHTTPRoute` and also how
+these policies interact with each other.
+
+### Status quo
+
+With the new paradigm "no default creation for 2.0 policies" it becomes necessary
+for traffic to flow when there are no `TrafficRoutes` and no
+`MeshTCPRoutes`/`MeshHTTPRoute`. This break from the behavior of `TrafficRoutes` and the
+ensuing migration need some careful consideration.
+
+## Decision Drivers
+
+- When installing Kuma, traffic should continue to flow assuming the user takes no
+  explicit action to configure routing.
+- Avoid creation of resources by the CP when a `Mesh` is created
+- Provide a smooth transition for `TrafficRoutes` to `Mesh*Route`
+
+## Decision Outcome
+
+- Depend on the existence of _any_ `TrafficRoute` resources in the `Mesh` to determine which behavior wins.
+
+### Scenarios
+
+So when would we generate Envoy listeners and routes allowing traffic to flow from
+service A to B?
+
+|                                       | Any `TrafficRoutes` resource exists | No `TrafficRoutes`                        |
+| ------------------------------------- | ----------------------------------- | ----------------------------------------- |
+| Some `Mesh*Route.spec.to` targets `B` | configured by `Mesh*Route`          | configured by `Mesh*Route`                |
+| No `Mesh*Route.spec.to` targets `B`   | configured by `TrafficRoutes`       | traffic flows, configured by `Mesh*Route` |
+
+Note that currently, no `TrafficRoutes`, no `Mesh*Routes` would mean a broken
+cluster and is therefore in some sense an invalid state. This state is the only
+one for which behavior changes in a breaking way. Right now, we
+require a `TrafficRoute` to exist in order to route traffic if there are _no_
+`Mesh*Routes` matching a given data plane proxy. This will no longer be
+necessary.
+
+#### Destination is `HTTP`
+
+|        | Both exist                    | Some `MeshHTTPRoute`, no `MeshTCPRoute` | No `MeshHTTPRoute`, no `MeshTCPRoute` | No `MeshHTTPRoute`, some `MeshTCPRoute` |
+| ------ | ----------------------------- | --------------------------------------- | ------------------------------------- | --------------------------------------- |
+| `HTTP` | configured by `MeshHTTPRoute` | configured by `MeshHTTPRoute`           | configured by `MeshHTTPRoute`         | configured by `MeshTCPRoute`, as TCP    |
+
+#### Destination is `TCP`
+
+Routes to `TCP` protocol services are always configured by `MeshTCPRoute`.
+
+### Positive Consequences <!-- optional -->
+
+- Users can transition to the intended behavior of `Mesh*Route` where no
+  resource is necessary
+
+### Negative Consequences <!-- optional -->
+
+None?


### PR DESCRIPTION
[Rendered](https://github.com/michaelbeaumont/kuma/blob/docs/madr-route-transition/docs/madr/decisions/036-route-transition.md)

For the record.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
