### PR TITLE
feat(vip): record generation metrics

### DIFF
--- a/pkg/dns/metrics/metrics.go
+++ b/pkg/dns/metrics/metrics.go
@@ -1,0 +1,32 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	core_metrics "github.com/kumahq/kuma/pkg/metrics"
+)
+
+type Metrics struct {
+	VipGenerations       prometheus.Summary
+	VipGenerationsErrors prometheus.Counter
+}
+
+func NewMetrics(metrics core_metrics.Metrics) (*Metrics, error) {
+	vipGenerations := prometheus.NewSummary(prometheus.SummaryOpts{
+		Name:       "vip_generation",
+		Help:       "Summary of VIP generation",
+		Objectives: core_metrics.DefaultObjectives,
+	})
+	vipGenerationsErrors := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "vip_generation_errors",
+		Help: "Counter of errors during VIP generation",
+	})
+	if err := metrics.BulkRegister(vipGenerations, vipGenerationsErrors); err != nil {
+		return nil, err
+	}
+
+	return &Metrics{
+		VipGenerations:       vipGenerations,
+		VipGenerationsErrors: vipGenerationsErrors,
+	}, nil
+}

--- a/pkg/dns/vips_allocator.go
+++ b/pkg/dns/vips_allocator.go
@@ -19,7 +19,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
-	dnsmetrics "github.com/kumahq/kuma/pkg/dns/metrics"
+	dns_metrics "github.com/kumahq/kuma/pkg/dns/metrics"
 	"github.com/kumahq/kuma/pkg/dns/vips"
 	core_metrics "github.com/kumahq/kuma/pkg/metrics"
 )
@@ -33,7 +33,7 @@ type VIPsAllocator struct {
 	serviceVipEnabled bool
 	dnsSuffix         string
 	zone              string
-	metrics           *dnsmetrics.Metrics
+	metrics           *dns_metrics.Metrics
 }
 
 // NewVIPsAllocator creates new object of VIPsAllocator. You can either
