### PR TITLE
feat(policy): allow policies with from and to configuring egress

### DIFF
--- a/pkg/plugins/policies/core/matchers/egress.go
+++ b/pkg/plugins/policies/core/matchers/egress.go
@@ -29,10 +29,6 @@ func EgressMatchedPolicies(rType core_model.ResourceType, tags map[string]string
 	_, isFrom := p.GetSpec().(core_model.PolicyWithFromList)
 	_, isTo := p.GetSpec().(core_model.PolicyWithToList)
 
-	if isFrom && isTo {
-		return core_xds.TypedMatchingPolicies{}, errors.Errorf("zone egress doesn't support policies that have both 'from' and 'to'")
-	}
-
 	if !isFrom && !isTo {
 		return core_xds.TypedMatchingPolicies{}, nil
 	}

--- a/pkg/plugins/policies/core/matchers/egress_test.go
+++ b/pkg/plugins/policies/core/matchers/egress_test.go
@@ -10,8 +10,8 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/matchers"
-	mfi_api "github.com/kumahq/kuma/pkg/plugins/policies/meshfaultinjection/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1"
+	mt_api "github.com/kumahq/kuma/pkg/plugins/policies/meshtimeout/api/v1alpha1"
 	mtp_api "github.com/kumahq/kuma/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1"
 	test_matchers "github.com/kumahq/kuma/pkg/test/matchers"
 )
