### PR TITLE
ci(github): use GitHub public artifact API when downloading artifacts from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,7 @@ parameters:
   gh_action_build_artifact_name:
     type: string
     default: ""
-  gh_action_artifact_list_url:
-    type: string
-    default: ""
-  gh_action_runtime_token:
+  gh_action_run_id:
     type: string
     default: ""
   e2e_param_k8sVersion:
@@ -415,6 +412,7 @@ jobs:
       - run:
           name: Download build output from GitHub action
           command: |
+            set -e
             echo "Running with: \
               k8s:<< parameters.k8sVersion >> \
               target:<< parameters.target >> \
@@ -423,42 +421,40 @@ jobs:
               legacyKDS:<< parameters.legacyKDS >> \
               cniNetworkPlugin:<< parameters.cniNetworkPlugin >> \
             "
-            set +x
-
-            GH_ARTIFACT_LIST_URL=<< pipeline.parameters.gh_action_artifact_list_url >>
-            GH_ACTIONS_RUNTIME_TOKEN=<< pipeline.parameters.gh_action_runtime_token >>
-            GH_ACTIONS_BUILD_ARTIFACT_NAME=<< pipeline.parameters.gh_action_build_artifact_name >>
-            BASE_DIR=build
-
-            if [[ "$GH_ACTIONS_RUNTIME_TOKEN" == "" ]]; then
-                echo "Please set these environment variables: GH_ACTIONS_RUNTIME_TOKEN"
+            if [[ "${GITHUB_TOKEN}" == "" ]]; then
+                echo "Please set value for environment variables: GITHUB_TOKEN"
                 exit 1
             fi
+
+            GH_ACTIONS_RUN_ID=<< pipeline.parameters.gh_action_run_id >>
+            GH_ACTIONS_BUILD_ARTIFACT_NAME=<< pipeline.parameters.gh_action_build_artifact_name >>
+            ARCH='<< parameters.arch >>'
+            BASE_DIR=build
 
             if [[ "$BASE_DIR" == "" ]]; then
                 BASE_DIR="."
             fi
 
             function request(){
-                METHOD=$1
-                URL=$2
-                IS_STREAM=$3
+                URL=$1
+                IS_STREAM=$2
 
                 if [[ "$URL" == "" ]]; then
-                    echo "Unknown URL"
-                    exit 1
+                    echo "Error: unknown URL"
+            	    return
                 fi
 
-                ACCEPT=application/json
+                ACCEPT=application/vnd.github+json
                 if [[ "$IS_STREAM" == "1" ]]; then
                     ACCEPT="*/*"
                 fi
 
                 OUTPUT_FILE=/tmp/gh-response-$RANDOM
+                touch $OUTPUT_FILE
                 STATUS_CODE=
                 while [[ "$STATUS_CODE" == "" ]]; do
-                    STATUS_CODE=$(curl --compressed -o $OUTPUT_FILE -sL -w "%{http_code}" -X $METHOD $URL \
-                    --header "accept: $ACCEPT" --header "Authorization: Bearer $GH_ACTIONS_RUNTIME_TOKEN")
+                    STATUS_CODE=$(curl --compressed -o $OUTPUT_FILE -sL -w "%{http_code}" $URL \
+                    --header "accept: $ACCEPT" --header "Authorization: Bearer ${GITHUB_TOKEN}" --header "X-GitHub-Api-Version: 2022-11-28")
 
                     if [[ "$STATUS_CODE" == "429" ]]; then
                         STATUS_CODE=
@@ -468,49 +464,56 @@ jobs:
                 done
 
                 if [ $STATUS_CODE -lt 200 ] || [ $STATUS_CODE -gt 399 ] ; then
-                    echo "Error requesting $METHOD $URL (status $STATUS_CODE)"
-                    exit 1
+                    echo "Error requesting $URL (status $STATUS_CODE)"
+                    return
                 fi
                 if [[ "$IS_STREAM" != "1" ]]; then
-                    cat $OUTPUT_FILE
+                    cat $OUTPUT_FILE | tr '\n' ' ' | jq -Rc "fromjson | ."
                     rm $OUTPUT_FILE
                 else
                     echo "$OUTPUT_FILE"
                 fi
             }
