### PR TITLE
fix(meshcircuitbreaker): revert validator and check if config is empty

### DIFF
--- a/pkg/defaults/mesh/meshcircuitbreaker.go
+++ b/pkg/defaults/mesh/meshcircuitbreaker.go
@@ -27,7 +27,11 @@ var defaultMeshCircuitBreakerResource = func() model.Resource {
 						},
 						OutlierDetection: &v1alpha1.OutlierDetection{
 							Disabled:  pointer.To[bool](false),
-							Detectors: &v1alpha1.Detectors{},
+							Detectors: &v1alpha1.Detectors{
+								TotalFailures: &v1alpha1.DetectorTotalFailures{},
+								GatewayFailures: &v1alpha1.DetectorGatewayFailures{},
+								LocalOriginFailures: &v1alpha1.DetectorLocalOriginFailures{},
+							},
 						},
 					},
 				},

--- a/pkg/defaults/mesh/meshcircuitbreaker.go
+++ b/pkg/defaults/mesh/meshcircuitbreaker.go
@@ -26,10 +26,10 @@ var defaultMeshCircuitBreakerResource = func() model.Resource {
 							MaxRetries:         pointer.To[uint32](3),
 						},
 						OutlierDetection: &v1alpha1.OutlierDetection{
-							Disabled:  pointer.To[bool](false),
+							Disabled: pointer.To[bool](false),
 							Detectors: &v1alpha1.Detectors{
-								TotalFailures: &v1alpha1.DetectorTotalFailures{},
-								GatewayFailures: &v1alpha1.DetectorGatewayFailures{},
+								TotalFailures:       &v1alpha1.DetectorTotalFailures{},
+								GatewayFailures:     &v1alpha1.DetectorGatewayFailures{},
 								LocalOriginFailures: &v1alpha1.DetectorLocalOriginFailures{},
 							},
 						},

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/validator.go
@@ -117,6 +117,13 @@ func validateDetectors(path validators.PathBuilder, detectors *Detectors) valida
 		return verr
 	}
 
+	if detectors.FailurePercentage == nil && detectors.GatewayFailures == nil &&
+		detectors.LocalOriginFailures == nil && detectors.TotalFailures == nil &&
+		detectors.SuccessRate == nil {
+		verr.AddViolationAt(path, validators.MustHaveAtLeastOne("totalFailures", "gatewayFailures", "localOriginFailures", "successRate", "failurePercentage"))
+		return verr
+	}
+
 	verr.Add(validateDetectorTotalFailures(path.Field("totalFailures"), detectors.TotalFailures))
 	verr.Add(validateDetectorGatewayFailures(path.Field("gatewayFailures"), detectors.GatewayFailures))
 	verr.Add(validateDetectorLocalOriginFailures(path.Field("localOriginFailures"), detectors.LocalOriginFailures))

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/validator_test.go
@@ -446,6 +446,24 @@ to:
       name: web-backend
     default:
       outlierDetection:
+        maxEjectionPercent: 100
+        detectors: {}`,
+				expected: `
+violations:
+  - field: spec.to[0].default.outlierDetection.detectors
+    message: 'must have at least one defined: totalFailures, gatewayFailures, localOriginFailures, successRate, failurePercentage'`,
+			}),
+			Entry("detector has incorrect values", testCase{
+				inputYaml: `
+targetRef:
+  kind: MeshService
+  name: web-frontend
+to:
+  - targetRef:
+      kind: MeshService
+      name: web-backend
+    default:
+      outlierDetection:
         detectors:
           successRate:
             standardDeviationFactor: "xyz"`,

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/xds/configurer.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/xds/configurer.go
@@ -175,7 +175,7 @@ func configureGatewayFailures(
 	outlierDetection *envoy_cluster.OutlierDetection,
 	gatewayFailures *api.DetectorGatewayFailures,
 ) {
-	if gatewayFailures == nil {
+	if gatewayFailures == nil || gatewayFailures.Consecutive == nil {
 		outlierDetection.EnforcingConsecutiveGatewayFailure = util_proto.UInt32(0)
 		return
 	}
@@ -188,7 +188,7 @@ func configureLocalOriginFailures(
 	outlierDetection *envoy_cluster.OutlierDetection,
 	conf *api.DetectorLocalOriginFailures,
 ) {
-	if conf == nil {
+	if conf == nil || conf.Consecutive == nil {
 		outlierDetection.EnforcingConsecutiveLocalOriginFailure = util_proto.UInt32(0)
 		return
 	}
@@ -201,7 +201,7 @@ func configureTotalFailures(
 	outlierDetection *envoy_cluster.OutlierDetection,
 	conf *api.DetectorTotalFailures,
 ) {
-	if conf == nil {
+	if conf == nil || conf.Consecutive == nil {
 		outlierDetection.EnforcingConsecutive_5Xx = util_proto.UInt32(0)
 		return
 	}


### PR DESCRIPTION
### Checklist prior to review

Revert validation but check for nil so we can set defaults 

- [X] [Link to relevant issue][1] as well as docs and UI issues -- fix: https://github.com/kumahq/kuma/issues/9015
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
