### PR TITLE
fix(kds): fix resource naming and backward compatibility

### DIFF
--- a/pkg/kds/context/context.go
+++ b/pkg/kds/context/context.go
@@ -17,6 +17,7 @@ import (
 	config_core "github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/pkg/core"
 	config_manager "github.com/kumahq/kuma/pkg/core/config/manager"
+	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
@@ -69,7 +70,10 @@ func DefaultContext(
 			),
 			MapZoneTokenSigningKeyGlobalToPublicKey),
 		reconcile.If(
-			reconcile.IsKubernetes(cfg.Store.Type),
+			reconcile.And(
+				reconcile.IsKubernetes(cfg.Store.Type),
+				reconcile.Not(reconcile.TypeIs(mesh.ZoneIngressType)),
+			),
 			RemoveK8sSystemNamespaceSuffixMapper(cfg.Store.Kubernetes.SystemNamespace)),
 		reconcile.If(
 			reconcile.And(
@@ -88,7 +92,10 @@ func DefaultContext(
 		),
 		MapInsightResourcesZeroGeneration,
 		reconcile.If(
-			reconcile.IsKubernetes(cfg.Store.Type),
+			reconcile.And(
+				reconcile.IsKubernetes(cfg.Store.Type),
+				reconcile.Not(reconcile.TypeIs(mesh.ZoneIngressType)),
+			),
 			RemoveK8sSystemNamespaceSuffixMapper(cfg.Store.Kubernetes.SystemNamespace)),
 		HashSuffixMapper(false, mesh_proto.ZoneTag, mesh_proto.KubeNamespaceTag),
 	}

--- a/pkg/plugins/resources/k8s/store.go
+++ b/pkg/plugins/resources/k8s/store.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/pkg/core"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/registry"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
@@ -273,9 +274,11 @@ func (m *KubernetesMetaAdapter) GetLabels() map[string]string {
 	if _, ok := labels[v1alpha1.DisplayName]; !ok {
 		labels[v1alpha1.DisplayName] = m.GetObjectMeta().GetName()
 	}
-	if m.Namespace != "" {
+	if _, ok := labels[v1alpha1.KubeNamespaceTag]; !ok {
 		labels[v1alpha1.KubeNamespaceTag] = m.Namespace
 	}
+
+	core.Log.Info("GetLabels", " m.GetObjectMeta().GetName()", labels[v1alpha1.DisplayName], "m.GetObjectMeta().GetName()", m.GetObjectMeta().GetName(), "labels[v1alpha1.KubeNamespaceTag]", labels[v1alpha1.KubeNamespaceTag])
 	return labels
 }
 


### PR DESCRIPTION
### Checklist prior to review

Still there is one issue. There is no way to distinguish between Universal and K8s (since 2.6) and because of this we are adding a namespace to each request on universal 

- [ ] [Link to relevant issue][1] as well as docs and UI issues -- fix: https://github.com/kumahq/kuma/issues/9011
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
