### PR TITLE
fix(MeshGateway): fix MeshTCPRoute on MeshGateway

### DIFF
--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
@@ -422,11 +422,13 @@ var _ = Describe("MeshHealthCheck", func() {
 						rules.NewInboundListenerHostname("192.168.0.1", 8081, "*"): {
 							{
 								Subset: core_rules.MeshSubset(),
-								Conf: meshtcproute_api.RuleConf{
-									BackendRefs: []common_api.BackendRef{{
-										TargetRef: builders.TargetRefService("backend"),
-										Weight:    pointer.To(uint(100)),
-									}},
+								Conf: meshtcproute_api.Rule{
+									Default: meshtcproute_api.RuleConf{
+										BackendRefs: []common_api.BackendRef{{
+											TargetRef: builders.TargetRefService("backend"),
+											Weight:    pointer.To(uint(100)),
+										}},
+									},
 								},
 							},
 						},

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/gateway_routes.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/gateway_routes.go
@@ -121,7 +121,7 @@ func sortRulesToHosts(
 			hostInfo := plugin_gateway.GatewayHostInfo{
 				Host: host,
 			}
-			hostInfo.AppendEntries(GenerateEnvoyRouteEntries(host, rules))
+			hostInfo.AppendEntries(generateEnvoyRouteEntries(host, rules))
 
 			meshroute.AddToListenerByHostname(
 				hostInfosByHostname,
@@ -136,7 +136,7 @@ func sortRulesToHosts(
 	return meshroute.SortByHostname(hostInfosByHostname)
 }
 
-func GenerateEnvoyRouteEntries(host plugin_gateway.GatewayHost, toRules []ruleByHostname) []route.Entry {
+func generateEnvoyRouteEntries(host plugin_gateway.GatewayHost, toRules []ruleByHostname) []route.Entry {
 	var entries []route.Entry
 
 	toRules = match.SortHostnamesOn(toRules, func(r ruleByHostname) string { return r.Hostname })

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/gateway.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/gateway.go
@@ -67,7 +67,7 @@ func generateGatewayClusters(
 	return resources, nil
 }
 
-func GenerateEnvoyRouteEntries(host plugin_gateway.GatewayHost, toRules rules.Rules) []route.Entry {
+func generateEnvoyRouteEntries(host plugin_gateway.GatewayHost, toRules rules.Rules) []route.Entry {
 	var entries []route.Entry
 
 	for _, rule := range toRules {
@@ -76,18 +76,18 @@ func GenerateEnvoyRouteEntries(host plugin_gateway.GatewayHost, toRules rules.Ru
 			names = append(names, orig.GetName())
 		}
 		slices.Sort(names)
-		entries = append(entries, makeTcpRouteEntry(strings.Join(names, "_"), rule.Conf.(api.RuleConf)))
+		entries = append(entries, makeTcpRouteEntry(strings.Join(names, "_"), rule.Conf.(api.Rule)))
 	}
 
 	return plugin_gateway.HandlePrefixMatchesAndPopulatePolicies(host, nil, nil, entries)
 }
 
-func makeTcpRouteEntry(name string, rule api.RuleConf) route.Entry {
+func makeTcpRouteEntry(name string, rule api.Rule) route.Entry {
 	entry := route.Entry{
 		Route: name,
 	}
 
-	for _, b := range rule.BackendRefs {
+	for _, b := range rule.Default.BackendRefs {
 		dest, ok := tags.FromTargetRef(b.TargetRef)
 		if !ok {
 			// This should be caught by validation

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin.go
@@ -178,11 +178,11 @@ func sortRulesToHosts(
 			listener.GetPort(),
 			hostnameTag.Hostname,
 		)
-		rules, ok := rawRules.ToRules.ByListenerAndHostname[inboundListener]
+		rulesForListener, ok := rawRules.ToRules.ByListenerAndHostname[inboundListener]
 		if !ok {
 			continue
 		}
-		hostInfo.AppendEntries(GenerateEnvoyRouteEntries(host, rules))
+		hostInfo.AppendEntries(generateEnvoyRouteEntries(host, rulesForListener))
 		meshroute.AddToListenerByHostname(
 			hostInfosByHostname,
 			listener.Protocol,

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
@@ -705,32 +705,38 @@ var _ = Describe("MeshTCPRoute", func() {
 
 			rules := core_rules.Rule{
 				Subset: core_rules.MeshSubset(),
-				Conf: api.RuleConf{
-					BackendRefs: []common_api.BackendRef{{
-						TargetRef: builders.TargetRefService("backend"),
-						Weight:    pointer.To(uint(100)),
-					}},
+				Conf: api.Rule{
+					Default: api.RuleConf{
+						BackendRefs: []common_api.BackendRef{{
+							TargetRef: builders.TargetRefService("backend"),
+							Weight:    pointer.To(uint(100)),
+						}},
+					},
 				},
 			}
 			tlsGoRules := core_rules.Rule{
 				Subset: core_rules.MeshSubset(),
-				Conf: api.RuleConf{
-					BackendRefs: []common_api.BackendRef{{
-						TargetRef: builders.TargetRefService("go-backend-1"),
-						Weight:    pointer.To(uint(50)),
-					}, {
-						TargetRef: builders.TargetRefService("go-backend-2"),
-						Weight:    pointer.To(uint(50)),
-					}},
+				Conf: api.Rule{
+					Default: api.RuleConf{
+						BackendRefs: []common_api.BackendRef{{
+							TargetRef: builders.TargetRefService("go-backend-1"),
+							Weight:    pointer.To(uint(50)),
+						}, {
+							TargetRef: builders.TargetRefService("go-backend-2"),
+							Weight:    pointer.To(uint(50)),
+						}},
+					},
 				},
 			}
 			tlsOtherRules := core_rules.Rule{
 				Subset: core_rules.MeshSubset(),
-				Conf: api.RuleConf{
-					BackendRefs: []common_api.BackendRef{{
-						TargetRef: builders.TargetRefService("other-backend"),
-						Weight:    pointer.To(uint(100)),
-					}},
+				Conf: api.Rule{
+					Default: api.RuleConf{
+						BackendRefs: []common_api.BackendRef{{
+							TargetRef: builders.TargetRefService("other-backend"),
+							Weight:    pointer.To(uint(100)),
+						}},
+					},
 				},
 			}
 			return outboundsTestCase{

--- a/pkg/plugins/runtime/k8s/util/util.go
+++ b/pkg/plugins/runtime/k8s/util/util.go
@@ -167,6 +167,7 @@ func MeshOfByLabelOrAnnotation(log logr.Logger, obj kube_client.Object, namespac
 		return mesh
 	}
 
+	// Label wasn't found on the object, let's look on the namespace instead
 	if mesh, exists := metadata.Annotations(namespace.GetAnnotations()).GetString(metadata.KumaMeshAnnotation); exists && mesh != "" {
 		return mesh
 	}

--- a/test/e2e_env/kubernetes/gateway/delegated.go
+++ b/test/e2e_env/kubernetes/gateway/delegated.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/kumahq/kuma/test/e2e_env/kubernetes/gateway/delegated"
 	. "github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	"github.com/kumahq/kuma/test/framework/deployments/kic"
@@ -13,43 +14,37 @@ import (
 	"github.com/kumahq/kuma/test/framework/envs/kubernetes"
 )
 
-type delegatedE2EConfig struct {
-	namespace            string
-	namespaceOutsideMesh string
-	mesh                 string
-	kicIP                string
-}
-
 func Delegated() {
-	config := &delegatedE2EConfig{
-		namespace:            "delegated-gateway",
-		namespaceOutsideMesh: "delegated-gateway-outside-mesh",
-		mesh:                 "delegated-gateway",
-		kicIP:                "",
+	config := delegated.Config{
+		Namespace:            "delegated-gateway",
+		NamespaceOutsideMesh: "delegated-gateway-outside-mesh",
+		Mesh:                 "delegated-gateway",
+		KicIP:                "",
+		CpNamespace:          Config.KumaNamespace,
 	}
 
 	BeforeAll(func() {
 		err := NewClusterSetup().
-			Install(MTLSMeshKubernetes(config.mesh)).
-			Install(MeshTrafficPermissionAllowAllKubernetes(config.mesh)).
-			Install(NamespaceWithSidecarInjection(config.namespace)).
-			Install(Namespace(config.namespaceOutsideMesh)).
+			Install(MTLSMeshKubernetes(config.Mesh)).
+			Install(MeshTrafficPermissionAllowAllKubernetes(config.Mesh)).
+			Install(NamespaceWithSidecarInjection(config.Namespace)).
+			Install(Namespace(config.NamespaceOutsideMesh)).
 			Install(democlient.Install(
-				democlient.WithNamespace(config.namespaceOutsideMesh),
+				democlient.WithNamespace(config.NamespaceOutsideMesh),
 			)).
 			Install(testserver.Install(
-				testserver.WithMesh(config.mesh),
-				testserver.WithNamespace(config.namespace),
+				testserver.WithMesh(config.Mesh),
+				testserver.WithNamespace(config.Namespace),
 				testserver.WithName("test-server"),
 			)).
 			Install(kic.KongIngressController(
 				kic.WithName("delegated"),
-				kic.WithNamespace(config.namespace),
-				kic.WithMesh(config.mesh),
+				kic.WithNamespace(config.Namespace),
+				kic.WithMesh(config.Mesh),
 			)).
 			Install(kic.KongIngressService(
 				kic.WithName("delegated"),
-				kic.WithNamespace(config.namespace),
+				kic.WithNamespace(config.Namespace),
 			)).
 			Install(YamlK8s(fmt.Sprintf(`
 apiVersion: networking.k8s.io/v1
@@ -70,24 +65,24 @@ spec:
             name: test-server
             port:
               number: 80
-`, config.namespace, config.mesh))).
+`, config.Namespace, config.Mesh))).
 			Setup(kubernetes.Cluster)
 		Expect(err).ToNot(HaveOccurred())
 
-		kicIP, err := kic.From(kubernetes.Cluster).IP(config.namespace)
-		Expect(err).To(Succeed())
+		kicIP, err := kic.From(kubernetes.Cluster).IP(config.Namespace)
+		Expect(err).ToNot(HaveOccurred())
 
-		config.kicIP = kicIP
+		config.KicIP = kicIP
 	})
 
 	E2EAfterAll(func() {
-		Expect(kubernetes.Cluster.TriggerDeleteNamespace(config.namespace)).
+		Expect(kubernetes.Cluster.TriggerDeleteNamespace(config.Namespace)).
 			To(Succeed())
-		Expect(kubernetes.Cluster.TriggerDeleteNamespace(config.namespaceOutsideMesh)).
+		Expect(kubernetes.Cluster.TriggerDeleteNamespace(config.NamespaceOutsideMesh)).
 			To(Succeed())
-		Expect(kubernetes.Cluster.DeleteMesh(config.mesh)).To(Succeed())
+		Expect(kubernetes.Cluster.DeleteMesh(config.Mesh)).To(Succeed())
 	})
 
-	Context("MeshCircuitBreaker", CircuitBreaker(config))
-	Context("MeshProxyPatch", MeshProxyPatch(config))
+	Context("MeshCircuitBreaker", delegated.CircuitBreaker(&config))
+	Context("MeshProxyPatch", delegated.MeshProxyPatch(&config))
 }

--- a/test/e2e_env/kubernetes/gateway/delegated/common.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/common.go
@@ -1,0 +1,9 @@
+package delegated
+
+type Config struct {
+	Namespace            string
+	NamespaceOutsideMesh string
+	Mesh                 string
+	KicIP                string
+	CpNamespace          string
+}

--- a/test/e2e_env/kubernetes/gateway/gateway.go
+++ b/test/e2e_env/kubernetes/gateway/gateway.go
@@ -71,6 +71,8 @@ spec:
     - port: 8082
       protocol: HTTP
       hostname: '*'
+    - port: 8083
+      protocol: TCP
 `
 	httpsSecret := func() string {
 		cert, key, err := CreateCertsFor("example.kuma.io")
@@ -89,6 +91,7 @@ data:
 type: system.kuma.io/secret
 `, Config.KumaNamespace, secretData)
 	}
+	var clusterIP string
 
 	BeforeAll(func() {
 		err := NewClusterSetup().
@@ -99,12 +102,29 @@ type: system.kuma.io/secret
 				testserver.WithName("demo-client"),
 				testserver.WithNamespace(clientNamespace),
 			)).
+			Install(testserver.Install(
+				testserver.WithName("echo-server"),
+				testserver.WithMesh(meshName),
+				testserver.WithNamespace(namespace),
+				testserver.WithEchoArgs("echo", "--instance", "echo-server"),
+			)).
 			Install(YamlK8s(httpsSecret())).
 			Install(YamlK8s(meshGateway)).
 			Install(YamlK8s(MkGatewayInstance("simple-gateway", namespace, meshName))).
 			Install(MeshTrafficPermissionAllowAllKubernetes(meshName)).
 			Setup(kubernetes.Cluster)
 		Expect(err).ToNot(HaveOccurred())
+
+		Eventually(func(g Gomega) {
+			var err error
+			clusterIP, err = k8s.RunKubectlAndGetOutputE(
+				kubernetes.Cluster.GetTesting(),
+				kubernetes.Cluster.GetKubectlOptions(namespace),
+				"get", "service", "simple-gateway", "-ojsonpath={.spec.clusterIP}",
+			)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(clusterIP).ToNot(BeEmpty())
+		}, "30s", "1s").Should(Succeed())
 	})
 
 	E2EAfterAll(func() {
@@ -113,7 +133,7 @@ type: system.kuma.io/secret
 		Expect(kubernetes.Cluster.DeleteMesh(meshName)).To(Succeed())
 	})
 
-	route := func(name, path, destination string) []string {
+	meshGatewayRoutes := func(name, path, destination string) []string {
 		return []string{
 			fmt.Sprintf(`
 apiVersion: kuma.io/v1alpha1
@@ -298,29 +318,11 @@ spec:
 
 	basicRouting := func(name string, routeYAMLs []string) {
 		Context(fmt.Sprintf("Mesh service - %s", name), func() {
-			var clusterIP string
 			BeforeAll(func() {
 				Expect(NewClusterSetup().
-					Install(testserver.Install(
-						testserver.WithName("echo-server"),
-						testserver.WithMesh(meshName),
-						testserver.WithNamespace(namespace),
-						testserver.WithEchoArgs("echo", "--instance", "echo-server"),
-					)).
 					Install(YamlK8s(routeYAMLs...)).
 					Setup(kubernetes.Cluster),
 				).To(Succeed())
-
-				Eventually(func(g Gomega) {
-					var err error
-					clusterIP, err = k8s.RunKubectlAndGetOutputE(
-						kubernetes.Cluster.GetTesting(),
-						kubernetes.Cluster.GetKubectlOptions(namespace),
-						"get", "service", "simple-gateway", "-ojsonpath={.spec.clusterIP}",
-					)
-					g.Expect(err).ToNot(HaveOccurred())
-					g.Expect(clusterIP).ToNot(BeEmpty())
-				}, "30s", "1s").Should(Succeed())
 			})
 
 			E2EAfterAll(func() {
@@ -342,7 +344,7 @@ spec:
 					g.Expect(err).ToNot(HaveOccurred())
 					g.Expect(response.Instance).To(Equal("echo-server"))
 					g.Expect(response.Received.Headers).ToNot(HaveKey("X-Specific-Hostname-Header"))
-				}, "30s", "1s").Should(Succeed())
+				}, "1m", "1s").Should(Succeed())
 			})
 			It("should proxy to service via HTTP with port in host", func() {
 				Eventually(func(g Gomega) {
@@ -460,7 +462,7 @@ spec:
 		})
 	}
 
-	basicRouting("MeshGatewayRoute", route("internal-service", "/", "echo-server_simple-gateway_svc_80"))
+	basicRouting("MeshGatewayRoute", meshGatewayRoutes("internal-service", "/", "echo-server_simple-gateway_svc_80"))
 	basicRouting("MeshHTTPRoute", httpRoute("internal-service", "/", "echo-server_simple-gateway_svc_80"))
 
 	Context("Rate Limit", func() {
@@ -480,6 +482,7 @@ spec:
     http:
       requests: 5
       interval: 10s`
+		routes := meshGatewayRoutes("rt-echo-server", "/rt", "rt-echo-server_simple-gateway_svc_80")
 
 		BeforeAll(func() {
 			err := NewClusterSetup().
@@ -490,7 +493,14 @@ spec:
 					testserver.WithEchoArgs("echo", "--instance", "rt-echo-server"),
 				)).
 				Install(YamlK8s(rt)).
-				Install(YamlK8s(route("rt-echo-server", "/rt", "rt-echo-server_simple-gateway_svc_80")...)).
+				Install(YamlK8s(routes...)).
+				Setup(kubernetes.Cluster)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterAll(func() {
+			err := NewClusterSetup().
+				Install(DeleteYamlK8s(routes...)).
 				Setup(kubernetes.Cluster)
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -508,6 +518,62 @@ spec:
 
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(response.ResponseCode).To(Equal(429))
+			}, "30s", "1s").Should(Succeed())
+		})
+	})
+
+	Context("TCPRoute", func() {
+		routes := []string{
+			fmt.Sprintf(`
+apiVersion: kuma.io/v1alpha1
+kind: MeshTCPRoute
+metadata:
+  name: simple-gateway-tcp-route
+  namespace: %s
+  labels:
+    kuma.io/mesh: simple-gateway
+spec:
+  targetRef:
+    kind: MeshGateway
+    name: simple-gateway
+  to:
+    - targetRef:
+        kind: Mesh
+      rules:
+        - default:
+            backendRefs:
+              - kind: MeshService
+                name: test-tcp-server_simple-gateway_svc_80 
+`, Config.KumaNamespace),
+		}
+		BeforeAll(func() {
+			err := NewClusterSetup().
+				Install(testserver.Install(
+					testserver.WithName("test-tcp-server"),
+					testserver.WithServicePortAppProtocol("tcp"),
+					testserver.WithMesh(meshName),
+					testserver.WithNamespace(namespace),
+				)).
+				Install(YamlK8s(routes...)).
+				Setup(kubernetes.Cluster)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		AfterAll(func() {
+			err := NewClusterSetup().
+				Install(DeleteYamlK8s(routes...)).
+				Setup(kubernetes.Cluster)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should work on TCP service", func() {
+			Eventually(func(g Gomega) {
+				response, err := client.CollectEchoResponse(
+					kubernetes.Cluster, "demo-client",
+					"http://simple-gateway.simple-gateway:8083/",
+					client.FromKubernetesPod(clientNamespace, "demo-client"),
+				)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(response.Instance).To(HavePrefix("test-tcp-server"))
 			}, "30s", "1s").Should(Succeed())
 		})
 	})
@@ -533,14 +599,13 @@ spec:
 					testserver.WithNamespace(clientNamespace),
 					testserver.WithEchoArgs("echo", "--instance", "es-echo-server"),
 				)).
-				Install(MeshTrafficPermissionAllowAllKubernetes(meshName)).
 				Install(YamlK8s(externalService)).
 				Setup(kubernetes.Cluster)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should proxy to service via HTTP", func() {
-			route := route("es-echo-server", "/external-service", "external-service")
+			route := meshGatewayRoutes("es-echo-server", "/external-service", "external-service")
 			setup := NewClusterSetup().Install(YamlK8s(route...))
 			Expect(setup.Setup(kubernetes.Cluster)).To(Succeed())
 
@@ -560,7 +625,7 @@ spec:
 		})
 
 		It("should automatically set host header from external service address when rewrite.hostToBackendHostname is set to true", func() {
-			route := route("es-echo-server", "/external-service", "external-service")
+			route := meshGatewayRoutes("es-echo-server", "/external-service", "external-service")
 			setup := NewClusterSetup().Install(YamlK8s(route...))
 			Expect(setup.Setup(kubernetes.Cluster)).To(Succeed())
 

--- a/test/e2e_env/kubernetes/gateway/utils.go
+++ b/test/e2e_env/kubernetes/gateway/utils.go
@@ -101,7 +101,7 @@ kind: MeshGatewayInstance
 metadata:
   name: %s
   namespace: %s
-  annotations:
+  labels:
     kuma.io/mesh: %s
 spec:
   replicas: 1


### PR DESCRIPTION
- MeshTCPRoute when applied to a MeshGateway would panic thus making it unusable. This fixes this and backfills e2e tests
- Refactor tests to make them easier to maintain

Fix #9154

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
