### PR TITLE
chore(policy): fix `spec.spec` in validation errors

### DIFF
--- a/pkg/plugins/runtime/k8s/webhooks/dataplane_validator.go
+++ b/pkg/plugins/runtime/k8s/webhooks/dataplane_validator.go
@@ -63,7 +63,7 @@ func (h *DataplaneValidator) ValidateCreate(ctx context.Context, req admission.R
 
 	if err := h.validator.ValidateCreate(ctx, core_model.MetaToResourceKey(coreRes.GetMeta()), coreRes, mesh); err != nil {
 		if kumaErr, ok := err.(*validators.ValidationError); ok {
-			return convertSpecValidationError(kumaErr, k8sRes)
+			return convertSpecValidationError(kumaErr, false, k8sRes)
 		}
 		return admission.Denied(err.Error())
 	}
@@ -96,7 +96,7 @@ func (h *DataplaneValidator) ValidateUpdate(ctx context.Context, req admission.R
 
 	if err := h.validator.ValidateUpdate(ctx, coreRes, mesh); err != nil {
 		if kumaErr, ok := err.(*validators.ValidationError); ok {
-			return convertSpecValidationError(kumaErr, k8sRes)
+			return convertSpecValidationError(kumaErr, false, k8sRes)
 		}
 		return admission.Denied(err.Error())
 	}

--- a/pkg/plugins/runtime/k8s/webhooks/externalservice_validator.go
+++ b/pkg/plugins/runtime/k8s/webhooks/externalservice_validator.go
@@ -61,7 +61,7 @@ func (h *ExternalServiceValidator) ValidateCreate(ctx context.Context, req admis
 	}
 	if err := h.validator.ValidateCreate(ctx, k8sRes.Mesh, coreRes); err != nil {
 		if kumaErr, ok := err.(*validators.ValidationError); ok {
-			return convertSpecValidationError(kumaErr, k8sRes)
+			return convertSpecValidationError(kumaErr, false, k8sRes)
 		}
 		return admission.Denied(err.Error())
 	}
@@ -89,7 +89,7 @@ func (h *ExternalServiceValidator) ValidateUpdate(ctx context.Context, req admis
 
 	if err := h.validator.ValidateUpdate(ctx, oldCoreRes, coreRes); err != nil {
 		if kumaErr, ok := err.(*validators.ValidationError); ok {
-			return convertSpecValidationError(kumaErr, k8sRes)
+			return convertSpecValidationError(kumaErr, false, k8sRes)
 		}
 		return admission.Denied(err.Error())
 	}

--- a/pkg/plugins/runtime/k8s/webhooks/mesh_validator.go
+++ b/pkg/plugins/runtime/k8s/webhooks/mesh_validator.go
@@ -69,7 +69,7 @@ func (h *MeshValidator) ValidateCreate(ctx context.Context, req admission.Reques
 	}
 	if err := h.validator.ValidateCreate(ctx, req.Name, coreRes); err != nil {
 		if kumaErr, ok := err.(*validators.ValidationError); ok {
-			return convertSpecValidationError(kumaErr, k8sRes)
+			return convertSpecValidationError(kumaErr, false, k8sRes)
 		}
 		return admission.Denied(err.Error())
 	}
@@ -97,7 +97,7 @@ func (h *MeshValidator) ValidateUpdate(ctx context.Context, req admission.Reques
 
 	if err := h.validator.ValidateUpdate(ctx, oldCoreRes, coreRes); err != nil {
 		if kumaErr, ok := err.(*validators.ValidationError); ok {
-			return convertSpecValidationError(kumaErr, k8sRes)
+			return convertSpecValidationError(kumaErr, false, k8sRes)
 		}
 		return admission.Denied(err.Error())
 	}

--- a/pkg/plugins/runtime/k8s/webhooks/ratelimit_validator.go
+++ b/pkg/plugins/runtime/k8s/webhooks/ratelimit_validator.go
@@ -61,7 +61,7 @@ func (h *RateLimitValidator) ValidateCreate(ctx context.Context, req admission.R
 	}
 	if err := h.validator.ValidateCreate(ctx, k8sRes.Mesh, coreRes); err != nil {
 		if kumaErr, ok := err.(*validators.ValidationError); ok {
-			return convertSpecValidationError(kumaErr, k8sRes)
+			return convertSpecValidationError(kumaErr, false, k8sRes)
 		}
 		return admission.Denied(err.Error())
 	}
@@ -89,7 +89,7 @@ func (h *RateLimitValidator) ValidateUpdate(ctx context.Context, req admission.R
 
 	if err := h.validator.ValidateUpdate(ctx, oldCoreRes, coreRes); err != nil {
 		if kumaErr, ok := err.(*validators.ValidationError); ok {
-			return convertSpecValidationError(kumaErr, k8sRes)
+			return convertSpecValidationError(kumaErr, false, k8sRes)
 		}
 		return admission.Denied(err.Error())
 	}


### PR DESCRIPTION
Atm there are errors like:

```
spec.spec.to[0].rules[0].default.backendRefs[0].kind: value is not supported
```

on Kubernetes. This checks if we need to add the extra `spec.`. Tested universal/k8s and targetRef/non-targetRef matrix.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
