### PR TITLE
fix(kds): make status tracker work when there's no metadata

### DIFF
--- a/pkg/kds/global/components.go
+++ b/pkg/kds/global/components.go
@@ -44,7 +44,6 @@ var (
 )
 
 func Setup(rt runtime.Runtime) error {
-	var err error
 	if rt.Config().Mode != config_core.Global {
 		// Only run on global
 		return nil

--- a/pkg/kds/v2/server/status_tracker.go
+++ b/pkg/kds/v2/server/status_tracker.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"sync"
+
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_sd "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	envoy_xds "github.com/envoyproxy/go-control-plane/pkg/server/v3"

--- a/pkg/kds/v2/server/status_tracker.go
+++ b/pkg/kds/v2/server/status_tracker.go
@@ -3,11 +3,11 @@ package server
 import (
 	"context"
 	"sync"
-
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_sd "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	envoy_xds "github.com/envoyproxy/go-control-plane/pkg/server/v3"
 	"github.com/go-logr/logr"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -70,14 +70,20 @@ func (c *statusTracker) OnDeltaStreamOpen(ctx context.Context, streamID int64, t
 	c.mu.Lock() // write access to the map of all ADS streams
 	defer c.mu.Unlock()
 
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		md = metadata.New(map[string]string{})
+	}
+
 	// initialize subscription
 	now := core.Now()
 	subscription := &system_proto.KDSSubscription{
-		Id:               core.NewUUID(),
-		GlobalInstanceId: c.runtimeInfo.GetInstanceId(),
-		ConnectTime:      util_proto.MustTimestampProto(now),
-		Status:           system_proto.NewSubscriptionStatus(now),
-		Version:          system_proto.NewVersion(),
+		Id:                core.NewUUID(),
+		GlobalInstanceId:  c.runtimeInfo.GetInstanceId(),
+		ConnectTime:       util_proto.MustTimestampProto(now),
+		Status:            system_proto.NewSubscriptionStatus(now),
+		Version:           system_proto.NewVersion(),
+		AuthTokenProvided: len(md.Get("authorization")) == 1,
 	}
 	// initialize state per ADS stream
 	state := &streamState{


### PR DESCRIPTION
Since we now do status tracking on the zone we need to support not having metadata as these are only sent to global.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
