### PR TITLE
feat(meshmetrics): rename used only to include unused 

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -2559,9 +2559,9 @@ spec:
                       usedOnly:
                         default: false
                         description: |-
-                          UsedOnly will scrape only metrics that has been by sidecar (counters incremented
+                          IncludeUnused if false will scrape only metrics that has been by sidecar (counters incremented
                           at least once, gauges changed at least once, and histograms added to at
-                          least once).
+                          least once). If true will scrape all metrics (even the ones with zeros).
                         type: boolean
                     type: object
                 type: object

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
@@ -2559,9 +2559,9 @@ spec:
                       usedOnly:
                         default: false
                         description: |-
-                          UsedOnly will scrape only metrics that has been by sidecar (counters incremented
+                          IncludeUnused if false will scrape only metrics that has been by sidecar (counters incremented
                           at least once, gauges changed at least once, and histograms added to at
-                          least once).
+                          least once). If true will scrape all metrics (even the ones with zeros).
                         type: boolean
                     type: object
                 type: object

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -2782,9 +2782,9 @@ spec:
                       usedOnly:
                         default: false
                         description: |-
-                          UsedOnly will scrape only metrics that has been by sidecar (counters incremented
+                          IncludeUnused if false will scrape only metrics that has been by sidecar (counters incremented
                           at least once, gauges changed at least once, and histograms added to at
-                          least once).
+                          least once). If true will scrape all metrics (even the ones with zeros).
                         type: boolean
                     type: object
                 type: object

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -2579,9 +2579,9 @@ spec:
                       usedOnly:
                         default: false
                         description: |-
-                          UsedOnly will scrape only metrics that has been by sidecar (counters incremented
+                          IncludeUnused if false will scrape only metrics that has been by sidecar (counters incremented
                           at least once, gauges changed at least once, and histograms added to at
-                          least once).
+                          least once). If true will scrape all metrics (even the ones with zeros).
                         type: boolean
                     type: object
                 type: object

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -3967,9 +3967,9 @@ spec:
                       usedOnly:
                         default: false
                         description: |-
-                          UsedOnly will scrape only metrics that has been by sidecar (counters incremented
+                          IncludeUnused if false will scrape only metrics that has been by sidecar (counters incremented
                           at least once, gauges changed at least once, and histograms added to at
-                          least once).
+                          least once). If true will scrape all metrics (even the ones with zeros).
                         type: boolean
                     type: object
                 type: object

--- a/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
@@ -4190,9 +4190,9 @@ spec:
                       usedOnly:
                         default: false
                         description: |-
-                          UsedOnly will scrape only metrics that has been by sidecar (counters incremented
+                          IncludeUnused if false will scrape only metrics that has been by sidecar (counters incremented
                           at least once, gauges changed at least once, and histograms added to at
-                          least once).
+                          least once). If true will scrape all metrics (even the ones with zeros).
                         type: boolean
                     type: object
                 type: object

--- a/deployments/charts/kuma/crds/kuma.io_meshmetrics.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshmetrics.yaml
@@ -143,9 +143,9 @@ spec:
                       usedOnly:
                         default: false
                         description: |-
-                          UsedOnly will scrape only metrics that has been by sidecar (counters incremented
+                          IncludeUnused if false will scrape only metrics that has been by sidecar (counters incremented
                           at least once, gauges changed at least once, and histograms added to at
-                          least once).
+                          least once). If true will scrape all metrics (even the ones with zeros).
                         type: boolean
                     type: object
                 type: object

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -5452,13 +5452,14 @@ components:
                     usedOnly:
                       default: false
                       description: >-
-                        UsedOnly will scrape only metrics that has been by
-                        sidecar (counters incremented
+                        IncludeUnused if false will scrape only metrics that has
+                        been by sidecar (counters incremented
 
                         at least once, gauges changed at least once, and
                         histograms added to at
 
-                        least once).
+                        least once). If true will scrape all metrics (even the
+                        ones with zeros).
                       type: boolean
                   type: object
               type: object

--- a/docs/generated/raw/crds/kuma.io_meshmetrics.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshmetrics.yaml
@@ -143,9 +143,9 @@ spec:
                       usedOnly:
                         default: false
                         description: |-
