### PR TITLE
ci(github): don't rely on artifacts, instead rebuild each time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -411,66 +411,6 @@ jobs:
     parallelism: << parameters.parallelism >>
     steps:
       - checkout
-      - gh/install
-      - run:
-          name: Download build output from GitHub action
-          command: |
-            set -e
-            echo "Running with: \
-              k8s:<< parameters.k8sVersion >> \
-              target:<< parameters.target >> \
-              parallelism:<< parameters.parallelism >> \
-              arch:<< parameters.arch >> \
-              legacyKDS:<< parameters.legacyKDS >> \
-              cniNetworkPlugin:<< parameters.cniNetworkPlugin >> \
-            "
-            if [[ "${GITHUB_TOKEN}" == "" ]]; then
-                echo "Please set value for environment variables: GITHUB_TOKEN"
-                exit 1
-            fi
-
-            GH_ACTIONS_RUN_ID=<< pipeline.parameters.gh_action_run_id >>
-            GH_ACTIONS_BUILD_ARTIFACT_NAME=<< pipeline.parameters.gh_action_build_artifact_name >>
-            ARCH='<< parameters.arch >>'
-
-            echo "Downloading..."
-            MAX_ATTEMPTS=5
-            ATTEMPTS=0
-
-            while [[ $ATTEMPTS -lt $MAX_ATTEMPTS ]]; do
-              if [[ $ATTEMPTS -gt 0 ]]; then echo "Retrying..."; fi
-              gh run download $GH_ACTIONS_RUN_ID --name $GH_ACTIONS_BUILD_ARTIFACT_NAME -D build \
-                --repo $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME || true
-              if [ ! -z "$(ls build/distributions/out)" ]; then
-                break
-              else
-                ATTEMPTS=$((ATTEMPTS + 1))
-                sleep $(( RANDOM % 5 ))
-              fi
-            done
-            if [ ! -z "$(ls build/distributions/out)" ]; then
-              echo "Downloading complete."
-            else
-              echo "Could not download build output artifacts from GitHub."
-              exit 1
-            fi
-
-            echo "Extracting files..."
-            TARBALL=$(find build/distributions/out/*-linux-$ARCH.tar.gz)
-            if [[ "$TARBALL" == "" ]]; then
-              echo "Could not find built artifact for linux($ARCH)."
-              exit 1
-            fi
-            cat ${TARBALL}.sha256 | sha256sum --check
-
-            mkdir build/distributions/artifacts
-            tar -xzf $TARBALL -C build/distributions/artifacts
-            SRC_DIR=$(find build/distributions/artifacts/*/bin -type d)
-            DEST_DIR=build/artifacts-linux-$ARCH
-            for BIN in $(ls $SRC_DIR); do
-              mkdir -p $DEST_DIR/$BIN
-              cp $SRC_DIR/$BIN $DEST_DIR/$BIN/
-            done
       - install_build_tools:
           go_arch: << parameters.arch >>
       - run:
@@ -479,6 +419,18 @@ jobs:
           name: "Download Go modules"
           command: |
             go mod download -x
+      - run:
+          name: "Build"
+          command: |
+            make build
+      - run:
+          name: "Distributions"
+          command: |
+            make -j build/distributions
+      - run:
+          name: "Images"
+            make -j images
+            make -j docker/save
       - run:
           name: "Setup Helm"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -429,6 +429,7 @@ jobs:
             make -j build/distributions
       - run:
           name: "Images"
+          command: |
             make -j images
             make -j docker/save
       - run:

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -240,7 +240,7 @@ jobs:
               "test_e2e": {
                 "target": [""],
                 "k8sVersion": ["kindIpv6", "${{ env.K8S_MIN_VERSION }}", "${{ env.K8S_MAX_VERSION }}"],
-                "arch": ["amd64", "arm64"],
+                "arch": ["amd64"],
                 "parallelism": [3],
                 "cniNetworkPlugin": ["flannel"],
                 "legacyKDS": [false]
@@ -248,19 +248,19 @@ jobs:
               "test_e2e_env": {
                 "target": ["kubernetes", "universal", "multizone"],
                 "k8sVersion": ["kind", "kindIpv6", "${{ env.K8S_MIN_VERSION }}", "${{ env.K8S_MAX_VERSION }}"],
-                "arch": ["amd64", "arm64"],
+                "arch": ["amd64"],
                 "parallelism": [1],
                 "cniNetworkPlugin": ["flannel"],
                 "legacyKDS": [false],
                 "exclude":[
                   {"target": "kubernetes", "k8sVersion":"kind"},
                   {"target": "multizone", "k8sVersion":"kind"},
-                  {"arch": "arm64", "k8sVersion":"${{ env.K8S_MIN_VERSION }}"},
                   {"target":"universal", "k8sVersion":"${{ env.K8S_MIN_VERSION }}"},
                   {"target":"universal", "k8sVersion":"${{ env.K8S_MAX_VERSION }}"}
                 ],
                 "include":[
                   {"legacyKDS": true, "k8sVersion": "${{ env.K8S_MAX_VERSION }}", "target": "multizone", "arch": "amd64"},
+                  {"k8sVersion": "${{ env.K8S_MAX_VERSION }}", "target": "multizone", "arch": "arm64"},
                   {"cniNetworkPlugin": "calico", "k8sVersion": "${{ env.K8S_MAX_VERSION }}", "target": "multizone", "arch": "amd64"}
                 ]
               }

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -261,6 +261,8 @@ jobs:
                 "include":[
                   {"legacyKDS": true, "k8sVersion": "${{ env.K8S_MAX_VERSION }}", "target": "multizone", "arch": "amd64"},
                   {"k8sVersion": "${{ env.K8S_MAX_VERSION }}", "target": "multizone", "arch": "arm64"},
+                  {"k8sVersion": "${{ env.K8S_MAX_VERSION }}", "target": "kubernetes", "arch": "arm64"},
+                  {"k8sVersion": "${{ env.K8S_MAX_VERSION }}", "target": "universal", "arch": "arm64"},
                   {"cniNetworkPlugin": "calico", "k8sVersion": "${{ env.K8S_MAX_VERSION }}", "target": "multizone", "arch": "amd64"}
                 ]
               }

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -153,6 +153,7 @@ jobs:
           sudo apt-get update; sudo apt-get install -y qemu-user-static binfmt-support
       - run: |
           make -j images
