### PR TITLE
chore(kuma-cp): improve log messages about default creation

### DIFF
--- a/pkg/core/tokens/default_signing_key.go
+++ b/pkg/core/tokens/default_signing_key.go
@@ -75,7 +75,6 @@ func CreateDefaultSigningKeyIfNotExist(
 	if _, ok := err.(*SigningKeyNotFound); !ok {
 		return err
 	}
-	logger.Info("trying to create signing key")
 	if err := signingKeyManager.CreateDefaultSigningKey(ctx); err != nil {
 		logger.V(1).Info("could not create signing key", "err", err)
 		return err

--- a/pkg/defaults/envoy_admin_ca.go
+++ b/pkg/defaults/envoy_admin_ca.go
@@ -60,15 +60,14 @@ func EnsureEnvoyAdminCaExist(
 		return nil
 	}
 	if !store.IsResourceNotFound(err) {
-		return errors.Wrap(err, "error while loading admin client certificate")
+		return errors.Wrap(err, "error while loading envoy admin CA")
 	}
-	logger.V(1).Info("trying to create Envoy Admin CA")
 	pair, err := tls.GenerateCA()
 	if err != nil {
-		return errors.Wrap(err, "could not generate admin client certificate")
+		return errors.Wrap(err, "could not generate envoy admin CA")
 	}
 	if err := tls.CreateCA(ctx, *pair, resManager); err != nil {
-		return errors.Wrap(err, "could not create admin client certificate")
+		return errors.Wrap(err, "could not create envoy admin CA")
 	}
 	logger.Info("Envoy Admin CA created")
 	return nil

--- a/pkg/defaults/mesh.go
+++ b/pkg/defaults/mesh.go
@@ -29,7 +29,6 @@ func CreateMeshIfNotExist(
 	if !core_store.IsResourceNotFound(err) {
 		return nil, err
 	}
-	logger.Info("trying to create default Mesh")
 	if err := resManager.Create(ctx, mesh, core_store.CreateBy(defaultMeshKey)); err != nil {
 		logger.V(1).Info("could not create default mesh", "err", err)
 		return nil, err

--- a/pkg/intercp/tls/defaults.go
+++ b/pkg/intercp/tls/defaults.go
@@ -46,19 +46,19 @@ func (e DefaultsComponent) NeedLeaderElection() bool {
 func (e *DefaultsComponent) ensureInterCpCaExist(ctx context.Context) error {
 	_, err := LoadCA(ctx, e.ResManager)
 	if err == nil {
-		e.Log.V(1).Info("Inter CP CA already exists. Skip creating Envoy Admin CA.")
+		e.Log.V(1).Info("Inter CP CA already exists. Skip creating inter-cp CA.")
 		return nil
 	}
 	if !store.IsResourceNotFound(err) {
-		return errors.Wrap(err, "error while loading admin client certificate")
+		return errors.Wrap(err, "error while loading inter-cp CA")
 	}
 	e.Log.V(1).Info("trying to create Inter CP CA")
 	pair, err := GenerateCA()
 	if err != nil {
-		return errors.Wrap(err, "could not generate admin client certificate")
+		return errors.Wrap(err, "could not generate inter-cp CA")
 	}
 	if err := CreateCA(ctx, *pair, e.ResManager); err != nil {
-		return errors.Wrap(err, "could not create admin client certificate")
+		return errors.Wrap(err, "could not create inter-cp CA")
 	}
 	e.Log.Info("Inter CP CA created")
 	return nil


### PR DESCRIPTION
I don't see a good reason to log "trying..." when we log on both success and failure.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