-                          UsedOnly will scrape only metrics that has been by sidecar (counters incremented
+                          IncludeUnused if false will scrape only metrics that has been by sidecar (counters incremented
                           at least once, gauges changed at least once, and histograms added to at
-                          least once).
+                          least once). If true will scrape all metrics (even the ones with zeros).
                         type: boolean
                     type: object
                 type: object

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/meshmetric.go
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/meshmetric.go
@@ -27,11 +27,11 @@ type Conf struct {
 type Sidecar struct {
 	// Regex that will be used to filter sidecar metrics. It uses Google RE2 engine https://github.com/google/re2
 	Regex *string `json:"regex,omitempty"`
-	// UsedOnly will scrape only metrics that has been by sidecar (counters incremented
+	// IncludeUnused if false will scrape only metrics that has been by sidecar (counters incremented
 	// at least once, gauges changed at least once, and histograms added to at
-	// least once).
+	// least once). If true will scrape all metrics (even the ones with zeros).
 	// +kubebuilder:default=false
-	UsedOnly *bool `json:"usedOnly,omitempty"`
+	IncludeUnused *bool `json:"usedOnly,omitempty"`
 }
 
 type Application struct {

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/schema.yaml
@@ -102,9 +102,9 @@ properties:
               usedOnly:
                 default: false
                 description: |-
-                  UsedOnly will scrape only metrics that has been by sidecar (counters incremented
+                  IncludeUnused if false will scrape only metrics that has been by sidecar (counters incremented
                   at least once, gauges changed at least once, and histograms added to at
-                  least once).
+                  least once). If true will scrape all metrics (even the ones with zeros).
                 type: boolean
             type: object
         type: object

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/zz_generated.deepcopy.go
@@ -178,8 +178,8 @@ func (in *Sidecar) DeepCopyInto(out *Sidecar) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.UsedOnly != nil {
-		in, out := &in.UsedOnly, &out.UsedOnly
+	if in.IncludeUnused != nil {
+		in, out := &in.IncludeUnused, &out.IncludeUnused
 		*out = new(bool)
 		**out = **in
 	}

--- a/pkg/plugins/policies/meshmetric/k8s/crd/kuma.io_meshmetrics.yaml
+++ b/pkg/plugins/policies/meshmetric/k8s/crd/kuma.io_meshmetrics.yaml
@@ -143,9 +143,9 @@ spec:
                       usedOnly:
                         default: false
                         description: |-
-                          UsedOnly will scrape only metrics that has been by sidecar (counters incremented
+                          IncludeUnused if false will scrape only metrics that has been by sidecar (counters incremented
                           at least once, gauges changed at least once, and histograms added to at
-                          least once).
+                          least once). If true will scrape all metrics (even the ones with zeros).
                         type: boolean
                     type: object
                 type: object

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin.go
@@ -134,7 +134,7 @@ func configureDynamicDPPConfig(rs *core_xds.ResourceSet, proxy *core_xds.Proxy, 
 
 func envoyMetricsFilter(conf api.Conf) string {
 	if conf.Sidecar == nil {
-		return ""
+		return "?usedonly" // as the default for IncludeUnused is false
 	}
 	var query string
 	if pointer.Deref(conf.Sidecar.Regex) != "" {

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin.go
@@ -143,7 +143,7 @@ func envoyMetricsFilter(conf api.Conf) string {
 	if query != "" {
 		query += "&"
 	}
-	if pointer.Deref(conf.Sidecar.UsedOnly) {
+	if !pointer.Deref(conf.Sidecar.IncludeUnused) {
 		query += "usedonly"
 	}
 	if query != "" {

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin_test.go
@@ -63,8 +63,8 @@ var _ = Describe("MeshMetric", func() {
 								Subset: []core_rules.Tag{},
 								Conf: api.Conf{
 									Sidecar: &api.Sidecar{
-										Regex:    pointer.To("http.*"),
-										UsedOnly: pointer.To(true),
+										Regex:         pointer.To("http.*"),
+										IncludeUnused: pointer.To(false),
 									},
 									Applications: &[]api.Application{
 										{

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/default.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/default.clusters.golden.yaml
@@ -1,0 +1,16 @@
+resources:
+- name: _kuma:metrics:hijacker
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    altStatName: _kuma_metrics_hijacker
+    connectTimeout: 5s
+    loadAssignment:
+      clusterName: _kuma:metrics:hijacker
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              pipe:
+                path: /tmp/kuma-metrics-backend-default.sock
+    name: _kuma:metrics:hijacker
+    type: STATIC

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/default.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/default.listeners.golden.yaml
@@ -22,7 +22,7 @@ resources:
               routes:
               - directResponse:
                   body:
-                    inlineString: '{"observability":{"metrics":{"applications":null,"backends":[{"type":"Prometheus"}]}}}'
+                    inlineString: '{"observability":{"metrics":{"applications":[{"path":"/metrics","port":8080,"address":""}],"backends":[{"type":"Prometheus"}]}}}'
                   status: 200
                 match:
                   prefix: /
@@ -37,29 +37,6 @@ resources:
         portValue: 5670
     enableReusePort: false
     filterChains:
-    - filterChainMatch:
-        transportProtocol: tls
-      filters:
-      - name: envoy.filters.network.http_connection_manager
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-          httpFilters:
-          - name: envoy.filters.http.router
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-          routeConfig:
-            validateClusters: false
-            virtualHosts:
-            - domains:
-              - '*'
-              name: _kuma:metrics:prometheus
-              routes:
-              - match:
-                  prefix: /metrics
-                route:
-                  cluster: _kuma:metrics:hijacker
-                  prefixRewrite: /?usedonly
-          statPrefix: _kuma_metrics_prometheus
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typedConfig:
@@ -81,15 +58,5 @@ resources:
                   cluster: _kuma:metrics:hijacker
                   prefixRewrite: /?usedonly
           statPrefix: _kuma_metrics_prometheus
-      transportSocket:
-        name: envoy.transport_sockets.tls
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
-          commonTlsContext:
-            tlsCertificates:
-            - certificateChain:
-                filename: /path/cert
-              privateKey:
-                filename: /path/key
     name: _kuma:metrics:prometheus
     trafficDirection: INBOUND


### PR DESCRIPTION
rename used only to include unused and revert the logic

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues -- reported via slack
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
