### PR TITLE
test(xds): add default allow all to ingress test resources

### DIFF
--- a/pkg/xds/generator/ingress_generator_test.go
+++ b/pkg/xds/generator/ingress_generator_test.go
@@ -944,6 +944,25 @@ var _ = Describe("IngressGenerator", func() {
 						},
 					},
 					Resources: map[core_model.ResourceType]core_model.ResourceList{
+						core_mesh.TrafficRouteType: &core_mesh.TrafficRouteResourceList{
+							Items: []*core_mesh.TrafficRouteResource{{
+								Meta: &test_model.ResourceMeta{Name: "default-allow-all"},
+								Spec: &mesh_proto.TrafficRoute{
+									Sources: []*mesh_proto.Selector{{
+										Match: mesh_proto.MatchAnyService(),
+									}},
+									Destinations: []*mesh_proto.Selector{{
+										Match: mesh_proto.MatchAnyService(),
+									}},
+									Conf: &mesh_proto.TrafficRoute_Conf{
+										Destination: mesh_proto.MatchAnyService(),
+										LoadBalancer: &mesh_proto.TrafficRoute_LoadBalancer{
+											LbType: &mesh_proto.TrafficRoute_LoadBalancer_RoundRobin_{},
+										},
+									},
+								},
+							}},
+						},
 						core_mesh.VirtualOutboundType: &core_mesh.VirtualOutboundResourceList{
 							Items: []*core_mesh.VirtualOutboundResource{
 								{

--- a/pkg/xds/generator/testdata/ingress/virtual-outbound.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/virtual-outbound.envoy.golden.yaml
@@ -87,6 +87,16 @@ resources:
               envoy.lb:
                 kuma.io/instance: ins-1
           statPrefix: mesh1_backend
+    - filterChainMatch:
+        serverNames:
+        - backend{mesh=mesh1}
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: mesh1:backend
+          statPrefix: mesh1_backend
     listenerFilters:
     - name: envoy.filters.listener.tls_inspector
       typedConfig:


### PR DESCRIPTION
Otherwise there are no traffic routes present for this test which isn't a realistic scenario.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
