### PR TITLE
fix(policy): improve validator messages, allow string failoverthreshold

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -38,6 +38,12 @@ To ensure a smooth transition to Kuma 2.6.0, carefully review your existing conf
 The postgres driver `postgres` (lib/pq) is deprecated and will be removed in the future.
 Please migrate to the new postgres driver `pgx` by setting `DriverName=pgx` configuration option or `KUMA_STORE_POSTGRES_DRIVER_NAME=pgx` env variable.
 
+### Make format SI valid for bandwidth in MeshFaultInjection policy
+
+Prior to this upgrade `mbps` and `gbps` were used for units for parameter `conf.responseBandwidth.percentage`.
+These are not valid units according to the [International System of Units](https://en.wikipedia.org/wiki/International_System_of_Units) they are respectively corrected to `Gbps` and `Mbps` if using
+these invalid units convert them into `kbps` prior to upgrade to avoid invalid format.
+
 ## Upgrade to `2.5.x`
 
 ### Transparent-proxy and CNI v1 removal

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -312,7 +312,7 @@ spec:
                                 properties:
                                   limit:
                                     description: |-
-                                      Limit is represented by value measure in gbps, mbps, kbps or bps, e.g.
+                                      Limit is represented by value measure in Gbps, Mbps, kbps, e.g.
                                       10kbps
                                     type: string
                                   percentage:
@@ -488,7 +488,7 @@ spec:
                                 properties:
                                   limit:
                                     description: |-
-                                      Limit is represented by value measure in gbps, mbps, kbps or bps, e.g.
+                                      Limit is represented by value measure in Gbps, Mbps, kbps, e.g.
                                       10kbps
                                     type: string
                                   percentage:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
@@ -312,7 +312,7 @@ spec:
                                 properties:
                                   limit:
                                     description: |-
-                                      Limit is represented by value measure in gbps, mbps, kbps or bps, e.g.
+                                      Limit is represented by value measure in Gbps, Mbps, kbps, e.g.
                                       10kbps
                                     type: string
                                   percentage:
@@ -488,7 +488,7 @@ spec:
                                 properties:
                                   limit:
                                     description: |-
-                                      Limit is represented by value measure in gbps, mbps, kbps or bps, e.g.
+                                      Limit is represented by value measure in Gbps, Mbps, kbps, e.g.
                                       10kbps
                                     type: string
                                   percentage:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -312,7 +312,7 @@ spec:
                                 properties:
                                   limit:
                                     description: |-
-                                      Limit is represented by value measure in gbps, mbps, kbps or bps, e.g.
+                                      Limit is represented by value measure in Gbps, Mbps, kbps, e.g.
                                       10kbps
                                     type: string
                                   percentage:
@@ -488,7 +488,7 @@ spec:
                                 properties:
                                   limit:
                                     description: |-
-                                      Limit is represented by value measure in gbps, mbps, kbps or bps, e.g.
+                                      Limit is represented by value measure in Gbps, Mbps, kbps, e.g.
                                       10kbps
                                     type: string
                                   percentage:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -332,7 +332,7 @@ spec:
                                 properties:
                                   limit:
                                     description: |-
-                                      Limit is represented by value measure in gbps, mbps, kbps or bps, e.g.
+                                      Limit is represented by value measure in Gbps, Mbps, kbps, e.g.
                                       10kbps
                                     type: string
                                   percentage:
@@ -508,7 +508,7 @@ spec:
                                 properties:
                                   limit:
                                     description: |-
-                                      Limit is represented by value measure in gbps, mbps, kbps or bps, e.g.
+                                      Limit is represented by value measure in Gbps, Mbps, kbps, e.g.
                                       10kbps
                                     type: string
                                   percentage:

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -1786,7 +1786,7 @@ spec:
                                 properties:
                                   limit:
                                     description: |-
-                                      Limit is represented by value measure in gbps, mbps, kbps or bps, e.g.
+                                      Limit is represented by value measure in Gbps, Mbps, kbps, e.g.
                                       10kbps
                                     type: string
                                   percentage:
@@ -1962,7 +1962,7 @@ spec:
                                 properties:
                                   limit:
                                     description: |-
-                                      Limit is represented by value measure in gbps, mbps, kbps or bps, e.g.
+                                      Limit is represented by value measure in Gbps, Mbps, kbps, e.g.
                                       10kbps
                                     type: string
                                   percentage:

--- a/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
@@ -1786,7 +1786,7 @@ spec:
                                 properties:
                                   limit:
                                     description: |-
-                                      Limit is represented by value measure in gbps, mbps, kbps or bps, e.g.
+                                      Limit is represented by value measure in Gbps, Mbps, kbps, e.g.
                                       10kbps
                                     type: string
                                   percentage:
@@ -1962,7 +1962,7 @@ spec:
                                 properties:
                                   limit:
                                     description: |-
-                                      Limit is represented by value measure in gbps, mbps, kbps or bps, e.g.
+                                      Limit is represented by value measure in Gbps, Mbps, kbps, e.g.
                                       10kbps
                                     type: string
                                   percentage:

--- a/deployments/charts/kuma/crds/kuma.io_meshfaultinjections.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshfaultinjections.yaml
@@ -115,7 +115,7 @@ spec:
                                 properties:
                                   limit:
                                     description: |-
-                                      Limit is represented by value measure in gbps, mbps, kbps or bps, e.g.
+                                      Limit is represented by value measure in Gbps, Mbps, kbps, e.g.
                                       10kbps
                                     type: string
                                   percentage:
@@ -291,7 +291,7 @@ spec:
                                 properties:
                                   limit:
                                     description: |-
-                                      Limit is represented by value measure in gbps, mbps, kbps or bps, e.g.
+                                      Limit is represented by value measure in Gbps, Mbps, kbps, e.g.
                                       10kbps
                                     type: string
                                   percentage:

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -3524,7 +3524,7 @@ components:
                                 limit:
                                   description: >-
                                     Limit is represented by value measure in
-                                    gbps, mbps, kbps or bps, e.g.
+                                    Gbps, Mbps, kbps, e.g.
 
                                     10kbps
                                   type: string
@@ -3742,7 +3742,7 @@ components:
                                 limit:
                                   description: >-
                                     Limit is represented by value measure in
-                                    gbps, mbps, kbps or bps, e.g.
+                                    Gbps, Mbps, kbps, e.g.
 
                                     10kbps
                                   type: string

--- a/docs/generated/raw/crds/kuma.io_meshfaultinjections.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshfaultinjections.yaml
@@ -115,7 +115,7 @@ spec:
                                 properties:
                                   limit:
                                     description: |-
-                                      Limit is represented by value measure in gbps, mbps, kbps or bps, e.g.
+                                      Limit is represented by value measure in Gbps, Mbps, kbps, e.g.
                                       10kbps
                                     type: string
                                   percentage:
@@ -291,7 +291,7 @@ spec:
                                 properties:
                                   limit:
                                     description: |-
-                                      Limit is represented by value measure in gbps, mbps, kbps or bps, e.g.
+                                      Limit is represented by value measure in Gbps, Mbps, kbps, e.g.
                                       10kbps
                                     type: string
                                   percentage:

--- a/pkg/core/validators/messages.go
+++ b/pkg/core/validators/messages.go
@@ -18,10 +18,15 @@ const (
 	MustBeDefinedAndGreaterThanZero   = "must be defined and greater than zero"
 	WhenDefinedHasToBeNonNegative     = "must not be negative when defined"
 	WhenDefinedHasToBeGreaterThanZero = "must be greater than zero when defined"
-	HasToBeInPercentageRange          = "has to be in [0.0 - 100.0] range"
-	HasToBeInUintPercentageRange      = "has to be in [0 - 100] range"
-	WhenDefinedHasToBeValidPath       = "has to be a valid path when defined"
-	StringHasToBeValidNumber          = "string has to be a valid number"
+	HasToBeInRangeFormat              = "must be in inclusive range [%v, %v]"
+	WhenDefinedHasToBeValidPath       = "must be a valid path when defined"
+	StringHasToBeValidNumber          = "string must be a valid number"
+	MustHaveBPSUnit                   = "must be in kbps/Mbps/Gbps units"
+)
+
+var (
+	HasToBeInPercentageRange     = fmt.Sprintf(HasToBeInRangeFormat, "0.0", "100.0")
+	HasToBeInUintPercentageRange = fmt.Sprintf(HasToBeInRangeFormat, 0, 100)
 )
 
 func MustHaveOnlyOne(entity string, allowedValues ...string) string {

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/validator_test.go
@@ -414,9 +414,9 @@ to:
 				expected: `
 violations:
   - field: spec.to[0].default.outlierDetection.maxEjectionPercent
-    message: has to be in [0 - 100] range
+    message: must be in inclusive range [0, 100]
   - field: spec.to[0].default.outlierDetection.detectors.failurePercentage.threshold
-    message: has to be in [0 - 100] range`,
+    message: must be in inclusive range [0, 100]`,
 			}),
 			Entry("detectors are not defined", testCase{
 				inputYaml: `

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/meshfaultinjection.go
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/meshfaultinjection.go
@@ -75,7 +75,7 @@ type DelayConf struct {
 }
 
 type ResponseBandwidthConf struct {
-	// Limit is represented by value measure in gbps, mbps, kbps or bps, e.g.
+	// Limit is represented by value measure in Gbps, Mbps, kbps, e.g.
 	// 10kbps
 	Limit string `json:"limit"`
 	// Percentage of requests on which response bandwidth limit will be

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/schema.yaml
@@ -76,7 +76,7 @@ properties:
                         properties:
                           limit:
                             description: |-
-                              Limit is represented by value measure in gbps, mbps, kbps or bps, e.g.
+                              Limit is represented by value measure in Gbps, Mbps, kbps, e.g.
                               10kbps
                             type: string
                           percentage:
@@ -244,7 +244,7 @@ properties:
                         properties:
                           limit:
                             description: |-
-                              Limit is represented by value measure in gbps, mbps, kbps or bps, e.g.
+                              Limit is represented by value measure in Gbps, Mbps, kbps, e.g.
                               10kbps
                             type: string
                           percentage:

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/validator.go
@@ -80,17 +80,17 @@ func validateDefault(path validators.PathBuilder, conf Conf) validators.Validati
 		if fault.Abort != nil {
 			path := path.Field("abort").Index(idx)
 			verr.Add(validators.ValidateStatusCode(path.Field("httpStatus"), fault.Abort.HttpStatus))
-			verr.Add(validators.ValidatePercentage(path.Field("percentage"), &fault.Abort.Percentage))
+			verr.Add(validators.ValidatePercentage(path.Field("percentage"), &fault.Abort.Percentage, true))
 		}
 		if fault.Delay != nil {
 			path := path.Field("delay").Index(idx)
 			verr.Add(validators.ValidateDurationNotNegative(path.Field("value"), &fault.Delay.Value))
-			verr.Add(validators.ValidatePercentage(path.Field("percentage"), &fault.Delay.Percentage))
+			verr.Add(validators.ValidatePercentage(path.Field("percentage"), &fault.Delay.Percentage, true))
 		}
 		if fault.ResponseBandwidth != nil {
 			path := path.Field("responseBandwidth").Index(idx)
 			verr.Add(validators.ValidateBandwidth(path.Field("responseBandwidth"), fault.ResponseBandwidth.Limit))
-			verr.Add(validators.ValidatePercentage(path.Field("percentage"), &fault.ResponseBandwidth.Percentage))
+			verr.Add(validators.ValidatePercentage(path.Field("percentage"), &fault.ResponseBandwidth.Percentage, true))
 		}
 	}
 	return verr

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/validator_test.go
@@ -75,11 +75,11 @@ to:
 			[]validators.Violation{
 				{
 					Field:   `spec.from[0].default.http.abort[0].httpStatus`,
-					Message: `must be in range [100, 600)`,
+					Message: `must be in inclusive range [100, 599]`,
 				},
 				{
 					Field:   `spec.from[0].default.http.abort[0].percentage`,
-					Message: `has to be in [0.0 - 100.0] range`,
+					Message: `must be in inclusive range [0.0, 100.0]`,
 				},
 				{
 					Field:   "spec.from[0].default.http.delay[1].value",
@@ -87,15 +87,15 @@ to:
 				},
 				{
 					Field:   `spec.from[0].default.http.delay[1].percentage`,
-					Message: `has to be in [0.0 - 100.0] range`,
+					Message: `must be in inclusive range [0.0, 100.0]`,
 				},
 				{
 					Field:   `spec.from[0].default.http.responseBandwidth[2].responseBandwidth`,
-					Message: `has to be in kbps/mbps/gbps units`,
+					Message: `must be in kbps/Mbps/Gbps units`,
 				},
 				{
 					Field:   `spec.from[0].default.http.responseBandwidth[2].percentage`,
-					Message: `has to be in [0.0 - 100.0] range`,
+					Message: `must be in inclusive range [0.0, 100.0]`,
 				},
 			}, `
 type: MeshFaultInjection
@@ -124,11 +124,11 @@ from:
 			[]validators.Violation{
 				{
 					Field:   "spec.from[0].default.http.abort[0].httpStatus",
-					Message: "must be in range [100, 600)",
+					Message: "must be in inclusive range [100, 599]",
 				},
 				{
 					Field:   "spec.from[0].default.http.responseBandwidth[2].responseBandwidth",
-					Message: "has to be in kbps/mbps/gbps units",
+					Message: "must be in kbps/Mbps/Gbps units",
 				},
 			}, `
 type: MeshFaultInjection
@@ -152,11 +152,11 @@ from:
 			[]validators.Violation{
 				{
 					Field:   "spec.from[0].default.http.responseBandwidth[0].responseBandwidth",
-					Message: "has to be in kbps/mbps/gbps units",
+					Message: "must be in kbps/Mbps/Gbps units",
 				},
 				{
 					Field:   "spec.from[0].default.http.responseBandwidth[0].percentage",
-					Message: "string has to be a valid number",
+					Message: "string must be a valid number",
 				},
 			}, `
 type: MeshFaultInjection

--- a/pkg/plugins/policies/meshfaultinjection/k8s/crd/kuma.io_meshfaultinjections.yaml
+++ b/pkg/plugins/policies/meshfaultinjection/k8s/crd/kuma.io_meshfaultinjections.yaml
@@ -115,7 +115,7 @@ spec:
                                 properties:
                                   limit:
                                     description: |-
-                                      Limit is represented by value measure in gbps, mbps, kbps or bps, e.g.
+                                      Limit is represented by value measure in Gbps, Mbps, kbps, e.g.
                                       10kbps
                                     type: string
                                   percentage:
@@ -291,7 +291,7 @@ spec:
                                 properties:
                                   limit:
                                     description: |-
-                                      Limit is represented by value measure in gbps, mbps, kbps or bps, e.g.
+                                      Limit is represented by value measure in Gbps, Mbps, kbps, e.g.
                                       10kbps
                                     type: string
                                   percentage:

--- a/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin_test.go
@@ -137,7 +137,7 @@ var _ = Describe("MeshFaultInjection", func() {
 											Percentage: intstr.FromString("55"),
 										},
 										ResponseBandwidth: &api.ResponseBandwidthConf{
-											Limit:      "111mbps",
+											Limit:      "111Mbps",
 											Percentage: intstr.FromString("62.9"),
 										},
 									},
@@ -164,7 +164,7 @@ var _ = Describe("MeshFaultInjection", func() {
 											Percentage: intstr.FromInt32(22),
 										},
 										ResponseBandwidth: &api.ResponseBandwidthConf{
-											Limit:      "333mbps",
+											Limit:      "333Mbps",
 											Percentage: intstr.FromString("33.3"),
 										},
 									},
@@ -186,7 +186,7 @@ var _ = Describe("MeshFaultInjection", func() {
 										Percentage: intstr.FromInt(55),
 									},
 									ResponseBandwidth: &api.ResponseBandwidthConf{
-										Limit:      "111mbps",
+										Limit:      "111Mbps",
 										Percentage: intstr.FromString("62.9"),
 									},
 								},
@@ -305,7 +305,7 @@ var _ = Describe("MeshFaultInjection", func() {
 																	Percentage: intstr.FromString("55"),
 																},
 																ResponseBandwidth: &api.ResponseBandwidthConf{
-																	Limit:      "111mbps",
+																	Limit:      "111Mbps",
 																	Percentage: intstr.FromString("62.9"),
 																},
 															},
@@ -374,7 +374,7 @@ var _ = Describe("MeshFaultInjection", func() {
 																	Percentage: intstr.FromString("55"),
 																},
 																ResponseBandwidth: &api.ResponseBandwidthConf{
-																	Limit:      "111mbps",
+																	Limit:      "111Mbps",
 																	Percentage: intstr.FromString("62.9"),
 																},
 															},
@@ -407,7 +407,7 @@ var _ = Describe("MeshFaultInjection", func() {
 																	Percentage: intstr.FromString("55"),
 																},
 																ResponseBandwidth: &api.ResponseBandwidthConf{
-																	Limit:      "111mbps",
+																	Limit:      "111Mbps",
 																	Percentage: intstr.FromString("62.9"),
 																},
 															},
@@ -456,7 +456,7 @@ var _ = Describe("MeshFaultInjection", func() {
 									Percentage: intstr.FromString("55"),
 								},
 								ResponseBandwidth: &api.ResponseBandwidthConf{
-									Limit:      "111mbps",
+									Limit:      "111Mbps",
 									Percentage: intstr.FromString("62.9"),
 								},
 							},

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/validator_test.go
@@ -220,9 +220,9 @@ to:
 				expected: `
 violations:
   - field: spec.to[0].default.intervalJitterPercent
-    message: has to be in [0 - 100] range
+    message: must be in inclusive range [0, 100]
   - field: spec.to[0].default.healthyPanicThreshold
-    message: has to be in [0.0 - 100.0] range`,
+    message: must be in inclusive range [0.0, 100.0]`,
 			}),
 			Entry("path is invalid", testCase{
 				inputYaml: `
@@ -244,7 +244,7 @@ to:
 				expected: `
 violations:
   - field: spec.to[0].default.eventLogPath
-    message: has to be a valid path when defined`,
+    message: must be a valid path when defined`,
 			}),
 			Entry("status codes out of range in expectedStatuses", testCase{
 				inputYaml: `
@@ -267,9 +267,9 @@ to:
 				expected: `
 violations:
   - field: spec.to[0].default.http.expectedStatuses[0]
-    message: must be in range [100, 600)
+    message: must be in inclusive range [100, 599]
   - field: spec.to[0].default.http.expectedStatuses[1]
-    message: must be in range [100, 600)`,
+    message: must be in inclusive range [100, 599]`,
 			}),
 		)
 	})

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator.go
@@ -136,8 +136,7 @@ func validateFailoverThreshold(failoverThreshold *FailoverThreshold) validators.
 	if failoverThreshold == nil {
 		return verr
 	}
