### PR TITLE
chore(kuma-cp): improve docs around KDS client-id/peerID

### DIFF
--- a/pkg/kds/mux/server.go
+++ b/pkg/kds/mux/server.go
@@ -174,11 +174,11 @@ func (s *server) Start(stop <-chan struct{}) error {
 
 // StreamMessage handle Mux messages for KDS V1. It's not used in KDS V2
 func (s *server) StreamMessage(stream mesh_proto.MultiplexService_StreamMessageServer) error {
-	clientID, err := util.ClientIDFromIncomingCtx(stream.Context())
+	zoneID, err := util.ClientIDFromIncomingCtx(stream.Context())
 	if err != nil {
 		return err
 	}
-	log := muxServerLog.WithValues("client-id", clientID)
+	log := muxServerLog.WithValues("client-id", zoneID)
 	log.Info("initializing Kuma Discovery Service (KDS) stream for global-zone sync of resources")
 	// The buffer size should be of a size of all inflight request, so we never write to a blocked buffer.
 	// The buffer is separate for each direction (send/receive) on each multiplexed stream (global acting as server/global acting as client)
@@ -187,7 +187,7 @@ func (s *server) StreamMessage(stream mesh_proto.MultiplexService_StreamMessageS
 	// Therefore the maximum number of inflight requests are number of synced resources.
 	// For the simplicity we just take all resources available in Kuma (.
 	bufferSize := len(registry.Global().ObjectTypes())
-	session := NewSession(clientID, stream, uint32(bufferSize), s.config.MsgSendTimeout.Duration)
+	session := NewSession(zoneID, stream, uint32(bufferSize), s.config.MsgSendTimeout.Duration)
 	for _, filter := range s.filters {
 		if err := filter.InterceptSession(session); err != nil {
 			log.Error(err, "closing KDS stream following a callback error")

--- a/pkg/kds/mux/session.go
+++ b/pkg/kds/mux/session.go
@@ -14,6 +14,7 @@ import (
 type Session interface {
 	ServerStream() mesh_proto.KumaDiscoveryService_StreamKumaResourcesServer
 	ClientStream() mesh_proto.KumaDiscoveryService_StreamKumaResourcesClient
+	// PeerID is also known as the client id.
 	PeerID() string
 	Error() <-chan error
 	SetError(err error)

--- a/pkg/kds/util/client_id.go
+++ b/pkg/kds/util/client_id.go
@@ -22,7 +22,7 @@ func metadataFromIncomingCtx(ctx context.Context, key string) (string, error) {
 		return "", errors.New("metadata is not provided")
 	}
 	if len(md[key]) == 0 {
-		return "", errors.New(fmt.Sprintf("'%s' is not present in metadata", clientIDKey))
+		return "", errors.New(fmt.Sprintf("%q is not present in metadata", key))
 	}
 	return md[key][0], nil
 }

--- a/pkg/kds/util/client_id.go
+++ b/pkg/kds/util/client_id.go
@@ -2,22 +2,27 @@ package util
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/metadata"
 )
 
+const clientIDKey = "client-id"
+
+// ClientIDFromIncomingCtx returns the ID of the peer. Global has the ID
+// "global" while zones have the zone name. This is also known as the peer ID.
 func ClientIDFromIncomingCtx(ctx context.Context) (string, error) {
-	return MetadataFromIncomingCtx(ctx, "client-id")
+	return metadataFromIncomingCtx(ctx, clientIDKey)
 }
 
-func MetadataFromIncomingCtx(ctx context.Context, key string) (string, error) {
+func metadataFromIncomingCtx(ctx context.Context, key string) (string, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		return "", errors.New("metadata is not provided")
 	}
 	if len(md[key]) == 0 {
-		return "", errors.New("'client-id' is not present in metadata")
+		return "", errors.New(fmt.Sprintf("'%s' is not present in metadata", clientIDKey))
 	}
 	return md[key][0], nil
 }


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
