### PR TITLE
test(postgres): simplify tests to hope to get stability

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,3 +30,4 @@ updates:
     open-pull-requests-limit: 15
     labels:
       - "dependencies"      
+      - "ci/skip-test" # No need to run tests on github actions updates

--- a/pkg/plugins/leader/postgres/leader_elector_test.go
+++ b/pkg/plugins/leader/postgres/leader_elector_test.go
@@ -23,7 +23,7 @@ var _ = Describe("postgresLeaderElector", func() {
 		Expect(c.Start()).To(Succeed())
 		cfg, err := c.Config()
 		Expect(err).ToNot(HaveOccurred())
-		sql, err := common_postgres.ConnectToDb(*cfg)
+		sql, err := common_postgres.ConnectToDb(cfg)
 		Expect(err).ToNot(HaveOccurred())
 
 		createElector := func(name string) component.LeaderElector {

--- a/pkg/plugins/leader/postgres/postgres_suite_test.go
+++ b/pkg/plugins/leader/postgres/postgres_suite_test.go
@@ -1,4 +1,4 @@
-package postgres
+package postgres_test
 
 import (
 	"testing"

--- a/pkg/plugins/resources/postgres/listener_test.go
+++ b/pkg/plugins/resources/postgres/listener_test.go
@@ -1,4 +1,4 @@
-package postgres
+package postgres_test
 
 import (
 	"context"
@@ -7,34 +7,28 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	postgres_config "github.com/kumahq/kuma/pkg/config/plugins/resources/postgres"
+	config_postgres "github.com/kumahq/kuma/pkg/config/plugins/resources/postgres"
 	"github.com/kumahq/kuma/pkg/core"
-	"github.com/kumahq/kuma/pkg/core/plugins"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	"github.com/kumahq/kuma/pkg/core/runtime/component"
 	kuma_events "github.com/kumahq/kuma/pkg/events"
 	core_metrics "github.com/kumahq/kuma/pkg/metrics"
+	"github.com/kumahq/kuma/pkg/plugins/resources/postgres"
 	"github.com/kumahq/kuma/pkg/plugins/resources/postgres/config"
-	postgres_events "github.com/kumahq/kuma/pkg/plugins/resources/postgres/events"
+	events_postgres "github.com/kumahq/kuma/pkg/plugins/resources/postgres/events"
 	"github.com/kumahq/kuma/pkg/util/channels"
 )
 
 var _ = Describe("Events", func() {
-	var cfg postgres_config.PostgresStoreConfig
-
-	BeforeEach(func() {
-		c, err := c.Config()
-		Expect(err).ToNot(HaveOccurred())
-		cfg = *c
-		ver, err := MigrateDb(cfg)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(ver).To(Equal(plugins.DbVersion(1701180642)))
-	})
-
 	DescribeTable("should receive a notification from pq listener",
 		func(driverName string) {
+			cfg, err := c.Config()
+			Expect(err).ToNot(HaveOccurred())
+			ver, err := postgres.MigrateDb(cfg)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ver).To(Equal(dbVersion))
 			// given
 			listenerStopCh, listenerErrCh, eventBusStopCh, storeErrCh := setupChannels()
 			defer close(eventBusStopCh)
@@ -59,13 +53,18 @@ var _ = Describe("Events", func() {
 			Eventually(channelClosesWithoutErrors(listenerErrCh), "5s", "10ms").Should(BeTrue())
 			Eventually(channelClosesWithoutErrors(storeErrCh), "5s", "10ms").Should(BeTrue())
 		},
-		Entry("When using pq", postgres_config.DriverNamePq),
-		Entry("When using pgx", postgres_config.DriverNamePgx),
+		Entry("When using pq", config_postgres.DriverNamePq),
+		Entry("When using pgx", config_postgres.DriverNamePgx),
 	)
 
 	DescribeTable("should continue handling notification after postgres recovery",
 		func(driverName string) {
 			// given
+			cfg, err := c.Config()
+			Expect(err).ToNot(HaveOccurred())
+			ver, err := postgres.MigrateDb(cfg)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ver).To(Equal(dbVersion))
 			listenerStopCh, listenerErrCh, eventBusStopCh, storeErrCh := setupChannels()
 			defer close(eventBusStopCh)
 			listener := setupListeners(cfg, driverName, listenerErrCh, listenerStopCh)
@@ -92,8 +91,8 @@ var _ = Describe("Events", func() {
 			Expect(resourceChanged.Operation).To(Equal(kuma_events.Create))
 			Expect(resourceChanged.Type).To(Equal(model.ResourceType("Mesh")))
 		},
-		Entry("When using pq", postgres_config.DriverNamePq),
-		Entry("When using pgx", postgres_config.DriverNamePgx),
+		Entry("When using pq", config_postgres.DriverNamePq),
+		Entry("When using pgx", config_postgres.DriverNamePgx),
 	)
 })
 
@@ -106,29 +105,29 @@ func setupChannels() (chan struct{}, chan error, chan struct{}, chan error) {
 	return listenerStopCh, listenerErrCh, eventBusStopCh, storeErrCh
 }
 
-func setupStore(cfg postgres_config.PostgresStoreConfig, driverName string) store.ResourceStore {
+func setupStore(cfg config_postgres.PostgresStoreConfig, driverName string) store.ResourceStore {
 	metrics, err := core_metrics.NewMetrics("Zone")
 	Expect(err).ToNot(HaveOccurred())
 	var pStore store.ResourceStore
 	if driverName == "pgx" {
-		cfg.DriverName = postgres_config.DriverNamePgx
-		pStore, err = NewPgxStore(metrics, cfg, config.NoopPgxConfigCustomizationFn)
+		cfg.DriverName = config_postgres.DriverNamePgx
+		pStore, err = postgres.NewPgxStore(metrics, cfg, config.NoopPgxConfigCustomizationFn)
 	} else {
-		cfg.DriverName = postgres_config.DriverNamePq
-		pStore, err = NewPqStore(metrics, cfg)
+		cfg.DriverName = config_postgres.DriverNamePq
+		pStore, err = postgres.NewPqStore(metrics, cfg)
 	}
 	Expect(err).ToNot(HaveOccurred())
 	return pStore
 }
 
-func setupListeners(cfg postgres_config.PostgresStoreConfig, driverName string, listenerErrCh chan error, listenerStopCh chan struct{}) kuma_events.Listener {
+func setupListeners(cfg config_postgres.PostgresStoreConfig, driverName string, listenerErrCh chan error, listenerStopCh chan struct{}) kuma_events.Listener {
 	cfg.DriverName = driverName
 	metrics, err := core_metrics.NewMetrics("")
 	Expect(err).ToNot(HaveOccurred())
 	eventsBus, err := kuma_events.NewEventBus(20, metrics)
 	Expect(err).ToNot(HaveOccurred())
 	listener := eventsBus.Subscribe()
-	l := postgres_events.NewListener(cfg, eventsBus)
+	l := events_postgres.NewListener(cfg, eventsBus)
 	resilientListener := component.NewResilientComponent(core.Log.WithName("postgres-event-listener-component"), l)
 	go func() {
 		listenerErrCh <- resilientListener.Start(listenerStopCh)
@@ -137,7 +136,7 @@ func setupListeners(cfg postgres_config.PostgresStoreConfig, driverName string, 
 	return listener
 }
 
-func triggerNotifications(cfg postgres_config.PostgresStoreConfig, driverName string, storeErrCh chan error) {
+func triggerNotifications(cfg config_postgres.PostgresStoreConfig, driverName string, storeErrCh chan error) {
 	pStore := setupStore(cfg, driverName)
 	defer GinkgoRecover()
 	for i := 0; !channels.IsClosed(storeErrCh); i++ {

--- a/pkg/plugins/resources/postgres/migrate.go
+++ b/pkg/plugins/resources/postgres/migrate.go
@@ -70,7 +70,7 @@ func newMigrate(cfg postgres_cfg.PostgresStoreConfig) (*migrate.Migrate, error) 
 	return m, nil
 }
 
-func isDbMigrated(cfg postgres_cfg.PostgresStoreConfig) (bool, error) {
+func IsDbMigrated(cfg postgres_cfg.PostgresStoreConfig) (bool, error) {
 	m, err := newMigrate(cfg)
 	if err != nil {
 		return false, err

--- a/pkg/plugins/resources/postgres/migrate_test.go
+++ b/pkg/plugins/resources/postgres/migrate_test.go
@@ -1,42 +1,40 @@
-package postgres
+package postgres_test
 
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/kumahq/kuma/pkg/config/plugins/resources/postgres"
 	"github.com/kumahq/kuma/pkg/core/plugins"
 	common_postgres "github.com/kumahq/kuma/pkg/plugins/common/postgres"
+	"github.com/kumahq/kuma/pkg/plugins/resources/postgres"
 )
 
 var _ = Describe("Migrate", func() {
-	var cfg postgres.PostgresStoreConfig
-
-	BeforeEach(func() {
-		c, err := c.Config()
-		Expect(err).ToNot(HaveOccurred())
-		cfg = *c
-	})
-
 	It("should migrate DB", func() {
+		// given
+		cfg, err := c.Config()
+		Expect(err).ToNot(HaveOccurred())
+
 		// when
-		ver, err := MigrateDb(cfg)
+		ver, err := postgres.MigrateDb(cfg)
 
 		// then
 		Expect(err).ToNot(HaveOccurred())
-		Expect(ver).To(Equal(plugins.DbVersion(1701180642)))
+		Expect(ver).To(Equal(dbVersion))
 
 		// and when migrating again
-		ver, err = MigrateDb(cfg)
+		ver, err = postgres.MigrateDb(cfg)
 
 		// then
 		Expect(err).To(Equal(plugins.AlreadyMigrated))
-		Expect(ver).To(Equal(plugins.DbVersion(1701180642)))
+		Expect(ver).To(Equal(dbVersion))
 	})
 
 	It("should throw an error when trying to run migrations on newer migration version of DB than in Kuma", func() {
-		// setup
-		_, err := MigrateDb(cfg)
+		// given
+		cfg, err := c.Config()
+		Expect(err).ToNot(HaveOccurred())
+		_, err = postgres.MigrateDb(cfg)
 		Expect(err).ToNot(HaveOccurred())
 
 		sql, err := common_postgres.ConnectToDb(cfg)
@@ -46,28 +44,32 @@ var _ = Describe("Migrate", func() {
 		Expect(res.RowsAffected()).To(Equal(int64(1)))
 
 		// when
-		_, err = MigrateDb(cfg)
+		_, err = postgres.MigrateDb(cfg)
 
 		// then
 		Expect(err).To(MatchError("DB is migrated to newer version than Kuma. DB migration version 9999999999. Kuma migration version 1701180642. Run newer version of Kuma"))
 	})
 
 	It("should indicate if db is migrated", func() {
+		// given
+		cfg, err := c.Config()
+		Expect(err).ToNot(HaveOccurred())
+
 		// when
-		migrated, err := isDbMigrated(cfg)
+		migrated, err := postgres.IsDbMigrated(cfg)
 
 		// then
 		Expect(err).ToNot(HaveOccurred())
 		Expect(migrated).To(BeFalse())
 
 		// when
-		_, err = MigrateDb(cfg)
+		_, err = postgres.MigrateDb(cfg)
 
 		// then
 		Expect(err).ToNot(HaveOccurred())
 
 		// when
-		migrated, err = isDbMigrated(cfg)
+		migrated, err = postgres.IsDbMigrated(cfg)
 
 		// then
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/plugins/resources/postgres/plugin.go
+++ b/pkg/plugins/resources/postgres/plugin.go
@@ -25,7 +25,7 @@ func (p *plugin) NewResourceStore(pc core_plugins.PluginContext, config core_plu
 	if !ok {
 		return nil, nil, errors.New("invalid type of the config. Passed config should be a PostgresStoreConfig")
 	}
-	migrated, err := isDbMigrated(*cfg)
+	migrated, err := IsDbMigrated(*cfg)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/plugins/resources/postgres/store_suite_test.go
+++ b/pkg/plugins/resources/postgres/store_suite_test.go
@@ -1,4 +1,4 @@
-package postgres
+package postgres_test
 
 import (
 	"testing"
@@ -7,11 +7,16 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/testcontainers/testcontainers-go"
 
+	"github.com/kumahq/kuma/pkg/core/plugins"
 	"github.com/kumahq/kuma/pkg/test"
 	test_postgres "github.com/kumahq/kuma/pkg/test/store/postgres"
 )
 
 var c test_postgres.PostgresContainer
+
+const (
+	dbVersion plugins.DbVersion = 1701180642
+)
 
 func TestPostgresStore(t *testing.T) {
 	testcontainers.SkipIfProviderIsNotHealthy(t)

--- a/pkg/plugins/resources/postgres/store_template_test.go
+++ b/pkg/plugins/resources/postgres/store_template_test.go
@@ -1,13 +1,14 @@
-package postgres
+package postgres_test
 
 import (
 	"github.com/gruntwork-io/terratest/modules/logger"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/kumahq/kuma/pkg/config/plugins/resources/postgres"
+	config_postgres "github.com/kumahq/kuma/pkg/config/plugins/resources/postgres"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	core_metrics "github.com/kumahq/kuma/pkg/metrics"
+	"github.com/kumahq/kuma/pkg/plugins/resources/postgres"
 	"github.com/kumahq/kuma/pkg/plugins/resources/postgres/config"
 	test_store "github.com/kumahq/kuma/pkg/test/store"
 )
@@ -15,10 +16,10 @@ import (
 var _ = Describe("PostgresStore template", func() {
 	createStore := func(storeName string, maxListQueryElements int) func() store.ResourceStore {
 		return func() store.ResourceStore {
-			cfg, err := c.Config()
+			dbCfg, err := c.Config()
 			Expect(err).ToNot(HaveOccurred())
-			cfg.MaxListQueryElements = uint32(maxListQueryElements)
-			cfg.MaxOpenConnections = 2
+			dbCfg.MaxListQueryElements = uint32(maxListQueryElements)
+			dbCfg.MaxOpenConnections = 2
 
 			pqMetrics, err := core_metrics.NewMetrics("Zone")
 			Expect(err).ToNot(HaveOccurred())
@@ -26,8 +27,7 @@ var _ = Describe("PostgresStore template", func() {
 			pgxMetrics, err := core_metrics.NewMetrics("Zone")
 			Expect(err).ToNot(HaveOccurred())
 
-			dbCfg := *cfg
-			_, err = MigrateDb(dbCfg)
+			_, err = postgres.MigrateDb(dbCfg)
 			if err != nil {
 				logger.Default.Logf(GinkgoT(), "error migrating database: %v", err)
 				c.PrintDebugInfo(dbCfg.DbName, dbCfg.Port)
@@ -36,11 +36,11 @@ var _ = Describe("PostgresStore template", func() {
 
 			var pStore store.ResourceStore
 			if storeName == "pgx" {
-				cfg.DriverName = postgres.DriverNamePgx
-				pStore, err = NewPgxStore(pgxMetrics, dbCfg, config.NoopPgxConfigCustomizationFn)
+				dbCfg.DriverName = config_postgres.DriverNamePgx
+				pStore, err = postgres.NewPgxStore(pgxMetrics, dbCfg, config.NoopPgxConfigCustomizationFn)
 			} else {
-				cfg.DriverName = postgres.DriverNamePq
-				pStore, err = NewPqStore(pqMetrics, dbCfg)
+				dbCfg.DriverName = config_postgres.DriverNamePq
+				pStore, err = postgres.NewPqStore(pqMetrics, dbCfg)
 			}
 			if err != nil {
 				logger.Default.Logf(GinkgoT(), "error connecting to database: db name: %s, host: %s, port: %d, error: %v",

--- a/pkg/test/store/postgres/test_container.go
+++ b/pkg/test/store/postgres/test_container.go
@@ -109,15 +109,15 @@ func (v *PostgresContainer) Stop() error {
 
 type DbOption string
 
-func (v *PostgresContainer) Config() (*pg_config.PostgresStoreConfig, error) {
+func (v *PostgresContainer) Config() (pg_config.PostgresStoreConfig, error) {
 	cfg := pg_config.DefaultPostgresStoreConfig()
 	ip, err := v.container.Host(context.Background())
 	if err != nil {
-		return nil, err
+		return pg_config.PostgresStoreConfig{}, err
 	}
 	port, err := v.container.MappedPort(context.Background(), "5432")
 	if err != nil {
-		return nil, err
+		return pg_config.PostgresStoreConfig{}, err
 	}
 	cfg.Host = ip
 	cfg.Port = port.Int()
@@ -129,7 +129,7 @@ func (v *PostgresContainer) Config() (*pg_config.PostgresStoreConfig, error) {
 		cfg.TLS.CAPath = path.Join(rDir, "certs/rootCA.crt")
 	}
 	if err := config.Load("", cfg); err != nil {
-		return nil, err
+		return pg_config.PostgresStoreConfig{}, err
 	}
 	// make sure the server is reachable
 	Eventually(func() error {
@@ -155,7 +155,7 @@ func (v *PostgresContainer) Config() (*pg_config.PostgresStoreConfig, error) {
 		return nil
 	}, "10s", "100ms").Should(Succeed())
 	GinkgoLogr.Info("Database successfully created and started", "name", cfg.DbName)
-	return cfg, nil
+	return *cfg, nil
 }
 
 func (v *PostgresContainer) PrintDebugInfo(expectedDbName string, expectedDbPort int) {


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
