### PR TITLE
fix(kuma-cp): prevent violating kubernetes label limit

### DIFF
--- a/pkg/config/multizone/multicluster.go
+++ b/pkg/config/multizone/multicluster.go
@@ -80,6 +80,9 @@ func (r *ZoneConfig) Validate() error {
 	if !govalidator.IsDNSName(r.Name) {
 		return errors.Errorf("Zone name %s has to be a valid DNS name", r.Name)
 	}
+	if len(r.Name) > 63 {
+		return errors.New("Zone name cannot be longer than 63 characters")
+	}
 	if r.GlobalAddress != "" {
 		u, err := url.Parse(r.GlobalAddress)
 		if err != nil {

--- a/pkg/core/managers/apis/mesh/mesh_manager_test.go
+++ b/pkg/core/managers/apis/mesh/mesh_manager_test.go
@@ -216,6 +216,17 @@ var _ = Describe("Mesh Manager", func() {
 			// then
 			Expect(err).To(MatchError("mtls.backends[0].conf.cert: has to be defined; mtls.backends[0].conf.key: has to be defined"))
 		})
+
+		It("should not create mesh with name longer than 64 chars", func() {
+			name := ""
+			for i := 0; i < 64; i++ {
+				name += "x"
+			}
+			err := resManager.Create(context.Background(), core_mesh.NewMeshResource(), store.CreateByKey(name, model.NoMesh))
+
+			// then
+			Expect(err).To(MatchError("name: cannot be longer than 63 characters"))
+		})
 	})
 
 	Describe("Delete()", func() {

--- a/pkg/core/managers/apis/mesh/mesh_validator.go
+++ b/pkg/core/managers/apis/mesh/mesh_validator.go
@@ -31,6 +31,11 @@ func NewMeshValidator(caManagers core_ca.Managers, store core_store.ResourceStor
 }
 
 func (m *meshValidator) ValidateCreate(ctx context.Context, name string, resource *core_mesh.MeshResource) error {
+	if len(name) > 63 {
+		var verr validators.ValidationError
+		verr.AddViolation("name", "cannot be longer than 63 characters")
+		return verr.OrNil()
+	}
 	if err := ValidateMTLSBackends(ctx, m.CaManagers, name, resource); err != nil {
 		return err
 	}

--- a/pkg/core/managers/apis/mesh/mesh_validator.go
+++ b/pkg/core/managers/apis/mesh/mesh_validator.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_ca "github.com/kumahq/kuma/pkg/core/ca"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
@@ -31,18 +30,15 @@ func NewMeshValidator(caManagers core_ca.Managers, store core_store.ResourceStor
 }
 
 func (m *meshValidator) ValidateCreate(ctx context.Context, name string, resource *core_mesh.MeshResource) error {
+	var verr validators.ValidationError
 	if len(name) > 63 {
-		var verr validators.ValidationError
 		verr.AddViolation("name", "cannot be longer than 63 characters")
-		return verr.OrNil()
 	}
-	if err := ValidateMTLSBackends(ctx, m.CaManagers, name, resource); err != nil {
-		return err
-	}
-	return nil
+	verr.Add(ValidateMTLSBackends(ctx, m.CaManagers, name, resource))
+	return verr.OrNil()
 }
 
-func ValidateMTLSBackends(ctx context.Context, caManagers core_ca.Managers, name string, resource *core_mesh.MeshResource) error {
+func ValidateMTLSBackends(ctx context.Context, caManagers core_ca.Managers, name string, resource *core_mesh.MeshResource) validators.ValidationError {
 	verr := validators.ValidationError{}
 	path := validators.RootedAt("mtls").Field("backends")
 
@@ -50,43 +46,25 @@ func ValidateMTLSBackends(ctx context.Context, caManagers core_ca.Managers, name
 		caManager, exist := caManagers[backend.Type]
 		if !exist {
 			verr.AddViolationAt(path.Index(idx).Field("type"), "could not find installed plugin for this type")
-			return verr.OrNil()
+			return verr
 		} else if !resource.Spec.GetMtls().GetSkipValidation() {
-			if err := validateMTLSBackend(ctx, caManager, name, backend, path.Index(idx), &verr); err != nil {
-				return err
+			if err := caManager.ValidateBackend(ctx, name, backend); err != nil {
+				if configErr, ok := err.(*validators.ValidationError); ok {
+					verr.AddErrorAt(path.Index(idx).Field("conf"), *configErr)
+				} else {
+					verr.AddViolationAt(path, err.Error())
+				}
 			}
 		}
 	}
-	return verr.OrNil()
-}
-
-func validateMTLSBackend(
-	ctx context.Context,
-	caManager core_ca.Manager,
-	name string,
-	backend *mesh_proto.CertificateAuthorityBackend,
-	path validators.PathBuilder,
-	verr *validators.ValidationError,
-) error {
-	if err := caManager.ValidateBackend(ctx, name, backend); err != nil {
-		if configErr, ok := err.(*validators.ValidationError); ok {
-			verr.AddErrorAt(path.Field("conf"), *configErr)
-		} else {
-			verr.AddViolationAt(path, err.Error())
-			return err
-		}
-	}
-	return nil
+	return verr
 }
 
 func (m *meshValidator) ValidateUpdate(ctx context.Context, previousMesh *core_mesh.MeshResource, newMesh *core_mesh.MeshResource) error {
-	if err := m.validateMTLSBackendChange(previousMesh, newMesh); err != nil {
-		return err
-	}
-	if err := ValidateMTLSBackends(ctx, m.CaManagers, newMesh.Meta.GetName(), newMesh); err != nil {
-		return err
-	}
-	return nil
+	var verr validators.ValidationError
+	verr.Add(m.validateMTLSBackendChange(previousMesh, newMesh))
+	verr.Add(ValidateMTLSBackends(ctx, m.CaManagers, newMesh.Meta.GetName(), newMesh))
+	return verr.OrNil()
 }
 
 func (m *meshValidator) ValidateDelete(ctx context.Context, name string) error {
@@ -109,10 +87,10 @@ func ValidateNoActiveDP(ctx context.Context, name string, store core_store.Resou
 	return nil
 }
 
-func (m *meshValidator) validateMTLSBackendChange(previousMesh *core_mesh.MeshResource, newMesh *core_mesh.MeshResource) error {
+func (m *meshValidator) validateMTLSBackendChange(previousMesh *core_mesh.MeshResource, newMesh *core_mesh.MeshResource) validators.ValidationError {
 	verr := validators.ValidationError{}
 	if previousMesh.MTLSEnabled() && newMesh.MTLSEnabled() && previousMesh.Spec.GetMtls().GetEnabledBackend() != newMesh.Spec.GetMtls().GetEnabledBackend() {
 		verr.AddViolation("mtls.enabledBackend", "Changing CA when mTLS is enabled is forbidden. Disable mTLS first and then change the CA")
 	}
-	return verr.OrNil()
+	return verr
 }

--- a/pkg/plugins/resources/k8s/store.go
+++ b/pkg/plugins/resources/k8s/store.go
@@ -58,7 +58,9 @@ func (s *KubernetesStore) Create(ctx context.Context, r core_model.Resource, fs 
 		return err
 	}
 
-	obj.GetObjectMeta().SetLabels(opts.Labels)
+	labels, annotations := splitLabelsAndAnnotations(opts.Labels)
+	obj.GetObjectMeta().SetLabels(labels)
+	obj.GetObjectMeta().SetAnnotations(annotations)
 	obj.SetMesh(opts.Mesh)
 	obj.GetObjectMeta().SetName(name)
 	obj.GetObjectMeta().SetNamespace(namespace)
@@ -97,7 +99,9 @@ func (s *KubernetesStore) Update(ctx context.Context, r core_model.Resource, fs 
 		return errors.Wrapf(err, "failed to convert core model of type %s into k8s counterpart", r.Descriptor().Name)
 	}
 
-	obj.GetObjectMeta().SetLabels(opts.Labels)
+	labels, annotations := splitLabelsAndAnnotations(opts.Labels)
+	obj.GetObjectMeta().SetLabels(labels)
+	obj.GetObjectMeta().SetAnnotations(annotations)
 	obj.SetMesh(r.GetMeta().GetMesh())
 
 	if err := s.Client.Update(ctx, obj); err != nil {
@@ -231,6 +235,16 @@ func k8sNameNamespace(coreName string, scope k8s_model.Scope) (string, string, e
 	}
 }
 
+func splitLabelsAndAnnotations(coreLabels map[string]string) (map[string]string, map[string]string) {
+	labels := maps.Clone(coreLabels)
+	annotations := map[string]string{}
+	if v, ok := labels[v1alpha1.DisplayName]; ok {
+		annotations[v1alpha1.DisplayName] = v
+		delete(labels, v1alpha1.DisplayName)
+	}
+	return labels, annotations
+}
+
 var _ core_model.ResourceMeta = &KubernetesMetaAdapter{}
 
 type KubernetesMetaAdapter struct {
@@ -270,7 +284,9 @@ func (m *KubernetesMetaAdapter) GetLabels() map[string]string {
 	if labels == nil {
 		labels = map[string]string{}
 	}
-	if _, ok := labels[v1alpha1.DisplayName]; !ok {
+	if displayName, ok := m.GetObjectMeta().GetAnnotations()[v1alpha1.DisplayName]; ok {
+		labels[v1alpha1.DisplayName] = displayName
+	} else {
 		labels[v1alpha1.DisplayName] = m.GetObjectMeta().GetName()
 	}
 	if _, ok := labels[v1alpha1.KubeNamespaceTag]; !ok && m.Namespace != "" {

--- a/pkg/plugins/resources/k8s/store.go
+++ b/pkg/plugins/resources/k8s/store.go
@@ -235,6 +235,8 @@ func k8sNameNamespace(coreName string, scope k8s_model.Scope) (string, string, e
 	}
 }
 
+// Kuma resource labels are generally stored on Kubernetes as labels, except "kuma.io/display-name".
+// We store it as an annotation because the resource name on k8s is limited by 253 and the label value is limited by 63.
 func splitLabelsAndAnnotations(coreLabels map[string]string) (map[string]string, map[string]string) {
 	labels := maps.Clone(coreLabels)
 	annotations := map[string]string{}

--- a/pkg/plugins/resources/k8s/store_test.go
+++ b/pkg/plugins/resources/k8s/store_test.go
@@ -532,6 +532,34 @@ var _ = Describe("KubernetesStore", func() {
 				},
 			}))
 		})
+
+		It("should return a display name from annotation", func() {
+			// setup
+			expected := backend.ParseYAML(fmt.Sprintf(`
+            apiVersion: kuma.io/v1alpha1
+            kind: TrafficRoute
+            mesh: default
+            metadata:
+              annotations:
+                kuma.io/display-name: dn
+              name: %s
+            spec:
+              conf:
+                destination:
+                  path: /example
+`, name))
+			backend.Create(expected)
+
+			// given
+			actual := core_mesh.NewTrafficRouteResource()
+
+			// when
+			err := s.Get(context.Background(), actual, store.GetByKey(name, mesh))
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual.Meta.GetLabels()[mesh_proto.DisplayName]).To(Equal("dn"))
+		})
 	})
 
 	Describe("Delete()", func() {


### PR DESCRIPTION
### Checklist prior to review

Fix #9168

Introduce limit for mesh name to 63. This is a limit of a label in Kubernetes. Since attach policy to a mesh via label, there is no way to attach a policy if a mesh name is longer than 63 chars. Store `display-name` as annotation on Kubernetes to escape the limit of 63 chars.
Other labels already have a validation of 63 chars.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
