### PR TITLE
fix(routes): share logic between new route resources

### DIFF
--- a/pkg/plugins/policies/core/xds/meshroute/gateway.go
+++ b/pkg/plugins/policies/core/xds/meshroute/gateway.go
@@ -41,7 +41,7 @@ func CollectListenerInfos(
 	rawRules rules.GatewayRules,
 	validProtocols []mesh_proto.MeshGateway_Listener_Protocol,
 	mapRules MapGatewayRulesToHosts,
-) []plugin_gateway.GatewayListenerInfo {
+) map[uint32]plugin_gateway.GatewayListenerInfo {
 	networking := proxy.Dataplane.Spec.GetNetworking()
 	listenersByPort := map[uint32]listenersHostnames{}
 	for _, listener := range gateway.Spec.GetConf().GetListeners() {
@@ -67,7 +67,7 @@ func CollectListenerInfos(
 		listenersByPort[listener.GetPort()] = listenerAcc
 	}
 
-	var infos []plugin_gateway.GatewayListenerInfo
+	infos := map[uint32]plugin_gateway.GatewayListenerInfo{}
 
 	for port, listener := range listenersByPort {
 		externalServices := meshCtx.Resources.ExternalServices()
@@ -106,7 +106,7 @@ func CollectListenerInfos(
 				TLS:       sublistener.TLS,
 			})
 		}
-		infos = append(infos, plugin_gateway.GatewayListenerInfo{
+		infos[port] = plugin_gateway.GatewayListenerInfo{
 			Proxy:             proxy,
 			Gateway:           gateway,
 			HostInfos:         hostInfos,
@@ -124,7 +124,7 @@ func CollectListenerInfos(
 				Resources: listener.listener.GetResources(),
 				Filters:   filters,
 			},
-		})
+		}
 	}
 
 	return infos

