### PR TITLE
fix(MeshHTTPRoute): generate better resources when using HTTPS

### DIFF
--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
@@ -9,18 +9,25 @@ import (
 	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	system_proto "github.com/kumahq/kuma/api/system/v1alpha1"
+	"github.com/kumahq/kuma/pkg/core/datasource"
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/secrets/cipher"
+	secret_manager "github.com/kumahq/kuma/pkg/core/secrets/manager"
+	secret_store "github.com/kumahq/kuma/pkg/core/secrets/store"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/metrics"
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
 	core_rules "github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
 	api "github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
 	plugin "github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/plugin/v1alpha1"
+	"github.com/kumahq/kuma/pkg/plugins/resources/memory"
 	plugin_gateway "github.com/kumahq/kuma/pkg/plugins/runtime/gateway"
 	"github.com/kumahq/kuma/pkg/test/matchers"
 	"github.com/kumahq/kuma/pkg/test/resources/builders"
@@ -55,6 +62,10 @@ var _ = Describe("MeshHTTPRoute", func() {
 			claCache, err := cla.NewCache(1*time.Second, metrics)
 			Expect(err).ToNot(HaveOccurred())
 			given.xdsContext.ControlPlane.CLACache = claCache
+
+			secretManager := secret_manager.NewSecretManager(secret_store.NewSecretStore(memory.NewStore()), cipher.None(), nil, false)
+			dataSourceLoader := datasource.NewDataSourceLoader(secretManager)
+			given.xdsContext.Mesh.DataSourceLoader = dataSourceLoader
 
 			for n, p := range core_plugins.Plugins().ProxyPlugins() {
 				Expect(p.Apply(context.Background(), given.xdsContext.Mesh, given.proxy)).To(Succeed(), n)
@@ -819,6 +830,38 @@ var _ = Describe("MeshHTTPRoute", func() {
 									"hostname": "wild",
 								},
 							},
+							{
+								Protocol: mesh_proto.MeshGateway_Listener_HTTPS,
+								Hostname: "*.secure.dev",
+								Port:     8083,
+								Tags: map[string]string{
+									"hostname": "secure",
+								},
+								Tls: &mesh_proto.MeshGateway_TLS_Conf{
+									Mode: mesh_proto.MeshGateway_TLS_TERMINATE,
+									Certificates: []*system_proto.DataSource{{
+										Type: &system_proto.DataSource_Inline{
+											Inline: wrapperspb.Bytes([]byte(secret)),
+										},
+									}},
+								},
+							},
+							{
+								Protocol: mesh_proto.MeshGateway_Listener_HTTPS,
+								Hostname: "*.super-secure.dev",
+								Port:     8083,
+								Tags: map[string]string{
+									"hostname": "super-secure",
+								},
+								Tls: &mesh_proto.MeshGateway_TLS_Conf{
+									Mode: mesh_proto.MeshGateway_TLS_TERMINATE,
+									Certificates: []*system_proto.DataSource{{
+										Type: &system_proto.DataSource_Inline{
+											Inline: wrapperspb.Bytes([]byte(secret)),
+										},
+									}},
+								},
+							},
 						},
 					},
 				},
@@ -946,6 +989,84 @@ var _ = Describe("MeshHTTPRoute", func() {
 												}},
 											},
 										}},
