### PR TITLE
test(e2e): use `kumactl get meshes` to check on kuma health

### DIFF
--- a/test/framework/k8s_controlplane.go
+++ b/test/framework/k8s_controlplane.go
@@ -134,10 +134,7 @@ func (c *K8sControlPlane) VerifyKumaCtl() error {
 		return errors.Errorf("API port not forwarded")
 	}
 
-	output, err := c.kumactl.RunKumactlAndGetOutputV(c.verbose, "get", "dataplanes")
-	fmt.Println(output)
-
-	return err
+	return c.kumactl.RunKumactl("get", "meshes")
 }
 
 func (c *K8sControlPlane) VerifyKumaREST() error {

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -216,7 +216,7 @@ func (c *UniversalCluster) GetKumaCPLogs() (string, error) {
 }
 
 func (c *UniversalCluster) VerifyKuma() error {
-	return c.controlplane.kumactl.RunKumactl("get", "dataplanes")
+	return c.controlplane.kumactl.RunKumactl("get", "meshes")
 }
 
 func (c *UniversalCluster) DeleteKuma() error {


### PR DESCRIPTION
Before we were doing `kumactl get dataplanes`.
but since #9175 this returns 404 when the default mesh doesn't exist. We have e2e tests where we skip the creation of the default mesh. We now use just `get meshes` so that this always works

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
