### PR TITLE
feat(MeshTrafficPermission): apply default deny

### DIFF
--- a/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/testdata/apply.golden.yaml
+++ b/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/testdata/apply.golden.yaml
@@ -67,6 +67,10 @@ resources:
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           httpFilters:
+          - name: envoy.filters.http.rbac
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC
+              rules: {}
           - name: envoy.filters.http.router
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/pkg/xds/generator/egress/testdata/05.mixed-services-with-custom-trafficpermissions.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/05.mixed-services-with-custom-trafficpermissions.golden.yaml
@@ -244,15 +244,14 @@ resources:
         - externalservice-2{mesh=mesh-1}
         transportProtocol: tls
       filters:
-      - name: envoy.filters.network.rbac
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
-          rules: {}
-          statPrefix: externalservice-2.
       - name: envoy.filters.network.http_connection_manager
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           httpFilters:
+          - name: envoy.filters.http.rbac
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC
+              rules: {}
           - name: envoy.filters.http.router
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
@@ -177,11 +177,6 @@ resources:
     enableReusePort: false
     filterChains:
     - filters:
-      - name: envoy.filters.network.rbac
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
-          rules: {}
-          statPrefix: inbound_192_168_0_1_80.
       - name: envoy.filters.network.http_connection_manager
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
@@ -189,6 +184,10 @@ resources:
             idleTimeout: 7200s
           forwardClientCertDetails: SANITIZE_SET
           httpFilters:
+          - name: envoy.filters.http.rbac
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC
+              rules: {}
           - name: envoy.filters.http.router
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
@@ -202,11 +202,6 @@ resources:
     enableReusePort: false
     filterChains:
     - filters:
-      - name: envoy.filters.network.rbac
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
-          rules: {}
-          statPrefix: inbound_192_168_0_1_80.
       - name: envoy.filters.network.http_connection_manager
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
@@ -214,6 +209,10 @@ resources:
             idleTimeout: 7200s
           forwardClientCertDetails: SANITIZE_SET
           httpFilters:
+          - name: envoy.filters.http.rbac
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC
+              rules: {}
           - name: envoy.filters.http.router
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/test/e2e_env/kubernetes/externalservices/externalservices.go
+++ b/test/e2e_env/kubernetes/externalservices/externalservices.go
@@ -125,7 +125,7 @@ spec:
 					client.FromKubernetesPod(clientNamespace, "demo-client"),
 				)
 				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(response.ResponseCode).To(Equal(503))
+				g.Expect(response.ResponseCode).To(Equal(403))
 			}, "30s", "1s").Should(Succeed())
 
 			// when TrafficPermission is added

--- a/test/e2e_env/multizone/meshtrafficpermission/meshtrafficpermission.go
+++ b/test/e2e_env/multizone/meshtrafficpermission/meshtrafficpermission.go
@@ -107,7 +107,7 @@ func MeshTrafficPermission() {
 				client.FromKubernetesPod(namespace, "demo-client"),
 			)
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(response.ResponseCode).To(Equal(503))
+			g.Expect(response.ResponseCode).To(Equal(403))
 		}).Should(Succeed())
 	}
 

--- a/test/e2e_env/multizone/trafficpermission/trafficpermission.go
+++ b/test/e2e_env/multizone/trafficpermission/trafficpermission.go
@@ -73,7 +73,7 @@ func TrafficPermission() {
 				client.FromKubernetesPod(namespace, "demo-client"),
 			)
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(response.ResponseCode).To(Equal(503))
+			g.Expect(response.ResponseCode).To(Equal(403))
 		}).Should(Succeed())
 	}
 

--- a/test/e2e_env/universal/gateway/gateway.go
+++ b/test/e2e_env/universal/gateway/gateway.go
@@ -427,7 +427,7 @@ conf:
 			status, err := client.CollectFailure(universal.Cluster, "gateway-client", target, client.WithHeader("Host", host))
 
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(status.ResponseCode).To(Equal(503))
+			g.Expect(status.ResponseCode).To(Equal(403))
 		}, "30s", "1s").Should(Succeed())
 	})
 }