+										core_rules.NewInboundListenerHostname("192.168.0.1", 8083, "*.secure.dev"): {{
+											Subset: core_rules.MeshSubset(),
+											Conf: api.PolicyDefault{
+												Hostnames: []string{"first-specific.secure.dev"},
+												Rules: []api.Rule{{
+													Matches: []api.Match{{
+														Path: &api.PathMatch{
+															Type:  api.PathPrefix,
+															Value: "/first-specific-dev",
+														},
+													}},
+													Default: api.RuleConf{
+														BackendRefs: &[]common_api.BackendRef{{
+															TargetRef: builders.TargetRefService("backend"),
+															Weight:    pointer.To(uint(100)),
+														}},
+													},
+												}},
+											},
+										}, {
+											Subset: core_rules.MeshSubset(),
+											Conf: api.PolicyDefault{
+												Hostnames: []string{"second-specific.secure.dev"},
+												Rules: []api.Rule{{
+													Matches: []api.Match{{
+														Path: &api.PathMatch{
+															Type:  api.PathPrefix,
+															Value: "/second-specific-dev",
+														},
+													}},
+													Default: api.RuleConf{
+														BackendRefs: &[]common_api.BackendRef{{
+															TargetRef: builders.TargetRefService("backend"),
+															Weight:    pointer.To(uint(100)),
+														}},
+													},
+												}},
+											},
+										}},
+										core_rules.NewInboundListenerHostname("192.168.0.1", 8083, "*.super-secure.dev"): {{
+											Subset: core_rules.MeshSubset(),
+											Conf: api.PolicyDefault{
+												Hostnames: []string{"first-specific.super-secure.dev"},
+												Rules: []api.Rule{{
+													Matches: []api.Match{{
+														Path: &api.PathMatch{
+															Type:  api.PathPrefix,
+															Value: "/first-specific-super-dev",
+														},
+													}},
+													Default: api.RuleConf{
+														BackendRefs: &[]common_api.BackendRef{{
+															TargetRef: builders.TargetRefService("backend"),
+															Weight:    pointer.To(uint(100)),
+														}},
+													},
+												}},
+											},
+										}, {
+											Subset: core_rules.MeshSubset(),
+											Conf: api.PolicyDefault{
+												Hostnames: []string{"second-specific.super-secure.dev"},
+												Rules: []api.Rule{{
+													Matches: []api.Match{{
+														Path: &api.PathMatch{
+															Type:  api.PathPrefix,
+															Value: "/second-specific-super-dev",
+														},
+													}},
+													Default: api.RuleConf{
+														BackendRefs: &[]common_api.BackendRef{{
+															TargetRef: builders.TargetRefService("backend"),
+															Weight:    pointer.To(uint(100)),
+														}},
+													},
+												}},
+											},
+										}},
 									},
 								},
 							}),
@@ -955,3 +1076,54 @@ var _ = Describe("MeshHTTPRoute", func() {
 		}()),
 	)
 })
