### PR TITLE
test(MeshLoadBalancingStrategy): improve gateway case golden files

### DIFF
--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
@@ -1258,21 +1258,15 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 			plugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
 			Expect(plugin.Apply(generatedResources, xdsCtx, proxy)).To(Succeed())
 
-			getResourceYaml := func(list core_xds.ResourceList) []byte {
-				actualResource, err := util_proto.ToYAML(list[0].Resource)
-				Expect(err).ToNot(HaveOccurred())
-				return actualResource
-			}
-
 			// then
-			Expect(getResourceYaml(generatedResources.ListOf(envoy_resource.ClusterType))).
-				To(matchers.MatchGoldenYAML(filepath.Join("testdata", fmt.Sprintf("%s.gateway_cluster.golden.yaml", given.name))))
-			Expect(getResourceYaml(generatedResources.ListOf(envoy_resource.EndpointType))).
-				To(matchers.MatchGoldenYAML(filepath.Join("testdata", fmt.Sprintf("%s.gateway_endpoint.golden.yaml", given.name))))
-			Expect(getResourceYaml(generatedResources.ListOf(envoy_resource.ListenerType))).
-				To(matchers.MatchGoldenYAML(filepath.Join("testdata", fmt.Sprintf("%s.gateway_listener.golden.yaml", given.name))))
-			Expect(getResourceYaml(generatedResources.ListOf(envoy_resource.RouteType))).
-				To(matchers.MatchGoldenYAML(filepath.Join("testdata", fmt.Sprintf("%s.gateway_route.golden.yaml", given.name))))
+			Expect(getResource(generatedResources, envoy_resource.ClusterType)).
+				To(matchers.MatchGoldenYAML(filepath.Join("testdata", fmt.Sprintf("%s.gateway.clusters.golden.yaml", given.name))))
+			Expect(getResource(generatedResources, envoy_resource.EndpointType)).
+				To(matchers.MatchGoldenYAML(filepath.Join("testdata", fmt.Sprintf("%s.gateway.endpoints.golden.yaml", given.name))))
+			Expect(getResource(generatedResources, envoy_resource.ListenerType)).
+				To(matchers.MatchGoldenYAML(filepath.Join("testdata", fmt.Sprintf("%s.gateway.listeners.golden.yaml", given.name))))
+			Expect(getResource(generatedResources, envoy_resource.RouteType)).
+				To(matchers.MatchGoldenYAML(filepath.Join("testdata", fmt.Sprintf("%s.gateway.routes.golden.yaml", given.name))))
 		},
 		Entry("basic outbound cluster", gatewayTestCase{
 			name: "basic",

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/basic.gateway.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/basic.gateway.clusters.golden.yaml
@@ -1,0 +1,24 @@
+resources:
+- name: backend-d230d75c0fcb71dc
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+        resourceApiVersion: V3
+    lbPolicy: RING_HASH
+    name: backend-d230d75c0fcb71dc
+    perConnectionBufferLimitBytes: 32768
+    ringHashLbConfig:
+      hashFunction: MURMUR_HASH_2
+      maximumRingSize: "1000"
+      minimumRingSize: "100"
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        commonHttpProtocolOptions:
+          idleTimeout: 0s
+        explicitHttpConfig:
+          httpProtocolOptions: {}

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/basic.gateway.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/basic.gateway.endpoints.golden.yaml
@@ -1,0 +1,39 @@
+resources:
+- name: backend-d230d75c0fcb71dc
+  resource:
+    '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
+    clusterName: backend-d230d75c0fcb71dc
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.1.1
+              portValue: 8080
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              kuma.io/protocol: http
+              kuma.io/zone: test-zone
+            envoy.transport_socket_match:
+              kuma.io/protocol: http
+              kuma.io/zone: test-zone
+      locality:
+        zone: test-zone
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.1.2
+              portValue: 8080
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              kuma.io/protocol: http
+              kuma.io/zone: test-zone-2
+            envoy.transport_socket_match:
+              kuma.io/protocol: http
+              kuma.io/zone: test-zone-2
+      locality:
+        zone: test-zone-2
+      priority: 1

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/basic.gateway.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/basic.gateway.listeners.golden.yaml
@@ -1,0 +1,60 @@
+resources:
+- name: sample-gateway:HTTP:8080
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.1
+        portValue: 8080
+    enableReusePort: true
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          commonHttpProtocolOptions:
+            headersWithUnderscoresAction: REJECT_REQUEST
+            idleTimeout: 300s
+          http2ProtocolOptions:
+            allowConnect: true
+            initialConnectionWindowSize: 1048576
+            initialStreamWindowSize: 65536
+            maxConcurrentStreams: 100
+          httpFilters:
+          - name: envoy.filters.http.local_ratelimit
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              statPrefix: rate_limit
+          - name: gzip-compress
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+              compressorLibrary:
+                name: gzip
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+              responseDirectionConfig:
+                disableOnEtagHeader: true
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+              startChildSpan: true
+          mergeSlashes: true
+          normalizePath: true
+          pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
+          rds:
+            configSource:
+              ads: {}
+              resourceApiVersion: V3
+            routeConfigName: sample-gateway:HTTP:8080
+          requestHeadersTimeout: 0.500s
+          serverName: Kuma Gateway
+          statPrefix: sample-gateway
+          streamIdleTimeout: 5s
+          useRemoteAddress: true
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: sample-gateway:HTTP:8080
+    perConnectionBufferLimitBytes: 32768
+    trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/basic.gateway.routes.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/basic.gateway.routes.golden.yaml
@@ -1,0 +1,33 @@
+resources:
+- name: sample-gateway:HTTP:8080
+  resource:
+    '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+    ignorePortInHostMatching: true
+    name: sample-gateway:HTTP:8080
+    requestHeadersToRemove:
+    - x-kuma-tags
+    validateClusters: false
+    virtualHosts:
+    - domains:
+      - '*'
+      name: '*'
+      routes:
+      - match:
+          path: /
+        route:
+          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+          hashPolicy:
+          - queryParameter:
+              name: queryparam
+            terminal: true
+          - connectionProperties:
+              sourceIp: true
+          idleTimeout: 5s
+          weightedClusters:
+            clusters:
+            - name: backend-d230d75c0fcb71dc
+              requestHeadersToAdd:
+              - header:
+                  key: x-kuma-tags
+                  value: '&k8s.io/az=test&&k8s.io/node=node1&&k8s.io/region=test&&kuma.io/service=sample-gateway&'
+              weight: 1

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware.gateway.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware.gateway.clusters.golden.yaml
@@ -1,0 +1,21 @@
+resources:
+- name: backend-d230d75c0fcb71dc
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    commonLbConfig:
+      localityWeightedLbConfig: {}
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+        resourceApiVersion: V3
+    name: backend-d230d75c0fcb71dc
+    perConnectionBufferLimitBytes: 32768
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        commonHttpProtocolOptions:
+          idleTimeout: 0s
+        explicitHttpConfig:
+          httpProtocolOptions: {}

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware.gateway.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware.gateway.endpoints.golden.yaml
@@ -1,0 +1,121 @@
+resources:
+- name: backend-d230d75c0fcb71dc
+  resource:
+    '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
+    clusterName: backend-d230d75c0fcb71dc
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.1.2
+              portValue: 8080
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              k8s.io/node: node2
+              kuma.io/protocol: http
+              kuma.io/zone: test-zone
+            envoy.transport_socket_match:
+              k8s.io/node: node2
+              kuma.io/protocol: http
+              kuma.io/zone: test-zone
+      loadBalancingWeight: 1
+      locality:
+        zone: test-zone
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.1.3
+              portValue: 8080
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              k8s.io/az: test
+              kuma.io/protocol: http
+              kuma.io/zone: test-zone
+            envoy.transport_socket_match:
+              k8s.io/az: test
+              kuma.io/protocol: http
+              kuma.io/zone: test-zone
+      loadBalancingWeight: 900
+      locality:
+        subZone: k8s.io/az=test
+        zone: test-zone
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.1.1
+              portValue: 8080
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              k8s.io/node: node1
+              kuma.io/protocol: http
+              kuma.io/zone: test-zone
+            envoy.transport_socket_match:
+              k8s.io/node: node1
+              kuma.io/protocol: http
+              kuma.io/zone: test-zone
+      loadBalancingWeight: 9000
+      locality:
+        subZone: k8s.io/node=node1
+        zone: test-zone
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.1.4
+              portValue: 8080
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              k8s.io/region: test
+              kuma.io/protocol: http
+              kuma.io/zone: test-zone
+            envoy.transport_socket_match:
+              k8s.io/region: test
+              kuma.io/protocol: http
+              kuma.io/zone: test-zone
+      loadBalancingWeight: 90
+      locality:
+        subZone: k8s.io/region=test
+        zone: test-zone
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.1.5
+              portValue: 8080
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              kuma.io/protocol: http
+              kuma.io/zone: zone-2
+            envoy.transport_socket_match:
+              kuma.io/protocol: http
+              kuma.io/zone: zone-2
+      locality:
+        zone: zone-2
+      priority: 1
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.1.7
+              portValue: 8080
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              kuma.io/protocol: http
+              kuma.io/zone: zone-4
+            envoy.transport_socket_match:
+              kuma.io/protocol: http
+              kuma.io/zone: zone-4
+      locality:
+        zone: zone-4
+      priority: 3
+    policy:
+      overprovisioningFactor: 200

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware.gateway.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware.gateway.listeners.golden.yaml
@@ -1,0 +1,60 @@
+resources:
+- name: sample-gateway:HTTP:8080
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.1
+        portValue: 8080
+    enableReusePort: true
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          commonHttpProtocolOptions:
+            headersWithUnderscoresAction: REJECT_REQUEST
+            idleTimeout: 300s
+          http2ProtocolOptions:
+            allowConnect: true
+            initialConnectionWindowSize: 1048576
+            initialStreamWindowSize: 65536
+            maxConcurrentStreams: 100
+          httpFilters:
+          - name: envoy.filters.http.local_ratelimit
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              statPrefix: rate_limit
+          - name: gzip-compress
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+              compressorLibrary:
+                name: gzip
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+              responseDirectionConfig:
+                disableOnEtagHeader: true
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+              startChildSpan: true
+          mergeSlashes: true
+          normalizePath: true
+          pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
+          rds:
+            configSource:
+              ads: {}
+              resourceApiVersion: V3
+            routeConfigName: sample-gateway:HTTP:8080
+          requestHeadersTimeout: 0.500s
+          serverName: Kuma Gateway
+          statPrefix: sample-gateway
+          streamIdleTimeout: 5s
+          useRemoteAddress: true
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: sample-gateway:HTTP:8080
+    perConnectionBufferLimitBytes: 32768
+    trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware.gateway.routes.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware.gateway.routes.golden.yaml
@@ -1,0 +1,27 @@
+resources:
+- name: sample-gateway:HTTP:8080
+  resource:
+    '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+    ignorePortInHostMatching: true
+    name: sample-gateway:HTTP:8080
+    requestHeadersToRemove:
+    - x-kuma-tags
+    validateClusters: false
+    virtualHosts:
+    - domains:
+      - '*'
+      name: '*'
+      routes:
+      - match:
+          path: /
+        route:
+          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+          idleTimeout: 5s
+          weightedClusters:
+            clusters:
+            - name: backend-d230d75c0fcb71dc
+              requestHeadersToAdd:
+              - header:
+                  key: x-kuma-tags
+                  value: '&k8s.io/az=test&&k8s.io/node=node1&&k8s.io/region=test&&kuma.io/service=sample-gateway&'
+              weight: 1


### PR DESCRIPTION
We were somewhat unnecessarily only taking the first resource of the given type.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
