### PR TITLE
feat(intercp): drop leader on cp shutdown

### DIFF
--- a/pkg/intercp/catalog/catalog.go
+++ b/pkg/intercp/catalog/catalog.go
@@ -28,6 +28,7 @@ type Catalog interface {
 	Reader
 	Replace(context.Context, []Instance) (bool, error)
 	ReplaceLeader(context.Context, Instance) error
+	DropLeader(context.Context, Instance) error
 }
 
 var (

--- a/pkg/intercp/catalog/catalog_test.go
+++ b/pkg/intercp/catalog/catalog_test.go
@@ -142,6 +142,48 @@ var _ = Describe("Catalog", func() {
 		})
 	})
 
+	Context("DropLeader", func() {
+		leader := catalog.Instance{
+			Id:     "leader-1",
+			Leader: true,
+		}
+
+		It("should drop a leader", func() {
+			// given
+			_, err := c.Replace(context.Background(), []catalog.Instance{leader})
+			Expect(err).ToNot(HaveOccurred())
+
+			// when
+			err = c.DropLeader(context.Background(), leader)
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+
+			readInstances, err := c.Instances(context.Background())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(readInstances).To(HaveLen(1))
+			Expect(readInstances[0].Leader).To(BeFalse())
+		})
+
+		It("should ignore when there is no leader", func() {
+			// given
+			instances := []catalog.Instance{
+				{
+					Id:     "instance-1",
+					Leader: false,
+				},
+			}
+			_, err := c.Replace(context.Background(), instances)
+			Expect(err).ToNot(HaveOccurred())
+
+			// when
+			err = c.DropLeader(context.Background(), leader)
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
 	Context("Leader", func() {
 		It("should return a leader if there is a leader in the list", func() {
 			// given

--- a/pkg/intercp/catalog/heartbeat_component.go
+++ b/pkg/intercp/catalog/heartbeat_component.go
@@ -89,7 +89,11 @@ func (h *heartbeatComponent) heartbeat(ctx context.Context, ready bool) bool {
 	)
 	if h.leader == nil {
 		if err := h.connectToLeader(ctx); err != nil {
-			heartbeatLog.Error(err, "could not connect to leader")
+			if err == ErrNoLeader {
+				heartbeatLog.Info("leader is not yet present in the cluster. No heartbeat to send")
+			} else {
+				heartbeatLog.Error(err, "could not connect to leader")
+			}
 			return false
 		}
 	}
@@ -110,7 +114,7 @@ func (h *heartbeatComponent) heartbeat(ctx context.Context, ready bool) bool {
 	}
 	resp, err := client.Ping(ctx, h.request)
 	if err != nil {
-		heartbeatLog.Error(err, "could not send a heartbeat to a leader")
+		heartbeatLog.Info("could not send a heartbeat to a leader. It's likely due to leader change", "cause", err)
 		h.leader = nil
 		return false
 	}


### PR DESCRIPTION
### Checklist prior to review

This PR fixes ERROR logs and behavior of inter-cp on redeploy of CP.
Leader will replace itself in the catalog. Followers will log info instead of errors, so it looks more like this

```
2024-01-26T16:47:25.010Z	INFO	intercp.catalog.heartbeat	could not send a heartbeat to a leader. It's likely due to leader change	{"instanceId": "kuma-control-plane-68454686fc-2lwbg-0c21", "ready": true, "leaderAddress": "10.42.0.7", "cause": "rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp 10.42.0.7:5683: connect: connection refused\""}
2024-01-26T16:47:30.013Z	INFO	intercp.catalog.heartbeat	leader is not yet present in the cluster. No heartbeat to send	{"instanceId": "kuma-control-plane-68454686fc-2lwbg-0c21", "ready": true}
2024-01-26T16:47:35.011Z	INFO	intercp.catalog.heartbeat	leader is not yet present in the cluster. No heartbeat to send	{"instanceId": "kuma-control-plane-68454686fc-2lwbg-0c21", "ready": true}
2024-01-26T16:47:40.011Z	INFO	intercp.catalog.heartbeat	leader has changed. Creating connection to the new leader.	{"previousLeaderAddress": "10.42.0.8", "newLeaderAddress": true}
```

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
