### PR TITLE
fix(api): secret in k8s format

### DIFF
--- a/pkg/plugins/secrets/k8s/mapper.go
+++ b/pkg/plugins/secrets/k8s/mapper.go
@@ -1,0 +1,57 @@
+package k8s
+
+import (
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	secret_model "github.com/kumahq/kuma/pkg/core/resources/apis/system"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
+	common_k8s "github.com/kumahq/kuma/pkg/plugins/common/k8s"
+	"github.com/kumahq/kuma/pkg/plugins/resources/k8s"
+	k8s_model "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/model"
+)
+
+// NewKubernetesMapper creates a ResourceMapper that returns the k8s object as is. This is meant to be used when the underlying store is kubernetes
+func NewKubernetesMapper() k8s.ResourceMapperFunc {
+	return func(resource model.Resource, namespace string) (k8s_model.KubernetesObject, error) {
+		res, err := DefaultConverter().ToKubernetesObject(resource)
+		res.TypeMeta = metav1.TypeMeta{
+			APIVersion: v1.SchemeGroupVersion.String(),
+			Kind:       "Secret",
+		}
+		if err != nil {
+			return nil, err
+		}
+		if namespace != "" {
+			res.SetNamespace(namespace)
+		}
+		return &Secret{Secret: *res}, nil
+	}
+}
+
+// NewInferenceMapper creates a ResourceMapper that infers a k8s resource from the core_model. Extract namespace from the name if necessary.
+// This mostly useful when the underlying store is not kubernetes but you want to show what a kubernetes version of the policy would be like (in global for example).
+func NewInferenceMapper(systemNamespace string) k8s.ResourceMapperFunc {
+	return func(resource model.Resource, namespace string) (k8s_model.KubernetesObject, error) {
+		var rs k8s_model.KubernetesObject
+		switch resource.Descriptor().Name {
+		case secret_model.SecretType:
+			rs = NewSecret(common_k8s.MeshSecretType)
+			rs.SetMesh(resource.GetMeta().GetMesh())
+		case secret_model.GlobalSecretType:
+			rs = NewSecret(common_k8s.GlobalSecretType)
+		default:
+			return nil, errors.New("invalid resource type")
+		}
+		if namespace != "" { // If the user is forcing the namespace accept it.
+			rs.SetNamespace(namespace)
+		} else {
+			rs.SetNamespace(systemNamespace)
+		}
+		rs.SetName(resource.GetMeta().GetName())
+		rs.SetCreationTimestamp(v1.NewTime(resource.GetMeta().GetCreationTime()))
+		rs.SetSpec(resource.GetSpec())
+		return rs, nil
+	}
+}

--- a/pkg/plugins/secrets/k8s/secret.go
+++ b/pkg/plugins/secrets/k8s/secret.go
@@ -1,0 +1,84 @@
+package k8s
+
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/types/known/wrapperspb"
+	v1 "k8s.io/api/core/v1"
+	k8s "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	system_proto "github.com/kumahq/kuma/api/system/v1alpha1"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/model"
+	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/metadata"
+)
+
+// Secret is a KubernetesObject for Kuma's Secret and GlobalSecret.
+// Note that it's not registered in TypeRegistry because we cannot multiply KubernetesObject
+// for a single Spec (both Secret and GlobalSecret has same Spec).
+type Secret struct {
+	v1.Secret
+}
+
+func NewSecret(typ v1.SecretType) *Secret {
+	return &Secret{
+		Secret: v1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: v1.SchemeGroupVersion.String(),
+				Kind:       "Secret",
+			},
+			Type: typ,
+		},
+	}
+}
+
+var _ model.KubernetesObject = &Secret{}
+
+func (s *Secret) GetObjectMeta() *k8s.ObjectMeta {
+	return &s.ObjectMeta
+}
+
+func (s *Secret) SetObjectMeta(meta *k8s.ObjectMeta) {
+	s.ObjectMeta = *meta
+}
+
+func (s *Secret) GetMesh() string {
+	if mesh, ok := s.ObjectMeta.Labels[metadata.KumaMeshLabel]; ok {
+		return mesh
+	} else {
+		return core_model.DefaultMesh
+	}
+}
+
+func (s *Secret) SetMesh(mesh string) {
+	if s.ObjectMeta.Labels == nil {
+		s.ObjectMeta.Labels = map[string]string{}
+	}
+	s.ObjectMeta.Labels[metadata.KumaMeshLabel] = mesh
+}
+
+func (s *Secret) GetSpec() (core_model.ResourceSpec, error) {
+	bytes, ok := s.Data["value"]
+	if !ok {
+		return nil, nil
+	}
+	return &system_proto.Secret{
+		Data: &wrapperspb.BytesValue{
+			Value: bytes,
+		},
+	}, nil
+}
+
+func (s *Secret) SetSpec(spec core_model.ResourceSpec) {
+	if _, ok := spec.(*system_proto.Secret); !ok {
+		panic(fmt.Sprintf("unexpected protobuf message type %T", spec))
+	}
+	s.Data = map[string][]byte{
+		"value": spec.(*system_proto.Secret).GetData().GetValue(),
+	}
+}
+
+func (s *Secret) Scope() model.Scope {
+	return model.ScopeNamespace
+}

