### PR TITLE
ci(github): fix branch name for reference PR branches to trigger CircleCI builds

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -176,7 +176,7 @@ jobs:
             };
 
             if ( "${{ github.event_name }}" == "pull_request" ) {
-              circleCIBody["branch"] = 'pull/${{ github.event.pull_request.id }}/merge';
+              circleCIBody["branch"] = 'pull/${{ github.event.pull_request.number }}/merge';
             } else {
               circleCIBody["tag"] = '${{ github.sha }}'
             }


### PR DESCRIPTION
The fix on yesterday didn't work, the correct field for reference PRs should be PR number instead of PR id.

```
Calling CircleCI api with parameters:
  URL: https://circleci.com/api/v2/project/gh/kumahq/kuma/pipeline
  BODY: {parameters:{gh_action_build_artifact_name:build-output,gh_action_run_id:7469668214,e2e_param_target:universal,e2e_param_k8sVersion:kind,e2e_param_arch:arm64,e2e_param_parallelism:1,e2e_param_cniNetworkPlugin:flannel,e2e_param_legacyKDS:false},branch:pull/1649958655/merge}
jq: error (at <stdin>:0): Invalid numeric literal at line 1, column 6 (while parsing 'Error requesting POST https://circleci.com/api/v2/project/gh/kumahq/kuma/pipeline (status 400) {"message":"Branch not found"}{"message":"Branch not found"}')
Error: Process completed with exit code 5.
```

https://github.com/kumahq/kuma/actions/runs/7469668214/job/20327235971?pr=8676#step:15:82

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues 
  - N/A
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS 
  - Confirmed
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Manual tested
  - Don't forget `ci/` labels to run additional/fewer tests
    - Added
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - No
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) 
  - No

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
