### PR TITLE
fix(kuma-cp): use pagination store for secret store

### DIFF
--- a/pkg/core/bootstrap/bootstrap.go
+++ b/pkg/core/bootstrap/bootstrap.go
@@ -313,7 +313,7 @@ func initializeSecretStore(cfg kuma_cp.Config, builder *core_runtime.Builder) er
 	if ss, err := plugin.NewSecretStore(builder, pluginConfig); err != nil {
 		return err
 	} else {
-		builder.WithSecretStore(ss)
+		builder.WithSecretStore(core_store.NewPaginationStore(ss))
 		return nil
 	}
 }

--- a/pkg/plugins/secrets/k8s/store.go
+++ b/pkg/plugins/secrets/k8s/store.go
@@ -3,7 +3,6 @@ package k8s
 import (
 	"context"
 	"fmt"
-	"sort"
 	"time"
 
 	"github.com/pkg/errors"
@@ -302,9 +301,6 @@ func (c *SimpleConverter) ToCoreList(in *kube_core.SecretList, out core_model.Re
 			}
 			secOut.Items[i] = r
 		}
-		sort.SliceStable(secOut.Items, func(i, j int) bool {
-			return secOut.Items[i].GetMeta().GetName() < secOut.Items[j].GetMeta().GetName()
-		})
 	case secret_model.GlobalSecretType:
 		secOut := out.(*secret_model.GlobalSecretResourceList)
 		secOut.Items = make([]*secret_model.GlobalSecretResource, len(in.Items))
@@ -315,9 +311,6 @@ func (c *SimpleConverter) ToCoreList(in *kube_core.SecretList, out core_model.Re
 			}
 			secOut.Items[i] = r
 		}
-		sort.SliceStable(secOut.Items, func(i, j int) bool {
-			return secOut.Items[i].GetMeta().GetName() < secOut.Items[j].GetMeta().GetName()
-		})
 	default:
 		return errors.Errorf("invalid type %s, expected %s or %s", out.GetItemType(), secret_model.SecretType, secret_model.GlobalSecretType)
 	}

