### PR TITLE
fix(policy): allow period in targetRef names

### DIFF
--- a/pkg/core/resources/apis/mesh/validators.go
+++ b/pkg/core/resources/apis/mesh/validators.go
@@ -20,7 +20,7 @@ import (
 const dnsLabel = `[a-z0-9]([-a-z0-9]*[a-z0-9])?`
 
 var (
-	nameCharacterSet     = regexp.MustCompile(`^[0-9a-z-_]*$`)
+	nameCharacterSet     = regexp.MustCompile(`^[0-9a-z.\-_]*$`)
 	tagNameCharacterSet  = regexp.MustCompile(`^[a-zA-Z0-9.\-_:/]*$`)
 	tagValueCharacterSet = regexp.MustCompile(`^[a-zA-Z0-9.\-_:]*$`)
 	selectorCharacterSet = regexp.MustCompile(`^([a-zA-Z0-9.\-_:/]*|\*)$`)

--- a/pkg/core/resources/apis/mesh/validators.go
+++ b/pkg/core/resources/apis/mesh/validators.go
@@ -376,7 +376,7 @@ func validateName(value string) validators.ValidationError {
 	if !nameCharacterSet.MatchString(value) {
 		err.AddViolation(
 			"name",
-			"invalid characters. Valid characters are numbers, lowercase latin letters and '-', '_' symbols.",
+			"invalid characters: must consist of lower case alphanumeric characters, '-', '.' and '_'.",
 		)
 	}
 

--- a/pkg/core/resources/apis/mesh/validators_test.go
+++ b/pkg/core/resources/apis/mesh/validators_test.go
@@ -477,7 +477,7 @@ name: "*"
 			expected: `
 violations:
   - field: targetRef.name
-    message: invalid characters. Valid characters are numbers, lowercase latin letters and '-', '_' symbols. 
+    message: "invalid characters: must consist of lower case alphanumeric characters, '-', '.' and '_'."
 `,
 		}),
 		Entry("MeshGateway when it's not supported", testCase{
@@ -540,7 +540,7 @@ name: "*"
 			expected: `
 violations:
   - field: targetRef.name
-    message: invalid characters. Valid characters are numbers, lowercase latin letters and '-', '_' symbols. 
+    message: "invalid characters: must consist of lower case alphanumeric characters, '-', '.' and '_'."
 `,
 		}),
 		Entry("MeshServiceSubset when it's not supported", testCase{
@@ -588,7 +588,7 @@ tags: {}
 			expected: `
 violations:
  - field: targetRef.name
-   message: invalid characters. Valid characters are numbers, lowercase latin letters and '-', '_' symbols.
+   message: "invalid characters: must consist of lower case alphanumeric characters, '-', '.' and '_'."
 `,
 		}),
 		Entry("MeshServiceSubset with mesh", testCase{

--- a/pkg/core/resources/apis/mesh/validators_test.go
+++ b/pkg/core/resources/apis/mesh/validators_test.go
@@ -178,6 +178,17 @@ tags:
 				GatewayListenerTagsAllowed: true,
 			},
 		}),
+		Entry("MeshGateway with period", testCase{
+			inputYaml: `
+kind: MeshGateway
+name: gateway.namespace
+`,
+			opts: &ValidateTargetRefOpts{
+				SupportedKinds: []common_api.TargetRefKind{
+					common_api.MeshGateway,
+				},
+			},
+		}),
 		Entry("MeshHTTPRoute", testCase{
 			inputYaml: `
 kind: MeshHTTPRoute


### PR DESCRIPTION
Since these refer to K8s objects

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
