### PR TITLE
test(e2e): fix test failure for syncing when on legacyKDS mode

### DIFF
--- a/test/e2e_env/multizone/sync/sync.go
+++ b/test/e2e_env/multizone/sync/sync.go
@@ -49,7 +49,7 @@ func Sync() {
 		}, "30s", "1s").Should(Succeed())
 	})
 
-	PIt("show have insights in global and in zone", func() { // flaky test https://github.com/kumahq/kuma/issues/8756
+	It("show have insights in global and in zone", func() {
 		// Ensure each side of KDS has the respective values for Global and Zone instance info
 		globalName := ""
 		zoneInstance := ""
@@ -61,7 +61,9 @@ func Sync() {
 			sub := result.Spec.Subscriptions[0]
 			g.Expect(sub.GlobalInstanceId).ToNot(BeEmpty())
 			globalName = sub.GlobalInstanceId
-			g.Expect(sub.ZoneInstanceId).ToNot(BeEmpty())
+			if !Config.KumaLegacyKDS {
+				g.Expect(sub.ZoneInstanceId).ToNot(BeEmpty())
+			}
 			zoneInstance = sub.ZoneInstanceId
 		}, "30s", "1s").Should(Succeed())
 
@@ -71,9 +73,11 @@ func Sync() {
 
 			g.Expect(result.Spec.Subscriptions).ToNot(BeEmpty())
 			sub := result.Spec.Subscriptions[0]
-			// Check that this is the other side of the connection
-			g.Expect(sub.GlobalInstanceId).To(Equal(globalName))
-			g.Expect(sub.ZoneInstanceId).To(Equal(zoneInstance))
+			if !Config.KumaLegacyKDS {
+				// Check that this is the other side of the connection
+				g.Expect(sub.GlobalInstanceId).To(Equal(globalName))
+				g.Expect(sub.ZoneInstanceId).To(Equal(zoneInstance))
+			}
 		}, "30s", "1s").Should(Succeed())
 	})
 


### PR DESCRIPTION
fixes https://github.com/kumahq/kuma/issues/8756

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues 
  - https://github.com/kumahq/kuma/issues/8756
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS 
  - Confirmed
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) 
  - Manual tested
  - Don't forget `ci/` labels to run additional/fewer tests
    - Added
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - No
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) 
  - No

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