-	verr.Add(validators.ValidateIntOrStringGreaterThan(validators.RootedAt("percentage"), &failoverThreshold.Percentage, 0))
-	verr.Add(validators.ValidateIntOrStringLessThan(validators.RootedAt("percentage"), &failoverThreshold.Percentage, 100))
+	verr.Add(validators.ValidatePercentage(validators.RootedAt("percentage"), &failoverThreshold.Percentage, false))
 	return verr
 }
 

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator_test.go
@@ -292,7 +292,7 @@ to:
 `),
 		resources.ErrorCases("percentage can't be zero", []validators.Violation{{
 			Field:   "spec.to[0].default.localityAwareness.crossZone.failoverThreshold.percentage",
-			Message: "must be greater than: 0",
+			Message: "must be greater than 0",
 		}}, `
 type: MeshLoadBalancingStrategy
 mesh: mesh-1
@@ -309,9 +309,9 @@ to:
           failoverThreshold:
             percentage: 0
 `),
-		resources.ErrorCases("percentage can't be set to 100", []validators.Violation{{
+		resources.ErrorCases("percentage is not a parseable number", []validators.Violation{{
 			Field:   "spec.to[0].default.localityAwareness.crossZone.failoverThreshold.percentage",
-			Message: "must be less than: 100",
+			Message: "string must be a valid number",
 		}}, `
 type: MeshLoadBalancingStrategy
 mesh: mesh-1
