### PR TITLE
fix(gateway): check if external service from context when no trafficpermission

### DIFF
--- a/pkg/plugins/runtime/gateway/route/configurers.go
+++ b/pkg/plugins/runtime/gateway/route/configurers.go
@@ -179,6 +179,9 @@ func RouteActionForward(xdsCtx xds_context.Context, endpoints core_xds.EndpointM
 			var requestHeadersToAdd []*envoy_config_core.HeaderValueOption
 
 			isMeshCluster := xdsCtx.Mesh.Resource.ZoneEgressEnabled() || !xdsCtx.Mesh.IsExternalService(destination.Destination[mesh_proto.ServiceTag])
+			if len(xdsCtx.Mesh.Resources.TrafficPermissions().Items) > 0 {
+				isMeshCluster = xdsCtx.Mesh.Resource.ZoneEgressEnabled() || !HasExternalServiceEndpoint(xdsCtx.Mesh.Resource, endpoints, destination)
+			}
 
 			if isMeshCluster {
 				requestHeadersToAdd = []*envoy_config_core.HeaderValueOption{{

--- a/pkg/plugins/runtime/gateway/route_table_generator.go
+++ b/pkg/plugins/runtime/gateway/route_table_generator.go
@@ -69,7 +69,7 @@ func GenerateVirtualHost(
 				envoy_routes.RouteMatchExactHeader(":method", e.Match.Method),
 
 				route.RouteActionRedirect(e.Action.Redirect, info.Listener.Port),
-				route.RouteActionForward(ctx.Mesh.Resource, info.OutboundEndpoints, info.Proxy.Dataplane.Spec.TagSet(), e.Action.Forward),
+				route.RouteActionForward(ctx, info.OutboundEndpoints, info.Proxy.Dataplane.Spec.TagSet(), e.Action.Forward),
 				envoy_routes.RouteActionIdleTimeout(policies_defaults.DefaultGatewayStreamIdleTimeout),
 			)
 

--- a/pkg/plugins/runtime/gateway/testdata/http/external-service-without-default-traffic-permission.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/external-service-without-default-traffic-permission.yaml
@@ -135,10 +135,6 @@ Routes:
             weightedClusters:
               clusters:
               - name: external-httpbin-8490df2e58a77ae0
-                requestHeadersToAdd:
-                - header:
-                    key: x-kuma-tags
-                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
 Runtimes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/external-service-without-default-traffic-permission.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/external-service-without-default-traffic-permission.yaml
@@ -161,10 +161,6 @@ Routes:
             weightedClusters:
               clusters:
               - name: external-httpbin-8490df2e58a77ae0
-                requestHeadersToAdd:
-                - header:
-                    key: x-kuma-tags
-                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
 Runtimes:
   Resources:


### PR DESCRIPTION
### Checklist prior to review

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