--- a/pkg/plugins/secrets/k8s/store_test.go
+++ b/pkg/plugins/secrets/k8s/store_test.go
@@ -24,6 +24,7 @@ import (
 
 var _ = Describe("KubernetesStore", func() {
 	var s secret_store.SecretStore
+	var rs store.ResourceStore
 	var ns string // each test should run in a dedicated k8s namespace
 	const name = "demo"
 	const noMesh = ""
@@ -82,6 +83,7 @@ var _ = Describe("KubernetesStore", func() {
 		// otherwise we will get "no kind is registered for the type v1alpha1.Mesh in scheme"
 		s, err = k8s.NewStore(k8sClient, k8sClient, runtime.NewScheme(), ns)
 		Expect(err).ToNot(HaveOccurred())
+		rs = store.NewPaginationStore(s)
 	})
 
 	Describe("Create()", func() {
@@ -104,7 +106,7 @@ var _ = Describe("KubernetesStore", func() {
 `).(*kube_core.Secret)
 
 			// when
-			err := s.Create(context.Background(), secret, store.CreateByKey(name, "demo"))
+			err := rs.Create(context.Background(), secret, store.CreateByKey(name, "demo"))
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
@@ -165,13 +167,13 @@ var _ = Describe("KubernetesStore", func() {
 			backend.AssertNotExists(&kube_core.Secret{}, "ignored", name)
 
 			// when
-			err := s.Create(context.Background(), core_system.NewSecretResource(), store.CreateByKey(name, noMesh))
+			err := rs.Create(context.Background(), core_system.NewSecretResource(), store.CreateByKey(name, noMesh))
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
 
 			// when
-			err = s.Create(context.Background(), core_system.NewSecretResource(), store.CreateByKey(name, noMesh))
+			err = rs.Create(context.Background(), core_system.NewSecretResource(), store.CreateByKey(name, noMesh))
 
 			// then
 			Expect(err).To(MatchError(store.ErrorResourceAlreadyExists(core_system.SecretType, name, noMesh)))
@@ -207,14 +209,14 @@ var _ = Describe("KubernetesStore", func() {
 			secret := core_system.NewSecretResource()
 
 			// when
-			err := s.Get(context.Background(), secret, store.GetByKey(name, "demo"))
+			err := rs.Get(context.Background(), secret, store.GetByKey(name, "demo"))
 			// then
 			Expect(err).ToNot(HaveOccurred())
 			version := secret.Meta.GetVersion()
 
 			// when
 			secret.Spec.Data.Value = []byte("another")
-			err = s.Update(context.Background(), secret)
+			err = rs.Update(context.Background(), secret)
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
@@ -259,14 +261,14 @@ var _ = Describe("KubernetesStore", func() {
 			secret := core_system.NewGlobalSecretResource()
 
 			// when
-			err := s.Get(context.Background(), secret, store.GetByKey(name, noMesh))
+			err := rs.Get(context.Background(), secret, store.GetByKey(name, noMesh))
 			// then
 			Expect(err).ToNot(HaveOccurred())
 			version := secret.Meta.GetVersion()
 
 			// when
 			secret.Spec.Data.Value = []byte("another")
-			err = s.Update(context.Background(), secret)
+			err = rs.Update(context.Background(), secret)
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
@@ -303,14 +305,14 @@ var _ = Describe("KubernetesStore", func() {
 			secret := core_system.NewSecretResource()
 
 			// when
-			err := s.Get(context.Background(), secret, store.GetByKey(name, "demo"))
+			err := rs.Get(context.Background(), secret, store.GetByKey(name, "demo"))
 			// then
 			Expect(err).ToNot(HaveOccurred())
 
 			// when
 			backend.Delete(initial)
 			// and
-			err = s.Update(context.Background(), secret)
+			err = rs.Update(context.Background(), secret)
 
 			// then
 			Expect(err).To(MatchError(store.ErrorResourceConflict(core_system.SecretType, name, "demo")))
@@ -334,7 +336,7 @@ var _ = Describe("KubernetesStore", func() {
 			secret1 := core_system.NewSecretResource()
 
 			// when
-			err := s.Get(context.Background(), secret1, store.GetByKey(name, "demo"))
+			err := rs.Get(context.Background(), secret1, store.GetByKey(name, "demo"))
 			// then
 			Expect(err).ToNot(HaveOccurred())
 
@@ -342,7 +344,7 @@ var _ = Describe("KubernetesStore", func() {
 			secret2 := core_system.NewSecretResource()
 
 			// when
-			err = s.Get(context.Background(), secret2, store.GetByKey(name, "demo"))
+			err = rs.Get(context.Background(), secret2, store.GetByKey(name, "demo"))
 			// then
 			Expect(err).ToNot(HaveOccurred())
 
@@ -350,7 +352,7 @@ var _ = Describe("KubernetesStore", func() {
 			secret1.Spec = &system_proto.Secret{
 				Data: util_proto.Bytes([]byte("example")),
 			}
-			err = s.Update(context.Background(), secret1)
+			err = rs.Update(context.Background(), secret1)
 			// then
 			Expect(err).ToNot(HaveOccurred())
 
@@ -358,7 +360,7 @@ var _ = Describe("KubernetesStore", func() {
 			secret2.Spec = &system_proto.Secret{
 				Data: util_proto.Bytes([]byte("another")),
 			}
-			err = s.Update(context.Background(), secret2)
+			err = rs.Update(context.Background(), secret2)
 			// then
 			Expect(err).To(MatchError(store.ErrorResourceConflict(core_system.SecretType, name, "demo")))
 		})
@@ -370,7 +372,7 @@ var _ = Describe("KubernetesStore", func() {
 			backend.AssertNotExists(&kube_core.Secret{}, ns, name)
 
 			// when
-			err := s.Get(context.Background(), core_system.NewSecretResource(), store.GetByKey(name, "demo"))
+			err := rs.Get(context.Background(), core_system.NewSecretResource(), store.GetByKey(name, "demo"))
 
 			// then
 			Expect(err).To(MatchError(store.ErrorResourceNotFound(core_system.SecretType, name, "demo")))
@@ -396,7 +398,7 @@ var _ = Describe("KubernetesStore", func() {
 			actual := core_system.NewSecretResource()
 
 			// when
-			err := s.Get(context.Background(), actual, store.GetByKey(name, "demo"))
+			err := rs.Get(context.Background(), actual, store.GetByKey(name, "demo"))
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
@@ -425,7 +427,7 @@ var _ = Describe("KubernetesStore", func() {
 			actual := core_system.NewGlobalSecretResource()
 
 			// when
-			err := s.Get(context.Background(), actual, store.GetByKey(name, noMesh))
+			err := rs.Get(context.Background(), actual, store.GetByKey(name, noMesh))
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
@@ -454,13 +456,13 @@ var _ = Describe("KubernetesStore", func() {
 			actual := core_system.NewSecretResource()
 
 			// when
-			err := s.Get(context.Background(), actual, store.GetByKey(name, "default"))
+			err := rs.Get(context.Background(), actual, store.GetByKey(name, "default"))
 
 			// then
 			Expect(err).To(MatchError(`Resource not found: type="Secret" name="demo" mesh="default"`))
 
 			// when
-			err = s.Get(context.Background(), actual, store.GetByKey(name, noMesh))
+			err = rs.Get(context.Background(), actual, store.GetByKey(name, noMesh))
 
 			// then
 			Expect(err).To(MatchError(`Resource not found: type="Secret" name="demo" mesh=""`))
@@ -484,13 +486,13 @@ var _ = Describe("KubernetesStore", func() {
 			actual := core_system.NewGlobalSecretResource()
 
 			// when
-			err := s.Get(context.Background(), actual, store.GetByKey(name, "default"))
+			err := rs.Get(context.Background(), actual, store.GetByKey(name, "default"))
 
 			// then
 			Expect(err).To(MatchError(`Resource not found: type="GlobalSecret" name="demo" mesh="default"`))
 
 			// when
-			err = s.Get(context.Background(), actual, store.GetByKey(name, noMesh))
+			err = rs.Get(context.Background(), actual, store.GetByKey(name, noMesh))
 
 			// then
 			Expect(err).To(MatchError(`Resource not found: type="GlobalSecret" name="demo" mesh=""`))
@@ -514,7 +516,7 @@ var _ = Describe("KubernetesStore", func() {
 			actual := core_system.NewSecretResource()
 
 			// when
-			err := s.Get(context.Background(), actual, store.GetByKey(name, "default"))
+			err := rs.Get(context.Background(), actual, store.GetByKey(name, "default"))
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
@@ -545,7 +547,7 @@ var _ = Describe("KubernetesStore", func() {
 			actual := core_system.NewSecretResource()
 
 			// when
-			err := s.Get(context.Background(), actual, store.GetByKey(name, "another-mesh"))
+			err := rs.Get(context.Background(), actual, store.GetByKey(name, "another-mesh"))
 
 			// then
 			Expect(err).To(MatchError(store.ErrorResourceNotFound(core_system.SecretType, name, "another-mesh")))
@@ -569,7 +571,7 @@ var _ = Describe("KubernetesStore", func() {
 			backend.Create(initial)
 
 			// when
-			err := s.Delete(context.Background(), core_system.NewSecretResource(), store.DeleteByKey(name, "demo"))
+			err := rs.Delete(context.Background(), core_system.NewSecretResource(), store.DeleteByKey(name, "demo"))
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
@@ -590,7 +592,7 @@ var _ = Describe("KubernetesStore", func() {
 			backend.Create(initial)
 
 			// when
-			err := s.Delete(context.Background(), core_system.NewGlobalSecretResource(), store.DeleteByKey(name, noMesh))
+			err := rs.Delete(context.Background(), core_system.NewGlobalSecretResource(), store.DeleteByKey(name, noMesh))
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
@@ -611,7 +613,7 @@ var _ = Describe("KubernetesStore", func() {
 			backend.Create(initial)
 
 			// when
-			err := s.Delete(context.Background(), core_system.NewSecretResource(), store.DeleteByKey(name, noMesh))
+			err := rs.Delete(context.Background(), core_system.NewSecretResource(), store.DeleteByKey(name, noMesh))
 
 			// then
 			Expect(err).To(MatchError(`failed to delete k8s secret: Resource not found: type="Secret" name="demo" mesh=""`))
@@ -630,7 +632,7 @@ var _ = Describe("KubernetesStore", func() {
 			backend.Create(initial)
 
 			// when
-			err := s.Delete(context.Background(), core_system.NewGlobalSecretResource(), store.DeleteByKey(name, "default"))
+			err := rs.Delete(context.Background(), core_system.NewGlobalSecretResource(), store.DeleteByKey(name, "default"))
 
 			// then
 			Expect(err).To(MatchError(`failed to delete k8s secret: Resource not found: type="GlobalSecret" name="demo" mesh="default"`))
@@ -643,7 +645,7 @@ var _ = Describe("KubernetesStore", func() {
 			secrets := &core_system.SecretResourceList{}
 
 			// when
-			err := s.List(context.Background(), secrets, store.ListByMesh("ignored"))
+			err := rs.List(context.Background(), secrets, store.ListByMesh("ignored"))
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
@@ -714,7 +716,7 @@ var _ = Describe("KubernetesStore", func() {
 				secrets := &core_system.SecretResourceList{}
 
 				// when
-				err := s.List(context.Background(), secrets)
+				err := rs.List(context.Background(), secrets)
 
 				// then
 				Expect(err).ToNot(HaveOccurred())
@@ -737,7 +739,7 @@ var _ = Describe("KubernetesStore", func() {
 				secrets := &core_system.SecretResourceList{}
 
 				// when
-				err := s.List(context.Background(), secrets, store.ListByMesh("default"))
+				err := rs.List(context.Background(), secrets, store.ListByMesh("default"))
 
 				// then
 				Expect(err).ToNot(HaveOccurred())
@@ -750,7 +752,7 @@ var _ = Describe("KubernetesStore", func() {
 				secrets := &core_system.GlobalSecretResourceList{}
 
 				// when
-				err := s.List(context.Background(), secrets)
+				err := rs.List(context.Background(), secrets)
 
 				// then
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
### Checklist prior to review

SecretStore wasn't using a pagination store so there was a risk that resources might not be sorted. Changed SecretStore to use pagination store.

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
