### PR TITLE
fix(kds): avoid rare cases where onStreamClosed is called with no state

### DIFF
--- a/pkg/kds/server/status_tracker.go
+++ b/pkg/kds/server/status_tracker.go
@@ -105,6 +105,9 @@ func (c *statusTracker) OnStreamClosed(streamID int64, _ *envoy_core.Node) {
 	defer c.mu.Unlock()
 
 	state := c.streams[streamID]
+	if state == nil {
+		return
+	}
 
 	delete(c.streams, streamID)
 

--- a/pkg/kds/server/status_tracker.go
+++ b/pkg/kds/server/status_tracker.go
@@ -106,6 +106,7 @@ func (c *statusTracker) OnStreamClosed(streamID int64, _ *envoy_core.Node) {
 
 	state := c.streams[streamID]
 	if state == nil {
+		c.log.Info("[WARNING] OnDeltaStreamClosed but no state in the status_tracker", "streamid", streamID)
 		return
 	}
 

--- a/pkg/kds/v2/server/status_tracker.go
+++ b/pkg/kds/v2/server/status_tracker.go
@@ -99,6 +99,7 @@ func (c *statusTracker) OnDeltaStreamClosed(streamID int64, _ *envoy_core.Node) 
 
 	state := c.streams[streamID]
 	if state == nil {
+		c.log.Info("[WARNING] OnDeltaStreamClosed but no state in the status_tracker", "streamid", streamID)
 		return
 	}
 

--- a/pkg/kds/v2/server/status_tracker.go
+++ b/pkg/kds/v2/server/status_tracker.go
@@ -98,6 +98,9 @@ func (c *statusTracker) OnDeltaStreamClosed(streamID int64, _ *envoy_core.Node) 
 	defer c.mu.Unlock()
 
 	state := c.streams[streamID]
+	if state == nil {
+		return
+	}
 
 	delete(c.streams, streamID)
 

--- a/pkg/xds/server/callbacks/dataplane_status_tracker.go
+++ b/pkg/xds/server/callbacks/dataplane_status_tracker.go
@@ -95,7 +95,6 @@ func (c *dataplaneStatusTracker) OnStreamClosed(streamID int64) {
 	if state == nil {
 		statusTrackerLog.Info("[WARNING] proxy disconnected but no state in the status_tracker", "streamID", streamID)
 		return
-
 	}
 
 	delete(c.streams, streamID)

--- a/pkg/xds/server/callbacks/dataplane_status_tracker.go
+++ b/pkg/xds/server/callbacks/dataplane_status_tracker.go
@@ -92,6 +92,11 @@ func (c *dataplaneStatusTracker) OnStreamClosed(streamID int64) {
 	defer c.mu.Unlock()
 
 	state := c.streams[streamID]
+	if state == nil {
+		statusTrackerLog.Info("[WARNING] proxy disconnected but no state in the status_tracker", "streamID", streamID)
+		return
+
+	}
 
 	delete(c.streams, streamID)
 


### PR DESCRIPTION
There were rare cases where state is not in the streams map. We simply avoid a nil pointer by returning early in this case. There shouldn't be any problems with this as the entry is not in the map anyway

However, maybe there's a race where streamClosed is called before streamOpen

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
