### PR TITLE
test(bootstrap): move corefile template e2e test to test/e2e from test/e2e_env/kubernetes

### DIFF
--- a/test/e2e/bootstrap/e2e_suite_test.go
+++ b/test/e2e/bootstrap/e2e_suite_test.go
@@ -1,0 +1,16 @@
+package bootstrap_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+
+	"github.com/kumahq/kuma/pkg/test"
+	"github.com/kumahq/kuma/test/e2e/bootstrap"
+)
+
+func TestE2E(t *testing.T) {
+	test.RunE2ESpecs(t, "Bootstrap Suite")
+}
+
+var _ = Describe("Corefile Template", bootstrap.CorefileTemplate, Ordered)

--- a/test/e2e_env/kubernetes/kubernetes_suite_test.go
+++ b/test/e2e_env/kubernetes/kubernetes_suite_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/kumahq/kuma/pkg/test"
 	"github.com/kumahq/kuma/test/e2e_env/kubernetes/api"
-	"github.com/kumahq/kuma/test/e2e_env/kubernetes/bootstrap"
 	"github.com/kumahq/kuma/test/e2e_env/kubernetes/connectivity"
 	"github.com/kumahq/kuma/test/e2e_env/kubernetes/container_patch"
 	"github.com/kumahq/kuma/test/e2e_env/kubernetes/defaults"
@@ -50,7 +49,6 @@ var _ = E2ESynchronizedBeforeSuite(kubernetes.SetupAndGetState, kubernetes.Resto
 var _ = SynchronizedAfterSuite(func() {}, func() {})
 
 var (
-	_ = Describe("Corefile Template", bootstrap.CorefileTemplate, Ordered)
 	_ = Describe("Virtual Probes", healthcheck.VirtualProbes, Ordered)
 	_ = Describe("Gateway", gateway.Gateway, Ordered)
 	_ = Describe("Gateway - Cross-mesh", gateway.CrossMeshGatewayOnKubernetes, Ordered)


### PR DESCRIPTION
To fix comments from this previous PR https://github.com/kumahq/kuma/pull/8634

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - N/A
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS 
  - Confirmed
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - N/A
  - Don't forget `ci/` labels to run additional/fewer tests
    - No need
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? 
  - No
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) 
  - No

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
