### PR TITLE
fix(kuma-cp): upgrade from Zone CP without labels to new one

### DIFF
--- a/pkg/kds/v2/client/zone_sync_test.go
+++ b/pkg/kds/v2/client/zone_sync_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Zone Delta Sync", func() {
 			core.Log.WithName("kds-sink"),
 			registry.Global().ObjectTypes(model.HasKDSFlag(model.GlobalToZoneSelector)),
 			client_v2.NewDeltaKDSStream(cs, zoneName, &runtimeInfo, ""),
-			sync_store_v2.ZoneSyncCallback(context.Background(), configs, resourceSyncer, false, nil, "kuma-system"), 0,
+			sync_store_v2.ZoneSyncCallback(context.Background(), configs, resourceSyncer, false, zoneName, nil, "kuma-system"), 0,
 		)
 	}
 	ingressFunc := func(zone string) *mesh_proto.ZoneIngress {

--- a/pkg/kds/v2/store/sync.go
+++ b/pkg/kds/v2/store/sync.go
@@ -276,7 +276,7 @@ func newIndexed(rs core_model.ResourceList) *indexed {
 	return &indexed{indexByResourceKey: idxByRk}
 }
 
-func ZoneSyncCallback(ctx context.Context, configToSync map[string]bool, syncer ResourceSyncer, k8sStore bool, kubeFactory resources_k8s.KubeFactory, systemNamespace string) *client_v2.Callbacks {
+func ZoneSyncCallback(ctx context.Context, configToSync map[string]bool, syncer ResourceSyncer, k8sStore bool, localZone string, kubeFactory resources_k8s.KubeFactory, systemNamespace string) *client_v2.Callbacks {
 	return &client_v2.Callbacks{
 		OnResourcesReceived: func(upstream client_v2.UpstreamResponse) error {
 			if k8sStore && upstream.Type != system.ConfigType && upstream.Type != system.SecretType && upstream.Type != system.GlobalSecretType {
@@ -302,6 +302,14 @@ func ZoneSyncCallback(ctx context.Context, configToSync map[string]bool, syncer 
 			}
 
 			return syncer.Sync(ctx, upstream, PrefilterBy(func(r core_model.Resource) bool {
+				if zi, ok := r.(*core_mesh.ZoneIngressResource); ok {
+					// Old zones don't have a 'kuma.io/zone' label on ZoneIngress, when upgrading to the new 2.6 version
+					// we don't want Zone CP to sync ZoneIngresses without 'kuma.io/zone' label to Global pretending
+					// they're originating here. That's why upgrade from 2.5 to 2.6 (and 2.7) requires casting resource
+					// to *core_mesh.ZoneIngressResource and checking its 'spec.zone' field.
+					// todo: remove in 2 releases after 2.6.x
+					return zi.IsRemoteIngress(localZone)
+				}
 				return !core_model.IsLocallyOriginated(config_core.Zone, r)
 			}))
 		},

--- a/pkg/kds/zone/components.go
+++ b/pkg/kds/zone/components.go
@@ -124,6 +124,7 @@ func Setup(rt core_runtime.Runtime) error {
 				rt.KDSContext().Configs,
 				resourceSyncerV2,
 				rt.Config().Store.Type == store.KubernetesStore,
+				zone,
 				kubeFactory,
 				rt.Config().Store.Kubernetes.SystemNamespace,
 			),

--- a/pkg/kds/zone/components_test.go
+++ b/pkg/kds/zone/components_test.go
@@ -243,7 +243,7 @@ var _ = Describe("Zone Sync", func() {
 				core.Log.WithName("kds-sink"),
 				registry.Global().ObjectTypes(model.HasKDSFlag(model.GlobalToZoneSelector)),
 				kds_client_v2.NewDeltaKDSStream(cs, zoneName, &runtimeInfo, ""),
-				sync_store_v2.ZoneSyncCallback(context.Background(), configs, resourceSyncer, false, nil, "kuma-system"),
+				sync_store_v2.ZoneSyncCallback(context.Background(), configs, resourceSyncer, false, zoneName, nil, "kuma-system"),
 				0,
 			)
 		}


### PR DESCRIPTION
Old zones don't have a `kuma.io/zone` label on ZoneIngress when upgrading to the new `master` we don't want Zone CP to sync ZoneIngresses without a `kuma.io/zone` label to Global pretending they're originating here. That's why upgrading from 2.5 to 2.6 (and 2.7) requires casting resources to `*core_mesh.ZoneIngressResource` and checking its `spec.zone` field.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
