### PR TITLE
fix(policies): first lexicographically wins, kind MeshGateway with tags over kind MeshGateway

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ does not have any particular instructions.
 
 ## Upgrade to `2.6.x`
 
+### Policy sorting
+
+Policy merging now gives precedence to policies lexicographically before
+other policies.
+
 ### Unifying Default Connection Timeout Values
 
 To simplify configuration and provide a more consistent user experience, we've unified the default connection timeout values. When no `MeshTimeout` or `Timeout` policy is specified, the connection timeout will now be the same as the default `connectTimeout` values for `MeshTimeout` and `Timeout` policies. This value is now `5s`, which is a decrease from the previous default of `10s`.

--- a/pkg/api-server/inspect_endpoints_test.go
+++ b/pkg/api-server/inspect_endpoints_test.go
@@ -943,13 +943,14 @@ var _ = Describe("Inspect WS", func() {
 					AddOutbound(builders.Outbound().WithService("backend").WithAddress("240.0.0.0").WithPort(80)).
 					Build(),
 				builders.MeshTrafficPermission().
+					WithName("mtp-1").
 					WithTargetRef(builders.TargetRefService("web")).
-					AddFrom(builders.TargetRefServiceSubset("client", "kuma.io/zone", "east"), v1alpha1.Deny).
+					AddFrom(builders.TargetRefServiceSubset("client", "kuma.io/zone", "east", "version", "2"), v1alpha1.Allow).
 					Build(),
 				builders.MeshTrafficPermission().
 					WithName("mtp-2").
 					WithTargetRef(builders.TargetRefService("web")).
-					AddFrom(builders.TargetRefServiceSubset("client", "kuma.io/zone", "east", "version", "2"), v1alpha1.Allow).
+					AddFrom(builders.TargetRefServiceSubset("client", "kuma.io/zone", "east"), v1alpha1.Deny).
 					Build(),
 				builders.MeshAccessLog().
 					WithTargetRef(builders.TargetRefService("web")).

--- a/pkg/api-server/testdata/inspect/dataplanes/_rules/meshhttproute.golden.json
+++ b/pkg/api-server/testdata/inspect/dataplanes/_rules/meshhttproute.golden.json
@@ -24,6 +24,47 @@
          "backendRefs": [
           {
            "kind": "MeshServiceSubset",
+           "name": "backend_kuma-demo_svc_3001",
+           "tags": {
+            "version": "1.0"
+           }
+          }
+         ]
+        }
+       }
+      ]
+     },
+     "matchers": [
+      {
+       "key": "kuma.io/service",
+       "not": false,
+       "value": "backend_kuma-demo_svc_3001"
+      }
+     ],
+     "origin": [
+      {
+       "mesh": "default",
+       "name": "the-http-route",
+       "type": "MeshHTTPRoute"
+      }
+     ]
+    },
+    {
+     "conf": {
+      "Rules": [
+       {
+        "matches": [
+         {
+          "path": {
+           "value": "/api",
+           "type": "PathPrefix"
+          }
+         }
+        ],
+        "default": {
+         "backendRefs": [
+          {
+           "kind": "MeshServiceSubset",
            "name": "other-svc",
            "tags": {
             "version": "1.0"
@@ -52,47 +93,6 @@
       {
        "mesh": "default",
        "name": "the-other-http-route",
-       "type": "MeshHTTPRoute"
-      }
-     ]
-    },
-    {
-     "conf": {
-      "Rules": [
-       {
-        "matches": [
-         {
-          "path": {
-           "value": "/api",
-           "type": "PathPrefix"
-          }
-         }
-        ],
-        "default": {
-         "backendRefs": [
-          {
-           "kind": "MeshServiceSubset",
-           "name": "backend_kuma-demo_svc_3001",
-           "tags": {
-            "version": "1.0"
-           }
-          }
-         ]
-        }
-       }
-      ]
-     },
-     "matchers": [
-      {
-       "key": "kuma.io/service",
-       "not": false,
-       "value": "backend_kuma-demo_svc_3001"
-      }
-     ],
-     "origin": [
-      {
-       "mesh": "default",
-       "name": "the-http-route",
        "type": "MeshHTTPRoute"
       }
      ]

--- a/pkg/api-server/testdata/inspect_dataplane_rules_subset.golden.json
+++ b/pkg/api-server/testdata/inspect_dataplane_rules_subset.golden.json
@@ -166,7 +166,7 @@
    "origins": [
     {
      "mesh": "default",
-     "name": "mtp-1"
+     "name": "mtp-2"
     }
    ]
   }

--- a/pkg/plugins/policies/core/matchers/dataplane.go
+++ b/pkg/plugins/policies/core/matchers/dataplane.go
@@ -205,7 +205,7 @@ func (b ByTargetRef) Less(i, j int) bool {
 		return tr1.Kind.Less(tr2.Kind)
 	}
 
-	return b[i].GetMeta().GetName() < b[j].GetMeta().GetName()
+	return b[i].GetMeta().GetName() > b[j].GetMeta().GetName()
 }
 
 func (b ByTargetRef) Swap(i, j int) { b[i], b[j] = b[j], b[i] }

--- a/pkg/plugins/policies/core/matchers/dataplane.go
+++ b/pkg/plugins/policies/core/matchers/dataplane.go
@@ -205,6 +205,12 @@ func (b ByTargetRef) Less(i, j int) bool {
 		return tr1.Kind.Less(tr2.Kind)
 	}
 
+	if tr1.Kind == common_api.MeshGateway {
+		if len(tr1.Tags) != len(tr2.Tags) {
+			return len(tr1.Tags) < len(tr2.Tags)
+		}
+	}
+
 	return b[i].GetMeta().GetName() > b[j].GetMeta().GetName()
 }
 

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/dataplanepolicies/02.golden.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/dataplanepolicies/02.golden.yaml
@@ -2,19 +2,6 @@ items:
 - creationTime: "0001-01-01T00:00:00Z"
   mesh: mesh-1
   modificationTime: "0001-01-01T00:00:00Z"
-  name: 1-my-policy
-  spec:
-    from:
-    - default:
-        action: Allow
-      targetRef:
-        kind: Mesh
-    targetRef:
-      kind: Mesh
-  type: MeshTrafficPermission
-- creationTime: "0001-01-01T00:00:00Z"
-  mesh: mesh-1
-  modificationTime: "0001-01-01T00:00:00Z"
   name: 2-my-policy
   spec:
     from:
@@ -28,7 +15,7 @@ items:
 - creationTime: "0001-01-01T00:00:00Z"
   mesh: mesh-1
   modificationTime: "0001-01-01T00:00:00Z"
-  name: "111"
+  name: 1-my-policy
   spec:
     from:
     - default:
@@ -36,9 +23,7 @@ items:
       targetRef:
         kind: Mesh
     targetRef:
-      kind: MeshSubset
-      tags:
-        version: v1
+      kind: Mesh
   type: MeshTrafficPermission
 - creationTime: "0001-01-01T00:00:00Z"
   mesh: mesh-1
@@ -58,7 +43,7 @@ items:
 - creationTime: "0001-01-01T00:00:00Z"
   mesh: mesh-1
   modificationTime: "0001-01-01T00:00:00Z"
-  name: my-policy-1
+  name: "111"
   spec:
     from:
     - default:
@@ -66,8 +51,9 @@ items:
       targetRef:
         kind: Mesh
     targetRef:
-      kind: MeshService
-      name: web
+      kind: MeshSubset
+      tags:
+        version: v1
   type: MeshTrafficPermission
 - creationTime: "0001-01-01T00:00:00Z"
   mesh: mesh-1
@@ -86,7 +72,21 @@ items:
 - creationTime: "0001-01-01T00:00:00Z"
   mesh: mesh-1
   modificationTime: "0001-01-01T00:00:00Z"
-  name: aaa
+  name: my-policy-1
+  spec:
+    from:
+    - default:
+        action: Allow
+      targetRef:
+        kind: Mesh
+    targetRef:
+      kind: MeshService
+      name: web
+  type: MeshTrafficPermission
+- creationTime: "0001-01-01T00:00:00Z"
+  mesh: mesh-1
+  modificationTime: "0001-01-01T00:00:00Z"
+  name: bbb
   spec:
     from:
     - default:
@@ -102,7 +102,7 @@ items:
 - creationTime: "0001-01-01T00:00:00Z"
   mesh: mesh-1
   modificationTime: "0001-01-01T00:00:00Z"
-  name: bbb
+  name: aaa
   spec:
     from:
     - default:

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/fromrules/multiple-policies-lexicog-order.golden.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/fromrules/multiple-policies-lexicog-order.golden.yaml
@@ -1,57 +1,6 @@
 Rules:
   1.1.1.1:8080:
   - Conf:
-      action: Allow
-    Origin:
-    - creationTime: "0001-01-01T00:00:00Z"
-      mesh: default
-      modificationTime: "0001-01-01T00:00:00Z"
-      name: rule-a
-      type: MeshTrafficPermission
-    - creationTime: "0001-01-01T00:00:00Z"
-      mesh: default
-      modificationTime: "0001-01-01T00:00:00Z"
-      name: rule-b
-      type: MeshTrafficPermission
-    Subset:
-    - Key: app.kubernetes.io/name
-      Not: false
-      Value: ui
-  - Conf:
-      action: Allow
-    Origin:
-    - creationTime: "0001-01-01T00:00:00Z"
-      mesh: default
-      modificationTime: "0001-01-01T00:00:00Z"
-      name: rule-a
-      type: MeshTrafficPermission
-    - creationTime: "0001-01-01T00:00:00Z"
-      mesh: default
-      modificationTime: "0001-01-01T00:00:00Z"
-      name: rule-b
-      type: MeshTrafficPermission
-    Subset:
-    - Key: app.kubernetes.io/name
-      Not: false
-      Value: service-payment
-  - Conf:
-      action: Allow
-    Origin:
-    - creationTime: "0001-01-01T00:00:00Z"
-      mesh: default
-      modificationTime: "0001-01-01T00:00:00Z"
-      name: rule-a
-      type: MeshTrafficPermission
-    - creationTime: "0001-01-01T00:00:00Z"
-      mesh: default
-      modificationTime: "0001-01-01T00:00:00Z"
-      name: rule-b
-      type: MeshTrafficPermission
-    Subset:
-    - Key: app.kubernetes.io/name
-      Not: false
-      Value: service-order
-  - Conf:
       action: Deny
     Origin:
     - creationTime: "0001-01-01T00:00:00Z"
@@ -59,13 +8,36 @@ Rules:
       modificationTime: "0001-01-01T00:00:00Z"
       name: rule-a
       type: MeshTrafficPermission
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: default
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: rule-b
+      type: MeshTrafficPermission
     Subset:
     - Key: app.kubernetes.io/name
-      Not: true
-      Value: service-order
-    - Key: app.kubernetes.io/name
-      Not: true
+      Not: false
       Value: service-payment
+  - Conf:
+      action: Allow
+    Origin:
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: default
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: rule-b
+      type: MeshTrafficPermission
+    Subset:
     - Key: app.kubernetes.io/name
-      Not: true
+      Not: false
+      Value: service-order
+  - Conf:
+      action: Allow
+    Origin:
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: default
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: rule-b
+      type: MeshTrafficPermission
+    Subset:
+    - Key: app.kubernetes.io/name
+      Not: false
       Value: ui

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/fromrules/multiple-policies-lexicog-order.policies.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/fromrules/multiple-policies-lexicog-order.policies.yaml
@@ -39,5 +39,6 @@ spec:
     - default:
         action: Deny
       targetRef:
-        kind: Mesh
-
+        kind: MeshSubset
+        tags:
+          app.kubernetes.io/name: service-payment

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.golden.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.golden.yaml
@@ -10,7 +10,7 @@ ToRules:
   - Conf:
       backends:
       - file:
-          path: /gateway
+          path: /gateway-listener
         type: File
     Origin:
     - creationTime: "0001-01-01T00:00:00Z"

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.golden.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.golden.yaml
@@ -10,7 +10,7 @@ ToRules:
   - Conf:
       backends:
       - file:
-          path: /gateway-listener
+          path: /gateway
         type: File
     Origin:
     - creationTime: "0001-01-01T00:00:00Z"

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/torules/02.golden.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/torules/02.golden.yaml
@@ -17,7 +17,7 @@ Rules:
     Value: another-test-server
 - Conf:
     http:
-      requestTimeout: 3s
+      requestTimeout: 1s
   Origin:
   - creationTime: "0001-01-01T00:00:00Z"
     mesh: mesh-1

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/merge_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/merge_test.go
@@ -217,7 +217,7 @@ var _ = DescribeTable("MatchedPolicies", func(given policiesTestCase) {
 						}},
 						Default: api.RuleConf{
 							BackendRefs: &[]common_api.BackendRef{{
-								TargetRef: builders.TargetRefServiceSubset("b-backend", "version", "v1"),
+								TargetRef: builders.TargetRefServiceSubset("a-backend", "version", "v1"),
 								Weight:    pointer.To(uint(100)),
 							}},
 						},

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/merge_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/merge_test.go
@@ -1,0 +1,148 @@
+package v1alpha1_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
+	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+	core_rules "github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
+	api "github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
+	plugin "github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/plugin/v1alpha1"
+	"github.com/kumahq/kuma/pkg/test/resources/builders"
+	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
+	"github.com/kumahq/kuma/pkg/test/resources/samples"
+	"github.com/kumahq/kuma/pkg/util/pointer"
+	xds_context "github.com/kumahq/kuma/pkg/xds/context"
+)
+
+type policiesTestCase struct {
+	dataplane      *core_mesh.DataplaneResource
+	resources      xds_context.Resources
+	expectedRoutes core_rules.ToRules
+}
+
+var _ = DescribeTable("MatchedPolicies", func(given policiesTestCase) {
+	routes, err := plugin.NewPlugin().(core_plugins.PolicyPlugin).MatchedPolicies(given.dataplane, given.resources)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(routes.ToRules).To(Equal(given.expectedRoutes))
+}, Entry("basic", policiesTestCase{
+	dataplane: samples.DataplaneWeb(),
+	resources: xds_context.Resources{
+		MeshLocalResources: map[core_model.ResourceType]core_model.ResourceList{
+			api.MeshHTTPRouteType: &api.MeshHTTPRouteResourceList{
+				Items: []*api.MeshHTTPRouteResource{{
+					Meta: &test_model.ResourceMeta{
+						Mesh: core_model.DefaultMesh,
+						Name: "route-1",
+					},
+					Spec: &api.MeshHTTPRoute{
+						TargetRef: builders.TargetRefMesh(),
+						To: []api.To{{
+							TargetRef: builders.TargetRefService("backend"),
+							Rules: []api.Rule{{
+								Matches: []api.Match{{
+									Path: &api.PathMatch{
+										Type:  api.PathPrefix,
+										Value: "/v1",
+									},
+								}},
+								Default: api.RuleConf{
+									Filters: &[]api.Filter{{}},
+								},
+							}},
+						}},
+					},
+				}, {
+					Meta: &test_model.ResourceMeta{
+						Mesh: core_model.DefaultMesh,
+						Name: "route-2",
+					},
+					Spec: &api.MeshHTTPRoute{
+						TargetRef: builders.TargetRefService("web"),
+						To: []api.To{{
+							TargetRef: builders.TargetRefService("backend"),
+							Rules: []api.Rule{{
+								Matches: []api.Match{{
+									Path: &api.PathMatch{
+										Type:  api.PathPrefix,
+										Value: "/v1",
+									},
+								}},
+								Default: api.RuleConf{
+									BackendRefs: &[]common_api.BackendRef{{
+										TargetRef: builders.TargetRefServiceSubset("backend", "version", "v1"),
+										Weight:    pointer.To(uint(100)),
+									}},
+								},
+							}, {
+								Matches: []api.Match{{
+									Path: &api.PathMatch{
+										Type:  api.PathPrefix,
+										Value: "/v2",
+									},
+								}},
+								Default: api.RuleConf{
+									BackendRefs: &[]common_api.BackendRef{{
+										TargetRef: builders.TargetRefServiceSubset("backend", "version", "v2"),
+										Weight:    pointer.To(uint(100)),
+									}},
+								},
+							}},
+						}},
+					},
+				}},
+			},
+		},
+	},
+	expectedRoutes: core_rules.ToRules{
+		Rules: core_rules.Rules{
+			{
+				Subset: core_rules.MeshService("backend"),
+				Conf: api.PolicyDefault{
+					Rules: []api.Rule{{
+						Matches: []api.Match{{
+							Path: &api.PathMatch{
+								Type:  api.PathPrefix,
+								Value: "/v1",
+							},
+						}},
+						Default: api.RuleConf{
+							Filters: &[]api.Filter{{}},
+							BackendRefs: &[]common_api.BackendRef{{
+								TargetRef: builders.TargetRefServiceSubset("backend", "version", "v1"),
+								Weight:    pointer.To(uint(100)),
+							}},
+						},
+					}, {
+						Matches: []api.Match{{
+							Path: &api.PathMatch{
+								Type:  api.PathPrefix,
+								Value: "/v2",
+							},
+						}},
+						Default: api.RuleConf{
+							BackendRefs: &[]common_api.BackendRef{{
+								TargetRef: builders.TargetRefServiceSubset("backend", "version", "v2"),
+								Weight:    pointer.To(uint(100)),
+							}},
+						},
+					}},
+				},
+				Origin: []core_model.ResourceMeta{
+					&test_model.ResourceMeta{
+						Mesh: "default",
+						Name: "route-1",
+					},
+					&test_model.ResourceMeta{
+						Mesh: "default",
+						Name: "route-2",
+					},
+				},
+			},
+		},
+	},
+}),
+)

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/merge_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/merge_test.go
@@ -144,5 +144,97 @@ var _ = DescribeTable("MatchedPolicies", func(given policiesTestCase) {
 			},
 		},
 	},
+}), Entry("tie-breaking", policiesTestCase{
+	dataplane: samples.DataplaneWeb(),
+	resources: xds_context.Resources{
+		MeshLocalResources: map[core_model.ResourceType]core_model.ResourceList{
+			api.MeshHTTPRouteType: &api.MeshHTTPRouteResourceList{
+				Items: []*api.MeshHTTPRouteResource{{
+					Meta: &test_model.ResourceMeta{
+						Mesh: core_model.DefaultMesh,
+						Name: "a-route",
+					},
+					Spec: &api.MeshHTTPRoute{
+						TargetRef: builders.TargetRefMesh(),
+						To: []api.To{{
+							TargetRef: builders.TargetRefService("backend"),
+							Rules: []api.Rule{{
+								Matches: []api.Match{{
+									Path: &api.PathMatch{
+										Type:  api.PathPrefix,
+										Value: "/v1",
+									},
+								}},
+								Default: api.RuleConf{
+									BackendRefs: &[]common_api.BackendRef{{
+										TargetRef: builders.TargetRefServiceSubset("a-backend", "version", "v1"),
+										Weight:    pointer.To(uint(100)),
+									}},
+								},
+							}},
+						}},
+					},
+				}, {
+					Meta: &test_model.ResourceMeta{
+						Mesh: core_model.DefaultMesh,
+						Name: "b-route",
+					},
+					Spec: &api.MeshHTTPRoute{
+						TargetRef: builders.TargetRefMesh(),
+						To: []api.To{{
+							TargetRef: builders.TargetRefService("backend"),
+							Rules: []api.Rule{{
+								Matches: []api.Match{{
+									Path: &api.PathMatch{
+										Type:  api.PathPrefix,
+										Value: "/v1",
+									},
+								}},
+								Default: api.RuleConf{
+									BackendRefs: &[]common_api.BackendRef{{
+										TargetRef: builders.TargetRefServiceSubset("b-backend", "version", "v1"),
+										Weight:    pointer.To(uint(100)),
+									}},
+								},
+							}},
+						}},
+					},
+				}},
+			},
+		},
+	},
+	expectedRoutes: core_rules.ToRules{
+		Rules: core_rules.Rules{
+			{
+				Subset: core_rules.MeshService("backend"),
+				Conf: api.PolicyDefault{
+					Rules: []api.Rule{{
+						Matches: []api.Match{{
+							Path: &api.PathMatch{
+								Type:  api.PathPrefix,
+								Value: "/v1",
+							},
+						}},
+						Default: api.RuleConf{
+							BackendRefs: &[]common_api.BackendRef{{
+								TargetRef: builders.TargetRefServiceSubset("b-backend", "version", "v1"),
+								Weight:    pointer.To(uint(100)),
+							}},
+						},
+					}},
+				},
+				Origin: []core_model.ResourceMeta{
+					&test_model.ResourceMeta{
+						Mesh: "default",
+						Name: "a-route",
+					},
+					&test_model.ResourceMeta{
+						Mesh: "default",
+						Name: "b-route",
+					},
+				},
+			},
+		},
+	},
 }),
 )

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
@@ -15,7 +15,6 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/metrics"
 	core_rules "github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
