### PR TITLE
docs(contributing): update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -288,10 +288,8 @@ Once the PR is approved and merged the action `backport.yaml` will open a new PR
 You can indicate that you are reviewing a PR by using the `eyes` emoji on the PR description.
 If you give up on doing so please remove the emoji.
 
-### Contributor T-shirt
+### Contributor Badge
 
-If your Pull Request to [kumahq/kuma](https://github.com/kumahq/kuma) was
-accepted, and it fixes a bug, adds functionality, or makes it significantly
-easier to use or understand Kuma, congratulations! You are eligible to
-receive the very special Contributor T-shirt! Go ahead and fill out the
-[Contributors Submissions form](https://goo.gl/forms/5w6mxLaE4tz2YM0L2).
+If your Pull Request to [kumahq/kuma](https://github.com/kumahq/kuma) was accepted, and it fixes a bug, adds functionality, or makes it significantly easier to use or understand Kuma, congratulations! You are eligible to receive a digital Contributor Badge! Go ahead and fill out the [Contributor Submissions form](https://goo.gl/forms/5w6mxLaE4tz2YM0L2).
+
+*Badges expire after 1 year, at which point you may submit a new contribution to renew the badge.* 


### PR DESCRIPTION
Adding digital contributor badge information

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
