### PR TITLE
feat(universal): add VIP_REFRESH_INTERVAL

### DIFF
--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -400,6 +400,8 @@ runtime:
   universal:
     # DataplaneCleanupAge defines how long Dataplane should be offline to be cleaned up by GC
     dataplaneCleanupAge: 72h0m0s # ENV: KUMA_RUNTIME_UNIVERSAL_DATAPLANE_CLEANUP_AGE
+    # VIPRefreshInterval defines how often all meshes' VIPs should be recomputed
+    vipRefreshInterval: 500ms # ENV: KUMA_RUNTIME_UNIVERSAL_VIP_REFRESH_INTERVAL
 
 # Default Kuma entities configuration
 defaults:

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -400,6 +400,8 @@ runtime:
   universal:
     # DataplaneCleanupAge defines how long Dataplane should be offline to be cleaned up by GC
     dataplaneCleanupAge: 72h0m0s # ENV: KUMA_RUNTIME_UNIVERSAL_DATAPLANE_CLEANUP_AGE
+    # VIPRefreshInterval defines how often all meshes' VIPs should be recomputed
+    vipRefreshInterval: 500ms
 
 # Default Kuma entities configuration
 defaults:

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -401,7 +401,7 @@ runtime:
     # DataplaneCleanupAge defines how long Dataplane should be offline to be cleaned up by GC
     dataplaneCleanupAge: 72h0m0s # ENV: KUMA_RUNTIME_UNIVERSAL_DATAPLANE_CLEANUP_AGE
     # VIPRefreshInterval defines how often all meshes' VIPs should be recomputed
-    vipRefreshInterval: 500ms
+    vipRefreshInterval: 500ms # ENV: KUMA_RUNTIME_UNIVERSAL_VIP_REFRESH_INTERVAL
 
 # Default Kuma entities configuration
 defaults:

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -225,6 +225,7 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.Runtime.Kubernetes.LeaderElection.LeaseDuration.Duration).To(Equal(199 * time.Second))
 			Expect(cfg.Runtime.Kubernetes.LeaderElection.RenewDeadline.Duration).To(Equal(99 * time.Second))
 			Expect(cfg.Runtime.Universal.DataplaneCleanupAge.Duration).To(Equal(1 * time.Hour))
+			Expect(cfg.Runtime.Universal.VIPRefreshInterval.Duration).To(Equal(10 * time.Second))
 
 			Expect(cfg.Reports.Enabled).To(BeFalse())
 
@@ -462,6 +463,7 @@ monitoringAssignmentServer:
 runtime:
   universal:
     dataplaneCleanupAge: 1h
+    vipRefreshInterval: 10s
   kubernetes:
     serviceAccountName: custom-sa
     allowedUsers: ["allowed-usr-1", "allowed-usr-2"]
@@ -854,6 +856,7 @@ tracing:
 				"KUMA_RUNTIME_KUBERNETES_LEADER_ELECTION_LEASE_DURATION":                                   "199s",
 				"KUMA_RUNTIME_KUBERNETES_LEADER_ELECTION_RENEW_DEADLINE":                                   "99s",
 				"KUMA_RUNTIME_UNIVERSAL_DATAPLANE_CLEANUP_AGE":                                             "1h",
+				"KUMA_RUNTIME_UNIVERSAL_VIP_REFRESH_INTERVAL":                                              "10s",
 				"KUMA_GENERAL_TLS_CERT_FILE":                                                               "/tmp/cert",
 				"KUMA_GENERAL_TLS_KEY_FILE":                                                                "/tmp/key",
 				"KUMA_GENERAL_TLS_MAX_VERSION":                                                             "TLSv1_3",