+
+// nolint:gosec
+const secret = `
+-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAqEhj+XS8qgm3raPrP554uXDiPv0np2lCx1wJF4KiwFGJMAV8
+qHul/0pcUCX742irsAV39f6sMytXlRpMfBAbJNyZDuqx36s0yMolMxsqMjUHmI+X
+W7zrj1xAkPLjB+kireohXkyXESBy3QbcaAW+ftZdFDcNHC7a9W8eSZzCB5R0Sb1S
+YMrMq8gXrDbB99fLb2G5wsGXq9xW1g6u7TqWy5TAvYkErMfXfsx3BcvJPPAaI4vb
+hPp034KVlucB3h5QSEDF1AIV7A8r1m3I/yHRZqyvhg6Dp4ZTgZw1Sh7QwYsJr6/h
+kIVaBjq+gT+I6oPBOnVrc5W3N/fO8yalaAdvswIDAQABAoIBAQCS8ywCMRNy9Ktl
+wQdz9aF8Zfvbf1t6UGvVBSSXWCdhA5Jl0dTKl7ccGEZGYvTz33pVamEX+j1LLaT8
+eguiJrpdVRl/MikDpVChqgwT9bvCPhaU/YbxwCZ/eNKVANSKGuaCsjpTS1R7yzci
+lZQwbhusTOrY9T3Ih44C1va+11mEHY7rAy96r2MgTdpDdWAqhGKxQ88IyNCTvp6u
+1I/oWXYDm7QW7HCEWcw2PyFfcfLy4LCPYG7BMX6n1DMSSu6U2PeV1fm6wleawCCN
+KxuKQSBHARM9B0pcPpAhGuXO9fHBllz3Tmw0yJYCUopIxPK/r+yMufpsto6KRJOz
+had7o4XJAoGBAMSdr1eRG2TBwfQtGS9WxMUrYiCdNCDMFnXsFrKp5kF7ebRyX0lY
+41O/KS3SPRmqn6F8t77+VjAvIcCtVWPgTLGo4QyOV09UAcPOrv4qBHRkT8tNyM1n
+q15DGd7ICE0LFuK1zjWu1HBz/64hNqJJxC8tcJ1HgQ7sO9Vl0FMHeXcNAoGBANsb
+/QqyRixj0UMhST4MoZzxwV+3Y+//mpEL4R1kcFa0K1BrIq80xCzJzK7jrU7XtaeG
+0WZpksYqexzN6kXvuJy3w5rC4LC2/+MHspYKvdkUMjctB1XIAPF2FtdrSfMDjweS
+ItJ1QqALcc83XzAMkrrCUUeL45SGWxRp3yLljtG/AoGAcPAWwRkEADtf+q9RESUp
+QAysgAls4Q36NOBZJWV8cs7HWQR9gXdClV9v+vcRy8V7jlpCfb5AqcrY+4FVVFqK
+E17rbrfwpQufO+dkE3D1QBpCz4gtuPc8s5edq5+BTSf6jF1cRu/W7YVkL5S6ejwf
+Ke5TCrUBCB5gPDMQmDDp750CgYAHMdwVRdVYD88HTUiCaRfFd4rKAdOeRd5ldOZn
+eKzXrALgGSSCbFEkx1uZQpCmTh8A6URnAIB5UVvJjllrAnwlaUNbCZsnMlsksVQD
+6UZiom8jsK7U+kRNqXsGh9ddy3ge34WVM5SEfNu32jGd+ku3JjpVBxrp/Z9wBCn3
+k2IlMQKBgQCWsVuAoLcEvtKYSBb4KZZY3+pHkLLxe+K7Cpq5fK7RnueaH9+o1g+8
+AdY6vX/j9yVHqfF6DI2tyq0qMcuNkjDirlY3yosZEQOXjW8SIGk3YaHwd4JMqVL6
+vBGM7k3/smF7hEG97wUeaMe3IDkP7G4SNZOWbLUy1IjLw8BBK+2FVQ==
+-----END RSA PRIVATE KEY-----
+-----BEGIN CERTIFICATE-----
+MIIDNTCCAh2gAwIBAgIRAK2DKOd4qR4eTfFpTHCY0KAwDQYJKoZIhvcNAQELBQAw
+GzEZMBcGA1UEAxMQZWNoby5leGFtcGxlLmNvbTAeFw0yMTExMDEwNDMzNDhaFw0z
+MTEwMzAwNDMzNDhaMBsxGTAXBgNVBAMTEGVjaG8uZXhhbXBsZS5jb20wggEiMA0G
+CSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCoSGP5dLyqCbeto+s/nni5cOI+/Sen
+aULHXAkXgqLAUYkwBXyoe6X/SlxQJfvjaKuwBXf1/qwzK1eVGkx8EBsk3JkO6rHf
+qzTIyiUzGyoyNQeYj5dbvOuPXECQ8uMH6SKt6iFeTJcRIHLdBtxoBb5+1l0UNw0c
+Ltr1bx5JnMIHlHRJvVJgysyryBesNsH318tvYbnCwZer3FbWDq7tOpbLlMC9iQSs
+x9d+zHcFy8k88Boji9uE+nTfgpWW5wHeHlBIQMXUAhXsDyvWbcj/IdFmrK+GDoOn
+hlOBnDVKHtDBiwmvr+GQhVoGOr6BP4jqg8E6dWtzlbc3987zJqVoB2+zAgMBAAGj
+dDByMA4GA1UdDwEB/wQEAwICpDATBgNVHSUEDDAKBggrBgEFBQcDATAPBgNVHRMB
+Af8EBTADAQH/MB0GA1UdDgQWBBS+iZdWqEBq5IT4b9Dcdx09MTUuCzAbBgNVHREE
+FDASghBlY2hvLmV4YW1wbGUuY29tMA0GCSqGSIb3DQEBCwUAA4IBAQBRUD8uWq0s
+IM3sW+MCAtBQq5ppNstlAeH24w3yO+4v64FqjDUwRLq7uMJza9iNdbYDQZW/NRrv
+30Om9PSn02WzlANa2Knm/EoCwgPyA4ED1UD77uWnxOUxfEWeqdOYDElJpIRb+7RO
+tW9zD7ZJ89ipvEjL2zGuvKCQKkdYaIm7W2aljDz1olsMgQolHpbTEPjN+RMWiyNs
+tDaan+pwBI0OoXzuWPpB8o9jfL7I8YeOQXOmNy/qpvELV8ji3vdPH1xu1NSt1EGV
+rZigv0SZ20Y+BHgf0y3Tv0X+Rx96lYiUtfU+54vjokEjSsfF+iauxfL75QuVvAf9
+7G3tiTJPwFKA
+-----END CERTIFICATE-----
+`

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.clusters.golden.yaml
@@ -1,4 +1,22 @@
 resources:
