### PR TITLE
chore(kuma-cp): introduce helper type for semantics

### DIFF
--- a/pkg/envoy/admin/kds_client.go
+++ b/pkg/envoy/admin/kds_client.go
@@ -38,9 +38,9 @@ func (k *kdsEnvoyAdminClient) ConfigDump(ctx context.Context, proxy core_model.R
 	zone := core_model.ZoneOfResource(proxy)
 	nameInZone := resNameInZone(proxy)
 	reqId := core.NewUUID()
-	clientID := service.ClientID(ctx, zone)
+	tenantZoneID := service.TenantZoneClientIDFromCtx(ctx, zone)
 
-	err := k.rpcs.XDSConfigDump.Send(clientID, &mesh_proto.XDSConfigRequest{
+	err := k.rpcs.XDSConfigDump.Send(tenantZoneID.String(), &mesh_proto.XDSConfigRequest{
 		RequestId:    reqId,
 		ResourceType: string(proxy.Descriptor().Name),
 		ResourceName: nameInZone,                // send the name which without the added prefix
@@ -50,9 +50,9 @@ func (k *kdsEnvoyAdminClient) ConfigDump(ctx context.Context, proxy core_model.R
 		return nil, &KDSTransportError{requestType: "XDSConfigRequest", reason: err.Error()}
 	}
 
-	defer k.rpcs.XDSConfigDump.DeleteWatch(clientID, reqId)
+	defer k.rpcs.XDSConfigDump.DeleteWatch(tenantZoneID.String(), reqId)
 	ch := make(chan util_grpc.ReverseUnaryMessage)
-	if err := k.rpcs.XDSConfigDump.WatchResponse(clientID, reqId, ch); err != nil {
+	if err := k.rpcs.XDSConfigDump.WatchResponse(tenantZoneID.String(), reqId, ch); err != nil {
 		return nil, errors.Wrapf(err, "could not watch the response")
 	}
 
@@ -75,9 +75,9 @@ func (k *kdsEnvoyAdminClient) Stats(ctx context.Context, proxy core_model.Resour
 	zone := core_model.ZoneOfResource(proxy)
 	nameInZone := resNameInZone(proxy)
 	reqId := core.NewUUID()
-	clientID := service.ClientID(ctx, zone)
+	tenantZoneId := service.TenantZoneClientIDFromCtx(ctx, zone)
 
-	err := k.rpcs.Stats.Send(clientID, &mesh_proto.StatsRequest{
+	err := k.rpcs.Stats.Send(tenantZoneId.String(), &mesh_proto.StatsRequest{
 		RequestId:    reqId,
 		ResourceType: string(proxy.Descriptor().Name),
 		ResourceName: nameInZone,                // send the name which without the added prefix
@@ -87,9 +87,9 @@ func (k *kdsEnvoyAdminClient) Stats(ctx context.Context, proxy core_model.Resour
 		return nil, &KDSTransportError{requestType: "StatsRequest", reason: err.Error()}
 	}
 
-	defer k.rpcs.Stats.DeleteWatch(clientID, reqId)
+	defer k.rpcs.Stats.DeleteWatch(tenantZoneId.String(), reqId)
 	ch := make(chan util_grpc.ReverseUnaryMessage)
-	if err := k.rpcs.Stats.WatchResponse(clientID, reqId, ch); err != nil {
+	if err := k.rpcs.Stats.WatchResponse(tenantZoneId.String(), reqId, ch); err != nil {
 		return nil, errors.Wrapf(err, "could not watch the response")
 	}
 
@@ -112,9 +112,9 @@ func (k *kdsEnvoyAdminClient) Clusters(ctx context.Context, proxy core_model.Res
 	zone := core_model.ZoneOfResource(proxy)
 	nameInZone := resNameInZone(proxy)
 	reqId := core.NewUUID()
-	clientID := service.ClientID(ctx, zone)
+	tenantZoneID := service.TenantZoneClientIDFromCtx(ctx, zone)
 
-	err := k.rpcs.Clusters.Send(clientID, &mesh_proto.ClustersRequest{
+	err := k.rpcs.Clusters.Send(tenantZoneID.String(), &mesh_proto.ClustersRequest{
 		RequestId:    reqId,
 		ResourceType: string(proxy.Descriptor().Name),
 		ResourceName: nameInZone,                // send the name which without the added prefix
@@ -124,9 +124,9 @@ func (k *kdsEnvoyAdminClient) Clusters(ctx context.Context, proxy core_model.Res
 		return nil, &KDSTransportError{requestType: "ClustersRequest", reason: err.Error()}
 	}
 
-	defer k.rpcs.Clusters.DeleteWatch(clientID, reqId)
+	defer k.rpcs.Clusters.DeleteWatch(tenantZoneID.String(), reqId)
 	ch := make(chan util_grpc.ReverseUnaryMessage)
-	if err := k.rpcs.Clusters.WatchResponse(clientID, reqId, ch); err != nil {
+	if err := k.rpcs.Clusters.WatchResponse(tenantZoneID.String(), reqId, ch); err != nil {
 		return nil, errors.Wrapf(err, "could not watch the response")
 	}
 

--- a/pkg/envoy/admin/kds_client_test.go
+++ b/pkg/envoy/admin/kds_client_test.go
@@ -21,14 +21,14 @@ var _ = Describe("KDS client", func() {
 		client := admin.NewKDSEnvoyAdminClient(rpcs, false)
 
 		zoneName := "zone-1"
-		clientID := service.ClientID(context.Background(), zoneName)
+		tenantZoneID := service.TenantZoneClientIDFromCtx(context.Background(), zoneName)
 		var stream *mockStream
 
 		BeforeEach(func() {
 			stream = &mockStream{
 				receivedRequests: make(chan *mesh_proto.XDSConfigRequest, 1),
 			}
-			rpcs.XDSConfigDump.ClientConnected(clientID, stream)
+			rpcs.XDSConfigDump.ClientConnected(tenantZoneID.String(), stream)
 		})
 
 		It("should execute config dump", func() {
@@ -57,7 +57,7 @@ var _ = Describe("KDS client", func() {
 			Expect(request.ResourceName).To(Equal("dp-1"))
 
 			Eventually(func() error {
-				return rpcs.XDSConfigDump.ResponseReceived(clientID, &mesh_proto.XDSConfigResponse{
+				return rpcs.XDSConfigDump.ResponseReceived(tenantZoneID.String(), &mesh_proto.XDSConfigResponse{
 					RequestId: request.RequestId,
 					Result: &mesh_proto.XDSConfigResponse_Config{
 						Config: configContent,
@@ -126,7 +126,7 @@ var _ = Describe("KDS client", func() {
 			Expect(request.ResourceName).To(Equal("dp-1"))
 
 			Eventually(func() error {
-				return rpcs.XDSConfigDump.ResponseReceived(clientID, &mesh_proto.XDSConfigResponse{
+				return rpcs.XDSConfigDump.ResponseReceived(tenantZoneID.String(), &mesh_proto.XDSConfigResponse{
 					RequestId: request.RequestId,
 					Result: &mesh_proto.XDSConfigResponse_Error{
 						Error: "failed",
@@ -144,14 +144,14 @@ var _ = Describe("KDS client", func() {
 		client := admin.NewKDSEnvoyAdminClient(streams, true)
 
 		zoneName := "zone-1"
-		clientID := service.ClientID(context.Background(), zoneName)
+		tenantZoneID := service.TenantZoneClientIDFromCtx(context.Background(), zoneName)
 		var stream *mockStream
 
 		BeforeEach(func() {
 			stream = &mockStream{
 				receivedRequests: make(chan *mesh_proto.XDSConfigRequest, 1),
 			}
-			streams.XDSConfigDump.ClientConnected(clientID, stream)
+			streams.XDSConfigDump.ClientConnected(tenantZoneID.String(), stream)
 		})
 
 		It("should execute config dump", func() {
@@ -180,7 +180,7 @@ var _ = Describe("KDS client", func() {
 			Expect(request.ResourceName).To(Equal("dp-1.my-namespace"))
 
 			Eventually(func() error {
-				return streams.XDSConfigDump.ResponseReceived(clientID, &mesh_proto.XDSConfigResponse{
+				return streams.XDSConfigDump.ResponseReceived(tenantZoneID.String(), &mesh_proto.XDSConfigResponse{
 					RequestId: request.RequestId,
 					Result: &mesh_proto.XDSConfigResponse_Config{
 						Config: configContent,


### PR DESCRIPTION
This shouldn't change anything, it's just for internal documentation.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
