### PR TITLE
fix(meshratelimit): remove validation of Mesh type and proxyTypes for…

### DIFF
--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/validator.go
@@ -38,9 +38,6 @@ func validateFrom(topTargetRef common_api.TargetRef, from []From) validators.Val
 		verr.AddViolationAt(validators.RootedAt("from"), validators.MustNotBeDefined)
 		return verr
 	}
-	if topTargetRef.Kind != common_api.MeshGateway && len(from) == 0 {
-		verr.AddViolationAt(validators.RootedAt("from"), "needs at least one item")
-	}
 	for idx, fromItem := range from {
 		path := validators.RootedAt("from").Index(idx)
 		defaultField := path.Field("default")
@@ -59,9 +56,6 @@ func validateTo(topTargetRef common_api.TargetRef, to []To) validators.Validatio
 	if !common_api.IncludesGateways(topTargetRef) && len(to) != 0 {
 		verr.AddViolationAt(validators.RootedAt("to"), validators.MustNotBeDefined)
 		return verr
-	}
-	if topTargetRef.Kind == common_api.MeshGateway && len(to) == 0 {
-		verr.AddViolationAt(validators.RootedAt("to"), "needs at least one item")
 	}
 	for idx, toItem := range to {
 		path := validators.RootedAt("to").Index(idx)

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/validator_test.go
@@ -151,16 +151,6 @@ to:
 				// then
 				Expect(actual).To(MatchYAML(given.expected))
 			},
-			Entry("empty 'from'", testCase{
-				inputYaml: `
-targetRef:
-  kind: Mesh
-`,
-				expected: `
-violations:
-  - field: spec.from
-    message: needs at least one item`,
-			}),
 			Entry("unsupported kind in from selector", testCase{
 				inputYaml: `
 targetRef:
@@ -355,9 +345,7 @@ from:
 				expected: `
 violations:
   - field: spec.from
-    message: 'must not be defined'
-  - field: spec.to
-    message: needs at least one item`,
+    message: 'must not be defined'`,
 			}),
 		)
 	})


### PR DESCRIPTION
… gateway

### Checklist prior to review

Related to https://github.com/kumahq/kuma/pull/8943

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
