### PR TITLE
test(framework): get logs from pods when it's not available to help diagnose CI issues

### DIFF
--- a/test/framework/k8s.go
+++ b/test/framework/k8s.go
@@ -282,8 +282,9 @@ func getObjectEvents(testingT testing.TestingT, kubectlOptions *k8s.KubectlOptio
 
 func getPodLogs(testingT testing.TestingT, kubectlOptions *k8s.KubectlOptions, pod *v1.Pod) map[string]string {
 	var allLogs map[string]string
-
-	for _, c := range pod.Status.ContainerStatuses {
+	allContainers := append([]v1.ContainerStatus{}, pod.Status.InitContainerStatuses...)
+	allContainers = append(allContainers, pod.Status.ContainerStatuses...)
+	for _, c := range allContainers {
 		logs, err := k8s.GetPodLogsE(testingT, kubectlOptions, pod, c.Name)
 		if err != nil {
 			continue


### PR DESCRIPTION


### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - N/A
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS 
  - Confirmed
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) 
  - Manual tested
  - Don't forget `ci/` labels to run additional/fewer tests
    - Added
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? 
  - No need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) 
  - No need

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
