### PR TITLE
fix(MeshTrace): don't support MeshGateway listener selection 

### DIFF
--- a/pkg/plugins/policies/core/rules/rules.go
+++ b/pkg/plugins/policies/core/rules/rules.go
@@ -47,9 +47,8 @@ type ToRules struct {
 }
 
 type GatewayRules struct {
-	ToRules         map[InboundListener]Rules
-	FromRules       map[InboundListener]Rules
-	SingleItemRules map[InboundListener]SingleItemRules
+	ToRules   map[InboundListener]Rules
+	FromRules map[InboundListener]Rules
 }
 
 type SingleItemRules struct {
@@ -262,7 +261,6 @@ func BuildGatewayRules(
 	matchedPoliciesByInbound map[InboundListener][]core_model.Resource,
 	httpRoutes []core_model.Resource,
 ) (GatewayRules, error) {
-	singleItemRules := map[InboundListener]SingleItemRules{}
 	toRulesByInbound := map[InboundListener]Rules{}
 	for inbound, policies := range matchedPoliciesByInbound {
 		toRules, err := BuildToRules(policies, httpRoutes)
@@ -274,11 +272,6 @@ func BuildGatewayRules(
 			return GatewayRules{}, err
 		}
 		toRulesByInbound[inbound] = toRules.Rules
-
-		singleItemRules[inbound], err = BuildSingleItemRules(policies)
-		if err != nil {
-			return GatewayRules{}, err
-		}
 	}
 
 	fromRules, err := BuildFromRules(matchedPoliciesByInbound)
@@ -287,9 +280,8 @@ func BuildGatewayRules(
 	}
 
 	return GatewayRules{
-		ToRules:         toRulesByInbound,
-		FromRules:       fromRules.Rules,
-		SingleItemRules: singleItemRules,
+		ToRules:   toRulesByInbound,
+		FromRules: fromRules.Rules,
 	}, nil
 }
 

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/validator.go
@@ -33,7 +33,7 @@ func validateTop(targetRef common_api.TargetRef) validators.ValidationError {
 			common_api.MeshService,
 			common_api.MeshServiceSubset,
 		},
-		GatewayListenerTagsAllowed: true,
+		GatewayListenerTagsAllowed: false,
 	})
 	return targetRefErr
 }

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/validator_test.go
@@ -97,8 +97,6 @@ default:
 targetRef:
   kind: MeshGateway
   name: edge
-  tags:
-    name: listener-1
 default:
   backends:
     - type: Datadog
@@ -394,6 +392,24 @@ default:
 violations:
   - field: spec.default.backends[0].openTelemetry
     message: must be defined`,
+			}),
+			Entry("gateway listener tags not allowed", testCase{
+				inputYaml: `
+targetRef:
+  kind: MeshGateway
+  name: edge
+  tags:
+    name: listener-1
+default:
+  backends:
+    - type: Datadog
+      datadog:
+        url: http://intake.datadoghq.eu:8126
+        splitService: true`,
+				expected: `
+violations:
+  - field: spec.targetRef.tags
+    message: must not be set with kind MeshGateway`,
 			}),
 		)
 	})

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin.go
@@ -52,7 +52,7 @@ func (p plugin) Apply(rs *xds.ResourceSet, ctx xds_context.Context, proxy *xds.P
 	if err := applyToClusters(policies.SingleItemRules, rs, proxy); err != nil {
 		return err
 	}
-	if err := applyToGateway(policies.GatewayRules.SingleItemRules, listeners.Gateway, ctx.Mesh.Resources.MeshLocalResources, proxy.Dataplane); err != nil {
+	if err := applyToGateway(policies.SingleItemRules, listeners.Gateway, ctx.Mesh.Resources.MeshLocalResources, proxy.Dataplane); err != nil {
 		return err
 	}
 
@@ -60,7 +60,7 @@ func (p plugin) Apply(rs *xds.ResourceSet, ctx xds_context.Context, proxy *xds.P
 }
 
 func applyToGateway(
-	listenerRules map[core_rules.InboundListener]core_rules.SingleItemRules,
+	rules core_rules.SingleItemRules,
 	gatewayListeners map[core_rules.InboundListener]*envoy_listener.Listener,
 	resources xds_context.ResourceMap,
 	dataplane *core_mesh.DataplaneResource,
@@ -85,10 +85,6 @@ func applyToGateway(
 			Port:    port,
 		}
 		listener, ok := gatewayListeners[inboundListener]
-		if !ok {
-			continue
-		}
-		rules, ok := listenerRules[inboundListener]
 		if !ok {
 			continue
 		}

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin_test.go
@@ -605,7 +605,7 @@ var _ = Describe("MeshTrace", func() {
 		}),
 	)
 	type gatewayTestCase struct {
-		rules map[core_rules.InboundListener]core_rules.SingleItemRules
+		rules core_rules.SingleItemRules
 	}
 	DescribeTable("should generate proper Envoy config for gateways",
 		func(given gatewayTestCase) {
@@ -621,9 +621,7 @@ var _ = Describe("MeshTrace", func() {
 
 			proxy := xds_builders.Proxy().
 				WithDataplane(samples.GatewayDataplaneBuilder()).
-				WithPolicies(xds_builders.MatchedPolicies().WithGatewayPolicy(api.MeshTraceType, core_rules.GatewayRules{
-					SingleItemRules: given.rules,
-				})).
+				WithPolicies(xds_builders.MatchedPolicies().WithSingleItemPolicy(api.MeshTraceType, given.rules)).
 				Build()
 			for n, p := range core_plugins.Plugins().ProxyPlugins() {
 				Expect(p.Apply(context.Background(), xdsCtx.Mesh, proxy)).To(Succeed(), n)
@@ -643,9 +641,9 @@ var _ = Describe("MeshTrace", func() {
 				To(matchers.MatchGoldenYAML(filepath.Join("testdata", fmt.Sprintf("%s.listeners.golden.yaml", name))))
 		},
 		Entry("simple-gateway", gatewayTestCase{
-			rules: map[core_rules.InboundListener]core_rules.SingleItemRules{
-				{Address: "192.168.0.1", Port: 8080}: {
-					Rules: []*core_rules.Rule{{
+			rules: core_rules.SingleItemRules{
+				Rules: []*core_rules.Rule{
+					{
 						Subset: []core_rules.Tag{},
 						Conf: api.Conf{
 							Backends: &[]api.Backend{{
@@ -656,7 +654,7 @@ var _ = Describe("MeshTrace", func() {
 								},
 							}},
 						},
-					}},
+					},
 				},
 			},
 		}),


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
