### PR TITLE
feat(meshtcproute): add kafka protocol support

### DIFF
--- a/pkg/plugins/policies/core/xds/meshroute/listeners.go
+++ b/pkg/plugins/policies/core/xds/meshroute/listeners.go
@@ -23,6 +23,7 @@ func MakeTCPSplit(
 	return makeSplit(
 		map[core_mesh.Protocol]struct{}{
 			core_mesh.ProtocolUnknown: {},
+			core_mesh.ProtocolKafka:   {},
 			core_mesh.ProtocolTCP:     {},
 			core_mesh.ProtocolHTTP:    {},
 			core_mesh.ProtocolHTTP2:   {},

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners.go
@@ -41,7 +41,7 @@ func generateListeners(
 		}
 
 		splits := meshroute_xds.MakeTCPSplit(clusterCache, servicesAccumulator, backendRefs, meshCtx)
-		filterChain := buildFilterChain(proxy, serviceName, splits)
+		filterChain := buildFilterChain(proxy, serviceName, splits, protocol)
 
 		listener, err := buildOutboundListener(proxy, outbound, filterChain)
 		if err != nil {

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners_filterchain.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners_filterchain.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	envoy_listeners "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
@@ -10,10 +11,15 @@ func buildFilterChain(
 	proxy *core_xds.Proxy,
 	serviceName string,
 	splits []envoy_common.Split,
+	protocol core_mesh.Protocol,
 ) envoy_listeners.ListenerBuilderOpt {
 	tcpProxy := envoy_listeners.TCPProxy(serviceName, splits...)
-	builder := envoy_listeners.NewFilterChainBuilder(proxy.APIVersion, envoy_common.AnonymousResource).
-		Configure(tcpProxy)
+	builder := envoy_listeners.NewFilterChainBuilder(proxy.APIVersion, envoy_common.AnonymousResource)
+	switch protocol {
+	case core_mesh.ProtocolKafka:
+		builder.Configure(envoy_listeners.Kafka(serviceName))
+	}
+	builder.Configure(tcpProxy)
 
 	return envoy_listeners.FilterChain(builder)
 }

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
@@ -513,5 +513,63 @@ var _ = Describe("MeshTCPRoute", func() {
 					Build(),
 			}
 		}()),
+
+		Entry("kafka", func() outboundsTestCase {
+			outboundTargets := xds_builders.EndpointMap().
+				AddEndpoints("backend",
+					xds_builders.Endpoint().
+						WithTarget("192.168.0.4").
+						WithPort(8004).
+						WithWeight(1).
+						WithTags(mesh_proto.ServiceTag, "backend", mesh_proto.ProtocolTag, core_mesh.ProtocolKafka, "region", "eu"),
+					xds_builders.Endpoint().
+						WithTarget("192.168.0.5").
+						WithPort(8005).
+						WithWeight(1).
+						WithTags(mesh_proto.ServiceTag, "backend", mesh_proto.ProtocolTag, core_mesh.ProtocolKafka, "region", "us"))
+			rules := core_rules.ToRules{
+				Rules: core_rules.Rules{
+					{
+						Subset: core_rules.MeshService("backend"),
+						Conf: api.Rule{
+							Default: api.RuleConf{
+								BackendRefs: []common_api.BackendRef{
+									{
+										TargetRef: builders.TargetRefServiceSubset(
+											"backend",
+											"region", "eu",
+										),
+										Weight: pointer.To(uint(60)),
+									},
+									{
+										TargetRef: builders.TargetRefServiceSubset(
+											"backend",
+											"region", "us",
+										),
+										Weight: pointer.To(uint(40)),
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			return outboundsTestCase{
+				xdsContext: *xds_builders.Context().WithEndpointMap(outboundTargets).
+					AddServiceProtocol("backend", core_mesh.ProtocolKafka).
+					Build(),
+				proxy: xds_builders.Proxy().
+					WithDataplane(
+						samples.DataplaneWebBuilder(),
+					).
+					WithRouting(
+						xds_builders.Routing().
+							WithOutboundTargets(outboundTargets),
+					).
+					WithPolicies(xds_builders.MatchedPolicies().WithToPolicy(api.MeshTCPRouteType, rules)).
+					Build(),
+			}
+		}()),
 	)
 })

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/kafka.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/kafka.clusters.golden.yaml
@@ -1,0 +1,29 @@
+resources:
+- name: backend-bb38a94289f18fb9
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+        resourceApiVersion: V3
+    name: backend-bb38a94289f18fb9
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
+- name: backend-c72efb5be46fae6b
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+        resourceApiVersion: V3
+    name: backend-c72efb5be46fae6b
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/kafka.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/kafka.endpoints.golden.yaml
@@ -1,0 +1,41 @@
+resources:
+- name: backend-bb38a94289f18fb9
+  resource:
+    '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
+    clusterName: backend-bb38a94289f18fb9
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.0.4
+              portValue: 8004
+        loadBalancingWeight: 1
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              kuma.io/protocol: kafka
+              region: eu
+            envoy.transport_socket_match:
+              kuma.io/protocol: kafka
+              region: eu
+- name: backend-c72efb5be46fae6b
+  resource:
+    '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
+    clusterName: backend-c72efb5be46fae6b
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.0.5
+              portValue: 8005
+        loadBalancingWeight: 1
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              kuma.io/protocol: kafka
+              region: us
+            envoy.transport_socket_match:
+              kuma.io/protocol: kafka
+              region: us

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/kafka.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/kafka.listeners.golden.yaml
@@ -1,0 +1,30 @@
+resources:
+- name: outbound:127.0.0.1:10001
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 127.0.0.1
+        portValue: 10001
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.kafka_broker
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.kafka_broker.v3.KafkaBroker
+          statPrefix: backend
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          statPrefix: backend
+          weightedClusters:
+            clusters:
+            - name: backend-bb38a94289f18fb9
+              weight: 60
+            - name: backend-c72efb5be46fae6b
+              weight: 40
+    metadata:
+      filterMetadata:
+        io.kuma.tags:
+          kuma.io/service: backend
+    name: outbound:127.0.0.1:10001
+    trafficDirection: OUTBOUND


### PR DESCRIPTION
### Checklist prior to review

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
