### PR TITLE
chore(kubernetes): better logs of namespace termination

### DIFF
--- a/pkg/xds/sync/dataplane_watchdog.go
+++ b/pkg/xds/sync/dataplane_watchdog.go
@@ -131,6 +131,12 @@ func (d *DataplaneWatchdog) syncDataplane(ctx context.Context, metadata *core_xd
 		ControlPlane: d.EnvoyCpCtx,
 		Mesh:         meshCtx,
 	}
+	if _, found := meshCtx.DataplanesByName[d.key.Name]; !found {
+		d.log.Info("Dataplane object not found. Can't regenerate XDS configuration. It's expected during Kubernetes namespace termination. " +
+			"If it persists it might be an indication of a race condition.")
+		result.Status = SkipStatus
+		return result, nil
+	}
 	proxy, err := d.DataplaneProxyBuilder.Build(ctx, d.key, meshCtx)
 	if err != nil {
 		return SyncResult{}, errors.Wrap(err, "could not build dataplane proxy")

--- a/pkg/xds/sync/dataplane_watchdog.go
+++ b/pkg/xds/sync/dataplane_watchdog.go
@@ -133,7 +133,7 @@ func (d *DataplaneWatchdog) syncDataplane(ctx context.Context, metadata *core_xd
 	}
 	if _, found := meshCtx.DataplanesByName[d.key.Name]; !found {
 		d.log.Info("Dataplane object not found. Can't regenerate XDS configuration. It's expected during Kubernetes namespace termination. " +
-			"If it persists it might be an indication of a race condition.")
+			"If it persists it's a bug.")
 		result.Status = SkipStatus
 		return result, nil
 	}


### PR DESCRIPTION
### Checklist prior to review

I noticed that we produce quite a lot of error logs on a simple namespace termination.

We should just ignore reconciliation if namespace is terminating. Kuberenetes errors out on modyfing objects when namespace is being terminated.
```
2024-02-02T14:31:55.590Z	ERROR	kube-manager	Reconciler error	{"controller": "pod", "controllerGroup": "", "controllerKind": "Pod", "Pod": {"name":"demo-app-gateway-75fcbdc9f5-hdmsw","namespace":"kuma-demo"}, "namespace": "kuma-demo", "name": "demo-app-gateway-75fcbdc9f5-hdmsw", "reconcileID": "edb796aa-15b7-424f-944d-63614cb8480a", "error": "dataplanes.kuma.io \"demo-app-gateway-75fcbdc9f5-hdmsw\" is forbidden: unable to create new content in namespace kuma-demo because it is being terminated"}
```

Additionally, on delete namespace, Kubernetes deletes all objects in namespace at the same time. It means that Dataplane is not deleted after Pod, but immediately. 
```
2024-02-02T14:32:12.592Z	ERROR	xds-server.dataplane-sync-watchdog	OnTick() failed	{"dataplaneKey": {"Mesh":"default","Name":"redis-686bbbb5c8-nbtfx.kuma-demo"}, "error": "could not build dataplane proxy: Resource not found: type=\"Dataplane\" name=\"redis-686bbbb5c8-nbtfx.kuma-demo\" mesh=\"default\"", "errorVerbose": "Resource not found: type=\"Dataplane\" name=\"redis-686bbbb5c8-nbtfx.kuma-demo\" mesh=\"default\"\ncould not build dataplane proxy\ngithub.com/kumahq/kuma/pkg/xds/sync.(*DataplaneWatchdog).syncDataplane\n\tgithub.com/kumahq/kuma/pkg/xds/sync/dataplane_watchdog.go:136\ngithub.com/kumahq/kuma/pkg/xds/sync.(*DataplaneWatchdog).Sync\n\tgithub.com/kumahq/kuma/pkg/xds/sync/dataplane_watchdog.go:79\ngithub.com/kumahq/kuma/pkg/xds/sync.(*dataplaneWatchdogFactory).New.func2\n\tgithub.com/kumahq/kuma/pkg/xds/sync/dataplane_watchdog_factory.go:43\ngithub.com/kumahq/kuma/pkg/util/watchdog.(*SimpleWatchdog).onTick\n\tgithub.com/kumahq/kuma/pkg/util/watchdog/watchdog.go:70\ngithub.com/kumahq/kuma/pkg/util/watchdog.(*SimpleWatchdog).Start\n\tgithub.com/kumahq/kuma/pkg/util/watchdog/watchdog.go:40\nruntime.goexit\n\truntime/asm_arm64.s:1197"}
```

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