@@ -77,7 +77,7 @@ var _ = Describe("EgressMatchedPolicies", func() {
 			resources, _ := readPolicies(given.policiesFile)
 
 			// when
-			policies, err := matchers.EgressMatchedPolicies(mfi_api.MeshFaultInjectionType, es.Spec.Tags, resources)
+			policies, err := matchers.EgressMatchedPolicies(mt_api.MeshTimeoutType, es.Spec.Tags, resources)
 			Expect(err).ToNot(HaveOccurred())
 
 			// then

--- a/pkg/plugins/policies/core/matchers/egress_test.go
+++ b/pkg/plugins/policies/core/matchers/egress_test.go
@@ -10,8 +10,9 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/matchers"
+	mfi_api "github.com/kumahq/kuma/pkg/plugins/policies/meshfaultinjection/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1"
-	policies_api "github.com/kumahq/kuma/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1"
+	mtp_api "github.com/kumahq/kuma/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1"
 	test_matchers "github.com/kumahq/kuma/pkg/test/matchers"
 )
 
@@ -59,7 +60,7 @@ var _ = Describe("EgressMatchedPolicies", func() {
 			resources, _ := readPolicies(given.policiesFile)
 
 			// when
-			policies, err := matchers.EgressMatchedPolicies(policies_api.MeshTrafficPermissionType, es.Spec.Tags, resources)
+			policies, err := matchers.EgressMatchedPolicies(mtp_api.MeshTrafficPermissionType, es.Spec.Tags, resources)
 			Expect(err).ToNot(HaveOccurred())
 
 			// then
@@ -67,6 +68,23 @@ var _ = Describe("EgressMatchedPolicies", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(bytes).To(test_matchers.MatchGoldenYAML(given.goldenFile))
 		}, generateTableEntries(filepath.Join("testdata", "egressmatchedpolicies", "fromrules")))
+
+	DescribeTable("should return egress fromRules for the given external service when policy has From and To",
+		func(given testCase) {
+			// given external service resource
+			es := readES(given.esFile)
+			// given policies
+			resources, _ := readPolicies(given.policiesFile)
+
+			// when
+			policies, err := matchers.EgressMatchedPolicies(mfi_api.MeshFaultInjectionType, es.Spec.Tags, resources)
+			Expect(err).ToNot(HaveOccurred())
+
+			// then
+			bytes, err := yaml.Marshal(policies.FromRules)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(bytes).To(test_matchers.MatchGoldenYAML(given.goldenFile))
+		}, generateTableEntries(filepath.Join("testdata", "egressmatchedpolicies", "fromtorules")))
 
 	DescribeTable("should return egress toRules for the given external service",
 		func(given testCase) {

--- a/pkg/plugins/policies/core/matchers/testdata/egressmatchedpolicies/fromtorules/01.es.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/egressmatchedpolicies/fromtorules/01.es.yaml
@@ -1,0 +1,10 @@
+type: ExternalService
+mesh: mesh-1
+name: es-1
+networking:
+  address: "external-database.ns.svc:80"
+tags:
+  kuma.io/service: external-database
+  kuma.io/protocol: http
+  kuma.io/zone: zone-1
+  version: v1

--- a/pkg/plugins/policies/core/matchers/testdata/egressmatchedpolicies/fromtorules/01.golden.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/egressmatchedpolicies/fromtorules/01.golden.yaml
@@ -1,0 +1,66 @@
+Rules:
+  :0:
+  - Conf:
+      http:
+      - abort:
+          httpStatus: 500
+          percentage: 2
+      - abort:
+          httpStatus: 500
+          percentage: 10
+      - delay:
+          percentage: 5
+          value: 5s
+    Origin:
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-1
+      type: MeshFaultInjection
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-2
+      type: MeshFaultInjection
+    Subset:
+    - Key: kuma.io/service
+      Not: false
+      Value: orders
+  - Conf:
+      http:
+      - delay:
+          percentage: 50
+          value: 5s
+    Origin:
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-1
+      type: MeshFaultInjection
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-2
+      type: MeshFaultInjection
+    Subset:
+    - Key: kuma.io/service
+      Not: false
+      Value: backend
+  - Conf:
+      http:
+      - abort:
+          httpStatus: 555
+          percentage: 2
+    Origin:
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-2
+      type: MeshFaultInjection
+    Subset:
+    - Key: kuma.io/service
+      Not: true
+      Value: backend
+    - Key: kuma.io/service
+      Not: true
+      Value: orders

--- a/pkg/plugins/policies/core/matchers/testdata/egressmatchedpolicies/fromtorules/01.golden.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/egressmatchedpolicies/fromtorules/01.golden.yaml
@@ -1,66 +1,18 @@
 Rules:
   :0:
   - Conf:
+      connectionTimeout: 33s
       http:
-      - abort:
-          httpStatus: 500
-          percentage: 2
-      - abort:
-          httpStatus: 500
-          percentage: 10
-      - delay:
-          percentage: 5
-          value: 5s
+        requestTimeout: 33s
     Origin:
     - creationTime: "0001-01-01T00:00:00Z"
       mesh: mesh-1
       modificationTime: "0001-01-01T00:00:00Z"
-      name: mtp-1
-      type: MeshFaultInjection
+      name: mt-1
+      type: MeshTimeout
     - creationTime: "0001-01-01T00:00:00Z"
       mesh: mesh-1
       modificationTime: "0001-01-01T00:00:00Z"
-      name: mtp-2
-      type: MeshFaultInjection
-    Subset:
-    - Key: kuma.io/service
-      Not: false
-      Value: orders
-  - Conf:
-      http:
-      - delay:
-          percentage: 50
-          value: 5s
-    Origin:
-    - creationTime: "0001-01-01T00:00:00Z"
-      mesh: mesh-1
-      modificationTime: "0001-01-01T00:00:00Z"
-      name: mtp-1
-      type: MeshFaultInjection
-    - creationTime: "0001-01-01T00:00:00Z"
-      mesh: mesh-1
-      modificationTime: "0001-01-01T00:00:00Z"
-      name: mtp-2
-      type: MeshFaultInjection
-    Subset:
-    - Key: kuma.io/service
-      Not: false
-      Value: backend
-  - Conf:
-      http:
-      - abort:
-          httpStatus: 555
-          percentage: 2
-    Origin:
-    - creationTime: "0001-01-01T00:00:00Z"
-      mesh: mesh-1
-      modificationTime: "0001-01-01T00:00:00Z"
-      name: mtp-2
-      type: MeshFaultInjection
-    Subset:
-    - Key: kuma.io/service
-      Not: true
-      Value: backend
-    - Key: kuma.io/service
-      Not: true
-      Value: orders
+      name: mt-2
+      type: MeshTimeout
+    Subset: []

--- a/pkg/plugins/policies/core/matchers/testdata/egressmatchedpolicies/fromtorules/01.policies.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/egressmatchedpolicies/fromtorules/01.policies.yaml
@@ -1,0 +1,47 @@
+type: MeshFaultInjection
+mesh: mesh-1
+name: mtp-1
+spec:
+  targetRef:
+    kind: MeshServiceSubset
+    name: external-database
+    tags:
+      version: v1
+  from:
+    - targetRef:
+        kind: MeshService
+        name: backend
+      default:
+        http:
+        - delay:
+            percentage: 50
+            value: 5s
+    - targetRef:
+        kind: MeshService
+        name: orders
+      default:
+        http:
+        - abort:
+            httpStatus: 500
+            percentage: 2
+        - abort:
+            httpStatus: 500
+            percentage: 10
+        - delay:
+            value: 5s
+            percentage: 5
+---
+type: MeshFaultInjection
+mesh: mesh-1
+name: mtp-2
+spec:
+  targetRef:
+    kind: Mesh
+  from:
+    - targetRef:
+        kind: Mesh
+      default:
+        http:
+        - abort:
+            httpStatus: 555
+            percentage: 2

--- a/pkg/plugins/policies/core/matchers/testdata/egressmatchedpolicies/fromtorules/01.policies.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/egressmatchedpolicies/fromtorules/01.policies.yaml
@@ -1,39 +1,31 @@
-type: MeshFaultInjection
+type: MeshTimeout
 mesh: mesh-1
-name: mtp-1
+name: mt-1
 spec:
   targetRef:
     kind: MeshServiceSubset
     name: external-database
     tags:
-      version: v1
+      version: v1  
   from:
+    - targetRef:
+        kind: Mesh
+      default:
+        connectionTimeout: 33s
+        http:
+          requestTimeout: 33s
+  to:
     - targetRef:
         kind: MeshService
         name: backend
       default:
+        connectionTimeout: 77s
         http:
-        - delay:
-            percentage: 50
-            value: 5s
-    - targetRef:
-        kind: MeshService
-        name: orders
-      default:
-        http:
-        - abort:
-            httpStatus: 500
-            percentage: 2
-        - abort:
-            httpStatus: 500
-            percentage: 10
-        - delay:
-            value: 5s
-            percentage: 5
+          requestTimeout: 77s
 ---
-type: MeshFaultInjection
+type: MeshTimeout
 mesh: mesh-1
-name: mtp-2
+name: mt-2
 spec:
   targetRef:
     kind: Mesh
@@ -41,7 +33,6 @@ spec:
     - targetRef:
         kind: Mesh
       default:
+        connectionTimeout: 22s
         http:
-        - abort:
-            httpStatus: 555
-            percentage: 2
+          requestTimeout: 22s


### PR DESCRIPTION
### Checklist prior to review

When policy has `from` and `to` it cannot configure egress. `MeshFaultInjection` is a policy that has both and should configure so instead of checking if policy has both, in case it has both we are taking `from` https://github.com/kumahq/kuma/pull/8739/files#diff-26e4e045ed595ee5e2ddec0d50aa1d944fddf095cf98773505a6f713d892d469L42

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