@@ -326,7 +326,7 @@ to:
       localityAwareness:
         crossZone:
           failoverThreshold:
-            percentage: 100
+            percentage: "hello"
 `),
 		resources.ErrorCases("broken failover rules", []validators.Violation{
 			{

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
@@ -472,6 +472,7 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 												},
 											},
 											CrossZone: &v1alpha1.CrossZone{
+												FailoverThreshold: &v1alpha1.FailoverThreshold{Percentage: intstr.FromString("99")},
 												Failover: []v1alpha1.Failover{
 													{
 														To: v1alpha1.ToZone{

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware_basic.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware_basic.endpoints.golden.yaml
@@ -135,4 +135,4 @@ resources:
         zone: zone-4
       priority: 3
     policy:
-      overprovisioningFactor: 200
+      overprovisioningFactor: 100

--- a/pkg/test/resources/validation.go
+++ b/pkg/test/resources/validation.go
@@ -85,6 +85,7 @@ func ErrorCase(description string, err validators.Violation, yaml string) TableE
 }
 
 func ErrorCases(description string, errs []validators.Violation, yaml string) TableEntry {
+	GinkgoHelper()
 	return Entry(
 		description,
 		ResourceValidationCase{

--- a/pkg/xds/envoy/listeners/v3/util.go
+++ b/pkg/xds/envoy/listeners/v3/util.go
@@ -3,7 +3,6 @@ package v3
 import (
 	"fmt"
 	"math"
-	"regexp"
 	"strconv"
 
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
@@ -14,6 +13,8 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/kumahq/kuma/pkg/core/validators"
 )
 
 func UpdateHTTPConnectionManager(filterChain *envoy_listener.FilterChain, updateFunc func(manager *envoy_hcm.HttpConnectionManager) error) error {
@@ -110,10 +111,8 @@ func ConvertPercentage(percentage *wrapperspb.DoubleValue) *envoy_type.Fractiona
 	}
 }
 
-var bandwidthRegex = regexp.MustCompile(`(\d*)\s?([gmk]?bps)`)
-
 func ConvertBandwidthToKbps(bandwidth string) (uint64, error) {
-	match := bandwidthRegex.FindStringSubmatch(bandwidth)
+	match := validators.BandwidthRegex.FindStringSubmatch(bandwidth)
 	value, err := strconv.Atoi(match[1])
 	if err != nil {
 		return 0, err
@@ -125,9 +124,9 @@ func ConvertBandwidthToKbps(bandwidth string) (uint64, error) {
 	switch units {
 	case "kbps":
 		factor = 1
-	case "mbps":
+	case "Mbps":
 		factor = 1000
-	case "gbps":
+	case "Gbps":
 		factor = 1000000
 	default:
 		return 0, errors.New("unsupported unit type")

--- a/pkg/xds/envoy/listeners/v3/util_test.go
+++ b/pkg/xds/envoy/listeners/v3/util_test.go
@@ -223,7 +223,7 @@ var _ = Describe("ConvertBandwidth", func() {
 		input    string
 		expected uint64
 	}
-	DescribeTable("should properly converts to kbps from gbps, mbps, kbps",
+	DescribeTable("should properly convert to kbps from gbps, mbps, kbps",
 		func(given testCase) {
 			// when
 			limitKbps, err := ConvertBandwidthToKbps(given.input)
@@ -236,11 +236,11 @@ var _ = Describe("ConvertBandwidth", func() {
 			expected: 120,
 		}),
 		Entry("mbps input", testCase{
-			input:    "120 mbps",
+			input:    "120 Mbps",
 			expected: 120000,
 		}),
 		Entry("gbps input", testCase{
-			input:    "120 gbps",
+			input:    "120 Gbps",
 			expected: 120000000,
 		}),
 	)


### PR DESCRIPTION
- MeshFaultInjection were not using SI notation for bandwidth (using m for Mega)
- Make error messages more coherent (use always "must" never "has to")
- When intOrString is a not a number don't validate ranges too
- MeshLocalityAwareLoadBalancing failoverthreshold was just ignoring string values

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
