### PR TITLE
ci(mk): stop exporting and importing kuma-universal image

### DIFF
--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -101,9 +101,9 @@ docker/%/manifest:
 ALL_RELEASE_WITH_ARCH=$(foreach arch,$(ENABLED_GOARCHES),$(patsubst %,%/$(arch),$(IMAGES_RELEASE)))
 ALL_TEST_WITH_ARCH=$(foreach arch,$(ENABLED_GOARCHES),$(patsubst %,%/$(arch),$(IMAGES_TEST)))
 .PHONY: docker/save
-docker/save: $(patsubst %,docker/%/save,$(ALL_RELEASE_WITH_ARCH) $(ALL_TEST_WITH_ARCH))
+docker/save: $(patsubst %,docker/%/save,$(ALL_RELEASE_WITH_ARCH))
 .PHONY: docker/load
-docker/load: $(patsubst %,docker/%/load,$(ALL_RELEASE_WITH_ARCH) $(ALL_TEST_WITH_ARCH))
+docker/load: $(patsubst %,docker/%/load,$(ALL_RELEASE_WITH_ARCH))
 .PHONY: docker/tag
 docker/tag: docker/tag/test docker/tag/release ## Tag local arch containers with the version with the arch (this is mostly to use non multi-arch images as if they were released images in e2e tests)
 .PHONY: docker/tag/release

--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -10,8 +10,8 @@ E2E_DEPS_TARGETS ?=
 # Environment veriables the tests should run with
 E2E_ENV_VARS ?=
 
-E2E_K8S_BIN_DEPS =
-E2E_UNIVERSAL_BIN_DEPS =
+E2E_K8S_BIN_DEPS = images/test
+E2E_UNIVERSAL_BIN_DEPS = images/test
 ifdef CI
 # In circleCI all this was built from previous targets let's reuse them!
 E2E_K8S_BIN_DEPS+= docker/load
@@ -19,7 +19,7 @@ E2E_UNIVERSAL_BIN_DEPS+= docker/load
 E2E_ENV_VARS+= CLEANUP_LOGS_ON_SUCCESS=true
 else
 E2E_K8S_BIN_DEPS+= build/kumactl images
-E2E_UNIVERSAL_BIN_DEPS+= build/kumactl images/test
+E2E_UNIVERSAL_BIN_DEPS+= build/kumactl
 E2E_ENV_VARS+= GINKGO_EDITOR_INTEGRATION=true
 endif
 


### PR DESCRIPTION
This was making a big artifact which slowed down the entire build

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