+          make -j docker/save
       - name: Run container structure test
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-container-structure-test') && !contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
         run: |

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -1,7 +1,7 @@
 name: "build-test-distribute"
 on:
   push:
-    branches: ["master", "release-*", "!*-merge-master"]
+    branches: ["master", "release-*", "!*-merge-master", "reworkCI"]
     tags: ["*"]
   pull_request:
     branches: ["master", "release-*"]

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -1,7 +1,7 @@
 name: "build-test-distribute"
 on:
   push:
-    branches: ["master", "release-*", "!*-merge-master", "reworkCI"]
+    branches: ["master", "release-*", "!*-merge-master"]
     tags: ["*"]
   pull_request:
     branches: ["master", "release-*"]

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -22,11 +22,6 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
-      - name: "Check if should run on all arch/os combinations"
-        if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix')
-        run: |
-          echo 'RUN_FULL_MATRIX=true' > .run-full-matrix
-          echo 'RUN_FULL_MATRIX=true' >> $GITHUB_ENV
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version-file: go.mod
@@ -48,76 +43,6 @@ jobs:
           make clean
       - run: |
           make check
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          fetch-depth: 0
-      - name: "Check if should run on all arch/os combinations"
-        if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix')
-        run: |
-          echo 'RUN_FULL_MATRIX=true' > .run-full-matrix
-          echo 'RUN_FULL_MATRIX=true' >> $GITHUB_ENV
-      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
-        with:
-          go-version-file: go.mod
-          cache-dependency-path: |
-            .run-full-matrix
-            go.sum
-      - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
-        with:
-          path: |
-            ${{ env.CI_TOOLS_DIR }}
-          key: ${{ runner.os }}-${{ runner.arch }}-devtools-${{ hashFiles('mk/dependencies/deps.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-devtools
-      - run: |
-          make dev/tools
-      - name: Free up disk space for the Runner
-        run: |
-          echo "Disk usage before cleanup"
-          sudo df -h
-          echo "Removing big directories"
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
-          echo "Removing images"
-          docker system prune --all -f
-          echo "Disk usage after cleanup"
-          sudo df -h
-      - name: "Set switches based on if run full matrix"
-        if: ${{ env.RUN_FULL_MATRIX == 'true' }}
-        id: set-full-matrix-switches
-        run: |
-          echo 'ENABLED_GOARCHES=arm64 amd64' >> $GITHUB_ENV
-          echo 'ENABLED_GOOSES=linux darwin' >> $GITHUB_ENV
-      - run: |
-          make build
-      - run: |
-          make -j build/distributions
-      - name: Install dependencies for cross builds
-        run: |
-          sudo apt-get update; sudo apt-get install -y qemu-user-static binfmt-support
-      - run: |
-          make -j images
-      - run: |
-          make -j docker/save
-      - name: Cleanup redundant build outputs
-        run: |
-          find  ./build/artifacts-* -maxdepth 0 -type d | xargs -I % rm -rf %
-          find ./build/distributions/* -maxdepth 0 -type d | grep -v '/out' | xargs -I % rm -rf %
-          find  ./build/tools-* -maxdepth 0 -type d | xargs -I % rm -rf %
-          rm -rf ./build/oapitmp
-          rm -rf ./build/ebpf/
-      - name: Upload build output
-        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
-        with:
-          name: build-output
-          path: build
-          retention-days: 1
-      - name: Run container structure test
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-container-structure-test') && !contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
-        run: |
-          make test/container-structure
   test:
     runs-on: ubuntu-latest
     if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
@@ -209,16 +134,29 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-devtools-${{ hashFiles('mk/dependencies/deps.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-devtools
-      # FIXME: Workaround for Request Timeout issue of artifacts https://github.com/actions/download-artifact/issues/249
-      - name: Download artifacts with retry
-        uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # master
-        with:
-          action: actions/download-artifact@v4
-          with: |
-            path: build
-            name: build-output
-          attempt_limit: 5
-          attempt_delay: 1000
+      - name: Free up disk space for the Runner
+        run: |
+          echo "Disk usage before cleanup"
+          sudo df -h
+          echo "Removing big directories"
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+          echo "Removing images"
+          docker system prune --all -f
+          echo "Disk usage after cleanup"
+          sudo df -h
+      - run: |
+          make build
+      - run: |
+          make -j build/distributions
+      - name: Install dependencies for cross builds
+        run: |
+          sudo apt-get update; sudo apt-get install -y qemu-user-static binfmt-support
+      - run: |
+          make -j images
+      - name: Run container structure test
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-container-structure-test') && !contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
+        run: |
+          make test/container-structure
       - name: Inspect created tars
         run: |
           for i in build/distributions/out/*.tar.gz; do echo $i; tar -tvf $i; done
@@ -229,9 +167,6 @@ jobs:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
         run: |
           make publish/pulp
-      - name: Load images
-        run: |
-          make docker/load
       - name: Publish images
         env:
           DOCKER_API_KEY: ${{ secrets.DOCKER_API_KEY }}
@@ -345,7 +280,7 @@ jobs:
           echo "$BASE_MATRIX_ALL" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
   test_e2e:
-    needs: ["gen_e2e_matrix", "build"]
+    needs: ["gen_e2e_matrix"]
     if: fromJSON(needs.gen_e2e_matrix.outputs.matrix).test_e2e
     strategy:
       matrix: ${{ fromJSON(needs.gen_e2e_matrix.outputs.matrix).test_e2e }}
@@ -356,7 +291,7 @@ jobs:
     secrets:
       circleCIToken: ${{ secrets.CIRCLECI_TOKEN }}
   test_e2e_env:
-    needs: ["gen_e2e_matrix", "build"]
+    needs: ["gen_e2e_matrix"]
     if: fromJSON(needs.gen_e2e_matrix.outputs.matrix).test_e2e_env
     strategy:
       matrix: ${{ fromJSON(needs.gen_e2e_matrix.outputs.matrix).test_e2e_env }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: "Check if should run on all arch/os combinations"
         if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix')
         run: |
-          echo 'RUN_FULL_MATRIX=true' > .run-full-matrix
+          echo 'RUN_FULL_MATRIX=${{ env.E2E_PARAM_ARCH }}' > .run-full-matrix
           echo 'RUN_FULL_MATRIX=true' >> $GITHUB_ENV
       - name: "GitHub Actions: check out code"
         if: steps.eval-params.outputs.run-type == 'github'
@@ -77,37 +77,19 @@ jobs:
           docker system prune --all -f
           echo "Disk usage after cleanup"
           sudo df -h
-      # FIXME: Workaround for Request Timeout issue of artifacts https://github.com/actions/download-artifact/issues/249
-      - name: "GitHub Actions: download build artifacts with retry"
-        if: steps.eval-params.outputs.run-type == 'github'
-        uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # master
-        with:
-          action: actions/download-artifact@v4
-          with: |
-            path: build
-            name: build-output
-          attempt_limit: 5
-          attempt_delay: 1000
-      - name: "GitHub Actions: extract artifacts"
+      - name: "Github Actions: build"
         if: steps.eval-params.outputs.run-type == 'github'
         run: |
-          echo "Extracting artifacts..."
-          ARTIFACT=$(find build/distributions/out/*-linux-${{ env.E2E_PARAM_ARCH }}.tar.gz)
-          if [[ "$ARTIFACT" == "" ]]; then
-            echo "Could not find built artifact for linux(${{ env.E2E_PARAM_ARCH }})."
-            exit 1
-          fi
-          cat $ARTIFACT.sha256 | sha256sum --check
-
-          mkdir build/distributions/artifacts
-          tar -xzf $ARTIFACT -C build/distributions/artifacts
-
-          SRC_DIR=$(find build/distributions/artifacts/*/bin -type d)
-          DEST_DIR=build/artifacts-linux-${{ env.E2E_PARAM_ARCH }}
-          for BIN in $(ls $SRC_DIR); do
-            mkdir -p $DEST_DIR/$BIN
-            cp $SRC_DIR/$BIN $DEST_DIR/$BIN/
-          done
+          make build
+      - name: "Github Actions: distributions"
+        if: steps.eval-params.outputs.run-type == 'github'
+        run: |
+          make -j build/distributions
+      - name: "Github Actions: images"
+        if: steps.eval-params.outputs.run-type == 'github'
+        run: |
+          make -j images
+          make -j docker/save
       - name: "GitHub Actions: setup helm"
         if: steps.eval-params.outputs.run-type == 'github'
         run: |


### PR DESCRIPTION
- Storing build artifacts was slow and unstable, we now rebuild each time.
- We also reduce the number of arm test cases (there's no real reason to rerun tests on arm so many times).


Example full run: https://github.com/kumahq/kuma/actions/runs/7478606778/job/20353924056

### Checklist prior to review


<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
