### PR TITLE
fix(ZoneWatch): stop watching Zone if ZoneInsight not found

### DIFF
--- a/pkg/kds/mux/zone_watch.go
+++ b/pkg/kds/mux/zone_watch.go
@@ -86,17 +86,14 @@ func (zw *ZoneWatch) Start(stop <-chan struct{}) error {
 				log := kuma_log.AddFieldsFromCtx(zw.log, ctx, zw.extensions)
 				if err := zw.rm.Get(ctx, zoneInsight, store.GetByKey(zone.zone, model.NoMesh)); err != nil {
 					if store.IsResourceNotFound(err) {
-						zoneRes := system.NewZoneResource()
-						if err := zw.rm.Get(ctx, zoneRes, store.GetByKey(zone.zone, model.NoMesh)); err != nil && store.IsResourceNotFound(err) {
-							zw.bus.Send(service.ZoneWentOffline{
-								Zone:     zone.zone,
-								TenantID: zone.tenantID,
-							})
-							delete(zw.zones, zone)
-							continue
-						}
+						zw.bus.Send(service.ZoneWentOffline{
+							Zone:     zone.zone,
+							TenantID: zone.tenantID,
+						})
+						delete(zw.zones, zone)
+					} else {
+						log.Info("error getting ZoneInsight", "zone", zone.zone, "error", err)
 					}
-					log.Info("error getting ZoneInsight", "zone", zone.zone, "error", err)
 					continue
 				}
 


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
