### PR TITLE
feat(kumactl): export in kube format

### DIFF
--- a/app/kumactl/pkg/client/client_suite_test.go
+++ b/app/kumactl/pkg/client/client_suite_test.go
@@ -1,0 +1,11 @@
+package client_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/pkg/test"
+)
+
+func TestClient(t *testing.T) {
+	test.RunSpecs(t, "Client")
+}

--- a/app/kumactl/pkg/client/kube_resources_client.go
+++ b/app/kumactl/pkg/client/kube_resources_client.go
@@ -1,0 +1,65 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/pkg/errors"
+
+	"github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/core/resources/model/rest"
+	util_http "github.com/kumahq/kuma/pkg/util/http"
+)
+
+type KubernetesResourcesClient interface {
+	Get(ctx context.Context, descriptor model.ResourceTypeDescriptor, name, mesh string) (map[string]interface{}, error)
+}
+
+type HTTPKubernetesResourcesClient struct {
+	client util_http.Client
+	api    rest.Api
+}
+
+func NewHTTPKubernetesResourcesClient(client util_http.Client, defs []model.ResourceTypeDescriptor) KubernetesResourcesClient {
+	mapping := make(map[model.ResourceType]rest.ResourceApi)
+	for _, ws := range defs {
+		mapping[ws.Name] = rest.NewResourceApi(ws.Scope, ws.WsPath)
+	}
+	return &HTTPKubernetesResourcesClient{
+		client: client,
+		api: &rest.ApiDescriptor{
+			Resources: mapping,
+		},
+	}
+}
+
+func (k *HTTPKubernetesResourcesClient) Get(ctx context.Context, descriptor model.ResourceTypeDescriptor, name, mesh string) (map[string]interface{}, error) {
+	api, err := k.api.GetResourceApi(descriptor.Name)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest("GET", api.Item(mesh, name)+"?format=k8s", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := k.client.Do(req.WithContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		return nil, errors.Errorf("unexpected status code: %d %s", resp.StatusCode, b)
+	}
+	obj := map[string]interface{}{}
+	if err := json.Unmarshal(b, &obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}

--- a/app/kumactl/pkg/client/kube_resources_client_test.go
+++ b/app/kumactl/pkg/client/kube_resources_client_test.go
@@ -1,0 +1,61 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/core/resources/registry"
+	util_http "github.com/kumahq/kuma/pkg/util/http"
+)
+
+var _ = Describe("Kube Resources Client", func() {
+	It("should return kube resource", func() {
+		// given
+		mux := http.NewServeMux()
+		server := httptest.NewServer(mux)
+		defer server.Close()
+		mux.HandleFunc("/global-secrets/zone-token-signing-key-1", func(writer http.ResponseWriter, req *http.Request) {
+			defer GinkgoRecover()
+			Expect(req.Header.Get("accept")).To(Equal("application/json"))
+			Expect(req.URL.Query().Get("format")).To(Equal("k8s"))
+
+			resp := `{
+ "kind": "Secret",
+ "apiVersion": "v1",
+ "metadata": {
+  "name": "zone-token-signing-key-1",
+  "namespace": "kuma-system",
+  "creationTimestamp": "2024-01-03T15:33:33Z"
+ },
+ "data": {
+  "value": "XYZ"
+ },
+ "type": "system.kuma.io/global-secret"
+}`
+
+			_, err := writer.Write([]byte(resp))
+			Expect(err).ToNot(HaveOccurred())
+		})
+		serverURL, err := url.Parse(server.URL)
+		Expect(err).ToNot(HaveOccurred())
+
+		kubeResClient := NewHTTPKubernetesResourcesClient(
+			util_http.ClientWithBaseURL(http.DefaultClient, serverURL, nil),
+			registry.Global().ObjectDescriptors(),
+		)
+
+		// when
+		obj, err := kubeResClient.Get(context.Background(), system.NewGlobalSecretResource().Descriptor(), "zone-token-signing-key-1", model.NoMesh)
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		Expect(obj["kind"]).To(Equal("Secret"))
+	})
+})

--- a/app/kumactl/pkg/cmd/root_context.go
+++ b/app/kumactl/pkg/cmd/root_context.go
@@ -60,6 +60,7 @@ type RootRuntime struct {
 	NewZoneIngressTokenClient    func(util_http.Client) tokens.ZoneIngressTokenClient
 	NewZoneTokenClient           func(util_http.Client) tokens.ZoneTokenClient
 	NewAPIServerClient           func(util_http.Client) kumactl_resources.ApiServerClient
+	NewKubernetesResourcesClient func(util_http.Client) client.KubernetesResourcesClient
 	Registry                     registry.TypeRegistry
 }
 
@@ -114,6 +115,9 @@ func DefaultRootContext() *RootContext {
 			NewZoneIngressTokenClient:    tokens.NewZoneIngressTokenClient,
 			NewZoneTokenClient:           tokens.NewZoneTokenClient,
 			NewAPIServerClient:           kumactl_resources.NewAPIServerClient,
+			NewKubernetesResourcesClient: func(c util_http.Client) client.KubernetesResourcesClient {
+				return client.NewHTTPKubernetesResourcesClient(c, registry.Global().ObjectDescriptors())
+			},
 		},
 		InstallCpContext:                    install_context.DefaultInstallCpContext(),
 		InstallCRDContext:                   install_context.DefaultInstallCrdsContext(),
@@ -208,6 +212,14 @@ func (rc *RootContext) CurrentResourceStore() (core_store.ResourceStore, error) 
 		return nil, err
 	}
 	return rc.Runtime.NewResourceStore(client), nil
+}
+
+func (rc *RootContext) CurrentKubernetesResourcesClient() (client.KubernetesResourcesClient, error) {
+	client, err := rc.BaseAPIServerClient()
+	if err != nil {
+		return nil, err
+	}
+	return rc.Runtime.NewKubernetesResourcesClient(client), nil
 }
 
 func (rc *RootContext) CurrentDataplaneOverviewClient() (kumactl_resources.DataplaneOverviewClient, error) {


### PR DESCRIPTION
### Checklist prior to review

Kumactl export in Kubernetes format.

It converts resources one by one. Obviously, this is not optimal, but my reasoning is
* We would need to introduce new list APIs with two alternative schemas based on query param which is not a great design. We cannot reuse `rest.ResourceList` for this, because it requires `ResourceSpec`
* It does not matter if kumactl export will run in 1s or 5s, because it's run once when you do a federation.
* It probably won't be used for backup either, because if you operate on Kubernetes you do a backup on your Kube API Server / etcd level.

We can optimize this if needed.

I plan to write E2E tests when we have applying resources on Zone CP. This way we can test full flow of Zone federation.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
