### PR TITLE
refactor(policy): control whether MeshGateway tags are allowed

### DIFF
--- a/pkg/core/resources/apis/mesh/validators.go
+++ b/pkg/core/resources/apis/mesh/validators.go
@@ -48,7 +48,8 @@ type ValidateSelectorsOpts struct {
 }
 
 type ValidateTargetRefOpts struct {
-	SupportedKinds []common_api.TargetRefKind
+	SupportedKinds             []common_api.TargetRefKind
+	GatewayListenerTagsAllowed bool
 }
 
 func ValidateSelectors(path validators.PathBuilder, sources []*mesh_proto.Selector, opts ValidateSelectorsOpts) validators.ValidationError {
@@ -361,6 +362,9 @@ func ValidateTargetRef(
 		err.Add(validateName(ref.Name))
 		err.Add(disallowedField("mesh", ref.Mesh, ref.Kind))
 		err.Add(ValidateTags(validators.RootedAt("tags"), ref.Tags, ValidateTagsOpts{}))
+		if ref.Kind == common_api.MeshGateway && len(ref.Tags) > 0 && !opts.GatewayListenerTagsAllowed {
+			err.Add(disallowedField("tags", ref.Tags, ref.Kind))
+		}
 	}
 
 	return err

--- a/pkg/core/resources/apis/mesh/validators_test.go
+++ b/pkg/core/resources/apis/mesh/validators_test.go
@@ -175,6 +175,7 @@ tags:
 				SupportedKinds: []common_api.TargetRefKind{
 					common_api.MeshGateway,
 				},
+				GatewayListenerTagsAllowed: true,
 			},
 		}),
 		Entry("MeshHTTPRoute", testCase{
@@ -611,6 +612,24 @@ kind: MeshGatewayRoute
 violations:
   - field: targetRef.kind
     message: value is not supported
+`,
+		}),
+		Entry("MeshGateway and no tags allowed", testCase{
+			inputYaml: `
+kind: MeshGateway
+name: edge
+tags:
+  port: http
+`,
+			opts: &ValidateTargetRefOpts{
+				SupportedKinds: []common_api.TargetRefKind{
+					common_api.MeshGateway,
+				},
+			},
+			expected: `
+violations:
+  - field: targetRef.tags
+    message: must not be set with kind MeshGateway
 `,
 		}),
 	)

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/validator.go
@@ -31,6 +31,7 @@ func validateTop(targetRef common_api.TargetRef) validators.ValidationError {
 			common_api.MeshService,
 			common_api.MeshServiceSubset,
 		},
+		GatewayListenerTagsAllowed: true,
 	})
 	return targetRefErr
 }

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/validator.go
@@ -29,6 +29,7 @@ func validateTop(targetRef common_api.TargetRef) validators.ValidationError {
 			common_api.MeshGateway,
 			common_api.MeshServiceSubset,
 		},
+		GatewayListenerTagsAllowed: true,
 	})
 	return targetRefErr
 }

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/validator.go
@@ -25,6 +25,7 @@ func validateTop(targetRef common_api.TargetRef) validators.ValidationError {
 			common_api.MeshService,
 			common_api.MeshServiceSubset,
 		},
+		GatewayListenerTagsAllowed: true,
 	})
 	return targetRefErr
 }

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/validator.go
@@ -23,6 +23,7 @@ func validateTop(targetRef common_api.TargetRef) validators.ValidationError {
 			common_api.MeshService,
 			common_api.MeshServiceSubset,
 		},
+		GatewayListenerTagsAllowed: true,
 	})
 	return targetRefErr
 }

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation.go
@@ -28,6 +28,7 @@ func validateTop(targetRef common_api.TargetRef) validators.ValidationError {
 			common_api.MeshService,
 			common_api.MeshServiceSubset,
 		},
+		GatewayListenerTagsAllowed: true,
 	})
 }
 

--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/validator.go
@@ -38,6 +38,7 @@ func validateTop(targetRef common_api.TargetRef) validators.ValidationError {
 			common_api.MeshServiceSubset,
 			common_api.MeshGateway,
 		},
+		GatewayListenerTagsAllowed: false,
 	})
 	return targetRefErr
 }

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/validator.go
@@ -28,6 +28,7 @@ func validateTop(targetRef common_api.TargetRef) validators.ValidationError {
 			common_api.MeshServiceSubset,
 			common_api.MeshHTTPRoute,
 		},
+		GatewayListenerTagsAllowed: true,
 	})
 	return targetRefErr
 }


### PR DESCRIPTION
This doesn't change any behavior just allows validating the presence of tags.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- #8549 
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
