### PR TITLE
feat(kuma-cp): enable zone-originated policies

### DIFF
--- a/pkg/plugins/policies/core/matchers/dataplane.go
+++ b/pkg/plugins/policies/core/matchers/dataplane.go
@@ -213,6 +213,11 @@ func (b ByTargetRef) Less(i, j int) bool {
 		return tr1.Kind.Less(tr2.Kind)
 	}
 
+	o1, o2 := originToNumber(b[i]), originToNumber(b[j])
+	if o1 != o2 {
+		return o1 < o2
+	}
+
 	if tr1.Kind == common_api.MeshGateway {
 		if len(tr1.Tags) != len(tr2.Tags) {
 			return len(tr1.Tags) < len(tr2.Tags)
@@ -223,3 +228,27 @@ func (b ByTargetRef) Less(i, j int) bool {
 }
 
 func (b ByTargetRef) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
+
+// The logic of this method is to recreate the following comparison table:
+
+// origin_1 | origin_2 | has_more_priority
+// ---------|----------|-------------
+// Global   | Zone     | origin_2
+// Global   | Unknown  | origin_2
+// Zone     | Global   | origin_1
+// Zone     | Unknown  | origin_1
+// Unknown  | Global   | origin_1
+// Unknown  | Zone     | origin_2
+//
+// If we assign numbers to origins like Global=-1, Zone=1, Unknown=0, then we can compare them as numbers
+// and get the same result as in the table above.
+func originToNumber(r core_model.Resource) int {
+	switch r.GetMeta().GetLabels()[mesh_proto.ResourceOriginLabel] {
+	case mesh_proto.ResourceOriginGlobal:
+		return -1
+	case mesh_proto.ResourceOriginZone:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/torules/04.dataplane.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/torules/04.dataplane.yaml
@@ -1,0 +1,11 @@
+type: Dataplane
+mesh: mesh-1
+name: dp-1
+networking:
+  address: 1.1.1.1
+  inbound:
+    - port: 8080
+      tags:
+        kuma.io/service: web
+        version: v1
+        team: mesh

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/torules/04.golden.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/torules/04.golden.yaml
@@ -1,0 +1,27 @@
+Rules:
+- Conf:
+    http:
+      requestTimeout: 3s
+      streamIdleTimeout: 5s
+  Origin:
+  - creationTime: "0001-01-01T00:00:00Z"
+    mesh: mesh-1
+    modificationTime: "0001-01-01T00:00:00Z"
+    name: aaa
+    type: MeshTimeout
+  - creationTime: "0001-01-01T00:00:00Z"
+    labels:
+      kuma.io/origin: zone
+    mesh: mesh-1
+    modificationTime: "0001-01-01T00:00:00Z"
+    name: bbb
+    type: MeshTimeout
+  - creationTime: "0001-01-01T00:00:00Z"
+    mesh: mesh-1
+    modificationTime: "0001-01-01T00:00:00Z"
+    name: ccc
+    type: MeshTimeout
+  Subset:
+  - Key: kuma.io/service
+    Not: false
+    Value: backend

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/torules/04.policies.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/torules/04.policies.yaml
@@ -1,0 +1,51 @@
+type: MeshTimeout
+mesh: mesh-1
+name: aaa
+spec:
+  targetRef:
+    kind: Mesh
+  to:
+    - targetRef:
+        kind: MeshService
+        name: backend
+      default:
+        http:
+          requestTimeout: 1s
+          streamIdleTimeout: 1s
+---
+# 'bbb' has less priority than 'aaa' based on the name, but it should take precedence because it's a zone-originated policy
+type: MeshTimeout
+mesh: mesh-1
+name: bbb
+labels:
+  kuma.io/origin: zone
+spec:
+  targetRef:
+    kind: Mesh
+  to:
+    - targetRef:
+        kind: MeshService
+        name: backend
+      default:
+        http:
+          requestTimeout: 3s
+          streamIdleTimeout: 3s
+---
+# 'ccc' has more priority than other even though it's a global-originated policy
+type: MeshTimeout
+mesh: mesh-1
+name: ccc
+spec:
+  targetRef:
+    kind: MeshServiceSubset
+    name: web
+    tags:
+      version: v1
+      team: mesh
+  to:
+    - targetRef:
+        kind: MeshService
+        name: backend
+      default:
+        http:
+          streamIdleTimeout: 5s

--- a/pkg/plugins/policies/donothingpolicy/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/donothingpolicy/api/v1alpha1/zz_generated.resource.go
@@ -126,7 +126,7 @@ var DoNothingPolicyResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	Resource:            NewDoNothingPolicyResource(),
 	ResourceList:        &DoNothingPolicyResourceList{},
 	Scope:               model.ScopeMesh,
-	KDSFlags:            model.GlobalToAllZonesFlag,
+	KDSFlags:            model.GlobalToAllZonesFlag | model.ZoneToGlobalFlag,
 	WsPath:              "donothingpolicies",
 	KumactlArg:          "donothingpolicy",
 	KumactlListArg:      "donothingpolicies",

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/zz_generated.resource.go
@@ -126,7 +126,7 @@ var MeshAccessLogResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	Resource:            NewMeshAccessLogResource(),
 	ResourceList:        &MeshAccessLogResourceList{},
 	Scope:               model.ScopeMesh,
-	KDSFlags:            model.GlobalToAllZonesFlag,
+	KDSFlags:            model.GlobalToAllZonesFlag | model.ZoneToGlobalFlag,
 	WsPath:              "meshaccesslogs",
 	KumactlArg:          "meshaccesslog",
 	KumactlListArg:      "meshaccesslogs",

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/zz_generated.resource.go
@@ -126,7 +126,7 @@ var MeshCircuitBreakerResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	Resource:            NewMeshCircuitBreakerResource(),
 	ResourceList:        &MeshCircuitBreakerResourceList{},
 	Scope:               model.ScopeMesh,
-	KDSFlags:            model.GlobalToAllZonesFlag,
+	KDSFlags:            model.GlobalToAllZonesFlag | model.ZoneToGlobalFlag,
 	WsPath:              "meshcircuitbreakers",
 	KumactlArg:          "meshcircuitbreaker",
 	KumactlListArg:      "meshcircuitbreakers",

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/zz_generated.resource.go
@@ -126,7 +126,7 @@ var MeshFaultInjectionResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	Resource:            NewMeshFaultInjectionResource(),
 	ResourceList:        &MeshFaultInjectionResourceList{},
 	Scope:               model.ScopeMesh,
-	KDSFlags:            model.GlobalToAllZonesFlag,
+	KDSFlags:            model.GlobalToAllZonesFlag | model.ZoneToGlobalFlag,
 	WsPath:              "meshfaultinjections",
 	KumactlArg:          "meshfaultinjection",
 	KumactlListArg:      "meshfaultinjections",

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/zz_generated.resource.go
@@ -126,7 +126,7 @@ var MeshHealthCheckResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	Resource:            NewMeshHealthCheckResource(),
 	ResourceList:        &MeshHealthCheckResourceList{},
 	Scope:               model.ScopeMesh,
-	KDSFlags:            model.GlobalToAllZonesFlag,
+	KDSFlags:            model.GlobalToAllZonesFlag | model.ZoneToGlobalFlag,
 	WsPath:              "meshhealthchecks",
 	KumactlArg:          "meshhealthcheck",
 	KumactlListArg:      "meshhealthchecks",

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/zz_generated.resource.go
@@ -126,7 +126,7 @@ var MeshHTTPRouteResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	Resource:            NewMeshHTTPRouteResource(),
 	ResourceList:        &MeshHTTPRouteResourceList{},
 	Scope:               model.ScopeMesh,
-	KDSFlags:            model.GlobalToAllZonesFlag,
+	KDSFlags:            model.GlobalToAllZonesFlag | model.ZoneToGlobalFlag,
 	WsPath:              "meshhttproutes",
 	KumactlArg:          "meshhttproute",
 	KumactlListArg:      "meshhttproutes",

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/zz_generated.resource.go
@@ -126,7 +126,7 @@ var MeshLoadBalancingStrategyResourceTypeDescriptor = model.ResourceTypeDescript
 	Resource:            NewMeshLoadBalancingStrategyResource(),
 	ResourceList:        &MeshLoadBalancingStrategyResourceList{},
 	Scope:               model.ScopeMesh,
-	KDSFlags:            model.GlobalToAllZonesFlag,
+	KDSFlags:            model.GlobalToAllZonesFlag | model.ZoneToGlobalFlag,
 	WsPath:              "meshloadbalancingstrategies",
 	KumactlArg:          "meshloadbalancingstrategy",
 	KumactlListArg:      "meshloadbalancingstrategies",

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/zz_generated.resource.go
@@ -126,7 +126,7 @@ var MeshMetricResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	Resource:            NewMeshMetricResource(),
 	ResourceList:        &MeshMetricResourceList{},
 	Scope:               model.ScopeMesh,
-	KDSFlags:            model.GlobalToAllZonesFlag,
+	KDSFlags:            model.GlobalToAllZonesFlag | model.ZoneToGlobalFlag,
 	WsPath:              "meshmetrics",
 	KumactlArg:          "meshmetric",
 	KumactlListArg:      "meshmetrics",

--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/zz_generated.resource.go
@@ -126,7 +126,7 @@ var MeshProxyPatchResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	Resource:            NewMeshProxyPatchResource(),
 	ResourceList:        &MeshProxyPatchResourceList{},
 	Scope:               model.ScopeMesh,
-	KDSFlags:            model.GlobalToAllZonesFlag,
+	KDSFlags:            model.GlobalToAllZonesFlag | model.ZoneToGlobalFlag,
 	WsPath:              "meshproxypatches",
 	KumactlArg:          "meshproxypatch",
 	KumactlListArg:      "meshproxypatches",

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/zz_generated.resource.go
@@ -126,7 +126,7 @@ var MeshRateLimitResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	Resource:            NewMeshRateLimitResource(),
 	ResourceList:        &MeshRateLimitResourceList{},
 	Scope:               model.ScopeMesh,
-	KDSFlags:            model.GlobalToAllZonesFlag,
+	KDSFlags:            model.GlobalToAllZonesFlag | model.ZoneToGlobalFlag,
 	WsPath:              "meshratelimits",
 	KumactlArg:          "meshratelimit",
 	KumactlListArg:      "meshratelimits",

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/zz_generated.resource.go
@@ -126,7 +126,7 @@ var MeshRetryResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	Resource:            NewMeshRetryResource(),
 	ResourceList:        &MeshRetryResourceList{},
 	Scope:               model.ScopeMesh,
-	KDSFlags:            model.GlobalToAllZonesFlag,
+	KDSFlags:            model.GlobalToAllZonesFlag | model.ZoneToGlobalFlag,
 	WsPath:              "meshretries",
 	KumactlArg:          "meshretry",
 	KumactlListArg:      "meshretries",

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/zz_generated.resource.go
@@ -126,7 +126,7 @@ var MeshTCPRouteResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	Resource:            NewMeshTCPRouteResource(),
 	ResourceList:        &MeshTCPRouteResourceList{},
 	Scope:               model.ScopeMesh,
-	KDSFlags:            model.GlobalToAllZonesFlag,
+	KDSFlags:            model.GlobalToAllZonesFlag | model.ZoneToGlobalFlag,
 	WsPath:              "meshtcproutes",
 	KumactlArg:          "meshtcproute",
 	KumactlListArg:      "meshtcproutes",

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/zz_generated.resource.go
@@ -126,7 +126,7 @@ var MeshTimeoutResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	Resource:            NewMeshTimeoutResource(),
 	ResourceList:        &MeshTimeoutResourceList{},
 	Scope:               model.ScopeMesh,
-	KDSFlags:            model.GlobalToAllZonesFlag,
+	KDSFlags:            model.GlobalToAllZonesFlag | model.ZoneToGlobalFlag,
 	WsPath:              "meshtimeouts",
 	KumactlArg:          "meshtimeout",
 	KumactlListArg:      "meshtimeouts",

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/zz_generated.resource.go
@@ -126,7 +126,7 @@ var MeshTraceResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	Resource:            NewMeshTraceResource(),
 	ResourceList:        &MeshTraceResourceList{},
 	Scope:               model.ScopeMesh,
-	KDSFlags:            model.GlobalToAllZonesFlag,
+	KDSFlags:            model.GlobalToAllZonesFlag | model.ZoneToGlobalFlag,
 	WsPath:              "meshtraces",
 	KumactlArg:          "meshtrace",
 	KumactlListArg:      "meshtraces",

--- a/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/zz_generated.resource.go
@@ -126,7 +126,7 @@ var MeshTrafficPermissionResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	Resource:            NewMeshTrafficPermissionResource(),
 	ResourceList:        &MeshTrafficPermissionResourceList{},
 	Scope:               model.ScopeMesh,
-	KDSFlags:            model.GlobalToAllZonesFlag,
+	KDSFlags:            model.GlobalToAllZonesFlag | model.ZoneToGlobalFlag,
 	WsPath:              "meshtrafficpermissions",
 	KumactlArg:          "meshtrafficpermission",
 	KumactlListArg:      "meshtrafficpermissions",

--- a/tools/policy-gen/generator/cmd/core_resource.go
+++ b/tools/policy-gen/generator/cmd/core_resource.go
@@ -166,7 +166,7 @@ var {{.Name}}ResourceTypeDescriptor = model.ResourceTypeDescriptor{
 		Resource: New{{.Name}}Resource(),
 		ResourceList: &{{.Name}}ResourceList{},
 		Scope: model.ScopeMesh,
-		KDSFlags: model.GlobalToAllZonesFlag,
+		KDSFlags: model.GlobalToAllZonesFlag | model.ZoneToGlobalFlag,
 		WsPath: "{{.Path}}",
 		KumactlArg: "{{index .AlternativeNames 0}}",
 		KumactlListArg: "{{.Path}}",


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues -- fix https://github.com/kumahq/kuma/issues/4318
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
