### PR TITLE
fix(meshaccesslog): add back `from` support for gateways

### DIFF
--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.golden.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.golden.yaml
@@ -1,3 +1,43 @@
+FromRules:
+  127.0.0.1:8080:
+  - Conf:
+      backends:
+      - file:
+          path: /from-gateway
+        type: File
+    Origin:
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: gateway
+      type: MeshAccessLog
+    Subset: []
+  127.0.0.1:8081:
+  - Conf:
+      backends:
+      - file:
+          path: /from-gateway
+        type: File
+    Origin:
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: gateway
+      type: MeshAccessLog
+    Subset: []
+  127.0.0.1:8082:
+  - Conf:
+      backends:
+      - file:
+          path: /from-gateway
+        type: File
+    Origin:
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: gateway
+      type: MeshAccessLog
+    Subset: []
 SingleItemRules:
   127.0.0.1:8080:
     Rules: null
@@ -56,7 +96,7 @@ ToRules:
   - Conf:
       backends:
       - file:
-          path: /gateway
+          path: /to-gateway
         type: File
     Origin:
     - creationTime: "0001-01-01T00:00:00Z"

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.policies.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.policies.yaml
@@ -39,6 +39,14 @@ spec:
  targetRef:
   kind: MeshGateway
   name: gateway-1
+ from:
+  - targetRef:
+     kind: Mesh
+    default:
+      backends:
+        - type: File
+          file:
+            path: /from-gateway
  to:
   - targetRef:
      kind: Mesh
@@ -46,7 +54,7 @@ spec:
       backends:
         - type: File
           file:
-            path: /gateway
+            path: /to-gateway
 ---
 type: MeshAccessLog
 mesh: mesh-1

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
@@ -998,6 +998,20 @@ var _ = Describe("MeshAccessLog", func() {
 					Build(),
 			},
 			rules: core_rules.GatewayRules{
+				FromRules: map[core_rules.InboundListener]core_rules.Rules{
+					{Address: "127.0.0.1", Port: 8080}: {
+						{
+							Subset: core_rules.Subset{},
+							Conf: api.Conf{
+								Backends: &[]api.Backend{{
+									File: &api.FileBackend{
+										Path: "/tmp/from-log",
+									},
+								}},
+							},
+						},
+					},
+				},
 				ToRules: map[core_rules.InboundListener]core_rules.Rules{
 					{Address: "127.0.0.1", Port: 8080}: {
 						{
@@ -1005,7 +1019,7 @@ var _ = Describe("MeshAccessLog", func() {
 							Conf: api.Conf{
 								Backends: &[]api.Backend{{
 									File: &api.FileBackend{
-										Path: "/tmp/log",
+										Path: "/tmp/to-log",
 									},
 								}},
 							},

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic-gateway.gateway.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic-gateway.gateway.listener.golden.yaml
@@ -16,7 +16,15 @@ filterChains:
             textFormatSource:
               inlineString: |
                 [%START_TIME%] default "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-B3-TRACEID?X-DATADOG-TRACEID)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "gateway" "*" "127.0.0.1" "%UPSTREAM_HOST%"
-          path: /tmp/log
+          path: /tmp/to-log
+      - name: envoy.access_loggers.file
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+          logFormat:
+            textFormatSource:
+              inlineString: |
+                [%START_TIME%] default "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-B3-TRACEID?X-DATADOG-TRACEID)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "unknown" "gateway" "127.0.0.1" "%UPSTREAM_HOST%"
+          path: /tmp/from-log
       commonHttpProtocolOptions:
         headersWithUnderscoresAction: REJECT_REQUEST
         idleTimeout: 300s


### PR DESCRIPTION
This was introduced when implementing #8549

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- Fixes https://github.com/kumahq/kuma/issues/8875
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
