### PR TITLE
chore(security): fix quoting in some format

### DIFF
--- a/app/kumactl/cmd/apply/apply_test.go
+++ b/app/kumactl/cmd/apply/apply_test.go
@@ -505,7 +505,7 @@ mesh: default
 networking:
   inbound: 0 # should be a string
 `,
-			err: `YAML contains invalid resource: invalid Dataplane object: 'error unmarshaling JSON: while decoding JSON: json: cannot unmarshal number into Go value of type []json.RawMessage'`,
+			err: `YAML contains invalid resource: invalid Dataplane object: "error unmarshaling JSON: while decoding JSON: json: cannot unmarshal number into Go value of type []json.RawMessage"`,
 		}),
 		Entry("no resource", testCase{
 			resource: ``,

--- a/pkg/api-server/testdata/resource_400onInvalidJson.golden.json
+++ b/pkg/api-server/testdata/resource_400onInvalidJson.golden.json
@@ -2,6 +2,6 @@
  "type": "/std-errors",
  "status": 400,
  "title": "Bad Request",
- "detail": "invalid TrafficRoute object: 'invalid character '}' looking for beginning of value'",
- "details": "invalid TrafficRoute object: 'invalid character '}' looking for beginning of value'"
+ "detail": "invalid TrafficRoute object: \"invalid character '}' looking for beginning of value\"",
+ "details": "invalid TrafficRoute object: \"invalid character '}' looking for beginning of value\""
 }

--- a/pkg/api-server/testdata/resource_400onInvalidMetaSchema.golden.json
+++ b/pkg/api-server/testdata/resource_400onInvalidMetaSchema.golden.json
@@ -2,6 +2,6 @@
  "type": "/std-errors",
  "status": 400,
  "title": "Bad Request",
- "detail": "invalid TrafficRoute object: 'json: cannot unmarshal number into Go struct field ResourceMeta.name of type string'",
- "details": "invalid TrafficRoute object: 'json: cannot unmarshal number into Go struct field ResourceMeta.name of type string'"
+ "detail": "invalid TrafficRoute object: \"json: cannot unmarshal number into Go struct field ResourceMeta.name of type string\"",
+ "details": "invalid TrafficRoute object: \"json: cannot unmarshal number into Go struct field ResourceMeta.name of type string\""
 }

--- a/pkg/api-server/testdata/resource_400onInvalidSpecSchema.golden.json
+++ b/pkg/api-server/testdata/resource_400onInvalidSpecSchema.golden.json
@@ -2,6 +2,6 @@
  "type": "/std-errors",
  "status": 400,
  "title": "Bad Request",
- "detail": "invalid TrafficRoute object: 'json: cannot unmarshal number into Go value of type string'",
- "details": "invalid TrafficRoute object: 'json: cannot unmarshal number into Go value of type string'"
+ "detail": "invalid TrafficRoute object: \"json: cannot unmarshal number into Go value of type string\"",
+ "details": "invalid TrafficRoute object: \"json: cannot unmarshal number into Go value of type string\""
 }

--- a/pkg/core/resources/apis/mesh/virtual_outbound_helpers.go
+++ b/pkg/core/resources/apis/mesh/virtual_outbound_helpers.go
@@ -30,11 +30,11 @@ func (t *VirtualOutboundResource) evalTemplate(tmplStr string, tags map[string]s
 	sb := strings.Builder{}
 	tmpl, err := template.New("").Parse(tmplStr)
 	if err != nil {
-		return "", fmt.Errorf("failed compiling gotemplate error='%s'", err.Error())
+		return "", fmt.Errorf("failed compiling gotemplate error=%q", err.Error())
 	}
 	err = tmpl.Execute(&sb, entries)
 	if err != nil {
-		return "", fmt.Errorf("pre evaluation of template with parameters failed with error='%s'", err.Error())
+		return "", fmt.Errorf("pre evaluation of template with parameters failed with error=%q", err.Error())
 	}
 	return sb.String(), nil
 }
@@ -46,10 +46,10 @@ func (t *VirtualOutboundResource) EvalPort(tags map[string]string) (uint32, erro
 	}
 	i, err := strconv.ParseInt(s, 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("evaluation of template with parameters didn't evaluate to a parsable number result='%s'", s)
+		return 0, fmt.Errorf("evaluation of template with parameters didn't evaluate to a parsable number result=%q", s)
 	}
 	if i <= 0 || i > 65535 {
-		return 0, fmt.Errorf("evaluation of template returned a port outside of the range [1..65535] result='%d'", i)
+		return 0, fmt.Errorf("evaluation of template returned a port outside of the range [1..65535] result=%d", i)
 	}
 	return uint32(i), nil
 }
@@ -60,7 +60,7 @@ func (t *VirtualOutboundResource) EvalHost(tags map[string]string) (string, erro
 		return "", err
 	}
 	if !govalidator.IsDNSName(s) {
-		return "", fmt.Errorf("evaluation of template with parameters didn't return a valid dns name result='%s'", s)
+		return "", fmt.Errorf("evaluation of template with parameters didn't return a valid dns name result=%q", s)
 	}
 	return s, nil
 }

--- a/pkg/core/resources/apis/mesh/virtual_outbound_helpers_test.go
+++ b/pkg/core/resources/apis/mesh/virtual_outbound_helpers_test.go
@@ -40,7 +40,7 @@ var _ = Describe("VirtualOutbound_Helpers", func() {
 				},
 			},
 			givenTags: map[string]string{"port": "hello"},
-			thenErr:   "evaluation of template with parameters didn't evaluate to a parsable number result='hello'",
+			thenErr:   `evaluation of template with parameters didn't evaluate to a parsable number result="hello"`,
 		}),
 		Entry("complex template", portTestCase{
 			in: &mesh_proto.VirtualOutbound_Conf{
@@ -61,7 +61,7 @@ var _ = Describe("VirtualOutbound_Helpers", func() {
 				},
 			},
 			givenTags: map[string]string{"port": "80000", "offset": "81"},
-			thenErr:   "a port outside of the range [1..65535] result='80000'",
+			thenErr:   "a port outside of the range [1..65535] result=80000",
 		}),
 	)
 
