### PR TITLE
refactor(gateway): avoid manual creation of envoy resource names

### DIFF
--- a/pkg/plugins/policies/core/xds/meshroute/gateway.go
+++ b/pkg/plugins/policies/core/xds/meshroute/gateway.go
@@ -111,7 +111,7 @@ func CollectListenerInfos(
 			Listener: plugin_gateway.GatewayListener{
 				Port:     port,
 				Protocol: listener.listener.GetProtocol(),
-				ResourceName: envoy_names.GetGatewayListenerName(
+				EnvoyListenerName: envoy_names.GetGatewayListenerName(
 					gateway.Meta.GetName(),
 					listener.listener.GetProtocol().String(),
 					port,

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/gateway.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/gateway.go
@@ -90,8 +90,11 @@ func generateGatewayRoutes(
 	resources := core_xds.NewResourceSet()
 	// Make a pass over the generators for each virtual host.
 	for _, hostInfos := range listenerHostnames {
-		hostname := hostInfos.Hostname
-		routeConfig := plugin_gateway.GenerateRouteConfig(info.Proxy, info.Listener.Protocol, info.Listener.ResourceName+":"+hostname)
+		routeConfig := plugin_gateway.GenerateRouteConfig(
+			info.Proxy,
+			info.Listener.Protocol,
+			hostInfos.EnvoyRouteName(info.Listener.EnvoyListenerName),
+		)
 		for _, hostInfo := range hostInfos.HostInfos {
 			vh, err := plugin_gateway.GenerateVirtualHost(ctx, info, hostInfo.Host, hostInfo.Entries())
 			if err != nil {

--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin.go
@@ -84,7 +84,7 @@ func applyToGateways(
 		}
 
 		for _, listenerHostname := range listenerInfo.ListenerHostnames {
-			route, ok := gatewayRoutes[listenerInfo.Listener.ResourceName+":"+listenerHostname.Hostname]
+			route, ok := gatewayRoutes[listenerHostname.EnvoyRouteName(listenerInfo.Listener.EnvoyListenerName)]
 			if !ok {
 				continue
 			}

--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin.go
@@ -115,7 +115,7 @@ func applyToGateway(
 		}
 
 		for _, listenerHostname := range listenerInfo.ListenerHostnames {
-			route, ok := gatewayRoutes[listenerInfo.Listener.ResourceName+":"+listenerHostname.Hostname]
+			route, ok := gatewayRoutes[listenerHostname.EnvoyRouteName(listenerInfo.Listener.EnvoyListenerName)]
 			if !ok {
 				continue
 			}

--- a/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
@@ -191,7 +191,7 @@ func applyToGateway(
 
 		conf = getConf(toRules, core_rules.MeshSubset())
 		for _, listenerHostname := range listenerInfo.ListenerHostnames {
-			route, ok := gatewayRoutes[listenerInfo.Listener.ResourceName+":"+listenerHostname.Hostname]
+			route, ok := gatewayRoutes[listenerHostname.EnvoyRouteName(listenerInfo.Listener.EnvoyListenerName)]
 
 			if conf != nil && ok {
 				for _, vh := range route.VirtualHosts {


### PR DESCRIPTION
Not needed for release but good to have IMO in the branch

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
