### PR TITLE
ci(circle): debug arm builds and not have it fail CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,6 +423,7 @@ jobs:
               legacyKDS:<< parameters.legacyKDS >> \
               cniNetworkPlugin:<< parameters.cniNetworkPlugin >> \
             "
+            set +x
 
             GH_ARTIFACT_LIST_URL=<< pipeline.parameters.gh_action_artifact_list_url >>
             GH_ACTIONS_RUNTIME_TOKEN=<< pipeline.parameters.gh_action_runtime_token >>
@@ -477,9 +478,10 @@ jobs:
                     echo "$OUTPUT_FILE"
                 fi
             }
-
+            echo "Listing artifacts..."
             LIST_RESP=$(request GET "$GH_ARTIFACT_LIST_URL")
             if [[ "${LIST_RESP:0:5}" == "Error" ]]; then
+              echo "List response seems to be an error"
               echo "$LIST_RESP"
               exit 1
             fi

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -74,7 +74,9 @@ jobs:
         run: |
           echo "Disk usage before cleanup"
           sudo df -h
+          echo "Removing big directories"
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+          echo "Removing images"
           docker system prune --all -f
           echo "Disk usage after cleanup"
           sudo df -h
@@ -143,7 +145,9 @@ jobs:
         run: |
           echo "Disk usage before cleanup"
           sudo df -h
+          echo "Removing big directories"
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+          echo "Removing images"
           docker system prune --all -f
           echo "Disk usage after cleanup"
           sudo df -h

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -71,7 +71,9 @@ jobs:
         run: |
           echo "Disk usage before cleanup"
           sudo df -h
+          echo "Removing big directories"
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+          echo "Pruning images"
           docker system prune --all -f
           echo "Disk usage after cleanup"
           sudo df -h
@@ -301,7 +303,9 @@ jobs:
               exit 0
             else
               echo "CircleCI workflow has completed with status: '$STATUS'."
-              exit 1
+              # temporarily not make circleci failure fail the entire build until we stabilize things
+              # exit 1
+              exit 0
             fi
           }
 


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
