### PR TITLE
ci(distribute/helm-charts): add missing GH_USER/GH_EMAIL env vars

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -17,6 +17,8 @@ env:
   GH_OWNER: ${{ github.repository_owner }}
   KUMA_DIR: "."
   CI_TOOLS_DIR: /home/runner/work/kuma/kuma/.ci_tools
+  GH_USER: "github-actions[bot]"
+  GH_EMAIL: "<41898282+github-actions[bot]@users.noreply.github.com>"
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -159,8 +161,6 @@ jobs:
         id: package-helm
         env:
           HELM_DEV: ${{ !startsWith(github.event.ref, 'refs/tags/') }}
-          GH_USER: "github-actions[bot]"
-          GH_EMAIL: "<41898282+github-actions[bot]@users.noreply.github.com>"
         run: |
           make helm/update-version
 
@@ -182,7 +182,7 @@ jobs:
           path: .cr-release-packages/${{ steps.package-helm.outputs.filename }}
           retention-days: ${{ github.event_name == 'pull_request' && 1 || 30 }}
       # Everything from here is only running on releases.
-      # Ideally we'd finish the workflow early but this isn't possible: https://github.com/actions/runner/issues/662
+      # Ideally we'd finish the workflow early, but this isn't possible: https://github.com/actions/runner/issues/662
       - name: Generate GitHub app token
         id: github-app-token
         if: ${{ startsWith(github.event.ref, 'refs/tags/') }}


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