+- name: backend-348a834721ead661
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+        resourceApiVersion: V3
+    name: backend-348a834721ead661
+    perConnectionBufferLimitBytes: 32768
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        commonHttpProtocolOptions:
+          idleTimeout: 0s
+        explicitHttpConfig:
+          httpProtocolOptions: {}
 - name: backend-6d0a1cf7605e8b1e
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
@@ -26,6 +44,24 @@ resources:
         ads: {}
         resourceApiVersion: V3
     name: backend-a285094d9b0d7032
+    perConnectionBufferLimitBytes: 32768
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        commonHttpProtocolOptions:
+          idleTimeout: 0s
+        explicitHttpConfig:
+          httpProtocolOptions: {}
+- name: backend-dda53ef9426194b2
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+        resourceApiVersion: V3
+    name: backend-dda53ef9426194b2
     perConnectionBufferLimitBytes: 32768
     type: EDS
     typedExtensionProtocolOptions:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.endpoints.golden.yaml
@@ -1,4 +1,24 @@
 resources:
+- name: backend-348a834721ead661
+  resource:
+    '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
+    clusterName: backend-348a834721ead661
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.0.4
+              portValue: 8084
+        loadBalancingWeight: 1
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              kuma.io/protocol: http
+              region: us
+            envoy.transport_socket_match:
+              kuma.io/protocol: http
+              region: us
 - name: backend-6d0a1cf7605e8b1e
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
@@ -23,6 +43,26 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
     clusterName: backend-a285094d9b0d7032
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.0.4
+              portValue: 8084
+        loadBalancingWeight: 1
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              kuma.io/protocol: http
+              region: us
+            envoy.transport_socket_match:
+              kuma.io/protocol: http
+              region: us
+- name: backend-dda53ef9426194b2
+  resource:
+    '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
+    clusterName: backend-dda53ef9426194b2
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.listeners.golden.yaml
@@ -187,7 +187,7 @@ resources:
     filterChains:
     - filterChainMatch:
         serverNames:
-        - second-specific.super-secure.dev
+        - '*.secure.dev'
         transportProtocol: tls
       filters:
       - name: envoy.filters.network.http_connection_manager
@@ -241,7 +241,7 @@ resources:
             - h2
             - http/1.1
             tlsCertificateSdsSecretConfigs:
-            - name: cert.rsa:inline:second-specific.super-secure.dev
+            - name: cert.rsa:inline:*.secure.dev
               sdsConfig:
                 ads: {}
                 resourceApiVersion: V3
@@ -250,7 +250,7 @@ resources:
           requireClientCertificate: false
     - filterChainMatch:
         serverNames:
-        - second-specific.secure.dev
+        - '*.super-secure.dev'
         transportProtocol: tls
       filters:
       - name: envoy.filters.network.http_connection_manager
@@ -304,133 +304,7 @@ resources:
             - h2
             - http/1.1
             tlsCertificateSdsSecretConfigs:
