### PR TITLE
chore(check): allow to ignore other paths in shellcheck

### DIFF
--- a/mk/check.mk
+++ b/mk/check.mk
@@ -1,3 +1,5 @@
+SHELLCHECK_IGNORE_PATH=
+
 .PHONY: fmt
 fmt: golangci-lint-fmt fmt/proto fmt/ci ## Dev: Run various format tools
 
@@ -14,7 +16,7 @@ tidy:
 
 .PHONY: shellcheck
 shellcheck:
-	find . -name "*.sh" -not -path "./.git/*" -exec $(SHELLCHECK) -P SCRIPTDIR -x {} +
+	find . -name "*.sh" -not \( -path "./.git/*" -o -path "$(SHELLCHECK_IGNORE_PATH)" \) -exec $(SHELLCHECK) -P SCRIPTDIR -x {} +
 
 .PHONY: golangci-lint
 golangci-lint: ## Dev: Runs golangci-lint linter


### PR DESCRIPTION
### Checklist prior to review

If dependent project has a different directory with the name `*.sh` we can observer error.

```
find . -name "*.sh" -not -path "./.git/*" -exec /work/kong-mesh/kong-mesh/.ci_tools/bin/shellcheck -P SCRIPTDIR -x {} +
./kuma/.git/refs/remotes/origin/dependabot/go_modules/helm.sh: ./kuma/.git/refs/remotes/origin/dependabot/go_modules/helm.sh: openBinaryFile: inappropriate type (is a directory)
```

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
