### PR TITLE
ci(github): allow arm/circleci failures to fail GH Actions CI

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -304,9 +304,7 @@ jobs:
               exit 0
             else
               echo "CircleCI workflow has completed with status: '$STATUS'."
-              # temporarily not make circleci failure fail the entire build until we stabilize things
-              # exit 1
-              exit 0
+              exit 1
             fi
           }
 


### PR DESCRIPTION
In a previous PR, we prevented arm e2e test failures from failing the GitHub Actions runs, because we didn't fix the CIecleCI run at that time.

https://github.com/kumahq/kuma/pull/8719

And now the arm E2E tests are run stably, so we are openning the ability to fail CI on test failures.

https://app.circleci.com/pipelines/gh/kumahq/kuma

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - N/A
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS 
  - Confirmed
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) 
  - Tested
  - Don't forget `ci/` labels to run additional/fewer tests
    - Added
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? 
  - No need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) 
  - No need

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