-            - name: cert.rsa:inline:second-specific.secure.dev
-              sdsConfig:
-                ads: {}
-                resourceApiVersion: V3
-            tlsParams:
-              tlsMinimumProtocolVersion: TLSv1_2
-          requireClientCertificate: false
-    - filterChainMatch:
-        serverNames:
-        - first-specific.super-secure.dev
-        transportProtocol: tls
-      filters:
-      - name: envoy.filters.network.http_connection_manager
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-          commonHttpProtocolOptions:
-            headersWithUnderscoresAction: REJECT_REQUEST
-            idleTimeout: 300s
-          http2ProtocolOptions:
-            allowConnect: true
-            initialConnectionWindowSize: 1048576
-            initialStreamWindowSize: 65536
-            maxConcurrentStreams: 100
-          httpFilters:
-          - name: envoy.filters.http.local_ratelimit
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
-              statPrefix: rate_limit
-          - name: gzip-compress
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
-              compressorLibrary:
-                name: gzip
-                typedConfig:
-                  '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
-              responseDirectionConfig:
-                disableOnEtagHeader: true
-          - name: envoy.filters.http.router
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-              startChildSpan: true
-          mergeSlashes: true
-          normalizePath: true
-          pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
-          rds:
-            configSource:
-              ads: {}
-              resourceApiVersion: V3
-            routeConfigName: sample-gateway:HTTPS:8083
-          requestHeadersTimeout: 0.500s
-          serverName: Kuma Gateway
-          statPrefix: sample-gateway
-          streamIdleTimeout: 5s
-          useRemoteAddress: true
-      transportSocket:
-        name: envoy.transport_sockets.tls
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
-          commonTlsContext:
-            alpnProtocols:
-            - h2
-            - http/1.1
-            tlsCertificateSdsSecretConfigs:
-            - name: cert.rsa:inline:first-specific.super-secure.dev
-              sdsConfig:
-                ads: {}
-                resourceApiVersion: V3
-            tlsParams:
-              tlsMinimumProtocolVersion: TLSv1_2
-          requireClientCertificate: false
-    - filterChainMatch:
-        serverNames:
-        - first-specific.secure.dev
-        transportProtocol: tls
-      filters:
-      - name: envoy.filters.network.http_connection_manager
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-          commonHttpProtocolOptions:
-            headersWithUnderscoresAction: REJECT_REQUEST
-            idleTimeout: 300s
-          http2ProtocolOptions:
-            allowConnect: true
-            initialConnectionWindowSize: 1048576
-            initialStreamWindowSize: 65536
-            maxConcurrentStreams: 100
-          httpFilters:
-          - name: envoy.filters.http.local_ratelimit
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
-              statPrefix: rate_limit
-          - name: gzip-compress
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
-              compressorLibrary:
-                name: gzip
-                typedConfig:
-                  '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
-              responseDirectionConfig:
-                disableOnEtagHeader: true
-          - name: envoy.filters.http.router
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-              startChildSpan: true
-          mergeSlashes: true
-          normalizePath: true
-          pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
-          rds:
-            configSource:
-              ads: {}
-              resourceApiVersion: V3
-            routeConfigName: sample-gateway:HTTPS:8083
-          requestHeadersTimeout: 0.500s
-          serverName: Kuma Gateway
-          statPrefix: sample-gateway
-          streamIdleTimeout: 5s
-          useRemoteAddress: true
-      transportSocket:
-        name: envoy.transport_sockets.tls
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
-          commonTlsContext:
-            alpnProtocols:
-            - h2
-            - http/1.1
-            tlsCertificateSdsSecretConfigs:
-            - name: cert.rsa:inline:first-specific.secure.dev
+            - name: cert.rsa:inline:*.super-secure.dev
               sdsConfig:
                 ads: {}
                 resourceApiVersion: V3

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.listeners.golden.yaml
@@ -176,3 +176,271 @@ resources:
     name: sample-gateway:HTTP:8082
     perConnectionBufferLimitBytes: 32768
     trafficDirection: INBOUND
