### PR TITLE
feat(MeshHTTPRoute): add hostToBackendHostname rewrite with MeshGateway

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -1600,7 +1600,8 @@ spec:
                                         hostToBackendHostname:
                                           description: HostToBackendHostname rewrites
                                             the hostname to the hostname of the upstream
-                                            host.
+                                            host. This option is only available when
+                                            targeting MeshGateways.
                                           type: boolean
                                         hostname:
                                           description: Hostname is the value to be

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -1597,6 +1597,11 @@ spec:
                                       type: string
                                     urlRewrite:
                                       properties:
+                                        hostToBackendHostname:
+                                          description: HostToBackendHostname rewrites
+                                            the hostname to the hostname of the upstream
+                                            host.
+                                          type: boolean
                                         hostname:
                                           description: Hostname is the value to be
                                             used to replace the host header value

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
@@ -1600,7 +1600,8 @@ spec:
                                         hostToBackendHostname:
                                           description: HostToBackendHostname rewrites
                                             the hostname to the hostname of the upstream
-                                            host.
+                                            host. This option is only available when
+                                            targeting MeshGateways.
                                           type: boolean
                                         hostname:
                                           description: Hostname is the value to be

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
@@ -1597,6 +1597,11 @@ spec:
                                       type: string
                                     urlRewrite:
                                       properties:
+                                        hostToBackendHostname:
+                                          description: HostToBackendHostname rewrites
+                                            the hostname to the hostname of the upstream
+                                            host.
+                                          type: boolean
                                         hostname:
                                           description: Hostname is the value to be
                                             used to replace the host header value

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -1801,6 +1801,11 @@ spec:
                                       type: string
                                     urlRewrite:
                                       properties:
+                                        hostToBackendHostname:
+                                          description: HostToBackendHostname rewrites
+                                            the hostname to the hostname of the upstream
+                                            host.
+                                          type: boolean
                                         hostname:
                                           description: Hostname is the value to be
                                             used to replace the host header value

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -1804,7 +1804,8 @@ spec:
                                         hostToBackendHostname:
                                           description: HostToBackendHostname rewrites
                                             the hostname to the hostname of the upstream
-                                            host.
+                                            host. This option is only available when
+                                            targeting MeshGateways.
                                           type: boolean
                                         hostname:
                                           description: Hostname is the value to be

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -1617,6 +1617,11 @@ spec:
                                       type: string
                                     urlRewrite:
                                       properties:
+                                        hostToBackendHostname:
+                                          description: HostToBackendHostname rewrites
+                                            the hostname to the hostname of the upstream
+                                            host.
+                                          type: boolean
                                         hostname:
                                           description: Hostname is the value to be
                                             used to replace the host header value

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -1620,7 +1620,8 @@ spec:
                                         hostToBackendHostname:
                                           description: HostToBackendHostname rewrites
                                             the hostname to the hostname of the upstream
-                                            host.
+                                            host. This option is only available when
+                                            targeting MeshGateways.
                                           type: boolean
                                         hostname:
                                           description: Hostname is the value to be

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -2959,7 +2959,8 @@ spec:
                                         hostToBackendHostname:
                                           description: HostToBackendHostname rewrites
                                             the hostname to the hostname of the upstream
-                                            host.
+                                            host. This option is only available when
+                                            targeting MeshGateways.
                                           type: boolean
                                         hostname:
                                           description: Hostname is the value to be

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -2956,6 +2956,11 @@ spec:
                                       type: string
                                     urlRewrite:
                                       properties:
+                                        hostToBackendHostname:
+                                          description: HostToBackendHostname rewrites
+                                            the hostname to the hostname of the upstream
+                                            host.
+                                          type: boolean
                                         hostname:
                                           description: Hostname is the value to be
                                             used to replace the host header value

--- a/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
@@ -3160,6 +3160,11 @@ spec:
                                       type: string
                                     urlRewrite:
                                       properties:
