### PR TITLE
feat(policy): add tags to backends for support VirtualOutbounds

### DIFF
--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
@@ -167,19 +167,14 @@ func prepareRoutes(
 		if rule.Default.BackendRefs != nil {
 			route.BackendRefs = *rule.Default.BackendRefs
 		} else {
-			targetRef := common_api.TargetRef{
-				Kind: common_api.MeshService,
-				Name: serviceName,
-			}
-			if mesh, ok := tags[mesh_proto.MeshTag]; ok {
-				targetRef.Tags = map[string]string{
-					mesh_proto.MeshTag: mesh,
-				}
-			}
 			route.BackendRefs = []common_api.BackendRef{
 				{
-					TargetRef: targetRef,
-					Weight:    pointer.To(uint(100)),
+					TargetRef: common_api.TargetRef{
+						Kind: common_api.MeshService,
+						Name: serviceName,
+						Tags: tags,
+					},
+					Weight: pointer.To(uint(100)),
 				},
 			}
 		}

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners_backendrefs.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners_backendrefs.go
@@ -2,7 +2,6 @@ package v1alpha1
 
 import (
 	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
-	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
 	meshhttproute_api "github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
@@ -42,19 +41,14 @@ func getBackendRefs(
 	if tcpConf != nil {
 		return tcpConf.Default.BackendRefs
 	}
-	targetRef := common_api.TargetRef{
-		Kind: common_api.MeshService,
-		Name: serviceName,
-	}
-	if mesh, ok := tags[mesh_proto.MeshTag]; ok {
-		targetRef.Tags = map[string]string{
-			mesh_proto.MeshTag: mesh,
-		}
-	}
 	return []common_api.BackendRef{
 		{
-			TargetRef: targetRef,
-			Weight:    pointer.To(uint(100)),
+			TargetRef: common_api.TargetRef{
+				Kind: common_api.MeshService,
+				Name: serviceName,
+				Tags: tags,
+			},
+			Weight: pointer.To(uint(100)),
 		},
 	}
 }


### PR DESCRIPTION
### Checklist prior to review

We need to propagate tags to backendsRefs so that later in the case of VirtualOutbounds we can match them and create the correct configuration

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
