### PR TITLE
test(localitylb): fixed zone name and changes mesh name to shorter

### DIFF
--- a/test/e2e_env/multizone/localityawarelb/locality_multizone_hybrid.go
+++ b/test/e2e_env/multizone/localityawarelb/locality_multizone_hybrid.go
@@ -69,9 +69,9 @@ networking:
 `, mesh, name, name, zone, net.JoinHostPort(ip, "8080"))
 	}
 
-	const mesh = "external-service-locality-lb"
-	const meshNoZoneEgress = "external-service-locality-lb-no-egress"
-	const namespace = "external-service-locality-lb"
+	const mesh = "es-locality-lb"
+	const meshNoZoneEgress = "es-locality-lb-no-egress"
+	const namespace = "es-locality-lb"
 
 	BeforeAll(func() {
 		// Global
@@ -109,7 +109,7 @@ networking:
 
 		Expect(NewClusterSetup().
 			Install(YamlUniversal(zoneExternalService(mesh, multizone.UniZone1.GetApp("external-service-in-uni-zone4").GetIP(), "external-service-in-uni-zone4", "kuma-4"))).
-			Install(YamlUniversal(zoneExternalService(mesh, multizone.UniZone1.GetApp("external-service-in-kube-zone1").GetIP(), "external-service-in-kube-zone1", "kuma-1-zone"))).
+			Install(YamlUniversal(zoneExternalService(mesh, multizone.UniZone1.GetApp("external-service-in-kube-zone1").GetIP(), "external-service-in-kube-zone1", "kuma-1"))).
 			Install(YamlUniversal(externalService(mesh, multizone.UniZone1.GetApp("external-service-in-both-zones").GetIP()))).
 			Install(YamlUniversal(zoneExternalService(meshNoZoneEgress, multizone.UniZone1.GetApp("external-service-in-uni-zone4").GetIP(), "demo-es-in-uni-zone4", "kuma-4"))).
 			Setup(multizone.Global)).ToNot(HaveOccurred())
@@ -135,7 +135,7 @@ networking:
 		}
 	}
 
-	XIt("should route to external-service from universal through k8s", func() {
+	It("should route to external-service from universal through k8s", func() {
 		// given no request on path
 		filterEgress := fmt.Sprintf(
 			"cluster.%s_%s.upstream_rq_total",


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
