### PR TITLE
test(e2e): add nice output with info when pod or deployment fail

### DIFF
--- a/test/e2e_env/kubernetes/observability/tracing.go
+++ b/test/e2e_env/kubernetes/observability/tracing.go
@@ -61,8 +61,8 @@ func Tracing() {
 			Install(testserver.Install(testserver.WithMesh(mesh), testserver.WithNamespace(ns))).
 			Install(obs.Install(obsDeployment, obs.WithNamespace(obsNs), obs.WithComponents(obs.JaegerComponent))).
 			Setup(kubernetes.Cluster)
-		obsClient = obs.From(obsDeployment, kubernetes.Cluster)
 		Expect(err).ToNot(HaveOccurred())
+		obsClient = obs.From(obsDeployment, kubernetes.Cluster)
 	})
 	E2EAfterAll(func() {
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(ns)).To(Succeed())

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -17,7 +17,6 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
-	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/testing"
@@ -575,7 +574,8 @@ func (c *K8sCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOption) e
 				return k8s.RunKubectlAndGetOutputE(c.t, c.GetKubectlOptions(), "get", "mesh", "default")
 			})
 		if err != nil {
-			return err
+			deploymentDetails := ExtractDeploymentDetails(c.t, c.GetKubectlOptions(Config.KumaNamespace), Config.KumaServiceName)
+			return &K8sDecoratedError{Err: err, Details: deploymentDetails}
 		}
 	}
 
@@ -1099,10 +1099,8 @@ func (c *K8sCluster) WaitApp(name, namespace string, replicas int) error {
 		c.defaultRetries,
 		c.defaultTimeout)
 	if err != nil {
-		deployPrinter := NewK8sDeploymentDetailPrinter(c.t, c.GetKubectlOptions(namespace), namespace, name)
-		logger.Default.Logf(c.t, "Details of deployment '%s/%s': %s",
-			namespace, name, deployPrinter.Print())
-		return err
+		deploymentDetails := ExtractDeploymentDetails(c.t, c.GetKubectlOptions(namespace), name)
+		return &K8sDecoratedError{Err: err, Details: deploymentDetails}
 	}
 
 	pods := k8s.ListPods(c.t,
@@ -1123,9 +1121,8 @@ func (c *K8sCluster) WaitApp(name, namespace string, replicas int) error {
 			c.defaultTimeout)
 
 		if podError != nil {
-			podPrinter := NewK8sPodDetailPrinter(c.t, c.GetKubectlOptions(namespace), &pods[i])
-			podError = errors.New(podError.Error() + "\nPod details:\n" + podPrinter.Print())
-			return podError
+			podDetails := ExtractPodDetails(c.t, c.GetKubectlOptions(namespace), pods[i].Name)
+			return &K8sDecoratedError{Err: podError, Details: podDetails}
 		}
 	}
 	return nil

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -245,8 +245,8 @@ func WaitPodsAvailableWithLabel(namespace, labelKey, labelValue string) InstallF
 			pod := p
 			podError = k8s.WaitUntilPodAvailableE(testingT, kubectlOptions, pod.GetName(), ck8s.defaultRetries, ck8s.defaultTimeout)
 			if podError != nil {
-				podPrinter := NewK8sPodDetailPrinter(testingT, c.GetKubectlOptions(namespace), &pod)
-				return errors.New(podError.Error() + "\nPod details:\n" + podPrinter.Print())
+				podDetails := ExtractPodDetails(testingT, c.GetKubectlOptions(namespace), pod.Name)
+				return &K8sDecoratedError{Err: podError, Details: podDetails}
 			}
 		}
 		return nil


### PR DESCRIPTION
Display a nice and complete failure like: https://gist.github.com/lahabana/5f25fe340b532523b578503bb13267af

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
