### PR TITLE
test(framework): extract getting IP for KIC service to deployment

### DIFF
--- a/test/e2e_env/kubernetes/kic/kong_ingress.go
+++ b/test/e2e_env/kubernetes/kic/kong_ingress.go
@@ -3,7 +3,6 @@ package kic
 import (
 	"fmt"
 
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -33,21 +32,6 @@ func KICKubernetes() {
 	mesh := "kic"
 	namespaceOutsideMesh := "kic-external"
 
-	getKICIP := func() string {
-		var ip string
-		Eventually(func(g Gomega) {
-			out, err := k8s.RunKubectlAndGetOutputE(
-				kubernetes.Cluster.GetTesting(),
-				kubernetes.Cluster.GetKubectlOptions(namespace),
-				"get", "service", "gateway", "-ojsonpath={.spec.clusterIP}",
-			)
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(out).ToNot(BeEmpty())
-			ip = out
-		}, "60s", "1s").Should(Succeed(), "could not get the clusterIP of the Service")
-		return ip
-	}
-
 	var kicIP string
 
 	BeforeAll(func() {
@@ -68,7 +52,10 @@ func KICKubernetes() {
 			)).
 			Setup(kubernetes.Cluster)).To(Succeed())
 
-		kicIP = getKICIP()
+		ip, err := kic.From(kubernetes.Cluster).IP(namespace)
+		Expect(err).To(Succeed())
+
+		kicIP = ip
 	})
 
 	E2EAfterAll(func() {

--- a/test/framework/deployments/kic/deployment.go
+++ b/test/framework/deployments/kic/deployment.go
@@ -10,7 +10,7 @@ import (
 
 const DeploymentName = "kongingresscontroller"
 
-type KIC interface{
+type KIC interface {
 	IP(namespace string) (string, error)
 }
 

--- a/test/framework/deployments/kic/deployment.go
+++ b/test/framework/deployments/kic/deployment.go
@@ -10,7 +10,9 @@ import (
 
 const DeploymentName = "kongingresscontroller"
 
-type KIC interface{}
+type KIC interface{
+	IP(namespace string) (string, error)
+}
 
 type Deployment interface {
 	framework.Deployment


### PR DESCRIPTION
This functionallity will be heavy reused when introducing e2e test cases for testing new policies with delegated gateway.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - related to: https://github.com/kumahq/kuma/issues/8746
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Tested with existing e2e tests as well as locally on newly created tests which will be added in the following pull requests
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - There is no need

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
