### PR TITLE
test(e2e): print kube state on failure

### DIFF
--- a/test/e2e_env/kubernetes/kubernetes_suite_test.go
+++ b/test/e2e_env/kubernetes/kubernetes_suite_test.go
@@ -50,6 +50,7 @@ var _ = E2ESynchronizedBeforeSuite(kubernetes.SetupAndGetState, kubernetes.Resto
 var _ = SynchronizedAfterSuite(func() {}, func() {})
 
 var _ = ReportAfterSuite("cp logs", kubernetes.PrintCPLogsOnFailure)
+var _ = ReportAfterSuite("kube state", kubernetes.PrintKubeState)
 
 var (
 	_ = Describe("Virtual Probes", healthcheck.VirtualProbes, Ordered)

--- a/test/e2e_env/multizone/multizone_suite_test.go
+++ b/test/e2e_env/multizone/multizone_suite_test.go
@@ -43,6 +43,7 @@ var (
 		}
 	})
 	_ = ReportAfterSuite("cp logs", multizone.PrintCPLogsOnFailure)
+	_ = ReportAfterSuite("kube state", multizone.PrintKubeState)
 )
 
 var (

--- a/test/framework/envs/kubernetes/env.go
+++ b/test/framework/envs/kubernetes/env.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"encoding/json"
 
+	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -79,6 +80,15 @@ func PrintCPLogsOnFailure(report ginkgo.Report) {
 			framework.Logf("could not retrieve cp logs")
 		} else {
 			framework.Logf(logs)
+		}
+	}
+}
+
+func PrintKubeState(report ginkgo.Report) {
+	if !report.SuiteSucceeded {
+		// just running it, prints the logs
+		if err := k8s.RunKubectlE(Cluster.GetTesting(), Cluster.GetKubectlOptions(), "get", "pods", "-A"); err != nil {
+			framework.Logf("could not retrieve kube pods")
 		}
 	}
 }


### PR DESCRIPTION
### Checklist prior to review

From time to time we see failure on cluster startup like this one
https://app.circleci.com/pipelines/gh/kumahq/kuma/30999/workflows/9b3bcae4-8ab5-431d-ba48-6ff20be468af/jobs/578955

The error is
```
 2024-02-06T15:07:44Z logger.go:66: 2024-02-06T15:05:53.318Z	INFO	kds-delta-zone	error during callback received, sending NACK	{"kds-version": "v2", "err": "failed to create k8s resource: Internal error occurred: failed calling webhook \"mesh.defaulter.kuma-admission.kuma.io\": failed to call webhook: Post \"https://kuma-control-plane.kuma-system.svc:443/default-kuma-io-v1alpha1-mesh?timeout=10s\": no endpoints available for service \"kuma-control-plane\"", "errVerbose": "Internal error occurred: failed calling webhook \"mesh.defaulter.kuma-admission.kuma.io\": failed to call webhook: Post \"https://kuma-control-plane.kuma-system.svc:443/default-kuma-io-v1alpha1-mesh?timeout=10s\": no endpoints available for service \"kuma-control-plane\"\nfailed to create k8s resource\ngithub.com/kumahq/kuma/pkg/plugins/resources/k8s.(*KubernetesStore).Create\n\tgithub.com/kumahq/kuma/pkg/plugins/resources/k8s/store.go:80\ngithub.com/kumahq/kuma/pkg/core/resources/store.(*paginationStore).Create\n\tgithub.com/kumahq/kuma/pkg/core/resources/store/pagination_store.go:30\ngithub.com/kumahq/kuma/pkg/metrics/store.(*MeteredStore).Create\n\tgithub.com/kumahq/kuma/pkg/metrics/store/store.go:44\ngithub.com/kumahq/kuma/pkg/core/resources/store.(*customizableResourceStore).Create\n\tgithub.com/kumahq/kuma/pkg/core/resources/store/customizable_store.go:44\ngithub.com/kumahq/kuma/pkg/kds/v2/store.(*syncResourceStore).Sync.func2\n\tgithub.com/kumahq/kuma/pkg/kds/v2/store/sync.go:230\ngithub.com/kumahq/kuma/pkg/core/resources/store.InTx\n\tgithub.com/kumahq/kuma/pkg/core/resources/store/transactions.go:46\ngithub.com/kumahq/kuma/pkg/kds/v2/store.(*syncResourceStore).Sync\n\tgithub.com/kumahq/kuma/pkg/kds/v2/store/sync.go:205\ngithub.com/kumahq/kuma/pkg/kds/zone.Setup.func2.ZoneSyncCallback.func3\n\tgithub.com/kumahq/kuma/pkg/kds/v2/store/sync.go:305\ngithub.com/kumahq/kuma/pkg/kds/v2/client.(*kdsSyncClient).Receive\n\tgithub.com/kumahq/kuma/pkg/kds/v2/client/kds_client.go:90\ngithub.com/kumahq/kuma/pkg/kds/zone.Setup.func2.1\n\tgithub.com/kumahq/kuma/pkg/kds/zone/components.go:134\nruntime.goexit\n\truntime/asm_arm64.s:1197"}
```

Which either means that CP is unhealthy or there is some general problem with networking in a cluster. I want to print pods in this case to see what's wrong.

Any other suggestions how to combat this are welcomed.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
