### PR TITLE
ci(github): use a ci_tools dir inside the checkout

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -9,6 +9,7 @@ env:
   # This is automatically managed by CI
   K8S_MIN_VERSION: v1.23.17-k3s1
   K8S_MAX_VERSION: v1.28.1-k3s1
+  CI_TOOLS_DIR: /home/runner/work/kuma/kuma/.ci_tools
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -22,7 +23,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: |
-            ~/.kuma-dev
+            ${{ env.CI_TOOLS_DIR }}
           key: ${{ runner.os }}-devtools-${{ hashFiles('mk/dependencies/deps.lock') }}
           restore-keys: |
             ${{ runner.os }}-devtools
@@ -46,7 +47,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: |
-            ~/.kuma-dev
+            ${{ env.CI_TOOLS_DIR }}
           key: ${{ runner.os }}-devtools-${{ hashFiles('mk/dependencies/deps.lock') }}
           restore-keys: |
             ${{ runner.os }}-devtools
@@ -107,7 +108,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: |
-            ~/.kuma-dev
+            ${{ env.CI_TOOLS_DIR }}
           key: ${{ runner.os }}-devtools-${{ hashFiles('mk/dependencies/deps.lock') }}
           restore-keys: |
             ${{ runner.os }}-devtools
@@ -163,7 +164,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: |
-            ~/.kuma-dev
+            ${{ env.CI_TOOLS_DIR }}
           key: ${{ runner.os }}-devtools-${{ hashFiles('mk/dependencies/deps.lock') }}
           restore-keys: |
             ${{ runner.os }}-devtools

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 # IDE: VS Code
 .vscode/
 
+.ci_tools/
+
 # asdf
 .tool-versions
 


### PR DESCRIPTION
Because it makes sense and it's easier on self-hosted runners

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
