### PR TITLE
feat(metrics): add create conflicts to the metric

### DIFF
--- a/pkg/metrics/store/store_test.go
+++ b/pkg/metrics/store/store_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Metered Store", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("should public metrics of GET", func() {
+	It("should public metrics of Get", func() {
 		// when
 		err := store.Get(context.Background(), core_mesh.NewMeshResource(), core_store.GetByKey(model.DefaultMesh, model.NoMesh))
 
@@ -41,7 +41,7 @@ var _ = Describe("Metered Store", func() {
 		Expect(test_metrics.FindMetric(metrics, "store", "operation", "get", "resource_type", "Mesh").GetHistogram().GetSampleCount()).To(Equal(uint64(1)))
 	})
 
-	It("should public metrics of LIST", func() {
+	It("should public metrics of List", func() {
 		// when
 		err := store.List(context.Background(), &core_mesh.MeshResourceList{}, core_store.ListByMesh(model.DefaultMesh))
 
@@ -50,7 +50,7 @@ var _ = Describe("Metered Store", func() {
 		Expect(test_metrics.FindMetric(metrics, "store", "operation", "list", "resource_type", "Mesh").GetHistogram().GetSampleCount()).To(Equal(uint64(1)))
 	})
 
-	It("should public metrics of DELETE", func() {
+	It("should public metrics of Delete", func() {
 		// when
 		err := store.Delete(context.Background(), core_mesh.NewMeshResource(), core_store.DeleteByKey(model.DefaultMesh, model.NoMesh))
 
@@ -59,7 +59,7 @@ var _ = Describe("Metered Store", func() {
 		Expect(test_metrics.FindMetric(metrics, "store", "operation", "delete", "resource_type", "Mesh").GetHistogram().GetSampleCount()).To(Equal(uint64(1)))
 	})
 
-	It("should public metrics of UPDATE", func() {
+	It("should public metrics of Update", func() {
 		// when
 		mesh := core_mesh.NewMeshResource()
 		err := store.Get(context.Background(), mesh, core_store.GetByKey(model.DefaultMesh, model.NoMesh))
@@ -74,7 +74,7 @@ var _ = Describe("Metered Store", func() {
 		Expect(test_metrics.FindMetric(metrics, "store", "operation", "update", "resource_type", "Mesh").GetHistogram().GetSampleCount()).To(Equal(uint64(1)))
 	})
 
-	It("should public metrics of UPDATE conflict", func() {
+	It("should public metrics of Update conflict", func() {
 		// when
 		mesh := core_mesh.NewMeshResource()
 		anotherMesh := core_mesh.NewMeshResource()
@@ -87,6 +87,15 @@ var _ = Describe("Metered Store", func() {
 		err = store.Update(context.Background(), mesh)
 		Expect(err).ToNot(HaveOccurred())
 		err = store.Update(context.Background(), anotherMesh)
+
+		// then
+		Expect(err).To(MatchError(&core_store.ResourceConflictError{}))
+		Expect(test_metrics.FindMetric(metrics, "store_conflicts", "resource_type", "Mesh").GetCounter().GetValue()).To(Equal(1.0))
+	})
+
+	It("should public metrics of Create conflict", func() {
+		// when
+		err := store.Create(context.Background(), core_mesh.NewMeshResource(), core_store.CreateByKey(model.DefaultMesh, model.NoMesh))
 
 		// then
 		Expect(err).To(MatchError(&core_store.ResourceConflictError{}))


### PR DESCRIPTION
### Checklist prior to review

Resource Already Exist is considered conflict therefore we should add this to the existing metric.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
