### PR TITLE
docs(MADR): internal listener naming

### DIFF
--- a/docs/madr/decisions/036-internal-listeners.md
+++ b/docs/madr/decisions/036-internal-listeners.md
@@ -1,0 +1,15 @@
+# Internal listeners naming convention
+* status: accepted
+
+## Context and Problem statement
+At the moment we don't clearly distinguish between listeners used for service to service communication
+and internal listeners, like Prometheus listeners.
+
+## Decision Outcome
+
+We will add prefix `_` to internal listeners.
+
+## Solution
+At the moments internal listeners names start with `kuma` prefix, problem is that service can also have this prefix.
+To be able to easily distinguish between service listeners and internal listeners, we can
+add `_` prefix to listener name

--- a/docs/madr/decisions/036-internal-listeners.md
+++ b/docs/madr/decisions/036-internal-listeners.md
@@ -12,4 +12,9 @@ We will add prefix `_` to internal listeners.
 ## Solution
 At the moments internal listeners names start with `kuma` prefix, problem is that service can also have this prefix.
 To be able to easily distinguish between service listeners and internal listeners, we can
-add `_` prefix to listener name
+add `_` prefix to listener name.
+
+I've looked into usage of these names in metrics, dashboards and other places and didn't find anything we 
+should worry about. Also this convention is already used in MeshMetric and we didn't find any issues.
+
+When migrating resources names remember to add info on how to migrate in UPGRADE.md.


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
