### PR TITLE
ci(.github): add retry to download artifacts to work around the RequestTimeout issue of downloading artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -434,9 +434,26 @@ jobs:
             ARCH='<< parameters.arch >>'
 
             echo "Downloading..."
-            gh run download $GH_ACTIONS_RUN_ID --name $GH_ACTIONS_BUILD_ARTIFACT_NAME -D build \
-              --repo $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
-            echo "Downloading complete."
+            MAX_ATTEMPTS=5
+            ATTEMPTS=0
+
+            while [[ $ATTEMPTS -lt $MAX_ATTEMPTS ]]; do
+              if [[ $ATTEMPTS -gt 0 ]]; then echo "Retrying..."; fi
+              gh run download $GH_ACTIONS_RUN_ID --name $GH_ACTIONS_BUILD_ARTIFACT_NAME -D build \
+                --repo $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME || true
+              if [ ! -z "$(ls build/distributions/out)" ]; then
+                break
+              else
+                ATTEMPTS=$((ATTEMPTS + 1))
+                sleep $(( RANDOM % 5 ))
+              fi
+            done
+            if [ ! -z "$(ls build/distributions/out)" ]; then
+              echo "Downloading complete."
+            else
+              echo "Could not download build output artifacts from GitHub."
+              exit 1
+            fi
 
             echo "Extracting files..."
             TARBALL=$(find build/distributions/out/*-linux-$ARCH.tar.gz)

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -207,10 +207,16 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-devtools-${{ hashFiles('mk/dependencies/deps.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-devtools
-      - uses: actions/download-artifact@v4
+      # FIXME: Workaround for Request Timeout issue of artifacts https://github.com/actions/download-artifact/issues/249
+      - name: Download artifacts with retry
+        uses: Wandalen/wretry.action@master
         with:
-          name: build-output
-          path: build
+          action: actions/download-artifact@v4
+          with: |
+            path: build
+            name: build-output
+          attempt_limit: 5
+          attempt_delay: 1000
       - name: Inspect created tars
         run: |
           for i in build/distributions/out/*.tar.gz; do echo $i; tar -tvf $i; done

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -77,12 +77,16 @@ jobs:
           docker system prune --all -f
           echo "Disk usage after cleanup"
           sudo df -h
-      - name: "GitHub Actions: download build artifacts"
-        if: steps.eval-params.outputs.run-type == 'github'
-        uses: actions/download-artifact@v4
+      # FIXME: Workaround for Request Timeout issue of artifacts https://github.com/actions/download-artifact/issues/249
+      - name: "GitHub Actions: download build artifacts with retry"
+        uses: Wandalen/wretry.action@master
         with:
-          name: build-output
-          path: build
+          action: actions/download-artifact@v4
+          with: |
+            path: build
+            name: build-output
+          attempt_limit: 5
+          attempt_delay: 1000
       - name: "GitHub Actions: extract artifacts"
         if: steps.eval-params.outputs.run-type == 'github'
         run: |


### PR DESCRIPTION
The download-artifact action plugin was updated to v4 recently and we are seeing request timeouts after that updating.
This is a known issue at GitHub Actions server side and it's tracked at https://github.com/actions/download-artifact/issues/249

I'm adding some retries to work around this issue for the moment. This work around does not break the main run process, we can see successful artifact downloading from the following run:

https://github.com/jijiechen/kuma/actions/runs/7394542119/job/20117851713

(The run failed eventually because of flaky e2e tests, but we can stil know the PR here will not break the CI process)

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - https://github.com/kumahq/kuma/actions/runs/7291088227/job/19869652348#step:9:21
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - Confirmed
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Manual tested
  - Don't forget `ci/` labels to run additional/fewer tests
    - No need to add
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? 
  - No
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) 
  - No

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
