### PR TITLE
feat(policy): support targeting many gateways

### DIFF
--- a/api/common/v1alpha1/ref.go
+++ b/api/common/v1alpha1/ref.go
@@ -12,21 +12,23 @@ import (
 type TargetRefKind string
 
 var (
-	Mesh              TargetRefKind = "Mesh"
-	MeshSubset        TargetRefKind = "MeshSubset"
-	MeshGateway       TargetRefKind = "MeshGateway"
-	MeshService       TargetRefKind = "MeshService"
-	MeshServiceSubset TargetRefKind = "MeshServiceSubset"
-	MeshHTTPRoute     TargetRefKind = "MeshHTTPRoute"
+	Mesh               TargetRefKind = "Mesh"
+	MeshSubset         TargetRefKind = "MeshSubset"
+	MeshGatewaysSubset TargetRefKind = "MeshGatewaysSubset"
+	MeshGateway        TargetRefKind = "MeshGateway"
+	MeshService        TargetRefKind = "MeshService"
+	MeshServiceSubset  TargetRefKind = "MeshServiceSubset"
+	MeshHTTPRoute      TargetRefKind = "MeshHTTPRoute"
 )
 
 var order = map[TargetRefKind]int{
-	Mesh:              1,
-	MeshSubset:        2,
-	MeshGateway:       3,
-	MeshService:       4,
-	MeshServiceSubset: 5,
-	MeshHTTPRoute:     6,
+	Mesh:               1,
+	MeshSubset:         2,
+	MeshGatewaysSubset: 3,
+	MeshGateway:        4,
+	MeshService:        5,
+	MeshServiceSubset:  6,
+	MeshHTTPRoute:      7,
 }
 
 func (k TargetRefKind) Less(o TargetRefKind) bool {
@@ -36,7 +38,7 @@ func (k TargetRefKind) Less(o TargetRefKind) bool {
 // TargetRef defines structure that allows attaching policy to various objects
 type TargetRef struct {
 	// Kind of the referenced resource
-	// +kubebuilder:validation:Enum=Mesh;MeshSubset;MeshGateway;MeshService;MeshServiceSubset;MeshHTTPRoute
+	// +kubebuilder:validation:Enum=Mesh;MeshSubset;MeshGatewaysSubset;MeshGateway;MeshService;MeshServiceSubset;MeshHTTPRoute
 	Kind TargetRefKind `json:"kind,omitempty"`
 	// Name of the referenced resource. Can only be used with kinds: `MeshService`,
 	// `MeshServiceSubset` and `MeshGatewayRoute`

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -320,6 +320,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -355,6 +356,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -466,6 +468,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -982,6 +985,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -1208,6 +1212,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -1294,6 +1299,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -1346,6 +1352,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGatewaysSubset
                                       - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
@@ -1440,6 +1447,7 @@ spec:
                                               enum:
                                               - Mesh
                                               - MeshSubset
+                                              - MeshGatewaysSubset
                                               - MeshGateway
                                               - MeshService
                                               - MeshServiceSubset
@@ -1739,6 +1747,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -1866,6 +1875,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -2317,6 +2327,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -2494,6 +2505,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -3005,6 +3017,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -3251,6 +3264,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -3286,6 +3300,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -3436,6 +3451,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -3522,6 +3538,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -3883,6 +3900,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -3969,6 +3987,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -4013,6 +4032,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGatewaysSubset
                                       - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
@@ -4058,6 +4078,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -4196,6 +4217,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -4231,6 +4253,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -4312,6 +4335,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -4551,6 +4575,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -4650,6 +4675,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -4685,6 +4711,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -5814,6 +5841,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -5849,6 +5877,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -6026,6 +6055,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -6368,6 +6398,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -6403,6 +6434,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -6688,6 +6720,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
@@ -320,6 +320,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -355,6 +356,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -466,6 +468,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -982,6 +985,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -1208,6 +1212,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -1294,6 +1299,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -1346,6 +1352,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGatewaysSubset
                                       - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
@@ -1440,6 +1447,7 @@ spec:
                                               enum:
                                               - Mesh
                                               - MeshSubset
+                                              - MeshGatewaysSubset
                                               - MeshGateway
                                               - MeshService
                                               - MeshServiceSubset
@@ -1739,6 +1747,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -1866,6 +1875,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -2317,6 +2327,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -2494,6 +2505,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -3005,6 +3017,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -3251,6 +3264,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -3286,6 +3300,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -3436,6 +3451,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -3522,6 +3538,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -3883,6 +3900,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -3969,6 +3987,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -4013,6 +4032,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGatewaysSubset
                                       - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
@@ -4058,6 +4078,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -4196,6 +4217,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -4231,6 +4253,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -4312,6 +4335,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -4551,6 +4575,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -4650,6 +4675,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -4685,6 +4711,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -5814,6 +5841,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -5849,6 +5877,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -6026,6 +6055,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -6368,6 +6398,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -6403,6 +6434,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -6688,6 +6720,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -320,6 +320,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -355,6 +356,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -466,6 +468,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -1186,6 +1189,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -1412,6 +1416,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -1498,6 +1503,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -1550,6 +1556,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGatewaysSubset
                                       - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
@@ -1644,6 +1651,7 @@ spec:
                                               enum:
                                               - Mesh
                                               - MeshSubset
+                                              - MeshGatewaysSubset
                                               - MeshGateway
                                               - MeshService
                                               - MeshServiceSubset
@@ -1943,6 +1951,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -2070,6 +2079,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -2521,6 +2531,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -2698,6 +2709,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -3253,6 +3265,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -3455,6 +3468,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -3490,6 +3504,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -3640,6 +3655,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -3726,6 +3742,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -4087,6 +4104,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -4173,6 +4191,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -4217,6 +4236,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGatewaysSubset
                                       - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
@@ -4262,6 +4282,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -4400,6 +4421,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -4435,6 +4457,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -4516,6 +4539,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -4755,6 +4779,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -4854,6 +4879,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -4889,6 +4915,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -6018,6 +6045,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -6053,6 +6081,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -6230,6 +6259,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -6572,6 +6602,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -6607,6 +6638,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -6892,6 +6924,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -340,6 +340,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -375,6 +376,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -486,6 +488,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -1002,6 +1005,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -1228,6 +1232,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -1314,6 +1319,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -1366,6 +1372,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGatewaysSubset
                                       - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
@@ -1460,6 +1467,7 @@ spec:
                                               enum:
                                               - Mesh
                                               - MeshSubset
+                                              - MeshGatewaysSubset
                                               - MeshGateway
                                               - MeshService
                                               - MeshServiceSubset
@@ -1759,6 +1767,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -1886,6 +1895,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -2337,6 +2347,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -2514,6 +2525,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -3025,6 +3037,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -3271,6 +3284,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -3306,6 +3320,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -3456,6 +3471,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -3542,6 +3558,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -3903,6 +3920,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -3989,6 +4007,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -4033,6 +4052,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGatewaysSubset
                                       - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
@@ -4078,6 +4098,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -4216,6 +4237,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -4251,6 +4273,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -4332,6 +4355,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -4571,6 +4595,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -4670,6 +4695,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -4705,6 +4731,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -5834,6 +5861,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -5869,6 +5897,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -6046,6 +6075,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -6388,6 +6418,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -6423,6 +6454,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -6708,6 +6740,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -593,6 +593,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -628,6 +629,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -805,6 +807,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -1147,6 +1150,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -1182,6 +1186,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -1467,6 +1472,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -1679,6 +1685,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -1714,6 +1721,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -1825,6 +1833,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -2341,6 +2350,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -2567,6 +2577,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -2653,6 +2664,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -2705,6 +2717,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGatewaysSubset
                                       - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
@@ -2799,6 +2812,7 @@ spec:
                                               enum:
                                               - Mesh
                                               - MeshSubset
+                                              - MeshGatewaysSubset
                                               - MeshGateway
                                               - MeshService
                                               - MeshServiceSubset
@@ -3098,6 +3112,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -3225,6 +3240,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -3676,6 +3692,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -3853,6 +3870,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -4364,6 +4382,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -4566,6 +4585,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -4601,6 +4621,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -4751,6 +4772,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -4837,6 +4859,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -5198,6 +5221,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -5284,6 +5308,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -5328,6 +5353,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGatewaysSubset
                                       - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
@@ -5373,6 +5399,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -5511,6 +5538,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -5546,6 +5574,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -5627,6 +5656,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -5866,6 +5896,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -5965,6 +5996,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -6000,6 +6032,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset

--- a/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
@@ -593,6 +593,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -628,6 +629,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -805,6 +807,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -1147,6 +1150,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -1182,6 +1186,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -1467,6 +1472,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -1679,6 +1685,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -1714,6 +1721,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -1825,6 +1833,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -2545,6 +2554,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -2771,6 +2781,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -2857,6 +2868,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -2909,6 +2921,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGatewaysSubset
                                       - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
@@ -3003,6 +3016,7 @@ spec:
                                               enum:
                                               - Mesh
                                               - MeshSubset
+                                              - MeshGatewaysSubset
                                               - MeshGateway
                                               - MeshService
                                               - MeshServiceSubset
@@ -3302,6 +3316,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -3429,6 +3444,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -3880,6 +3896,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -4057,6 +4074,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -4568,6 +4586,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -4770,6 +4789,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -4805,6 +4825,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -4955,6 +4976,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -5041,6 +5063,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -5402,6 +5425,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -5488,6 +5512,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -5532,6 +5557,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGatewaysSubset
                                       - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
@@ -5577,6 +5603,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -5715,6 +5742,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -5750,6 +5778,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -5831,6 +5860,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -6070,6 +6100,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -6169,6 +6200,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -6204,6 +6236,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset

--- a/deployments/charts/kuma/crds/kuma.io_meshaccesslogs.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshaccesslogs.yaml
@@ -199,6 +199,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -234,6 +235,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -411,6 +413,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/deployments/charts/kuma/crds/kuma.io_meshcircuitbreakers.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshcircuitbreakers.yaml
@@ -308,6 +308,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -343,6 +344,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -628,6 +630,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/deployments/charts/kuma/crds/kuma.io_meshfaultinjections.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshfaultinjections.yaml
@@ -134,6 +134,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -169,6 +170,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -280,6 +282,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/deployments/charts/kuma/crds/kuma.io_meshhealthchecks.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshhealthchecks.yaml
@@ -52,6 +52,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -278,6 +279,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/deployments/charts/kuma/crds/kuma.io_meshhttproutes.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshhttproutes.yaml
@@ -52,6 +52,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -104,6 +105,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGatewaysSubset
                                       - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
@@ -198,6 +200,7 @@ spec:
                                               enum:
                                               - Mesh
                                               - MeshSubset
+                                              - MeshGatewaysSubset
                                               - MeshGateway
                                               - MeshService
                                               - MeshServiceSubset
@@ -497,6 +500,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/deployments/charts/kuma/crds/kuma.io_meshloadbalancingstrategies.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshloadbalancingstrategies.yaml
@@ -53,6 +53,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -504,6 +505,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/deployments/charts/kuma/crds/kuma.io_meshmetrics.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshmetrics.yaml
@@ -143,6 +143,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset

--- a/deployments/charts/kuma/crds/kuma.io_meshproxypatches.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshproxypatches.yaml
@@ -482,6 +482,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset

--- a/deployments/charts/kuma/crds/kuma.io_meshratelimits.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshratelimits.yaml
@@ -172,6 +172,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -207,6 +208,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -357,6 +359,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/deployments/charts/kuma/crds/kuma.io_meshretries.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshretries.yaml
@@ -52,6 +52,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -413,6 +414,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/deployments/charts/kuma/crds/kuma.io_meshtcproutes.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtcproutes.yaml
@@ -52,6 +52,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -96,6 +97,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGatewaysSubset
                                       - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
@@ -141,6 +143,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/deployments/charts/kuma/crds/kuma.io_meshtimeouts.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtimeouts.yaml
@@ -103,6 +103,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -138,6 +139,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -219,6 +221,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/deployments/charts/kuma/crds/kuma.io_meshtraces.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtraces.yaml
@@ -205,6 +205,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset

--- a/deployments/charts/kuma/crds/kuma.io_meshtrafficpermissions.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtrafficpermissions.yaml
@@ -70,6 +70,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -105,6 +106,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -1967,6 +1967,7 @@ components:
                         enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -2007,6 +2008,7 @@ components:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -2205,6 +2207,7 @@ components:
                         enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -2576,6 +2579,7 @@ components:
                         enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -2616,6 +2620,7 @@ components:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -2959,6 +2964,7 @@ components:
                         enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -3116,6 +3122,7 @@ components:
                         enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -3156,6 +3163,7 @@ components:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -3285,6 +3293,7 @@ components:
                         enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -3348,6 +3357,7 @@ components:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -3603,6 +3613,7 @@ components:
                         enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -3666,6 +3677,7 @@ components:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -3725,6 +3737,7 @@ components:
                                     enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGatewaysSubset
                                       - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
@@ -3822,6 +3835,7 @@ components:
                                             enum:
                                               - Mesh
                                               - MeshSubset
+                                              - MeshGatewaysSubset
                                               - MeshGateway
                                               - MeshService
                                               - MeshServiceSubset
@@ -4140,6 +4154,7 @@ components:
                         enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -4201,6 +4216,7 @@ components:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -4706,6 +4722,7 @@ components:
                         enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -4870,6 +4887,7 @@ components:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -5348,6 +5366,7 @@ components:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -5544,6 +5563,7 @@ components:
                         enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -5584,6 +5604,7 @@ components:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -5756,6 +5777,7 @@ components:
                         enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -5819,6 +5841,7 @@ components:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -6225,6 +6248,7 @@ components:
                         enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -6288,6 +6312,7 @@ components:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -6338,6 +6363,7 @@ components:
                                     enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGatewaysSubset
                                       - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
@@ -6387,6 +6413,7 @@ components:
                         enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -6510,6 +6537,7 @@ components:
                         enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -6550,6 +6578,7 @@ components:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -6644,6 +6673,7 @@ components:
                         enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -6875,6 +6905,7 @@ components:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -6955,6 +6986,7 @@ components:
                         enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -6995,6 +7027,7 @@ components:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset

--- a/docs/generated/raw/crds/kuma.io_meshaccesslogs.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshaccesslogs.yaml
@@ -199,6 +199,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -234,6 +235,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -411,6 +413,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/docs/generated/raw/crds/kuma.io_meshcircuitbreakers.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshcircuitbreakers.yaml
@@ -308,6 +308,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -343,6 +344,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -628,6 +630,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/docs/generated/raw/crds/kuma.io_meshfaultinjections.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshfaultinjections.yaml
@@ -134,6 +134,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -169,6 +170,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -280,6 +282,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/docs/generated/raw/crds/kuma.io_meshhealthchecks.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshhealthchecks.yaml
@@ -52,6 +52,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -278,6 +279,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/docs/generated/raw/crds/kuma.io_meshhttproutes.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshhttproutes.yaml
@@ -52,6 +52,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -104,6 +105,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGatewaysSubset
                                       - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
@@ -198,6 +200,7 @@ spec:
                                               enum:
                                               - Mesh
                                               - MeshSubset
+                                              - MeshGatewaysSubset
                                               - MeshGateway
                                               - MeshService
                                               - MeshServiceSubset
@@ -497,6 +500,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/docs/generated/raw/crds/kuma.io_meshloadbalancingstrategies.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshloadbalancingstrategies.yaml
@@ -53,6 +53,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -504,6 +505,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/docs/generated/raw/crds/kuma.io_meshmetrics.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshmetrics.yaml
@@ -143,6 +143,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset

--- a/docs/generated/raw/crds/kuma.io_meshproxypatches.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshproxypatches.yaml
@@ -482,6 +482,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset

--- a/docs/generated/raw/crds/kuma.io_meshratelimits.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshratelimits.yaml
@@ -172,6 +172,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -207,6 +208,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -357,6 +359,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/docs/generated/raw/crds/kuma.io_meshretries.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshretries.yaml
@@ -52,6 +52,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -413,6 +414,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/docs/generated/raw/crds/kuma.io_meshtcproutes.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshtcproutes.yaml
@@ -52,6 +52,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -96,6 +97,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGatewaysSubset
                                       - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
@@ -141,6 +143,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/docs/generated/raw/crds/kuma.io_meshtimeouts.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshtimeouts.yaml
@@ -103,6 +103,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -138,6 +139,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -219,6 +221,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/docs/generated/raw/crds/kuma.io_meshtraces.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshtraces.yaml
@@ -205,6 +205,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset

--- a/docs/generated/raw/crds/kuma.io_meshtrafficpermissions.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshtrafficpermissions.yaml
@@ -70,6 +70,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -105,6 +106,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset

--- a/pkg/core/resources/apis/mesh/validators.go
+++ b/pkg/core/resources/apis/mesh/validators.go
@@ -348,10 +348,13 @@ func ValidateTargetRef(
 		}
 		err.Add(disallowedField("mesh", ref.Mesh, ref.Kind))
 		err.Add(disallowedField("tags", ref.Tags, ref.Kind))
-	case common_api.MeshSubset:
+	case common_api.MeshSubset, common_api.MeshGatewaysSubset:
 		err.Add(disallowedField("name", ref.Name, ref.Kind))
 		err.Add(disallowedField("mesh", ref.Mesh, ref.Kind))
 		err.Add(ValidateTags(validators.RootedAt("tags"), ref.Tags, ValidateTagsOpts{}))
+		if ref.Kind == common_api.MeshGatewaysSubset && len(ref.Tags) > 0 && !opts.GatewayListenerTagsAllowed {
+			err.Add(disallowedField("tags", ref.Tags, ref.Kind))
+		}
 	case common_api.MeshService, common_api.MeshHTTPRoute:
 		err.Add(requiredField("name", ref.Name, ref.Kind))
 		err.Add(validateName(ref.Name))

--- a/pkg/core/resources/apis/mesh/validators_test.go
+++ b/pkg/core/resources/apis/mesh/validators_test.go
@@ -178,6 +178,19 @@ tags:
 				GatewayListenerTagsAllowed: true,
 			},
 		}),
+		Entry("MeshGatewaysSubset", testCase{
+			inputYaml: `
+kind: MeshGatewaysSubset
+tags:
+  listener: one
+`,
+			opts: &ValidateTargetRefOpts{
+				SupportedKinds: []common_api.TargetRefKind{
+					common_api.MeshGatewaysSubset,
+				},
+				GatewayListenerTagsAllowed: true,
+			},
+		}),
 		Entry("MeshGateway with period", testCase{
 			inputYaml: `
 kind: MeshGateway
@@ -641,6 +654,39 @@ tags:
 violations:
   - field: targetRef.tags
     message: must not be set with kind MeshGateway
+`,
+		}),
+		Entry("MeshGatewaysSubset and no tags allowed", testCase{
+			inputYaml: `
+kind: MeshGatewaysSubset
+tags:
+  port: http
+`,
+			opts: &ValidateTargetRefOpts{
+				SupportedKinds: []common_api.TargetRefKind{
+					common_api.MeshGatewaysSubset,
+				},
+			},
+			expected: `
+violations:
+  - field: targetRef.tags
+    message: must not be set with kind MeshGatewaysSubset
+`,
+		}),
+		Entry("MeshGatewaysSubset and name not supported", testCase{
+			inputYaml: `
+kind: MeshGatewaysSubset
+name: not-possible
+`,
+			opts: &ValidateTargetRefOpts{
+				SupportedKinds: []common_api.TargetRefKind{
+					common_api.MeshGatewaysSubset,
+				},
+			},
+			expected: `
+violations:
+  - field: targetRef.name
+    message: must not be set with kind MeshGatewaysSubset
 `,
 		}),
 	)

