### PR TITLE
test(e2e): print cp logs on failure

### DIFF
--- a/test/e2e_env/kubernetes/kubernetes_suite_test.go
+++ b/test/e2e_env/kubernetes/kubernetes_suite_test.go
@@ -49,6 +49,8 @@ var _ = E2ESynchronizedBeforeSuite(kubernetes.SetupAndGetState, kubernetes.Resto
 // Otherwise, we would close port-forward to the CP and remaining tests executed in different processes may fail.
 var _ = SynchronizedAfterSuite(func() {}, func() {})
 
+var _ = ReportAfterSuite("cp logs", kubernetes.PrintCPLogsOnFailure)
+
 var (
 	_ = Describe("Virtual Probes", healthcheck.VirtualProbes, Ordered)
 	_ = Describe("Gateway", gateway.Gateway, Ordered)

--- a/test/e2e_env/multizone/multizone_suite_test.go
+++ b/test/e2e_env/multizone/multizone_suite_test.go
@@ -42,6 +42,7 @@ var (
 			universal_logs.CleanupIfSuccess(Config.UniversalE2ELogsPath, report)
 		}
 	})
+	_ = ReportAfterSuite("cp logs", multizone.PrintCPLogsOnFailure)
 )
 
 var (

--- a/test/e2e_env/universal/universal_suite_test.go
+++ b/test/e2e_env/universal/universal_suite_test.go
@@ -56,6 +56,7 @@ var (
 			universal_logs.CleanupIfSuccess(Config.UniversalE2ELogsPath, report)
 		}
 	})
+	_ = ReportAfterSuite("cp logs", universal.PrintCPLogsOnFailure)
 )
 
 var (

--- a/test/framework/envs/kubernetes/env.go
+++ b/test/framework/envs/kubernetes/env.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"encoding/json"
 
+	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/kumahq/kuma/pkg/config/core"
@@ -69,4 +70,15 @@ func RestoreState(bytes []byte) {
 	)
 	Expect(cp.FinalizeAddWithPortFwd(state.KumaCp, state.MADS)).To(Succeed())
 	Cluster.SetCP(cp)
+}
+
+func PrintCPLogsOnFailure(report ginkgo.Report) {
+	if !report.SuiteSucceeded {
+		logs, err := Cluster.GetKumaCPLogs()
+		if err != nil {
+			framework.Logf("could not retrieve cp logs")
+		} else {
+			framework.Logf(logs)
+		}
+	}
 }

--- a/test/framework/envs/multizone/env.go
+++ b/test/framework/envs/multizone/env.go
@@ -270,3 +270,15 @@ func RestoreState(bytes []byte) {
 	Expect(UniZone2.AddNetworking(state.UniZone2.ZoneEgress, Config.ZoneEgressApp)).To(Succeed())
 	Expect(UniZone2.AddNetworking(state.UniZone2.ZoneIngress, Config.ZoneIngressApp)).To(Succeed())
 }
+
+func PrintCPLogsOnFailure(report Report) {
+	for _, cluster := range append(Zones(), Global) {
+		Logf("\n\n\n\n\nCP logs of: " + cluster.Name())
+		logs, err := cluster.GetKumaCPLogs()
+		if err != nil {
+			Logf("could not retrieve cp logs")
+		} else {
+			Logf(logs)
+		}
+	}
+}

--- a/test/framework/envs/universal/env.go
+++ b/test/framework/envs/universal/env.go
@@ -3,6 +3,7 @@ package universal
 import (
 	"encoding/json"
 
+	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/kumahq/kuma/pkg/config/core"
@@ -54,4 +55,15 @@ func RestoreState(bytes []byte) {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(Cluster.AddNetworking(state.ZoneEgress, framework.Config.ZoneEgressApp)).To(Succeed())
 	Cluster.SetCp(cp)
+}
+
+func PrintCPLogsOnFailure(report ginkgo.Report) {
+	if !report.SuiteSucceeded {
+		logs, err := Cluster.GetKumaCPLogs()
+		if err != nil {
+			framework.Logf("could not retrieve cp logs")
+		} else {
+			framework.Logf(logs)
+		}
+	}
 }


### PR DESCRIPTION
### Checklist prior to review

We had a test flake failure. I see that now we print logs of a container that failed, so we printed that Envoy did not receive XDS config (initial fetch timeout). However, there is no way to inspect CP logs during this time (at least at kubernetes). This PR prints CP logs after test fails.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
