### PR TITLE
feat(kds): protect agains fail on federation

### DIFF
--- a/pkg/kds/v2/store/sync.go
+++ b/pkg/kds/v2/store/sync.go
@@ -270,14 +270,14 @@ func (s *syncResourceStore) validateResourceDelete(ctx context.Context, deleteOn
 			return errors.Errorf("could not get mesh %s to verify whether we can delete a resource", r.GetMeta().GetMesh())
 		}
 		if origin, ok := core_model.ResourceOrigin(mesh.GetMeta()); !ok || origin != deleteOnlyWithOrigin {
-			return errors.Errorf("failed to delete resouce %s %s. The resource is managed by mesh %s which is was not exported to %s control plane. "+
+			return errors.Errorf("failed to delete resource %s %s. The resource is managed by mesh %s which is was not exported to %s control plane. "+
 				"This is protection from accidentally removing resources. "+
 				"Either export the resource to %s control plane or remove the resource on this control plane",
 				r.Descriptor().Name, r.GetMeta().GetName(), mesh.GetMeta().GetName(), deleteOnlyWithOrigin, deleteOnlyWithOrigin,
 			)
 		}
 	case core_model.ScopeGlobal:
-		return errors.Errorf("failed to delete resouce %s %s. The resource was not exported to %s control plane. "+
+		return errors.Errorf("failed to delete resource %s %s. The resource was not exported to %s control plane. "+
 			"This is protection from accidentally removing resources. "+
 			"Either export the resource to %s control plane or remove the resource on this control plane",
 			r.Descriptor().Name, r.GetMeta().GetName(), deleteOnlyWithOrigin, deleteOnlyWithOrigin,


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