--- a/pkg/plugins/policies/core/matchers/dataplane.go
+++ b/pkg/plugins/policies/core/matchers/dataplane.go
@@ -141,6 +141,20 @@ func dppSelectedByPolicy(
 			}
 		}
 		return result, false, nil
+	case common_api.MeshGatewaysSubset:
+		if gateway == nil || !dpp.Spec.IsBuiltinGateway() {
+			return nil, false, nil
+		}
+		var result []core_rules.InboundListener
+		for _, listener := range gateway.Spec.GetConf().GetListeners() {
+			if mesh_proto.TagSelector(ref.Tags).Matches(listener.GetTags()) {
+				result = append(result, core_rules.InboundListener{
+					Address: dpp.Spec.GetNetworking().GetAddress(),
+					Port:    listener.Port,
+				})
+			}
+		}
+		return result, false, nil
 	case common_api.MeshHTTPRoute:
 		mhr := resolveMeshHTTPRouteRef(meta, ref.Name, referencableResources.ListOrEmpty(meshhttproute_api.MeshHTTPRouteType))
 		if mhr == nil {

--- a/pkg/plugins/policies/core/matchers/dataplane_test.go
+++ b/pkg/plugins/policies/core/matchers/dataplane_test.go
@@ -152,7 +152,7 @@ var _ = Describe("MatchedPolicies", func() {
 		generateTableEntries(filepath.Join("testdata", "matchedpolicies", "torules")),
 	)
 
-	DescribeTable("should match MeshGateways",
+	FDescribeTable("should match MeshGateways",
 		func(given testCase) {
 			dpp := readDPP(given.dppFile)
 

--- a/pkg/plugins/policies/core/matchers/dataplane_test.go
+++ b/pkg/plugins/policies/core/matchers/dataplane_test.go
@@ -152,7 +152,7 @@ var _ = Describe("MatchedPolicies", func() {
 		generateTableEntries(filepath.Join("testdata", "matchedpolicies", "torules")),
 	)
 
-	FDescribeTable("should match MeshGateways",
+	DescribeTable("should match MeshGateways",
 		func(given testCase) {
 			dpp := readDPP(given.dppFile)
 

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.golden.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.golden.yaml
@@ -21,6 +21,11 @@ ToRules:
     - creationTime: "0001-01-01T00:00:00Z"
       mesh: mesh-1
       modificationTime: "0001-01-01T00:00:00Z"
+      name: gateway-subset
+      type: MeshAccessLog
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
       name: gatewaylistener
       type: MeshAccessLog
     - creationTime: "0001-01-01T00:00:00Z"
@@ -44,6 +49,11 @@ ToRules:
     - creationTime: "0001-01-01T00:00:00Z"
       mesh: mesh-1
       modificationTime: "0001-01-01T00:00:00Z"
+      name: gateway-subset
+      type: MeshAccessLog
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
       name: mesh
       type: MeshAccessLog
     - creationTime: "0001-01-01T00:00:00Z"
@@ -63,6 +73,11 @@ ToRules:
       mesh: mesh-1
       modificationTime: "0001-01-01T00:00:00Z"
       name: gateway
+      type: MeshAccessLog
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: gateway-subset
       type: MeshAccessLog
     - creationTime: "0001-01-01T00:00:00Z"
       mesh: mesh-1

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.policies.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.policies.yaml
@@ -68,6 +68,21 @@ spec:
 ---
 type: MeshAccessLog
 mesh: mesh-1
+name: gateway-subset
+spec:
+ targetRef:
+  kind: MeshGatewaysSubset
+ to:
+  - targetRef:
+     kind: Mesh
+    default:
+      backends:
+        - type: File
+          file:
+            path: /gateway-subset
+---
+type: MeshAccessLog
+mesh: mesh-1
 name: nonmatchinggatewaylistener
 spec:
  targetRef:

--- a/pkg/plugins/policies/donothingpolicy/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/donothingpolicy/api/v1alpha1/schema.yaml
@@ -34,6 +34,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -63,6 +64,7 @@ properties:
             enum:
               - Mesh
               - MeshSubset
+              - MeshGatewaysSubset
               - MeshGateway
               - MeshService
               - MeshServiceSubset
@@ -99,6 +101,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset

--- a/pkg/plugins/policies/donothingpolicy/k8s/crd/kuma.io_donothingpolicies.yaml
+++ b/pkg/plugins/policies/donothingpolicy/k8s/crd/kuma.io_donothingpolicies.yaml
@@ -65,6 +65,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -100,6 +101,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -143,6 +145,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/schema.yaml
@@ -161,6 +161,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -190,6 +191,7 @@ properties:
             enum:
               - Mesh
               - MeshSubset
+              - MeshGatewaysSubset
               - MeshGateway
               - MeshService
               - MeshServiceSubset
@@ -353,6 +355,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/validator.go
@@ -27,6 +27,7 @@ func validateTop(targetRef common_api.TargetRef) validators.ValidationError {
 		SupportedKinds: []common_api.TargetRefKind{
 			common_api.Mesh,
 			common_api.MeshSubset,
+			common_api.MeshGatewaysSubset,
 			common_api.MeshGateway,
 			common_api.MeshService,
 			common_api.MeshServiceSubset,

--- a/pkg/plugins/policies/meshaccesslog/k8s/crd/kuma.io_meshaccesslogs.yaml
+++ b/pkg/plugins/policies/meshaccesslog/k8s/crd/kuma.io_meshaccesslogs.yaml
@@ -199,6 +199,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -234,6 +235,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -411,6 +413,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/schema.yaml
@@ -137,6 +137,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -166,6 +167,7 @@ properties:
             enum:
               - Mesh
               - MeshSubset
+              - MeshGatewaysSubset
               - MeshGateway
               - MeshService
               - MeshServiceSubset
@@ -305,6 +307,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/validator.go
@@ -26,6 +26,7 @@ func validateTop(targetRef common_api.TargetRef) validators.ValidationError {
 			common_api.Mesh,
 			common_api.MeshSubset,
 			common_api.MeshService,
+			common_api.MeshGatewaysSubset,
 			common_api.MeshGateway,
 			common_api.MeshServiceSubset,
 		},

--- a/pkg/plugins/policies/meshcircuitbreaker/k8s/crd/kuma.io_meshcircuitbreakers.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/k8s/crd/kuma.io_meshcircuitbreakers.yaml
@@ -308,6 +308,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -343,6 +344,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -628,6 +630,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/schema.yaml
@@ -87,6 +87,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -116,6 +117,7 @@ properties:
             enum:
               - Mesh
               - MeshSubset
+              - MeshGatewaysSubset
               - MeshGateway
               - MeshService
               - MeshServiceSubset
@@ -205,6 +207,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/validator.go
@@ -55,7 +55,7 @@ func validateFrom(topTargetRef common_api.TargetRef, from []From) validators.Val
 
 func validateTo(topTargetRef common_api.TargetRef, to []To) validators.ValidationError {
 	var verr validators.ValidationError
-	if topTargetRef.Kind != common_api.MeshGateway && len(to) != 0 {
+	if (topTargetRef.Kind != common_api.MeshGateway && topTargetRef.Kind != common_api.MeshGatewaysSubset) && len(to) != 0 {
 		verr.AddViolationAt(validators.RootedAt("to"), validators.MustNotBeDefined)
 		return verr
 	}

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/validator.go
@@ -21,6 +21,7 @@ func validateTop(targetRef common_api.TargetRef) validators.ValidationError {
 		SupportedKinds: []common_api.TargetRefKind{
 			common_api.Mesh,
 			common_api.MeshSubset,
+			common_api.MeshGatewaysSubset,
 			common_api.MeshGateway,
 			common_api.MeshService,
 			common_api.MeshServiceSubset,

--- a/pkg/plugins/policies/meshfaultinjection/k8s/crd/kuma.io_meshfaultinjections.yaml
+++ b/pkg/plugins/policies/meshfaultinjection/k8s/crd/kuma.io_meshfaultinjections.yaml
@@ -134,6 +134,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -169,6 +170,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -280,6 +282,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/schema.yaml
@@ -23,6 +23,7 @@ properties:
             enum:
               - Mesh
               - MeshSubset
+              - MeshGatewaysSubset
               - MeshGateway
               - MeshService
               - MeshServiceSubset
@@ -192,6 +193,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset

--- a/pkg/plugins/policies/meshhealthcheck/k8s/crd/kuma.io_meshhealthchecks.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/k8s/crd/kuma.io_meshhealthchecks.yaml
@@ -52,6 +52,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -278,6 +279,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/schema.yaml
@@ -23,6 +23,7 @@ properties:
             enum:
               - Mesh
               - MeshSubset
+              - MeshGatewaysSubset
               - MeshGateway
               - MeshService
               - MeshServiceSubset
@@ -65,6 +66,7 @@ properties:
                               enum:
                                 - Mesh
                                 - MeshSubset
+                                - MeshGatewaysSubset
                                 - MeshGateway
                                 - MeshService
                                 - MeshServiceSubset
@@ -147,6 +149,7 @@ properties:
                                       enum:
                                         - Mesh
                                         - MeshSubset
+                                        - MeshGatewaysSubset
                                         - MeshGateway
                                         - MeshService
                                         - MeshServiceSubset
@@ -400,6 +403,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation.go
@@ -23,6 +23,7 @@ func validateTop(targetRef common_api.TargetRef) validators.ValidationError {
 	return mesh.ValidateTargetRef(targetRef, &mesh.ValidateTargetRefOpts{
 		SupportedKinds: []common_api.TargetRefKind{
 			common_api.Mesh,
+			common_api.MeshGatewaysSubset,
 			common_api.MeshGateway,
 			common_api.MeshSubset,
 			common_api.MeshService,

--- a/pkg/plugins/policies/meshhttproute/k8s/crd/kuma.io_meshhttproutes.yaml
+++ b/pkg/plugins/policies/meshhttproute/k8s/crd/kuma.io_meshhttproutes.yaml
@@ -52,6 +52,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -104,6 +105,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGatewaysSubset
                                       - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
@@ -198,6 +200,7 @@ spec:
                                               enum:
                                               - Mesh
                                               - MeshSubset
+                                              - MeshGatewaysSubset
                                               - MeshGateway
                                               - MeshService
                                               - MeshServiceSubset
@@ -497,6 +500,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/schema.yaml
@@ -23,6 +23,7 @@ properties:
             enum:
               - Mesh
               - MeshSubset
+              - MeshGatewaysSubset
               - MeshGateway
               - MeshService
               - MeshServiceSubset
@@ -334,6 +335,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset

--- a/pkg/plugins/policies/meshloadbalancingstrategy/k8s/crd/kuma.io_meshloadbalancingstrategies.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/k8s/crd/kuma.io_meshloadbalancingstrategies.yaml
@@ -53,6 +53,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -504,6 +505,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/schema.yaml
@@ -103,6 +103,7 @@ properties:
             enum:
               - Mesh
               - MeshSubset
+              - MeshGatewaysSubset
               - MeshGateway
               - MeshService
               - MeshServiceSubset

--- a/pkg/plugins/policies/meshmetric/k8s/crd/kuma.io_meshmetrics.yaml
+++ b/pkg/plugins/policies/meshmetric/k8s/crd/kuma.io_meshmetrics.yaml
@@ -143,6 +143,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset

--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/schema.yaml
@@ -336,6 +336,7 @@ properties:
             enum:
               - Mesh
               - MeshSubset
+              - MeshGatewaysSubset
               - MeshGateway
               - MeshService
               - MeshServiceSubset

--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/validator.go
@@ -36,6 +36,7 @@ func validateTop(targetRef common_api.TargetRef) validators.ValidationError {
 			common_api.MeshSubset,
 			common_api.MeshService,
 			common_api.MeshServiceSubset,
+			common_api.MeshGatewaysSubset,
 			common_api.MeshGateway,
 		},
 		GatewayListenerTagsAllowed: false,

--- a/pkg/plugins/policies/meshproxypatch/k8s/crd/kuma.io_meshproxypatches.yaml
+++ b/pkg/plugins/policies/meshproxypatch/k8s/crd/kuma.io_meshproxypatches.yaml
@@ -482,6 +482,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/schema.yaml
@@ -127,6 +127,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -156,6 +157,7 @@ properties:
             enum:
               - Mesh
               - MeshSubset
+              - MeshGatewaysSubset
               - MeshGateway
               - MeshService
               - MeshServiceSubset
@@ -285,6 +287,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/validator.go
@@ -21,6 +21,7 @@ func validateTop(targetRef common_api.TargetRef) validators.ValidationError {
 	supportedKinds := []common_api.TargetRefKind{
 		common_api.Mesh,
 		common_api.MeshSubset,
+		common_api.MeshGatewaysSubset,
 		common_api.MeshGateway,
 		common_api.MeshService,
 		common_api.MeshServiceSubset,

--- a/pkg/plugins/policies/meshratelimit/k8s/crd/kuma.io_meshratelimits.yaml
+++ b/pkg/plugins/policies/meshratelimit/k8s/crd/kuma.io_meshratelimits.yaml
@@ -172,6 +172,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -207,6 +208,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -357,6 +359,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/schema.yaml
@@ -23,6 +23,7 @@ properties:
             enum:
               - Mesh
               - MeshSubset
+              - MeshGatewaysSubset
               - MeshGateway
               - MeshService
               - MeshServiceSubset
@@ -293,6 +294,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/validator.go
@@ -26,6 +26,7 @@ func validateTop(targetRef common_api.TargetRef) validators.ValidationError {
 		SupportedKinds: []common_api.TargetRefKind{
 			common_api.Mesh,
 			common_api.MeshSubset,
+			common_api.MeshGatewaysSubset,
 			common_api.MeshGateway,
 			common_api.MeshService,
 			common_api.MeshServiceSubset,

--- a/pkg/plugins/policies/meshretry/k8s/crd/kuma.io_meshretries.yaml
+++ b/pkg/plugins/policies/meshretry/k8s/crd/kuma.io_meshretries.yaml
@@ -52,6 +52,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -413,6 +414,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/schema.yaml
@@ -23,6 +23,7 @@ properties:
             enum:
               - Mesh
               - MeshSubset
+              - MeshGatewaysSubset
               - MeshGateway
               - MeshService
               - MeshServiceSubset
@@ -60,6 +61,7 @@ properties:
                               enum:
                                 - Mesh
                                 - MeshSubset
+                                - MeshGatewaysSubset
                                 - MeshGateway
                                 - MeshService
                                 - MeshServiceSubset
@@ -99,6 +101,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset

--- a/pkg/plugins/policies/meshtcproute/k8s/crd/kuma.io_meshtcproutes.yaml
+++ b/pkg/plugins/policies/meshtcproute/k8s/crd/kuma.io_meshtcproutes.yaml
@@ -52,6 +52,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -96,6 +97,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGatewaysSubset
                                       - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
@@ -141,6 +143,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/schema.yaml
@@ -53,6 +53,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -82,6 +83,7 @@ properties:
             enum:
               - Mesh
               - MeshSubset
+              - MeshGatewaysSubset
               - MeshGateway
               - MeshService
               - MeshServiceSubset
@@ -137,6 +139,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/validator.go
@@ -23,6 +23,7 @@ func validateTop(targetRef common_api.TargetRef) validators.ValidationError {
 		SupportedKinds: []common_api.TargetRefKind{
 			common_api.Mesh,
 			common_api.MeshSubset,
+			common_api.MeshGatewaysSubset,
 			common_api.MeshGateway,
 			common_api.MeshService,
 			common_api.MeshServiceSubset,

--- a/pkg/plugins/policies/meshtimeout/k8s/crd/kuma.io_meshtimeouts.yaml
+++ b/pkg/plugins/policies/meshtimeout/k8s/crd/kuma.io_meshtimeouts.yaml
@@ -103,6 +103,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -138,6 +139,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -219,6 +221,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/schema.yaml
@@ -143,6 +143,7 @@ properties:
             enum:
               - Mesh
               - MeshSubset
+              - MeshGatewaysSubset
               - MeshGateway
               - MeshService
               - MeshServiceSubset

--- a/pkg/plugins/policies/meshtrace/k8s/crd/kuma.io_meshtraces.yaml
+++ b/pkg/plugins/policies/meshtrace/k8s/crd/kuma.io_meshtraces.yaml
@@ -205,6 +205,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset

--- a/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/schema.yaml
@@ -38,6 +38,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset
@@ -67,6 +68,7 @@ properties:
             enum:
               - Mesh
               - MeshSubset
+              - MeshGatewaysSubset
               - MeshGateway
               - MeshService
               - MeshServiceSubset

--- a/pkg/plugins/policies/meshtrafficpermission/k8s/crd/kuma.io_meshtrafficpermissions.yaml
+++ b/pkg/plugins/policies/meshtrafficpermission/k8s/crd/kuma.io_meshtrafficpermissions.yaml
@@ -70,6 +70,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGatewaysSubset
                           - MeshGateway
                           - MeshService
                           - MeshServiceSubset
@@ -105,6 +106,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGatewaysSubset
                     - MeshGateway
                     - MeshService
                     - MeshServiceSubset

--- a/test/e2e_env/universal/gateway/gateway.go
+++ b/test/e2e_env/universal/gateway/gateway.go
@@ -24,6 +24,7 @@ func Gateway() {
 	mesh := "gateway"
 
 	const gatewayPort = 8080
+	const gateway2Port = 8088
 
 	BeforeAll(func() {
 		setup := NewClusterSetup().
@@ -31,7 +32,9 @@ func Gateway() {
 			Install(GatewayClientAppUniversal("gateway-client")).
 			Install(echoServerApp(mesh, "echo-server", "echo-service", "universal")).
 			Install(GatewayProxyUniversal(mesh, "gateway-proxy")).
-			Install(YamlUniversal(MkGateway("edge-gateway", mesh, false, "example.kuma.io", "echo-service", gatewayPort)))
+			Install(YamlUniversal(MkGateway("gateway-proxy", mesh, false, "example.kuma.io", "echo-service", gatewayPort))).
+			Install(GatewayProxyUniversal(mesh, "second-gateway-proxy")).
+			Install(YamlUniversal(MkGateway("second-gateway-proxy", mesh, false, "test.kuma.io", "echo-service", gateway2Port)))
 
 		Expect(setup.Setup(universal.Cluster)).To(Succeed())
 	})
@@ -85,7 +88,7 @@ mesh: %s
 name: external-routes
 selectors:
 - match:
-    kuma.io/service: edge-gateway
+    kuma.io/service: gateway-proxy
 conf:
   http:
     rules:
@@ -125,10 +128,10 @@ networking:
 				universal.Cluster.Install(YamlUniversal(fmt.Sprintf(`
 type: ProxyTemplate
 mesh: %s
-name: edge-gateway
+name: gateway-proxy
 selectors:
   - match:
-      kuma.io/service: edge-gateway
+      kuma.io/service: gateway-proxy
 conf:
   imports:
     - gateway-proxy
@@ -153,7 +156,7 @@ mesh: %s
 name: echo-rate-limit
 sources:
 - match:
-    kuma.io/service: edge-gateway
+    kuma.io/service: gateway-proxy
 destinations:
 - match:
     kuma.io/service: echo-service
@@ -194,7 +197,7 @@ name: mesh-rate-limit-all-sources
 spec:
   targetRef:
     kind: MeshGateway
-    name: edge-gateway
+    name: gateway-proxy
   to:
     - targetRef:
         kind: Mesh
@@ -233,7 +236,12 @@ spec:
 	})
 
 	Context("when a MeshFaultInjection is configured", func() {
-		BeforeAll(func() {
+		E2EAfterEach(func() {
+			Expect(DeleteMeshResources(universal.Cluster, mesh, meshfaultinjection_api.MeshFaultInjectionResourceTypeDescriptor)).To(Succeed())
+		})
+
+		It("should return custom error code for all requests", func() {
+			// given
 			Expect(
 				universal.Cluster.Install(YamlUniversal(fmt.Sprintf(`
 type: MeshFaultInjection
@@ -242,7 +250,7 @@ name: mesh-fault-injection-all-sources
 spec:
   targetRef:
     kind: MeshGateway
-    name: edge-gateway
+    name: gateway-proxy
   to:
     - targetRef:
         kind: Mesh
@@ -252,12 +260,7 @@ spec:
               httpStatus: 421
               percentage: 100`, mesh))),
 			).To(Succeed())
-		})
-		AfterAll(func() {
-			Expect(DeleteMeshResources(universal.Cluster, mesh, meshfaultinjection_api.MeshFaultInjectionResourceTypeDescriptor)).To(Succeed())
-		})
 
-		It("should return custom error code for all requests", func() {
 			gatewayAddr := GatewayAddressPort("gateway-proxy", gatewayPort)
 			Logf("expecting 421 response from %q", gatewayAddr)
 			Eventually(func(g Gomega) {
@@ -271,6 +274,56 @@ spec:
 				g.Expect(response.ResponseCode).To(Equal(421))
 			}, "30s", "1s").Should(Succeed())
 		})
+
+		It("should return custom error code for all requests from both gateways", func() {
+			// given
+			Expect(
+				universal.Cluster.Install(YamlUniversal(fmt.Sprintf(`
+type: MeshFaultInjection
+mesh: "%s"
+name: mesh-fault-injection-all-sources-all-gateways
+spec:
+  targetRef:
+    kind: MeshGatewaysSubset
+  to:
+    - targetRef:
+        kind: Mesh
+      default:
+        http:
+          - abort:
+              httpStatus: 422
+              percentage: 100`, mesh))),
+			).To(Succeed())
+
+			// then
+			gatewayAddr := GatewayAddressPort("gateway-proxy", gatewayPort)
+			Logf("expecting 422 response from %q", gatewayAddr)
+			Eventually(func(g Gomega) {
+				target := fmt.Sprintf("http://%s/%s",
+					gatewayAddr, path.Join("test", url.PathEscape(GinkgoT().Name())),
+				)
+
+				response, err := client.CollectFailure(universal.Cluster, "gateway-client", target, client.WithHeader("Host", "example.kuma.io"))
+
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(response.ResponseCode).To(Equal(422))
+			}, "30s", "1s").Should(Succeed())
+
+			// and second gateway returns the same error
+			gatewayAddr = GatewayAddressPort("second-gateway-proxy", gateway2Port)
+			Logf("expecting 422 response from %q", gatewayAddr)
+			Eventually(func(g Gomega) {
+				target := fmt.Sprintf("http://%s/%s",
+					gatewayAddr, path.Join("test", url.PathEscape(GinkgoT().Name())),
+				)
+
+				response, err := client.CollectFailure(universal.Cluster, "gateway-client", target, client.WithHeader("Host", "test.kuma.io"))
+
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(response.ResponseCode).To(Equal(422))
+			}, "30s", "1s").Should(Succeed())
+		})
+
 	})
 
 	Context("when targeting a HTTPS gateway listener", func() {
@@ -295,10 +348,10 @@ data: %s
 				universal.Cluster.Install(YamlUniversal(fmt.Sprintf(`
 type: MeshGateway
 mesh: %s
-name: edge-gateway
+name: gateway-proxy
 selectors:
 - match:
-    kuma.io/service: edge-gateway
+    kuma.io/service: gateway-proxy
 conf:
   listeners:
   - port: 8080

--- a/test/e2e_env/universal/gateway/gateway.go
+++ b/test/e2e_env/universal/gateway/gateway.go
@@ -323,7 +323,6 @@ spec:
 				g.Expect(response.ResponseCode).To(Equal(422))
 			}, "30s", "1s").Should(Succeed())
 		})
-
 	})
 
 	Context("when targeting a HTTPS gateway listener", func() {

--- a/test/framework/gateway.go
+++ b/test/framework/gateway.go
@@ -4,7 +4,7 @@ import "fmt"
 
 func GatewayProxyUniversal(mesh, name string) InstallFunc {
 	return func(cluster Cluster) error {
-		token, err := cluster.GetKuma().GenerateDpToken(mesh, "edge-gateway")
+		token, err := cluster.GetKuma().GenerateDpToken(mesh, name)
 		if err != nil {
 			return err
 		}
@@ -18,8 +18,8 @@ networking:
   gateway:
     type: BUILTIN
     tags:
-      kuma.io/service: edge-gateway
-`, mesh)
+      kuma.io/service: %s
+`, mesh, name)
 		return cluster.DeployApp(
 			WithName(name),
 			WithMesh(mesh),


### PR DESCRIPTION
### Checklist prior to review

There was no way to target all gateways with the common configuration. Added new type `MeshGatewaysSubset` which allows pointing many gateways at once.

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