@@ -96,7 +96,7 @@ var _ = Describe("VirtualOutbound_Helpers", func() {
 				},
 			},
 			givenTags: map[string]string{"kuma.io/service": "foo()bar"},
-			thenErr:   "evaluation of template with parameters didn't return a valid dns name result='foo()bar'",
+			thenErr:   `evaluation of template with parameters didn't return a valid dns name result="foo()bar"`,
 		}),
 		Entry("simple eval", hostTestCase{
 			in: &mesh_proto.VirtualOutbound_Conf{

--- a/pkg/core/resources/apis/mesh/virtual_outbound_validator.go
+++ b/pkg/core/resources/apis/mesh/virtual_outbound_validator.go
@@ -83,7 +83,7 @@ func (t *VirtualOutboundResource) validateHost(path validators.PathBuilder) vali
 	}
 	_, lerr := t.EvalHost(fakeTags)
 	if lerr != nil {
-		err.AddViolationAt(path, fmt.Sprintf("template pre evaluation failed with error='%s'", lerr.Error()))
+		err.AddViolationAt(path, fmt.Sprintf("template pre evaluation failed with error=%q", lerr.Error()))
 	}
 	return err
 }
@@ -101,7 +101,7 @@ func (t *VirtualOutboundResource) validatePort(path validators.PathBuilder) vali
 	}
 	_, lerr := t.EvalPort(fakeTags)
 	if lerr != nil {
-		err.AddViolationAt(path, fmt.Sprintf("template pre evaluation failed with error='%s'", lerr.Error()))
+		err.AddViolationAt(path, fmt.Sprintf("template pre evaluation failed with error=%q", lerr.Error()))
 	}
 	return err
 }