--- a/pkg/config/plugins/runtime/universal/config.go
+++ b/pkg/config/plugins/runtime/universal/config.go
@@ -13,6 +13,7 @@ import (
 func DefaultUniversalRuntimeConfig() *UniversalRuntimeConfig {
 	return &UniversalRuntimeConfig{
 		DataplaneCleanupAge: config_types.Duration{Duration: 3 * 24 * time.Hour},
+		VIPRefreshInterval:  config_types.Duration{Duration: 500 * time.Millisecond},
 	}
 }
 
@@ -24,12 +25,17 @@ type UniversalRuntimeConfig struct {
 
 	// DataplaneCleanupAge defines how long Dataplane should be offline to be cleaned up by GC
 	DataplaneCleanupAge config_types.Duration `json:"dataplaneCleanupAge" envconfig:"kuma_runtime_universal_dataplane_cleanup_age"`
+	// VIPRefreshInterval defines how often all meshes' VIPs should be recomputed
+	VIPRefreshInterval config_types.Duration `json:"vipRefreshInterval" envconfig:"kuma_runtime_universal_vip_refresh_interval"`
 }
 
 func (u *UniversalRuntimeConfig) Validate() error {
 	var errs error
 	if u.DataplaneCleanupAge.Duration <= 0 {
 		errs = multierr.Append(errs, errors.Errorf(".DataplaneCleanupAge must be positive"))
+	}
+	if u.VIPRefreshInterval.Duration <= 0 {
+		errs = multierr.Append(errs, errors.Errorf(".VIPRefreshInterval must be positive"))
 	}
 	return errs
 }

--- a/pkg/config/plugins/runtime/universal/config_test.go
+++ b/pkg/config/plugins/runtime/universal/config_test.go
@@ -24,6 +24,7 @@ var _ = Describe("Config", func() {
 
 		// and
 		Expect(cfg.DataplaneCleanupAge.Duration).To(Equal(5 * time.Hour))
+		Expect(cfg.VIPRefreshInterval.Duration).To(Equal(5 * time.Second))
 	})
 
 	It("should have consistent defaults", func() {
@@ -52,6 +53,6 @@ var _ = Describe("Config", func() {
 
 		// then
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal(`Invalid configuration: .DataplaneCleanupAge must be positive`))
+		Expect(err.Error()).To(Equal(`Invalid configuration: .DataplaneCleanupAge must be positive; .VIPRefreshInterval must be positive`))
 	})
 })

--- a/pkg/config/plugins/runtime/universal/testdata/default-config.golden.yaml
+++ b/pkg/config/plugins/runtime/universal/testdata/default-config.golden.yaml
@@ -1,1 +1,2 @@
 dataplaneCleanupAge: 72h0m0s
+vipRefreshInterval: 500ms

--- a/pkg/config/plugins/runtime/universal/testdata/invalid-config.input.yaml
+++ b/pkg/config/plugins/runtime/universal/testdata/invalid-config.input.yaml
@@ -1,1 +1,2 @@
 dataplaneCleanupAge: -3
+vipRefreshInterval: -5

--- a/pkg/config/plugins/runtime/universal/testdata/valid-config.input.yaml
+++ b/pkg/config/plugins/runtime/universal/testdata/valid-config.input.yaml
@@ -1,1 +1,2 @@
 dataplaneCleanupAge: 5h
+vipRefreshInterval: 5s

--- a/pkg/plugins/runtime/universal/plugin.go
+++ b/pkg/plugins/runtime/universal/plugin.go
@@ -51,7 +51,7 @@ func addDNS(rt core_runtime.Runtime) error {
 		return err
 	}
 	return rt.Add(component.LeaderComponentFunc(func(stop <-chan struct{}) error {
-		ticker := time.NewTicker(time.Millisecond * 500)
+		ticker := time.NewTicker(time.Millisecond * rt.Config().Runtime.Universal.VIPRefreshInterval.Duration)
 		defer ticker.Stop()
 
 		dns.Log.Info("starting the DNS VIPs allocator")

--- a/pkg/plugins/runtime/universal/plugin.go
+++ b/pkg/plugins/runtime/universal/plugin.go
@@ -51,7 +51,7 @@ func addDNS(rt core_runtime.Runtime) error {
 		return err
 	}
 	return rt.Add(component.LeaderComponentFunc(func(stop <-chan struct{}) error {
-		ticker := time.NewTicker(time.Millisecond * rt.Config().Runtime.Universal.VIPRefreshInterval.Duration)
+		ticker := time.NewTicker(rt.Config().Runtime.Universal.VIPRefreshInterval.Duration)
 		defer ticker.Stop()
 
 		dns.Log.Info("starting the DNS VIPs allocator")


### PR DESCRIPTION
It allows to customize at which rate all VIPs should be re-computed for all meshes. The default is unchanged, 500ms

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- no issue on this
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? -- no breaking change
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
