### PR TITLE
fix(vips): skip ignored listeners

### DIFF
--- a/pkg/dns/vips_allocator.go
+++ b/pkg/dns/vips_allocator.go
@@ -195,6 +195,9 @@ func (d *VIPsAllocator) BuildVirtualOutboundMeshView(ctx context.Context, mesh s
 	var errs error
 	for _, dp := range dataplanes.Items {
 		for _, inbound := range dp.Spec.GetNetworking().GetInbound() {
+			if inbound.State == mesh_proto.Dataplane_Networking_Inbound_Ignored {
+				continue
+			}
 			if d.serviceVipEnabled {
 				errs = multierr.Append(errs, addDefault(outboundSet, inbound.GetService(), 0))
 			}

--- a/pkg/plugins/runtime/k8s/controllers/endpoints.go
+++ b/pkg/plugins/runtime/k8s/controllers/endpoints.go
@@ -28,6 +28,9 @@ func endpointsByService(dataplanes []*core_mesh.DataplaneResource) EndpointsBySe
 	result := EndpointsByService{}
 	for _, other := range dataplanes {
 		for _, inbound := range other.Spec.Networking.GetInbound() {
+			if inbound.State == mesh_proto.Dataplane_Networking_Inbound_Ignored {
+				continue
+			}
 			svc, ok := inbound.GetTags()[mesh_proto.ServiceTag]
 			if !ok {
 				continue

--- a/pkg/test/resources/samples/dataplane_samples.go
+++ b/pkg/test/resources/samples/dataplane_samples.go
@@ -34,3 +34,9 @@ func GatewayDataplaneBuilder() *builders.DataplaneBuilder {
 		WithAddress("192.168.0.1").
 		WithBuiltInGateway("sample-gateway")
 }
+
+func IgnoredDataplaneBackendBuilder() *builders.DataplaneBuilder {
+	return DataplaneBackendBuilder().With(func(resource *mesh.DataplaneResource) {
+		resource.Spec.Networking.Inbound[0].State = mesh_proto.Dataplane_Networking_Inbound_Ignored
+	})
+}

--- a/test/e2e_env/kubernetes/graceful/change_service.go
+++ b/test/e2e_env/kubernetes/graceful/change_service.go
@@ -32,6 +32,12 @@ func ChangeService() {
 		"changesvc-test-label": "second",
 	}
 
+	thirdTestServerLabels := map[string]string{
+		"kuma.io/sidecar-injection": "disabled",
+		"app":                       "test-server",
+		"changesvc-test-label":      "third",
+	}
+
 	newSvc := func(selector map[string]string) *corev1.Service {
 		return &corev1.Service{
 			TypeMeta: kube_meta.TypeMeta{
@@ -82,6 +88,14 @@ func ChangeService() {
 				testserver.WithoutService(),
 				testserver.WithoutWaitingToBeReady(), // WaitForPods assumes that app label is name, but we change this in WithPodLabels
 				testserver.WithPodLabels(secondTestServerLabels),
+			)).
+			Install(testserver.Install(
+				testserver.WithNamespace(namespace),
+				testserver.WithName("test-server-third"),
+				testserver.WithEchoArgs("echo", "--instance", "test-server-third"),
+				testserver.WithoutService(),
+				testserver.WithoutWaitingToBeReady(), // WaitForPods assumes that app label is name, but we change this in WithPodLabels
+				testserver.WithPodLabels(thirdTestServerLabels),
 			)).
 			Install(YamlK8sObject(newSvc(firstTestServerLabels))).
 			Setup(kubernetes.Cluster)
@@ -145,5 +159,26 @@ func ChangeService() {
 
 		// and we did not drop a single request
 		Expect(failedErr).ToNot(HaveOccurred())
+	})
+
+	It("should switch to the instance of a service that in not in the mesh", func() {
+		// given
+		Expect(kubernetes.Cluster.Install(YamlK8sObject(newSvc(firstTestServerLabels)))).To(Succeed())
+		Eventually(func(g Gomega) {
+			instance, err := doRequest()
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(instance).To(Equal("test-server-first"))
+		}, "30s", "1s").Should(Succeed())
+
+		// when
+		err := kubernetes.Cluster.Install(YamlK8sObject(newSvc(thirdTestServerLabels)))
+
+		// then
+		Expect(err).To(Succeed())
+		Eventually(func(g Gomega) {
+			instance, err := doRequest()
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(instance).To(Equal("test-server-third"))
+		}, "30s", "1s").Should(Succeed())
 	})
 }


### PR DESCRIPTION
### Checklist prior to review

We should skip ignored listeners when building vips.
If you use ArgoCD rollouts and you have very long `scaleDownDelaySeconds` (pod running, not in terminating state) and you disable a mesh from the pod, you want to get rid of Kube/Kuma VIP from the map. Without this change you are stuck with VIP which makes client send mTLSed requests which breaks the traffic.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
