### PR TITLE
fix(MeshHTTPRoute): apply gateway rules properly to listeners

### DIFF
--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
@@ -118,7 +118,12 @@ func prepareRoutes(
 	protocol core_mesh.Protocol,
 	tags map[string]string,
 ) []Route {
-	apiRules := rules.ComputeConf[api.PolicyDefault](toRules, core_rules.MeshService(serviceName)).Rules
+	conf := rules.ComputeConf[api.PolicyDefault](toRules, core_rules.MeshService(serviceName))
+
+	var apiRules []api.Rule
+	if conf != nil {
+		apiRules = conf.Rules
+	}
 
 	if len(apiRules) == 0 {
 		switch protocol {

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin.go
@@ -62,22 +62,12 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, xdsCtx xds_context.Context, prox
 		return nil
 	}
 
-	var toRules []ToRouteRule
-	for _, policy := range policies.ToRules.Rules {
-		toRules = append(toRules, ToRouteRule{
-			Subset:    policy.Subset,
-			Rules:     policy.Conf.(api.PolicyDefault).Rules,
-			Hostnames: policy.Conf.(api.PolicyDefault).Hostnames,
-			Origin:    policy.Origin,
-		})
-	}
-
-	if err := ApplyToOutbounds(proxy, rs, xdsCtx, toRules); err != nil {
+	if err := ApplyToOutbounds(proxy, rs, xdsCtx, policies.ToRules.Rules); err != nil {
 		return err
 	}
 
 	ctx := context.TODO()
-	if err := ApplyToGateway(ctx, proxy, rs, xdsCtx, toRules); err != nil {
+	if err := ApplyToGateway(ctx, proxy, rs, xdsCtx, policies.ToRules.Rules); err != nil {
 		return err
 	}
 
@@ -88,7 +78,7 @@ func ApplyToOutbounds(
 	proxy *core_xds.Proxy,
 	rs *core_xds.ResourceSet,
 	xdsCtx xds_context.Context,
-	rules []ToRouteRule,
+	rules rules.Rules,
 ) error {
 	tlsReady := xdsCtx.Mesh.GetTLSReadiness()
 	servicesAcc := envoy_common.NewServicesAccumulator(tlsReady)

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin.go
@@ -67,7 +67,7 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, xdsCtx xds_context.Context, prox
 	}
 
 	ctx := context.TODO()
-	if err := ApplyToGateway(ctx, proxy, rs, xdsCtx, policies.ToRules.Rules); err != nil {
+	if err := ApplyToGateway(ctx, proxy, rs, xdsCtx, policies.GatewayRules); err != nil {
 		return err
 	}
 
@@ -111,31 +111,49 @@ func ApplyToGateway(
 	proxy *core_xds.Proxy,
 	resources *core_xds.ResourceSet,
 	xdsCtx xds_context.Context,
-	rawRules []ToRouteRule,
+	rawRules rules.GatewayRules,
 ) error {
-	if len(rawRules) == 0 {
+	var limits []plugin_gateway.RuntimeResoureLimitListener
+
+	if len(rawRules.ToRules) == 0 {
 		return nil
 	}
 
-	var keys []string
-	rulesByHostname := map[string][]ToRouteRule{}
-	for _, rule := range rawRules {
-		hostnames := rule.Hostnames
-		if len(rule.Hostnames) == 0 {
-			hostnames = []string{"*"}
-		}
-		for _, hostname := range hostnames {
-			accRule, ok := rulesByHostname[hostname]
-			if !ok {
-				keys = append(keys, hostname)
-			}
-			rulesByHostname[hostname] = append(accRule, rule)
-		}
-	}
-
-	var limits []plugin_gateway.RuntimeResoureLimitListener
-
 	for _, info := range plugin_gateway.ExtractGatewayListeners(proxy) {
+		address := proxy.Dataplane.Spec.GetNetworking().Address
+		port := info.Listener.Port
+		inboundListener := rules.InboundListener{
+			Address: address,
+			Port:    port,
+		}
+		rawRules, ok := rawRules.ToRules[inboundListener]
+		if !ok {
+			continue
+		}
+
+		var keys []string
+		rulesByHostname := map[string][]ToRouteRule{}
+		for _, rawRule := range rawRules {
+			conf := rawRule.Conf.(api.PolicyDefault)
+			rule := ToRouteRule{
+				Subset:    rawRule.Subset,
+				Rules:     conf.Rules,
+				Hostnames: conf.Hostnames,
+				Origin:    rawRule.Origin,
+			}
+			hostnames := rule.Hostnames
+			if len(rule.Hostnames) == 0 {
+				hostnames = []string{"*"}
+			}
+			for _, hostname := range hostnames {
+				accRule, ok := rulesByHostname[hostname]
+				if !ok {
+					keys = append(keys, hostname)
+				}
+				rulesByHostname[hostname] = append(accRule, rule)
+			}
+		}
+
 		var hostInfos []plugin_gateway.GatewayHostInfo
 		for _, info := range info.HostInfos {
 			listenerHostname := info.Host.Hostname

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-specific.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-specific.clusters.golden.yaml
@@ -1,0 +1,19 @@
+resources:
+- name: backend-26cb64fa4e85e7b7
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+        resourceApiVersion: V3
+    name: backend-26cb64fa4e85e7b7
+    perConnectionBufferLimitBytes: 32768
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        commonHttpProtocolOptions:
+          idleTimeout: 0s
+        explicitHttpConfig:
+          httpProtocolOptions: {}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-specific.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-specific.endpoints.golden.yaml
@@ -1,0 +1,21 @@
+resources:
+- name: backend-26cb64fa4e85e7b7
+  resource:
+    '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
+    clusterName: backend-26cb64fa4e85e7b7
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.0.4
+              portValue: 8084
+        loadBalancingWeight: 1
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              kuma.io/protocol: http
+              region: us
+            envoy.transport_socket_match:
+              kuma.io/protocol: http
+              region: us

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-specific.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-specific.listeners.golden.yaml
@@ -1,0 +1,119 @@
+resources:
+- name: sample-gateway:HTTP:8080
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.1
+        portValue: 8080
+    enableReusePort: true
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          commonHttpProtocolOptions:
+            headersWithUnderscoresAction: REJECT_REQUEST
+            idleTimeout: 300s
+          http2ProtocolOptions:
+            allowConnect: true
+            initialConnectionWindowSize: 1048576
+            initialStreamWindowSize: 65536
+            maxConcurrentStreams: 100
+          httpFilters:
+          - name: envoy.filters.http.local_ratelimit
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              statPrefix: rate_limit
+          - name: gzip-compress
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+              compressorLibrary:
+                name: gzip
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+              responseDirectionConfig:
+                disableOnEtagHeader: true
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+              startChildSpan: true
+          mergeSlashes: true
+          normalizePath: true
+          pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
+          rds:
+            configSource:
+              ads: {}
+              resourceApiVersion: V3
+            routeConfigName: sample-gateway:HTTP:8080
+          requestHeadersTimeout: 0.500s
+          serverName: Kuma Gateway
+          statPrefix: sample-gateway
+          streamIdleTimeout: 5s
+          useRemoteAddress: true
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: sample-gateway:HTTP:8080
+    perConnectionBufferLimitBytes: 32768
+    trafficDirection: INBOUND
+- name: sample-gateway:HTTP:8081
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.1
+        portValue: 8081
+    enableReusePort: true
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          commonHttpProtocolOptions:
+            headersWithUnderscoresAction: REJECT_REQUEST
+            idleTimeout: 300s
+          http2ProtocolOptions:
+            allowConnect: true
+            initialConnectionWindowSize: 1048576
+            initialStreamWindowSize: 65536
+            maxConcurrentStreams: 100
+          httpFilters:
+          - name: envoy.filters.http.local_ratelimit
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              statPrefix: rate_limit
+          - name: gzip-compress
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+              compressorLibrary:
+                name: gzip
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+              responseDirectionConfig:
+                disableOnEtagHeader: true
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+              startChildSpan: true
+          mergeSlashes: true
+          normalizePath: true
+          pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
+          rds:
+            configSource:
+              ads: {}
+              resourceApiVersion: V3
+            routeConfigName: sample-gateway:HTTP:8081
+          requestHeadersTimeout: 0.500s
+          serverName: Kuma Gateway
+          statPrefix: sample-gateway
+          streamIdleTimeout: 5s
+          useRemoteAddress: true
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: sample-gateway:HTTP:8081
+    perConnectionBufferLimitBytes: 32768
+    trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-specific.routes.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-specific.routes.golden.yaml
@@ -1,0 +1,66 @@
+resources:
+- name: sample-gateway:HTTP:8080
+  resource:
+    '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+    ignorePortInHostMatching: true
+    name: sample-gateway:HTTP:8080
+    requestHeadersToRemove:
+    - x-kuma-tags
+    validateClusters: false
+    virtualHosts:
+    - domains:
+      - '*'
+      name: '*'
+      routes:
+      - match:
+          prefix: /
+        route:
+          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+          idleTimeout: 5s
+          weightedClusters:
+            clusters:
+            - name: backend-26cb64fa4e85e7b7
+              requestHeadersToAdd:
+              - header:
+                  key: x-kuma-tags
+                  value: '&kuma.io/service=sample-gateway&'
+              weight: 100
+- name: sample-gateway:HTTP:8081
+  resource:
+    '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+    ignorePortInHostMatching: true
+    name: sample-gateway:HTTP:8081
+    requestHeadersToRemove:
+    - x-kuma-tags
+    validateClusters: false
+    virtualHosts:
+    - domains:
+      - go.dev
+      name: go.dev
+      routes:
+      - match:
+          path: /go
+        route:
+          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+          idleTimeout: 5s
+          weightedClusters:
+            clusters:
+            - name: backend-26cb64fa4e85e7b7
+              requestHeadersToAdd:
+              - header:
+                  key: x-kuma-tags
+                  value: '&kuma.io/service=sample-gateway&'
+              weight: 100
+      - match:
+          prefix: /go/
+        route:
+          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+          idleTimeout: 5s
+          weightedClusters:
+            clusters:
+            - name: backend-26cb64fa4e85e7b7
+              requestHeadersToAdd:
+              - header:
+                  key: x-kuma-tags
+                  value: '&kuma.io/service=sample-gateway&'
+              weight: 100


### PR DESCRIPTION
Per listener attachment was being ignored

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

> Changelog: skip
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