+- name: sample-gateway:HTTPS:8083
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.1
+        portValue: 8083
+    enableReusePort: true
+    filterChains:
+    - filterChainMatch:
+        serverNames:
+        - second-specific.super-secure.dev
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          commonHttpProtocolOptions:
+            headersWithUnderscoresAction: REJECT_REQUEST
+            idleTimeout: 300s
+          http2ProtocolOptions:
+            allowConnect: true
+            initialConnectionWindowSize: 1048576
+            initialStreamWindowSize: 65536
+            maxConcurrentStreams: 100
+          httpFilters:
+          - name: envoy.filters.http.local_ratelimit
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              statPrefix: rate_limit
+          - name: gzip-compress
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+              compressorLibrary:
+                name: gzip
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+              responseDirectionConfig:
+                disableOnEtagHeader: true
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+              startChildSpan: true
+          mergeSlashes: true
+          normalizePath: true
+          pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
+          rds:
+            configSource:
+              ads: {}
+              resourceApiVersion: V3
+            routeConfigName: sample-gateway:HTTPS:8083
+          requestHeadersTimeout: 0.500s
+          serverName: Kuma Gateway
+          statPrefix: sample-gateway
+          streamIdleTimeout: 5s
+          useRemoteAddress: true
+      transportSocket:
+        name: envoy.transport_sockets.tls
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          commonTlsContext:
+            alpnProtocols:
+            - h2
+            - http/1.1
+            tlsCertificateSdsSecretConfigs:
+            - name: cert.rsa:inline:second-specific.super-secure.dev
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+            tlsParams:
+              tlsMinimumProtocolVersion: TLSv1_2
+          requireClientCertificate: false
+    - filterChainMatch:
+        serverNames:
+        - second-specific.secure.dev
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          commonHttpProtocolOptions:
+            headersWithUnderscoresAction: REJECT_REQUEST
+            idleTimeout: 300s
+          http2ProtocolOptions:
+            allowConnect: true
+            initialConnectionWindowSize: 1048576
+            initialStreamWindowSize: 65536
+            maxConcurrentStreams: 100
+          httpFilters:
+          - name: envoy.filters.http.local_ratelimit
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              statPrefix: rate_limit
+          - name: gzip-compress
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+              compressorLibrary:
+                name: gzip
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+              responseDirectionConfig:
+                disableOnEtagHeader: true
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+              startChildSpan: true
+          mergeSlashes: true
+          normalizePath: true
+          pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
+          rds:
+            configSource:
+              ads: {}
+              resourceApiVersion: V3
+            routeConfigName: sample-gateway:HTTPS:8083
+          requestHeadersTimeout: 0.500s
+          serverName: Kuma Gateway
+          statPrefix: sample-gateway
+          streamIdleTimeout: 5s
+          useRemoteAddress: true
+      transportSocket:
+        name: envoy.transport_sockets.tls
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          commonTlsContext:
+            alpnProtocols:
+            - h2
+            - http/1.1
+            tlsCertificateSdsSecretConfigs:
+            - name: cert.rsa:inline:second-specific.secure.dev
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+            tlsParams:
+              tlsMinimumProtocolVersion: TLSv1_2
+          requireClientCertificate: false
+    - filterChainMatch:
+        serverNames:
+        - first-specific.super-secure.dev
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          commonHttpProtocolOptions:
+            headersWithUnderscoresAction: REJECT_REQUEST
+            idleTimeout: 300s
+          http2ProtocolOptions:
+            allowConnect: true
+            initialConnectionWindowSize: 1048576
+            initialStreamWindowSize: 65536
+            maxConcurrentStreams: 100
+          httpFilters:
+          - name: envoy.filters.http.local_ratelimit
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              statPrefix: rate_limit
+          - name: gzip-compress
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+              compressorLibrary:
+                name: gzip
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+              responseDirectionConfig:
+                disableOnEtagHeader: true
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+              startChildSpan: true
+          mergeSlashes: true
+          normalizePath: true
+          pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
+          rds:
+            configSource:
+              ads: {}
+              resourceApiVersion: V3
+            routeConfigName: sample-gateway:HTTPS:8083
+          requestHeadersTimeout: 0.500s
+          serverName: Kuma Gateway
+          statPrefix: sample-gateway
+          streamIdleTimeout: 5s
+          useRemoteAddress: true
+      transportSocket:
+        name: envoy.transport_sockets.tls
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          commonTlsContext:
+            alpnProtocols:
+            - h2
+            - http/1.1
+            tlsCertificateSdsSecretConfigs:
+            - name: cert.rsa:inline:first-specific.super-secure.dev
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+            tlsParams:
+              tlsMinimumProtocolVersion: TLSv1_2
+          requireClientCertificate: false
+    - filterChainMatch:
+        serverNames:
+        - first-specific.secure.dev
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          commonHttpProtocolOptions:
+            headersWithUnderscoresAction: REJECT_REQUEST
+            idleTimeout: 300s
+          http2ProtocolOptions:
+            allowConnect: true
+            initialConnectionWindowSize: 1048576
+            initialStreamWindowSize: 65536
+            maxConcurrentStreams: 100
+          httpFilters:
+          - name: envoy.filters.http.local_ratelimit
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              statPrefix: rate_limit
+          - name: gzip-compress
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+              compressorLibrary:
+                name: gzip
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+              responseDirectionConfig:
+                disableOnEtagHeader: true
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+              startChildSpan: true
+          mergeSlashes: true
+          normalizePath: true
+          pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
+          rds:
+            configSource:
+              ads: {}
+              resourceApiVersion: V3
+            routeConfigName: sample-gateway:HTTPS:8083
+          requestHeadersTimeout: 0.500s
+          serverName: Kuma Gateway
+          statPrefix: sample-gateway
+          streamIdleTimeout: 5s
+          useRemoteAddress: true
+      transportSocket:
+        name: envoy.transport_sockets.tls
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          commonTlsContext:
+            alpnProtocols:
+            - h2
+            - http/1.1
+            tlsCertificateSdsSecretConfigs:
+            - name: cert.rsa:inline:first-specific.secure.dev
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+            tlsParams:
+              tlsMinimumProtocolVersion: TLSv1_2
+          requireClientCertificate: false
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: sample-gateway:HTTPS:8083
+    perConnectionBufferLimitBytes: 32768
+    trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.routes.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.routes.golden.yaml
@@ -202,3 +202,156 @@ resources:
                   key: x-kuma-tags
                   value: '&kuma.io/service=sample-gateway&'
               weight: 100
