### PR TITLE
feat(ExternalService): validate same value for service and address

### DIFF
--- a/pkg/core/resources/apis/mesh/external_service_validator.go
+++ b/pkg/core/resources/apis/mesh/external_service_validator.go
@@ -30,6 +30,12 @@ func (es *ExternalServiceResource) Validate() error {
 		ExtraTagsValidators: []TagsValidatorFunc{validateProtocol},
 	}))
 
+	if service := es.Spec.GetService(); service != "" {
+		if host, _, e := net.SplitHostPort(es.Spec.GetNetworking().GetAddress()); e == nil && service == host {
+			err.AddViolationAt(validators.RootedAt("tags").Key(mesh_proto.ServiceTag), "cannot be the same as networking.address")
+		}
+	}
+
 	return err.OrNil()
 }
 

--- a/pkg/core/resources/apis/mesh/external_service_validator_test.go
+++ b/pkg/core/resources/apis/mesh/external_service_validator_test.go
@@ -329,5 +329,19 @@ var _ = Describe("ExternalService", func() {
                 - field: networking.tls.clientKey
                   message: data source cannot be empty`,
 		}),
+		Entry("kuma.io/service and networking address clash", testCase{
+			dataplane: `
+                type: ExternalService
+                name: es-1
+                mesh: default
+                networking:
+                  address: httpbin.org:80
+                tags:
+                  kuma.io/service: httpbin.org`,
+			expected: `
+                violations:
+                - field: tags["kuma.io/service"]
+                  message: cannot be the same as networking.address`,
+		}),
 	)
 })


### PR DESCRIPTION
### Checklist prior to review

We cannot use same service tag as hostname.
When we do this, we create Envoy Cluster of name "hostname.org" then when Envoy does DNS resolution instead of returning VIPs it returns actual IPs. It seems that it's a (not documented?) behavior of DNSFilter that it first lookup for host = cluster name and only then it goes through the static list of IPs https://github.com/envoyproxy/envoy/blob/2c7edc491b6e5b0e4a9fa76b5f3aa647f41eb1af/source/extensions/filters/udp/dns_filter/dns_filter.cc#L325C1-L326C1

fix #8075

Technically it's a breaking change, but since the behavior was broken I don't think anyone uses it

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
