### PR TITLE
fix(MeshHTTPRoute): ensure order of rules by hostname

### DIFF
--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
@@ -911,17 +911,35 @@ var _ = Describe("MeshHTTPRoute", func() {
 										core_rules.NewInboundListenerHostname("192.168.0.1", 8082, ""): {{
 											Subset: core_rules.MeshSubset(),
 											Conf: api.PolicyDefault{
+												Rules: []api.Rule{{
+													Matches: []api.Match{{
+														Path: &api.PathMatch{
+															Type:  api.PathPrefix,
+															Value: "/same-path",
+														},
+													}},
+													Default: api.RuleConf{
+														BackendRefs: &[]common_api.BackendRef{{
+															TargetRef: builders.TargetRefService("backend-wild"),
+															Weight:    pointer.To(uint(100)),
+														}},
+													},
+												}},
+											},
+										}, {
+											Subset: core_rules.MeshSubset(),
+											Conf: api.PolicyDefault{
 												Hostnames: []string{"*.dev"},
 												Rules: []api.Rule{{
 													Matches: []api.Match{{
 														Path: &api.PathMatch{
 															Type:  api.PathPrefix,
-															Value: "/wild-dev",
+															Value: "/same-path",
 														},
 													}},
 													Default: api.RuleConf{
 														BackendRefs: &[]common_api.BackendRef{{
-															TargetRef: builders.TargetRefService("backend"),
+															TargetRef: builders.TargetRefService("backend-wild-dev"),
 															Weight:    pointer.To(uint(100)),
 														}},
 													},

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.clusters.golden.yaml
@@ -53,3 +53,39 @@ resources:
           idleTimeout: 0s
         explicitHttpConfig:
           httpProtocolOptions: {}
+- name: backend-wild-aac0221a73d6116a
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+        resourceApiVersion: V3
+    name: backend-wild-aac0221a73d6116a
+    perConnectionBufferLimitBytes: 32768
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        commonHttpProtocolOptions:
+          idleTimeout: 0s
+        explicitHttpConfig:
+          httpProtocolOptions: {}
+- name: backend-wild-dev-52ee11d917faac3e
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+        resourceApiVersion: V3
+    name: backend-wild-dev-52ee11d917faac3e
+    perConnectionBufferLimitBytes: 32768
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        commonHttpProtocolOptions:
+          idleTimeout: 0s
+        explicitHttpConfig:
+          httpProtocolOptions: {}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.endpoints.golden.yaml
@@ -59,3 +59,11 @@ resources:
             envoy.transport_socket_match:
               kuma.io/protocol: http
               region: us
+- name: backend-wild-aac0221a73d6116a
+  resource:
+    '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
+    clusterName: backend-wild-aac0221a73d6116a
+- name: backend-wild-dev-52ee11d917faac3e
+  resource:
+    '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
+    clusterName: backend-wild-dev-52ee11d917faac3e

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.routes.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.routes.golden.yaml
@@ -121,26 +121,82 @@ resources:
       name: '*.dev'
       routes:
       - match:
-          path: /wild-dev
+          path: /same-path
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
           weightedClusters:
             clusters:
-            - name: backend-6d0a1cf7605e8b1e
+            - name: backend-wild-aac0221a73d6116a
               requestHeadersToAdd:
               - header:
                   key: x-kuma-tags
                   value: '&kuma.io/service=sample-gateway&'
               weight: 100
       - match:
-          prefix: /wild-dev/
+          path: /same-path
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
           weightedClusters:
             clusters:
-            - name: backend-6d0a1cf7605e8b1e
+            - name: backend-wild-dev-52ee11d917faac3e
+              requestHeadersToAdd:
+              - header:
+                  key: x-kuma-tags
+                  value: '&kuma.io/service=sample-gateway&'
+              weight: 100
+      - match:
+          prefix: /same-path/
+        route:
+          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+          idleTimeout: 5s
+          weightedClusters:
+            clusters:
+            - name: backend-wild-aac0221a73d6116a
+              requestHeadersToAdd:
+              - header:
+                  key: x-kuma-tags
+                  value: '&kuma.io/service=sample-gateway&'
+              weight: 100
+      - match:
+          prefix: /same-path/
+        route:
+          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+          idleTimeout: 5s
+          weightedClusters:
+            clusters:
+            - name: backend-wild-dev-52ee11d917faac3e
+              requestHeadersToAdd:
+              - header:
+                  key: x-kuma-tags
+                  value: '&kuma.io/service=sample-gateway&'
+              weight: 100
+    - domains:
+      - '*'
+      name: '*'
+      routes:
+      - match:
+          path: /same-path
+        route:
+          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+          idleTimeout: 5s
+          weightedClusters:
+            clusters:
+            - name: backend-wild-aac0221a73d6116a
+              requestHeadersToAdd:
+              - header:
+                  key: x-kuma-tags
+                  value: '&kuma.io/service=sample-gateway&'
+              weight: 100
+      - match:
+          prefix: /same-path/
+        route:
+          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+          idleTimeout: 5s
+          weightedClusters:
+            clusters:
+            - name: backend-wild-aac0221a73d6116a
               requestHeadersToAdd:
               - header:
                   key: x-kuma-tags

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.routes.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.routes.golden.yaml
@@ -127,7 +127,7 @@ resources:
           idleTimeout: 5s
           weightedClusters:
             clusters:
-            - name: backend-wild-aac0221a73d6116a
+            - name: backend-wild-dev-52ee11d917faac3e
               requestHeadersToAdd:
               - header:
                   key: x-kuma-tags
@@ -140,19 +140,6 @@ resources:
           idleTimeout: 5s
           weightedClusters:
             clusters:
-            - name: backend-wild-dev-52ee11d917faac3e
-              requestHeadersToAdd:
-              - header:
-                  key: x-kuma-tags
-                  value: '&kuma.io/service=sample-gateway&'
-              weight: 100
-      - match:
-          prefix: /same-path/
-        route:
-          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
-          idleTimeout: 5s
-          weightedClusters:
-            clusters:
             - name: backend-wild-aac0221a73d6116a
               requestHeadersToAdd:
               - header:
@@ -167,6 +154,19 @@ resources:
           weightedClusters:
             clusters:
             - name: backend-wild-dev-52ee11d917faac3e
+              requestHeadersToAdd:
+              - header:
+                  key: x-kuma-tags
+                  value: '&kuma.io/service=sample-gateway&'
+              weight: 100
+      - match:
+          prefix: /same-path/
+        route:
+          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+          idleTimeout: 5s
+          weightedClusters:
+            clusters:
+            - name: backend-wild-aac0221a73d6116a
               requestHeadersToAdd:
               - header:
                   key: x-kuma-tags


### PR DESCRIPTION
See the first commit for the unit test that displays the problem. Note that the match+cluster for the _less_ specific hostname comes first, the third commit shows the fix.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
