### PR TITLE
test(e2e): avoid flake on postgres tests

### DIFF
--- a/test/e2e_env/multizone/resilience/resilience_multizone_universal_postgres.go
+++ b/test/e2e_env/multizone/resilience/resilience_multizone_universal_postgres.go
@@ -12,14 +12,17 @@ import (
 )
 
 func ResilienceMultizoneUniversalPostgres() {
-	const clusterName1 = "kuma-respos1"
-	const clusterName2 = "kuma-respos2"
+	var clusterName1 string
+	var clusterName2 string
 
 	var global, zoneUniversal Cluster
 
 	BeforeEach(func() {
+		testingT := NewTestingT()
+		clusterName1 = "kuma1-" + testingT.Hash()
+		clusterName2 = "kuma2-" + testingT.Hash()
 		// Global
-		global = NewUniversalCluster(NewTestingT(), clusterName1, Verbose)
+		global = NewUniversalCluster(testingT, clusterName1, Verbose)
 
 		err := NewClusterSetup().
 			Install(postgres.Install(clusterName1)).

--- a/test/framework/testing.go
+++ b/test/framework/testing.go
@@ -1,6 +1,8 @@
 package framework
 
 import (
+	"hash/fnv"
+
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/onsi/ginkgo/v2"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -23,7 +25,9 @@ func (i *TestingT) Name() string {
 }
 
 func (i *TestingT) Hash() string {
-	return rand.SafeEncodeString(i.Name())
+	hash := fnv.New32()
+	_, _ = hash.Write([]byte(i.Name()))
+	return rand.SafeEncodeString(string(hash.Sum(nil)))
 }
 
 // Logf logs a test progress message.

--- a/test/framework/testing.go
+++ b/test/framework/testing.go
@@ -3,6 +3,7 @@ package framework
 import (
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/onsi/ginkgo/v2"
+	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 type TestingT struct {
@@ -19,6 +20,10 @@ func (i *TestingT) Helper() {
 
 func (i *TestingT) Name() string {
 	return i.desc.FullText()
+}
+
+func (i *TestingT) Hash() string {
+	return rand.SafeEncodeString(i.Name())
 }
 
 // Logf logs a test progress message.


### PR DESCRIPTION
Looks like in some cases the containers are not fully removed before we create the new ones. We make sure to use different container names to avoid these kind of flakes

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
