### PR TITLE
ci(publish): don't use -i in docker

### DIFF
--- a/mk/distribution.mk
+++ b/mk/distribution.mk
@@ -75,7 +75,7 @@ publish/pulp/$(DISTRIBUTION_TARGET_NAME)-$(1)-$(2):
 		-e USE_CLOUDSMITH=x \
 		-e USE_PULP=x \
 		-v $(TOP)/build/distributions/out:/files:ro \
-		-it \
+		-t \
 		$(PULP_RELEASE_IMAGE) \
 		release \
 		--file=/files/$(DISTRIBUTION_TARGET_NAME)-$(1)-$(2).tar.gz \

--- a/mk/distribution.mk
+++ b/mk/distribution.mk
@@ -75,7 +75,6 @@ publish/pulp/$(DISTRIBUTION_TARGET_NAME)-$(1)-$(2):
 		-e USE_CLOUDSMITH=x \
 		-e USE_PULP=x \
 		-v $(TOP)/build/distributions/out:/files:ro \
-		-t \
 		$(PULP_RELEASE_IMAGE) \
 		release \
 		--file=/files/$(DISTRIBUTION_TARGET_NAME)-$(1)-$(2).tar.gz \


### PR DESCRIPTION
This was causing issues in CI like GH actions which don't have tty

addresses the failure: https://github.com/kumahq/kuma/actions/runs/7185343654/job/19571263923#step:11:17

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
