### PR TITLE
fix: allow targeting meshgateway in meshmetric 

### DIFF
--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/validator.go
@@ -23,6 +23,7 @@ func validateTop(targetRef common_api.TargetRef) validators.ValidationError {
 		SupportedKinds: []common_api.TargetRefKind{
 			common_api.Mesh, common_api.MeshSubset, common_api.MeshService, common_api.MeshServiceSubset, common_api.MeshGateway,
 		},
+		GatewayListenerTagsAllowed: true,
 	})
 	return targetRefErr
 }

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/validator.go
@@ -21,7 +21,7 @@ func (r *MeshMetricResource) validate() error {
 func validateTop(targetRef common_api.TargetRef) validators.ValidationError {
 	targetRefErr := mesh.ValidateTargetRef(targetRef, &mesh.ValidateTargetRefOpts{
 		SupportedKinds: []common_api.TargetRefKind{
-			common_api.Mesh, common_api.MeshSubset, common_api.MeshService, common_api.MeshServiceSubset,
+			common_api.Mesh, common_api.MeshSubset, common_api.MeshService, common_api.MeshServiceSubset, common_api.MeshGateway,
 		},
 	})
 	return targetRefErr


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
