### PR TITLE
feat(policy): add `MeshMetric` policy e2e tests

### DIFF
--- a/pkg/mads/v1/generator/meshmetrics.go
+++ b/pkg/mads/v1/generator/meshmetrics.go
@@ -4,13 +4,12 @@ import (
 	"net"
 	"strconv"
 
-	"github.com/kumahq/kuma/pkg/util/pointer"
-
 	observability_v1 "github.com/kumahq/kuma/api/observability/v1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/mads"
 	"github.com/kumahq/kuma/pkg/plugins/policies/meshmetric/api/v1alpha1"
+	"github.com/kumahq/kuma/pkg/util/pointer"
 )
 
 func Generate(meshMetricToDataplane map[*v1alpha1.Conf]*core_mesh.DataplaneResource, clientId string) ([]*core_xds.Resource, error) {

--- a/pkg/mads/v1/reconcile/snapshot_generator.go
+++ b/pkg/mads/v1/reconcile/snapshot_generator.go
@@ -79,7 +79,7 @@ func (s *snapshotGenerator) GenerateSnapshot(ctx context.Context, node *envoy_co
 			return nil, err
 		}
 
-		resources, err = meshmetrics_generator.Generate(meshMetricConfToDataplanes)
+		resources, err = meshmetrics_generator.Generate(meshMetricConfToDataplanes, node.Id)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/mads/v1/service/components.go
+++ b/pkg/mads/v1/service/components.go
@@ -46,11 +46,11 @@ func (r *restReconcilerCallbacks) OnFetchRequest(ctx context.Context, request ut
 		return errors.Errorf("expecting a v3 Node, got: %v", nodei)
 	}
 
-	// only reconcile if there is not a valid response present
-	if !r.reconciler.NeedsReconciliation(node) {
-		return nil
-	}
-
+	// TODO we need to reconcile on demand because if we us MeshMetric we will only reconcile in watchdog for single client
+	// that send request first because of watchdog callback implementation: pkg/util/xds/v3/watchdog_callbacks.go:48
+	// Moreover grpc sotw server is never used in real world scenario so we probably need to thing of different syncing cache mechanism
+	// if performance of ondemand reconcile will turn out to be poor.
+	// Also we probably can remove sync tracker since it will run and recompute MADS response that won't be used
 	return r.reconciler.Reconcile(ctx, node)
 }
 

--- a/pkg/mads/v1/service/components.go
+++ b/pkg/mads/v1/service/components.go
@@ -51,6 +51,7 @@ func (r *restReconcilerCallbacks) OnFetchRequest(ctx context.Context, request ut
 	// Moreover grpc sotw server is never used in real world scenario so we probably need to thing of different syncing cache mechanism
 	// if performance of ondemand reconcile will turn out to be poor.
 	// Also we probably can remove sync tracker since it will run and recompute MADS response that won't be used
+	// Issue: https://github.com/kumahq/kuma/issues/8764
 	return r.reconciler.Reconcile(ctx, node)
 }
 

