### PR TITLE
ci(ossf): create SECURITY-INSIGHTS.yml

### DIFF
--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -1,0 +1,60 @@
+header:
+  schema-version: '1.0.0'
+  expiration-date: '2025-01-24T01:00:00.000Z'
+  last-updated: '2024-01-24'
+  last-reviewed: '2024-01-24'
+  project-url: https://github.com/kumahq/kuma
+  changelog: https://github.com/kumahq/kuma/blob/master/CHANGELOG.md
+  license: https://github.com/kumahq/kuma/blob/master/LICENSE
+project-lifecycle:
+  status: active
+  bug-fixes-only: false
+  roadmap: https://github.com/kumahq/kuma/milestones
+  core-maintainers:
+    - github:Automaat
+    - github:bartsmykla
+    - github:lahabana
+    - github:jakubdyszkiewicz
+    - github:lobkovilya
+    - github:lukidzi
+    - github:michaelbeaumont
+    - github:slonka
+contribution-policy:
+  accepts-pull-requests: true
+  accepts-automated-pull-requests: true
+    automated-tools-list:
+    - automated-tool: dependabot
+      action: allowed
+      path:
+        - /
+  code-of-conduct: https://github.com/kumahq/kuma/blob/master/CODE_OF_CONDUCT.md
+dependencies:
+  third-party-packages: true
+  dependencies-lists:
+    - https://github.com/kumahq/kuma/blob/master/go.mod
+distribution-points:
+  - https://github.com/kumahq/kuma/releases
+  - https://download.konghq.com/kuma-binaries-release/
+documentation:
+  - https://kuma.io/docs/
+security-contacts:
+  - type: url
+    value: https://github.com/kumahq/kuma/security/advisories
+security-testing:
+- tool-type: sca
+  tool-name: Dependabot
+  tool-version: latest
+  integration:
+    ad-hoc: false
+    ci: true
+    before-release: true
+- tool-type: sast
+  tool-name: CodeQL
+  tool-version: '3.23.1'
+  integration:
+    ad-hoc: false
+    ci: true
+    before-release: true
+vulnerability-reporting:
+  accepts-vulnerability-reports: true
+  security-policy: https://github.com/kumahq/kuma/security/policy


### PR DESCRIPTION
Following what @lahabana started on sbom and clomonitor

Clomonitor requires a SECURITY-INSIGHTS.yml

This is a first draft based https://github.com/ossf/security-insights-spec/blob/v1.0.0/specification.md and what I could find on the repository. 

I could not find a security mail adress. Is there any ?

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
