### PR TITLE
ci(docs): change auto-generated docs path in kuma-website

### DIFF
--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -36,7 +36,7 @@ jobs:
             echo "${b} ${name}"
             git checkout --force "${b}"
             mkdir -p ../docs-build/${name}/raw
-            cp -R docs/generated/raw/* ../docs-build/${name}/raw/
+            cp -R docs/generated/raw ../docs-build/${name}/
             mkdir -p ../docs-build/raw
             if [[ "${b}" == "master" ]]; then
               if [[ -f UPGRADE.md ]]; then

--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -13,7 +13,7 @@ on:
     - cron: 0 8 * * *
 env:
   DOCS_REPO: kumahq/kuma-website
-  OUTPUT_PATH: app/docs
+  OUTPUT_PATH: app/assets
   VERSION_FILE: app/_data/versions.yml
   EDITION: kuma
 jobs:
@@ -35,8 +35,8 @@ jobs:
             name=$(echo "${b}" | sed 's/release-\(.*\)/\1.x/g' | sed 's/master/dev/g')
             echo "${b} ${name}"
             git checkout --force "${b}"
-            mkdir -p ../docs-build/${name}
-            cp -R docs/generated/raw/* ../docs-build/${name}/
+            mkdir -p ../docs-build/${name}/raw
+            cp -R docs/generated/raw/* ../docs-build/${name}/raw/
             mkdir -p ../docs-build/raw
             if [[ "${b}" == "master" ]]; then
               if [[ -f UPGRADE.md ]]; then


### PR DESCRIPTION
[Related PR](https://github.com/kumahq/kuma-website/pull/1554)

Update github action to copy the auto-generated docs to `app/assets/<versions>/raw/`

These are static files and shoudn't be processed by Jekyll, moving them to app/assets prevents that from happening.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
