### PR TITLE
fix(kuma-cp): return wrapped forward KDS client errors

### DIFF
--- a/pkg/core/rest/errors/error_handler.go
+++ b/pkg/core/rest/errors/error_handler.go
@@ -146,7 +146,7 @@ func HandleError(ctx context.Context, response *restful.Response, err error, tit
 			Title:  title,
 			Detail: err.Error(),
 		}
-	case errors.Is(err, &admin.KDSTransportError{}):
+	case errors.Is(err, &admin.KDSTransportError{}), errors.Is(err, &envoyadmin.ForwardKDSRequestError{}):
 		kumaErr = &types.Error{
 			Status: 400,
 			Title:  title,

--- a/pkg/envoy/admin/kds_client.go
+++ b/pkg/envoy/admin/kds_client.go
@@ -58,6 +58,9 @@ func (k *kdsEnvoyAdminClient) ConfigDump(ctx context.Context, proxy core_model.R
 		ResourceMesh: proxy.GetMeta().GetMesh(), // should be empty for ZoneIngress/ZoneEgress
 	})
 	if err != nil {
+		if errors.Is(err, KDSTransportError{}){
+			return nil, &KDSTransportError{requestType: "XDSConfigRequest", reason: err.Error()}
+		}
 		return nil, &KDSTransportError{requestType: "XDSConfigRequest", reason: err.Error()}
 	}
 

--- a/pkg/envoy/admin/kds_client.go
+++ b/pkg/envoy/admin/kds_client.go
@@ -58,9 +58,6 @@ func (k *kdsEnvoyAdminClient) ConfigDump(ctx context.Context, proxy core_model.R
 		ResourceMesh: proxy.GetMeta().GetMesh(), // should be empty for ZoneIngress/ZoneEgress
 	})
 	if err != nil {
-		if errors.Is(err, KDSTransportError{}){
-			return nil, &KDSTransportError{requestType: "XDSConfigRequest", reason: err.Error()}
-		}
 		return nil, &KDSTransportError{requestType: "XDSConfigRequest", reason: err.Error()}
 	}
 

--- a/pkg/intercp/envoyadmin/forwarding_kds_client.go
+++ b/pkg/intercp/envoyadmin/forwarding_kds_client.go
@@ -85,6 +85,9 @@ func (f *forwardingKdsEnvoyAdminClient) ConfigDump(ctx context.Context, proxy co
 	if err != nil {
 		return nil, err
 	}
+	if resp != nil && resp.GetError() != "" {
+		return nil, &ForwardKDSRequestError{reason: resp.GetError()}
+	}
 	return resp.GetConfig(), nil
 }
 
@@ -111,6 +114,9 @@ func (f *forwardingKdsEnvoyAdminClient) Stats(ctx context.Context, proxy core_mo
 	if err != nil {
 		return nil, err
 	}
+	if resp != nil && resp.GetError() != "" {
+		return nil, &ForwardKDSRequestError{reason: resp.GetError()}
+	}
 	return resp.GetStats(), nil
 }
 
@@ -136,6 +142,9 @@ func (f *forwardingKdsEnvoyAdminClient) Clusters(ctx context.Context, proxy core
 	resp, err := client.Clusters(ctx, req)
 	if err != nil {
 		return nil, err
+	}
+	if resp != nil && resp.GetError() != "" {
+		return nil, &ForwardKDSRequestError{reason: resp.GetError()}
 	}
 	return resp.GetClusters(), nil
 }
@@ -194,5 +203,17 @@ func (e *StreamNotConnectedError) Error() string {
 }
 
 func (e *StreamNotConnectedError) Is(err error) bool {
+	return reflect.TypeOf(e) == reflect.TypeOf(err)
+}
+
+type ForwardKDSRequestError struct {
+	reason string
+}
+
+func (e *ForwardKDSRequestError) Error() string {
+	return e.reason
+}
+
+func (e *ForwardKDSRequestError) Is(err error) bool {
 	return reflect.TypeOf(e) == reflect.TypeOf(err)
 }

