### PR TITLE
chore(kuma-cp): improve intercp log messages

### DIFF
--- a/pkg/intercp/catalog/heartbeat_component.go
+++ b/pkg/intercp/catalog/heartbeat_component.go
@@ -83,7 +83,7 @@ func (h *heartbeatComponent) Start(stop <-chan struct{}) error {
 }
 
 func (h *heartbeatComponent) heartbeat(ctx context.Context, ready bool) bool {
-	heartbeatLog = heartbeatLog.WithValues(
+	heartbeatLog := heartbeatLog.WithValues(
 		"instanceId", h.request.InstanceId,
 		"ready", ready,
 	)

--- a/pkg/intercp/catalog/heartbeat_component.go
+++ b/pkg/intercp/catalog/heartbeat_component.go
@@ -112,7 +112,7 @@ func (h *heartbeatComponent) heartbeat(ctx context.Context, ready bool) bool {
 		return false
 	}
 	if !resp.Leader {
-		heartbeatLog.Info("instance responded that it is no longer a leader")
+		heartbeatLog.V(1).Info("instance responded that it is no longer a leader")
 		h.leader = nil
 	}
 	return true

--- a/pkg/intercp/catalog/heartbeat_component.go
+++ b/pkg/intercp/catalog/heartbeat_component.go
@@ -83,8 +83,13 @@ func (h *heartbeatComponent) Start(stop <-chan struct{}) error {
 }
 
 func (h *heartbeatComponent) heartbeat(ctx context.Context, ready bool) bool {
+	heartbeatLog = heartbeatLog.WithValues(
+		"instanceId", h.request.InstanceId,
+		"ready", ready,
+	)
 	if h.leader == nil {
 		if err := h.connectToLeader(ctx); err != nil {
+			heartbeatLog.Error(err, "could not connect to leader")
 			return false
 		}
 	}
@@ -93,9 +98,7 @@ func (h *heartbeatComponent) heartbeat(ctx context.Context, ready bool) bool {
 		return true
 	}
 	heartbeatLog = heartbeatLog.WithValues(
-		"instanceId", h.request.InstanceId,
 		"leaderAddress", h.leader.Address,
-		"ready", ready,
 	)
 	heartbeatLog.V(1).Info("sending a heartbeat to a leader")
 	h.request.Ready = ready

--- a/pkg/intercp/catalog/heartbeat_component.go
+++ b/pkg/intercp/catalog/heartbeat_component.go
@@ -70,52 +70,52 @@ func (h *heartbeatComponent) Start(stop <-chan struct{}) error {
 		select {
 		case <-ticker.C:
 			start := core.Now()
-			if err := h.heartbeat(ctx, true); err != nil {
-				h.leader = nil
-				heartbeatLog.Error(err, "could not heartbeat the leader")
+			if !h.heartbeat(ctx, true) {
 				continue
 			}
 			h.metric.Observe(float64(core.Now().Sub(start).Milliseconds()))
 		case <-stop:
 			// send final heartbeat to gracefully signal that the instance is going down
-			if err := h.heartbeat(ctx, false); err != nil {
-				h.leader = nil
-				heartbeatLog.Error(err, "could not heartbeat the leader")
-			}
+			_ = h.heartbeat(ctx, false)
 			return nil
 		}
 	}
 }
 
-func (h *heartbeatComponent) heartbeat(ctx context.Context, ready bool) error {
+func (h *heartbeatComponent) heartbeat(ctx context.Context, ready bool) bool {
 	if h.leader == nil {
 		if err := h.connectToLeader(ctx); err != nil {
-			return err
+			return false
 		}
 	}
 	if h.leader.Id == h.request.InstanceId {
 		heartbeatLog.V(1).Info("this instance is a leader. No need to send a heartbeat.")
-		return nil
+		return true
 	}
-	heartbeatLog.V(1).Info("sending a heartbeat to a leader",
+	heartbeatLog = heartbeatLog.WithValues(
 		"instanceId", h.request.InstanceId,
 		"leaderAddress", h.leader.Address,
 		"ready", ready,
 	)
+	heartbeatLog.V(1).Info("sending a heartbeat to a leader")
 	h.request.Ready = ready
 	client, err := h.getClientFn(h.leader.InterCpURL())
 	if err != nil {
-		return errors.Wrap(err, "could not get or create a client to a leader")
+		heartbeatLog.Error(err, "could not get or create a client to a leader")
+		h.leader = nil
+		return false
 	}
 	resp, err := client.Ping(ctx, h.request)
 	if err != nil {
-		return errors.Wrap(err, "could not send a heartbeat to a leader")
+		heartbeatLog.Error(err, "could not send a heartbeat to a leader")
+		h.leader = nil
+		return false
 	}
 	if !resp.Leader {
 		heartbeatLog.Info("instance responded that it is no longer a leader")
 		h.leader = nil
 	}
-	return nil
+	return true
 }
 
 func (h *heartbeatComponent) connectToLeader(ctx context.Context) error {

--- a/pkg/intercp/components.go
+++ b/pkg/intercp/components.go
@@ -59,7 +59,7 @@ func Setup(rt runtime.Runtime) error {
 			ClientCert: certs.client,
 		})
 
-		interCpServer, err := server.New(cfg.Server, rt.Metrics(), certs.server, certs.ca)
+		interCpServer, err := server.New(cfg.Server, rt.Metrics(), certs.server, certs.ca, instance.Id)
 		if err != nil {
 			return errors.Wrap(err, "could not start inter-cp server")
 		}

--- a/pkg/intercp/server/server.go
+++ b/pkg/intercp/server/server.go
@@ -29,6 +29,7 @@ const (
 type InterCpServer struct {
 	config     intercp.InterCpServerConfig
 	grpcServer *grpc.Server
+	instanceId string
 }
 
 var _ component.Component = &InterCpServer{}
@@ -38,6 +39,7 @@ func New(
 	metrics metrics.Metrics,
 	certificate tls.Certificate,
 	caCert x509.Certificate,
+	instanceId string,
 ) (*InterCpServer, error) {
 	grpcOptions := []grpc.ServerOption{
 		grpc.MaxConcurrentStreams(grpcMaxConcurrentStreams),
@@ -77,6 +79,7 @@ func New(
 	return &InterCpServer{
 		config:     config,
 		grpcServer: grpcServer,
+		instanceId: instanceId,
 	}, nil
 }
 
@@ -85,6 +88,10 @@ func (d *InterCpServer) Start(stop <-chan struct{}) error {
 	if err != nil {
 		return err
 	}
+	log := log.WithValues(
+		"instanceId",
+		d.instanceId,
+	)
 
 	errChan := make(chan error)
 	go func() {


### PR DESCRIPTION
This way we have the same values on all the log messages so we can debug error messages a little easier.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