@@ -24,7 +23,6 @@ import (
 	plugin_gateway "github.com/kumahq/kuma/pkg/plugins/runtime/gateway"
 	"github.com/kumahq/kuma/pkg/test/matchers"
 	"github.com/kumahq/kuma/pkg/test/resources/builders"
-	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
 	"github.com/kumahq/kuma/pkg/test/resources/samples"
 	xds_builders "github.com/kumahq/kuma/pkg/test/xds/builders"
 	"github.com/kumahq/kuma/pkg/util/pointer"
@@ -43,133 +41,6 @@ func getResource(resourceSet *core_xds.ResourceSet, typ envoy_resource.Type) []b
 }
 
 var _ = Describe("MeshHTTPRoute", func() {
-	type policiesTestCase struct {
-		dataplane      *core_mesh.DataplaneResource
-		resources      xds_context.Resources
-		expectedRoutes core_rules.ToRules
-	}
-	DescribeTable("MatchedPolicies", func(given policiesTestCase) {
-		routes, err := plugin.NewPlugin().(core_plugins.PolicyPlugin).MatchedPolicies(given.dataplane, given.resources)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(routes.ToRules).To(Equal(given.expectedRoutes))
-	}, Entry("basic", policiesTestCase{
-		dataplane: samples.DataplaneWeb(),
-		resources: xds_context.Resources{
-			MeshLocalResources: map[core_model.ResourceType]core_model.ResourceList{
-				api.MeshHTTPRouteType: &api.MeshHTTPRouteResourceList{
-					Items: []*api.MeshHTTPRouteResource{{
-						Meta: &test_model.ResourceMeta{
-							Mesh: core_model.DefaultMesh,
-							Name: "route-1",
-						},
-						Spec: &api.MeshHTTPRoute{
-							TargetRef: builders.TargetRefMesh(),
-							To: []api.To{{
-								TargetRef: builders.TargetRefService("backend"),
-								Rules: []api.Rule{{
-									Matches: []api.Match{{
-										Path: &api.PathMatch{
-											Type:  api.PathPrefix,
-											Value: "/v1",
-										},
-									}},
-									Default: api.RuleConf{
-										Filters: &[]api.Filter{{}},
-									},
-								}},
-							}},
-						},
-					}, {
-						Meta: &test_model.ResourceMeta{
-							Mesh: core_model.DefaultMesh,
-							Name: "route-2",
-						},
-						Spec: &api.MeshHTTPRoute{
-							TargetRef: builders.TargetRefService("web"),
-							To: []api.To{{
-								TargetRef: builders.TargetRefService("backend"),
-								Rules: []api.Rule{{
-									Matches: []api.Match{{
-										Path: &api.PathMatch{
-											Type:  api.PathPrefix,
-											Value: "/v1",
-										},
-									}},
-									Default: api.RuleConf{
-										BackendRefs: &[]common_api.BackendRef{{
-											TargetRef: builders.TargetRefServiceSubset("backend", "version", "v1"),
-											Weight:    pointer.To(uint(100)),
-										}},
-									},
-								}, {
-									Matches: []api.Match{{
-										Path: &api.PathMatch{
-											Type:  api.PathPrefix,
-											Value: "/v2",
-										},
-									}},
-									Default: api.RuleConf{
-										BackendRefs: &[]common_api.BackendRef{{
-											TargetRef: builders.TargetRefServiceSubset("backend", "version", "v2"),
-											Weight:    pointer.To(uint(100)),
-										}},
-									},
-								}},
-							}},
-						},
-					}},
-				},
-			},
-		},
-		expectedRoutes: core_rules.ToRules{
-			Rules: core_rules.Rules{
-				{
-					Subset: core_rules.MeshService("backend"),
-					Conf: api.PolicyDefault{
-						Rules: []api.Rule{{
-							Matches: []api.Match{{
-								Path: &api.PathMatch{
-									Type:  api.PathPrefix,
-									Value: "/v1",
-								},
-							}},
-							Default: api.RuleConf{
-								Filters: &[]api.Filter{{}},
-								BackendRefs: &[]common_api.BackendRef{{
-									TargetRef: builders.TargetRefServiceSubset("backend", "version", "v1"),
-									Weight:    pointer.To(uint(100)),
-								}},
-							},
-						}, {
-							Matches: []api.Match{{
-								Path: &api.PathMatch{
-									Type:  api.PathPrefix,
-									Value: "/v2",
-								},
-							}},
-							Default: api.RuleConf{
-								BackendRefs: &[]common_api.BackendRef{{
-									TargetRef: builders.TargetRefServiceSubset("backend", "version", "v2"),
-									Weight:    pointer.To(uint(100)),
-								}},
-							},
-						}},
-					},
-					Origin: []core_model.ResourceMeta{
-						&test_model.ResourceMeta{
-							Mesh: "default",
-							Name: "route-1",
-						},
-						&test_model.ResourceMeta{
-							Mesh: "default",
-							Name: "route-2",
-						},
-					},
-				},
-			},
-		},
-	}),
-	)
 	type outboundsTestCase struct {
 		proxy      *core_xds.Proxy
 		xdsContext xds_context.Context

--- a/pkg/plugins/policies/meshtrafficpermission/graph/reachable_services_graph_test.go
+++ b/pkg/plugins/policies/meshtrafficpermission/graph/reachable_services_graph_test.go
@@ -180,12 +180,12 @@ var _ = Describe("Reachable Services Graph", func() {
 		Entry("equal subsets matching is preserved because of the names", testCase{
 			mtps: []*v1alpha1.MeshTrafficPermissionResource{
 				builders.MeshTrafficPermission().
-					WithName("aaa").
+					WithName("bbb").
 					WithTargetRef(builders.TargetRefMeshSubset("kuma.io/zone", "east")).
 					AddFrom(builders.TargetRefMesh(), v1alpha1.Deny).
 					Build(),
 				builders.MeshTrafficPermission().
-					WithName("bbb").
+					WithName("aaa").
 					WithTargetRef(builders.TargetRefMeshSubset("version", "v1")).
 					AddFrom(builders.TargetRefMesh(), v1alpha1.Allow).
 					Build(),


### PR DESCRIPTION
As a potential reference, gateway api specifies the lexicographically first policy wins.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
