### PR TITLE
refactor(pkg/core): create MustNewList and MustNewObject for registry

### DIFF
--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -538,7 +538,7 @@ func (r *resourceEndpoints) matchingDataplanesForPolicy() restful.RouteFunction 
 			}
 			return false
 		}
-		dppList, _ := registry.Global().NewList(mesh.DataplaneType)
+		dppList := registry.Global().MustNewList(mesh.DataplaneType)
 		err = r.resManager.List(request.Request.Context(), dppList,
 			store.ListByMesh(meshName),
 			store.ListByNameContains(nameContains),

--- a/pkg/core/resources/registry/registry.go
+++ b/pkg/core/resources/registry/registry.go
@@ -115,18 +115,18 @@ func (t *typeRegistry) NewList(resType model.ResourceType) (model.ResourceList, 
 
 // MustNewObject implements TypeRegistry.
 func (t *typeRegistry) MustNewObject(resType model.ResourceType) model.Resource {
-	typDesc, ok := t.descriptors[resType]
-	if !ok {
-		panic(fmt.Sprintf("invalid resource type %q", resType))
+	res, err := t.NewObject(resType)
+	if err != nil {
+		panic(err)
 	}
-	return typDesc.NewObject()
+	return res
 }
 
 // MustNewList implements TypeRegistry.
 func (t *typeRegistry) MustNewList(resType model.ResourceType) model.ResourceList {
-	typDesc, ok := t.descriptors[resType]
-	if !ok {
-		panic(fmt.Sprintf("invalid resource type %q", resType))
+	resList, err := t.NewList(resType)
+	if err != nil {
+		panic(err)
 	}
-	return typDesc.NewList()
+	return resList
 }

--- a/pkg/core/resources/registry/registry.go
+++ b/pkg/core/resources/registry/registry.go
@@ -14,6 +14,10 @@ type TypeRegistry interface {
 
 	NewObject(model.ResourceType) (model.Resource, error)
 	NewList(model.ResourceType) (model.ResourceList, error)
+
+	MustNewObject(model.ResourceType) model.Resource
+	MustNewList(model.ResourceType) model.ResourceList
+
 	DescriptorFor(resourceType model.ResourceType) (model.ResourceTypeDescriptor, error)
 
 	ObjectTypes(filters ...model.TypeFilter) []model.ResourceType
@@ -107,4 +111,22 @@ func (t *typeRegistry) NewList(resType model.ResourceType) (model.ResourceList, 
 		return nil, errors.Errorf("invalid resource type %q", resType)
 	}
 	return typDesc.NewList(), nil
+}
+
+// MustNewObject implements TypeRegistry.
+func (t *typeRegistry) MustNewObject(resType model.ResourceType) model.Resource {
+	typDesc, ok := t.descriptors[resType]
+	if !ok {
+		panic(fmt.Sprintf("invalid resource type %q", resType))
+	}
+	return typDesc.NewObject()
+}
+
+// MustNewList implements TypeRegistry.
+func (t *typeRegistry) MustNewList(resType model.ResourceType) model.ResourceList {
+	typDesc, ok := t.descriptors[resType]
+	if !ok {
+		panic(fmt.Sprintf("invalid resource type %q", resType))
+	}
+	return typDesc.NewList()
 }

--- a/pkg/gc/finalizer.go
+++ b/pkg/gc/finalizer.go
@@ -123,7 +123,7 @@ func (f *subscriptionFinalizer) Start(stop <-chan struct{}) error {
 
 func (f *subscriptionFinalizer) checkGeneration(ctx context.Context, typ core_model.ResourceType, now time.Time) error {
 	// get all the insights for provided type
-	insights, _ := registry.Global().NewList(typ)
+	insights := registry.Global().MustNewList(typ)
 	if err := f.rm.List(ctx, insights); err != nil {
 		return err
 	}
@@ -165,7 +165,7 @@ func (f *subscriptionFinalizer) checkGeneration(ctx context.Context, typ core_mo
 			}
 		}
 
-		upsertInsight, _ := registry.Global().NewObject(typ)
+		upsertInsight := registry.Global().MustNewObject(typ)
 		if err := manager.Upsert(ctx, f.rm, key, upsertInsight, func(r core_model.Resource) error {
 			insight := upsertInsight.GetSpec().(generic.Insight)
 			for id := range subsToFinalize {

--- a/pkg/kds/reconcile/snapshot_generator.go
+++ b/pkg/kds/reconcile/snapshot_generator.go
@@ -77,7 +77,7 @@ func (s *snapshotGenerator) getResources(ctx context.Context, typ model.Resource
 func (s *snapshotGenerator) filter(ctx context.Context, rs model.ResourceList, node *envoy_core.Node) model.ResourceList {
 	features := getFeatures(node)
 
-	rv, _ := registry.Global().NewList(rs.GetItemType())
+	rv := registry.Global().MustNewList(rs.GetItemType())
 	for _, r := range rs.GetItems() {
 		if s.resourceFilter(ctx, node.GetId(), features, r) {
 			_ = rv.AddItem(r)
@@ -89,7 +89,7 @@ func (s *snapshotGenerator) filter(ctx context.Context, rs model.ResourceList, n
 func (s *snapshotGenerator) mapper(rs model.ResourceList, node *envoy_core.Node) (model.ResourceList, error) {
 	features := getFeatures(node)
 
-	rv, _ := registry.Global().NewList(rs.GetItemType())
+	rv := registry.Global().MustNewList(rs.GetItemType())
 	for _, r := range rs.GetItems() {
 		resource, err := s.resourceMapper(features, r)
 		if err != nil {

--- a/pkg/kds/v2/reconcile/snapshot_generator.go
+++ b/pkg/kds/v2/reconcile/snapshot_generator.go
@@ -75,7 +75,7 @@ func (s *snapshotGenerator) getResources(ctx context.Context, typ model.Resource
 func (s *snapshotGenerator) filter(ctx context.Context, rs model.ResourceList, node *envoy_core.Node) model.ResourceList {
 	features := getFeatures(node)
 
-	rv, _ := registry.Global().NewList(rs.GetItemType())
+	rv := registry.Global().MustNewList(rs.GetItemType())
 	for _, r := range rs.GetItems() {
 		if s.resourceFilter(ctx, node.GetId(), features, r) {
 			_ = rv.AddItem(r)
@@ -87,7 +87,7 @@ func (s *snapshotGenerator) filter(ctx context.Context, rs model.ResourceList, n
 func (s *snapshotGenerator) mapper(rs model.ResourceList, node *envoy_core.Node) (model.ResourceList, error) {
 	features := getFeatures(node)
 
-	rv, _ := registry.Global().NewList(rs.GetItemType())
+	rv := registry.Global().MustNewList(rs.GetItemType())
 	for _, r := range rs.GetItems() {
 		resource, err := s.resourceMapper(features, r)
 		if err != nil {


### PR DESCRIPTION
add MustNewList and MustNewObject to TypeRegistry interface, panic on error and replace calls where the errors are ignored

'Create Must* functions for registry.Global #2572'
https://github.com/kumahq/kuma/issues/2572

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