--- a/pkg/mads/v1/service/service.go
+++ b/pkg/mads/v1/service/service.go
@@ -21,6 +21,8 @@ func NewService(config *mads.MonitoringAssignmentServerConfig, rm core_manager.R
 	generator := NewSnapshotGenerator(rm, meshCache)
 	versioner := NewVersioner()
 	reconciler := NewReconciler(hasher, cache, generator, versioner)
+	// TODO Right now we are creating sync tracker for first REST request pkg/util/xds/v3/watchdog_callbacks.go:48, because of this
+	// using MeshMetrics with specified clientId will refresh only one client in background
 	syncTracker := NewSyncTracker(reconciler, config.AssignmentRefreshInterval.Duration, log)
 	callbacks := util_xds_v3.CallbacksChain{
 		util_xds_v3.AdaptMultiCallbacks(util_xds.LoggingCallbacks{Log: log}),

--- a/pkg/mads/v1/service/service.go
+++ b/pkg/mads/v1/service/service.go
@@ -23,6 +23,7 @@ func NewService(config *mads.MonitoringAssignmentServerConfig, rm core_manager.R
 	reconciler := NewReconciler(hasher, cache, generator, versioner)
 	// TODO Right now we are creating sync tracker for first REST request pkg/util/xds/v3/watchdog_callbacks.go:48, because of this
 	// using MeshMetrics with specified clientId will refresh only one client in background
+	// issue: https://github.com/kumahq/kuma/issues/8764
 	syncTracker := NewSyncTracker(reconciler, config.AssignmentRefreshInterval.Duration, log)
 	callbacks := util_xds_v3.CallbacksChain{
 		util_xds_v3.AdaptMultiCallbacks(util_xds.LoggingCallbacks{Log: log}),

--- a/test/e2e_env/kubernetes/kubernetes_suite_test.go
+++ b/test/e2e_env/kubernetes/kubernetes_suite_test.go
@@ -1,7 +1,6 @@
 package kubernetes_test
 
 import (
-	"github.com/kumahq/kuma/test/e2e_env/kubernetes/meshmetric"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -26,6 +25,7 @@ import (
 	"github.com/kumahq/kuma/test/e2e_env/kubernetes/meshfaultinjection"
 	"github.com/kumahq/kuma/test/e2e_env/kubernetes/meshhealthcheck"
 	"github.com/kumahq/kuma/test/e2e_env/kubernetes/meshhttproute"
+	"github.com/kumahq/kuma/test/e2e_env/kubernetes/meshmetric"
 	"github.com/kumahq/kuma/test/e2e_env/kubernetes/meshproxypatch"
 	"github.com/kumahq/kuma/test/e2e_env/kubernetes/meshratelimit"
 	"github.com/kumahq/kuma/test/e2e_env/kubernetes/meshretry"

--- a/test/e2e_env/kubernetes/kubernetes_suite_test.go
+++ b/test/e2e_env/kubernetes/kubernetes_suite_test.go
@@ -1,6 +1,7 @@
 package kubernetes_test
 
 import (
+	"github.com/kumahq/kuma/test/e2e_env/kubernetes/meshmetric"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -82,6 +83,7 @@ var (
 	_ = Describe("MeshHealthCheck API", meshhealthcheck.API, Ordered)
 	_ = Describe("MeshCircuitBreaker API", meshcircuitbreaker.API, Ordered)
 	_ = Describe("MeshCircuitBreaker", meshcircuitbreaker.MeshCircuitBreaker, Ordered)
+	_ = Describe("MeshMetric", meshmetric.MeshMetric, Ordered)
 	_ = Describe("MeshRetry", meshretry.API, Ordered)
 	_ = Describe("MeshProxyPatch", meshproxypatch.MeshProxyPatch, Ordered)
 	_ = Describe("MeshFaultInjection", meshfaultinjection.API, Ordered)

--- a/test/e2e_env/kubernetes/meshmetric/meshmetric.go
+++ b/test/e2e_env/kubernetes/meshmetric/meshmetric.go
@@ -261,5 +261,5 @@ func getServicesFrom(response MonitoringAssignmentResponse) []string {
 }
 
 type MonitoringAssignmentResponse struct {
-	Resources []mads.MonitoringAssignment `json:"resources"`
+	Resources []*mads.MonitoringAssignment `json:"resources"`
 }

--- a/test/e2e_env/kubernetes/meshmetric/meshmetric.go
+++ b/test/e2e_env/kubernetes/meshmetric/meshmetric.go
@@ -1,0 +1,248 @@
+package meshmetric
+
+import (
+	"encoding/json"
+	"fmt"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"net"
+
+	mads "github.com/kumahq/kuma/api/observability/v1"
+	"github.com/kumahq/kuma/pkg/plugins/policies/meshmetric/api/v1alpha1"
+	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/client"
+	"github.com/kumahq/kuma/test/framework/deployments/testserver"
+	"github.com/kumahq/kuma/test/framework/envs/kubernetes"
+)
+
+func BasicMeshMetricForMesh(policyName string, mesh string) InstallFunc {
+	meshMetric := fmt.Sprintf(`
+apiVersion: kuma.io/v1alpha1
+kind: MeshMetric
+metadata:
+  name: %s
+  namespace: %s
+  labels:
+    kuma.io/mesh: %s
+spec:
+  targetRef:
+    kind: Mesh
+  default:
+    backends:
+      - type: Prometheus
+        prometheus: 
+          port: 8080
+          path: /metrics
+          tls:
+            mode: Disabled
+`, policyName, Config.KumaNamespace, mesh)
+	return YamlK8s(meshMetric)
+}
+
+func MeshMetricWithSpecificPrometheusBackend(policyName string, mesh string, clientId string) InstallFunc {
+	meshMetric := fmt.Sprintf(`
+apiVersion: kuma.io/v1alpha1
+kind: MeshMetric
+metadata:
+  name: %s
+  namespace: %s
+  labels:
+    kuma.io/mesh: %s
+spec:
+  targetRef:
+    kind: Mesh
+  default:
+    backends:
+      - type: Prometheus
+        prometheus: 
+          clientId: %s
+          port: 8080
+          path: /metrics
+          tls:
+            mode: Disabled
+`, policyName, Config.KumaNamespace, mesh, clientId)
+	return YamlK8s(meshMetric)
+}
+
+func MeshMetricWithSpecificPrometheusBackendForMeshService(mesh string, clientId string, serviceName string) InstallFunc {
+	meshMetric := fmt.Sprintf(`
+apiVersion: kuma.io/v1alpha1
+kind: MeshMetric
+metadata:
+  name: mesh-metric-2
+  namespace: %s
+  labels:
+    kuma.io/mesh: %s
+spec:
+  targetRef:
+    kind: MeshService
+    name: %s
+  default:
+    backends:
+      - type: Prometheus
+        prometheus: 
+          clientId: %s
+          port: 8080
+          path: /metrics
+          tls:
+            mode: Disabled
+`, Config.KumaNamespace, mesh, serviceName, clientId)
+	return YamlK8s(meshMetric)
+}
+
+func MeshMetric() {
+	const (
+		namespace             = "meshmetric"
+		mainMesh              = "main-metrics-mesh"
+		mainPrometheusId      = "main-prometheus"
+		secondaryMesh         = "secondary-metrics-mesh"
+		secondaryPrometheusId = "secondary-prometheus"
+	)
+
+	BeforeAll(func() {
+		err := NewClusterSetup().
+			Install(MeshKubernetes(mainMesh)).
+			Install(MeshKubernetes(secondaryMesh)).
+			Install(NamespaceWithSidecarInjection(namespace)).
+			Setup(kubernetes.Cluster)
+		Expect(err).To(Succeed())
+
+		for i := 0; i < 3; i++ {
+			Expect(
+				kubernetes.Cluster.Install(testserver.Install(
+					testserver.WithName(fmt.Sprintf("test-server-%d", i)),
+					testserver.WithMesh(mainMesh),
+					testserver.WithNamespace(namespace),
+				)),
+			).To(Succeed())
+		}
+		for i := 3; i < 6; i++ {
+			Expect(
+				kubernetes.Cluster.Install(testserver.Install(
+					testserver.WithName(fmt.Sprintf("test-server-%d", i)),
+					testserver.WithMesh(secondaryMesh),
+					testserver.WithNamespace(namespace),
+				)),
+			).To(Succeed())
+		}
+	})
+
+	E2EAfterEach(func() {
+		Expect(DeleteMeshResources(kubernetes.Cluster, mainMesh, v1alpha1.MeshMetricResourceTypeDescriptor)).To(Succeed())
+		Expect(DeleteMeshResources(kubernetes.Cluster, secondaryMesh, v1alpha1.MeshMetricResourceTypeDescriptor)).To(Succeed())
+	})
+
+	E2EAfterAll(func() {
+		Expect(kubernetes.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
+		Expect(kubernetes.Cluster.DeleteMesh(mainMesh)).To(Succeed())
+		Expect(kubernetes.Cluster.DeleteMesh(secondaryMesh)).To(Succeed())
+	})
+
+	It("Basic MeshMetric", func() {
+		// given
+		Expect(kubernetes.Cluster.Install(BasicMeshMetricForMesh("mesh-policy", mainMesh))).To(Succeed())
+		podIp, err := PodIPOfApp(kubernetes.Cluster, "test-server-0", namespace)
+		Expect(err).ToNot(HaveOccurred())
+
+		// then
+		Eventually(func(g Gomega) {
+			stdout, _, err := client.CollectResponse(
+				kubernetes.Cluster, "test-server-0", "http://"+net.JoinHostPort(podIp, "8080")+"/metrics",
+				client.FromKubernetesPod(namespace, "test-server-0"),
+			)
+
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(stdout).ToNot(BeNil())
+			// metric from envoy
+			g.Expect(stdout).To(ContainSubstring("envoy_http_downstream_rq_xx"))
+		}).Should(Succeed())
+	})
+
+	It("Default MADS server response", func() {
+		// given
+		Expect(kubernetes.Cluster.Install(BasicMeshMetricForMesh("main-mesh-policy", mainMesh))).To(Succeed())
+		Expect(kubernetes.Cluster.Install(BasicMeshMetricForMesh("secondary-mesh-policy", secondaryMesh))).To(Succeed())
+
+		// then
+		Eventually(func(g Gomega) {
+			assignment, err := kubernetes.Cluster.GetKuma().GetMonitoringAssignment(mainPrometheusId)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			madsResponse := MonitoringAssignmentResponse{}
+			g.Expect(json.Unmarshal([]byte(assignment), &madsResponse)).To(Succeed())
+			// all DPPs from both meshes in single MADS response
+			g.Expect(madsResponse.Resources).To(HaveLen(6))
+		}).Should(Succeed())
+
+		// and same response for secondary backend
+		Eventually(func(g Gomega) {
+			assignment, err := kubernetes.Cluster.GetKuma().GetMonitoringAssignment(secondaryPrometheusId)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			madsResponse := MonitoringAssignmentResponse{}
+			g.Expect(json.Unmarshal([]byte(assignment), &madsResponse)).To(Succeed())
+			// all DPPs from both meshes in single MADS response
+			g.Expect(madsResponse.Resources).To(HaveLen(6))
+		}).Should(Succeed())
+	})
+
+	It("MADS server response for specific Prometheus backend", func() {
+		// given
+		Expect(kubernetes.Cluster.Install(MeshMetricWithSpecificPrometheusBackend("main-mesh-policy", mainMesh, mainPrometheusId))).To(Succeed())
+		Expect(kubernetes.Cluster.Install(MeshMetricWithSpecificPrometheusBackend("secondary-mesh-policy", secondaryMesh, secondaryPrometheusId))).To(Succeed())
+
+		// then
+		Eventually(func(g Gomega) {
+			assignment, err := kubernetes.Cluster.GetKuma().GetMonitoringAssignment(mainPrometheusId)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			madsResponse := MonitoringAssignmentResponse{}
+			g.Expect(json.Unmarshal([]byte(assignment), &madsResponse)).To(Succeed())
+			// all DPPs from primaryMesh for primary Prometheus backend
+			g.Expect(madsResponse.Resources).To(HaveLen(3))
+		}).Should(Succeed())
+
+		// and
+		Eventually(func(g Gomega) {
+			assignment, err := kubernetes.Cluster.GetKuma().GetMonitoringAssignment(secondaryPrometheusId)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			madsResponse := MonitoringAssignmentResponse{}
+			g.Expect(json.Unmarshal([]byte(assignment), &madsResponse)).To(Succeed())
+			// all DPPs from secondaryMesh for secondary Prometheus backend
+			g.Expect(madsResponse.Resources).To(HaveLen(3))
+		}).Should(Succeed())
+	})
+
+	It("override MADS response for single DPP in mesh", func() {
+		// given
+		Expect(kubernetes.Cluster.Install(MeshMetricWithSpecificPrometheusBackend("main-mesh-policy", mainMesh, mainPrometheusId))).To(Succeed())
+		Expect(kubernetes.Cluster.Install(MeshMetricWithSpecificPrometheusBackendForMeshService(mainMesh, secondaryPrometheusId, "test-server-1_meshmetric_svc_80"))).To(Succeed())
+
+		// then
+		Eventually(func(g Gomega) {
+			assignment, err := kubernetes.Cluster.GetKuma().GetMonitoringAssignment(mainPrometheusId)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			madsResponse := MonitoringAssignmentResponse{}
+			g.Expect(json.Unmarshal([]byte(assignment), &madsResponse)).To(Succeed())
+			// two DPPs configured by Mesh targetRef
+			g.Expect(madsResponse.Resources).To(HaveLen(2))
+		}).Should(Succeed())
+
+		// and
+		Eventually(func(g Gomega) {
+			assignment, err := kubernetes.Cluster.GetKuma().GetMonitoringAssignment(secondaryPrometheusId)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			madsResponse := MonitoringAssignmentResponse{}
+			g.Expect(json.Unmarshal([]byte(assignment), &madsResponse)).To(Succeed())
+			// single DPP overridden by MeshService targetRef
+			g.Expect(madsResponse.Resources).To(HaveLen(1))
+		}).Should(Succeed())
+	})
+}
+
+type MonitoringAssignmentResponse struct {
+	Resources []mads.MonitoringAssignment `json:"resources"`
+}

--- a/test/e2e_env/kubernetes/meshmetric/meshmetric.go
+++ b/test/e2e_env/kubernetes/meshmetric/meshmetric.go
@@ -3,9 +3,10 @@ package meshmetric
 import (
 	"encoding/json"
 	"fmt"
+	"net"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"net"
 
 	mads "github.com/kumahq/kuma/api/observability/v1"
 	"github.com/kumahq/kuma/pkg/plugins/policies/meshmetric/api/v1alpha1"

--- a/test/framework/envs/kubernetes/env.go
+++ b/test/framework/envs/kubernetes/env.go
@@ -31,9 +31,13 @@ func SetupAndGetState() []byte {
 	Eventually(func() error {
 		return Cluster.Install(framework.Kuma(core.Zone, kumaOptions...))
 	}, "90s", "3s").Should(Succeed())
-	portFwd := Cluster.GetKuma().(*framework.K8sControlPlane).PortFwd()
 
-	bytes, err := json.Marshal(portFwd)
+	state := framework.K8sNetworkingState{
+		KumaCp: Cluster.GetKuma().(*framework.K8sControlPlane).PortFwd(),
+		MADS:   Cluster.GetKuma().(*framework.K8sControlPlane).MadsPortFwd(),
+	}
+
+	bytes, err := json.Marshal(state)
 	Expect(err).ToNot(HaveOccurred())
 	// Deliberately do not delete Kuma to save execution time (30s).
 	// If everything is fine, K8S cluster will be deleted anyways
@@ -48,8 +52,8 @@ func RestoreState(bytes []byte) {
 	}
 	// Only one process should manage Kuma deployment
 	// Other parallel processes should just replicate CP with its port forwards
-	portFwd := framework.PortFwd{}
-	Expect(json.Unmarshal(bytes, &portFwd)).To(Succeed())
+	state := framework.K8sNetworkingState{}
+	Expect(json.Unmarshal(bytes, &state)).To(Succeed())
 
 	Cluster = framework.NewK8sCluster(framework.NewTestingT(), framework.Kuma1, framework.Verbose)
 	cp := framework.NewK8sControlPlane(
@@ -62,6 +66,6 @@ func RestoreState(bytes []byte) {
 		1,
 		nil, // headers were not configured in setup
 	)
-	Expect(cp.FinalizeAddWithPortFwd(portFwd)).To(Succeed())
+	Expect(cp.FinalizeAddWithPortFwd(state.KumaCp, state.MADS)).To(Succeed())
 	Cluster.SetCP(cp)
 }

--- a/test/framework/envs/multizone/env.go
+++ b/test/framework/envs/multizone/env.go
@@ -169,11 +169,13 @@ func SetupAndGetState() []byte {
 			ZoneEgress:  KubeZone1.GetPortForward(Config.ZoneEgressApp),
 			ZoneIngress: KubeZone1.GetPortForward(Config.ZoneIngressApp),
 			KumaCp:      KubeZone1.GetKuma().(*K8sControlPlane).PortFwd(),
+			MADS:        KubeZone1.GetKuma().(*K8sControlPlane).MadsPortFwd(),
 		},
 		KubeZone2: K8sNetworkingState{
 			ZoneEgress:  KubeZone2.GetPortForward(Config.ZoneEgressApp),
 			ZoneIngress: KubeZone2.GetPortForward(Config.ZoneIngressApp),
 			KumaCp:      KubeZone2.GetKuma().(*K8sControlPlane).PortFwd(),
+			MADS:        KubeZone2.GetKuma().(*K8sControlPlane).MadsPortFwd(),
 		},
 	}
 	bytes, err := json.Marshal(state)
@@ -214,7 +216,7 @@ func RestoreState(bytes []byte) {
 		1,
 		nil,
 	)
-	Expect(kubeCp.FinalizeAddWithPortFwd(state.KubeZone1.KumaCp)).To(Succeed())
+	Expect(kubeCp.FinalizeAddWithPortFwd(state.KubeZone1.KumaCp, state.KubeZone1.KumaCp)).To(Succeed())
 	KubeZone1.SetCP(kubeCp)
 	Expect(KubeZone1.AddPortForward(state.KubeZone1.ZoneEgress, Config.ZoneEgressApp)).To(Succeed())
 	Expect(KubeZone1.AddPortForward(state.KubeZone1.ZoneIngress, Config.ZoneIngressApp)).To(Succeed())
@@ -230,7 +232,7 @@ func RestoreState(bytes []byte) {
 		1,
 		nil, // headers were not configured in setup
 	)
-	Expect(kubeCp.FinalizeAddWithPortFwd(state.KubeZone2.KumaCp)).To(Succeed())
+	Expect(kubeCp.FinalizeAddWithPortFwd(state.KubeZone2.KumaCp, state.KubeZone2.MADS)).To(Succeed())
 	KubeZone2.SetCP(kubeCp)
 	Expect(KubeZone2.AddPortForward(state.KubeZone2.ZoneEgress, Config.ZoneEgressApp)).To(Succeed())
 	Expect(KubeZone2.AddPortForward(state.KubeZone2.ZoneIngress, Config.ZoneIngressApp)).To(Succeed())

--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -587,6 +587,7 @@ type Cluster interface {
 type ControlPlane interface {
 	GetName() string
 	GetMetrics() (string, error)
+	GetMonitoringAssignment(clientId string) (string, error)
 	GetKDSServerAddress() string
 	GetKDSInsecureServerAddress() string
 	GetXDSServerAddress() string

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -47,6 +47,7 @@ type K8sNetworkingState struct {
 	ZoneEgress  PortFwd `json:"zoneEgress"`
 	ZoneIngress PortFwd `json:"zoneIngress"`
 	KumaCp      PortFwd `json:"kumaCp"`
+	MADS        PortFwd `json:"mads"`
 }
 
 type K8sCluster struct {

--- a/test/framework/k8s_controlplane.go
+++ b/test/framework/k8s_controlplane.go
@@ -181,13 +181,18 @@ func (c *K8sControlPlane) PortFwd() PortFwd {
 	return c.portFwd
 }
 
-func (c *K8sControlPlane) FinalizeAdd() error {
-	c.PortForwardKumaCP()
-	return c.FinalizeAddWithPortFwd(c.portFwd)
+func (c *K8sControlPlane) MadsPortFwd() PortFwd {
+	return c.madsFwd
 }
 
-func (c *K8sControlPlane) FinalizeAddWithPortFwd(portFwd PortFwd) error {
+func (c *K8sControlPlane) FinalizeAdd() error {
+	c.PortForwardKumaCP()
+	return c.FinalizeAddWithPortFwd(c.portFwd, c.madsFwd)
+}
+
+func (c *K8sControlPlane) FinalizeAddWithPortFwd(portFwd PortFwd, madsPortForward PortFwd) error {
 	c.portFwd = portFwd
+	c.madsFwd = madsPortForward
 	if !c.cluster.opts.setupKumactl {
 		return nil
 	}

--- a/test/framework/universal_controlplane.go
+++ b/test/framework/universal_controlplane.go
@@ -112,6 +112,10 @@ func (c *UniversalControlPlane) GetMetrics() (string, error) {
 	})
 }
 
+func (c *UniversalControlPlane) GetMonitoringAssignment(clientId string) (string, error) {
+	panic("not implemented")
+}
+
 func (c *UniversalControlPlane) generateToken(
 	tokenPath string,
 	data string,


### PR DESCRIPTION
Fixes #8653 

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
