### PR TITLE
chore(helm): added action for helm release

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -1,0 +1,85 @@
+name: "Helm Charts"
+# This workflow provides two things:
+# On explicit dispatch, it packages, uploads and releases the chart to the
+# charts repo.
+#   It uses the appVersion and version as present in Chart.yaml.
+# On push to master, it packages and uploads a helm chart for the pushed commit.
+#   It updates both appVersion and version to be specific to this commit.
+#   See tools/release/helm.sh#dev_version
+# This workflow can be tested by any owner with a fork of kumahq/kuma and kumahq/charts
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: Release charts
+        required: false
+        default: false
+        type: boolean
+env:
+  GH_USER: "github-actions[bot]"
+  GH_EMAIL: "<41898282+github-actions[bot]@users.noreply.github.com>"
+  GH_OWNER: ${{ github.repository_owner }}
+  HELM_DEV: ${{ contains(fromJSON('["pull_request", "push"]'), github.event_name) }}
+  GITHUB_APP: "true"
+  KUMA_DIR: "."
+  CI_TOOLS_DIR: /home/runner/work/kuma/kuma/.ci_tools
+jobs:
+  package:
+    name: Package
+    runs-on: ubuntu-latest
+    outputs:
+      filename: ${{ steps.package.outputs.filename }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ${{ env.CI_TOOLS_DIR }}
+          key: ${{ runner.os }}-${{ runner.arch }}-devtools-${{ hashFiles('mk/dependencies/deps.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-devtools
+      - name: Install dependencies
+        run: |
+          make dev/tools
+      - name: package-helm-chart
+        id: package
+        run: |
+          make helm/update-version
+
+          git config user.name "${GH_USER}"
+          git config user.email "${GH_EMAIL}"
+          git add -u deployments/charts
+          # This commit never ends up in the repo
+          git commit --allow-empty -m "ci(helm): update versions"
+          # To get an idea of what's in the commit to debug
+          git show
+
+          make helm/package
+          PKG_FILENAME=$(find .cr-release-packages -type f -printf "%f\n")
+          echo "filename=${PKG_FILENAME}" >> $GITHUB_OUTPUT
+      - name: Upload packaged chart
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.package.outputs.filename }}
+          path: .cr-release-packages/${{ steps.package.outputs.filename }}
+          retention-days: ${{ github.event_name == 'pull_request' && 1 || 30 }}
+      # Everything from here is only running on releases.
+      # Ideally we'd finish the workflow early but this isn't possible: https://github.com/actions/runner/issues/662
+      - name: Generate GitHub app token
+        id: github-app-token
+        if: github.event.inputs.release == 'true'
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+      - name: Release chart
+        if: github.event.inputs.release == 'true'
+        env:
+          GH_TOKEN: ${{ steps.github-app-token.outputs.token }}
+        run: make helm/release


### PR DESCRIPTION
### Checklist prior to review


- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