@@ -41,7 +41,7 @@ type VIPsAllocator struct {
 // In the latter scenario it will call CreateOrUpdateVIPConfig every 'tickInterval'
 // for all meshes in the store.
 func NewVIPsAllocator(rm manager.ReadOnlyResourceManager, configManager config_manager.ConfigManager, config dns_server.Config, experimentalConfig config.ExperimentalConfig, zone string, metrics core_metrics.Metrics) (*VIPsAllocator, error) {
-	dnsMetrics, err := dnsmetrics.NewMetrics(metrics)
+	dnsMetrics, err := dns_metrics.NewMetrics(metrics)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/dns/vips_allocator.go
+++ b/pkg/dns/vips_allocator.go
@@ -19,7 +19,9 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
+	dnsmetrics "github.com/kumahq/kuma/pkg/dns/metrics"
 	"github.com/kumahq/kuma/pkg/dns/vips"
+	core_metrics "github.com/kumahq/kuma/pkg/metrics"
 )
 
 var Log = core.Log.WithName("dns-vips-allocator")
@@ -31,13 +33,19 @@ type VIPsAllocator struct {
 	serviceVipEnabled bool
 	dnsSuffix         string
 	zone              string
+	metrics           *dnsmetrics.Metrics
 }
 
 // NewVIPsAllocator creates new object of VIPsAllocator. You can either
 // call method CreateOrUpdateVIPConfig manually or start VIPsAllocator as a component.
 // In the latter scenario it will call CreateOrUpdateVIPConfig every 'tickInterval'
 // for all meshes in the store.
-func NewVIPsAllocator(rm manager.ReadOnlyResourceManager, configManager config_manager.ConfigManager, config dns_server.Config, experimentalConfig config.ExperimentalConfig, zone string) (*VIPsAllocator, error) {
+func NewVIPsAllocator(rm manager.ReadOnlyResourceManager, configManager config_manager.ConfigManager, config dns_server.Config, experimentalConfig config.ExperimentalConfig, zone string, metrics core_metrics.Metrics) (*VIPsAllocator, error) {
+	dnsMetrics, err := dnsmetrics.NewMetrics(metrics)
+	if err != nil {
+		return nil, err
+	}
+
 	return &VIPsAllocator{
 		rm:                rm,
 		persistence:       vips.NewPersistence(rm, configManager, experimentalConfig.UseTagFirstVirtualOutboundModel),
@@ -45,12 +53,16 @@ func NewVIPsAllocator(rm manager.ReadOnlyResourceManager, configManager config_m
 		cidr:              config.CIDR,
 		dnsSuffix:         config.Domain,
 		zone:              zone,
+		metrics:           dnsMetrics,
 	}, nil
 }
 
 func (d *VIPsAllocator) CreateOrUpdateVIPConfigs(ctx context.Context) error {
+	start := core.Now()
+
 	meshRes := core_mesh.MeshResourceList{}
 	if err := d.rm.List(ctx, &meshRes); err != nil {
+		d.metrics.VipGenerationsErrors.Inc()
 		return err
 	}
 
@@ -60,7 +72,14 @@ func (d *VIPsAllocator) CreateOrUpdateVIPConfigs(ctx context.Context) error {
 			errs = multierr.Append(errs, err)
 		}
 	}
-	return errs
+
+	if errs != nil {
+		d.metrics.VipGenerationsErrors.Inc()
+		return errs
+	}
+
+	d.metrics.VipGenerations.Observe(float64(core.Now().Sub(start).Milliseconds()))
+	return nil
 }
 
 func (d *VIPsAllocator) CreateOrUpdateVIPConfig(ctx context.Context, mesh string, viewModificator func(*vips.VirtualOutboundMeshView) error) error {

--- a/pkg/dns/vips_allocator_test.go
+++ b/pkg/dns/vips_allocator_test.go
@@ -18,7 +18,9 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	"github.com/kumahq/kuma/pkg/dns"
 	"github.com/kumahq/kuma/pkg/dns/vips"
+	metricspkg "github.com/kumahq/kuma/pkg/metrics"
 	"github.com/kumahq/kuma/pkg/plugins/resources/memory"
+	test_metrics "github.com/kumahq/kuma/pkg/test/metrics"
 	"github.com/kumahq/kuma/pkg/test/resources/samples"
 )
 
@@ -65,6 +67,8 @@ var _ = Describe("VIP Allocator", func() {
 	var rm manager.ResourceManager
 	var cm config_manager.ConfigManager
 	var allocator *dns.VIPsAllocator
+	var metrics metricspkg.Metrics
+	var err error
 
 	NoModifications := func(view *vips.VirtualOutboundMeshView) error {
 		return nil
@@ -75,7 +79,10 @@ var _ = Describe("VIP Allocator", func() {
 		rm = manager.NewResourceManager(s)
 		cm = config_manager.NewConfigManager(s)
 
-		err := rm.Create(context.Background(), mesh.NewMeshResource(), store.CreateByKey("mesh-1", model.NoMesh))
+		metrics, err = metricspkg.NewMetrics("")
+		Expect(err).ToNot(HaveOccurred())
+
+		err = rm.Create(context.Background(), mesh.NewMeshResource(), store.CreateByKey("mesh-1", model.NoMesh))
 		Expect(err).ToNot(HaveOccurred())
 
 		err = rm.Create(context.Background(), mesh.NewMeshResource(), store.CreateByKey("mesh-2", model.NoMesh))
@@ -90,7 +97,7 @@ var _ = Describe("VIP Allocator", func() {
 		err = rm.Create(context.Background(), &mesh.DataplaneResource{Spec: dp("web")}, store.CreateByKey("dp-3", "mesh-2"))
 		Expect(err).ToNot(HaveOccurred())
 
-		allocator, err = dns.NewVIPsAllocator(rm, cm, testConfig, config.ExperimentalConfig{UseTagFirstVirtualOutboundModel: false}, "")
+		allocator, err = dns.NewVIPsAllocator(rm, cm, testConfig, config.ExperimentalConfig{UseTagFirstVirtualOutboundModel: false}, "", metrics)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -111,6 +118,16 @@ var _ = Describe("VIP Allocator", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(vipList.HostnameEntries()).To(HaveLen(1))
+	})
+
+	It("should record a summary metric in case of success", func() {
+		// when
+		ctx := context.Background()
+		err := allocator.CreateOrUpdateVIPConfigs(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		// then
+		Expect(test_metrics.FindMetric(metrics, "vip_generation").GetSummary().GetSampleCount()).To(Equal(uint64(1)))
 	})
 
 	It("should respect already allocated VIPs in case of IPAM restarts", func() {
@@ -152,7 +169,10 @@ var _ = Describe("VIP Allocator", func() {
 	It("should return error if failed to update VIP config", func() {
 		errConfigManager := &errConfigManager{ConfigManager: cm}
 		ctx := context.Background()
-		errAllocator, err := dns.NewVIPsAllocator(rm, errConfigManager, testConfig, config.ExperimentalConfig{UseTagFirstVirtualOutboundModel: false}, "")
+		metrics, err := metricspkg.NewMetrics("")
+		Expect(err).ToNot(HaveOccurred())
+
+		errAllocator, err := dns.NewVIPsAllocator(rm, errConfigManager, testConfig, config.ExperimentalConfig{UseTagFirstVirtualOutboundModel: false}, "", metrics)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = errAllocator.CreateOrUpdateVIPConfig(ctx, "mesh-1", NoModifications)
@@ -168,7 +188,10 @@ var _ = Describe("VIP Allocator", func() {
 
 	It("should try to update all meshes and return combined error", func() {
 		errConfigManager := &errConfigManager{ConfigManager: cm}
-		errAllocator, err := dns.NewVIPsAllocator(rm, errConfigManager, testConfig, config.ExperimentalConfig{UseTagFirstVirtualOutboundModel: false}, "")
+		metrics, err := metricspkg.NewMetrics("")
+		Expect(err).ToNot(HaveOccurred())
+
+		errAllocator, err := dns.NewVIPsAllocator(rm, errConfigManager, testConfig, config.ExperimentalConfig{UseTagFirstVirtualOutboundModel: false}, "", metrics)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = errAllocator.CreateOrUpdateVIPConfigs(context.Background())
@@ -183,6 +206,8 @@ var _ = Describe("VIP Allocator", func() {
 		err = errAllocator.CreateOrUpdateVIPConfigs(context.Background())
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError("error during update, mesh = mesh-1; error during update, mesh = mesh-2"))
+
+		Expect(test_metrics.FindMetric(metrics, "vip_generation_errors").GetCounter().GetValue()).To(Equal(1.0))
 	})
 
 	It("will allocate the same VIPs for different services in multiple meshes", func() {
@@ -243,8 +268,11 @@ var _ = DescribeTable("outboundView",
 			CIDR:              "240.0.0.0/24",
 			ServiceVipEnabled: !tc.whenSkipServiceVips,
 		}
+		metrics, err := metricspkg.NewMetrics("")
+		Expect(err).ToNot(HaveOccurred())
+
 		// When
-		allocator, err := dns.NewVIPsAllocator(rm, nil, cfg, config.ExperimentalConfig{UseTagFirstVirtualOutboundModel: false}, tc.whenZone)
+		allocator, err := dns.NewVIPsAllocator(rm, nil, cfg, config.ExperimentalConfig{UseTagFirstVirtualOutboundModel: false}, tc.whenZone, metrics)
 		Expect(err).NotTo(HaveOccurred())
 		serviceSet, err := allocator.BuildVirtualOutboundMeshView(ctx, tc.whenMesh)
 

--- a/pkg/dns/vips_allocator_test.go
+++ b/pkg/dns/vips_allocator_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	"github.com/kumahq/kuma/pkg/dns"
 	"github.com/kumahq/kuma/pkg/dns/vips"
-	metricspkg "github.com/kumahq/kuma/pkg/metrics"
+	core_metrics "github.com/kumahq/kuma/pkg/metrics"
 	"github.com/kumahq/kuma/pkg/plugins/resources/memory"
 	test_metrics "github.com/kumahq/kuma/pkg/test/metrics"
 	"github.com/kumahq/kuma/pkg/test/resources/samples"
@@ -67,7 +67,7 @@ var _ = Describe("VIP Allocator", func() {
 	var rm manager.ResourceManager
 	var cm config_manager.ConfigManager
 	var allocator *dns.VIPsAllocator
-	var metrics metricspkg.Metrics
+	var metrics core_metrics.Metrics
 	var err error
 
 	NoModifications := func(view *vips.VirtualOutboundMeshView) error {
@@ -79,7 +79,7 @@ var _ = Describe("VIP Allocator", func() {
 		rm = manager.NewResourceManager(s)
 		cm = config_manager.NewConfigManager(s)
 
-		metrics, err = metricspkg.NewMetrics("")
+		metrics, err = core_metrics.NewMetrics("")
 		Expect(err).ToNot(HaveOccurred())
 
 		err = rm.Create(context.Background(), mesh.NewMeshResource(), store.CreateByKey("mesh-1", model.NoMesh))
@@ -169,7 +169,7 @@ var _ = Describe("VIP Allocator", func() {
 	It("should return error if failed to update VIP config", func() {
 		errConfigManager := &errConfigManager{ConfigManager: cm}
 		ctx := context.Background()
-		metrics, err := metricspkg.NewMetrics("")
+		metrics, err := core_metrics.NewMetrics("")
 		Expect(err).ToNot(HaveOccurred())
 
 		errAllocator, err := dns.NewVIPsAllocator(rm, errConfigManager, testConfig, config.ExperimentalConfig{UseTagFirstVirtualOutboundModel: false}, "", metrics)
@@ -188,7 +188,7 @@ var _ = Describe("VIP Allocator", func() {
 
 	It("should try to update all meshes and return combined error", func() {
 		errConfigManager := &errConfigManager{ConfigManager: cm}
-		metrics, err := metricspkg.NewMetrics("")
+		metrics, err := core_metrics.NewMetrics("")
 		Expect(err).ToNot(HaveOccurred())
 
 		errAllocator, err := dns.NewVIPsAllocator(rm, errConfigManager, testConfig, config.ExperimentalConfig{UseTagFirstVirtualOutboundModel: false}, "", metrics)
@@ -268,7 +268,7 @@ var _ = DescribeTable("outboundView",
 			CIDR:              "240.0.0.0/24",
 			ServiceVipEnabled: !tc.whenSkipServiceVips,
 		}
-		metrics, err := metricspkg.NewMetrics("")
+		metrics, err := core_metrics.NewMetrics("")
 		Expect(err).ToNot(HaveOccurred())
 
 		// When

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -215,6 +215,7 @@ func addDNS(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter k8s_common
 		*rt.Config().DNSServer,
 		rt.Config().Experimental,
 		zone,
+		rt.Metrics(),
 	)
 	if err != nil {
 		return err

--- a/pkg/plugins/runtime/universal/plugin.go
+++ b/pkg/plugins/runtime/universal/plugin.go
@@ -46,6 +46,7 @@ func addDNS(rt core_runtime.Runtime) error {
 		*rt.Config().DNSServer,
 		rt.Config().Experimental,
 		zone,
+		rt.Metrics(),
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- no issue
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? -- no
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) -- no

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
