### PR TITLE
feat(xds): skip generating clusters for external services without any endpoints

### DIFF
--- a/pkg/core/xds/types.go
+++ b/pkg/core/xds/types.go
@@ -233,8 +233,6 @@ type Routing struct {
 	// Since we take into account TrafficPermission to exclude external services from the map,
 	// it is specific for each data plane proxy.
 	ExternalServiceOutboundTargets EndpointMap
-	// Map to mark services are external even if there are no endpoints for them
-	ExternalServiceUnavailable map[string]struct{}
 }
 
 type CaSecret struct {

--- a/pkg/core/xds/types.go
+++ b/pkg/core/xds/types.go
@@ -233,6 +233,8 @@ type Routing struct {
 	// Since we take into account TrafficPermission to exclude external services from the map,
 	// it is specific for each data plane proxy.
 	ExternalServiceOutboundTargets EndpointMap
+	// Map to mark services are external even if there are no endpoints for them
+	ExternalServiceUnavailable map[string]struct{}
 }
 
 type CaSecret struct {

--- a/pkg/xds/generator/testdata/outbound-proxy/external-services-no-endpoints.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/external-services-no-endpoints.envoy.golden.yaml
@@ -1,0 +1,17 @@
+resources:
+- name: outbound:127.0.0.1:18081
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 127.0.0.1
+        portValue: 18081
+    bindToPort: false
+    filterChains:
+      - {}
+    metadata:
+      filterMetadata:
+        io.kuma.tags:
+          kuma.io/service: httpbin
+    name: outbound:127.0.0.1:18081
+    trafficDirection: OUTBOUND

--- a/pkg/xds/sync/dataplane_proxy_builder.go
+++ b/pkg/xds/sync/dataplane_proxy_builder.go
@@ -95,13 +95,11 @@ func (p *DataplaneProxyBuilder) resolveRouting(
 		meshContext.DataSourceLoader,
 		p.Zone,
 	)
-	unavailableExternalServices := diffExternalServices(meshContext.Resources.ExternalServices(), endpointMap)
 
 	routing := &core_xds.Routing{
 		TrafficRoutes:                  routes,
 		OutboundTargets:                meshContext.EndpointMap,
 		ExternalServiceOutboundTargets: endpointMap,
-		ExternalServiceUnavailable:     unavailableExternalServices,
 	}
 	return routing, destinations
 }
@@ -186,17 +184,4 @@ func (p *DataplaneProxyBuilder) matchPolicies(meshContext xds_context.MeshContex
 		matchedPolicies.Dynamic[res.Type] = res
 	}
 	return matchedPolicies, nil
-}
-
-func diffExternalServices(allExternalServices *core_mesh.ExternalServiceResourceList, endpointMap core_xds.EndpointMap) map[string]struct{} {
-	diff := make(map[string]struct{})
-
-	for _, external := range allExternalServices.Items {
-		service := external.Spec.GetService()
-		if _, ok := endpointMap[service]; !ok {
-			diff[service] = struct{}{}
-		}
-	}
-
-	return diff
 }

--- a/pkg/xds/sync/dataplane_proxy_builder.go
+++ b/pkg/xds/sync/dataplane_proxy_builder.go
@@ -95,10 +95,13 @@ func (p *DataplaneProxyBuilder) resolveRouting(
 		meshContext.DataSourceLoader,
 		p.Zone,
 	)
+	unavailableExternalServices := diffExternalServices(meshContext.Resources.ExternalServices(), endpointMap)
+
 	routing := &core_xds.Routing{
 		TrafficRoutes:                  routes,
 		OutboundTargets:                meshContext.EndpointMap,
 		ExternalServiceOutboundTargets: endpointMap,
+		ExternalServiceUnavailable:     unavailableExternalServices,
 	}
 	return routing, destinations
 }
@@ -183,4 +186,17 @@ func (p *DataplaneProxyBuilder) matchPolicies(meshContext xds_context.MeshContex
 		matchedPolicies.Dynamic[res.Type] = res
 	}
 	return matchedPolicies, nil
+}
+
+func diffExternalServices(allExternalServices *core_mesh.ExternalServiceResourceList, endpointMap core_xds.EndpointMap) map[string]struct{} {
+	diff := make(map[string]struct{})
+
+	for _, external := range allExternalServices.Items {
+		service := external.Spec.GetService()
+		if _, ok := endpointMap[service]; !ok {
+			diff[service] = struct{}{}
+		}
+	}
+
+	return diff
 }


### PR DESCRIPTION
In certain cases,  endpoints of external services can be invalidated by `TrafficPermission` policies. In such case,  these external services are actually treated as "non-external" in our current implementation of xDS generating. 

While it didn't cause any actual problems, it's still need to be fixed as they may mess up some time. For now, we can see, mTLS certificates can be unexpectedly issued for data planes that have outbound only to these external services. 

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues 
  - N/A
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - Should not break.
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) 
  - Added
  - Don't forget `ci/` labels to run additional/fewer tests
  - No need
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? 
  - No need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) 
  - No need

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
