### PR TITLE
fix(kuma-cp): return sorted list of k8s secrets

### DIFF
--- a/pkg/plugins/secrets/k8s/store.go
+++ b/pkg/plugins/secrets/k8s/store.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/pkg/errors"
@@ -301,6 +302,9 @@ func (c *SimpleConverter) ToCoreList(in *kube_core.SecretList, out core_model.Re
 			}
 			secOut.Items[i] = r
 		}
+		sort.SliceStable(secOut.Items, func(i, j int) bool {
+			return secOut.Items[i].GetMeta().GetName() < secOut.Items[j].GetMeta().GetName()
+		})
 	case secret_model.GlobalSecretType:
 		secOut := out.(*secret_model.GlobalSecretResourceList)
 		secOut.Items = make([]*secret_model.GlobalSecretResource, len(in.Items))
@@ -311,6 +315,9 @@ func (c *SimpleConverter) ToCoreList(in *kube_core.SecretList, out core_model.Re
 			}
 			secOut.Items[i] = r
 		}
+		sort.SliceStable(secOut.Items, func(i, j int) bool {
+			return secOut.Items[i].GetMeta().GetName() < secOut.Items[j].GetMeta().GetName()
+		})
 	default:
 		return errors.Errorf("invalid type %s, expected %s or %s", out.GetItemType(), secret_model.SecretType, secret_model.GlobalSecretType)
 	}

--- a/pkg/plugins/secrets/k8s/store_test.go
+++ b/pkg/plugins/secrets/k8s/store_test.go
@@ -707,6 +707,18 @@ var _ = Describe("KubernetesStore", func() {
                   value: Zm91cg== # base64(four)
 `, ns, "four"))
 				backend.Create(four)
+
+				five := backend.ParseYAML(fmt.Sprintf(`
+                apiVersion: v1
+                kind: Secret
+                type: system.kuma.io/global-secret
+                metadata:
+                  namespace: %s
+                  name: %s
+                data:
+                  value: Zml2ZQ== # base64(five)
+`, ns, "five"))
+				backend.Create(five)
 			})
 
 			It("should return a list of secrets in all meshes", func() {
@@ -745,7 +757,7 @@ var _ = Describe("KubernetesStore", func() {
 				Expect(secrets.Items[0].Spec.Data.Value).To(Equal([]byte("another")))
 			})
 
-			It("should return a list of global secrets", func() {
+			It("should return a list of global secrets sorted", func() {
 				// given
 				secrets := &core_system.GlobalSecretResourceList{}
 
@@ -754,8 +766,9 @@ var _ = Describe("KubernetesStore", func() {
 
 				// then
 				Expect(err).ToNot(HaveOccurred())
-				Expect(secrets.Items).To(HaveLen(1))
-				Expect(string(secrets.Items[0].Spec.Data.Value)).To(Equal("four"))
+				Expect(secrets.Items).To(HaveLen(2))
+				Expect(string(secrets.Items[0].Spec.Data.Value)).To(Equal("five"))
+				Expect(string(secrets.Items[1].Spec.Data.Value)).To(Equal("four"))
 			})
 		})
 	})


### PR DESCRIPTION
### Checklist prior to review

While debugging I've noticed that secrets are returned in a random order. That caused meshContext to be updated all the time and caused higher CPU usage. I've added sorting for secrets on K8s so now Context should be stable 

- [X] [Link to relevant issue][1] as well as docs and UI issues -- fix: https://github.com/kumahq/kuma/issues/9029
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