+                                        hostToBackendHostname:
+                                          description: HostToBackendHostname rewrites
+                                            the hostname to the hostname of the upstream
+                                            host.
+                                          type: boolean
                                         hostname:
                                           description: Hostname is the value to be
                                             used to replace the host header value

--- a/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
@@ -3163,7 +3163,8 @@ spec:
                                         hostToBackendHostname:
                                           description: HostToBackendHostname rewrites
                                             the hostname to the hostname of the upstream
-                                            host.
+                                            host. This option is only available when
+                                            targeting MeshGateways.
                                           type: boolean
                                         hostname:
                                           description: Hostname is the value to be

--- a/deployments/charts/kuma/crds/kuma.io_meshhttproutes.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshhttproutes.yaml
@@ -358,7 +358,8 @@ spec:
                                         hostToBackendHostname:
                                           description: HostToBackendHostname rewrites
                                             the hostname to the hostname of the upstream
-                                            host.
+                                            host. This option is only available when
+                                            targeting MeshGateways.
                                           type: boolean
                                         hostname:
                                           description: Hostname is the value to be

--- a/deployments/charts/kuma/crds/kuma.io_meshhttproutes.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshhttproutes.yaml
@@ -355,6 +355,11 @@ spec:
                                       type: string
                                     urlRewrite:
                                       properties:
+                                        hostToBackendHostname:
+                                          description: HostToBackendHostname rewrites
+                                            the hostname to the hostname of the upstream
+                                            host.
+                                          type: boolean
                                         hostname:
                                           description: Hostname is the value to be
                                             used to replace the host header value

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -3989,7 +3989,8 @@ components:
                                         description: >-
                                           HostToBackendHostname rewrites the
                                           hostname to the hostname of the upstream
-                                          host.
+                                          host. This option is only available when
+                                          targeting MeshGateways.
                                         type: boolean
                                       hostname:
                                         description: >-

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -3985,6 +3985,12 @@ components:
                                     type: string
                                   urlRewrite:
                                     properties:
+                                      hostToBackendHostname:
+                                        description: >-
+                                          HostToBackendHostname rewrites the
+                                          hostname to the hostname of the upstream
+                                          host.
+                                        type: boolean
                                       hostname:
                                         description: >-
                                           Hostname is the value to be used to

--- a/docs/generated/raw/crds/kuma.io_meshhttproutes.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshhttproutes.yaml
@@ -358,7 +358,8 @@ spec:
                                         hostToBackendHostname:
                                           description: HostToBackendHostname rewrites
                                             the hostname to the hostname of the upstream
-                                            host.
+                                            host. This option is only available when
+                                            targeting MeshGateways.
                                           type: boolean
                                         hostname:
                                           description: Hostname is the value to be

--- a/docs/generated/raw/crds/kuma.io_meshhttproutes.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshhttproutes.yaml
@@ -355,6 +355,11 @@ spec:
                                       type: string
                                     urlRewrite:
                                       properties:
