### PR TITLE
feat(kuma-cp): added comment and more explicit structure

### DIFF
--- a/pkg/plugins/policies/core/matchers/egress.go
+++ b/pkg/plugins/policies/core/matchers/egress.go
@@ -40,8 +40,8 @@ func EgressMatchedPolicies(rType core_model.ResourceType, tags map[string]string
 	switch {
 	case isFrom && isTo:
 		// we needed a strategy to choose what rules to apply on zone egress when a policy supports both "to" and "from".
-		// Picking "from" rules works for us today, because there is only MeshFaultInjection policy that has both "to" 
-		// and "from" and is applied on zone egress. In the future, we might want to move the strategy down to the policy plugins. 
+		// Picking "from" rules works for us today, because there is only MeshFaultInjection policy that has both "to"
+		// and "from" and is applied on zone egress. In the future, we might want to move the strategy down to the policy plugins.
 		fr, err = processFromRules(tags, policies)
 	case isFrom:
 		fr, err = processFromRules(tags, policies)

--- a/pkg/plugins/policies/core/matchers/egress.go
+++ b/pkg/plugins/policies/core/matchers/egress.go
@@ -35,11 +35,20 @@ func EgressMatchedPolicies(rType core_model.ResourceType, tags map[string]string
 
 	var fr core_rules.FromRules
 	var err error
-	if isFrom {
+
+	// in case the policy support
+	switch {
+	case isFrom && isTo:
+		// we intentionally choose From
 		fr, err = processFromRules(tags, policies)
-	} else {
+	case isFrom:
+		// choose From
+		fr, err = processFromRules(tags, policies)
+	case isTo:
+		// choose To
 		fr, err = processToRules(tags, policies)
 	}
+
 	if err != nil {
 		return core_xds.TypedMatchingPolicies{}, err
 	}

--- a/pkg/plugins/policies/core/matchers/egress.go
+++ b/pkg/plugins/policies/core/matchers/egress.go
@@ -39,13 +39,13 @@ func EgressMatchedPolicies(rType core_model.ResourceType, tags map[string]string
 	// in case the policy support
 	switch {
 	case isFrom && isTo:
-		// we intentionally choose From
+		// we needed a strategy to choose what rules to apply on zone egress when a policy supports both "to" and "from".
+		// Picking "from" rules works for us today, because there is only MeshFaultInjection policy that has both "to" 
+		// and "from" and is applied on zone egress. In the future, we might want to move the strategy down to the policy plugins. 
 		fr, err = processFromRules(tags, policies)
 	case isFrom:
-		// choose From
 		fr, err = processFromRules(tags, policies)
 	case isTo:
-		// choose To
 		fr, err = processToRules(tags, policies)
 	}
 


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
