### PR TITLE
fix(MeshHTTPRoute): make ordering more consistent

### DIFF
--- a/pkg/core/resources/model/resource.go
+++ b/pkg/core/resources/model/resource.go
@@ -474,6 +474,10 @@ type PolicyItem interface {
 	GetDefault() interface{}
 }
 
+type TransformDefaultAfterMerge interface {
+	Transform()
+}
+
 type Policy interface {
 	ResourceSpec
 	GetTargetRef() common_api.TargetRef

--- a/pkg/plugins/policies/core/rules/merge.go
+++ b/pkg/plugins/policies/core/rules/merge.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	jsonpatch "github.com/evanphx/json-patch/v5"
+
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
 // indicates that all slices that start with this prefix will be appended, not replaced
@@ -91,6 +93,9 @@ func handleMergeByKeyFields(valueResult reflect.Value) error {
 			return err
 		}
 		entriesValue.Set(merged)
+	}
+	if withSet, ok := valueResult.Interface().(core_model.TransformDefaultAfterMerge); ok {
+		withSet.Transform()
 	}
 	return nil
 }

--- a/pkg/plugins/policies/core/rules/merge_test.go
+++ b/pkg/plugins/policies/core/rules/merge_test.go
@@ -268,9 +268,9 @@ var _ = Describe("MergeConfs", func() {
 			}},
 			expected: testPolicy{
 				MergeValues: []mergeEntry{{
-					Key: mergeKey{Left: true}, Default: mergeConf{A: &t, B: &f},
-				}, {
 					Key: mergeKey{Right: true}, Default: mergeConf{B: &t},
+				}, {
+					Key: mergeKey{Left: true}, Default: mergeConf{A: &t, B: &f},
 				}},
 				OtherValues: &[]nonMergeEntry{{
 					Key: mergeKey{Left: true}, Default: mergeConf{A: &t},

--- a/pkg/plugins/policies/core/rules/merge_test.go
+++ b/pkg/plugins/policies/core/rules/merge_test.go
@@ -231,6 +231,7 @@ var _ = Describe("MergeConfs", func() {
 	}
 
 	t := true
+	f := false
 	DescribeTable("mergeValuesByKey",
 		func(given mergeValuesByKeyCase) {
 			var givens []interface{}
@@ -260,10 +261,14 @@ var _ = Describe("MergeConfs", func() {
 				MergeValues: []mergeEntry{{
 					Key: mergeKey{Right: true}, Default: mergeConf{B: &t},
 				}},
+			}, {
+				MergeValues: []mergeEntry{{
+					Key: mergeKey{Left: true}, Default: mergeConf{B: &f},
+				}},
 			}},
 			expected: testPolicy{
 				MergeValues: []mergeEntry{{
-					Key: mergeKey{Left: true}, Default: mergeConf{A: &t, B: &t},
+					Key: mergeKey{Left: true}, Default: mergeConf{A: &t, B: &f},
 				}, {
 					Key: mergeKey{Right: true}, Default: mergeConf{B: &t},
 				}},

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/helpers.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/helpers.go
@@ -1,11 +1,19 @@
 package v1alpha1
 
+import "slices"
+
 type PolicyDefault struct {
 	Rules []Rule `policyMerge:"mergeValuesByKey"`
 }
 
 func (x *To) GetDefault() interface{} {
+	reversed := slices.Clone(x.Rules)
+	slices.Reverse(reversed)
 	return PolicyDefault{
-		Rules: x.Rules,
+		Rules: reversed,
 	}
+}
+
+func (policy *PolicyDefault) Transform() {
+	slices.Reverse(policy.Rules)
 }

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/merge_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/merge_test.go
@@ -236,5 +236,162 @@ var _ = DescribeTable("MatchedPolicies", func(given policiesTestCase) {
 			},
 		},
 	},
+}), Entry("ordering", policiesTestCase{
+	dataplane: samples.DataplaneWeb(),
+	resources: xds_context.Resources{
+		MeshLocalResources: map[core_model.ResourceType]core_model.ResourceList{
+			api.MeshHTTPRouteType: &api.MeshHTTPRouteResourceList{
+				Items: []*api.MeshHTTPRouteResource{{
+					Meta: &test_model.ResourceMeta{
+						Mesh: core_model.DefaultMesh,
+						Name: "a-route",
+					},
+					Spec: &api.MeshHTTPRoute{
+						TargetRef: builders.TargetRefMesh(),
+						To: []api.To{{
+							TargetRef: builders.TargetRefService("backend"),
+							Rules: []api.Rule{{
+								Matches: []api.Match{{
+									Path: &api.PathMatch{
+										Type:  api.PathPrefix,
+										Value: "/a-first-prefix",
+									},
+								}},
+								Default: api.RuleConf{
+									BackendRefs: &[]common_api.BackendRef{{
+										TargetRef: builders.TargetRefService("backend"),
+										Weight:    pointer.To(uint(100)),
+									}},
+								},
+							}, {
+								Matches: []api.Match{{
+									Path: &api.PathMatch{
+										Type:  api.PathPrefix,
+										Value: "/a-second-prefix",
+									},
+								}},
+								Default: api.RuleConf{
+									BackendRefs: &[]common_api.BackendRef{{
+										TargetRef: builders.TargetRefService("backend"),
+										Weight:    pointer.To(uint(100)),
+									}},
+								},
+							}},
+						}},
+					},
+				}, {
+					Meta: &test_model.ResourceMeta{
+						Mesh: core_model.DefaultMesh,
+						Name: "b-route",
+					},
+					Spec: &api.MeshHTTPRoute{
+						TargetRef: builders.TargetRefMesh(),
+						To: []api.To{{
+							TargetRef: builders.TargetRefService("backend"),
+							Rules: []api.Rule{{
+								Matches: []api.Match{{
+									Path: &api.PathMatch{
+										Type:  api.PathPrefix,
+										Value: "/b-first-prefix",
+									},
+								}},
+								Default: api.RuleConf{
+									BackendRefs: &[]common_api.BackendRef{{
+										TargetRef: builders.TargetRefService("backend"),
+										Weight:    pointer.To(uint(100)),
+									}},
+								},
+							}, {
+								Matches: []api.Match{{
+									Path: &api.PathMatch{
+										Type:  api.PathPrefix,
+										Value: "/b-second-prefix",
+									},
+								}},
+								Default: api.RuleConf{
+									BackendRefs: &[]common_api.BackendRef{{
+										TargetRef: builders.TargetRefService("backend"),
+										Weight:    pointer.To(uint(100)),
+									}},
+								},
+							}},
+						}},
+					},
+				}},
+			},
+		},
+	},
+	expectedRoutes: core_rules.ToRules{
+		Rules: core_rules.Rules{
+			{
+				Subset: core_rules.MeshService("backend"),
+				Conf: api.PolicyDefault{
+					Rules: []api.Rule{{
+						Matches: []api.Match{{
+							Path: &api.PathMatch{
+								Type:  api.PathPrefix,
+								Value: "/b-first-prefix",
+							},
+						}},
+						Default: api.RuleConf{
+							BackendRefs: &[]common_api.BackendRef{{
+								TargetRef: builders.TargetRefService("backend"),
+								Weight:    pointer.To(uint(100)),
+							}},
+						},
+					}, {
+						Matches: []api.Match{{
+							Path: &api.PathMatch{
+								Type:  api.PathPrefix,
+								Value: "/b-second-prefix",
+							},
+						}},
+						Default: api.RuleConf{
+							BackendRefs: &[]common_api.BackendRef{{
+								TargetRef: builders.TargetRefService("backend"),
+								Weight:    pointer.To(uint(100)),
+							}},
+						},
+					}, {
+						Matches: []api.Match{{
+							Path: &api.PathMatch{
+								Type:  api.PathPrefix,
+								Value: "/a-first-prefix",
+							},
+						}},
+						Default: api.RuleConf{
+							BackendRefs: &[]common_api.BackendRef{{
+								TargetRef: builders.TargetRefService("backend"),
+								Weight:    pointer.To(uint(100)),
+							}},
+						},
+					}, {
+						Matches: []api.Match{{
+							Path: &api.PathMatch{
+								Type:  api.PathPrefix,
+								Value: "/a-second-prefix",
+							},
+						}},
+						Default: api.RuleConf{
+							BackendRefs: &[]common_api.BackendRef{{
+								TargetRef: builders.TargetRefService("backend"),
+								Weight:    pointer.To(uint(100)),
+							}},
+						},
+					}},
+				},
+				Origin: []core_model.ResourceMeta{
+					&test_model.ResourceMeta{
+						Mesh: "default",
+						Name: "a-route",
+					},
+					&test_model.ResourceMeta{
+						Mesh: "default",
+						Name: "b-route",
+					},
+				},
+			},
+		},
+	},
 }),
 )

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/merge_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/merge_test.go
@@ -272,7 +272,46 @@ var _ = DescribeTable("MatchedPolicies", func(given policiesTestCase) {
 								}},
 								Default: api.RuleConf{
 									BackendRefs: &[]common_api.BackendRef{{
-										TargetRef: builders.TargetRefService("backend"),
+										TargetRef: builders.TargetRefService("first-time-in-list-backend"),
+										Weight:    pointer.To(uint(100)),
+									}},
+								},
+							}, {
+								Matches: []api.Match{{
+									Path: &api.PathMatch{
+										Type:  api.PathPrefix,
+										Value: "/should-be-first-shared-prefix",
+									},
+								}},
+								Default: api.RuleConf{
+									BackendRefs: &[]common_api.BackendRef{{
+										TargetRef: builders.TargetRefService("a-backend"),
+										Weight:    pointer.To(uint(100)),
+									}},
+								},
+							}, {
+								Matches: []api.Match{{
+									Path: &api.PathMatch{
+										Type:  api.PathPrefix,
+										Value: "/should-be-second-shared-prefix",
+									},
+								}},
+								Default: api.RuleConf{
+									BackendRefs: &[]common_api.BackendRef{{
+										TargetRef: builders.TargetRefService("a-backend"),
+										Weight:    pointer.To(uint(100)),
+									}},
+								},
+							}, {
+								Matches: []api.Match{{
+									Path: &api.PathMatch{
+										Type:  api.PathPrefix,
+										Value: "/a-second-prefix",
+									},
+								}},
+								Default: api.RuleConf{
+									BackendRefs: &[]common_api.BackendRef{{
+										TargetRef: builders.TargetRefService("second-time-in-list-backend"),
 										Weight:    pointer.To(uint(100)),
 									}},
 								},
@@ -298,6 +337,32 @@ var _ = DescribeTable("MatchedPolicies", func(given policiesTestCase) {
 								Default: api.RuleConf{
 									BackendRefs: &[]common_api.BackendRef{{
 										TargetRef: builders.TargetRefService("backend"),
+										Weight:    pointer.To(uint(100)),
+									}},
+								},
+							}, {
+								Matches: []api.Match{{
+									Path: &api.PathMatch{
+										Type:  api.PathPrefix,
+										Value: "/should-be-second-shared-prefix",
+									},
+								}},
+								Default: api.RuleConf{
+									BackendRefs: &[]common_api.BackendRef{{
+										TargetRef: builders.TargetRefService("b-backend"),
+										Weight:    pointer.To(uint(100)),
+									}},
+								},
+							}, {
+								Matches: []api.Match{{
+									Path: &api.PathMatch{
+										Type:  api.PathPrefix,
+										Value: "/should-be-first-shared-prefix",
+									},
+								}},
+								Default: api.RuleConf{
+									BackendRefs: &[]common_api.BackendRef{{
+										TargetRef: builders.TargetRefService("b-backend"),
 										Weight:    pointer.To(uint(100)),
 									}},
 								},
@@ -348,7 +413,33 @@ var _ = DescribeTable("MatchedPolicies", func(given policiesTestCase) {
 						}},
 						Default: api.RuleConf{
 							BackendRefs: &[]common_api.BackendRef{{
-								TargetRef: builders.TargetRefService("backend"),
+								TargetRef: builders.TargetRefService("first-time-in-list-backend"),
+								Weight:    pointer.To(uint(100)),
+							}},
+						},
+					}, {
+						Matches: []api.Match{{
+							Path: &api.PathMatch{
+								Type:  api.PathPrefix,
+								Value: "/should-be-first-shared-prefix",
+							},
+						}},
+						Default: api.RuleConf{
+							BackendRefs: &[]common_api.BackendRef{{
+								TargetRef: builders.TargetRefService("a-backend"),
+								Weight:    pointer.To(uint(100)),
+							}},
+						},
+					}, {
+						Matches: []api.Match{{
+							Path: &api.PathMatch{
+								Type:  api.PathPrefix,
+								Value: "/should-be-second-shared-prefix",
+							},
+						}},
+						Default: api.RuleConf{
+							BackendRefs: &[]common_api.BackendRef{{
+								TargetRef: builders.TargetRefService("a-backend"),
 								Weight:    pointer.To(uint(100)),
 							}},
 						},

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/merge_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/merge_test.go
@@ -106,19 +106,6 @@ var _ = DescribeTable("MatchedPolicies", func(given policiesTestCase) {
 						Matches: []api.Match{{
 							Path: &api.PathMatch{
 								Type:  api.PathPrefix,
-								Value: "/v2",
-							},
-						}},
-						Default: api.RuleConf{
-							BackendRefs: &[]common_api.BackendRef{{
-								TargetRef: builders.TargetRefServiceSubset("backend", "version", "v2"),
-								Weight:    pointer.To(uint(100)),
-							}},
-						},
-					}, {
-						Matches: []api.Match{{
-							Path: &api.PathMatch{
-								Type:  api.PathPrefix,
 								Value: "/v1",
 							},
 						}},
@@ -126,6 +113,19 @@ var _ = DescribeTable("MatchedPolicies", func(given policiesTestCase) {
 							Filters: &[]api.Filter{{}},
 							BackendRefs: &[]common_api.BackendRef{{
 								TargetRef: builders.TargetRefServiceSubset("backend", "version", "v1"),
+								Weight:    pointer.To(uint(100)),
+							}},
+						},
+					}, {
+						Matches: []api.Match{{
+							Path: &api.PathMatch{
+								Type:  api.PathPrefix,
+								Value: "/v2",
+							},
+						}},
+						Default: api.RuleConf{
+							BackendRefs: &[]common_api.BackendRef{{
+								TargetRef: builders.TargetRefServiceSubset("backend", "version", "v2"),
 								Weight:    pointer.To(uint(100)),
 							}},
 						},

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/merge_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/merge_test.go
@@ -28,7 +28,7 @@ var _ = DescribeTable("MatchedPolicies", func(given policiesTestCase) {
 	routes, err := plugin.NewPlugin().(core_plugins.PolicyPlugin).MatchedPolicies(given.dataplane, given.resources)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(routes.ToRules).To(Equal(given.expectedRoutes))
-}, Entry("basic", policiesTestCase{
+}, Entry("basic-kind-specificity", policiesTestCase{
 	dataplane: samples.DataplaneWeb(),
 	resources: xds_context.Resources{
 		MeshLocalResources: map[core_model.ResourceType]core_model.ResourceList{
@@ -106,13 +106,12 @@ var _ = DescribeTable("MatchedPolicies", func(given policiesTestCase) {
 						Matches: []api.Match{{
 							Path: &api.PathMatch{
 								Type:  api.PathPrefix,
-								Value: "/v1",
+								Value: "/v2",
 							},
 						}},
 						Default: api.RuleConf{
-							Filters: &[]api.Filter{{}},
 							BackendRefs: &[]common_api.BackendRef{{
-								TargetRef: builders.TargetRefServiceSubset("backend", "version", "v1"),
+								TargetRef: builders.TargetRefServiceSubset("backend", "version", "v2"),
 								Weight:    pointer.To(uint(100)),
 							}},
 						},
@@ -120,12 +119,13 @@ var _ = DescribeTable("MatchedPolicies", func(given policiesTestCase) {
 						Matches: []api.Match{{
 							Path: &api.PathMatch{
 								Type:  api.PathPrefix,
-								Value: "/v2",
+								Value: "/v1",
 							},
 						}},
 						Default: api.RuleConf{
+							Filters: &[]api.Filter{{}},
 							BackendRefs: &[]common_api.BackendRef{{
-								TargetRef: builders.TargetRefServiceSubset("backend", "version", "v2"),
+								TargetRef: builders.TargetRefServiceSubset("backend", "version", "v1"),
 								Weight:    pointer.To(uint(100)),
 							}},
 						},
@@ -330,32 +330,6 @@ var _ = DescribeTable("MatchedPolicies", func(given policiesTestCase) {
 						Matches: []api.Match{{
 							Path: &api.PathMatch{
 								Type:  api.PathPrefix,
-								Value: "/b-first-prefix",
-							},
-						}},
-						Default: api.RuleConf{
-							BackendRefs: &[]common_api.BackendRef{{
-								TargetRef: builders.TargetRefService("backend"),
-								Weight:    pointer.To(uint(100)),
-							}},
-						},
-					}, {
-						Matches: []api.Match{{
-							Path: &api.PathMatch{
-								Type:  api.PathPrefix,
-								Value: "/b-second-prefix",
-							},
-						}},
-						Default: api.RuleConf{
-							BackendRefs: &[]common_api.BackendRef{{
-								TargetRef: builders.TargetRefService("backend"),
-								Weight:    pointer.To(uint(100)),
-							}},
-						},
-					}, {
-						Matches: []api.Match{{
-							Path: &api.PathMatch{
-								Type:  api.PathPrefix,
 								Value: "/a-first-prefix",
 							},
 						}},
@@ -370,6 +344,32 @@ var _ = DescribeTable("MatchedPolicies", func(given policiesTestCase) {
 							Path: &api.PathMatch{
 								Type:  api.PathPrefix,
 								Value: "/a-second-prefix",
+							},
+						}},
+						Default: api.RuleConf{
+							BackendRefs: &[]common_api.BackendRef{{
+								TargetRef: builders.TargetRefService("backend"),
+								Weight:    pointer.To(uint(100)),
+							}},
+						},
+					}, {
+						Matches: []api.Match{{
+							Path: &api.PathMatch{
+								Type:  api.PathPrefix,
+								Value: "/b-first-prefix",
+							},
+						}},
+						Default: api.RuleConf{
+							BackendRefs: &[]common_api.BackendRef{{
+								TargetRef: builders.TargetRefService("backend"),
+								Weight:    pointer.To(uint(100)),
+							}},
+						},
+					}, {
+						Matches: []api.Match{{
+							Path: &api.PathMatch{
+								Type:  api.PathPrefix,
+								Value: "/b-second-prefix",
 							},
 						}},
 						Default: api.RuleConf{


### PR DESCRIPTION
See the tests at https://github.com/michaelbeaumont/kuma/blob/fix/route-merging-order/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/merge_test.go

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