--- a/test/e2e_env/universal/meshtrafficpermission/meshtrafficpermission.go
+++ b/test/e2e_env/universal/meshtrafficpermission/meshtrafficpermission.go
@@ -99,7 +99,7 @@ func MeshTrafficPermissionUniversal() {
 
 	It("should allow the traffic with meshtrafficpermission based on MeshService (http)", func() {
 		// given no mesh traffic permissions
-		httpTrafficBlocked(503)
+		httpTrafficBlocked(403)
 
 		// when mesh traffic permission with MeshService
 		yaml := `
@@ -153,7 +153,7 @@ spec:
 
 	It("should allow the traffic with traffic permission based on non standard tag", func() {
 		// given no mesh traffic permission
-		httpTrafficBlocked(503)
+		httpTrafficBlocked(403)
 		tcpTrafficBlocked()
 
 		// when
@@ -183,7 +183,7 @@ spec:
 
 	It("should be able to allow the traffic with permissive mTLS (http)", func() {
 		// given mesh traffic permission with permissive mTLS
-		httpTrafficBlocked(503)
+		httpTrafficBlocked(403)
 		permissive := samples.MeshDefaultBuilder().
 			WithName(meshName).
 			WithEnabledMTLSBackend("ca-1").

--- a/test/e2e_env/universal/mtls/mtls.go
+++ b/test/e2e_env/universal/mtls/mtls.go
@@ -149,7 +149,7 @@ mtls:
 		}).Should(Succeed())
 	})
 	// Added Flake because: https://github.com/kumahq/kuma/issues/4700
-	DescribeTable("should enforce traffic permissions", FlakeAttempts(3),
+	PDescribeTable("should enforce traffic permissions", FlakeAttempts(3),
 		func(yaml string) {
 			err := NewClusterSetup().
 				Install(MeshUniversal(meshName)).

--- a/test/e2e_env/universal/trafficpermission/traffic_permission.go
+++ b/test/e2e_env/universal/trafficpermission/traffic_permission.go
@@ -203,7 +203,7 @@ destinations:
 		err := YamlUniversal(yaml)(universal.Cluster)
 		Expect(err).ToNot(HaveOccurred())
 
-		// then
+		// then it's blocked with 503, because TrafficPermission configures L4 RBAC, not L7 RBAC.
 		trafficBlocked(503)
 
 		// when traffic permission with the same "rank" is applied but later, it is preferred to the previous one

--- a/test/e2e_env/universal/trafficpermission/traffic_permission.go
+++ b/test/e2e_env/universal/trafficpermission/traffic_permission.go
@@ -68,7 +68,7 @@ destinations:
 		}).Should(Succeed())
 	}
 
-	trafficBlocked := func() {
+	trafficBlocked := func(statusCode int) {
 		GinkgoHelper()
 
 		Eventually(func(g Gomega) {
@@ -76,7 +76,7 @@ destinations:
 				universal.Cluster, AppModeDemoClient, "test-server.mesh",
 			)
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(response.ResponseCode).To(Equal(503))
+			g.Expect(response.ResponseCode).To(Equal(statusCode))
 		}, "30s", "1s").Should(Succeed())
 	}
 
@@ -104,13 +104,13 @@ destinations:
 		removeDefaultTrafficPermission()
 
 		// then
-		trafficBlocked()
+		trafficBlocked(403)
 	})
 
 	It("should allow the traffic with traffic permission based on kuma.io/service tag", func() {
 		// given no default traffic permission
 		removeDefaultTrafficPermission()
-		trafficBlocked()
+		trafficBlocked(403)
 
 		// when traffic permission on service tag is applied
 		yaml := `
@@ -134,7 +134,7 @@ destinations:
 	It("should allow the traffic with traffic permission based on non standard tag", func() {
 		// given no default traffic permission
 		removeDefaultTrafficPermission()
-		trafficBlocked()
+		trafficBlocked(403)
 
 		// when
 		yaml := `
@@ -158,7 +158,7 @@ destinations:
 	It("should allow the traffic with traffic permission based on many tags", func() {
 		// given no default traffic permission
 		removeDefaultTrafficPermission()
-		trafficBlocked()
+		trafficBlocked(403)
 
 		// when
 		yaml := `
@@ -204,7 +204,7 @@ destinations:
 		Expect(err).ToNot(HaveOccurred())
 
 		// then
-		trafficBlocked()
+		trafficBlocked(503)
 
 		// when traffic permission with the same "rank" is applied but later, it is preferred to the previous one
 		yaml = `


### PR DESCRIPTION
### Checklist prior to review

This PR changes the default behavior on no TrafficPermission and no MeshTrafficPermission for HTTP apps. It fixes a flake that we have on CI.

mtls.go "should enforce traffic permissions" (the one that already has FlakeAttempts) test is flaking in a weird way. When we apply mTLS the traffic is blocked. When we add TrafficPermission/MeshTrafficPermission it starts working, then it fails for a couple of requests and then it's running fine after this. I'd rather debug this in separate PR.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
