### PR TITLE
test(e2e): remove flake on multizone sync test

### DIFF
--- a/test/e2e_env/multizone/sync/sync.go
+++ b/test/e2e_env/multizone/sync/sync.go
@@ -49,7 +49,7 @@ func Sync() {
 		}, "30s", "1s").Should(Succeed())
 	})
 
-	It("show have insights in global and in zone", func() {
+	It("should have insights in global and in zone", func() {
 		// Ensure each side of KDS has the respective values for Global and Zone instance info
 		Eventually(func(g Gomega) {
 			result := &system.ZoneInsightResource{}
@@ -62,7 +62,7 @@ func Sync() {
 			}
 
 			zoneResult := &system.ZoneInsightResource{}
-			api.FetchResource(g, multizone.KubeZone1, result, "", multizone.KubeZone1.ZoneName())
+			api.FetchResource(g, multizone.KubeZone1, zoneResult, "", multizone.KubeZone1.ZoneName())
 			g.Expect(zoneResult.Spec.Subscriptions).ToNot(BeEmpty())
 			zoneSub := zoneResult.Spec.Subscriptions[0]
 			if !Config.KumaLegacyKDS {

--- a/test/e2e_env/multizone/sync/sync.go
+++ b/test/e2e_env/multizone/sync/sync.go
@@ -51,34 +51,26 @@ func Sync() {
 
 	It("show have insights in global and in zone", func() {
 		// Ensure each side of KDS has the respective values for Global and Zone instance info
-		globalName := ""
-		zoneInstance := ""
 		Eventually(func(g Gomega) {
 			result := &system.ZoneInsightResource{}
 			api.FetchResource(g, multizone.Global, result, "", multizone.KubeZone1.ZoneName())
-
 			g.Expect(result.Spec.Subscriptions).ToNot(BeEmpty())
-			sub := result.Spec.Subscriptions[0]
-			g.Expect(sub.GlobalInstanceId).ToNot(BeEmpty())
-			globalName = sub.GlobalInstanceId
+			globalSub := result.Spec.Subscriptions[0]
+			g.Expect(globalSub.GlobalInstanceId).ToNot(BeEmpty())
 			if !Config.KumaLegacyKDS {
-				g.Expect(sub.ZoneInstanceId).ToNot(BeEmpty())
+				g.Expect(globalSub.ZoneInstanceId).ToNot(BeEmpty())
 			}
-			zoneInstance = sub.ZoneInstanceId
-		}, "30s", "1s").Should(Succeed())
 
-		Eventually(func(g Gomega) {
-			result := &system.ZoneInsightResource{}
+			zoneResult := &system.ZoneInsightResource{}
 			api.FetchResource(g, multizone.KubeZone1, result, "", multizone.KubeZone1.ZoneName())
-
-			g.Expect(result.Spec.Subscriptions).ToNot(BeEmpty())
-			sub := result.Spec.Subscriptions[0]
+			g.Expect(zoneResult.Spec.Subscriptions).ToNot(BeEmpty())
+			zoneSub := zoneResult.Spec.Subscriptions[0]
 			if !Config.KumaLegacyKDS {
 				// Check that this is the other side of the connection
-				g.Expect(sub.GlobalInstanceId).To(Equal(globalName))
-				g.Expect(sub.ZoneInstanceId).To(Equal(zoneInstance))
+				g.Expect(zoneSub.GlobalInstanceId).To(Equal(globalSub.GlobalInstanceId))
+				g.Expect(zoneSub.ZoneInstanceId).To(Equal(globalSub.ZoneInstanceId))
 			}
-		}, "30s", "1s").Should(Succeed())
+		}, "1m", "1s").Should(Succeed())
 	})
 
 	Context("from Remote to Global", func() {


### PR DESCRIPTION
We need to check both sides in the same eventually block

Fix #8900

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