+- name: sample-gateway:HTTPS:8083
+  resource:
+    '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+    ignorePortInHostMatching: true
+    name: sample-gateway:HTTPS:8083
+    requestHeadersToRemove:
+    - x-kuma-tags
+    validateClusters: false
+    virtualHosts:
+    - domains:
+      - second-specific.super-secure.dev
+      name: second-specific.super-secure.dev
+      requireTls: ALL
+      responseHeadersToAdd:
+      - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
+        header:
+          key: Strict-Transport-Security
+          value: max-age=31536000; includeSubDomains
+      routes:
+      - match:
+          path: /second-specific-super-dev
+        route:
+          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+          idleTimeout: 5s
+          weightedClusters:
+            clusters:
+            - name: backend-dda53ef9426194b2
+              requestHeadersToAdd:
+              - header:
+                  key: x-kuma-tags
+                  value: '&kuma.io/service=sample-gateway&'
+              weight: 100
+      - match:
+          prefix: /second-specific-super-dev/
+        route:
+          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+          idleTimeout: 5s
+          weightedClusters:
+            clusters:
+            - name: backend-dda53ef9426194b2
+              requestHeadersToAdd:
+              - header:
+                  key: x-kuma-tags
+                  value: '&kuma.io/service=sample-gateway&'
+              weight: 100
+    - domains:
+      - second-specific.secure.dev
+      name: second-specific.secure.dev
+      requireTls: ALL
+      responseHeadersToAdd:
+      - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
+        header:
+          key: Strict-Transport-Security
+          value: max-age=31536000; includeSubDomains
+      routes:
+      - match:
+          path: /second-specific-dev
+        route:
+          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+          idleTimeout: 5s
+          weightedClusters:
+            clusters:
+            - name: backend-348a834721ead661
+              requestHeadersToAdd:
+              - header:
+                  key: x-kuma-tags
+                  value: '&kuma.io/service=sample-gateway&'
+              weight: 100
+      - match:
+          prefix: /second-specific-dev/
+        route:
+          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+          idleTimeout: 5s
+          weightedClusters:
+            clusters:
+            - name: backend-348a834721ead661
+              requestHeadersToAdd:
+              - header:
+                  key: x-kuma-tags
+                  value: '&kuma.io/service=sample-gateway&'
+              weight: 100
+    - domains:
+      - first-specific.super-secure.dev
+      name: first-specific.super-secure.dev
+      requireTls: ALL
+      responseHeadersToAdd:
+      - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
+        header:
+          key: Strict-Transport-Security
+          value: max-age=31536000; includeSubDomains
+      routes:
+      - match:
+          path: /first-specific-super-dev
+        route:
+          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+          idleTimeout: 5s
+          weightedClusters:
+            clusters:
+            - name: backend-dda53ef9426194b2
+              requestHeadersToAdd:
+              - header:
+                  key: x-kuma-tags
+                  value: '&kuma.io/service=sample-gateway&'
+              weight: 100
+      - match:
+          prefix: /first-specific-super-dev/
+        route:
+          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+          idleTimeout: 5s
+          weightedClusters:
+            clusters:
+            - name: backend-dda53ef9426194b2
+              requestHeadersToAdd:
+              - header:
+                  key: x-kuma-tags
+                  value: '&kuma.io/service=sample-gateway&'
+              weight: 100
+    - domains:
+      - first-specific.secure.dev
+      name: first-specific.secure.dev
+      requireTls: ALL
+      responseHeadersToAdd:
+      - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
+        header:
+          key: Strict-Transport-Security
+          value: max-age=31536000; includeSubDomains
+      routes:
+      - match:
+          path: /first-specific-dev
+        route:
+          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+          idleTimeout: 5s
+          weightedClusters:
+            clusters:
+            - name: backend-348a834721ead661
+              requestHeadersToAdd:
+              - header:
+                  key: x-kuma-tags
+                  value: '&kuma.io/service=sample-gateway&'
+              weight: 100
+      - match:
+          prefix: /first-specific-dev/
+        route:
+          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+          idleTimeout: 5s
+          weightedClusters:
+            clusters:
+            - name: backend-348a834721ead661
+              requestHeadersToAdd:
+              - header:
+                  key: x-kuma-tags
+                  value: '&kuma.io/service=sample-gateway&'
+              weight: 100