--- a/pkg/core/resources/apis/mesh/virtual_outbound_validator_test.go
+++ b/pkg/core/resources/apis/mesh/virtual_outbound_validator_test.go
@@ -166,7 +166,7 @@ var _ = Describe("VirtualOutbound_validator", func() {
 			expected: `
                 violations:
                 - field: conf.host
-                  message: 'template pre evaluation failed with error=''failed compiling gotemplate error=''template: :1: function "mesh" not defined'''''
+                  message: 'template pre evaluation failed with error="failed compiling gotemplate error=\"template: :1: function \\\"mesh\\\" not defined\""'
 `,
 		}),
 		Entry("bad port template", testCase{
@@ -184,7 +184,7 @@ var _ = Describe("VirtualOutbound_validator", func() {
 			expected: `
                 violations:
                 - field: conf.port
-                  message: 'template pre evaluation failed with error=''failed compiling gotemplate error=''template: :1: function "port" not defined'''''
+                  message: 'template pre evaluation failed with error="failed compiling gotemplate error=\"template: :1: function \\\"port\\\" not defined\""'
 `,
 		}),
 		Entry("port is not a number template", testCase{
@@ -204,7 +204,7 @@ var _ = Describe("VirtualOutbound_validator", func() {
 			expected: `
                 violations:
                 - field: conf.port
-                  message: template pre evaluation failed with error='evaluation of template with parameters didn't evaluate to a parsable number result='1a''
+                  message: template pre evaluation failed with error="evaluation of template with parameters didn't evaluate to a parsable number result=\"1a\""
 `,
 		}),
 		Entry("parameter is not good tag", testCase{

--- a/pkg/core/resources/model/rest/unmarshaller.go
+++ b/pkg/core/resources/model/rest/unmarshaller.go
@@ -45,7 +45,7 @@ func (e *InvalidResourceError) Is(target error) bool {
 func (u *unmarshaler) UnmarshalCore(bytes []byte) (core_model.Resource, error) {
 	m := v1alpha1.ResourceMeta{}
 	if err := u.unmarshalFn(bytes, &m); err != nil {
-		return nil, &InvalidResourceError{Reason: fmt.Sprintf("invalid meta type: '%s'", err.Error())}
+		return nil, &InvalidResourceError{Reason: fmt.Sprintf("invalid meta type: %q", err.Error())}
 	}
 	desc, err := registry.Global().DescriptorFor(core_model.ResourceType(m.Type))
 	if err != nil {
@@ -70,7 +70,7 @@ func (u *unmarshaler) Unmarshal(bytes []byte, desc core_model.ResourceTypeDescri
 		rawObj := map[string]interface{}{}
 		// Unfortunately to validate new policies we must first unmarshal into a rawObj
 		if err := u.unmarshalFn(bytes, &rawObj); err != nil {
-			return nil, &InvalidResourceError{Reason: fmt.Sprintf("invalid %s object: '%s'", desc.Name, err.Error())}
+			return nil, &InvalidResourceError{Reason: fmt.Sprintf("invalid %s object: %q", desc.Name, err.Error())}
 		}
 		validator := validate.NewSchemaValidator(desc.Schema, nil, "", strfmt.Default)
 		res := validator.Validate(rawObj)
@@ -80,7 +80,7 @@ func (u *unmarshaler) Unmarshal(bytes []byte, desc core_model.ResourceTypeDescri
 	}
 
 	if err := u.unmarshalFn(bytes, restResource); err != nil {
-		return nil, &InvalidResourceError{Reason: fmt.Sprintf("invalid %s object: '%s'", desc.Name, err.Error())}
+		return nil, &InvalidResourceError{Reason: fmt.Sprintf("invalid %s object: %q", desc.Name, err.Error())}
 	}
 
 	if err := core_model.Validate(resource); err != nil {

--- a/pkg/plugins/policies/core/matchers/dataplane.go
+++ b/pkg/plugins/policies/core/matchers/dataplane.go
@@ -43,7 +43,7 @@ func MatchedPolicies(rType core_model.ResourceType, dpp *core_mesh.DataplaneReso
 		selectedInbounds, delegatedGatewaySelected, err := dppSelectedByPolicy(policy.GetMeta(), refPolicy.GetTargetRef(), dpp, gateway, resources)
 		if err != nil {
 			warnings = append(warnings,
-				fmt.Sprintf("unable to resolve TargetRef on policy: mesh:'%s' name:'%s' error:'%s'",
+				fmt.Sprintf("unable to resolve TargetRef on policy: mesh:%s name:%s error:%q",
 					policy.GetMeta().GetMesh(), policy.GetMeta().GetName(), err.Error(),
 				),
 			)

--- a/pkg/transparentproxy/iptables/builder/builder.go
+++ b/pkg/transparentproxy/iptables/builder/builder.go
@@ -174,7 +174,7 @@ func restoreIPTablesWithRetry(cfg config.Config, rulesFile *os.File, ipv6 bool) 
 		}
 
 		_, _ = cfg.RuntimeStderr.Write([]byte(fmt.Sprintf(
-			"# [%d/%d] %s returned error: '%s'",
+			"# [%d/%d] %s returned error: %q",
 			i+1,
 			maxRetries+1,
 			strings.Join(append([]string{cmdName}, params...), " "),

--- a/test/framework/k8s.go
+++ b/test/framework/k8s.go
@@ -136,7 +136,7 @@ func (e *K8sDecoratedError) Error() string {
 			details = string(b)
 		}
 	}
-	return fmt.Sprintf("sourceError: %s K8sDetails:'%s'", e.Err.Error(), details)
+	return fmt.Sprintf("sourceError: %s K8sDetails:%q", e.Err.Error(), details)
 }
 
 func ExtractDeploymentDetails(testingT testing.TestingT,


### PR DESCRIPTION
We were using `'%s'` is a few places, this can be a problem and a potential security issue.
Use `%q` which does the right escaping of `"`.

Fix #8830

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
