### PR TITLE
test(e2e): fix dp auth flake

### DIFF
--- a/test/e2e_env/universal/auth/dp_auth.go
+++ b/test/e2e_env/universal/auth/dp_auth.go
@@ -99,18 +99,25 @@ data: %s`, base64.StdEncoding.EncodeToString([]byte(claims.ID)))
 			// we need to trigger XDS config change for this DP to disconnect it
 			// this limitation may be lifted in the future
 			yaml = fmt.Sprintf(`
-type: Retry
+type: MeshRetry
 name: retry-policy
 mesh: dp-auth
-sources:
-- match:
-    kuma.io/service: test-server-to-be-revoked
-destinations:
-- match:
-    kuma.io/service: test-server-to-be-revoked
-conf:
-  http:
-    numRetries: %d
+spec:
+  targetRef:
+    kind: MeshService
+    name: test-server-to-be-revoked
+  to:
+    - targetRef:
+        kind: MeshService
+        name: test-server-to-be-revoked
+      default:
+        http:
+          numRetries: %d
+          backOff:
+            baseInterval: 15s
+            maxInterval: 20m
+          retryOn:
+            - "5xx"
 `, rand.Int()%100+1) // #nosec G404 -- this is for tests no need to use secure rand
 			g.Expect(universal.Cluster.Install(YamlUniversal(yaml))).To(Succeed())
 


### PR DESCRIPTION
### Checklist prior to review

Retry without TrafficRoute does not trigger xds change. We need MeshRetry

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