--- a/pkg/plugins/policies/core/xds/meshroute/gateway.go
+++ b/pkg/plugins/policies/core/xds/meshroute/gateway.go
@@ -1,0 +1,131 @@
+package meshroute
+
+import (
+	"context"
+	"slices"
+
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/pkg/core/permissions"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+	"github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
+	plugin_gateway "github.com/kumahq/kuma/pkg/plugins/runtime/gateway"
+	xds_context "github.com/kumahq/kuma/pkg/xds/context"
+	envoy_names "github.com/kumahq/kuma/pkg/xds/envoy/names"
+	xds_topology "github.com/kumahq/kuma/pkg/xds/topology"
+)
+
+type Sublistener struct {
+	Hostname string
+	Tags     map[string]string
+	TLS      *mesh_proto.MeshGateway_TLS_Conf
+}
+type listenersHostnames struct {
+	listener     *mesh_proto.MeshGateway_Listener
+	sublisteners []Sublistener
+}
+
+type MapGatewayRulesToHosts func(
+	xds_context.ResourceMap,
+	rules.GatewayRules,
+	string,
+	*mesh_proto.MeshGateway_Listener,
+	[]Sublistener,
+) []plugin_gateway.GatewayHostInfo
+
+func CollectListenerInfos(
+	ctx context.Context,
+	meshCtx xds_context.MeshContext,
+	gateway *core_mesh.MeshGatewayResource,
+	proxy *core_xds.Proxy,
+	rawRules rules.GatewayRules,
+	validProtocols []mesh_proto.MeshGateway_Listener_Protocol,
+	mapRules MapGatewayRulesToHosts,
+) []plugin_gateway.GatewayListenerInfo {
+	networking := proxy.Dataplane.Spec.GetNetworking()
+	listenersByPort := map[uint32]listenersHostnames{}
+	for _, listener := range gateway.Spec.GetConf().GetListeners() {
+		if !slices.Contains(validProtocols, listener.Protocol) {
+			continue
+		}
+		listenerAcc, ok := listenersByPort[listener.GetPort()]
+		if !ok {
+			listenerAcc = listenersHostnames{
+				listener: listener,
+			}
+		}
+		hostname := listener.GetNonEmptyHostname()
+		listenerAcc.sublisteners = append(listenerAcc.sublisteners, Sublistener{
+			Hostname: hostname,
+			Tags: mesh_proto.Merge(
+				networking.GetGateway().GetTags(),
+				gateway.Spec.GetTags(),
+				listener.GetTags(),
+			),
+			TLS: listener.GetTls(),
+		})
+		listenersByPort[listener.GetPort()] = listenerAcc
+	}
+
+	var infos []plugin_gateway.GatewayListenerInfo
+
+	for port, listener := range listenersByPort {
+		externalServices := meshCtx.Resources.ExternalServices()
+
+		matchedExternalServices := permissions.MatchExternalServicesTrafficPermissions(
+			proxy.Dataplane, externalServices, meshCtx.Resources.TrafficPermissions(),
+		)
+
+		outboundEndpoints := core_xds.EndpointMap{}
+		for k, v := range meshCtx.EndpointMap {
+			outboundEndpoints[k] = v
+		}
+
+		esEndpoints := xds_topology.BuildExternalServicesEndpointMap(
+			ctx,
+			meshCtx.Resource,
+			matchedExternalServices,
+			meshCtx.DataSourceLoader,
+			proxy.Zone,
+		)
+		for k, v := range esEndpoints {
+			outboundEndpoints[k] = v
+		}
+
+		hostInfos := mapRules(
+			meshCtx.Resources.MeshLocalResources,
+			rawRules,
+			networking.Address,
+			listener.listener,
+			listener.sublisteners,
+		)
+		var filters []plugin_gateway.GatewayListenerFilter
+		for _, sublistener := range listener.sublisteners {
+			filters = append(filters, plugin_gateway.GatewayListenerFilter{
+				Hostnames: []string{sublistener.Hostname},
+				TLS:       sublistener.TLS,
+			})
+		}
+		infos = append(infos, plugin_gateway.GatewayListenerInfo{
+			Proxy:             proxy,
+			Gateway:           gateway,
+			HostInfos:         hostInfos,
+			ExternalServices:  externalServices,
+			OutboundEndpoints: outboundEndpoints,
+			Listener: plugin_gateway.GatewayListener{
+				Port:     port,
+				Protocol: listener.listener.GetProtocol(),
+				ResourceName: envoy_names.GetGatewayListenerName(
+					gateway.Meta.GetName(),
+					listener.listener.GetProtocol().String(),
+					port,
+				),
+				CrossMesh: listener.listener.GetCrossMesh(),
+				Resources: listener.listener.GetResources(),
+				Filters:   filters,
+			},
+		})
+	}
+
+	return infos
+}

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
@@ -21,11 +21,14 @@ import (
 	plugin "github.com/kumahq/kuma/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1"
 	meshhttproute_api "github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
 	meshhttproute_plugin "github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/plugin/v1alpha1"
+	meshtcproute_api "github.com/kumahq/kuma/pkg/plugins/policies/meshtcproute/api/v1alpha1"
+	meshtcproute_plugin "github.com/kumahq/kuma/pkg/plugins/policies/meshtcproute/plugin/v1alpha1"
 	gateway_plugin "github.com/kumahq/kuma/pkg/plugins/runtime/gateway"
 	"github.com/kumahq/kuma/pkg/test"
 	"github.com/kumahq/kuma/pkg/test/matchers"
 	test_matchers "github.com/kumahq/kuma/pkg/test/matchers"
 	"github.com/kumahq/kuma/pkg/test/resources/builders"
+	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
 	"github.com/kumahq/kuma/pkg/test/resources/samples"
 	xds_builders "github.com/kumahq/kuma/pkg/test/xds/builders"
 	xds_samples "github.com/kumahq/kuma/pkg/test/xds/samples"
@@ -246,14 +249,46 @@ var _ = Describe("MeshHealthCheck", func() {
 		name           string
 		gatewayRoutes  []*core_mesh.MeshGatewayRouteResource
 		meshhttproutes core_rules.GatewayRules
+		meshtcproutes  core_rules.GatewayRules
 		rules          core_rules.GatewayRules
 	}
 	DescribeTable("should generate proper Envoy config for MeshGateways",
 		func(given gatewayTestCase) {
 			Expect(given.name).ToNot(BeEmpty())
 			resources := xds_context.NewResources()
+
+			gateway := &core_mesh.MeshGatewayResource{
+				Meta: &test_model.ResourceMeta{Name: "sample-gateway", Mesh: "default"},
+				Spec: &mesh_proto.MeshGateway{
+					Selectors: []*mesh_proto.Selector{
+						{
+							Match: map[string]string{
+								mesh_proto.ServiceTag: "sample-gateway",
+							},
+						},
+					},
+					Conf: &mesh_proto.MeshGateway_Conf{
+						Listeners: []*mesh_proto.MeshGateway_Listener{
+							{
+								Protocol: mesh_proto.MeshGateway_Listener_HTTP,
+								Port:     8080,
+								Tags: map[string]string{
+									"protocol": "http",
+								},
+							},
+							{
+								Protocol: mesh_proto.MeshGateway_Listener_TCP,
+								Port:     8081,
+								Tags: map[string]string{
+									"protocol": "tcp",
+								},
+							},
+						},
+					},
+				},
+			}
 			resources.MeshLocalResources[core_mesh.MeshGatewayType] = &core_mesh.MeshGatewayResourceList{
-				Items: []*core_mesh.MeshGatewayResource{samples.GatewayResource()},
+				Items: []*core_mesh.MeshGatewayResource{gateway},
 			}
 			if len(given.gatewayRoutes) > 0 {
 				resources.MeshLocalResources[core_mesh.MeshGatewayRouteType] = &core_mesh.MeshGatewayRouteResourceList{
@@ -270,7 +305,8 @@ var _ = Describe("MeshHealthCheck", func() {
 				WithDataplane(samples.GatewayDataplaneBuilder()).
 				WithPolicies(xds_builders.MatchedPolicies().
 					WithGatewayPolicy(api.MeshHealthCheckType, given.rules).
-					WithGatewayPolicy(meshhttproute_api.MeshHTTPRouteType, given.meshhttproutes)).
+					WithGatewayPolicy(meshhttproute_api.MeshHTTPRouteType, given.meshhttproutes).
+					WithGatewayPolicy(meshtcproute_api.MeshTCPRouteType, given.meshtcproutes)).
 				Build()
 			for n, p := range core_plugins.Plugins().ProxyPlugins() {
 				Expect(p.Apply(context.Background(), xdsCtx.Mesh, proxy)).To(Succeed(), n)
@@ -279,8 +315,11 @@ var _ = Describe("MeshHealthCheck", func() {
 			generatedResources, err := gatewayGenerator.Generate(context.Background(), nil, xdsCtx, proxy)
 			Expect(err).NotTo(HaveOccurred())
 
-			routePlugin := meshhttproute_plugin.NewPlugin().(core_plugins.PolicyPlugin)
-			Expect(routePlugin.Apply(generatedResources, xdsCtx, proxy)).To(Succeed())
+			httpRoutePlugin := meshhttproute_plugin.NewPlugin().(core_plugins.PolicyPlugin)
+			Expect(httpRoutePlugin.Apply(generatedResources, xdsCtx, proxy)).To(Succeed())
+
+			tcpRoutePlugin := meshtcproute_plugin.NewPlugin().(core_plugins.PolicyPlugin)
+			Expect(tcpRoutePlugin.Apply(generatedResources, xdsCtx, proxy)).To(Succeed())
 
 			// when
 			plugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
@@ -348,7 +387,7 @@ var _ = Describe("MeshHealthCheck", func() {
 				},
 			},
 		}),
-		Entry("basic outbound cluster with HTTP health check and MeshHTTPRoute", gatewayTestCase{
+		Entry("basic outbound cluster with TCP/HTTP health check and MeshTCPRoute/MeshHTTPRoute", gatewayTestCase{
 			name: "basic-meshhttproute",
 			meshhttproutes: core_rules.GatewayRules{
 				ToRules: core_rules.GatewayToRules{
@@ -370,6 +409,23 @@ var _ = Describe("MeshHealthCheck", func() {
 												Weight:    pointer.To(uint(100)),
 											}},
 										},
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
+			meshtcproutes: core_rules.GatewayRules{
+				ToRules: core_rules.GatewayToRules{
+					ByListenerAndHostname: map[core_rules.InboundListenerHostname]core_rules.Rules{
+						rules.NewInboundListenerHostname("192.168.0.1", 8081, "*"): {
+							{
+								Subset: core_rules.MeshSubset(),
+								Conf: meshtcproute_api.RuleConf{
+									BackendRefs: []common_api.BackendRef{{
+										TargetRef: builders.TargetRefService("backend"),
+										Weight:    pointer.To(uint(100)),
 									}},
 								},
 							},
@@ -416,6 +472,26 @@ var _ = Describe("MeshHealthCheck", func() {
 										ExpectedStatuses: &[]int32{200, 201},
 									},
 									ReuseConnection: pointer.To(true),
+								},
+							},
+						},
+						{Address: "192.168.0.1", Port: 8081}: {
+							{
+								Subset: core_rules.Subset{},
+								Conf: api.Conf{
+									Interval:                     test.ParseDuration("10s"),
+									Timeout:                      test.ParseDuration("2s"),
+									UnhealthyThreshold:           pointer.To[int32](3),
+									HealthyThreshold:             pointer.To[int32](1),
+									InitialJitter:                test.ParseDuration("13s"),
+									IntervalJitter:               test.ParseDuration("15s"),
+									IntervalJitterPercent:        pointer.To[int32](10),
+									HealthyPanicThreshold:        pointer.To(intstr.FromString("72.9")),
+									FailTrafficOnPanic:           pointer.To(true),
+									EventLogPath:                 pointer.To("/tmp/log.txt"),
+									AlwaysLogHealthCheckFailures: pointer.To(false),
+									NoTrafficInterval:            test.ParseDuration("16s"),
+									ReuseConnection:              pointer.To(true),
 								},
 							},
 						},

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
@@ -286,14 +286,17 @@ var _ = Describe("MeshHealthCheck", func() {
 			plugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
 			Expect(plugin.Apply(generatedResources, xdsCtx, proxy)).To(Succeed())
 
-			getResourceYaml := func(list core_xds.ResourceList) []byte {
-				actualResource, err := util_proto.ToYAML(list[0].Resource)
+			getResourcesYaml := func(list core_xds.ResourceList) []byte {
+				resources, err := list.ToDeltaDiscoveryResponse()
 				Expect(err).ToNot(HaveOccurred())
-				return actualResource
+				actual, err := util_proto.ToYAML(resources)
+				Expect(err).ToNot(HaveOccurred())
+
+				return actual
 			}
 
 			// then
-			Expect(getResourceYaml(generatedResources.ListOf(envoy_resource.ClusterType))).
+			Expect(getResourcesYaml(generatedResources.ListOf(envoy_resource.ClusterType))).
 				To(matchers.MatchGoldenYAML(filepath.Join("testdata", fmt.Sprintf("%s.gateway_cluster.golden.yaml", given.name))))
 		},
 		Entry("basic outbound cluster with HTTP health check", gatewayTestCase{

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic-meshhttproute.gateway_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic-meshhttproute.gateway_cluster.golden.yaml
@@ -1,5 +1,5 @@
 resources:
-- name: backend-26cb64fa4e85e7b7
+- name: backend-89287678764ce0c5
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     commonLbConfig:
@@ -45,7 +45,7 @@ resources:
       reuseConnection: true
       timeout: 2s
       unhealthyThreshold: 3
-    name: backend-26cb64fa4e85e7b7
+    name: backend-89287678764ce0c5
     perConnectionBufferLimitBytes: 32768
     type: EDS
     typedExtensionProtocolOptions:
@@ -55,3 +55,19 @@ resources:
           idleTimeout: 0s
         explicitHttpConfig:
           httpProtocolOptions: {}
+- name: backend-945e63bff332f46a
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    commonLbConfig:
+      healthyPanicThreshold:
+        value: 72.9
+      zoneAwareLbConfig:
+        failTrafficOnPanic: true
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+        resourceApiVersion: V3
+    name: backend-945e63bff332f46a
+    perConnectionBufferLimitBytes: 32768
+    type: EDS

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic-meshhttproute.gateway_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic-meshhttproute.gateway_cluster.golden.yaml
@@ -1,53 +1,57 @@
-commonLbConfig:
-  healthyPanicThreshold:
-    value: 62.9
-  zoneAwareLbConfig:
-    failTrafficOnPanic: true
-connectTimeout: 5s
-edsClusterConfig:
-  edsConfig:
-    ads: {}
-    resourceApiVersion: V3
-healthChecks:
-- eventLogger:
-  - name: envoy.health_check.event_sinks.file
-    typedConfig:
-      '@type': type.googleapis.com/envoy.extensions.health_check.event_sinks.file.v3.HealthCheckEventFileSink
-      eventLogPath: /tmp/log.txt
-  healthyThreshold: 1
-  httpHealthCheck:
-    expectedStatuses:
-    - end: "201"
-      start: "200"
-    - end: "202"
-      start: "201"
-    path: /health
-    requestHeadersToAdd:
-    - header:
-        key: x-kuma-tags
-        value: '&kuma.io/service=sample-gateway&'
-    - header:
-        key: x-some-header
-        value: value
-    - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
-      header:
-        key: x-some-other-header
-        value: value
-  initialJitter: 13s
-  interval: 10s
-  intervalJitter: 15s
-  intervalJitterPercent: 10
-  noTrafficInterval: 16s
-  reuseConnection: true
-  timeout: 2s
-  unhealthyThreshold: 3
-name: backend-26cb64fa4e85e7b7
-perConnectionBufferLimitBytes: 32768
-type: EDS
-typedExtensionProtocolOptions:
-  envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-    '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-    commonHttpProtocolOptions:
-      idleTimeout: 0s
-    explicitHttpConfig:
-      httpProtocolOptions: {}
+resources:
+- name: backend-26cb64fa4e85e7b7
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    commonLbConfig:
+      healthyPanicThreshold:
+        value: 62.9
+      zoneAwareLbConfig:
+        failTrafficOnPanic: true
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+        resourceApiVersion: V3
+    healthChecks:
+    - eventLogger:
+      - name: envoy.health_check.event_sinks.file
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.health_check.event_sinks.file.v3.HealthCheckEventFileSink
+          eventLogPath: /tmp/log.txt
+      healthyThreshold: 1
+      httpHealthCheck:
+        expectedStatuses:
+        - end: "201"
+          start: "200"
+        - end: "202"
+          start: "201"
+        path: /health
+        requestHeadersToAdd:
+        - header:
+            key: x-kuma-tags
+            value: '&kuma.io/service=sample-gateway&'
+        - header:
+            key: x-some-header
+            value: value
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
+          header:
+            key: x-some-other-header
+            value: value
+      initialJitter: 13s
+      interval: 10s
+      intervalJitter: 15s
+      intervalJitterPercent: 10
+      noTrafficInterval: 16s
+      reuseConnection: true
+      timeout: 2s
+      unhealthyThreshold: 3
+    name: backend-26cb64fa4e85e7b7
+    perConnectionBufferLimitBytes: 32768
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        commonHttpProtocolOptions:
+          idleTimeout: 0s
+        explicitHttpConfig:
+          httpProtocolOptions: {}

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic.gateway_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic.gateway_cluster.golden.yaml
@@ -1,53 +1,57 @@
-commonLbConfig:
-  healthyPanicThreshold:
-    value: 62.9
-  zoneAwareLbConfig:
-    failTrafficOnPanic: true
-connectTimeout: 5s
-edsClusterConfig:
-  edsConfig:
-    ads: {}
-    resourceApiVersion: V3
-healthChecks:
-- eventLogger:
-  - name: envoy.health_check.event_sinks.file
-    typedConfig:
-      '@type': type.googleapis.com/envoy.extensions.health_check.event_sinks.file.v3.HealthCheckEventFileSink
-      eventLogPath: /tmp/log.txt
-  healthyThreshold: 1
-  httpHealthCheck:
-    expectedStatuses:
-    - end: "201"
-      start: "200"
-    - end: "202"
-      start: "201"
-    path: /health
-    requestHeadersToAdd:
-    - header:
-        key: x-kuma-tags
-        value: '&kuma.io/service=sample-gateway&'
-    - header:
-        key: x-some-header
-        value: value
-    - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
-      header:
-        key: x-some-other-header
-        value: value
-  initialJitter: 13s
-  interval: 10s
-  intervalJitter: 15s
-  intervalJitterPercent: 10
-  noTrafficInterval: 16s
-  reuseConnection: true
-  timeout: 2s
-  unhealthyThreshold: 3
-name: backend-26cb64fa4e85e7b7
-perConnectionBufferLimitBytes: 32768
-type: EDS
-typedExtensionProtocolOptions:
-  envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-    '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-    commonHttpProtocolOptions:
-      idleTimeout: 0s
-    explicitHttpConfig:
-      httpProtocolOptions: {}
+resources:
+- name: backend-26cb64fa4e85e7b7
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    commonLbConfig:
+      healthyPanicThreshold:
+        value: 62.9
+      zoneAwareLbConfig:
+        failTrafficOnPanic: true
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+        resourceApiVersion: V3
+    healthChecks:
+    - eventLogger:
+      - name: envoy.health_check.event_sinks.file
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.health_check.event_sinks.file.v3.HealthCheckEventFileSink
+          eventLogPath: /tmp/log.txt
+      healthyThreshold: 1
+      httpHealthCheck:
+        expectedStatuses:
+        - end: "201"
+          start: "200"
+        - end: "202"
+          start: "201"
+        path: /health
+        requestHeadersToAdd:
+        - header:
+            key: x-kuma-tags
+            value: '&kuma.io/service=sample-gateway&'
+        - header:
+            key: x-some-header
+            value: value
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
+          header:
+            key: x-some-other-header
+            value: value
+      initialJitter: 13s
+      interval: 10s
+      intervalJitter: 15s
+      intervalJitterPercent: 10
+      noTrafficInterval: 16s
+      reuseConnection: true
+      timeout: 2s
+      unhealthyThreshold: 3
+    name: backend-26cb64fa4e85e7b7
+    perConnectionBufferLimitBytes: 32768
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        commonHttpProtocolOptions:
+          idleTimeout: 0s
+        explicitHttpConfig:
+          httpProtocolOptions: {}

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic.gateway_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic.gateway_cluster.golden.yaml
@@ -1,5 +1,5 @@
 resources:
-- name: backend-26cb64fa4e85e7b7
+- name: backend-89287678764ce0c5
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     commonLbConfig:
@@ -45,7 +45,7 @@ resources:
       reuseConnection: true
       timeout: 2s
       unhealthyThreshold: 3
-    name: backend-26cb64fa4e85e7b7
+    name: backend-89287678764ce0c5
     perConnectionBufferLimitBytes: 32768
     type: EDS
     typedExtensionProtocolOptions:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/gateway_routes.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/gateway_routes.go
@@ -1,7 +1,6 @@
 package v1alpha1
 
 import (
-	"context"
 	"slices"
 	"sort"
 	"strings"
@@ -10,143 +9,34 @@ import (
 
 	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	"github.com/kumahq/kuma/pkg/core/permissions"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
-	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
+	"github.com/kumahq/kuma/pkg/plugins/policies/core/xds/meshroute"
 	api "github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
 	plugin_gateway "github.com/kumahq/kuma/pkg/plugins/runtime/gateway"
 	"github.com/kumahq/kuma/pkg/plugins/runtime/gateway/match"
 	"github.com/kumahq/kuma/pkg/plugins/runtime/gateway/route"
 	"github.com/kumahq/kuma/pkg/util/pointer"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
-	envoy_names "github.com/kumahq/kuma/pkg/xds/envoy/names"
 	"github.com/kumahq/kuma/pkg/xds/envoy/tags"
-	xds_topology "github.com/kumahq/kuma/pkg/xds/topology"
 )
-
-type sublistener struct {
-	Hostname string
-	Tags     map[string]string
-	TLS      *mesh_proto.MeshGateway_TLS_Conf
-}
-type listenersHostnames struct {
-	listener     *mesh_proto.MeshGateway_Listener
-	sublisteners []sublistener
-}
-
-func CollectListenerInfos(
-	ctx context.Context,
-	meshCtx xds_context.MeshContext,
-	gateway *core_mesh.MeshGatewayResource,
-	proxy *core_xds.Proxy,
-	rawRules rules.GatewayRules,
-) []plugin_gateway.GatewayListenerInfo {
-	networking := proxy.Dataplane.Spec.GetNetworking()
-	listenersByPort := map[uint32]listenersHostnames{}
-	for _, listener := range gateway.Spec.GetConf().GetListeners() {
-		if listener.Protocol == mesh_proto.MeshGateway_Listener_TCP {
-			continue
-		}
-
-		listenerAcc, ok := listenersByPort[listener.GetPort()]
-		if !ok {
-			listenerAcc = listenersHostnames{
-				listener: listener,
-			}
-		}
-		hostname := listener.GetNonEmptyHostname()
-		listenerAcc.sublisteners = append(listenerAcc.sublisteners, sublistener{
-			Hostname: hostname,
-			Tags: mesh_proto.Merge(
-				networking.GetGateway().GetTags(),
-				gateway.Spec.GetTags(),
-				listener.GetTags(),
-			),
-			TLS: listener.GetTls(),
-		})
-		listenersByPort[listener.GetPort()] = listenerAcc
-	}
-
-	var infos []plugin_gateway.GatewayListenerInfo
-
-	for port, listener := range listenersByPort {
-		externalServices := meshCtx.Resources.ExternalServices()
-
-		matchedExternalServices := permissions.MatchExternalServicesTrafficPermissions(
-			proxy.Dataplane, externalServices, meshCtx.Resources.TrafficPermissions(),
-		)
-
-		outboundEndpoints := core_xds.EndpointMap{}
-		for k, v := range meshCtx.EndpointMap {
-			outboundEndpoints[k] = v
-		}
-
-		esEndpoints := xds_topology.BuildExternalServicesEndpointMap(
-			ctx,
-			meshCtx.Resource,
-			matchedExternalServices,
-			meshCtx.DataSourceLoader,
-			proxy.Zone,
-		)
-		for k, v := range esEndpoints {
-			outboundEndpoints[k] = v
-		}
-
-		hostInfos := SortRulesToHosts(
-			meshCtx.Resources.MeshLocalResources,
-			rawRules,
-			networking.Address,
-			listener.listener,
-			listener.sublisteners,
-		)
-		var filters []plugin_gateway.GatewayListenerFilter
-		for _, sublistener := range listener.sublisteners {
-			filters = append(filters, plugin_gateway.GatewayListenerFilter{
-				Hostnames: []string{sublistener.Hostname},
-				TLS:       sublistener.TLS,
-			})
-		}
-		infos = append(infos, plugin_gateway.GatewayListenerInfo{
-			Proxy:             proxy,
-			Gateway:           gateway,
-			HostInfos:         hostInfos,
-			ExternalServices:  externalServices,
-			OutboundEndpoints: outboundEndpoints,
-			Listener: plugin_gateway.GatewayListener{
-				Port:     port,
-				Protocol: listener.listener.GetProtocol(),
-				ResourceName: envoy_names.GetGatewayListenerName(
-					gateway.Meta.GetName(),
-					listener.listener.GetProtocol().String(),
-					port,
-				),
-				CrossMesh: listener.listener.GetCrossMesh(),
-				Resources: listener.listener.GetResources(),
-				Filters:   filters,
-			},
-		})
-	}
-
-	return infos
-}
 
 type ruleByHostname struct {
 	Rule     ToRouteRule
 	Hostname string
 }
 
-func SortRulesToHosts(
+func sortRulesToHosts(
 	meshLocalResources xds_context.ResourceMap,
 	rawRules rules.GatewayRules,
 	address string,
 	listener *mesh_proto.MeshGateway_Listener,
-	hostnameTags []sublistener,
+	sublisteners []meshroute.Sublistener,
 ) []plugin_gateway.GatewayHostInfo {
 	var hostInfos []plugin_gateway.GatewayHostInfo
 
-	for _, hostnameTag := range hostnameTags {
+	for _, hostnameTag := range sublisteners {
 		inboundListener := rules.NewInboundListenerHostname(
 			address,
 			listener.GetPort(),

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pkg/errors"
 
 	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
@@ -129,12 +130,14 @@ func ApplyToGateway(
 		return nil
 	}
 
-	listeners := CollectListenerInfos(
+	listeners := meshroute.CollectListenerInfos(
 		ctx,
 		xdsCtx.Mesh,
 		gateway,
 		proxy,
 		rawRules,
+		[]mesh_proto.MeshGateway_Listener_Protocol{mesh_proto.MeshGateway_Listener_HTTP, mesh_proto.MeshGateway_Listener_HTTPS},
+		sortRulesToHosts,
 	)
 	plugin_gateway.SetGatewayListeners(proxy, listeners)
 


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- #8142 
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
