### PR TITLE
Revert "chore(mk): fix make kind/start (#8977)" (#9020)

### DIFF
--- a/mk/kind.mk
+++ b/mk/kind.mk
@@ -11,9 +11,9 @@ KIND_KUBECONFIG := $(KIND_KUBECONFIG_DIR)/kind-$(KIND_CLUSTER_NAME)-config
 unexport KUBECONFIG
 
 ifdef IPV6
-KIND_CONFIG ?= $(KUMA_DIR)/test/kind/cluster-ipv6-$(KIND_CLUSTER_NAME)-1.yaml
+KIND_CONFIG ?= $(KUMA_DIR)/test/kind/cluster-ipv6.yaml
 else
-KIND_CONFIG ?= $(KUMA_DIR)/test/kind/cluster-$(KIND_CLUSTER_NAME)-1.yaml
+KIND_CONFIG ?= $(KUMA_DIR)/test/kind/cluster.yaml
 endif
 
 ifeq ($(KUMACTL_INSTALL_USE_LOCAL_IMAGES),true)
@@ -32,7 +32,7 @@ kind/start: ${KUBECONFIG_DIR}
 	$(KIND) get clusters | grep $(KIND_CLUSTER_NAME) >/dev/null 2>&1 && echo "Kind cluster already running." && exit 0 || \
 		($(KIND) create cluster \
 			--name "$(KIND_CLUSTER_NAME)" \
-			--config "$(KIND_CONFIG)" \
+			--config "$(KUMA_DIR)/test/kind/cluster-$(if $(IPV6),ipv6-,)$(KIND_CLUSTER_NAME).yaml" \
 			--image=kindest/node:$(CI_KUBERNETES_VERSION) \
 			--kubeconfig $(KIND_KUBECONFIG) \
 			--quiet --wait 120s && \


### PR DESCRIPTION
This reverts commit 184a7366ffb0f86389bbeceb24573eea6f2778d9 which broke CI on branches. We'll solve whatever #8676 broke separately.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
