### PR TITLE
test(e2e): federate zone

### DIFF
--- a/test/e2e/federation/federation_kubernetes.go
+++ b/test/e2e/federation/federation_kubernetes.go
@@ -1,0 +1,111 @@
+package federation
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/pkg/config/core"
+	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/client"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
+	"github.com/kumahq/kuma/test/framework/deployments/testserver"
+)
+
+func FederateKubeZoneCPToKubeGlobal() {
+	var global, zone Cluster
+	var releaseName string
+
+	BeforeAll(func() {
+		global = NewK8sCluster(NewTestingT(), Kuma1, Silent).
+			WithTimeout(6 * time.Second).
+			WithRetries(60)
+		zone = NewK8sCluster(NewTestingT(), Kuma2, Silent).
+			WithTimeout(6 * time.Second).
+			WithRetries(60)
+
+		releaseName = fmt.Sprintf("kuma-%s", strings.ToLower(random.UniqueId()))
+
+		err := NewClusterSetup().
+			Install(Kuma(core.Global,
+				WithInstallationMode(HelmInstallationMode),
+				WithHelmReleaseName(releaseName),
+				WithEnv("KUMA_DEFAULTS_SKIP_MESH_CREATION", "true"),
+			)).
+			Setup(global)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = NewClusterSetup().
+			Install(Kuma(core.Zone,
+				WithInstallationMode(HelmInstallationMode),
+				WithHelmReleaseName(releaseName),
+			)).
+			Install(NamespaceWithSidecarInjection(TestNamespace)).
+			Install(MTLSMeshKubernetes("default")).
+			Install(MeshTrafficPermissionAllowAllKubernetes("default")).
+			Install(democlient.Install()).
+			Install(testserver.Install()).
+			Setup(zone)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	E2EAfterAll(func() {
+		Expect(zone.DeleteNamespace(TestNamespace)).To(Succeed())
+		Expect(global.DeleteKuma()).To(Succeed())
+		Expect(zone.DeleteKuma()).To(Succeed())
+		Expect(global.DismissCluster()).To(Succeed())
+		Expect(zone.DismissCluster()).To(Succeed())
+	})
+
+	Context("on federation", func() {
+		BeforeAll(func() {
+			Eventually(func(g Gomega) {
+				_, err := client.CollectEchoResponse(zone, "demo-client", "test-server",
+					client.FromKubernetesPod(TestNamespace, "demo-client"),
+				)
+				g.Expect(err).ToNot(HaveOccurred())
+			}, "30s", "1s").Should(Succeed())
+
+			out, err := zone.GetKumactlOptions().RunKumactlAndGetOutput("export", "--profile", "federation", "--format", "kubernetes")
+			Expect(err).ToNot(HaveOccurred())
+
+			err = k8s.KubectlApplyFromStringE(global.GetTesting(), global.GetKubectlOptions(), out)
+			Expect(err).ToNot(HaveOccurred())
+			err = zone.(*K8sCluster).UpgradeKuma(core.Zone,
+				WithHelmReleaseName(releaseName),
+				WithGlobalAddress(global.GetKuma().GetKDSServerAddress()),
+			)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should sync data plane proxies to global cp", func() {
+			Eventually(func(g Gomega) {
+				out, err := k8s.RunKubectlAndGetOutputE(global.GetTesting(), global.GetKubectlOptions(), "get", "dataplanes", "-A")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(out).Should(ContainSubstring("demo-client"))
+			}, "30s", "1s").Should(Succeed())
+		})
+
+		It("should sync data policies to global cp", func() {
+			Eventually(func(g Gomega) {
+				out, err := k8s.RunKubectlAndGetOutputE(global.GetTesting(), global.GetKubectlOptions(), "get", "meshcircuitbreakers", "-A")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(out).Should(ContainSubstring("mesh-circuit-breaker-all-default-zw856xvxdb7558d9"))
+			}, "30s", "1s").Should(Succeed())
+		})
+
+		It("should not break the traffic", func() {
+			Consistently(func(g Gomega) {
+				_, err := client.CollectEchoResponse(zone, "demo-client", "test-server",
+					client.FromKubernetesPod(TestNamespace, "demo-client"),
+				)
+				g.Expect(err).ToNot(HaveOccurred())
+			}, "3s", "100s").Should(Succeed())
+		})
+	})
+}

--- a/test/e2e/federation/federation_suite_test.go
+++ b/test/e2e/federation/federation_suite_test.go
@@ -1,0 +1,19 @@
+package federation_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+
+	"github.com/kumahq/kuma/pkg/test"
+	"github.com/kumahq/kuma/test/e2e/federation"
+)
+
+func TestE2E(t *testing.T) {
+	test.RunE2ESpecs(t, "Federation Suite")
+}
+
+var (
+	_ = Describe("Federation with Kube Global", Label("job-0"), federation.FederateKubeZoneCPToKubeGlobal, Ordered)
+	_ = Describe("Federation with Universal Global", Label("job-1"), federation.FederateKubeZoneCPToUniversalGlobal, Ordered)
+)

--- a/test/e2e/federation/federation_universal.go
+++ b/test/e2e/federation/federation_universal.go
@@ -1,0 +1,108 @@
+package federation
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/pkg/config/core"
+	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/client"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
+	"github.com/kumahq/kuma/test/framework/deployments/testserver"
+)
+
+func FederateKubeZoneCPToUniversalGlobal() {
+	var global, zone Cluster
+	var releaseName string
+
+	BeforeAll(func() {
+		global = NewUniversalCluster(NewTestingT(), Kuma4, Silent)
+		zone = NewK8sCluster(NewTestingT(), Kuma2, Silent).
+			WithTimeout(6 * time.Second).
+			WithRetries(60)
+
+		releaseName = fmt.Sprintf("kuma-%s", strings.ToLower(random.UniqueId()))
+
+		err := NewClusterSetup().
+			Install(Kuma(core.Global, WithEnv("KUMA_DEFAULTS_SKIP_MESH_CREATION", "true"))).
+			Setup(global)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = NewClusterSetup().
+			Install(Kuma(core.Zone,
+				WithInstallationMode(HelmInstallationMode),
+				WithHelmReleaseName(releaseName),
+			)).
+			Install(NamespaceWithSidecarInjection(TestNamespace)).
+			Install(MTLSMeshKubernetes("default")).
+			Install(MeshTrafficPermissionAllowAllKubernetes("default")).
+			Install(democlient.Install()).
+			Install(testserver.Install()).
+			Setup(zone)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	E2EAfterAll(func() {
+		Expect(zone.DeleteNamespace(TestNamespace)).To(Succeed())
+		Expect(zone.DeleteKuma()).To(Succeed())
+		Expect(global.DismissCluster()).To(Succeed())
+		Expect(zone.DismissCluster()).To(Succeed())
+	})
+
+	Context("on federation", func() {
+		BeforeAll(func() {
+			Eventually(func(g Gomega) {
+				_, err := client.CollectEchoResponse(zone, "demo-client", "test-server",
+					client.FromKubernetesPod(TestNamespace, "demo-client"),
+				)
+				g.Expect(err).ToNot(HaveOccurred())
+			}, "30s", "1s").Should(Succeed())
+
+			out, err := zone.GetKumactlOptions().RunKumactlAndGetOutput("export", "--profile", "federation", "--format", "universal")
+			Expect(err).ToNot(HaveOccurred())
+
+			tmpfile, err := os.CreateTemp("", "export-uni")
+			_, err = tmpfile.WriteString(out)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(global.GetKumactlOptions().RunKumactl("apply", "-f", tmpfile.Name())).To(Succeed())
+			err = zone.(*K8sCluster).UpgradeKuma(core.Zone,
+				WithHelmReleaseName(releaseName),
+				WithGlobalAddress(global.GetKuma().GetKDSServerAddress()),
+			)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should sync data plane proxies to global cp", func() {
+			Eventually(func(g Gomega) {
+				// we use API on localhost, because the auth data has changed on the global, so we would need to reconfigure kumactl
+				out, _, err := global.GetKuma().Exec("curl", "--fail", "--show-error", "http://localhost:5681/dataplanes")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(out).Should(ContainSubstring("demo-client"))
+			}, "30s", "1s").Should(Succeed())
+		})
+
+		It("should sync data policies to global cp", func() {
+			Eventually(func(g Gomega) {
+				out, _, err := global.GetKuma().Exec("curl", "--fail", "--show-error", "http://localhost:5681/meshcircuitbreakers")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(out).Should(ContainSubstring("mesh-circuit-breaker-all-default-zw856xvxdb7558d9"))
+			}, "30s", "1s").Should(Succeed())
+		})
+
+		It("should not break the traffic", func() {
+			Consistently(func(g Gomega) {
+				_, err := client.CollectEchoResponse(zone, "demo-client", "test-server",
+					client.FromKubernetesPod(TestNamespace, "demo-client"),
+				)
+				g.Expect(err).ToNot(HaveOccurred())
+			}, "3s", "100s").Should(Succeed())
+		})
+	})
+}


### PR DESCRIPTION
### Checklist prior to review

E2E tests for zone federation.
I also included a change in kumactl to order user token signing keys as last element. It makes federation into universal global (not mesh manager in konnect) smoother.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
