### PR TITLE
chore(kuma-cp): pass context.Context to plugin.Apply

### DIFF
--- a/pkg/core/plugins/interfaces.go
+++ b/pkg/core/plugins/interfaces.go
@@ -93,9 +93,9 @@ type PolicyPlugin interface {
 	Plugin
 	// MatchedPolicies return all the policies of the plugins' type matching this dataplane. This is used in the inspect api and accessible in Apply through `proxy.Policies.Dynamic`
 	MatchedPolicies(dataplane *core_mesh.DataplaneResource, resources xds_context.Resources) (core_xds.TypedMatchingPolicies, error)
-	// Apply to `rs` using the `ctx` and `proxy` the mutation for all policies of the type this plugin implements.
+	// Apply to `rs` using the `xdsCtx` and `proxy` the mutation for all policies of the type this plugin implements.
 	// You can access matching policies by using `proxy.Policies.Dynamic`.
-	Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *core_xds.Proxy) error
+	Apply(ctx context.Context, rs *core_xds.ResourceSet, xdsCtx xds_context.Context, proxy *core_xds.Proxy) error
 }
 
 type EgressPolicyPlugin interface {

--- a/pkg/plugins/policies/core/generator/generator.go
+++ b/pkg/plugins/policies/core/generator/generator.go
@@ -20,7 +20,7 @@ type generator struct{}
 
 func (g generator) Generate(ctx context.Context, rs *xds.ResourceSet, xdsCtx xds_context.Context, proxy *xds.Proxy) (*xds.ResourceSet, error) {
 	for _, policy := range plugins.Plugins().PolicyPlugins(ordered.Policies) {
-		if err := policy.Plugin.Apply(rs, xdsCtx, proxy); err != nil {
+		if err := policy.Plugin.Apply(ctx, rs, xdsCtx, proxy); err != nil {
 			return nil, errors.Wrapf(err, "could not apply policy plugin %s", policy.Name)
 		}
 	}

--- a/pkg/plugins/policies/donothingpolicy/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/donothingpolicy/plugin/v1alpha1/plugin.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"context"
+
 	"github.com/kumahq/kuma/pkg/core"
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
@@ -25,7 +27,7 @@ func (p plugin) MatchedPolicies(dataplane *core_mesh.DataplaneResource, resource
 	return matchers.MatchedPolicies(api.DoNothingPolicyType, dataplane, resources)
 }
 
-func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *core_xds.Proxy) error {
+func (p plugin) Apply(context.Context, *core_xds.ResourceSet, xds_context.Context, *core_xds.Proxy) error {
 	log.Info("apply is not implemented")
 	return nil
 }

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"context"
+
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	"github.com/pkg/errors"
 
@@ -33,7 +35,7 @@ func (p plugin) MatchedPolicies(dataplane *core_mesh.DataplaneResource, resource
 	return matchers.MatchedPolicies(api.MeshAccessLogType, dataplane, resources)
 }
 
-func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *core_xds.Proxy) error {
+func (p plugin) Apply(ctx context.Context, rs *core_xds.ResourceSet, xdsCtx xds_context.Context, proxy *core_xds.Proxy) error {
 	policies, ok := proxy.Policies.Dynamic[api.MeshAccessLogType]
 	if !ok {
 		return nil
@@ -55,7 +57,7 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 	if err := applyToDirectAccess(policies.ToRules, listeners.DirectAccess, proxy.Dataplane, endpoints, proxy.Metadata.AccessLogSocketPath); err != nil {
 		return err
 	}
-	if err := applyToGateway(policies.GatewayRules, listeners.Gateway, ctx.Mesh.Resources.MeshLocalResources, proxy.Dataplane, endpoints, proxy.Metadata.AccessLogSocketPath); err != nil {
+	if err := applyToGateway(policies.GatewayRules, listeners.Gateway, xdsCtx.Mesh.Resources.MeshLocalResources, proxy.Dataplane, endpoints, proxy.Metadata.AccessLogSocketPath); err != nil {
 		return err
 	}
 

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
@@ -79,7 +79,7 @@ var _ = Describe("MeshAccessLog", func() {
 				Build()
 			plugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
 
-			Expect(plugin.Apply(resourceSet, xdsCtx, proxy)).To(Succeed())
+			Expect(plugin.Apply(context.TODO(), resourceSet, xdsCtx, proxy)).To(Succeed())
 			policies_xds.ResourceArrayShouldEqual(resourceSet.ListOf(envoy_resource.ListenerType), given.expectedListeners)
 			policies_xds.ResourceArrayShouldEqual(resourceSet.ListOf(envoy_resource.ClusterType), given.expectedClusters)
 		},
@@ -980,7 +980,7 @@ var _ = Describe("MeshAccessLog", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			plugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
-			Expect(plugin.Apply(generatedResources, xdsCtx, proxy)).To(Succeed())
+			Expect(plugin.Apply(context.TODO(), generatedResources, xdsCtx, proxy)).To(Succeed())
 
 			nameSplit := strings.Split(GinkgoT().Name(), " ")
 			name := nameSplit[len(nameSplit)-1]

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"context"
+
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
@@ -33,8 +35,9 @@ func (p plugin) MatchedPolicies(
 }
 
 func (p plugin) Apply(
+	ctx context.Context,
 	rs *core_xds.ResourceSet,
-	ctx xds_context.Context,
+	xdsCtx xds_context.Context,
 	proxy *core_xds.Proxy,
 ) error {
 	policies, ok := proxy.Policies.Dynamic[api.MeshCircuitBreakerType]

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin_test.go
@@ -87,7 +87,7 @@ var _ = Describe("MeshCircuitBreaker", func() {
 			resourceSet := core_xds.NewResourceSet()
 			resourceSet.Add(given.resources...)
 
-			context := xds_samples.SampleContext()
+			xdsCtx := xds_samples.SampleContext()
 
 			proxy := xds_builders.Proxy().
 				WithDataplane(
@@ -104,7 +104,7 @@ var _ = Describe("MeshCircuitBreaker", func() {
 				Build()
 			plugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
 
-			Expect(plugin.Apply(resourceSet, context, proxy)).To(Succeed())
+			Expect(plugin.Apply(context.TODO(), resourceSet, xdsCtx, proxy)).To(Succeed())
 
 			for idx, expected := range given.expectedCluster {
 				Expect(util_proto.ToYAML(resourceSet.ListOf(envoy_resource.ClusterType)[idx].Resource)).
@@ -422,7 +422,7 @@ var _ = Describe("MeshCircuitBreaker", func() {
 
 			// when
 			plugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
-			Expect(plugin.Apply(generatedResources, xdsCtx, proxy)).To(Succeed())
+			Expect(plugin.Apply(context.TODO(), generatedResources, xdsCtx, proxy)).To(Succeed())
 
 			getResourceYaml := func(list core_xds.ResourceList) []byte {
 				actualResource, err := util_proto.ToYAML(list[0].Resource)

--- a/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"context"
+
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
@@ -39,7 +41,7 @@ func (p plugin) EgressMatchedPolicies(tags map[string]string, resources xds_cont
 	return matchers.EgressMatchedPolicies(api.MeshFaultInjectionType, tags, resources)
 }
 
-func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *core_xds.Proxy) error {
+func (p plugin) Apply(ctx context.Context, rs *core_xds.ResourceSet, xdsCtx xds_context.Context, proxy *core_xds.Proxy) error {
 	if proxy.ZoneEgressProxy != nil {
 		return applyToEgress(rs, proxy)
 	}

--- a/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin_test.go
@@ -49,7 +49,7 @@ var _ = Describe("MeshFaultInjection", func() {
 			resourceSet := core_xds.NewResourceSet()
 			resourceSet.Add(given.resources...)
 
-			context := xds_samples.SampleContext()
+			xdsCtx := xds_samples.SampleContext()
 			proxy := xds_builders.Proxy().
 				WithDataplane(
 					builders.Dataplane().
@@ -76,7 +76,7 @@ var _ = Describe("MeshFaultInjection", func() {
 			plugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
 
 			// when
-			Expect(plugin.Apply(resourceSet, context, proxy)).To(Succeed())
+			Expect(plugin.Apply(context.TODO(), resourceSet, xdsCtx, proxy)).To(Succeed())
 
 			// then
 			for i, expected := range given.expectedListeners {
@@ -427,7 +427,7 @@ var _ = Describe("MeshFaultInjection", func() {
 
 		// when
 		p := plugin.NewPlugin().(core_plugins.PolicyPlugin)
-		err = p.Apply(rs, *ctxMesh1, proxy)
+		err = p.Apply(context.TODO(), rs, *ctxMesh1, proxy)
 		Expect(err).ToNot(HaveOccurred())
 
 		// then
@@ -490,7 +490,7 @@ var _ = Describe("MeshFaultInjection", func() {
 		plugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
 
 		// then
-		Expect(plugin.Apply(generatedResources, xdsCtx, proxy)).To(Succeed())
+		Expect(plugin.Apply(context.TODO(), generatedResources, xdsCtx, proxy)).To(Succeed())
 		Expect(util_proto.ToYAML(generatedResources.ListOf(envoy_resource.ListenerType)[0].Resource)).To(test_matchers.MatchGoldenYAML(filepath.Join("testdata", "gateway_basic_listener.golden.yaml")))
 	})
 })

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"context"
+
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
@@ -28,7 +30,7 @@ func (p plugin) MatchedPolicies(dataplane *core_mesh.DataplaneResource, resource
 	return matchers.MatchedPolicies(api.MeshHealthCheckType, dataplane, resources)
 }
 
-func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *core_xds.Proxy) error {
+func (p plugin) Apply(ctx context.Context, rs *core_xds.ResourceSet, xdsCtx xds_context.Context, proxy *core_xds.Proxy) error {
 	policies, ok := proxy.Policies.Dynamic[api.MeshHealthCheckType]
 	if !ok {
 		return nil
@@ -36,7 +38,7 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 
 	clusters := policies_xds.GatherClusters(rs)
 
-	if err := applyToOutbounds(policies.ToRules, clusters.Outbound, clusters.OutboundSplit, proxy.Dataplane, ctx.Mesh); err != nil {
+	if err := applyToOutbounds(policies.ToRules, clusters.Outbound, clusters.OutboundSplit, proxy.Dataplane, xdsCtx.Mesh); err != nil {
 		return err
 	}
 

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
@@ -81,7 +81,7 @@ var _ = Describe("MeshHealthCheck", func() {
 				resources.Add(&r)
 			}
 
-			context := *xds_builders.Context().
+			xdsCtx := *xds_builders.Context().
 				WithMesh(samples.MeshDefaultBuilder()).
 				WithResources(xds_context.NewResources()).
 				AddServiceProtocol(httpServiceTag, core_mesh.ProtocolHTTP).
@@ -137,7 +137,7 @@ var _ = Describe("MeshHealthCheck", func() {
 				Build()
 			plugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
 
-			Expect(plugin.Apply(resources, context, proxy)).To(Succeed())
+			Expect(plugin.Apply(context.TODO(), resources, xdsCtx, proxy)).To(Succeed())
 
 			for idx, expected := range given.expectedClusters {
 				Expect(util_proto.ToYAML(resources.ListOf(envoy_resource.ClusterType)[idx].Resource)).
@@ -271,7 +271,7 @@ var _ = Describe("MeshHealthCheck", func() {
 
 			// when
 			plugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
-			Expect(plugin.Apply(generatedResources, xdsCtx, proxy)).To(Succeed())
+			Expect(plugin.Apply(context.TODO(), generatedResources, xdsCtx, proxy)).To(Succeed())
 
 			getResourceYaml := func(list core_xds.ResourceList) []byte {
 				actualResource, err := util_proto.ToYAML(list[0].Resource)

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin.go
@@ -72,7 +72,7 @@ func (p plugin) Apply(ctx context.Context, rs *core_xds.ResourceSet, xdsCtx xds_
 		})
 	}
 
-	if err := ApplyToOutbounds(proxy, rs, xdsCtx, toRules); err != nil {
+	if err := ApplyToOutbounds(ctx, proxy, rs, xdsCtx, toRules); err != nil {
 		return err
 	}
 
@@ -84,6 +84,7 @@ func (p plugin) Apply(ctx context.Context, rs *core_xds.ResourceSet, xdsCtx xds_
 }
 
 func ApplyToOutbounds(
+	ctx context.Context,
 	proxy *core_xds.Proxy,
 	rs *core_xds.ResourceSet,
 	xdsCtx xds_context.Context,
@@ -106,7 +107,7 @@ func ApplyToOutbounds(
 	}
 	rs.AddSet(clusters)
 
-	endpoints, err := meshroute.GenerateEndpoints(proxy, xdsCtx, services)
+	endpoints, err := meshroute.GenerateEndpoints(ctx, proxy, xdsCtx, services)
 	if err != nil {
 		return errors.Wrap(err, "couldn't generate endpoint resources")
 	}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin.go
@@ -47,7 +47,7 @@ func (p plugin) MatchedPolicies(dataplane *core_mesh.DataplaneResource, resource
 	return matchers.MatchedPolicies(api.MeshHTTPRouteType, dataplane, resources)
 }
 
-func (p plugin) Apply(rs *core_xds.ResourceSet, xdsCtx xds_context.Context, proxy *core_xds.Proxy) error {
+func (p plugin) Apply(ctx context.Context, rs *core_xds.ResourceSet, xdsCtx xds_context.Context, proxy *core_xds.Proxy) error {
 	if proxy.Dataplane == nil {
 		return nil
 	}
@@ -76,7 +76,6 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, xdsCtx xds_context.Context, prox
 		return err
 	}
 
-	ctx := context.TODO()
 	if err := ApplyToGateway(ctx, proxy, rs, xdsCtx, toRules); err != nil {
 		return err
 	}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
@@ -64,7 +64,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 			Expect(err).NotTo(HaveOccurred())
 			resourceSet := core_xds.NewResourceSet()
 			plugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
-			Expect(plugin.Apply(resourceSet, given.xdsContext, given.proxy)).To(Succeed())
+			Expect(plugin.Apply(context.TODO(), resourceSet, given.xdsContext, given.proxy)).To(Succeed())
 
 			nameSplit := strings.Split(GinkgoT().Name(), " ")
 			name := nameSplit[len(nameSplit)-1]

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"context"
+
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
@@ -44,7 +46,7 @@ func (p plugin) EgressMatchedPolicies(tags map[string]string, resources xds_cont
 	return matchers.EgressMatchedPolicies(api.MeshLoadBalancingStrategyType, tags, resources)
 }
 
-func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *core_xds.Proxy) error {
+func (p plugin) Apply(ctx context.Context, rs *core_xds.ResourceSet, xdsCtx xds_context.Context, proxy *core_xds.Proxy) error {
 	if proxy.ZoneEgressProxy != nil {
 		return p.configureEgress(rs, proxy)
 	}
@@ -59,11 +61,11 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 	endpoints := policies_xds.GatherOutboundEndpoints(rs)
 	routes := policies_xds.GatherRoutes(rs)
 
-	if err := p.configureGateway(proxy, policies.GatewayRules, listeners.Gateway, clusters.Gateway, routes.Gateway, rs, ctx.Mesh.Resource.ZoneEgressEnabled()); err != nil {
+	if err := p.configureGateway(proxy, policies.GatewayRules, listeners.Gateway, clusters.Gateway, routes.Gateway, rs, xdsCtx.Mesh.Resource.ZoneEgressEnabled()); err != nil {
 		return err
 	}
 
-	return p.configureDPP(proxy, policies.ToRules, listeners, clusters, endpoints, rs, ctx.Mesh.Resource.ZoneEgressEnabled())
+	return p.configureDPP(proxy, policies.ToRules, listeners, clusters, endpoints, rs, xdsCtx.Mesh.Resource.ZoneEgressEnabled())
 }
 
 func (p plugin) configureDPP(

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
@@ -59,7 +59,7 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 			}
 
 			plugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
-			Expect(plugin.Apply(resources, given.context, given.proxy)).To(Succeed())
+			Expect(plugin.Apply(context.TODO(), resources, given.context, given.proxy)).To(Succeed())
 
 			nameSplit := strings.Split(GinkgoT().Name(), " ")
 			name := nameSplit[len(nameSplit)-1]
@@ -1256,7 +1256,7 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 
 			// when
 			plugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
-			Expect(plugin.Apply(generatedResources, xdsCtx, proxy)).To(Succeed())
+			Expect(plugin.Apply(context.TODO(), generatedResources, xdsCtx, proxy)).To(Succeed())
 
 			getResourceYaml := func(list core_xds.ResourceList) []byte {
 				actualResource, err := util_proto.ToYAML(list[0].Resource)

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	"context"
 	"fmt"
 
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -36,7 +37,7 @@ func (p plugin) MatchedPolicies(dataplane *core_mesh.DataplaneResource, resource
 	return matchers.MatchedPolicies(api.MeshMetricType, dataplane, resources)
 }
 
-func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *core_xds.Proxy) error {
+func (p plugin) Apply(ctx context.Context, rs *core_xds.ResourceSet, xdsCtx xds_context.Context, proxy *core_xds.Proxy) error {
 	policies, ok := proxy.Policies.Dynamic[api.MeshMetricType]
 	if !ok || len(policies.SingleItemRules.Rules) == 0 {
 		return nil

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin_test.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	"context"
 	"path/filepath"
 	"strings"
 
@@ -45,7 +46,7 @@ var _ = Describe("MeshMetric", func() {
 		resources := core_xds.NewResourceSet()
 		plugin := NewPlugin().(core_plugins.PolicyPlugin)
 
-		Expect(plugin.Apply(resources, given.context, given.proxy)).To(Succeed())
+		Expect(plugin.Apply(context.TODO(), resources, given.context, given.proxy)).To(Succeed())
 
 		name := testCaseName(GinkgoT())
 

--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/plugin.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"context"
+
 	"github.com/pkg/errors"
 
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
@@ -30,7 +32,7 @@ func (p plugin) MatchedPolicies(dataplane *core_mesh.DataplaneResource, resource
 	return matchers.MatchedPolicies(api.MeshProxyPatchType, dataplane, resources)
 }
 
-func (p plugin) Apply(rs *core_xds.ResourceSet, _ xds_context.Context, proxy *core_xds.Proxy) error {
+func (p plugin) Apply(ctx context.Context, rs *core_xds.ResourceSet, _ xds_context.Context, proxy *core_xds.Proxy) error {
 	policies, ok := proxy.Policies.Dynamic[api.MeshProxyPatchType]
 	if !ok {
 		return nil

--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/plugin_test.go
@@ -1,6 +1,8 @@
 package v1alpha1_test
 
 import (
+	"context"
+
 	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -35,14 +37,14 @@ var _ = Describe("MeshProxyPatch", func() {
 				resources.Add(&r)
 			}
 
-			context := xds_samples.SampleContext()
+			xdsCtx := xds_samples.SampleContext()
 			proxy := xds_builders.Proxy().
 				WithDataplane(samples.DataplaneBackendBuilder()).
 				WithPolicies(xds_builders.MatchedPolicies().WithSingleItemPolicy(api.MeshProxyPatchType, given.rules)).
 				Build()
 			plugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
 
-			Expect(plugin.Apply(resources, context, proxy)).To(Succeed())
+			Expect(plugin.Apply(context.TODO(), resources, xdsCtx, proxy)).To(Succeed())
 			policies_xds.ResourceArrayShouldEqual(resources.ListOf(envoy_resource.ClusterType), given.expectedClusters)
 		},
 		Entry("add and patch a cluster", testCase{

--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"context"
+
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 
@@ -38,7 +40,7 @@ func (p plugin) EgressMatchedPolicies(tags map[string]string, resources xds_cont
 	return matchers.EgressMatchedPolicies(api.MeshRateLimitType, tags, resources)
 }
 
-func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *core_xds.Proxy) error {
+func (p plugin) Apply(ctx context.Context, rs *core_xds.ResourceSet, xdsCtx xds_context.Context, proxy *core_xds.Proxy) error {
 	if proxy.ZoneEgressProxy != nil {
 		return applyToEgress(rs, proxy)
 	}

--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin_test.go
@@ -53,7 +53,7 @@ var _ = Describe("MeshRateLimit", func() {
 			resourceSet := core_xds.NewResourceSet()
 			resourceSet.Add(given.resources...)
 
-			context := xds_samples.SampleContext()
+			xdsCtx := xds_samples.SampleContext()
 			proxy := xds_builders.Proxy().
 				WithDataplane(
 					builders.Dataplane().
@@ -82,7 +82,7 @@ var _ = Describe("MeshRateLimit", func() {
 			plugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
 
 			// when
-			Expect(plugin.Apply(resourceSet, context, proxy)).To(Succeed())
+			Expect(plugin.Apply(context.TODO(), resourceSet, xdsCtx, proxy)).To(Succeed())
 
 			// then
 			for i, expected := range given.expectedListeners {
@@ -616,7 +616,7 @@ var _ = Describe("MeshRateLimit", func() {
 
 		// when
 		p := plugin.NewPlugin().(core_plugins.PolicyPlugin)
-		err = p.Apply(rs, *ctx, proxy)
+		err = p.Apply(context.TODO(), rs, *ctx, proxy)
 		Expect(err).ToNot(HaveOccurred())
 
 		// then
@@ -688,7 +688,7 @@ var _ = Describe("MeshRateLimit", func() {
 		plugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
 
 		// then
-		Expect(plugin.Apply(generatedResources, xdsCtx, proxy)).To(Succeed())
+		Expect(plugin.Apply(context.TODO(), generatedResources, xdsCtx, proxy)).To(Succeed())
 		Expect(util_proto.ToYAML(generatedResources.ListOf(envoy_resource.RouteType)[0].Resource)).To(test_matchers.MatchGoldenYAML(filepath.Join("testdata", "gateway_basic_routes.golden.yaml")))
 		Expect(util_proto.ToYAML(generatedResources.ListOf(envoy_resource.ListenerType)[0].Resource)).To(test_matchers.MatchGoldenYAML(filepath.Join("testdata", "gateway_basic_listener.golden.yaml")))
 	})

--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"context"
+
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 
@@ -29,7 +31,7 @@ func (p plugin) MatchedPolicies(dataplane *core_mesh.DataplaneResource, resource
 	return matchers.MatchedPolicies(api.MeshRetryType, dataplane, resources)
 }
 
-func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *core_xds.Proxy) error {
+func (p plugin) Apply(ctx context.Context, rs *core_xds.ResourceSet, xdsCtx xds_context.Context, proxy *core_xds.Proxy) error {
 	policies, ok := proxy.Policies.Dynamic[api.MeshRetryType]
 	if !ok {
 		return nil
@@ -38,7 +40,7 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 	listeners := xds.GatherListeners(rs)
 	routes := xds.GatherRoutes(rs)
 
-	if err := applyToOutbounds(policies.ToRules, listeners.Outbound, proxy.Dataplane, ctx.Mesh); err != nil {
+	if err := applyToOutbounds(policies.ToRules, listeners.Outbound, proxy.Dataplane, xdsCtx.Mesh); err != nil {
 		return err
 	}
 

--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin_test.go
@@ -49,7 +49,7 @@ var _ = Describe("MeshRetry", func() {
 			resourceSet.Add(&r)
 		}
 
-		context := *xds_builders.Context().
+		xdsCtx := *xds_builders.Context().
 			WithMesh(samples.MeshDefaultBuilder()).
 			WithResources(xds_context.NewResources()).
 			AddServiceProtocol("http-service", core_mesh.ProtocolHTTP).
@@ -78,7 +78,7 @@ var _ = Describe("MeshRetry", func() {
 
 		// when
 		plugin := plugin_v1alpha1.NewPlugin().(core_plugins.PolicyPlugin)
-		Expect(plugin.Apply(resourceSet, context, proxy)).To(Succeed())
+		Expect(plugin.Apply(context.TODO(), resourceSet, xdsCtx, proxy)).To(Succeed())
 
 		// then
 		Expect(getResourceYaml(resourceSet.ListOf(envoy_resource.ListenerType))).
@@ -320,7 +320,7 @@ var _ = Describe("MeshRetry", func() {
 
 			// when
 			plugin := plugin_v1alpha1.NewPlugin().(core_plugins.PolicyPlugin)
-			Expect(plugin.Apply(generatedResources, xdsCtx, proxy)).To(Succeed())
+			Expect(plugin.Apply(context.TODO(), generatedResources, xdsCtx, proxy)).To(Succeed())
 
 			// then
 			Expect(getResourceYaml(generatedResources.ListOf(envoy_resource.ListenerType))).

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin.go
@@ -63,7 +63,7 @@ func (p plugin) Apply(
 	}
 	rs.AddSet(clusters)
 
-	endpoints, err := meshroute.GenerateEndpoints(proxy, xdsCtx, services)
+	endpoints, err := meshroute.GenerateEndpoints(ctx, proxy, xdsCtx, services)
 	if err != nil {
 		return errors.Wrap(err, "couldn't generate endpoint resources")
 	}

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
@@ -1,6 +1,7 @@
 package v1alpha1_test
 
 import (
+	"context"
 	"path/filepath"
 	"strings"
 	"time"
@@ -176,7 +177,7 @@ var _ = Describe("MeshTCPRoute", func() {
 
 			resourceSet := core_xds.NewResourceSet()
 			plugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
-			Expect(plugin.Apply(resourceSet, given.xdsContext, given.proxy)).
+			Expect(plugin.Apply(context.TODO(), resourceSet, given.xdsContext, given.proxy)).
 				To(Succeed())
 
 			nameSplit := strings.Split(GinkgoT().Name(), " ")

--- a/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin_test.go
@@ -51,7 +51,7 @@ var _ = Describe("MeshTimeout", func() {
 			resourceSet.Add(&r)
 		}
 
-		context := *xds_builders.Context().
+		xdsCtx := *xds_builders.Context().
 			WithMesh(samples.MeshDefaultBuilder()).
 			WithResources(xds_context.NewResources()).
 			AddServiceProtocol("other-service", core_mesh.ProtocolHTTP).
@@ -80,7 +80,7 @@ var _ = Describe("MeshTimeout", func() {
 
 		// when
 		plugin := NewPlugin().(core_plugins.PolicyPlugin)
-		Expect(plugin.Apply(resourceSet, context, proxy)).To(Succeed())
+		Expect(plugin.Apply(context.TODO(), resourceSet, xdsCtx, proxy)).To(Succeed())
 
 		// then
 		for i, expectedListener := range given.expectedListeners {
@@ -447,7 +447,7 @@ var _ = Describe("MeshTimeout", func() {
 
 		// when
 		plugin := NewPlugin().(core_plugins.PolicyPlugin)
-		Expect(plugin.Apply(generatedResources, xdsCtx, proxy)).To(Succeed())
+		Expect(plugin.Apply(context.TODO(), generatedResources, xdsCtx, proxy)).To(Succeed())
 
 		nameSplit := strings.Split(GinkgoT().Name(), " ")
 		name := nameSplit[len(nameSplit)-1]

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	"context"
 	net_url "net/url"
 	"strconv"
 	"strings"
@@ -36,7 +37,7 @@ func (p plugin) MatchedPolicies(dataplane *core_mesh.DataplaneResource, resource
 	return matchers.MatchedPolicies(api.MeshTraceType, dataplane, resources)
 }
 
-func (p plugin) Apply(rs *xds.ResourceSet, ctx xds_context.Context, proxy *xds.Proxy) error {
+func (p plugin) Apply(ctx context.Context, rs *xds.ResourceSet, xdsCtx xds_context.Context, proxy *xds.Proxy) error {
 	policies, ok := proxy.Policies.Dynamic[api.MeshTraceType]
 	if !ok {
 		return nil
@@ -52,7 +53,7 @@ func (p plugin) Apply(rs *xds.ResourceSet, ctx xds_context.Context, proxy *xds.P
 	if err := applyToClusters(policies.SingleItemRules, rs, proxy); err != nil {
 		return err
 	}
-	if err := applyToGateway(policies.GatewayRules.SingleItemRules, listeners.Gateway, ctx.Mesh.Resources.MeshLocalResources, proxy.Dataplane); err != nil {
+	if err := applyToGateway(policies.GatewayRules.SingleItemRules, listeners.Gateway, xdsCtx.Mesh.Resources.MeshLocalResources, proxy.Dataplane); err != nil {
 		return err
 	}
 

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin_test.go
@@ -66,7 +66,7 @@ var _ = Describe("MeshTrace", func() {
 				resources.Add(&r)
 			}
 
-			context := xds_samples.SampleContext()
+			xdsCtx := xds_samples.SampleContext()
 			proxy := xds_builders.Proxy().
 				WithDataplane(
 					builders.Dataplane().
@@ -84,7 +84,7 @@ var _ = Describe("MeshTrace", func() {
 				Build()
 			plugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
 
-			Expect(plugin.Apply(resources, context, proxy)).To(Succeed())
+			Expect(plugin.Apply(context.TODO(), resources, xdsCtx, proxy)).To(Succeed())
 			policies_xds.ResourceArrayShouldEqual(resources.ListOf(envoy_resource.ListenerType), given.expectedListeners)
 			policies_xds.ResourceArrayShouldEqual(resources.ListOf(envoy_resource.ClusterType), given.expectedClusters)
 		},
@@ -634,7 +634,7 @@ var _ = Describe("MeshTrace", func() {
 
 			// when
 			plugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
-			Expect(plugin.Apply(generatedResources, xdsCtx, proxy)).To(Succeed())
+			Expect(plugin.Apply(context.TODO(), generatedResources, xdsCtx, proxy)).To(Succeed())
 
 			nameSplit := strings.Split(GinkgoT().Name(), " ")
 			name := nameSplit[len(nameSplit)-1]

--- a/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"context"
+
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
@@ -39,7 +41,7 @@ func (p plugin) EgressMatchedPolicies(tags map[string]string, resources xds_cont
 	return matchers.EgressMatchedPolicies(api.MeshTrafficPermissionType, tags, resources)
 }
 
-func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *core_xds.Proxy) error {
+func (p plugin) Apply(ctx context.Context, rs *core_xds.ResourceSet, xdsCtx xds_context.Context, proxy *core_xds.Proxy) error {
 	if proxy.ZoneEgressProxy != nil {
 		return p.configureEgress(rs, proxy)
 	}
@@ -48,10 +50,10 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 		return nil
 	}
 
-	if !ctx.Mesh.Resource.MTLSEnabled() {
+	if !xdsCtx.Mesh.Resource.MTLSEnabled() {
 		log.V(1).Info("skip applying MeshTrafficPermission, MTLS is disabled",
 			"proxyName", proxy.Dataplane.GetMeta().GetName(),
-			"mesh", ctx.Mesh.Resource.GetMeta().GetName())
+			"mesh", xdsCtx.Mesh.Resource.GetMeta().GetName())
 		return nil
 	}
 

--- a/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin_test.go
@@ -1,6 +1,7 @@
 package v1alpha1_test
 
 import (
+	"context"
 	"path"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -118,7 +119,7 @@ var _ = Describe("RBAC", func() {
 				Build()
 			// when
 			p := meshtrafficpermission.NewPlugin().(plugins.PolicyPlugin)
-			err = p.Apply(rs, *ctx, proxy)
+			err = p.Apply(context.TODO(), rs, *ctx, proxy)
 			Expect(err).ToNot(HaveOccurred())
 
 			// then
@@ -271,7 +272,7 @@ var _ = Describe("RBAC", func() {
 
 			// when
 			p := meshtrafficpermission.NewPlugin().(plugins.PolicyPlugin)
-			err = p.Apply(rs, *ctx, proxy)
+			err = p.Apply(context.TODO(), rs, *ctx, proxy)
 			Expect(err).ToNot(HaveOccurred())
 
 			// then


### PR DESCRIPTION
Get rid of the current [use of `context.TODO()` in MeshHTTPRoute plugin](https://github.com/kumahq/kuma/pull/8782/files#diff-2d4e9cddeb9533b7e939184577a3c8dd84271a49d7b58919a8fc2612c595ab63L79-R79).

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
