### PR TITLE
fix(MeshHTTPRoute): isolate listeners

### DIFF
--- a/api/mesh/v1alpha1/gateway_helpers.go
+++ b/api/mesh/v1alpha1/gateway_helpers.go
@@ -10,3 +10,11 @@ func (g *MeshGateway) IsCrossMesh() bool {
 	}
 	return false
 }
+
+// GetNonEmptyHostname returns "*" if the hostname isn't set.
+func (l *MeshGateway_Listener) GetNonEmptyHostname() string {
+	if h := l.GetHostname(); h != "" {
+		return h
+	}
+	return WildcardHostname
+}

--- a/pkg/core/resources/apis/mesh/gateway_validator.go
+++ b/pkg/core/resources/apis/mesh/gateway_validator.go
@@ -80,10 +80,7 @@ func validateListenerCollapsibility(path validators.PathBuilder, listeners []*me
 		protocols[listener.GetProtocol().String()] = append(protocols[listener.GetProtocol().String()], i)
 
 		// An empty hostname is the same as "*", i.e. matches all hosts.
-		hostname := listener.GetHostname()
-		if hostname == "" {
-			hostname = mesh_proto.WildcardHostname
-		}
+		hostname := listener.GetNonEmptyHostname()
 
 		hostnames[hostname] = append(hostnames[hostname], i)
 

--- a/pkg/core/resources/apis/mesh/validators.go
+++ b/pkg/core/resources/apis/mesh/validators.go
@@ -205,7 +205,7 @@ func ValidatePort(path validators.PathBuilder, port uint32) validators.Validatio
 //   - '*.domain.name'
 //   - 'domain.name'
 func ValidateHostname(path validators.PathBuilder, hostname string) validators.ValidationError {
-	if hostname == "*" {
+	if hostname == mesh_proto.WildcardHostname {
 		return validators.ValidationError{}
 	}
 

--- a/pkg/plugins/policies/core/matchers/dataplane.go
+++ b/pkg/plugins/policies/core/matchers/dataplane.go
@@ -216,7 +216,7 @@ func inboundsSelectedByTags(tagsSelector mesh_proto.TagSelector, dpp *core_mesh.
 				gwListeners = append(gwListeners, core_rules.NewInboundListenerHostname(
 					dpp.Spec.GetNetworking().GetAddress(),
 					listener.Port,
-					listener.GetHostname(),
+					listener.GetNonEmptyHostname(),
 				))
 			}
 		}

--- a/pkg/plugins/policies/core/matchers/dataplane.go
+++ b/pkg/plugins/policies/core/matchers/dataplane.go
@@ -213,11 +213,11 @@ func inboundsSelectedByTags(tagsSelector mesh_proto.TagSelector, dpp *core_mesh.
 					inbounds = append(inbounds, inboundListener)
 					inboundSet[inboundListener] = struct{}{}
 				}
-				gwListeners = append(gwListeners, core_rules.InboundListenerHostname{
-					Address:  dpp.Spec.GetNetworking().GetAddress(),
-					Port:     listener.Port,
-					Hostname: listener.GetHostname(),
-				})
+				gwListeners = append(gwListeners, core_rules.NewInboundListenerHostname(
+					dpp.Spec.GetNetworking().GetAddress(),
+					listener.Port,
+					listener.GetHostname(),
+				))
 			}
 		}
 	}

--- a/pkg/plugins/policies/core/matchers/dataplane.go
+++ b/pkg/plugins/policies/core/matchers/dataplane.go
@@ -26,8 +26,8 @@ func PolicyMatches(resource core_model.Resource, dpp *core_mesh.DataplaneResourc
 	if !ok {
 		return false, errors.New("resource is not a targetRef policy")
 	}
-	selectedInbounds, delegatedGateway, err := dppSelectedByPolicy(resource.GetMeta(), refPolicy.GetTargetRef(), dpp, gateway, referencableResources)
-	return len(selectedInbounds) != 0 || delegatedGateway, err
+	selectedInbounds, selectedGatewayListener, delegatedGateway, err := dppSelectedByPolicy(resource.GetMeta(), refPolicy.GetTargetRef(), dpp, gateway, referencableResources)
+	return len(selectedInbounds) != 0 || len(selectedGatewayListener) != 0 || delegatedGateway, err
 }
 
 // MatchedPolicies match policies using the standard matchers using targetRef (madr-005)
