### PR TITLE
chore(test): added test for MeshHTTPRoute, ExternalService and ZoneEgress

### DIFF
--- a/pkg/xds/generator/egress/generator_test.go
+++ b/pkg/xds/generator/egress/generator_test.go
@@ -216,5 +216,9 @@ var _ = Describe("EgressGenerator", func() {
 			fileWithResourcesName: "subsets-with-meshhttproute.yaml",
 			expected:              "subsets-with-meshhttproute.golden.yaml",
 		}),
+		Entry("subsets with MeshHTTPRoute, external", testCase{
+			fileWithResourcesName: "subsets-with-external-meshhttproute.yaml",
+			expected:              "subsets-with-external-meshhttproute.golden.yaml",
+		}),
 	)
 })

--- a/pkg/xds/generator/egress/testdata/input/subsets-with-external-meshhttproute.yaml
+++ b/pkg/xds/generator/egress/testdata/input/subsets-with-external-meshhttproute.yaml
@@ -1,0 +1,62 @@
+type: Mesh
+name: mesh-1
+mtls:
+  enabledBackend: ca-1
+  backends:
+    - name: ca-1
+      type: builtin
+---
+type: ZoneEgress
+name: zoneegress-1
+zone: zone-1
+networking:
+  address: 192.168.0.1
+  port: 10002
+---
+type: TrafficPermission
+name: allow-all-traffic
+mesh: mesh-1
+sources:
+  - match:
+      kuma.io/service: "*"
+destinations:
+  - match:
+      kuma.io/service: "*"
+---
+type: ExternalService
+name: externalservice-2
+mesh: mesh-1
+tags:
+  kuma.io/service: externalservice-2
+  kuma.io/protocol: http
+networking:
+  address: kuma.io:80
+---
+type: MeshHTTPRoute
+name: route-1
+mesh: mesh-1
+spec:
+  targetRef:
+    kind: MeshService
+    name: externalservice-1
+  to:
+    - targetRef:
+        kind: MeshService
+        name: externalservice-2
+      rules:
+        - matches:
+            - path:
+                value: /
+                type: PathPrefix
+          default:
+            backendRefs:
+              - kind: MeshServiceSubset
+                name: externalservice-2
+                weight: 1
+                tags:
+                  version: v1
+              - kind: MeshServiceSubset
+                name: externalservice-2
+                weight: 1
+                tags:
+                  version: v2

