### PR TITLE
ci(go-deps): include `mk/dependencies/go-deps.versions` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 .vscode/
 
 .ci_tools/
-mk/dependencies/*.versions
 
 .tool-versions
 .run-full-matrix

--- a/mk/dependencies/go-deps.versions
+++ b/mk/dependencies/go-deps.versions
@@ -1,0 +1,12 @@
+
+google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.1
+google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1.0
+github.com/chrusty/protoc-gen-jsonschema/cmd/protoc-gen-jsonschema@v0.0.0-20230606235304-e35f2ad05c0c
+github.com/envoyproxy/protoc-gen-validate@v1.0.2
+github.com/kumahq/protoc-gen-kumadoc@v0.3.1
+github.com/onsi/ginkgo/v2/ginkgo@v2.14.0
+sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0
+github.com/mikefarah/yq/v4@v4.30.8
+github.com/norwoodj/helm-docs/cmd/helm-docs@v1.11.0
+golang.stackrox.io/kube-linter/cmd/kube-linter@v0.0.0-20220513142942-846f273ed465
+github.com/deepmap/oapi-codegen/cmd/oapi-codegen@v1.15.0


### PR DESCRIPTION
The `mk/dependencies/go-deps.versions` file is used to calculate the `mk/dependencies/deps.lock` hash. However, when calling `make dev/tools` from another project, the hash can vary depending on whether `make dev/tools` has been previously called in the kuma directory. This is because if it was, two `go-deps.versions` files are being used in hash.

To ensure consistent `mk/dependencies/deps.lock` hashes across projects, we have included the `mk/dependencies/go-deps.versions` file in the repository. This will allow `make dev/tools` to produce the same hash regardless of whether it is called from within the kuma directory or from another project.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - No relevant issues
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - No tests
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - There is no need

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