--- a/pkg/intercp/envoyadmin/server.go
+++ b/pkg/intercp/envoyadmin/server.go
@@ -40,6 +40,13 @@ func (s *server) XDSConfig(ctx context.Context, req *mesh_proto.XDSConfigRequest
 	}
 	configDump, err := s.adminClient.ConfigDump(ctx, resWithAddr)
 	if err != nil {
+		if errors.Is(err, &admin.KDSTransportError{}){
+			return &mesh_proto.XDSConfigResponse{
+				Result: &mesh_proto.XDSConfigResponse_Error{
+					Error: err.Error(),
+				},
+			}, nil
+		}
 		return nil, err
 	}
 	return &mesh_proto.XDSConfigResponse{
@@ -58,6 +65,13 @@ func (s *server) Stats(ctx context.Context, req *mesh_proto.StatsRequest) (*mesh
 	}
 	stats, err := s.adminClient.Stats(ctx, resWithAddr)
 	if err != nil {
+		if errors.Is(err, &admin.KDSTransportError{}){
+			return &mesh_proto.StatsResponse{
+				Result: &mesh_proto.StatsResponse_Error{
+					Error: err.Error(),
+				},
+			}, nil
+		}
 		return nil, err
 	}
 	return &mesh_proto.StatsResponse{
@@ -76,6 +90,13 @@ func (s *server) Clusters(ctx context.Context, req *mesh_proto.ClustersRequest) 
 	}
 	clusters, err := s.adminClient.Clusters(ctx, resWithAddr)
 	if err != nil {
+		if errors.Is(err, &admin.KDSTransportError{}){
+			return &mesh_proto.ClustersResponse{
+				Result: &mesh_proto.ClustersResponse_Error{
+					Error: err.Error(),
+				},
+			}, nil
+		}
 		return nil, err
 	}
 	return &mesh_proto.ClustersResponse{

--- a/pkg/intercp/envoyadmin/server.go
+++ b/pkg/intercp/envoyadmin/server.go
@@ -40,7 +40,7 @@ func (s *server) XDSConfig(ctx context.Context, req *mesh_proto.XDSConfigRequest
 	}
 	configDump, err := s.adminClient.ConfigDump(ctx, resWithAddr)
 	if err != nil {
-		if errors.Is(err, &admin.KDSTransportError{}){
+		if errors.Is(err, &admin.KDSTransportError{}) {
 			return &mesh_proto.XDSConfigResponse{
 				Result: &mesh_proto.XDSConfigResponse_Error{
 					Error: err.Error(),
@@ -65,7 +65,7 @@ func (s *server) Stats(ctx context.Context, req *mesh_proto.StatsRequest) (*mesh
 	}
 	stats, err := s.adminClient.Stats(ctx, resWithAddr)
 	if err != nil {
-		if errors.Is(err, &admin.KDSTransportError{}){
+		if errors.Is(err, &admin.KDSTransportError{}) {
 			return &mesh_proto.StatsResponse{
 				Result: &mesh_proto.StatsResponse_Error{
 					Error: err.Error(),
@@ -90,7 +90,7 @@ func (s *server) Clusters(ctx context.Context, req *mesh_proto.ClustersRequest) 
 	}
 	clusters, err := s.adminClient.Clusters(ctx, resWithAddr)
 	if err != nil {
-		if errors.Is(err, &admin.KDSTransportError{}){
+		if errors.Is(err, &admin.KDSTransportError{}) {
 			return &mesh_proto.ClustersResponse{
 				Result: &mesh_proto.ClustersResponse_Error{
 					Error: err.Error(),


### PR DESCRIPTION
### Checklist prior to review

Global control-plane forwards admin requests to an instance of global cp which has a connection. In case other instance returns errors, these errors are not mapped correctly by the handler and might return not expected API code.

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