--- a/pkg/xds/generator/egress/testdata/subsets-with-external-meshhttproute.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/subsets-with-external-meshhttproute.golden.yaml
@@ -1,0 +1,246 @@
+resources:
+- name: externalservice-2
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    altStatName: mesh-1_externalservice-2
+    connectTimeout: 5s
+    dnsLookupFamily: V4_ONLY
+    loadAssignment:
+      clusterName: mesh-1:externalservice-2
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: kuma.io
+                portValue: 80
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+                mesh: mesh-1
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
+                mesh: mesh-1
+    name: mesh-1:externalservice-2
+    type: STRICT_DNS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          httpProtocolOptions: {}
+- name: inbound:192.168.0.1:10002
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.1
+        portValue: 10002
+    enableReusePort: false
+    filterChains:
+    - filterChainMatch:
+        serverNames:
+        - externalservice-2{mesh=mesh-1,version=v1}
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.rbac
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
+          rules:
+            policies:
+              allow-all-traffic:
+                permissions:
+                - any: true
+                principals:
+                - any: true
+          statPrefix: externalservice-2.
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          httpFilters:
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          routeConfig:
+            name: outbound:externalservice-2
+            validateClusters: false
+            virtualHosts:
+            - domains:
+              - '*'
+              name: externalservice-2
+              routes:
+              - match:
+                  prefix: /
+                route:
+                  autoHostRewrite: true
+                  cluster: mesh-1:externalservice-2
+                  timeout: 0s
+          statPrefix: externalservice-2
+      name: externalservice-2_mesh-1
+      transportSocket:
+        name: envoy.transport_sockets.tls
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          commonTlsContext:
+            combinedValidationContext:
+              defaultValidationContext:
+                matchTypedSubjectAltNames:
+                - matcher:
+                    prefix: spiffe://mesh-1/
+                  sanType: URI
+              validationContextSdsSecretConfig:
+                name: mesh_ca:secret:mesh-1
+                sdsConfig:
+                  ads: {}
+                  resourceApiVersion: V3
+            tlsCertificateSdsSecretConfigs:
+            - name: identity_cert:secret:mesh-1
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+          requireClientCertificate: true
+    - filterChainMatch:
+        serverNames:
+        - externalservice-2{mesh=mesh-1,version=v2}
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.rbac
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
+          rules:
+            policies:
+              allow-all-traffic:
+                permissions:
+                - any: true
+                principals:
+                - any: true
+          statPrefix: externalservice-2.
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          httpFilters:
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          routeConfig:
+            name: outbound:externalservice-2
+            validateClusters: false
+            virtualHosts:
+            - domains:
+              - '*'
+              name: externalservice-2
+              routes:
+              - match:
+                  prefix: /
+                route:
+                  autoHostRewrite: true
+                  cluster: mesh-1:externalservice-2
+                  timeout: 0s
+          statPrefix: externalservice-2
+      name: externalservice-2_mesh-1
+      transportSocket:
+        name: envoy.transport_sockets.tls
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          commonTlsContext:
+            combinedValidationContext:
+              defaultValidationContext:
+                matchTypedSubjectAltNames:
+                - matcher:
+                    prefix: spiffe://mesh-1/
+                  sanType: URI
+              validationContextSdsSecretConfig:
+                name: mesh_ca:secret:mesh-1
+                sdsConfig:
+                  ads: {}
+                  resourceApiVersion: V3
+            tlsCertificateSdsSecretConfigs:
+            - name: identity_cert:secret:mesh-1
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+          requireClientCertificate: true
+    - filterChainMatch:
+        serverNames:
+        - externalservice-2{mesh=mesh-1}
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.rbac
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
+          rules:
+            policies:
+              allow-all-traffic:
+                permissions:
+                - any: true
+                principals:
+                - any: true
+          statPrefix: externalservice-2.
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          httpFilters:
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          routeConfig:
+            name: outbound:externalservice-2
+            validateClusters: false
+            virtualHosts:
+            - domains:
+              - '*'
+              name: externalservice-2
+              routes:
+              - match:
+                  prefix: /
+                route:
+                  autoHostRewrite: true
+                  cluster: mesh-1:externalservice-2
+                  timeout: 0s
+          statPrefix: externalservice-2
+      name: externalservice-2_mesh-1
+      transportSocket:
+        name: envoy.transport_sockets.tls
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          commonTlsContext:
+            combinedValidationContext:
+              defaultValidationContext:
+                matchTypedSubjectAltNames:
+                - matcher:
+                    prefix: spiffe://mesh-1/
+                  sanType: URI
+              validationContextSdsSecretConfig:
+                name: mesh_ca:secret:mesh-1
+                sdsConfig:
+                  ads: {}
+                  resourceApiVersion: V3
+            tlsCertificateSdsSecretConfigs:
+            - name: identity_cert:secret:mesh-1
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+          requireClientCertificate: true
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: inbound:192.168.0.1:10002
+    trafficDirection: INBOUND
+- name: identity_cert:secret:mesh-1
+  resource:
+    '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
+    name: identity_cert:secret:mesh-1
+    tlsCertificate:
+      certificateChain:
+        inlineBytes: Q0VSVA==
+      privateKey:
+        inlineBytes: S0VZ
+- name: mesh_ca:secret:mesh-1
+  resource:
+    '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
+    name: mesh_ca:secret:mesh-1
+    validationContext:
+      trustedCa:
+        inlineBytes: Q0E=


### PR DESCRIPTION
### Checklist prior to review

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