+
             echo "Listing artifacts..."
-            LIST_RESP=$(request GET "$GH_ARTIFACT_LIST_URL")
+            GITHUB_PROJECT="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
+            LIST_RESP=$(request "https://api.github.com/repos/$GITHUB_PROJECT/actions/runs/$GH_ACTIONS_RUN_ID/artifacts")
             if [[ "${LIST_RESP:0:5}" == "Error" ]]; then
               echo "List response seems to be an error"
               echo "$LIST_RESP"
               exit 1
             fi
-            FILE_LIST_URL=$(echo "$LIST_RESP" | jq -rc '.value[0].fileContainerResourceUrl //empty')
-            LIST_JSON_FILE=$(request GET "$FILE_LIST_URL" 1)
-            while read FILE_PATH; do
-              DOWNLOAD_URL=$(cat $LIST_JSON_FILE | jq -rc ".value[] | select(.path==\"$FILE_PATH\") | .contentLocation")
-              FILE_SIZE=$(cat $LIST_JSON_FILE | jq -rc ".value[] | select(.path==\"$FILE_PATH\") | .fileLength")
 
-              FILE_PATH=${FILE_PATH#*/}
-              echo "Downloading $FILE_PATH (size: $FILE_SIZE)"
-              mkdir -p $(dirname $BASE_DIR/$FILE_PATH)
-              FILE_SAVED=$(request GET "$DOWNLOAD_URL" 1)
-              mv $FILE_SAVED $BASE_DIR/$FILE_PATH
-            done < <(cat $LIST_JSON_FILE | jq -rc ".value[] | select((.itemType==\"file\") and (.path|startswith(\"$GH_ACTIONS_BUILD_ARTIFACT_NAME/\"))) | .path")
+            TARGET_ARTIFACT=$(echo "$LIST_RESP" | tr '\n' ' ' | jq -Rrc "fromjson | .artifacts[] | select(.name==\"$GH_ACTIONS_BUILD_ARTIFACT_NAME\") //empty")
+            if [[ "$TARGET_ARTIFACT" == "" ]]; then
+              echo "Could not find artifact $GH_ACTIONS_BUILD_ARTIFACT_NAME in run $GH_ACTIONS_RUN_ID."
+              exit 1
+            fi
+            if [[ "$(echo $TARGET_ARTIFACT | jq -rc '.expired')" == "true" ]]; then
+              echo "Artifact $GH_ACTIONS_BUILD_ARTIFACT_NAME in run $GH_ACTIONS_RUN_ID has expired."
+              exit 1
+            fi
 
+            DOWNLOAD_URL=$(echo $TARGET_ARTIFACT | jq -rc ".archive_download_url")
+            FILE_SIZE=$(echo $TARGET_ARTIFACT | jq -rc ".size_in_bytes")
+
+            echo "Downloading... (size: $FILE_SIZE)"
+            FILE_SAVED=$(request "$DOWNLOAD_URL" 1)
+            mv $FILE_SAVED ${FILE_SAVED}.zip
             echo "Downloading complete."
 
             echo "Extracting files..."
-            ARCH='<< parameters.arch >>'
-            ARTIFACT=$(find $BASE_DIR/distributions/out/*-linux-$ARCH.tar.gz)
-            if [[ "$ARTIFACT" == "" ]]; then
+            unzip ${FILE_SAVED}.zip -d $BASE_DIR
+
+            TARBALL=$(find $BASE_DIR/distributions/out/*-linux-$ARCH.tar.gz)
+            if [[ "$TARBALL" == "" ]]; then
               echo "Could not find built artifact for linux($ARCH)."
               exit 1
             fi
-            cat $ARTIFACT.sha256 | sha256sum --check
+            cat ${TARBALL}.sha256 | sha256sum --check
 
             mkdir $BASE_DIR/distributions/artifacts
-            tar -xzf $ARTIFACT -C $BASE_DIR/distributions/artifacts
+            tar -xzf $TARBALL -C $BASE_DIR/distributions/artifacts
 
             SRC_DIR=$(find build/distributions/artifacts/*/bin -type d)
             DEST_DIR=$BASE_DIR/artifacts-linux-$ARCH

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -429,94 +429,24 @@ jobs:
             GH_ACTIONS_RUN_ID=<< pipeline.parameters.gh_action_run_id >>
             GH_ACTIONS_BUILD_ARTIFACT_NAME=<< pipeline.parameters.gh_action_build_artifact_name >>
             ARCH='<< parameters.arch >>'
-            BASE_DIR=build
 
-            if [[ "$BASE_DIR" == "" ]]; then
-                BASE_DIR="."
-            fi
-
-            function request(){
-                URL=$1
-                IS_STREAM=$2
-
-                if [[ "$URL" == "" ]]; then
-                    echo "Error: unknown URL"
-            	    return
-                fi
-
-                ACCEPT=application/vnd.github+json
-                if [[ "$IS_STREAM" == "1" ]]; then
-                    ACCEPT="*/*"
-                fi
-
-                OUTPUT_FILE=/tmp/gh-response-$RANDOM
-                touch $OUTPUT_FILE
-                STATUS_CODE=
-                while [[ "$STATUS_CODE" == "" ]]; do
-                    STATUS_CODE=$(curl --compressed -o $OUTPUT_FILE -sL -w "%{http_code}" $URL \
-                    --header "accept: $ACCEPT" --header "Authorization: Bearer ${GITHUB_TOKEN}" --header "X-GitHub-Api-Version: 2022-11-28")
-
-                    if [[ "$STATUS_CODE" == "429" ]]; then
-                        STATUS_CODE=
-                        echo '' > $OUTPUT_FILE
-                        sleep $((RANDOM % 3))
-                    fi
-                done
-
-                if [ $STATUS_CODE -lt 200 ] || [ $STATUS_CODE -gt 399 ] ; then
-                    echo "Error requesting $URL (status $STATUS_CODE)"
-                    return
-                fi
-                if [[ "$IS_STREAM" != "1" ]]; then
-                    cat $OUTPUT_FILE | tr '\n' ' ' | jq -Rc "fromjson | ."
-                    rm $OUTPUT_FILE
-                else
-                    echo "$OUTPUT_FILE"
-                fi
-            }
-
-            echo "Listing artifacts..."
-            GITHUB_PROJECT="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
-            LIST_RESP=$(request "https://api.github.com/repos/$GITHUB_PROJECT/actions/runs/$GH_ACTIONS_RUN_ID/artifacts")
-            if [[ "${LIST_RESP:0:5}" == "Error" ]]; then
-              echo "List response seems to be an error"
-              echo "$LIST_RESP"
-              exit 1
-            fi
-
-            TARGET_ARTIFACT=$(echo "$LIST_RESP" | tr '\n' ' ' | jq -Rrc "fromjson | .artifacts[] | select(.name==\"$GH_ACTIONS_BUILD_ARTIFACT_NAME\") //empty")
-            if [[ "$TARGET_ARTIFACT" == "" ]]; then
-              echo "Could not find artifact $GH_ACTIONS_BUILD_ARTIFACT_NAME in run $GH_ACTIONS_RUN_ID."
-              exit 1
-            fi
-            if [[ "$(echo $TARGET_ARTIFACT | jq -rc '.expired')" == "true" ]]; then
-              echo "Artifact $GH_ACTIONS_BUILD_ARTIFACT_NAME in run $GH_ACTIONS_RUN_ID has expired."
-              exit 1
-            fi
-
-            DOWNLOAD_URL=$(echo $TARGET_ARTIFACT | jq -rc ".archive_download_url")
-            FILE_SIZE=$(echo $TARGET_ARTIFACT | jq -rc ".size_in_bytes")
-
-            echo "Downloading... (size: $FILE_SIZE)"
-            FILE_SAVED=$(request "$DOWNLOAD_URL" 1)
-            mv $FILE_SAVED ${FILE_SAVED}.zip
+            echo "Downloading..."
+            gh run download $GH_ACTIONS_RUN_ID --name $GH_ACTIONS_BUILD_ARTIFACT_NAME -D build \
+              --repo $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME 
             echo "Downloading complete."
 
             echo "Extracting files..."
-            unzip ${FILE_SAVED}.zip -d $BASE_DIR
-
-            TARBALL=$(find $BASE_DIR/distributions/out/*-linux-$ARCH.tar.gz)
+            TARBALL=$(find build/distributions/out/*-linux-$ARCH.tar.gz)
             if [[ "$TARBALL" == "" ]]; then
               echo "Could not find built artifact for linux($ARCH)."
               exit 1
             fi
             cat ${TARBALL}.sha256 | sha256sum --check
 
-            mkdir $BASE_DIR/distributions/artifacts
-            tar -xzf $TARBALL -C $BASE_DIR/distributions/artifacts
-
+            mkdir build/distributions/artifacts
+            tar -xzf $TARBALL -C build/distributions/artifacts
             SRC_DIR=$(find build/distributions/artifacts/*/bin -type d)
-            DEST_DIR=$BASE_DIR/artifacts-linux-$ARCH
+            DEST_DIR=build/artifacts-linux-$ARCH
             for BIN in $(ls $SRC_DIR); do
               mkdir -p $DEST_DIR/$BIN
               cp $SRC_DIR/$BIN $DEST_DIR/$BIN/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 version: 2.1 # Adds support for executors, parameterized jobs, etc
+orbs:
+  gh: circleci/github-cli@2.0
 parameters:
   # These parameters are not meant to be changed they are more constants for the build change these in mk/dev.mk
   go_version:
@@ -409,6 +411,7 @@ jobs:
     parallelism: << parameters.parallelism >>
     steps:
       - checkout
+      - gh/install
       - run:
           name: Download build output from GitHub action
           command: |
@@ -432,7 +435,7 @@ jobs:
 
             echo "Downloading..."
             gh run download $GH_ACTIONS_RUN_ID --name $GH_ACTIONS_BUILD_ARTIFACT_NAME -D build \
-              --repo $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME 
+              --repo $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
             echo "Downloading complete."
 
             echo "Extracting files..."

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -160,8 +160,7 @@ jobs:
           script: |
             let circleCIParams = {
               'gh_action_build_artifact_name': 'build-output',
-              'gh_action_runtime_token': process.env['ACTIONS_RUNTIME_TOKEN'],
-              'gh_action_artifact_list_url': `${process.env['ACTIONS_RUNTIME_URL']}/_apis/pipelines/workflows/${{ github.run_id }}/artifacts?api-version=6.0-preview`
+              'gh_action_run_id': '${{ github.run_id }}'
             };
             let inputs = JSON.parse(${{ toJSON(inputs.matrix) }});
             Object.keys(inputs).forEach(function(key) {
@@ -210,6 +209,7 @@ jobs:
             fi
 
             OUTPUT_FILE=/tmp/circleci-response-$RANDOM.json
+            touch $OUTPUT_FILE
             STATUS_CODE=
             while [[ "$STATUS_CODE" == "" ]]; do
               STATUS_CODE=$(curl -o $OUTPUT_FILE -sL -w "%{http_code}" -X $METHOD $URL \
@@ -224,19 +224,19 @@ jobs:
               fi
             done
 
-            cat $OUTPUT_FILE
-            rm $OUTPUT_FILE
             if [ $STATUS_CODE -lt 200 ] || [ $STATUS_CODE -gt 399 ] ; then
               echo "Error requesting $METHOD $URL (status $STATUS_CODE)"
-              exit 1
+              cat $OUTPUT_FILE
             fi
+            cat $OUTPUT_FILE
+            rm $OUTPUT_FILE
           }
 
-          PIPELINE_ID=$(request POST $CIRCLE_CI_API_PATH '${{ steps.circleci-gen-params.outputs.result }}' | jq -r '.id')
+          PIPELINE_ID=$(request POST $CIRCLE_CI_API_PATH '${{ steps.circleci-gen-params.outputs.result }}' | tr '\n' ' ' | jq -Rrc 'fromjson | .id')
           sleep 3
-          WORKFLOW_DETAILS=$(request GET https://circleci.com/api/v2/pipeline/$PIPELINE_ID/workflow | jq -cr '.items[] | select(.name == "manual-e2e")')
-          PIPELINE_NUMBER=$(echo $WORKFLOW_DETAILS | jq -r '.pipeline_number')
-          WORKFLOW_ID=$(echo $WORKFLOW_DETAILS | jq -r '.id')
+          WORKFLOW_DETAILS=$(request GET https://circleci.com/api/v2/pipeline/$PIPELINE_ID/workflow | tr '\n' ' ' | jq -Rrc 'fromjson | .items[] | select(.name == "manual-e2e")')
+          PIPELINE_NUMBER=$(echo $WORKFLOW_DETAILS | tr '\n' ' ' | jq -Rrc 'fromjson | .pipeline_number')
+          WORKFLOW_ID=$(echo $WORKFLOW_DETAILS | tr '\n' ' ' | jq -Rrc 'fromjson | .id')
 
           echo "pipeline_number=$PIPELINE_NUMBER" >> $GITHUB_OUTPUT
           echo "workflow_id=$WORKFLOW_ID" >> $GITHUB_OUTPUT
@@ -267,13 +267,12 @@ jobs:
             fi
 
             OUTPUT_FILE=/tmp/circleci-response-$RANDOM.json
+            touch $OUTPUT_FILE
             STATUS_CODE=$(curl -o $OUTPUT_FILE -sL -w "%{http_code}" -X $METHOD $URL \
               --header "content-type: application/json" --header "accept: application/json" \
               --header "x-attribution-login: ${{ github.actor }}" --header "x-attribution-actor-id: ${{ github.actor }}" \
               --header "Circle-Token: ${{ secrets.circleCIToken }}" $DATA )
 
-            cat $OUTPUT_FILE
-            rm $OUTPUT_FILE
             if [ "$STATUS_CODE" == "429" ]; then
               # we are exceeding rate limit, try again later
               echo '{"status": ""}'
@@ -281,8 +280,10 @@ jobs:
             fi
             if [ $STATUS_CODE -lt 200 ] || [ $STATUS_CODE -gt 399 ] ; then
               echo "Error requesting $METHOD $URL (status $STATUS_CODE)"
-              exit 1
+              cat $OUTPUT_FILE
             fi
+            cat $OUTPUT_FILE
+            rm $OUTPUT_FILE
           }
 
           function check_workflow(){
@@ -293,7 +294,7 @@ jobs:
             # status completed: "success" "not_run" "failed" "error" "failing" "canceled" "unauthorized"
             while [[ "$STATUS" == "" ]] || [[ "$STATUS" == "running" ]] || [[ "$STATUS" == "on_hold" ]]; do
               sleep $((RANDOM % 5 + 25))
-              STATUS=$(request GET https://circleci.com/api/v2/workflow/$WORKFLOW_ID | jq -r '.status')
+              STATUS=$(request GET https://circleci.com/api/v2/workflow/$WORKFLOW_ID | tr '\n' ' ' | jq -Rrc 'fromjson | .status')
               echo -n .
             done
 
@@ -303,9 +304,7 @@ jobs:
               exit 0
             else
               echo "CircleCI workflow has completed with status: '$STATUS'."
-              # temporarily not make circleci failure fail the entire build until we stabilize things
-              # exit 1
-              exit 0
+              exit 1
             fi
           }
 


### PR DESCRIPTION
To fix CI errors here:
https://github.com/kumahq/kuma/actions/runs/7273842586/job/19819186863#step:16:73

### Background
The artifact downloading failures started to occur after this PR: https://github.com/kumahq/kuma/pull/8701

There are some behavior changes between these two versions of the artifact plugin, according to GH documents:
https://github.com/actions/toolkit/tree/main/packages/artifact#improvements

These changes broke our download artifact implementation for CircleCI: artifacts uploaded by version 4 are not available to the "internal API" we are using (which worked for version 3).

Fortunately, according to GH docs, artifacts uploaded by version 4 are now available to their public rest APIs. So we are switching to use their public API. This will also be a more reliable way to achieve our goals.


### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - N/A
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - Confirmed, it will work with existing sync scripts
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Manually tested
  - Don't forget `ci/` labels to run additional/fewer tests
    - Added
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? 
  - No need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) 
  - No need

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
