### PR TITLE
test(e2e/MeshProxyPatch): add test for delegated gateway

### DIFF
--- a/test/e2e_env/kubernetes/gateway/delegated.go
+++ b/test/e2e_env/kubernetes/gateway/delegated.go
@@ -85,4 +85,5 @@ spec:
 	})
 
 	Context("MeshCircuitBreaker", CircuitBreaker(config))
+	Context("MeshProxyPatch", MeshProxyPatch(config))
 }

--- a/test/e2e_env/kubernetes/gateway/delegated_meshproxypatch.go
+++ b/test/e2e_env/kubernetes/gateway/delegated_meshproxypatch.go
@@ -1,0 +1,68 @@
+package gateway
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/client"
+	"github.com/kumahq/kuma/test/framework/envs/kubernetes"
+	"github.com/kumahq/kuma/test/server/types"
+)
+
+func MeshProxyPatch(config *delegatedE2EConfig) func() {
+	GinkgoHelper()
+
+	return func() {
+		It("should add a header using Lua filter", func() {
+			// given
+			meshProxyPatch := fmt.Sprintf(`
+apiVersion: kuma.io/v1alpha1 
+kind: MeshProxyPatch
+metadata:
+  name: backend-lua-filter
+  namespace: %s
+  labels:
+    kuma.io/mesh: %s
+spec:
+  targetRef:
+    kind: MeshService
+    name: gateway_%s_svc_80
+  default:
+    appendModifications:
+      - httpFilter:
+          operation: AddBefore
+          match:
+            name: envoy.filters.http.router
+            origin: outbound
+          value: |
+            name: envoy.filters.http.lua
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+              inline_code: |
+                function envoy_on_request(request_handle)
+                  request_handle:headers():add("X-Header", "test")
+                end
+`, Config.KumaNamespace, config.mesh, config.namespace)
+
+			// when
+			err := kubernetes.Cluster.Install(YamlK8s(meshProxyPatch))
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func() ([]types.EchoResponse, error) {
+				return client.CollectResponses(
+					kubernetes.Cluster,
+					"demo-client",
+					fmt.Sprintf("http://%s/test-server", config.kicIP),
+					client.FromKubernetesPod(config.namespaceOutsideMesh, "demo-client"),
+				)
+			}, "30s", "1s").Should(ContainElement(HaveField(
+				`Received.Headers`,
+				HaveKeyWithValue("X-Header", ContainElement("test")),
+			)))
+		})
+	}
+}


### PR DESCRIPTION
Add test for `MeshProxyPatch` targeting delegated gateway

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - Relates to https://github.com/kumahq/kuma/issues/8746
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  -  It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - This PR introduces e2e test
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - 🤔 

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
