### PR TITLE
ci(install-dev-tools.sh): add debug logs

### DIFF
--- a/tools/dev/install-dev-tools.sh
+++ b/tools/dev/install-dev-tools.sh
@@ -32,6 +32,9 @@ for i in ${DYNAMIC_VERSION_FILES}; do
 done
 # use dev.mk to calculate the hash
 FILES+=" "${TOOLS_MAKEFILE}
+echo "::debug::Files used to calculate hash:"
+for i in ${FILES}; do echo "::debug::  ${i}"; done
 for i in ${FILES}; do cat "${i}"; done | git hash-object --stdin > "$TOOLS_DEPS_LOCK_FILE"
+echo "::debug::Calculated hash: $(cat "${TOOLS_DEPS_LOCK_FILE}")"
 
 echo "All non code dependencies installed, if you use these tools outside of make add $CI_TOOLS_BIN_DIR to your PATH"


### PR DESCRIPTION
These logs will be shown when debug logging is enabled during the github action run and might be helpful in debugging issues related to generating deps.lock file.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - No relevant issues
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - No tests
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - There is no need

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