--- a/test/e2e_env/kubernetes/api/api.go
+++ b/test/e2e_env/kubernetes/api/api.go
@@ -11,7 +11,7 @@ import (
 )
 
 func Api() {
-	It("Works with /policies", func() {
+	It("works with /policies", func() {
 		r, err := http.Get(kubernetes.Cluster.GetKuma().GetAPIServerAddress() + "/policies")
 		Expect(err).ToNot(HaveOccurred())
 		defer r.Body.Close()
@@ -21,7 +21,7 @@ func Api() {
 		Expect(len(res["policies"])).To(BeNumerically(">", 2))
 	})
 
-	It("Works with /", func() {
+	It("works with /", func() {
 		r, err := http.Get(kubernetes.Cluster.GetKuma().GetAPIServerAddress())
 		Expect(err).ToNot(HaveOccurred())
 		defer r.Body.Close()
@@ -31,7 +31,7 @@ func Api() {
 		Expect(res["version"]).ToNot(BeEmpty())
 	})
 
-	It("Get k8s version of default mesh", func() {
+	It("get k8s version of default mesh", func() {
 		r, err := http.Get(kubernetes.Cluster.GetKuma().GetAPIServerAddress() + "/meshes/default?format=k8s")
 		Expect(err).ToNot(HaveOccurred())
 		defer r.Body.Close()
@@ -44,7 +44,7 @@ func Api() {
 		Expect(res["apiVersion"]).To(Equal("kuma.io/v1alpha1"))
 	})
 
-	It("Get kubernetes version of default mesh", func() {
+	It("get kubernetes version of default mesh", func() {
 		r, err := http.Get(kubernetes.Cluster.GetKuma().GetAPIServerAddress() + "/meshes/default")
 		Expect(err).ToNot(HaveOccurred())
 		defer r.Body.Close()
@@ -54,4 +54,44 @@ func Api() {
 		Expect(res).To(HaveKey("type"))
 		Expect(res["type"]).To(Equal("Mesh"))
 	})
+
+	type testCase struct {
+		path       string
+		k8sSecType string
+	}
+	DescribeTable("gets secret",
+		func(given testCase) {
+			token, err := kubernetes.Cluster.GetKumactlOptions().RunKumactlAndGetOutput("generate", "user-token",
+				"--name", "mesh-system:admin",
+				"--group", "mesh-system:admin",
+				"--valid-for", "24h",
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func(g Gomega) {
+				req, err := http.NewRequest("GET", kubernetes.Cluster.GetKuma().GetAPIServerAddress()+given.path, nil)
+				g.Expect(err).ToNot(HaveOccurred())
+				req.Header.Add("authorization", "Bearer "+token)
+				r, err := http.DefaultClient.Do(req)
+				g.Expect(err).ToNot(HaveOccurred())
+				defer r.Body.Close()
+
+				res := map[string]interface{}{}
+				g.Expect(json.NewDecoder(r.Body).Decode(&res)).To(Succeed())
+				g.Expect(res).To(HaveKey("kind"))
+				g.Expect(res["kind"]).To(Equal("Secret"))
+				g.Expect(res).To(HaveKey("apiVersion"))
+				g.Expect(res["apiVersion"]).To(Equal("meta.k8s.io/v1"))
+				g.Expect(res["type"]).To(Equal(given.k8sSecType))
+			}, "30s", "1s").Should(Succeed())
+		},
+		Entry("global secret", testCase{
+			path:       "/global-secrets/inter-cp-ca?format=k8s",
+			k8sSecType: "system.kuma.io/global-secret",
+		}),
+		Entry("mesh secret", testCase{
+			path:       "/meshes/default/secrets/dataplane-token-signing-key-default-1?format=k8s",
+			k8sSecType: "system.kuma.io/secret",
+		}),
+	)
 }

--- a/test/e2e_env/universal/api/api.go
+++ b/test/e2e_env/universal/api/api.go
@@ -11,7 +11,7 @@ import (
 )
 
 func Api() {
-	It("Works with /policies", func() {
+	It("works with /policies", func() {
 		r, err := http.Get(universal.Cluster.GetKuma().GetAPIServerAddress() + "/policies")
 		Expect(err).ToNot(HaveOccurred())
 		defer r.Body.Close()
@@ -21,7 +21,7 @@ func Api() {
 		Expect(len(res["policies"])).To(BeNumerically(">", 2))
 	})
 
-	It("Works with /", func() {
+	It("works with /", func() {
 		r, err := http.Get(universal.Cluster.GetKuma().GetAPIServerAddress())
 		Expect(err).ToNot(HaveOccurred())
 		defer r.Body.Close()
@@ -31,7 +31,7 @@ func Api() {
 		Expect(res["version"]).ToNot(BeEmpty())
 	})
 
-	It("Get k8s version of default mesh", func() {
+	It("gets k8s version of default mesh", func() {
 		r, err := http.Get(universal.Cluster.GetKuma().GetAPIServerAddress() + "/meshes/default?format=k8s")
 		Expect(err).ToNot(HaveOccurred())
 		defer r.Body.Close()
@@ -44,7 +44,7 @@ func Api() {
 		Expect(res["apiVersion"]).To(Equal("kuma.io/v1alpha1"))
 	})
 
-	It("Get universal version of default mesh", func() {
+	It("gets universal version of default mesh", func() {
 		r, err := http.Get(universal.Cluster.GetKuma().GetAPIServerAddress() + "/meshes/default")
 		Expect(err).ToNot(HaveOccurred())
 		defer r.Body.Close()
@@ -54,4 +54,44 @@ func Api() {
 		Expect(res).To(HaveKey("type"))
 		Expect(res["type"]).To(Equal("Mesh"))
 	})
+
+	type testCase struct {
+		path       string
+		k8sSecType string
+	}
+	DescribeTable("gets secret",
+		func(given testCase) {
+			token, err := universal.Cluster.GetKumactlOptions().RunKumactlAndGetOutput("generate", "user-token",
+				"--name", "mesh-system:admin",
+				"--group", "mesh-system:admin",
+				"--valid-for", "24h",
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func(g Gomega) {
+				req, err := http.NewRequest("GET", universal.Cluster.GetKuma().GetAPIServerAddress()+given.path, nil)
+				g.Expect(err).ToNot(HaveOccurred())
+				req.Header.Add("authorization", "Bearer "+token)
+				r, err := http.DefaultClient.Do(req)
+				g.Expect(err).ToNot(HaveOccurred())
+				defer r.Body.Close()
+
+				res := map[string]interface{}{}
+				g.Expect(json.NewDecoder(r.Body).Decode(&res)).To(Succeed())
+				g.Expect(res).To(HaveKey("kind"))
+				g.Expect(res["kind"]).To(Equal("Secret"))
+				g.Expect(res).To(HaveKey("apiVersion"))
+				g.Expect(res["apiVersion"]).To(Equal("v1"))
+				g.Expect(res["type"]).To(Equal(given.k8sSecType))
+			}, "30s", "1s").Should(Succeed())
+		},
+		Entry("global secret", testCase{
+			path:       "/global-secrets/inter-cp-ca?format=k8s",
+			k8sSecType: "system.kuma.io/global-secret",
+		}),
+		Entry("mesh secret", testCase{
+			path:       "/meshes/default/secrets/dataplane-token-signing-key-default-1?format=k8s",
+			k8sSecType: "system.kuma.io/secret",
+		}),
+	)
 }


### PR DESCRIPTION
### Checklist prior to review

Fix requesting Secrets in Kube format using Kuma API

xref #8212

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