+                                        hostToBackendHostname:
+                                          description: HostToBackendHostname rewrites
+                                            the hostname to the hostname of the upstream
+                                            host.
+                                          type: boolean
                                         hostname:
                                           description: Hostname is the value to be
                                             used to replace the host header value

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/meshhttproute.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/meshhttproute.go
@@ -196,6 +196,9 @@ type URLRewrite struct {
 	Hostname *PreciseHostname `json:"hostname,omitempty"`
 	// Path defines a path rewrite.
 	Path *PathRewrite `json:"path,omitempty"`
+	// HostToBackendHostname rewrites the hostname to the hostname of the
+	// upstream host.
+	HostToBackendHostname bool `json:"hostToBackendHostname,omitempty"`
 }
 
 type RequestMirror struct {

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/meshhttproute.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/meshhttproute.go
@@ -197,7 +197,7 @@ type URLRewrite struct {
 	// Path defines a path rewrite.
 	Path *PathRewrite `json:"path,omitempty"`
 	// HostToBackendHostname rewrites the hostname to the hostname of the
-	// upstream host.
+	// upstream host. This option is only available when targeting MeshGateways.
 	HostToBackendHostname bool `json:"hostToBackendHostname,omitempty"`
 }
 

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/schema.yaml
@@ -276,7 +276,7 @@ properties:
                             urlRewrite:
                               properties:
                                 hostToBackendHostname:
-                                  description: HostToBackendHostname rewrites the hostname to the hostname of the upstream host.
+                                  description: HostToBackendHostname rewrites the hostname to the hostname of the upstream host. This option is only available when targeting MeshGateways.
                                   type: boolean
                                 hostname:
                                   description: Hostname is the value to be used to replace the host header value during forwarding.

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/schema.yaml
@@ -275,6 +275,9 @@ properties:
                               type: string
                             urlRewrite:
                               properties:
+                                hostToBackendHostname:
+                                  description: HostToBackendHostname rewrites the hostname to the hostname of the upstream host.
+                                  type: boolean
                                 hostname:
                                   description: Hostname is the value to be used to replace the host header value during forwarding.
                                   maxLength: 253

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation_test.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation_test.go
@@ -305,11 +305,14 @@ to:
               version: v1
 
 `),
-		ErrorCase("hostnames not allowed with services",
-			validators.Violation{
+		ErrorCases("hostnames and hostname to backend rewrite not allowed with services",
+			[]validators.Violation{{
 				Field:   `spec.to[0].hostnames`,
 				Message: `must not be defined`,
-			}, `
+			}, {
+				Field:   "spec.to[0].rules[0].default.filters[0].urlRewrite.hostToBackendHostname",
+				Message: "can only be set with MeshGateway",
+			}}, `
 type: MeshHTTPRoute
 mesh: mesh-1
 name: route-1
@@ -328,6 +331,10 @@ to:
           type: PathPrefix
           value: /
       default:
+        filters:
+          - type: URLRewrite
+            urlRewrite:
+              hostToBackendHostname: true
         backendRefs:
           - kind: MeshService
             name: backend
@@ -600,6 +607,10 @@ to:
           value: /
           type: PathPrefix
       default:
+        filters:
+          - type: URLRewrite
+            urlRewrite:
+              hostToBackendHostname: true
         backendRefs:
           - kind: MeshService
             name: backend

--- a/pkg/plugins/policies/meshhttproute/k8s/crd/kuma.io_meshhttproutes.yaml
+++ b/pkg/plugins/policies/meshhttproute/k8s/crd/kuma.io_meshhttproutes.yaml
@@ -358,7 +358,8 @@ spec:
                                         hostToBackendHostname:
                                           description: HostToBackendHostname rewrites
                                             the hostname to the hostname of the upstream
-                                            host.
+                                            host. This option is only available when
+                                            targeting MeshGateways.
                                           type: boolean
                                         hostname:
                                           description: Hostname is the value to be

--- a/pkg/plugins/policies/meshhttproute/k8s/crd/kuma.io_meshhttproutes.yaml
+++ b/pkg/plugins/policies/meshhttproute/k8s/crd/kuma.io_meshhttproutes.yaml
@@ -355,6 +355,11 @@ spec:
                                       type: string
                                     urlRewrite:
                                       properties:
+                                        hostToBackendHostname:
+                                          description: HostToBackendHostname rewrites
+                                            the hostname to the hostname of the upstream
+                                            host.
+                                          type: boolean
                                         hostname:
                                           description: Hostname is the value to be
                                             used to replace the host header value

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/gateway_routes.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/gateway_routes.go
@@ -163,6 +163,10 @@ func makeHttpRouteEntry(name string, rule api.Rule) route.Entry {
 				rewrite.ReplaceHostname = pointer.To(string(*r.Hostname))
 			}
 
+			if r.HostToBackendHostname {
+				rewrite.HostToBackendHostname = true
+			}
+
 			entry.Rewrite = &rewrite
 		}
 	}


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- https://github.com/kumahq/kuma/issues/8142
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