@@ -36,12 +36,13 @@ func MatchedPolicies(rType core_model.ResourceType, dpp *core_mesh.DataplaneReso
 	var warnings []string
 
 	matchedPoliciesByInbound := map[core_rules.InboundListener][]core_model.Resource{}
+	matchedPoliciesByGatewayListener := map[core_rules.InboundListenerHostname][]core_model.Resource{}
 	var dpPolicies []core_model.Resource
 
 	gateway := xds_topology.SelectGateway(resources.Gateways().Items, dpp.Spec.Matches)
 	for _, policy := range policies.GetItems() {
 		refPolicy := policy.GetSpec().(core_model.Policy)
-		selectedInbounds, delegatedGatewaySelected, err := dppSelectedByPolicy(policy.GetMeta(), refPolicy.GetTargetRef(), dpp, gateway, resources)
+		selectedInbounds, matchedGatewayListeners, delegatedGatewaySelected, err := dppSelectedByPolicy(policy.GetMeta(), refPolicy.GetTargetRef(), dpp, gateway, resources)
 		if err != nil {
 			warnings = append(warnings,
 				fmt.Sprintf("unable to resolve TargetRef on policy: mesh:%s name:%s error:%q",
@@ -49,13 +50,16 @@ func MatchedPolicies(rType core_model.ResourceType, dpp *core_mesh.DataplaneReso
 				),
 			)
 		}
-		if len(selectedInbounds) == 0 && !delegatedGatewaySelected {
+		if len(selectedInbounds) == 0 && len(matchedGatewayListeners) == 0 && !delegatedGatewaySelected {
 			// DPP is not matched by the policy
 			continue
 		}
 
 		dpPolicies = append(dpPolicies, policy)
 
+		for _, listener := range matchedGatewayListeners {
+			matchedPoliciesByGatewayListener[listener] = append(matchedPoliciesByGatewayListener[listener], policy)
+		}
 		for _, inbound := range selectedInbounds {
 			matchedPoliciesByInbound[inbound] = append(matchedPoliciesByInbound[inbound], policy)
 		}
@@ -77,7 +81,11 @@ func MatchedPolicies(rType core_model.ResourceType, dpp *core_mesh.DataplaneReso
 		warnings = append(warnings, fmt.Sprintf("couldn't create To rules: %s", err.Error()))
 	}
 
-	gr, err := core_rules.BuildGatewayRules(matchedPoliciesByInbound, resources.ListOrEmpty(meshhttproute_api.MeshHTTPRouteType).GetItems())
+	gr, err := core_rules.BuildGatewayRules(
+		matchedPoliciesByInbound,
+		matchedPoliciesByGatewayListener,
+		resources.ListOrEmpty(meshhttproute_api.MeshHTTPRouteType).GetItems(),
+	)
 	if err != nil {
 		warnings = append(warnings, fmt.Sprintf("couldn't create Gateway rules: %s", err.Error()))
 	}
@@ -106,25 +114,25 @@ func dppSelectedByPolicy(
 	dpp *core_mesh.DataplaneResource,
 	gateway *core_mesh.MeshGatewayResource,
 	referencableResources xds_context.Resources,
-) ([]core_rules.InboundListener, bool, error) {
+) ([]core_rules.InboundListener, []core_rules.InboundListenerHostname, bool, error) {
 	switch ref.Kind {
 	case common_api.Mesh:
 		if isSupportedProxyType(ref.ProxyTypes, resolveDataplaneProxyType(dpp)) {
-			inbounds, gateway := inboundsSelectedByTags(nil, dpp, gateway)
-			return inbounds, gateway, nil
+			inbounds, gwListeners, gateway := inboundsSelectedByTags(nil, dpp, gateway)
+			return inbounds, gwListeners, gateway, nil
 		}
-		return []core_rules.InboundListener{}, false, nil
+		return []core_rules.InboundListener{}, nil, false, nil
 	case common_api.MeshSubset:
 		if isSupportedProxyType(ref.ProxyTypes, resolveDataplaneProxyType(dpp)) {
-			inbounds, gateway := inboundsSelectedByTags(ref.Tags, dpp, gateway)
-			return inbounds, gateway, nil
+			inbounds, gwListeners, gateway := inboundsSelectedByTags(ref.Tags, dpp, gateway)
+			return inbounds, gwListeners, gateway, nil
 		}
-		return []core_rules.InboundListener{}, false, nil
+		return []core_rules.InboundListener{}, nil, false, nil
 	case common_api.MeshService:
-		inbounds, gateway := inboundsSelectedByTags(map[string]string{
+		inbounds, gwListeners, gateway := inboundsSelectedByTags(map[string]string{
 			mesh_proto.ServiceTag: ref.Name,
 		}, dpp, gateway)
-		return inbounds, gateway, nil
+		return inbounds, gwListeners, gateway, nil
 	case common_api.MeshServiceSubset:
 		tags := map[string]string{
 			mesh_proto.ServiceTag: ref.Name,
@@ -132,30 +140,22 @@ func dppSelectedByPolicy(
 		for k, v := range ref.Tags {
 			tags[k] = v
 		}
-		inbounds, gateway := inboundsSelectedByTags(tags, dpp, gateway)
-		return inbounds, gateway, nil
+		inbounds, gwListeners, gateway := inboundsSelectedByTags(tags, dpp, gateway)
+		return inbounds, gwListeners, gateway, nil
 	case common_api.MeshGateway:
 		if gateway == nil || !dpp.Spec.IsBuiltinGateway() || !core_model.IsReferenced(meta, ref.Name, gateway.GetMeta()) {
-			return nil, false, nil
+			return nil, nil, false, nil
 		}
-		var result []core_rules.InboundListener
-		for _, listener := range gateway.Spec.GetConf().GetListeners() {
-			if mesh_proto.TagSelector(ref.Tags).Matches(listener.GetTags()) {
-				result = append(result, core_rules.InboundListener{
-					Address: dpp.Spec.GetNetworking().GetAddress(),
-					Port:    listener.Port,
-				})
-			}
-		}
-		return result, false, nil
+		inbounds, gwListeners, _ := inboundsSelectedByTags(ref.Tags, dpp, gateway)
+		return inbounds, gwListeners, false, nil
 	case common_api.MeshHTTPRoute:
 		mhr := resolveMeshHTTPRouteRef(meta, ref.Name, referencableResources.ListOrEmpty(meshhttproute_api.MeshHTTPRouteType))
 		if mhr == nil {
-			return nil, false, fmt.Errorf("couldn't resolve MeshHTTPRoute targetRef with name '%s'", ref.Name)
+			return nil, nil, false, fmt.Errorf("couldn't resolve MeshHTTPRoute targetRef with name '%s'", ref.Name)
 		}
 		return dppSelectedByPolicy(mhr.Meta, mhr.Spec.TargetRef, dpp, gateway, referencableResources)
 	default:
-		return nil, false, fmt.Errorf("unsupported targetRef kind '%s'", ref.Kind)
+		return nil, nil, false, fmt.Errorf("unsupported targetRef kind '%s'", ref.Kind)
 	}
 }
 
@@ -181,21 +181,22 @@ func isSupportedProxyType(supportedTypes []common_api.TargetRefProxyType, dppTyp
 
 // inboundsSelectedByTags returns which inbounds are selected and whether a
 // delegated gateway is selected
-func inboundsSelectedByTags(tagsSelector mesh_proto.TagSelector, dpp *core_mesh.DataplaneResource, gateway *core_mesh.MeshGatewayResource) ([]core_rules.InboundListener, bool) {
-	result := []core_rules.InboundListener{}
+func inboundsSelectedByTags(tagsSelector mesh_proto.TagSelector, dpp *core_mesh.DataplaneResource, gateway *core_mesh.MeshGatewayResource) ([]core_rules.InboundListener, []core_rules.InboundListenerHostname, bool) {
+	inbounds := []core_rules.InboundListener{}
 	for _, inbound := range dpp.Spec.GetNetworking().GetInbound() {
 		if inbound.State == mesh_proto.Dataplane_Networking_Inbound_Ignored {
 			continue
 		}
 		if tagsSelector.Matches(inbound.Tags) {
 			intf := dpp.Spec.GetNetworking().ToInboundInterface(inbound)
-			result = append(result, core_rules.InboundListener{
+			inbounds = append(inbounds, core_rules.InboundListener{
 				Address: intf.DataplaneIP,
 				Port:    intf.DataplanePort,
 			})
 		}
 	}
-	delegatedGatewaySelected := dpp.Spec.IsDelegatedGateway() && tagsSelector.Matches(dpp.Spec.GetNetworking().GetGateway().Tags)
+	gwListeners := []core_rules.InboundListenerHostname{}
+	inboundSet := map[core_rules.InboundListener]struct{}{}
 	if gateway != nil {
 		for _, listener := range gateway.Spec.GetConf().GetListeners() {
 			listenerTags := mesh_proto.Merge(
@@ -204,14 +205,24 @@ func inboundsSelectedByTags(tagsSelector mesh_proto.TagSelector, dpp *core_mesh.
 				listener.GetTags(),
 			)
 			if tagsSelector.Matches(listenerTags) {
-				result = append(result, core_rules.InboundListener{
+				inboundListener := core_rules.InboundListener{
 					Address: dpp.Spec.GetNetworking().GetAddress(),
 					Port:    listener.Port,
+				}
+				if _, ok := inboundSet[inboundListener]; !ok {
+					inbounds = append(inbounds, inboundListener)
+					inboundSet[inboundListener] = struct{}{}
+				}
+				gwListeners = append(gwListeners, core_rules.InboundListenerHostname{
+					Address:  dpp.Spec.GetNetworking().GetAddress(),
+					Port:     listener.Port,
+					Hostname: listener.GetHostname(),
 				})
 			}
 		}
 	}
-	return result, delegatedGatewaySelected
+	delegatedGatewaySelected := dpp.Spec.IsDelegatedGateway() && tagsSelector.Matches(dpp.Spec.GetNetworking().GetGateway().Tags)
+	return inbounds, gwListeners, delegatedGatewaySelected
 }
 
 type ByTargetRef []core_model.Resource

--- a/pkg/plugins/policies/core/matchers/egress.go
+++ b/pkg/plugins/policies/core/matchers/egress.go
@@ -9,7 +9,6 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
-	"github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
 	core_rules "github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 )
@@ -76,13 +75,9 @@ func processFromRules(
 
 	sort.Sort(ByTargetRef(matchedPolicies))
 
-	fromRules, err := core_rules.BuildFromRules(map[core_rules.InboundListener][]core_model.Resource{
+	return core_rules.BuildFromRules(map[core_rules.InboundListener][]core_model.Resource{
 		{}: matchedPolicies, // egress always has only 1 listener, so we can use empty key
 	})
-	if err != nil {
-		return rules.FromRules{}, err
-	}
-	return fromRules, nil
 }
 
 // It's not natural for zone egress to have 'to' policies. It doesn't make sense to target

--- a/pkg/plugins/policies/core/matchers/egress.go
+++ b/pkg/plugins/policies/core/matchers/egress.go
@@ -9,6 +9,7 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+	"github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
 	core_rules "github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 )
@@ -75,9 +76,13 @@ func processFromRules(
 
 	sort.Sort(ByTargetRef(matchedPolicies))
 
-	return core_rules.BuildFromRules(map[core_rules.InboundListener][]core_model.Resource{
+	fromRules, err := core_rules.BuildFromRules(map[core_rules.InboundListener][]core_model.Resource{
 		{}: matchedPolicies, // egress always has only 1 listener, so we can use empty key
 	})
+	if err != nil {
+		return rules.FromRules{}, err
+	}
+	return fromRules, nil
 }
 
 // It's not natural for zone egress to have 'to' policies. It doesn't make sense to target

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.golden.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.golden.yaml
@@ -39,67 +39,133 @@ FromRules:
       type: MeshAccessLog
     Subset: []
 ToRules:
-  127.0.0.1:8080:
-  - Conf:
-      backends:
-      - file:
-          path: /gateway-listener
-        type: File
-    Origin:
-    - creationTime: "0001-01-01T00:00:00Z"
-      mesh: mesh-1
-      modificationTime: "0001-01-01T00:00:00Z"
-      name: gateway
-      type: MeshAccessLog
-    - creationTime: "0001-01-01T00:00:00Z"
-      mesh: mesh-1
-      modificationTime: "0001-01-01T00:00:00Z"
-      name: gatewaylistener
-      type: MeshAccessLog
-    - creationTime: "0001-01-01T00:00:00Z"
-      mesh: mesh-1
-      modificationTime: "0001-01-01T00:00:00Z"
-      name: mesh
-      type: MeshAccessLog
-    Subset: []
-  127.0.0.1:8081:
-  - Conf:
-      backends:
-      - file:
-          path: /servicesubset
-        type: File
-    Origin:
-    - creationTime: "0001-01-01T00:00:00Z"
-      mesh: mesh-1
-      modificationTime: "0001-01-01T00:00:00Z"
-      name: gateway
-      type: MeshAccessLog
-    - creationTime: "0001-01-01T00:00:00Z"
-      mesh: mesh-1
-      modificationTime: "0001-01-01T00:00:00Z"
-      name: mesh
-      type: MeshAccessLog
-    - creationTime: "0001-01-01T00:00:00Z"
-      mesh: mesh-1
-      modificationTime: "0001-01-01T00:00:00Z"
-      name: servicesubset
-      type: MeshAccessLog
-    Subset: []
-  127.0.0.1:8082:
-  - Conf:
-      backends:
-      - file:
-          path: /to-gateway
-        type: File
-    Origin:
-    - creationTime: "0001-01-01T00:00:00Z"
-      mesh: mesh-1
-      modificationTime: "0001-01-01T00:00:00Z"
-      name: gateway
-      type: MeshAccessLog
-    - creationTime: "0001-01-01T00:00:00Z"
-      mesh: mesh-1
-      modificationTime: "0001-01-01T00:00:00Z"
-      name: mesh
-      type: MeshAccessLog
-    Subset: []
+  ByListener:
+    127.0.0.1:8080:
+    - Conf:
+        backends:
+        - file:
+            path: /gateway-listener
+          type: File
+      Origin:
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: gateway
+        type: MeshAccessLog
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: gatewaylistener
+        type: MeshAccessLog
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: mesh
+        type: MeshAccessLog
+      Subset: []
+    127.0.0.1:8081:
+    - Conf:
+        backends:
+        - file:
+            path: /servicesubset
+          type: File
+      Origin:
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: gateway
+        type: MeshAccessLog
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: mesh
+        type: MeshAccessLog
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: servicesubset
+        type: MeshAccessLog
+      Subset: []
+    127.0.0.1:8082:
+    - Conf:
+        backends:
+        - file:
+            path: /to-gateway
+          type: File
+      Origin:
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: gateway
+        type: MeshAccessLog
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: mesh
+        type: MeshAccessLog
+      Subset: []
+  ByListenerAndHostname:
+    '127.0.0.1:8080:':
+    - Conf:
+        backends:
+        - file:
+            path: /gateway-listener
+          type: File
+      Origin:
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: gateway
+        type: MeshAccessLog
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: gatewaylistener
+        type: MeshAccessLog
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: mesh
+        type: MeshAccessLog
+      Subset: []
+    '127.0.0.1:8081:':
+    - Conf:
+        backends:
+        - file:
+            path: /to-gateway
+          type: File
+      Origin:
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: gateway
+        type: MeshAccessLog
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: mesh
+        type: MeshAccessLog
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: servicesubset
+        type: MeshAccessLog
+      Subset: []
+    '127.0.0.1:8082:':
+    - Conf:
+        backends:
+        - file:
+            path: /to-gateway
+          type: File
+      Origin:
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: gateway
+        type: MeshAccessLog
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: mesh
+        type: MeshAccessLog
+      Subset: []

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.golden.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.golden.yaml
@@ -105,7 +105,7 @@ ToRules:
         type: MeshAccessLog
       Subset: []
   ByListenerAndHostname:
-    '127.0.0.1:8080:':
+    127.0.0.1:8080:*:
     - Conf:
         backends:
         - file:
@@ -128,7 +128,7 @@ ToRules:
         name: mesh
         type: MeshAccessLog
       Subset: []
-    '127.0.0.1:8081:':
+    127.0.0.1:8081:*:
     - Conf:
         backends:
         - file:
@@ -151,7 +151,7 @@ ToRules:
         name: servicesubset
         type: MeshAccessLog
       Subset: []
-    '127.0.0.1:8082:':
+    127.0.0.1:8082:*:
     - Conf:
         backends:
         - file:

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/02.golden.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/02.golden.yaml
@@ -2,58 +2,179 @@ FromRules:
   127.0.0.1:8080: []
   127.0.0.1:8081: []
   127.0.0.1:8082: []
+  127.0.0.1:8083: []
 ToRules:
-  127.0.0.1:8080:
-  - Conf:
-      backends:
-      - file:
-          path: /meshsubset
-        type: File
-    Origin:
-    - creationTime: "0001-01-01T00:00:00Z"
-      mesh: mesh-1
-      modificationTime: "0001-01-01T00:00:00Z"
-      name: mesh
-      type: MeshAccessLog
-    - creationTime: "0001-01-01T00:00:00Z"
-      mesh: mesh-1
-      modificationTime: "0001-01-01T00:00:00Z"
-      name: meshsubset
-      type: MeshAccessLog
-    Subset: []
-  127.0.0.1:8081:
-  - Conf:
-      backends:
-      - file:
-          path: /meshsubset
-        type: File
-    Origin:
-    - creationTime: "0001-01-01T00:00:00Z"
-      mesh: mesh-1
-      modificationTime: "0001-01-01T00:00:00Z"
-      name: mesh
-      type: MeshAccessLog
-    - creationTime: "0001-01-01T00:00:00Z"
-      mesh: mesh-1
-      modificationTime: "0001-01-01T00:00:00Z"
-      name: meshsubset
-      type: MeshAccessLog
-    Subset: []
-  127.0.0.1:8082:
-  - Conf:
-      backends:
-      - file:
-          path: /meshsubset
-        type: File
-    Origin:
-    - creationTime: "0001-01-01T00:00:00Z"
-      mesh: mesh-1
-      modificationTime: "0001-01-01T00:00:00Z"
-      name: mesh
-      type: MeshAccessLog
-    - creationTime: "0001-01-01T00:00:00Z"
-      mesh: mesh-1
-      modificationTime: "0001-01-01T00:00:00Z"
-      name: meshsubset
-      type: MeshAccessLog
-    Subset: []
+  ByListener:
+    127.0.0.1:8080:
+    - Conf:
+        backends:
+        - file:
+            path: /meshsubset
+          type: File
+      Origin:
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: mesh
+        type: MeshAccessLog
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: meshsubset
+        type: MeshAccessLog
+      Subset: []
+    127.0.0.1:8081:
+    - Conf:
+        backends:
+        - file:
+            path: /meshsubset
+          type: File
+      Origin:
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: mesh
+        type: MeshAccessLog
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: meshsubset
+        type: MeshAccessLog
+      Subset: []
+    127.0.0.1:8082:
+    - Conf:
+        backends:
+        - file:
+            path: /meshsubset
+          type: File
+      Origin:
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: mesh
+        type: MeshAccessLog
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: meshsubset
+        type: MeshAccessLog
+      Subset: []
+    127.0.0.1:8083:
+    - Conf:
+        backends:
+        - file:
+            path: /applied-only-to-hostname
+          type: File
+      Origin:
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: mesh
+        type: MeshAccessLog
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: meshsubset
+        type: MeshAccessLog
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: only-one-hostname-listener
+        type: MeshAccessLog
+      Subset: []
+  ByListenerAndHostname:
+    '127.0.0.1:8080:':
+    - Conf:
+        backends:
+        - file:
+            path: /meshsubset
+          type: File
+      Origin:
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: mesh
+        type: MeshAccessLog
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: meshsubset
+        type: MeshAccessLog
+      Subset: []
+    '127.0.0.1:8081:':
+    - Conf:
+        backends:
+        - file:
+            path: /meshsubset
+          type: File
+      Origin:
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: mesh
+        type: MeshAccessLog
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: meshsubset
+        type: MeshAccessLog
+      Subset: []
+    '127.0.0.1:8082:':
+    - Conf:
+        backends:
+        - file:
+            path: /meshsubset
+          type: File
+      Origin:
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: mesh
+        type: MeshAccessLog
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: meshsubset
+        type: MeshAccessLog
+      Subset: []
+    127.0.0.1:8083:four-hostname-1:
+    - Conf:
+        backends:
+        - file:
+            path: /applied-only-to-hostname
+          type: File
+      Origin:
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: mesh
+        type: MeshAccessLog
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: meshsubset
+        type: MeshAccessLog
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: only-one-hostname-listener
+        type: MeshAccessLog
+      Subset: []
+    127.0.0.1:8083:four-hostname-2:
+    - Conf:
+        backends:
+        - file:
+            path: /meshsubset
+          type: File
+      Origin:
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: mesh
+        type: MeshAccessLog
+      - creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: meshsubset
+        type: MeshAccessLog
+      Subset: []

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/02.golden.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/02.golden.yaml
@@ -83,7 +83,7 @@ ToRules:
         type: MeshAccessLog
       Subset: []
   ByListenerAndHostname:
-    '127.0.0.1:8080:':
+    127.0.0.1:8080:*:
     - Conf:
         backends:
         - file:
@@ -101,7 +101,7 @@ ToRules:
         name: meshsubset
         type: MeshAccessLog
       Subset: []
-    '127.0.0.1:8081:':
+    127.0.0.1:8081:*:
     - Conf:
         backends:
         - file:
@@ -119,7 +119,7 @@ ToRules:
         name: meshsubset
         type: MeshAccessLog
       Subset: []
-    '127.0.0.1:8082:':
+    127.0.0.1:8082:*:
     - Conf:
         backends:
         - file:

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/02.policies.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/02.policies.yaml
@@ -3,68 +3,96 @@ type: MeshAccessLog
 mesh: mesh-1
 name: mesh
 spec:
- targetRef:
-  kind: Mesh
- to:
-  - targetRef:
-     kind: Mesh
-    default:
-      backends:
-        - type: File
-          file:
-            path: /mesh
+  targetRef:
+    kind: Mesh
+  to:
+    - targetRef:
+        kind: Mesh
+      default:
+        backends:
+          - type: File
+            file:
+              path: /mesh
 ---
 type: MeshAccessLog
 mesh: mesh-1
 name: meshsubset
 spec:
- targetRef:
-  kind: MeshSubset
-  proxyTypes: ["Gateway"]
- to:
-  - targetRef:
-     kind: Mesh
-    default:
-      backends:
-        - type: File
-          file:
-            path: /meshsubset
+  targetRef:
+    kind: MeshSubset
+    proxyTypes: ["Gateway"]
+  to:
+    - targetRef:
+        kind: Mesh
+      default:
+        backends:
+          - type: File
+            file:
+              path: /meshsubset
 ---
 type: MeshAccessLog
 mesh: mesh-1
 name: nonmatchinggatewaylistener
 spec:
- targetRef:
-  kind: MeshGateway
-  name: other-gateway
-  tags:
-    listener: three
- to:
-  - targetRef:
-     kind: Mesh
-    default:
-      backends:
-        - type: File
-          file:
-            path: /shouldnt-be-applied
+  targetRef:
+    kind: MeshGateway
+    name: other-gateway
+    tags:
+      listener: three
+  to:
+    - targetRef:
+        kind: Mesh
+      default:
+        backends:
+          - type: File
+            file:
+              path: /shouldnt-be-applied
+---
+type: MeshAccessLog
+mesh: mesh-1
+name: only-one-hostname-listener
+spec:
+  targetRef:
+    kind: MeshGateway
+    name: gateway-1
+    tags:
+      listener: four-hostname-1
+  to:
+    - targetRef:
+        kind: Mesh
+      default:
+        backends:
+          - type: File
+            file:
+              path: /applied-only-to-hostname
 ---
 type: MeshGateway
 mesh: mesh-1
 name: gateway-1
 selectors:
- - match:
-    kuma.io/service: edge-gateway
+  - match:
+      kuma.io/service: edge-gateway
 conf:
- listeners:
-  - port: 8080
-    protocol: HTTP
-    tags:
-     listener: one
-  - port: 8081
-    protocol: HTTP
-    tags:
-     listener: two
-  - port: 8082
-    protocol: HTTP
-    tags:
-     listener: three
+  listeners:
+    - port: 8080
+      protocol: HTTP
+      tags:
+        listener: one
+    - port: 8081
+      protocol: HTTP
+      tags:
+        listener: two
+    - port: 8082
+      protocol: HTTP
+      tags:
+        listener: three
+    - port: 8083
+      protocol: HTTP
+      hostname: four-hostname-1
+      tags:
+        listener: four-hostname-1
+    - port: 8083
+      protocol: HTTP
+      hostname: four-hostname-2
+      tags:
+        listener: four-hostname-2

--- a/pkg/plugins/policies/core/rules/rules.go
+++ b/pkg/plugins/policies/core/rules/rules.go
@@ -49,7 +49,7 @@ type ToRules struct {
 type InboundListenerHostname struct {
 	Address  string
 	Port     uint32
-	Hostname string
+	hostname string
 }
 
 var _ encoding.TextMarshaler = InboundListenerHostname{}
@@ -59,18 +59,29 @@ func (i InboundListenerHostname) MarshalText() ([]byte, error) {
 }
 
 func (i InboundListenerHostname) String() string {
-	return fmt.Sprintf("%s:%d:%s", i.Address, i.Port, i.Hostname)
+	return fmt.Sprintf("%s:%d:%s", i.Address, i.Port, i.hostname)
+}
+
+func NewInboundListenerHostname(address string, port uint32, hostname string) InboundListenerHostname {
+	if hostname == "" {
+		hostname = "*"
+	}
+	return InboundListenerHostname{
+		Address:  address,
+		Port:     port,
+		hostname: hostname,
+	}
 }
 
 func InboundListenerHostnameFromGatewayListener(
 	l *mesh_proto.MeshGateway_Listener,
 	address string,
 ) InboundListenerHostname {
-	return InboundListenerHostname{
-		Address:  address,
-		Port:     l.GetPort(),
-		Hostname: l.GetHostname(),
-	}
+	return NewInboundListenerHostname(
+		address,
+		l.GetPort(),
+		l.GetHostname(),
+	)
 }
 
 type GatewayToRules struct {

--- a/pkg/plugins/policies/core/rules/rules.go
+++ b/pkg/plugins/policies/core/rules/rules.go
@@ -46,8 +46,40 @@ type ToRules struct {
 	Rules Rules
 }
 
+type InboundListenerHostname struct {
+	Address  string
+	Port     uint32
+	Hostname string
+}
+
+var _ encoding.TextMarshaler = InboundListenerHostname{}
+
+func (i InboundListenerHostname) MarshalText() ([]byte, error) {
+	return []byte(i.String()), nil
+}
+
+func (i InboundListenerHostname) String() string {
+	return fmt.Sprintf("%s:%d:%s", i.Address, i.Port, i.Hostname)
+}
+
+func InboundListenerHostnameFromGatewayListener(
+	l *mesh_proto.MeshGateway_Listener,
+	address string,
+) InboundListenerHostname {
+	return InboundListenerHostname{
+		Address:  address,
+		Port:     l.GetPort(),
+		Hostname: l.GetHostname(),
+	}
+}
+
+type GatewayToRules struct {
+	ByListenerAndHostname map[InboundListenerHostname]Rules
+	ByListener            map[InboundListener]Rules
+}
+
 type GatewayRules struct {
-	ToRules   map[InboundListener]Rules
+	ToRules   GatewayToRules
 	FromRules map[InboundListener]Rules
 }
 
@@ -236,7 +268,9 @@ func BuildFromRules(
 		}
 		rulesByInbound[inbound] = rules
 	}
-	return FromRules{Rules: rulesByInbound}, nil
+	return FromRules{
+		Rules: rulesByInbound,
+	}, nil
 }
 
 func BuildToRules(matchedPolicies []core_model.Resource, httpRoutes []core_model.Resource) (ToRules, error) {
@@ -259,15 +293,20 @@ func BuildToRules(matchedPolicies []core_model.Resource, httpRoutes []core_model
 
 func BuildGatewayRules(
 	matchedPoliciesByInbound map[InboundListener][]core_model.Resource,
+	matchedPoliciesByListener map[InboundListenerHostname][]core_model.Resource,
 	httpRoutes []core_model.Resource,
 ) (GatewayRules, error) {
 	toRulesByInbound := map[InboundListener]Rules{}
-	for inbound, policies := range matchedPoliciesByInbound {
+	toRulesByListenerHostname := map[InboundListenerHostname]Rules{}
+	for listener, policies := range matchedPoliciesByListener {
 		toRules, err := BuildToRules(policies, httpRoutes)
 		if err != nil {
 			return GatewayRules{}, err
 		}
-		toRulesByInbound[inbound] = toRules.Rules
+		toRulesByListenerHostname[listener] = toRules.Rules
+	}
+	for inbound, policies := range matchedPoliciesByInbound {
+		toRules, err := BuildToRules(policies, httpRoutes)
 		if err != nil {
 			return GatewayRules{}, err
 		}
@@ -280,7 +319,10 @@ func BuildGatewayRules(
 	}
 
 	return GatewayRules{
-		ToRules:   toRulesByInbound,
+		ToRules: GatewayToRules{
+			ByListenerAndHostname: toRulesByListenerHostname,
+			ByListener:            toRulesByInbound,
+		},
 		FromRules: fromRules.Rules,
 	}, nil
 }

--- a/pkg/plugins/policies/core/rules/rules.go
+++ b/pkg/plugins/policies/core/rules/rules.go
@@ -64,7 +64,7 @@ func (i InboundListenerHostname) String() string {
 
 func NewInboundListenerHostname(address string, port uint32, hostname string) InboundListenerHostname {
 	if hostname == "" {
-		hostname = "*"
+		hostname = mesh_proto.WildcardHostname
 	}
 	return InboundListenerHostname{
 		Address:  address,
@@ -80,7 +80,7 @@ func InboundListenerHostnameFromGatewayListener(
 	return NewInboundListenerHostname(
 		address,
 		l.GetPort(),
-		l.GetHostname(),
+		l.GetNonEmptyHostname(),
 	)
 }
 

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin.go
@@ -191,7 +191,7 @@ func applyToGateway(
 			continue
 		}
 
-		if toListenerRules, ok := rules.ToRules[listenerKey]; ok {
+		if toListenerRules, ok := rules.ToRules.ByListener[listenerKey]; ok {
 			if err := configureOutbound(
 				toListenerRules,
 				proxy.Dataplane,

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
@@ -1012,16 +1012,18 @@ var _ = Describe("MeshAccessLog", func() {
 						},
 					},
 				},
-				ToRules: map[core_rules.InboundListener]core_rules.Rules{
-					{Address: "127.0.0.1", Port: 8080}: {
-						{
-							Subset: core_rules.Subset{},
-							Conf: api.Conf{
-								Backends: &[]api.Backend{{
-									File: &api.FileBackend{
-										Path: "/tmp/to-log",
-									},
-								}},
+				ToRules: core_rules.GatewayToRules{
+					ByListener: map[core_rules.InboundListener]core_rules.Rules{
+						{Address: "127.0.0.1", Port: 8080}: {
+							{
+								Subset: core_rules.Subset{},
+								Conf: api.Conf{
+									Backends: &[]api.Backend{{
+										File: &api.FileBackend{
+											Path: "/tmp/to-log",
+										},
+									}},
+								},
 							},
 						},
 					},

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin.go
@@ -113,7 +113,7 @@ func applyToGateways(
 	proxy *core_xds.Proxy,
 ) error {
 	for _, listenerInfo := range gateway.ExtractGatewayListeners(proxy) {
-		rules, ok := gatewayRules.ToRules[core_rules.InboundListener{
+		rules, ok := gatewayRules.ToRules.ByListener[core_rules.InboundListener{
 			Address: proxy.Dataplane.Spec.GetNetworking().Address,
 			Port:    listenerInfo.Listener.Port,
 		}]

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin_test.go
@@ -437,16 +437,18 @@ var _ = Describe("MeshCircuitBreaker", func() {
 		Entry("basic outbound cluster with connection limits", gatewayTestCase{
 			name: "basic",
 			rules: core_rules.GatewayRules{
-				ToRules: map[core_rules.InboundListener]core_rules.Rules{
-					{Address: "192.168.0.1", Port: 8080}: {{
-						Subset: core_rules.Subset{core_rules.Tag{
-							Key:   mesh_proto.ServiceTag,
-							Value: "backend",
+				ToRules: core_rules.GatewayToRules{
+					ByListener: map[core_rules.InboundListener]core_rules.Rules{
+						{Address: "192.168.0.1", Port: 8080}: {{
+							Subset: core_rules.Subset{core_rules.Tag{
+								Key:   mesh_proto.ServiceTag,
+								Value: "backend",
+							}},
+							Conf: api.Conf{
+								ConnectionLimits: genConnectionLimits(),
+							},
 						}},
-						Conf: api.Conf{
-							ConnectionLimits: genConnectionLimits(),
-						},
-					}},
+					},
 				},
 			},
 		}),

--- a/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin.go
@@ -116,7 +116,7 @@ func applyToGateways(
 		if !ok {
 			continue
 		}
-		rules, ok := rules.ToRules[listenerKey]
+		rules, ok := rules.ToRules.ByListener[listenerKey]
 		if !ok {
 			continue
 		}

--- a/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin_test.go
@@ -441,28 +441,32 @@ var _ = Describe("MeshFaultInjection", func() {
 	It("should generate proper Envoy config for MeshGateway Dataplanes", func() {
 		// given
 		rules := core_rules.GatewayRules{
-			ToRules: map[core_rules.InboundListener]core_rules.Rules{
-				{Address: "192.168.0.1", Port: 8080}: {{
-					Subset: core_rules.Subset{},
-					Conf: api.Conf{
-						Http: &[]api.FaultInjectionConf{
-							{
-								Abort: &api.AbortConf{
-									HttpStatus: int32(444),
-									Percentage: intstr.FromInt(12),
-								},
-								Delay: &api.DelayConf{
-									Value:      *test.ParseDuration("55s"),
-									Percentage: intstr.FromString("55"),
-								},
-								ResponseBandwidth: &api.ResponseBandwidthConf{
-									Limit:      "111Mbps",
-									Percentage: intstr.FromString("62.9"),
+			ToRules: core_rules.GatewayToRules{
+				ByListener: map[core_rules.InboundListener]core_rules.Rules{
+					{Address: "192.168.0.1", Port: 8080}: {
+						{
+							Subset: core_rules.Subset{},
+							Conf: api.Conf{
+								Http: &[]api.FaultInjectionConf{
+									{
+										Abort: &api.AbortConf{
+											HttpStatus: int32(444),
+											Percentage: intstr.FromInt(12),
+										},
+										Delay: &api.DelayConf{
+											Value:      *test.ParseDuration("55s"),
+											Percentage: intstr.FromString("55"),
+										},
+										ResponseBandwidth: &api.ResponseBandwidthConf{
+											Limit:      "111Mbps",
+											Percentage: intstr.FromString("62.9"),
+										},
+									},
 								},
 							},
 						},
 					},
-				}},
+				},
 			},
 		}
 

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin.go
@@ -71,7 +71,7 @@ func applyToGateways(
 	proxy *core_xds.Proxy,
 ) error {
 	for _, listenerInfo := range gateway_plugin.ExtractGatewayListeners(proxy) {
-		rules, ok := gatewayRules.ToRules[core_rules.InboundListener{
+		rules, ok := gatewayRules.ToRules.ByListener[core_rules.InboundListener{
 			Address: proxy.Dataplane.Spec.GetNetworking().Address,
 			Port:    listenerInfo.Listener.Port,
 		}]

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
@@ -286,43 +286,45 @@ var _ = Describe("MeshHealthCheck", func() {
 		Entry("basic outbound cluster with HTTP health check", gatewayTestCase{
 			name: "basic",
 			rules: core_rules.GatewayRules{
-				ToRules: map[core_rules.InboundListener]core_rules.Rules{
-					{Address: "192.168.0.1", Port: 8080}: {
-						{
-							Subset: core_rules.Subset{},
-							Conf: api.Conf{
-								Interval:                     test.ParseDuration("10s"),
-								Timeout:                      test.ParseDuration("2s"),
-								UnhealthyThreshold:           pointer.To[int32](3),
-								HealthyThreshold:             pointer.To[int32](1),
-								InitialJitter:                test.ParseDuration("13s"),
-								IntervalJitter:               test.ParseDuration("15s"),
-								IntervalJitterPercent:        pointer.To[int32](10),
-								HealthyPanicThreshold:        pointer.To(intstr.FromString("62.9")),
-								FailTrafficOnPanic:           pointer.To(true),
-								EventLogPath:                 pointer.To("/tmp/log.txt"),
-								AlwaysLogHealthCheckFailures: pointer.To(false),
-								NoTrafficInterval:            test.ParseDuration("16s"),
-								Http: &api.HttpHealthCheck{
-									Disabled: pointer.To(false),
-									Path:     pointer.To("/health"),
-									RequestHeadersToAdd: &api.HeaderModifier{
-										Add: []api.HeaderKeyValue{
-											{
-												Name:  "x-some-header",
-												Value: "value",
+				ToRules: core_rules.GatewayToRules{
+					ByListener: map[core_rules.InboundListener]core_rules.Rules{
+						{Address: "192.168.0.1", Port: 8080}: {
+							{
+								Subset: core_rules.Subset{},
+								Conf: api.Conf{
+									Interval:                     test.ParseDuration("10s"),
+									Timeout:                      test.ParseDuration("2s"),
+									UnhealthyThreshold:           pointer.To[int32](3),
+									HealthyThreshold:             pointer.To[int32](1),
+									InitialJitter:                test.ParseDuration("13s"),
+									IntervalJitter:               test.ParseDuration("15s"),
+									IntervalJitterPercent:        pointer.To[int32](10),
+									HealthyPanicThreshold:        pointer.To(intstr.FromString("62.9")),
+									FailTrafficOnPanic:           pointer.To(true),
+									EventLogPath:                 pointer.To("/tmp/log.txt"),
+									AlwaysLogHealthCheckFailures: pointer.To(false),
+									NoTrafficInterval:            test.ParseDuration("16s"),
+									Http: &api.HttpHealthCheck{
+										Disabled: pointer.To(false),
+										Path:     pointer.To("/health"),
+										RequestHeadersToAdd: &api.HeaderModifier{
+											Add: []api.HeaderKeyValue{
+												{
+													Name:  "x-some-header",
+													Value: "value",
+												},
+											},
+											Set: []api.HeaderKeyValue{
+												{
+													Name:  "x-some-other-header",
+													Value: "value",
+												},
 											},
 										},
-										Set: []api.HeaderKeyValue{
-											{
-												Name:  "x-some-other-header",
-												Value: "value",
-											},
-										},
+										ExpectedStatuses: &[]int32{200, 201},
 									},
-									ExpectedStatuses: &[]int32{200, 201},
+									ReuseConnection: pointer.To(true),
 								},
-								ReuseConnection: pointer.To(true),
 							},
 						},
 					},

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/gateway_routes.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/gateway_routes.go
@@ -55,10 +55,7 @@ func CollectListenerInfos(
 				listener: listener,
 			}
 		}
-		hostname := listener.Hostname
-		if hostname == "" {
-			hostname = "*"
-		}
+		hostname := listener.GetNonEmptyHostname()
 		listenerAcc.hostnames = append(listenerAcc.hostnames, hostnameTags{
 			Hostname: hostname,
 			Tags: mesh_proto.Merge(

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/gateway_routes.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/gateway_routes.go
@@ -135,11 +135,11 @@ func SortRulesToHosts(
 	var hostInfos []plugin_gateway.GatewayHostInfo
 
 	for _, hostnameTag := range hostnameTags {
-		inboundListener := rules.InboundListenerHostname{
-			Address:  address,
-			Port:     listener.GetPort(),
-			Hostname: hostnameTag.Hostname,
-		}
+		inboundListener := rules.NewInboundListenerHostname(
+			address,
+			listener.GetPort(),
+			hostnameTag.Hostname,
+		)
 		rawRules, ok := rawRules.ToRules.ByListenerAndHostname[inboundListener]
 		if !ok {
 			continue

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/gateway_routes.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/gateway_routes.go
@@ -10,7 +10,6 @@ import (
 
 	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/permissions"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
@@ -27,10 +26,13 @@ import (
 	xds_topology "github.com/kumahq/kuma/pkg/xds/topology"
 )
 
+type hostnameTags struct {
+	Hostname string
+	Tags     map[string]string
+}
 type listenersHostnames struct {
-	hostnames []string
 	listener  *mesh_proto.MeshGateway_Listener
-	tags      map[string]string
+	hostnames []hostnameTags
 }
 
 func CollectListenerInfos(
@@ -43,6 +45,10 @@ func CollectListenerInfos(
 	networking := proxy.Dataplane.Spec.GetNetworking()
 	listenersByPort := map[uint32]listenersHostnames{}
 	for _, listener := range gateway.Spec.GetConf().GetListeners() {
+		if listener.Protocol == mesh_proto.MeshGateway_Listener_TCP {
+			continue
+		}
+
 		listenerAcc, ok := listenersByPort[listener.GetPort()]
 		if !ok {
 			listenerAcc = listenersHostnames{
@@ -53,30 +59,20 @@ func CollectListenerInfos(
 		if hostname == "" {
 			hostname = "*"
 		}
-		listenerAcc.hostnames = append(listenerAcc.hostnames, hostname)
-		// TODO fix this. we should track a _list_ of tags and then match
-		// policies to these instead of to inbound listener address/port
-		// this doesn't seem to be correct with MeshGatewayRoute either
-		listenerAcc.tags = mesh_proto.Merge(
-			networking.GetGateway().GetTags(),
-			gateway.Spec.GetTags(),
-			listener.GetTags(),
-		)
+		listenerAcc.hostnames = append(listenerAcc.hostnames, hostnameTags{
+			Hostname: hostname,
+			Tags: mesh_proto.Merge(
+				networking.GetGateway().GetTags(),
+				gateway.Spec.GetTags(),
+				listener.GetTags(),
+			),
+		})
 		listenersByPort[listener.GetPort()] = listenerAcc
 	}
 
 	var infos []plugin_gateway.GatewayListenerInfo
 
 	for port, listener := range listenersByPort {
-		address := networking.Address
-		inboundListener := rules.InboundListener{
-			Address: address,
-			Port:    port,
-		}
-		rawRules, ok := rawRules.ToRules[inboundListener]
-		if !ok {
-			continue
-		}
 		externalServices := meshCtx.Resources.ExternalServices()
 
 		matchedExternalServices := permissions.MatchExternalServicesTrafficPermissions(
@@ -99,7 +95,13 @@ func CollectListenerInfos(
 			outboundEndpoints[k] = v
 		}
 
-		hostInfos := SortRulesToHosts(meshCtx.Resources.MeshLocalResources, rawRules, listener)
+		hostInfos := SortRulesToHosts(
+			meshCtx.Resources.MeshLocalResources,
+			rawRules,
+			networking.Address,
+			listener.listener,
+			listener.hostnames,
+		)
 		infos = append(infos, plugin_gateway.GatewayListenerInfo{
 			Proxy:             proxy,
 			Gateway:           gateway,
@@ -123,48 +125,59 @@ func CollectListenerInfos(
 	return infos
 }
 
-func SortRulesToHosts(meshLocalResources xds_context.ResourceMap, rawRules rules.Rules, listener listenersHostnames) []plugin_gateway.GatewayHostInfo {
-	var ruleHostnames []string
-	rulesByHostname := map[string][]ToRouteRule{}
-	for _, rawRule := range rawRules {
-		conf := rawRule.Conf.(api.PolicyDefault)
-		rule := ToRouteRule{
-			Subset:    rawRule.Subset,
-			Rules:     conf.Rules,
-			Hostnames: conf.Hostnames,
-			Origin:    rawRule.Origin,
-		}
-		hostnames := rule.Hostnames
-		if len(rule.Hostnames) == 0 {
-			hostnames = []string{"*"}
-		}
-		for _, hostname := range hostnames {
-			accRule, ok := rulesByHostname[hostname]
-			if !ok {
-				ruleHostnames = append(ruleHostnames, hostname)
-			}
-			rulesByHostname[hostname] = append(accRule, rule)
-		}
-	}
-
-	if listener.listener.Protocol == mesh_proto.MeshGateway_Listener_TCP {
-		return nil
-	}
-
+func SortRulesToHosts(
+	meshLocalResources xds_context.ResourceMap,
+	rawRules rules.GatewayRules,
+	address string,
+	listener *mesh_proto.MeshGateway_Listener,
+	hostnameTags []hostnameTags,
+) []plugin_gateway.GatewayHostInfo {
 	var hostInfos []plugin_gateway.GatewayHostInfo
-	for _, listenerHostname := range listener.hostnames {
+
+	for _, hostnameTag := range hostnameTags {
+		inboundListener := rules.InboundListenerHostname{
+			Address:  address,
+			Port:     listener.GetPort(),
+			Hostname: hostnameTag.Hostname,
+		}
+		rawRules, ok := rawRules.ToRules.ByListenerAndHostname[inboundListener]
+		if !ok {
+			continue
+		}
+		var ruleHostnames []string
+		rulesByHostname := map[string][]ToRouteRule{}
+		for _, rawRule := range rawRules {
+			conf := rawRule.Conf.(api.PolicyDefault)
+			rule := ToRouteRule{
+				Subset:    rawRule.Subset,
+				Rules:     conf.Rules,
+				Hostnames: conf.Hostnames,
+				Origin:    rawRule.Origin,
+			}
+			hostnames := rule.Hostnames
+			if len(rule.Hostnames) == 0 {
+				hostnames = []string{"*"}
+			}
+			for _, hostname := range hostnames {
+				accRule, ok := rulesByHostname[hostname]
+				if !ok {
+					ruleHostnames = append(ruleHostnames, hostname)
+				}
+				rulesByHostname[hostname] = append(accRule, rule)
+			}
+		}
+
 		// We need to find the set of hostnames that are contained by the given
 		// listener hostname
 		var listenerSpecificHostnameMatches []string
 		listenerSpecificHostnameMatchSet := map[string]struct{}{}
 		for _, ruleHostname := range ruleHostnames {
-			if !match.Hostnames(listenerHostname, ruleHostname) {
-				core.Log.Info("skipping rule hostname for listener", "listener", listenerHostname, "rule", ruleHostname)
+			if !match.Hostnames(hostnameTag.Hostname, ruleHostname) {
 				continue
 			}
 			hostnameMatch := ruleHostname
-			if match.Contains(ruleHostname, listenerHostname) {
-				hostnameMatch = listenerHostname
+			if match.Contains(ruleHostname, hostnameTag.Hostname) {
+				hostnameMatch = hostnameTag.Hostname
 			}
 			if _, ok := listenerSpecificHostnameMatchSet[hostnameMatch]; !ok {
 				listenerSpecificHostnameMatches = append(listenerSpecificHostnameMatches, hostnameMatch)
@@ -192,8 +205,8 @@ func SortRulesToHosts(meshLocalResources xds_context.ResourceMap, rawRules rules
 				Hostname: hostnameMatch,
 				Routes:   nil,
 				Policies: map[model.ResourceType][]match.RankedPolicy{},
-				TLS:      listener.listener.Tls,
-				Tags:     listener.tags,
+				TLS:      listener.Tls,
+				Tags:     hostnameTag.Tags,
 			}
 			for _, t := range plugin_gateway.ConnectionPolicyTypes {
 				matches := match.ConnectionPoliciesBySource(

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin.go
@@ -56,7 +56,7 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, xdsCtx xds_context.Context, prox
 	policies := proxy.Policies.Dynamic[api.MeshHTTPRouteType]
 
 	// Only fallback if we have TrafficRoutes & No MeshHTTPRoutes
-	if len(xdsCtx.Mesh.Resources.TrafficRoutes().Items) != 0 && len(policies.ToRules.Rules) == 0 && len(policies.GatewayRules.ToRules) == 0 {
+	if len(xdsCtx.Mesh.Resources.TrafficRoutes().Items) != 0 && len(policies.ToRules.Rules) == 0 && len(policies.GatewayRules.ToRules.ByListenerAndHostname) == 0 {
 		return nil
 	}
 
@@ -113,7 +113,7 @@ func ApplyToGateway(
 ) error {
 	var limits []plugin_gateway.RuntimeResoureLimitListener
 
-	if len(rawRules.ToRules) == 0 {
+	if len(rawRules.ToRules.ByListenerAndHostname) == 0 {
 		return nil
 	}
 

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
@@ -668,9 +668,9 @@ var _ = Describe("MeshHTTPRoute", func() {
 							WithGatewayPolicy(api.MeshHTTPRouteType, core_rules.GatewayRules{
 								ToRules: core_rules.GatewayToRules{
 									ByListenerAndHostname: map[rules.InboundListenerHostname]rules.Rules{
-										{Address: "192.168.0.1", Port: 8080, Hostname: "*"}:      commonRules,
-										{Address: "192.168.0.1", Port: 8081, Hostname: "go.dev"}: commonRules,
-										{Address: "192.168.0.1", Port: 8082, Hostname: "*.dev"}:  commonRules,
+										core_rules.NewInboundListenerHostname("192.168.0.1", 8080, "*"):      commonRules,
+										core_rules.NewInboundListenerHostname("192.168.0.1", 8081, "go.dev"): commonRules,
+										core_rules.NewInboundListenerHostname("192.168.0.1", 8082, "*.dev"):  commonRules,
 									},
 								},
 							}),
@@ -729,7 +729,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 							WithGatewayPolicy(api.MeshHTTPRouteType, core_rules.GatewayRules{
 								ToRules: core_rules.GatewayToRules{
 									ByListenerAndHostname: map[rules.InboundListenerHostname]rules.Rules{
-										{Address: "192.168.0.1", Port: 8080, Hostname: "*"}: {{
+										core_rules.NewInboundListenerHostname("192.168.0.1", 8080, "*"): {{
 											Subset: core_rules.MeshSubset(),
 											Conf: api.PolicyDefault{
 												Rules: []api.Rule{{
@@ -748,7 +748,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 												}},
 											},
 										}},
-										{Address: "192.168.0.1", Port: 8081, Hostname: "go.dev"}: {{
+										core_rules.NewInboundListenerHostname("192.168.0.1", 8081, "go.dev"): {{
 											Subset: core_rules.MeshSubset(),
 											Conf: api.PolicyDefault{
 												Hostnames: []string{"go.dev"},
@@ -833,7 +833,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 							WithGatewayPolicy(api.MeshHTTPRouteType, core_rules.GatewayRules{
 								ToRules: core_rules.GatewayToRules{
 									ByListenerAndHostname: map[rules.InboundListenerHostname]rules.Rules{
-										{Address: "192.168.0.1", Port: 8080, Hostname: "other.dev"}: {{
+										core_rules.NewInboundListenerHostname("192.168.0.1", 8080, "other.dev"): {{
 											Subset: core_rules.MeshSubset(),
 											Conf: api.PolicyDefault{
 												Hostnames: []string{"*.dev"},
@@ -853,7 +853,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 												}},
 											},
 										}},
-										{Address: "192.168.0.1", Port: 8080, Hostname: "go.dev"}: {{
+										core_rules.NewInboundListenerHostname("192.168.0.1", 8080, "go.dev"): {{
 											Subset: core_rules.MeshSubset(),
 											Conf: api.PolicyDefault{
 												Hostnames: []string{"*.dev"},

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
@@ -804,6 +804,21 @@ var _ = Describe("MeshHTTPRoute", func() {
 									"hostname": "go",
 								},
 							},
+							{
+								Protocol: mesh_proto.MeshGateway_Listener_HTTP,
+								Port:     8081,
+								Tags: map[string]string{
+									"hostname": "wild",
+								},
+							},
+							{
+								Protocol: mesh_proto.MeshGateway_Listener_HTTP,
+								Hostname: "*",
+								Port:     8082,
+								Tags: map[string]string{
+									"hostname": "wild",
+								},
+							},
 						},
 					},
 				},
@@ -862,6 +877,46 @@ var _ = Describe("MeshHTTPRoute", func() {
 														Path: &api.PathMatch{
 															Type:  api.PathPrefix,
 															Value: "/to-go-dev",
+														},
+													}},
+													Default: api.RuleConf{
+														BackendRefs: &[]common_api.BackendRef{{
+															TargetRef: builders.TargetRefService("backend"),
+															Weight:    pointer.To(uint(100)),
+														}},
+													},
+												}},
+											},
+										}},
+										core_rules.NewInboundListenerHostname("192.168.0.1", 8081, ""): {{
+											Subset: core_rules.MeshSubset(),
+											Conf: api.PolicyDefault{
+												Hostnames: []string{"*.dev"},
+												Rules: []api.Rule{{
+													Matches: []api.Match{{
+														Path: &api.PathMatch{
+															Type:  api.PathPrefix,
+															Value: "/wild-dev",
+														},
+													}},
+													Default: api.RuleConf{
+														BackendRefs: &[]common_api.BackendRef{{
+															TargetRef: builders.TargetRefService("backend"),
+															Weight:    pointer.To(uint(100)),
+														}},
+													},
+												}},
+											},
+										}},
+										core_rules.NewInboundListenerHostname("192.168.0.1", 8082, ""): {{
+											Subset: core_rules.MeshSubset(),
+											Conf: api.PolicyDefault{
+												Hostnames: []string{"*.dev"},
+												Rules: []api.Rule{{
+													Matches: []api.Match{{
+														Path: &api.PathMatch{
+															Type:  api.PathPrefix,
+															Value: "/wild-dev",
 														},
 													}},
 													Default: api.RuleConf{

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
@@ -666,10 +666,12 @@ var _ = Describe("MeshHTTPRoute", func() {
 					WithPolicies(
 						xds_builders.MatchedPolicies().
 							WithGatewayPolicy(api.MeshHTTPRouteType, core_rules.GatewayRules{
-								ToRules: map[rules.InboundListener]rules.Rules{
-									{Address: "192.168.0.1", Port: 8080}: commonRules,
-									{Address: "192.168.0.1", Port: 8081}: commonRules,
-									{Address: "192.168.0.1", Port: 8082}: commonRules,
+								ToRules: core_rules.GatewayToRules{
+									ByListenerAndHostname: map[rules.InboundListenerHostname]rules.Rules{
+										{Address: "192.168.0.1", Port: 8080, Hostname: "*"}:      commonRules,
+										{Address: "192.168.0.1", Port: 8081, Hostname: "go.dev"}: commonRules,
+										{Address: "192.168.0.1", Port: 8082, Hostname: "*.dev"}:  commonRules,
+									},
 								},
 							}),
 					).
@@ -725,46 +727,153 @@ var _ = Describe("MeshHTTPRoute", func() {
 					WithPolicies(
 						xds_builders.MatchedPolicies().
 							WithGatewayPolicy(api.MeshHTTPRouteType, core_rules.GatewayRules{
-								ToRules: map[rules.InboundListener]rules.Rules{
-									{Address: "192.168.0.1", Port: 8080}: {{
-										Subset: core_rules.MeshSubset(),
-										Conf: api.PolicyDefault{
-											Rules: []api.Rule{{
-												Matches: []api.Match{{
-													Path: &api.PathMatch{
-														Type:  api.PathPrefix,
-														Value: "/wild",
+								ToRules: core_rules.GatewayToRules{
+									ByListenerAndHostname: map[rules.InboundListenerHostname]rules.Rules{
+										{Address: "192.168.0.1", Port: 8080, Hostname: "*"}: {{
+											Subset: core_rules.MeshSubset(),
+											Conf: api.PolicyDefault{
+												Rules: []api.Rule{{
+													Matches: []api.Match{{
+														Path: &api.PathMatch{
+															Type:  api.PathPrefix,
+															Value: "/wild",
+														},
+													}},
+													Default: api.RuleConf{
+														BackendRefs: &[]common_api.BackendRef{{
+															TargetRef: builders.TargetRefService("backend"),
+															Weight:    pointer.To(uint(100)),
+														}},
 													},
 												}},
-												Default: api.RuleConf{
-													BackendRefs: &[]common_api.BackendRef{{
-														TargetRef: builders.TargetRefService("backend"),
-														Weight:    pointer.To(uint(100)),
+											},
+										}},
+										{Address: "192.168.0.1", Port: 8081, Hostname: "go.dev"}: {{
+											Subset: core_rules.MeshSubset(),
+											Conf: api.PolicyDefault{
+												Hostnames: []string{"go.dev"},
+												Rules: []api.Rule{{
+													Matches: []api.Match{{
+														Path: &api.PathMatch{
+															Type:  api.PathPrefix,
+															Value: "/go-dev",
+														},
 													}},
-												},
-											}},
-										},
-									}},
-									{Address: "192.168.0.1", Port: 8081}: {{
-										Subset: core_rules.MeshSubset(),
-										Conf: api.PolicyDefault{
-											Hostnames: []string{"go.dev"},
-											Rules: []api.Rule{{
-												Matches: []api.Match{{
-													Path: &api.PathMatch{
-														Type:  api.PathPrefix,
-														Value: "/go-dev",
+													Default: api.RuleConf{
+														BackendRefs: &[]common_api.BackendRef{{
+															TargetRef: builders.TargetRefService("backend"),
+															Weight:    pointer.To(uint(100)),
+														}},
 													},
 												}},
-												Default: api.RuleConf{
-													BackendRefs: &[]common_api.BackendRef{{
-														TargetRef: builders.TargetRefService("backend"),
-														Weight:    pointer.To(uint(100)),
+											},
+										}},
+									},
+								},
+							}),
+					).
+					Build(),
+			}
+		}()),
+		Entry("gateway-listener-different-hostnames-specific", func() outboundsTestCase {
+			gateway := &core_mesh.MeshGatewayResource{
+				Meta: &test_model.ResourceMeta{Name: "sample-gateway", Mesh: "default"},
+				Spec: &mesh_proto.MeshGateway{
+					Selectors: []*mesh_proto.Selector{
+						{
+							Match: map[string]string{
+								mesh_proto.ServiceTag: "sample-gateway",
+							},
+						},
+					},
+					Conf: &mesh_proto.MeshGateway_Conf{
+						Listeners: []*mesh_proto.MeshGateway_Listener{
+							{
+								Protocol: mesh_proto.MeshGateway_Listener_HTTP,
+								Port:     8080,
+								Hostname: "other.dev",
+								Tags: map[string]string{
+									"hostname": "other",
+								},
+							},
+							{
+								Protocol: mesh_proto.MeshGateway_Listener_HTTP,
+								Port:     8080,
+								Hostname: "go.dev",
+								Tags: map[string]string{
+									"hostname": "go",
+								},
+							},
+						},
+					},
+				},
+			}
+			resources := xds_context.NewResources()
+			resources.MeshLocalResources[core_mesh.MeshGatewayType] = &core_mesh.MeshGatewayResourceList{
+				Items: []*core_mesh.MeshGatewayResource{gateway},
+			}
+			outboundTargets := xds_builders.EndpointMap().
+				AddEndpoint("backend", xds_builders.Endpoint().
+					WithTarget("192.168.0.4").
+					WithPort(8084).
+					WithWeight(1).
+					WithTags(mesh_proto.ServiceTag, "backend", mesh_proto.ProtocolTag, core_mesh.ProtocolHTTP, "region", "us"),
+				)
+			xdsContext := xds_builders.Context().
+				WithMesh(samples.MeshDefaultBuilder()).
+				WithResources(resources).
+				WithEndpointMap(outboundTargets).Build()
+			return outboundsTestCase{
+				xdsContext: *xdsContext,
+				proxy: xds_builders.Proxy().
+					WithDataplane(samples.GatewayDataplaneBuilder()).
+					WithRouting(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
+					WithPolicies(
+						xds_builders.MatchedPolicies().
+							WithGatewayPolicy(api.MeshHTTPRouteType, core_rules.GatewayRules{
+								ToRules: core_rules.GatewayToRules{
+									ByListenerAndHostname: map[rules.InboundListenerHostname]rules.Rules{
+										{Address: "192.168.0.1", Port: 8080, Hostname: "other.dev"}: {{
+											Subset: core_rules.MeshSubset(),
+											Conf: api.PolicyDefault{
+												Hostnames: []string{"*.dev"},
+												Rules: []api.Rule{{
+													Matches: []api.Match{{
+														Path: &api.PathMatch{
+															Type:  api.PathPrefix,
+															Value: "/to-other-dev",
+														},
 													}},
-												},
-											}},
-										},
-									}},
+													Default: api.RuleConf{
+														BackendRefs: &[]common_api.BackendRef{{
+															TargetRef: builders.TargetRefService("backend"),
+															Weight:    pointer.To(uint(100)),
+														}},
+													},
+												}},
+											},
+										}},
+										{Address: "192.168.0.1", Port: 8080, Hostname: "go.dev"}: {{
+											Subset: core_rules.MeshSubset(),
+											Conf: api.PolicyDefault{
+												Hostnames: []string{"*.dev"},
+												Rules: []api.Rule{{
+													Matches: []api.Match{{
+														Path: &api.PathMatch{
+															Type:  api.PathPrefix,
+															Value: "/to-go-dev",
+														},
+													}},
+													Default: api.RuleConf{
+														BackendRefs: &[]common_api.BackendRef{{
+															TargetRef: builders.TargetRefService("backend"),
+															Weight:    pointer.To(uint(100)),
+														}},
+													},
+												}},
+											},
+										}},
+									},
 								},
 							}),
 					).

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.clusters.golden.yaml
@@ -1,0 +1,37 @@
+resources:
+- name: backend-a285094d9b0d7032
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+        resourceApiVersion: V3
+    name: backend-a285094d9b0d7032
+    perConnectionBufferLimitBytes: 32768
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        commonHttpProtocolOptions:
+          idleTimeout: 0s
+        explicitHttpConfig:
+          httpProtocolOptions: {}
+- name: backend-ed49e74a1f66b25c
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+        resourceApiVersion: V3
+    name: backend-ed49e74a1f66b25c
+    perConnectionBufferLimitBytes: 32768
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        commonHttpProtocolOptions:
+          idleTimeout: 0s
+        explicitHttpConfig:
+          httpProtocolOptions: {}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.clusters.golden.yaml
@@ -1,4 +1,22 @@
 resources:
+- name: backend-6d0a1cf7605e8b1e
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+        resourceApiVersion: V3
+    name: backend-6d0a1cf7605e8b1e
+    perConnectionBufferLimitBytes: 32768
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        commonHttpProtocolOptions:
+          idleTimeout: 0s
+        explicitHttpConfig:
+          httpProtocolOptions: {}
 - name: backend-a285094d9b0d7032
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.endpoints.golden.yaml
@@ -1,4 +1,24 @@
 resources:
+- name: backend-6d0a1cf7605e8b1e
+  resource:
+    '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
+    clusterName: backend-6d0a1cf7605e8b1e
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.0.4
+              portValue: 8084
+        loadBalancingWeight: 1
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              kuma.io/protocol: http
+              region: us
+            envoy.transport_socket_match:
+              kuma.io/protocol: http
+              region: us
 - name: backend-a285094d9b0d7032
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.endpoints.golden.yaml
@@ -1,0 +1,41 @@
+resources:
+- name: backend-a285094d9b0d7032
+  resource:
+    '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
+    clusterName: backend-a285094d9b0d7032
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.0.4
+              portValue: 8084
+        loadBalancingWeight: 1
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              kuma.io/protocol: http
+              region: us
+            envoy.transport_socket_match:
+              kuma.io/protocol: http
+              region: us
+- name: backend-ed49e74a1f66b25c
+  resource:
+    '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
+    clusterName: backend-ed49e74a1f66b25c
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.0.4
+              portValue: 8084
+        loadBalancingWeight: 1
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              kuma.io/protocol: http
+              region: us
+            envoy.transport_socket_match:
+              kuma.io/protocol: http
+              region: us

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.listeners.golden.yaml
@@ -1,0 +1,60 @@
+resources:
+- name: sample-gateway:HTTP:8080
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.1
+        portValue: 8080
+    enableReusePort: true
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          commonHttpProtocolOptions:
+            headersWithUnderscoresAction: REJECT_REQUEST
+            idleTimeout: 300s
+          http2ProtocolOptions:
+            allowConnect: true
+            initialConnectionWindowSize: 1048576
+            initialStreamWindowSize: 65536
+            maxConcurrentStreams: 100
+          httpFilters:
+          - name: envoy.filters.http.local_ratelimit
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              statPrefix: rate_limit
+          - name: gzip-compress
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+              compressorLibrary:
+                name: gzip
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+              responseDirectionConfig:
+                disableOnEtagHeader: true
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+              startChildSpan: true
+          mergeSlashes: true
+          normalizePath: true
+          pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
+          rds:
+            configSource:
+              ads: {}
+              resourceApiVersion: V3
+            routeConfigName: sample-gateway:HTTP:8080
+          requestHeadersTimeout: 0.500s
+          serverName: Kuma Gateway
+          statPrefix: sample-gateway
+          streamIdleTimeout: 5s
+          useRemoteAddress: true
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: sample-gateway:HTTP:8080
+    perConnectionBufferLimitBytes: 32768
+    trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.listeners.golden.yaml
@@ -58,3 +58,121 @@ resources:
     name: sample-gateway:HTTP:8080
     perConnectionBufferLimitBytes: 32768
     trafficDirection: INBOUND
+- name: sample-gateway:HTTP:8081
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.1
+        portValue: 8081
+    enableReusePort: true
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          commonHttpProtocolOptions:
+            headersWithUnderscoresAction: REJECT_REQUEST
+            idleTimeout: 300s
+          http2ProtocolOptions:
+            allowConnect: true
+            initialConnectionWindowSize: 1048576
+            initialStreamWindowSize: 65536
+            maxConcurrentStreams: 100
+          httpFilters:
+          - name: envoy.filters.http.local_ratelimit
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              statPrefix: rate_limit
+          - name: gzip-compress
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+              compressorLibrary:
+                name: gzip
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+              responseDirectionConfig:
+                disableOnEtagHeader: true
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+              startChildSpan: true
+          mergeSlashes: true
+          normalizePath: true
+          pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
+          rds:
+            configSource:
+              ads: {}
+              resourceApiVersion: V3
+            routeConfigName: sample-gateway:HTTP:8081
+          requestHeadersTimeout: 0.500s
+          serverName: Kuma Gateway
+          statPrefix: sample-gateway
+          streamIdleTimeout: 5s
+          useRemoteAddress: true
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: sample-gateway:HTTP:8081
+    perConnectionBufferLimitBytes: 32768
+    trafficDirection: INBOUND
+- name: sample-gateway:HTTP:8082
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.1
+        portValue: 8082
+    enableReusePort: true
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          commonHttpProtocolOptions:
+            headersWithUnderscoresAction: REJECT_REQUEST
+            idleTimeout: 300s
+          http2ProtocolOptions:
+            allowConnect: true
+            initialConnectionWindowSize: 1048576
+            initialStreamWindowSize: 65536
+            maxConcurrentStreams: 100
+          httpFilters:
+          - name: envoy.filters.http.local_ratelimit
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              statPrefix: rate_limit
+          - name: gzip-compress
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+              compressorLibrary:
+                name: gzip
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+              responseDirectionConfig:
+                disableOnEtagHeader: true
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+              startChildSpan: true
+          mergeSlashes: true
+          normalizePath: true
+          pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
+          rds:
+            configSource:
+              ads: {}
+              resourceApiVersion: V3
+            routeConfigName: sample-gateway:HTTP:8082
+          requestHeadersTimeout: 0.500s
+          serverName: Kuma Gateway
+          statPrefix: sample-gateway
+          streamIdleTimeout: 5s
+          useRemoteAddress: true
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: sample-gateway:HTTP:8082
+    perConnectionBufferLimitBytes: 32768
+    trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.routes.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.routes.golden.yaml
@@ -68,3 +68,81 @@ resources:
                   key: x-kuma-tags
                   value: '&kuma.io/service=sample-gateway&'
               weight: 100
+- name: sample-gateway:HTTP:8081
+  resource:
+    '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+    ignorePortInHostMatching: true
+    name: sample-gateway:HTTP:8081
+    requestHeadersToRemove:
+    - x-kuma-tags
+    validateClusters: false
+    virtualHosts:
+    - domains:
+      - '*.dev'
+      name: '*.dev'
+      routes:
+      - match:
+          path: /wild-dev
+        route:
+          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+          idleTimeout: 5s
+          weightedClusters:
+            clusters:
+            - name: backend-6d0a1cf7605e8b1e
+              requestHeadersToAdd:
+              - header:
+                  key: x-kuma-tags
+                  value: '&kuma.io/service=sample-gateway&'
+              weight: 100
+      - match:
+          prefix: /wild-dev/
+        route:
+          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+          idleTimeout: 5s
+          weightedClusters:
+            clusters:
+            - name: backend-6d0a1cf7605e8b1e
+              requestHeadersToAdd:
+              - header:
+                  key: x-kuma-tags
+                  value: '&kuma.io/service=sample-gateway&'
+              weight: 100
+- name: sample-gateway:HTTP:8082
+  resource:
+    '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+    ignorePortInHostMatching: true
+    name: sample-gateway:HTTP:8082
+    requestHeadersToRemove:
+    - x-kuma-tags
+    validateClusters: false
+    virtualHosts:
+    - domains:
+      - '*.dev'
+      name: '*.dev'
+      routes:
+      - match:
+          path: /wild-dev
+        route:
+          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+          idleTimeout: 5s
+          weightedClusters:
+            clusters:
+            - name: backend-6d0a1cf7605e8b1e
+              requestHeadersToAdd:
+              - header:
+                  key: x-kuma-tags
+                  value: '&kuma.io/service=sample-gateway&'
+              weight: 100
+      - match:
+          prefix: /wild-dev/
+        route:
+          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+          idleTimeout: 5s
+          weightedClusters:
+            clusters:
+            - name: backend-6d0a1cf7605e8b1e
+              requestHeadersToAdd:
+              - header:
+                  key: x-kuma-tags
+                  value: '&kuma.io/service=sample-gateway&'
+              weight: 100

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.routes.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.routes.golden.yaml
@@ -1,0 +1,70 @@
+resources:
+- name: sample-gateway:HTTP:8080
+  resource:
+    '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+    ignorePortInHostMatching: true
+    name: sample-gateway:HTTP:8080
+    requestHeadersToRemove:
+    - x-kuma-tags
+    validateClusters: false
+    virtualHosts:
+    - domains:
+      - other.dev
+      name: other.dev
+      routes:
+      - match:
+          path: /to-other-dev
+        route:
+          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+          idleTimeout: 5s
+          weightedClusters:
+            clusters:
+            - name: backend-a285094d9b0d7032
+              requestHeadersToAdd:
+              - header:
+                  key: x-kuma-tags
+                  value: '&kuma.io/service=sample-gateway&'
+              weight: 100
+      - match:
+          prefix: /to-other-dev/
+        route:
+          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+          idleTimeout: 5s
+          weightedClusters:
+            clusters:
+            - name: backend-a285094d9b0d7032
+              requestHeadersToAdd:
+              - header:
+                  key: x-kuma-tags
+                  value: '&kuma.io/service=sample-gateway&'
+              weight: 100
+    - domains:
+      - go.dev
+      name: go.dev
+      routes:
+      - match:
+          path: /to-go-dev
+        route:
+          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+          idleTimeout: 5s
+          weightedClusters:
+            clusters:
+            - name: backend-ed49e74a1f66b25c
+              requestHeadersToAdd:
+              - header:
+                  key: x-kuma-tags
+                  value: '&kuma.io/service=sample-gateway&'
+              weight: 100
+      - match:
+          prefix: /to-go-dev/
+        route:
+          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+          idleTimeout: 5s
+          weightedClusters:
+            clusters:
+            - name: backend-ed49e74a1f66b25c
+              requestHeadersToAdd:
+              - header:
+                  key: x-kuma-tags
+                  value: '&kuma.io/service=sample-gateway&'
+              weight: 100

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
@@ -182,7 +182,7 @@ func (p plugin) configureGateway(
 			continue
 		}
 
-		rules, ok := rules.ToRules[inboundListener]
+		rules, ok := rules.ToRules.ByListener[inboundListener]
 		if !ok {
 			continue
 		}

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
@@ -1277,31 +1277,33 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 					createEndpointBuilderWith("test-zone-2", "192.168.1.2", map[string]string{}),
 				),
 			rules: core_rules.GatewayRules{
-				ToRules: map[core_rules.InboundListener]core_rules.Rules{
-					{Address: "192.168.0.1", Port: 8080}: {
-						{
-							Subset: core_rules.Subset{},
-							Conf: v1alpha1.Conf{
-								LoadBalancer: &v1alpha1.LoadBalancer{
-									Type: v1alpha1.RingHashType,
-									RingHash: &v1alpha1.RingHash{
-										MinRingSize:  pointer.To[uint32](100),
-										MaxRingSize:  pointer.To[uint32](1000),
-										HashFunction: pointer.To(v1alpha1.MurmurHash2Type),
-										HashPolicies: &[]v1alpha1.HashPolicy{
-											{
-												Type: v1alpha1.QueryParameterType,
-												QueryParameter: &v1alpha1.QueryParameter{
-													Name: "queryparam",
+				ToRules: core_rules.GatewayToRules{
+					ByListener: map[core_rules.InboundListener]core_rules.Rules{
+						{Address: "192.168.0.1", Port: 8080}: {
+							{
+								Subset: core_rules.Subset{},
+								Conf: v1alpha1.Conf{
+									LoadBalancer: &v1alpha1.LoadBalancer{
+										Type: v1alpha1.RingHashType,
+										RingHash: &v1alpha1.RingHash{
+											MinRingSize:  pointer.To[uint32](100),
+											MaxRingSize:  pointer.To[uint32](1000),
+											HashFunction: pointer.To(v1alpha1.MurmurHash2Type),
+											HashPolicies: &[]v1alpha1.HashPolicy{
+												{
+													Type: v1alpha1.QueryParameterType,
+													QueryParameter: &v1alpha1.QueryParameter{
+														Name: "queryparam",
+													},
+													Terminal: pointer.To(true),
 												},
-												Terminal: pointer.To(true),
-											},
-											{
-												Type: v1alpha1.ConnectionType,
-												Connection: &v1alpha1.Connection{
-													SourceIP: pointer.To(true),
+												{
+													Type: v1alpha1.ConnectionType,
+													Connection: &v1alpha1.Connection{
+														SourceIP: pointer.To(true),
+													},
+													Terminal: pointer.To(false),
 												},
-												Terminal: pointer.To(false),
 											},
 										},
 									},
@@ -1326,49 +1328,51 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 					createEndpointBuilderWith("zone-5", "192.168.1.8", map[string]string{}),
 				),
 			rules: core_rules.GatewayRules{
-				ToRules: map[core_rules.InboundListener]core_rules.Rules{
-					{Address: "192.168.0.1", Port: 8080}: {
-						{
-							Subset: core_rules.Subset{},
-							Conf: v1alpha1.Conf{
-								LocalityAwareness: &v1alpha1.LocalityAwareness{
-									LocalZone: &v1alpha1.LocalZone{
-										AffinityTags: &[]v1alpha1.AffinityTag{
-											{
-												Key:    "k8s.io/node",
-												Weight: pointer.To[uint32](9000),
-											},
-											{
-												Key:    "k8s.io/az",
-												Weight: pointer.To[uint32](900),
-											},
-											{
-												Key:    "k8s.io/region",
-												Weight: pointer.To[uint32](90),
+				ToRules: core_rules.GatewayToRules{
+					ByListener: map[core_rules.InboundListener]core_rules.Rules{
+						{Address: "192.168.0.1", Port: 8080}: {
+							{
+								Subset: core_rules.Subset{},
+								Conf: v1alpha1.Conf{
+									LocalityAwareness: &v1alpha1.LocalityAwareness{
+										LocalZone: &v1alpha1.LocalZone{
+											AffinityTags: &[]v1alpha1.AffinityTag{
+												{
+													Key:    "k8s.io/node",
+													Weight: pointer.To[uint32](9000),
+												},
+												{
+													Key:    "k8s.io/az",
+													Weight: pointer.To[uint32](900),
+												},
+												{
+													Key:    "k8s.io/region",
+													Weight: pointer.To[uint32](90),
+												},
 											},
 										},
-									},
-									CrossZone: &v1alpha1.CrossZone{
-										Failover: []v1alpha1.Failover{
-											{
-												To: v1alpha1.ToZone{
-													Type:  v1alpha1.AnyExcept,
-													Zones: &[]string{"zone-3", "zone-4", "zone-5"},
+										CrossZone: &v1alpha1.CrossZone{
+											Failover: []v1alpha1.Failover{
+												{
+													To: v1alpha1.ToZone{
+														Type:  v1alpha1.AnyExcept,
+														Zones: &[]string{"zone-3", "zone-4", "zone-5"},
+													},
 												},
-											},
-											{
-												From: &v1alpha1.FromZone{
-													Zones: []string{"zone-1"},
+												{
+													From: &v1alpha1.FromZone{
+														Zones: []string{"zone-1"},
+													},
+													To: v1alpha1.ToZone{
+														Type:  v1alpha1.Only,
+														Zones: &[]string{"zone-3"},
+													},
 												},
-												To: v1alpha1.ToZone{
-													Type:  v1alpha1.Only,
-													Zones: &[]string{"zone-3"},
-												},
-											},
-											{
-												To: v1alpha1.ToZone{
-													Type:  v1alpha1.Only,
-													Zones: &[]string{"zone-4"},
+												{
+													To: v1alpha1.ToZone{
+														Type:  v1alpha1.Only,
+														Zones: &[]string{"zone-4"},
+													},
 												},
 											},
 										},
@@ -1394,17 +1398,19 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 					createEndpointBuilderWith("zone-5", "192.168.1.8", map[string]string{}),
 				),
 			rules: core_rules.GatewayRules{
-				ToRules: map[core_rules.InboundListener]core_rules.Rules{
-					{Address: "192.168.0.1", Port: 8080}: {
-						{
-							Subset: core_rules.Subset{},
-							Conf: v1alpha1.Conf{
-								LocalityAwareness: &v1alpha1.LocalityAwareness{
-									CrossZone: &v1alpha1.CrossZone{
-										Failover: []v1alpha1.Failover{
-											{
-												To: v1alpha1.ToZone{
-													Type: v1alpha1.None,
+				ToRules: core_rules.GatewayToRules{
+					ByListener: map[core_rules.InboundListener]core_rules.Rules{
+						{Address: "192.168.0.1", Port: 8080}: {
+							{
+								Subset: core_rules.Subset{},
+								Conf: v1alpha1.Conf{
+									LocalityAwareness: &v1alpha1.LocalityAwareness{
+										CrossZone: &v1alpha1.CrossZone{
+											Failover: []v1alpha1.Failover{
+												{
+													To: v1alpha1.ToZone{
+														Type: v1alpha1.None,
+													},
 												},
 											},
 										},

--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin.go
@@ -78,7 +78,7 @@ func applyToGateways(
 		if !ok {
 			continue
 		}
-		rules, ok := toRules.ToRules[listenerKey]
+		rules, ok := toRules.ToRules.ByListener[listenerKey]
 		if !ok {
 			continue
 		}

--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin_test.go
@@ -630,35 +630,37 @@ var _ = Describe("MeshRateLimit", func() {
 	It("should generate proper Envoy config for MeshGateway Dataplanes", func() {
 		// given
 		gatewayRules := core_rules.GatewayRules{
-			ToRules: map[core_rules.InboundListener]core_rules.Rules{
-				{Address: "192.168.0.1", Port: 8080}: {{
-					Subset: core_rules.Subset{},
-					Conf: api.Conf{
-						Local: &api.Local{
-							HTTP: &api.LocalHTTP{
-								RequestRate: &api.Rate{
-									Num:      100,
-									Interval: v1.Duration{Duration: 10 * time.Second},
-								},
-								OnRateLimit: &api.OnRateLimit{
-									Status: pointer.To(uint32(444)),
-									Headers: &api.HeaderModifier{
-										Add: []api.HeaderKeyValue{
-											{
-												Name:  "x-kuma-rate-limit-header",
-												Value: "test-value",
-											},
-											{
-												Name:  "x-kuma-rate-limit",
-												Value: "other-value",
+			ToRules: core_rules.GatewayToRules{
+				ByListener: map[core_rules.InboundListener]core_rules.Rules{
+					{Address: "192.168.0.1", Port: 8080}: {{
+						Subset: core_rules.Subset{},
+						Conf: api.Conf{
+							Local: &api.Local{
+								HTTP: &api.LocalHTTP{
+									RequestRate: &api.Rate{
+										Num:      100,
+										Interval: v1.Duration{Duration: 10 * time.Second},
+									},
+									OnRateLimit: &api.OnRateLimit{
+										Status: pointer.To(uint32(444)),
+										Headers: &api.HeaderModifier{
+											Add: []api.HeaderKeyValue{
+												{
+													Name:  "x-kuma-rate-limit-header",
+													Value: "test-value",
+												},
+												{
+													Name:  "x-kuma-rate-limit",
+													Value: "other-value",
+												},
 											},
 										},
 									},
 								},
 							},
 						},
-					},
-				}},
+					}},
+				},
 			},
 		}
 

--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin.go
@@ -93,7 +93,7 @@ func applyToGateway(
 			continue
 		}
 
-		toRules := rules.ToRules[listenerKey]
+		toRules := rules.ToRules.ByListener[listenerKey]
 		if !ok {
 			continue
 		}

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin.go
@@ -113,11 +113,11 @@ func ApplyToGateway(
 		port := info.Listener.Port
 		var hostInfos []plugin_gateway.GatewayHostInfo
 		for _, info := range info.HostInfos {
-			inboundListener := rules.InboundListenerHostname{
-				Address:  address,
-				Port:     port,
-				Hostname: info.Host.Hostname,
-			}
+			inboundListener := rules.NewInboundListenerHostname(
+				address,
+				port,
+				info.Host.Hostname,
+			)
 			routes, ok := policies.GatewayRules.ToRules.ByListenerAndHostname[inboundListener]
 			if !ok {
 				continue

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
@@ -686,7 +686,7 @@ var _ = Describe("MeshTCPRoute", func() {
 							WithGatewayPolicy(api.MeshTCPRouteType, core_rules.GatewayRules{
 								ToRules: core_rules.GatewayToRules{
 									ByListenerAndHostname: map[core_rules.InboundListenerHostname]core_rules.Rules{
-										{Address: "192.168.0.1", Port: 9080, Hostname: "*"}: {&rules},
+										core_rules.NewInboundListenerHostname("192.168.0.1", 9080, "*"): {&rules},
 									},
 									ByListener: map[core_rules.InboundListener]core_rules.Rules{
 										{Address: "192.168.0.1", Port: 9080}: {&rules},

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
@@ -666,6 +666,16 @@ var _ = Describe("MeshTCPRoute", func() {
 				WithMesh(samples.MeshDefaultBuilder()).
 				WithResources(resources).
 				WithEndpointMap(outboundTargets).Build()
+
+			rules := core_rules.Rule{
+				Subset: core_rules.MeshSubset(),
+				Conf: api.RuleConf{
+					BackendRefs: []common_api.BackendRef{{
+						TargetRef: builders.TargetRefService("backend"),
+						Weight:    pointer.To(uint(100)),
+					}},
+				},
+			}
 			return outboundsTestCase{
 				xdsContext: *xdsContext,
 				proxy: xds_builders.Proxy().
@@ -674,17 +684,12 @@ var _ = Describe("MeshTCPRoute", func() {
 					WithPolicies(
 						xds_builders.MatchedPolicies().
 							WithGatewayPolicy(api.MeshTCPRouteType, core_rules.GatewayRules{
-								ToRules: map[core_rules.InboundListener]core_rules.Rules{
-									{Address: "192.168.0.1", Port: 9080}: {
-										{
-											Subset: core_rules.MeshSubset(),
-											Conf: api.RuleConf{
-												BackendRefs: []common_api.BackendRef{{
-													TargetRef: builders.TargetRefService("backend"),
-													Weight:    pointer.To(uint(100)),
-												}},
-											},
-										},
+								ToRules: core_rules.GatewayToRules{
+									ByListenerAndHostname: map[core_rules.InboundListenerHostname]core_rules.Rules{
+										{Address: "192.168.0.1", Port: 9080, Hostname: "*"}: {&rules},
+									},
+									ByListener: map[core_rules.InboundListener]core_rules.Rules{
+										{Address: "192.168.0.1", Port: 9080}: {&rules},
 									},
 								},
 							}),

--- a/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
@@ -37,7 +37,7 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 	if !ok {
 		return nil
 	}
-	if len(policies.ToRules.Rules) == 0 && len(policies.FromRules.Rules) == 0 && len(policies.GatewayRules.ToRules) == 0 {
+	if len(policies.ToRules.Rules) == 0 && len(policies.FromRules.Rules) == 0 && len(policies.GatewayRules.ToRules.ByListener) == 0 {
 		return nil
 	}
 
@@ -184,7 +184,7 @@ func applyToGateway(
 			return err
 		}
 
-		toRules, ok := gatewayRules.ToRules[key]
+		toRules, ok := gatewayRules.ToRules.ByListener[key]
 		if !ok {
 			continue
 		}

--- a/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin_test.go
@@ -475,18 +475,20 @@ var _ = Describe("MeshTimeout", func() {
 					},
 				},
 			},
-			ToRules: map[core_rules.InboundListener]core_rules.Rules{
-				{Address: "192.168.0.1", Port: 8080}: {
-					{
-						Subset: core_rules.MeshSubset(),
-						Conf: api.Conf{
-							ConnectionTimeout: test.ParseDuration("10s"),
-							IdleTimeout:       test.ParseDuration("1h"),
-							Http: &api.Http{
-								RequestTimeout:        test.ParseDuration("5s"),
-								StreamIdleTimeout:     test.ParseDuration("1s"),
-								MaxStreamDuration:     test.ParseDuration("10m"),
-								MaxConnectionDuration: test.ParseDuration("10m"),
+			ToRules: core_rules.GatewayToRules{
+				ByListener: map[core_rules.InboundListener]core_rules.Rules{
+					{Address: "192.168.0.1", Port: 8080}: {
+						{
+							Subset: core_rules.MeshSubset(),
+							Conf: api.Conf{
+								ConnectionTimeout: test.ParseDuration("10s"),
+								IdleTimeout:       test.ParseDuration("1h"),
+								Http: &api.Http{
+									RequestTimeout:        test.ParseDuration("5s"),
+									StreamIdleTimeout:     test.ParseDuration("1s"),
+									MaxStreamDuration:     test.ParseDuration("10m"),
+									MaxConnectionDuration: test.ParseDuration("10m"),
+								},
 							},
 						},
 					},
@@ -495,17 +497,19 @@ var _ = Describe("MeshTimeout", func() {
 		},
 	}), Entry("no-default-idle-timeout", gatewayTestCase{
 		rules: core_rules.GatewayRules{
-			ToRules: map[core_rules.InboundListener]core_rules.Rules{
-				{Address: "192.168.0.1", Port: 8080}: {
-					{
-						Subset: core_rules.MeshSubset(),
-						Conf: api.Conf{
-							ConnectionTimeout: test.ParseDuration("10s"),
-							IdleTimeout:       test.ParseDuration("1h"),
-							Http: &api.Http{
-								RequestTimeout:        test.ParseDuration("5s"),
-								MaxStreamDuration:     test.ParseDuration("10m"),
-								MaxConnectionDuration: test.ParseDuration("10m"),
+			ToRules: core_rules.GatewayToRules{
+				ByListener: map[core_rules.InboundListener]core_rules.Rules{
+					{Address: "192.168.0.1", Port: 8080}: {
+						{
+							Subset: core_rules.MeshSubset(),
+							Conf: api.Conf{
+								ConnectionTimeout: test.ParseDuration("10s"),
+								IdleTimeout:       test.ParseDuration("1h"),
+								Http: &api.Http{
+									RequestTimeout:        test.ParseDuration("5s"),
+									MaxStreamDuration:     test.ParseDuration("10m"),
+									MaxConnectionDuration: test.ParseDuration("10m"),
+								},
 							},
 						},
 					},
@@ -521,13 +525,15 @@ var _ = Describe("MeshTimeout", func() {
 				Build(),
 		},
 		rules: core_rules.GatewayRules{
-			ToRules: map[core_rules.InboundListener]core_rules.Rules{
-				{Address: "192.168.0.1", Port: 8080}: {
-					{
-						Subset: core_rules.MeshService("backend"),
-						Conf: api.Conf{
-							Http: &api.Http{
-								RequestTimeout: test.ParseDuration("24s"),
+			ToRules: core_rules.GatewayToRules{
+				ByListener: map[core_rules.InboundListener]core_rules.Rules{
+					{Address: "192.168.0.1", Port: 8080}: {
+						{
+							Subset: core_rules.MeshService("backend"),
+							Conf: api.Conf{
+								Http: &api.Http{
+									RequestTimeout: test.ParseDuration("24s"),
+								},
 							},
 						},
 					},

--- a/pkg/plugins/runtime/gateway/generator.go
+++ b/pkg/plugins/runtime/gateway/generator.go
@@ -373,11 +373,7 @@ func MakeGatewayListener(
 	// Hostnames must be unique to a listener to remove ambiguity
 	// in policy selection and TLS configuration.
 	for _, l := range listeners {
-		// An empty hostname is the same as "*", i.e. matches all hosts.
-		hostname := l.GetHostname()
-		if hostname == "" {
-			hostname = mesh_proto.WildcardHostname
-		}
+		hostname := l.GetNonEmptyHostname()
 
 		allRoutes := match.Routes(meshContext.Resources.GatewayRoutes().Items, l.GetTags())
 

--- a/pkg/plugins/runtime/gateway/match/hostnames.go
+++ b/pkg/plugins/runtime/gateway/match/hostnames.go
@@ -2,6 +2,8 @@ package match
 
 import (
 	"strings"
+
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 )
 
 type hostname struct {
@@ -10,7 +12,7 @@ type hostname struct {
 }
 
 func (h *hostname) wildcard() bool {
-	return h.Host == "*"
+	return h.Host == mesh_proto.WildcardHostname
 }
 
 func (h *hostname) matches(name string) bool {
@@ -36,7 +38,7 @@ func (h *hostname) contains(n hostname) bool {
 
 func makeHostname(name string) hostname {
 	if name == "" {
-		name = "*"
+		name = mesh_proto.WildcardHostname
 	}
 	parts := strings.Split(name, ".")
 	return hostname{Host: parts[0], DomainParts: parts[1:]}

--- a/pkg/plugins/runtime/gateway/match/hostnames.go
+++ b/pkg/plugins/runtime/gateway/match/hostnames.go
@@ -35,6 +35,9 @@ func (h *hostname) contains(n hostname) bool {
 }
 
 func makeHostname(name string) hostname {
+	if name == "" {
+		name = "*"
+	}
 	parts := strings.Split(name, ".")
 	return hostname{Host: parts[0], DomainParts: parts[1:]}
 }

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_conversion.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_conversion.go
@@ -19,6 +19,7 @@ import (
 	mesh_k8s "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers/gatewayapi/common"
 	referencegrants "github.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers/gatewayapi/referencegrants"
+	"github.com/kumahq/kuma/pkg/util/pointer"
 )
 
 type ListenerConditions map[gatewayapi.SectionName][]kube_meta.Condition
@@ -219,10 +220,7 @@ func (r *GatewayReconciler) gapiToKumaGateway(
 			)
 		}
 
-		listener.Hostname = "*"
-		if l.Hostname != nil {
-			listener.Hostname = string(*l.Hostname)
-		}
+		listener.Hostname = string(pointer.DerefOr(l.Hostname, mesh_proto.WildcardHostname))
 
 		var unresolvableCertRef *certRefCondition
 		if l.TLS != nil {


### PR DESCRIPTION
The idea behind this PR is to make sure the effects of MeshHTTPRoutes attached to MeshGateway listeners are limited to those listeners, thus the need to map `(address, port, hostname)` to routes instead of `(address, port)`.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
