### PR TITLE
fix(gateway): make MeshHTTPRoute-based routing available to plugins

### DIFF
--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin.go
@@ -120,7 +120,8 @@ func ApplyToGateway(
 		return nil
 	}
 
-	for _, info := range plugin_gateway.ExtractGatewayListeners(proxy) {
+	listeners := plugin_gateway.ExtractGatewayListeners(proxy)
+	for listenerIndex, info := range listeners {
 		address := proxy.Dataplane.Spec.GetNetworking().Address
 		port := info.Listener.Port
 		inboundListener := rules.InboundListener{
@@ -186,6 +187,10 @@ func ApplyToGateway(
 		sort.Slice(hostInfos, func(i, j int) bool {
 			return hostInfos[i].Host.Hostname > hostInfos[j].Host.Hostname
 		})
+
+		info.HostInfos = hostInfos
+		listeners[listenerIndex] = info
+		plugin_gateway.SetGatewayListeners(proxy, listeners)
 
 		cdsResources, err := generateGatewayClusters(ctx, xdsCtx, info, hostInfos)
 		if err != nil {

--- a/pkg/plugins/runtime/gateway/plugin.go
+++ b/pkg/plugins/runtime/gateway/plugin.go
@@ -62,6 +62,10 @@ func ExtractGatewayListeners(proxy *core_xds.Proxy) []GatewayListenerInfo {
 	return ext.([]GatewayListenerInfo)
 }
 
+func SetGatewayListeners(proxy *core_xds.Proxy, infos []GatewayListenerInfo) {
+	proxy.RuntimeExtensions[metadata.PluginName] = infos
+}
+
 func (p *plugin) AfterBootstrap(context *core_plugins.MutablePluginContext, config core_plugins.PluginConfig) error {
 	// Insert our resolver before the default so that we can intercept
 	// builtin gateway dataplanes.


### PR DESCRIPTION
The issue here is that we were only looking at what the gateway plugin itself generated, not what MeshHTTPRoute generates. This makes it so that MeshHTTPRoute writes to the context like the gateway plugin does.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --


> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