--- a/pkg/plugins/runtime/gateway/generator.go
+++ b/pkg/plugins/runtime/gateway/generator.go
@@ -74,6 +74,11 @@ type GatewayHost struct {
 	Tags mesh_proto.TagSelector
 }
 
+type GatewayListenerFilter struct {
+	Hostnames []string
+	TLS       *mesh_proto.MeshGateway_TLS_Conf
+}
+
 type GatewayListener struct {
 	Port         uint32
 	Protocol     mesh_proto.MeshGateway_Listener_Protocol
@@ -82,6 +87,9 @@ type GatewayListener struct {
 	// listener as if we have HTTPS with the Mesh cert for this Dataplane
 	CrossMesh bool
 	Resources *mesh_proto.MeshGateway_Listener_Resources // TODO verify these don't conflict when merging
+	// Filters, if set, is used for more control over filter chain matches
+	// independent of the routes
+	Filters []GatewayListenerFilter
 }
 
 // GatewayListenerInfo holds everything needed to generate resources for a


### PR DESCRIPTION
We shouldn't use the _route_ hostnames in the SNI level match. The SNI should match according to the listener hostnames and _then_ it should fail to match at the HTTP level.

See the diff between [the first and third commit.](https://github.com/kumahq/kuma/pull/9038/commits/1dc7df2cc766702c9649762fbeac96149c3d7f1a)

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
