### PR TITLE
fix(policy): fix meshmetric e2e flake

### DIFF
--- a/app/kuma-dp/pkg/dataplane/meshmetrics/component.go
+++ b/app/kuma-dp/pkg/dataplane/meshmetrics/component.go
@@ -119,7 +119,7 @@ func (cf *ConfigFetcher) mapApplicationToApplicationToScrape(applications []xds.
 			Address:       address,
 			Path:          application.Path,
 			Port:          application.Port,
-			IsIPv6:        utilnet.IsAddressIPv6(application.Address),
+			IsIPv6:        utilnet.IsAddressIPv6(address),
 			QueryModifier: metrics.RemoveQueryParameters,
 		})
 	}

--- a/test/e2e_env/kubernetes/meshmetric/meshmetric.go
+++ b/test/e2e_env/kubernetes/meshmetric/meshmetric.go
@@ -204,7 +204,7 @@ func MeshMetric() {
 			// metric from envoy
 			g.Expect(stdout).To(ContainSubstring("envoy_http_downstream_rq_xx"))
 			g.Expect(stdout).To(ContainSubstring("path-stats"))
-		}, "30s", "1s").Should(Succeed())
+		}, "1m", "1s").Should(Succeed())
 
 		// update policy config and check if changes was applied on DPP
 		Expect(kubernetes.Cluster.Install(MeshMetricWithApplicationForMesh("dynamic-config", mainMesh, "/app-stats"))).To(Succeed())
@@ -222,7 +222,7 @@ func MeshMetric() {
 			g.Expect(stdout).To(ContainSubstring("envoy_http_downstream_rq_xx"))
 			g.Expect(stdout).ToNot(ContainSubstring("path-stats"))
 			g.Expect(stdout).To(ContainSubstring("app-stats"))
-		}, "30s", "1s").Should(Succeed())
+		}, "1m", "1s").Should(Succeed())
 	})
 
 	It("MADS server response contains DPPs from all meshes when prometheus client id is empty", func() {

--- a/test/e2e_env/kubernetes/meshmetric/meshmetric.go
+++ b/test/e2e_env/kubernetes/meshmetric/meshmetric.go
@@ -204,7 +204,7 @@ func MeshMetric() {
 			// metric from envoy
 			g.Expect(stdout).To(ContainSubstring("envoy_http_downstream_rq_xx"))
 			g.Expect(stdout).To(ContainSubstring("path-stats"))
-		}).Should(Succeed())
+		}, "30s", "1s").Should(Succeed())
 
 		// update policy config and check if changes was applied on DPP
 		Expect(kubernetes.Cluster.Install(MeshMetricWithApplicationForMesh("dynamic-config", mainMesh, "/app-stats"))).To(Succeed())
@@ -222,7 +222,7 @@ func MeshMetric() {
 			g.Expect(stdout).To(ContainSubstring("envoy_http_downstream_rq_xx"))
 			g.Expect(stdout).ToNot(ContainSubstring("path-stats"))
 			g.Expect(stdout).To(ContainSubstring("app-stats"))
-		}).Should(Succeed())
+		}, "30s", "1s").Should(Succeed())
 	})
 
 	It("MADS server response contains DPPs from all meshes when prometheus client id is empty", func() {

--- a/test/e2e_env/kubernetes/meshmetric/meshmetric.go
+++ b/test/e2e_env/kubernetes/meshmetric/meshmetric.go
@@ -204,7 +204,7 @@ func MeshMetric() {
 			// metric from envoy
 			g.Expect(stdout).To(ContainSubstring("envoy_http_downstream_rq_xx"))
 			g.Expect(stdout).To(ContainSubstring("path-stats"))
-		}, "1m", "1s").Should(Succeed())
+		}, "2m", "5s").Should(Succeed())
 
 		// update policy config and check if changes was applied on DPP
 		Expect(kubernetes.Cluster.Install(MeshMetricWithApplicationForMesh("dynamic-config", mainMesh, "/app-stats"))).To(Succeed())
@@ -222,7 +222,7 @@ func MeshMetric() {
 			g.Expect(stdout).To(ContainSubstring("envoy_http_downstream_rq_xx"))
 			g.Expect(stdout).ToNot(ContainSubstring("path-stats"))
 			g.Expect(stdout).To(ContainSubstring("app-stats"))
-		}, "1m", "1s").Should(Succeed())
+		}, "2m", "5s").Should(Succeed())
 	})
 
 	It("MADS server response contains DPPs from all meshes when prometheus client id is empty", func() {

--- a/test/e2e_env/kubernetes/meshmetric/meshmetric.go
+++ b/test/e2e_env/kubernetes/meshmetric/meshmetric.go
@@ -204,7 +204,7 @@ func MeshMetric() {
 			// metric from envoy
 			g.Expect(stdout).To(ContainSubstring("envoy_http_downstream_rq_xx"))
 			g.Expect(stdout).To(ContainSubstring("path-stats"))
-		}, "2m", "5s").Should(Succeed())
+		}, "1m", "1s").Should(Succeed())
 
 		// update policy config and check if changes was applied on DPP
 		Expect(kubernetes.Cluster.Install(MeshMetricWithApplicationForMesh("dynamic-config", mainMesh, "/app-stats"))).To(Succeed())
@@ -222,7 +222,7 @@ func MeshMetric() {
 			g.Expect(stdout).To(ContainSubstring("envoy_http_downstream_rq_xx"))
 			g.Expect(stdout).ToNot(ContainSubstring("path-stats"))
 			g.Expect(stdout).To(ContainSubstring("app-stats"))
-		}, "2m", "5s").Should(Succeed())
+		}, "1m", "1s").Should(Succeed())
 	})
 
 	It("MADS server response contains DPPs from all meshes when prometheus client id is empty", func() {


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
