### PR TITLE
test(e2e): wait for CP to be started before other components

### DIFF
--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -510,49 +510,46 @@ func (c *K8sCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOption) e
 		}
 		err = c.deployKumaViaHelm(mode)
 	default:
-		return errors.Errorf("invalid installation mode: %s", c.opts.installationMode)
+		err = errors.Errorf("invalid installation mode: %s", c.opts.installationMode)
 	}
-
 	if err != nil {
 		return err
 	}
 
-	appsToInstall := make([]appInstallation, 0)
-	appsToInstall = append(appsToInstall, appInstallation{Config.KumaServiceName, Config.KumaNamespace, replicas})
-	if c.opts.cni {
-		appsToInstall = append(appsToInstall, appInstallation{Config.CNIApp, Config.CNINamespace, 1})
-	}
-	if c.opts.zoneIngress {
-		appsToInstall = append(appsToInstall, appInstallation{Config.ZoneIngressApp, Config.KumaNamespace, 1})
-	}
-	if c.opts.zoneEgress {
-		appsToInstall = append(appsToInstall, appInstallation{Config.ZoneEgressApp, Config.KumaNamespace, 1})
+	// First wait for kuma cp to start, then wait for the other components (they all need the CP anyway)
+	if err := c.WaitApp(Config.KumaServiceName, Config.KumaNamespace, replicas); err != nil {
+		return errors.Wrap(err, "Kuma control-plane failed to start")
 	}
 
 	var wg sync.WaitGroup
-	errCh := make(chan error, len(appsToInstall))
+	var appsToInstall []appInstallation
+	if c.opts.cni {
+		appsToInstall = append(appsToInstall, appInstallation{Config.CNIApp, Config.CNINamespace, 1, nil})
+	}
+	if c.opts.zoneIngress {
+		appsToInstall = append(appsToInstall, appInstallation{Config.ZoneIngressApp, Config.KumaNamespace, 1, nil})
+	}
+	if c.opts.zoneEgress {
+		appsToInstall = append(appsToInstall, appInstallation{Config.ZoneEgressApp, Config.KumaNamespace, 1, nil})
+	}
 
-	for _, app := range appsToInstall {
+	for i := range appsToInstall {
+		idx := i
 		wg.Add(1)
-		go func(installation appInstallation) {
+		go func() {
 			defer wg.Done()
-			if e := c.WaitApp(installation.Name, installation.Namespace, installation.Replicas); e != nil {
-				errCh <- e
-			}
-		}(app)
+			appsToInstall[idx].Outcome = c.WaitApp(appsToInstall[idx].Name, appsToInstall[idx].Namespace, appsToInstall[idx].Replicas)
+		}()
 	}
 
-	go func() {
-		wg.Wait()
-		close(errCh)
-	}()
-
-	var allErrors []error
-	for err := range errCh {
-		allErrors = append(allErrors, err)
+	wg.Wait() // Because of the wait group we have a memory barrier which allows us to read Outcome in a thread safe manner.
+	for _, appInstall := range appsToInstall {
+		if appInstall.Outcome != nil {
+			err = multierr.Append(err, errors.Wrapf(appInstall.Outcome, "%s failed to start", appInstall.Name))
+		}
 	}
-	if len(allErrors) > 0 {
-		return multierr.Combine(allErrors...)
+	if err != nil {
+		return err
 	}
 
 	if c.opts.zoneEgressEnvoyAdminTunnel {
@@ -1259,4 +1256,5 @@ type appInstallation struct {
 	Name      string
 	Namespace string
 	Replicas  int
+	Outcome   error
 }


### PR DESCRIPTION
We were waiting for everything at once. This might be the reason for things to be unstable.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
