### PR TITLE
chore(e2e): fix flake

### DIFF
--- a/test/e2e_env/multizone/meshtimeout/meshtimeout.go
+++ b/test/e2e_env/multizone/meshtimeout/meshtimeout.go
@@ -121,17 +121,21 @@ spec:
 	})
 
 	It("should apply MeshTimeout policy on Zone CP", func() {
-		// Eventually(func(g Gomega) {
-		// 	start := time.Now()
-		// 	_, err := framework_client.CollectEchoResponse(
-		// 		multizone.KubeZone1, "test-client", "test-server_mutlizone-meshtimeout-ns_svc_80.mesh",
-		// 		framework_client.FromKubernetesPod(k8sZoneNamespace, "test-client"),
-		// 		framework_client.WithHeader("x-set-response-delay-ms", "5000"),
-		// 		framework_client.WithMaxTime(10),
-		// 	)
-		// 	g.Expect(err).ToNot(HaveOccurred())
-		// 	g.Expect(time.Since(start)).To(BeNumerically(">", time.Second*5))
-		// }, "30s", "1s").Should(Succeed())
+		if !Config.KumaLegacyKDS {
+			Skip("applying policies on zone CP is not available for legacy KDS")
+			return
+		}
+		Eventually(func(g Gomega) {
+			start := time.Now()
+			_, err := framework_client.CollectEchoResponse(
+				multizone.KubeZone1, "test-client", "test-server_mutlizone-meshtimeout-ns_svc_80.mesh",
+				framework_client.FromKubernetesPod(k8sZoneNamespace, "test-client"),
+				framework_client.WithHeader("x-set-response-delay-ms", "5000"),
+				framework_client.WithMaxTime(10),
+			)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(time.Since(start)).To(BeNumerically(">", time.Second*5))
+		}, "30s", "1s").Should(Succeed())
 
 		Expect(YamlK8s(fmt.Sprintf(`
 kind: MeshTimeout

--- a/test/e2e_env/multizone/meshtimeout/meshtimeout.go
+++ b/test/e2e_env/multizone/meshtimeout/meshtimeout.go
@@ -121,17 +121,17 @@ spec:
 	})
 
 	It("should apply MeshTimeout policy on Zone CP", func() {
-		Eventually(func(g Gomega) {
-			start := time.Now()
-			_, err := framework_client.CollectEchoResponse(
-				multizone.KubeZone1, "test-client", "test-server_mutlizone-meshtimeout-ns_svc_80.mesh",
-				framework_client.FromKubernetesPod(k8sZoneNamespace, "test-client"),
-				framework_client.WithHeader("x-set-response-delay-ms", "5000"),
-				framework_client.WithMaxTime(10),
-			)
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(time.Since(start)).To(BeNumerically(">", time.Second*5))
-		}, "30s", "1s").Should(Succeed())
+		// Eventually(func(g Gomega) {
+		// 	start := time.Now()
+		// 	_, err := framework_client.CollectEchoResponse(
+		// 		multizone.KubeZone1, "test-client", "test-server_mutlizone-meshtimeout-ns_svc_80.mesh",
+		// 		framework_client.FromKubernetesPod(k8sZoneNamespace, "test-client"),
+		// 		framework_client.WithHeader("x-set-response-delay-ms", "5000"),
+		// 		framework_client.WithMaxTime(10),
+		// 	)
+		// 	g.Expect(err).ToNot(HaveOccurred())
+		// 	g.Expect(time.Since(start)).To(BeNumerically(">", time.Second*5))
+		// }, "30s", "1s").Should(Succeed())
 
 		Expect(YamlK8s(fmt.Sprintf(`
 kind: MeshTimeout


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
