### PR TITLE
fix(MeshTCPRoute): handle per TLS listener routes

### DIFF
--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
@@ -9,12 +9,18 @@ import (
 	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	system_proto "github.com/kumahq/kuma/api/system/v1alpha1"
+	"github.com/kumahq/kuma/pkg/core/datasource"
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/core/secrets/cipher"
+	secret_manager "github.com/kumahq/kuma/pkg/core/secrets/manager"
+	secret_store "github.com/kumahq/kuma/pkg/core/secrets/store"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/metrics"
 	_ "github.com/kumahq/kuma/pkg/plugins/policies"
@@ -22,6 +28,7 @@ import (
 	meshhttproute_api "github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
 	api "github.com/kumahq/kuma/pkg/plugins/policies/meshtcproute/api/v1alpha1"
 	plugin "github.com/kumahq/kuma/pkg/plugins/policies/meshtcproute/plugin/v1alpha1"
+	"github.com/kumahq/kuma/pkg/plugins/resources/memory"
 	"github.com/kumahq/kuma/pkg/test/matchers"
 	"github.com/kumahq/kuma/pkg/test/resources/builders"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
@@ -174,6 +181,10 @@ var _ = Describe("MeshTCPRoute", func() {
 			claCache, err := cla.NewCache(1*time.Second, metrics)
 			Expect(err).ToNot(HaveOccurred())
 			given.xdsContext.ControlPlane.CLACache = claCache
+
+			secretManager := secret_manager.NewSecretManager(secret_store.NewSecretStore(memory.NewStore()), cipher.None(), nil, false)
+			dataSourceLoader := datasource.NewDataSourceLoader(secretManager)
+			given.xdsContext.Mesh.DataSourceLoader = dataSourceLoader
 
 			for n, p := range core_plugins.Plugins().ProxyPlugins() {
 				Expect(p.Apply(context.Background(), given.xdsContext.Mesh, given.proxy)).To(Succeed(), n)
@@ -647,6 +658,32 @@ var _ = Describe("MeshTCPRoute", func() {
 								Protocol: mesh_proto.MeshGateway_Listener_TCP,
 								Port:     9080,
 							},
+							{
+								Protocol: mesh_proto.MeshGateway_Listener_TLS,
+								Port:     9081,
+								Hostname: "go.dev",
+								Tls: &mesh_proto.MeshGateway_TLS_Conf{
+									Mode: mesh_proto.MeshGateway_TLS_TERMINATE,
+									Certificates: []*system_proto.DataSource{{
+										Type: &system_proto.DataSource_Inline{
+											Inline: wrapperspb.Bytes([]byte(secret)),
+										},
+									}},
+								},
+							},
+							{
+								Protocol: mesh_proto.MeshGateway_Listener_TLS,
+								Port:     9081,
+								Hostname: "other.dev",
+								Tls: &mesh_proto.MeshGateway_TLS_Conf{
+									Mode: mesh_proto.MeshGateway_TLS_TERMINATE,
+									Certificates: []*system_proto.DataSource{{
+										Type: &system_proto.DataSource_Inline{
+											Inline: wrapperspb.Bytes([]byte(secret)),
+										},
+									}},
+								},
+							},
 						},
 					},
 				},
@@ -676,6 +713,27 @@ var _ = Describe("MeshTCPRoute", func() {
 					}},
 				},
 			}
+			tlsGoRules := core_rules.Rule{
+				Subset: core_rules.MeshSubset(),
+				Conf: api.RuleConf{
+					BackendRefs: []common_api.BackendRef{{
+						TargetRef: builders.TargetRefService("go-backend-1"),
+						Weight:    pointer.To(uint(50)),
+					}, {
+						TargetRef: builders.TargetRefService("go-backend-2"),
+						Weight:    pointer.To(uint(50)),
+					}},
+				},
+			}
+			tlsOtherRules := core_rules.Rule{
+				Subset: core_rules.MeshSubset(),
+				Conf: api.RuleConf{
+					BackendRefs: []common_api.BackendRef{{
+						TargetRef: builders.TargetRefService("other-backend"),
+						Weight:    pointer.To(uint(100)),
+					}},
+				},
+			}
 			return outboundsTestCase{
 				xdsContext: *xdsContext,
 				proxy: xds_builders.Proxy().
@@ -686,10 +744,9 @@ var _ = Describe("MeshTCPRoute", func() {
 							WithGatewayPolicy(api.MeshTCPRouteType, core_rules.GatewayRules{
 								ToRules: core_rules.GatewayToRules{
 									ByListenerAndHostname: map[core_rules.InboundListenerHostname]core_rules.Rules{
-										core_rules.NewInboundListenerHostname("192.168.0.1", 9080, "*"): {&rules},
-									},
-									ByListener: map[core_rules.InboundListener]core_rules.Rules{
-										{Address: "192.168.0.1", Port: 9080}: {&rules},
+										core_rules.NewInboundListenerHostname("192.168.0.1", 9080, "*"):         {&rules, &tlsOtherRules},
+										core_rules.NewInboundListenerHostname("192.168.0.1", 9081, "other.dev"): {&tlsOtherRules},
+										core_rules.NewInboundListenerHostname("192.168.0.1", 9081, "go.dev"):    {&tlsGoRules},
 									},
 								},
 							}),
@@ -699,3 +756,54 @@ var _ = Describe("MeshTCPRoute", func() {
 		}()),
 	)
 })
+
+// nolint:gosec
+const secret = `
+-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAqEhj+XS8qgm3raPrP554uXDiPv0np2lCx1wJF4KiwFGJMAV8
+qHul/0pcUCX742irsAV39f6sMytXlRpMfBAbJNyZDuqx36s0yMolMxsqMjUHmI+X
+W7zrj1xAkPLjB+kireohXkyXESBy3QbcaAW+ftZdFDcNHC7a9W8eSZzCB5R0Sb1S
+YMrMq8gXrDbB99fLb2G5wsGXq9xW1g6u7TqWy5TAvYkErMfXfsx3BcvJPPAaI4vb
+hPp034KVlucB3h5QSEDF1AIV7A8r1m3I/yHRZqyvhg6Dp4ZTgZw1Sh7QwYsJr6/h
+kIVaBjq+gT+I6oPBOnVrc5W3N/fO8yalaAdvswIDAQABAoIBAQCS8ywCMRNy9Ktl
+wQdz9aF8Zfvbf1t6UGvVBSSXWCdhA5Jl0dTKl7ccGEZGYvTz33pVamEX+j1LLaT8
+eguiJrpdVRl/MikDpVChqgwT9bvCPhaU/YbxwCZ/eNKVANSKGuaCsjpTS1R7yzci
+lZQwbhusTOrY9T3Ih44C1va+11mEHY7rAy96r2MgTdpDdWAqhGKxQ88IyNCTvp6u
+1I/oWXYDm7QW7HCEWcw2PyFfcfLy4LCPYG7BMX6n1DMSSu6U2PeV1fm6wleawCCN
+KxuKQSBHARM9B0pcPpAhGuXO9fHBllz3Tmw0yJYCUopIxPK/r+yMufpsto6KRJOz
+had7o4XJAoGBAMSdr1eRG2TBwfQtGS9WxMUrYiCdNCDMFnXsFrKp5kF7ebRyX0lY
+41O/KS3SPRmqn6F8t77+VjAvIcCtVWPgTLGo4QyOV09UAcPOrv4qBHRkT8tNyM1n
+q15DGd7ICE0LFuK1zjWu1HBz/64hNqJJxC8tcJ1HgQ7sO9Vl0FMHeXcNAoGBANsb
+/QqyRixj0UMhST4MoZzxwV+3Y+//mpEL4R1kcFa0K1BrIq80xCzJzK7jrU7XtaeG
+0WZpksYqexzN6kXvuJy3w5rC4LC2/+MHspYKvdkUMjctB1XIAPF2FtdrSfMDjweS
+ItJ1QqALcc83XzAMkrrCUUeL45SGWxRp3yLljtG/AoGAcPAWwRkEADtf+q9RESUp
+QAysgAls4Q36NOBZJWV8cs7HWQR9gXdClV9v+vcRy8V7jlpCfb5AqcrY+4FVVFqK
+E17rbrfwpQufO+dkE3D1QBpCz4gtuPc8s5edq5+BTSf6jF1cRu/W7YVkL5S6ejwf
+Ke5TCrUBCB5gPDMQmDDp750CgYAHMdwVRdVYD88HTUiCaRfFd4rKAdOeRd5ldOZn
+eKzXrALgGSSCbFEkx1uZQpCmTh8A6URnAIB5UVvJjllrAnwlaUNbCZsnMlsksVQD
+6UZiom8jsK7U+kRNqXsGh9ddy3ge34WVM5SEfNu32jGd+ku3JjpVBxrp/Z9wBCn3
+k2IlMQKBgQCWsVuAoLcEvtKYSBb4KZZY3+pHkLLxe+K7Cpq5fK7RnueaH9+o1g+8
+AdY6vX/j9yVHqfF6DI2tyq0qMcuNkjDirlY3yosZEQOXjW8SIGk3YaHwd4JMqVL6
+vBGM7k3/smF7hEG97wUeaMe3IDkP7G4SNZOWbLUy1IjLw8BBK+2FVQ==
+-----END RSA PRIVATE KEY-----
+-----BEGIN CERTIFICATE-----
+MIIDNTCCAh2gAwIBAgIRAK2DKOd4qR4eTfFpTHCY0KAwDQYJKoZIhvcNAQELBQAw
+GzEZMBcGA1UEAxMQZWNoby5leGFtcGxlLmNvbTAeFw0yMTExMDEwNDMzNDhaFw0z
+MTEwMzAwNDMzNDhaMBsxGTAXBgNVBAMTEGVjaG8uZXhhbXBsZS5jb20wggEiMA0G
+CSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCoSGP5dLyqCbeto+s/nni5cOI+/Sen
+aULHXAkXgqLAUYkwBXyoe6X/SlxQJfvjaKuwBXf1/qwzK1eVGkx8EBsk3JkO6rHf
+qzTIyiUzGyoyNQeYj5dbvOuPXECQ8uMH6SKt6iFeTJcRIHLdBtxoBb5+1l0UNw0c
+Ltr1bx5JnMIHlHRJvVJgysyryBesNsH318tvYbnCwZer3FbWDq7tOpbLlMC9iQSs
+x9d+zHcFy8k88Boji9uE+nTfgpWW5wHeHlBIQMXUAhXsDyvWbcj/IdFmrK+GDoOn
+hlOBnDVKHtDBiwmvr+GQhVoGOr6BP4jqg8E6dWtzlbc3987zJqVoB2+zAgMBAAGj
+dDByMA4GA1UdDwEB/wQEAwICpDATBgNVHSUEDDAKBggrBgEFBQcDATAPBgNVHRMB
+Af8EBTADAQH/MB0GA1UdDgQWBBS+iZdWqEBq5IT4b9Dcdx09MTUuCzAbBgNVHREE
+FDASghBlY2hvLmV4YW1wbGUuY29tMA0GCSqGSIb3DQEBCwUAA4IBAQBRUD8uWq0s
+IM3sW+MCAtBQq5ppNstlAeH24w3yO+4v64FqjDUwRLq7uMJza9iNdbYDQZW/NRrv
+30Om9PSn02WzlANa2Knm/EoCwgPyA4ED1UD77uWnxOUxfEWeqdOYDElJpIRb+7RO
+tW9zD7ZJ89ipvEjL2zGuvKCQKkdYaIm7W2aljDz1olsMgQolHpbTEPjN+RMWiyNs
+tDaan+pwBI0OoXzuWPpB8o9jfL7I8YeOQXOmNy/qpvELV8ji3vdPH1xu1NSt1EGV
+rZigv0SZ20Y+BHgf0y3Tv0X+Rx96lYiUtfU+54vjokEjSsfF+iauxfL75QuVvAf9
+7G3tiTJPwFKA
+-----END CERTIFICATE-----
+`

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/gateway.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/gateway.clusters.golden.yaml
@@ -10,3 +10,36 @@ resources:
     name: backend-26cb64fa4e85e7b7
     perConnectionBufferLimitBytes: 32768
     type: EDS
+- name: go-backend-1-a3e0f78d6b8a9607
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+        resourceApiVersion: V3
+    name: go-backend-1-a3e0f78d6b8a9607
+    perConnectionBufferLimitBytes: 32768
+    type: EDS
+- name: go-backend-2-3568c8790af04ca0
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+        resourceApiVersion: V3
+    name: go-backend-2-3568c8790af04ca0
+    perConnectionBufferLimitBytes: 32768
+    type: EDS
+- name: other-backend-d14e06e801b3b5d6
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+        resourceApiVersion: V3
+    name: other-backend-d14e06e801b3b5d6
+    perConnectionBufferLimitBytes: 32768
+    type: EDS

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/gateway.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/gateway.endpoints.golden.yaml
@@ -19,3 +19,15 @@ resources:
             envoy.transport_socket_match:
               kuma.io/protocol: tcp
               region: us
+- name: go-backend-1-a3e0f78d6b8a9607
+  resource:
+    '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
+    clusterName: go-backend-1-a3e0f78d6b8a9607
+- name: go-backend-2-3568c8790af04ca0
+  resource:
+    '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
+    clusterName: go-backend-2-3568c8790af04ca0
+- name: other-backend-d14e06e801b3b5d6
+  resource:
+    '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
+    clusterName: other-backend-d14e06e801b3b5d6

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/gateway.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/gateway.listeners.golden.yaml
@@ -12,12 +12,64 @@ resources:
       - name: envoy.filters.network.tcp_proxy
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: backend-26cb64fa4e85e7b7
           statPrefix: sample-gateway
+          weightedClusters:
+            clusters:
+            - name: backend-26cb64fa4e85e7b7
+              weight: 100
+            - name: other-backend-d14e06e801b3b5d6
+              weight: 100
     listenerFilters:
     - name: envoy.filters.listener.tls_inspector
       typedConfig:
         '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: sample-gateway:TCP:9080
+    perConnectionBufferLimitBytes: 32768
+    trafficDirection: INBOUND
+- name: sample-gateway:TLS:9081
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.1
+        portValue: 9081
+    enableReusePort: true
+    filterChains:
+    - filterChainMatch:
+        serverNames:
+        - go.dev
+        - other.dev
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          statPrefix: sample-gateway
+          weightedClusters:
+            clusters:
+            - name: go-backend-1-a3e0f78d6b8a9607
+              weight: 50
+            - name: go-backend-2-3568c8790af04ca0
+              weight: 50
+            - name: other-backend-d14e06e801b3b5d6
+              weight: 100
+      transportSocket:
+        name: envoy.transport_sockets.tls
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          commonTlsContext:
+            tlsCertificateSdsSecretConfigs:
+            - name: cert.rsa:inline:go.dev:other.dev
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+            tlsParams:
+              tlsMinimumProtocolVersion: TLSv1_2
+          requireClientCertificate: false
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: sample-gateway:TLS:9081
     perConnectionBufferLimitBytes: 32768
     trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/gateway.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/gateway.listeners.golden.yaml
@@ -38,7 +38,6 @@ resources:
     - filterChainMatch:
         serverNames:
         - go.dev
-        - other.dev
         transportProtocol: tls
       filters:
       - name: envoy.filters.network.tcp_proxy
@@ -51,15 +50,36 @@ resources:
               weight: 50
             - name: go-backend-2-3568c8790af04ca0
               weight: 50
-            - name: other-backend-d14e06e801b3b5d6
-              weight: 100
       transportSocket:
         name: envoy.transport_sockets.tls
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
           commonTlsContext:
             tlsCertificateSdsSecretConfigs:
-            - name: cert.rsa:inline:go.dev:other.dev
+            - name: cert.rsa:inline:go.dev
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+            tlsParams:
+              tlsMinimumProtocolVersion: TLSv1_2
+          requireClientCertificate: false
+    - filterChainMatch:
+        serverNames:
+        - other.dev
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: other-backend-d14e06e801b3b5d6
+          statPrefix: sample-gateway
+      transportSocket:
+        name: envoy.transport_sockets.tls
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          commonTlsContext:
+            tlsCertificateSdsSecretConfigs:
+            - name: cert.rsa:inline:other.dev
               sdsConfig:
                 ads: {}
                 resourceApiVersion: V3


### PR DESCRIPTION
Depends on https://github.com/kumahq/kuma/pull/9043

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
