### PR TITLE
ci(github): use merge commit sha for pull requests to trigger CircleCI builds

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -79,6 +79,7 @@ jobs:
           sudo df -h
       # FIXME: Workaround for Request Timeout issue of artifacts https://github.com/actions/download-artifact/issues/249
       - name: "GitHub Actions: download build artifacts with retry"
+        if: steps.eval-params.outputs.run-type == 'github'
         uses: Wandalen/wretry.action@master
         with:
           action: actions/download-artifact@v4
@@ -173,12 +174,11 @@ jobs:
             let circleCIBody = {
               "parameters": circleCIParams,
             };
-            // use pull/<number>/head if it's PR from a fork,
-            // otherwise, always use the current SHA to make sure all CircleCI e2e runnings are using the same commit SHA with this GH Action run
-            if ( "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}") {
-              circleCIBody["branch"] = '${{ github.ref_name}}'.replace(/^(refs\/)/,"");
+
+            if ( "${{ github.event_name }}" == "pull_request" ) {
+              circleCIBody["branch"] = 'pull/${{ github.event.pull_request.id }}/merge';
             } else {
-              circleCIBody["tag"] = '${{ github.event.pull_request.head.sha || github.sha }}'
+              circleCIBody["tag"] = '${{ github.sha }}'
             }
 
             core.info(`created request object for circleCI ${JSON.stringify(circleCIBody)}`);


### PR DESCRIPTION
When run a full-matrix CI for PRs, the git SHA passed to Circle was incorrect, so it was not possible to load correct images from the `build-output` generated on GH Actions.

An example failure can be found here (its a check of [PR 8738](https://github.com/kumahq/kuma/pull/8738)):
https://app.circleci.com/pipelines/gh/kumahq/kuma/29133/workflows/98afa0e8-1455-4fb3-bcb0-6e6649e99087/jobs/576232/parallel-runs/0/steps/0-110

To correct this, the only way is to use the same PR merge ref on CircleCI runs. We can not use a git SHA for PR builds, because:

1. The `github.event.pull_request.head.sha` is different from `github.sha`, which is identical to the SHA that had been checked out to on GH Actions. [See an example run](https://github.com/jijiechen/kuma/actions/runs/7456258131/job/20286615405?pr=4)
2. The `github.event.pull_request.head.sha` is also different from `github.event.pull_request.merge_commit_sha`, but neither is identical to `github.sha`. 
3. If direct pass the `github.sha` to CircleCI as a tag, it will fail with error "reference is not a tree". [See an example run](https://app.circleci.com/pipelines/github/jijiechen/kuma/1279/workflows/360d2302-8134-4e34-9f1b-c993579bca05/jobs/1729)



### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - N/A
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS 
  - Confirmed
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) 
  - Manually tested
  - Don't forget `ci/` labels to run additional/fewer tests
    - Added
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? 
  - No
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) 
  - No need

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
