### PR TITLE
test(MeshHealthCheck): add test with MeshGateway+MeshHTTPRoute

### DIFF
--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic-meshhttproute.gateway_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic-meshhttproute.gateway_cluster.golden.yaml
@@ -1,0 +1,53 @@
+commonLbConfig:
+  healthyPanicThreshold:
+    value: 62.9
+  zoneAwareLbConfig:
+    failTrafficOnPanic: true
+connectTimeout: 5s
+edsClusterConfig:
+  edsConfig:
+    ads: {}
+    resourceApiVersion: V3
+healthChecks:
+- eventLogger:
+  - name: envoy.health_check.event_sinks.file
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.health_check.event_sinks.file.v3.HealthCheckEventFileSink
+      eventLogPath: /tmp/log.txt
+  healthyThreshold: 1
+  httpHealthCheck:
+    expectedStatuses:
+    - end: "201"
+      start: "200"
+    - end: "202"
+      start: "201"
+    path: /health
+    requestHeadersToAdd:
+    - header:
+        key: x-kuma-tags
+        value: '&kuma.io/service=sample-gateway&'
+    - header:
+        key: x-some-header
+        value: value
+    - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
+      header:
+        key: x-some-other-header
+        value: value
+  initialJitter: 13s
+  interval: 10s
+  intervalJitter: 15s
+  intervalJitterPercent: 10
+  noTrafficInterval: 16s
+  reuseConnection: true
+  timeout: 2s
+  unhealthyThreshold: 3
+name: backend-26cb64fa4e85e7b7
+perConnectionBufferLimitBytes: 32768
+type: EDS
+typedExtensionProtocolOptions:
+  envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+    '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+    commonHttpProtocolOptions:
+      idleTimeout: 0s
+    explicitHttpConfig:
+      httpProtocolOptions: {}


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
