### PR TITLE
chore(logging): ignore missing mesh in aggregate context

### DIFF
--- a/pkg/xds/context/mesh_context_builder.go
+++ b/pkg/xds/context/mesh_context_builder.go
@@ -230,7 +230,7 @@ func (m *meshContextBuilder) BuildGlobalContextIfChanged(ctx context.Context, la
 func (m *meshContextBuilder) BuildBaseMeshContextIfChanged(ctx context.Context, meshName string, latest *BaseMeshContext) (*BaseMeshContext, error) {
 	mesh := core_mesh.NewMeshResource()
 	if err := m.rm.Get(ctx, mesh, core_store.GetByKey(meshName, core_model.NoMesh)); err != nil {
-		return nil, errors.Wrapf(err, "could not fetch mesh %s", meshName)
+		return nil, err
 	}
 	rmap := ResourceMap{}
 	// Add the mesh to the resourceMap


### PR DESCRIPTION
### Checklist prior to review

We cannot wrap the error because of how `core_store.IsResourceNotFound` works. Ideally, we should create a type for not found error, but that sounds like a big separate PR.
https://github.com/kumahq/kuma/blob/master/pkg/xds/context/aggregate_mesh_context.go#L31 

```
  2024-02-13T08:55:34.339Z	ERROR	xds-server.dataplane-sync-watchdog	OnTick() failed	{"dataplaneKey": {"Mesh":"","Name":"egress"}, "error": "could not aggregate mesh contexts: could not fetch mesh connectivity: Resource not found: type=\"Mesh\" name=\"connectivity\" mesh=\"\"", "errorVerbose": "Resource not found: type=\"Mesh\" name=\"connectivity\" mesh=\"\"\ncould not fetch mesh connectivity\ngithub.com/kumahq/kuma/pkg/xds/context.(*meshContextBuilder).BuildBaseMeshContextIfChanged\n\tgithub.com/kumahq/kuma/pkg/xds/context/mesh_context_builder.go:233\ngithub.com/kumahq/kuma/pkg/xds/context.(*meshContextBuilder).BuildIfChanged\n\tgithub.com/kumahq/kuma/pkg/xds/context/mesh_context_builder.go:103\ngithub.com/kumahq/kuma/pkg/xds/cache/mesh.(*Cache).GetMeshContext.func1\n\tgithub.com/kumahq/kuma/pkg/xds/cache/mesh/cache.go:61\ngithub.com/kumahq/kuma/pkg/xds/cache/once.RetrieverFunc.Call\n\tgithub.com/kumahq/kuma/pkg/xds/cache/once/cache.go:43\ngithub.com/kumahq/kuma/pkg/xds/cache/once.(*Cache).GetOrRetrieve.func1\n\tgithub.com/kumahq/kuma/pkg/xds/cache/once/cache.go:67\ngithub.com/kumahq/kuma/pkg/xds/cache/once.(*once).Do.func1\n\tgithub.com/kumahq/kuma/pkg/xds/cache/once/once.go:13\nsync.(*Once).doSlow\n\tsync/once.go:74\nsync.(*Once).Do\n\tsync/once.go:65\ngithub.com/kumahq/kuma/pkg/xds/cache/once.(*once).Do\n\tgithub.com/kumahq/kuma/pkg/xds/cache/once/once.go:12\ngithub.com/kumahq/kuma/pkg/xds/cache/once.(*Cache).GetOrRetrieve\n\tgithub.com/kumahq/kuma/pkg/xds/cache/once/cache.go:59\ngithub.com/kumahq/kuma/pkg/xds/cache/mesh.(*Cache).GetMeshContext\n\tgithub.com/kumahq/kuma/pkg/xds/cache/mesh/cache.go:52\ngithub.com/kumahq/kuma/pkg/xds/context.AggregateMeshContexts\n\tgithub.com/kumahq/kuma/pkg/xds/context/aggregate_mesh_context.go:29\ngithub.com/kumahq/kuma/pkg/xds/sync.(*DataplaneWatchdog).syncEgress\n\tgithub.com/kumahq/kuma/pkg/xds/sync/dataplane_watchdog.go:224\ngithub.com/kumahq/kuma/pkg/xds/sync.(*DataplaneWatchdog).Sync\n\tgithub.com/kumahq/kuma/pkg/xds/sync/dataplane_watchdog.go:83\ngithub.com/kumahq/kuma/pkg/xds/sync.(*dataplaneWatchdogFactory).New.func2\n\tgithub.com/kumahq/kuma/pkg/xds/sync/dataplane_watchdog_factory.go:43\ngithub.com/kumahq/kuma/pkg/util/watchdog.(*SimpleWatchdog).onTick\n\tgithub.com/kumahq/kuma/pkg/util/watchdog/watchdog.go:70\ngithub.com/kumahq/kuma/pkg/util/watchdog.(*SimpleWatchdog).Start\n\tgithub.com/kumahq/kuma/pkg/util/watchdog/watchdog.go:40\nruntime.goexit\n\truntime/asm_arm64.s:1197\ncould not aggregate mesh contexts\ngithub.com/kumahq/kuma/pkg/xds/sync.(*DataplaneWatchdog).syncEgress\n\tgithub.com/kumahq/kuma/pkg/xds/sync/dataplane_watchdog.go:226\ngithub.com/kumahq/kuma/pkg/xds/sync.(*DataplaneWatchdog).Sync\n\tgithub.com/kumahq/kuma/pkg/xds/sync/dataplane_watchdog.go:83\ngithub.com/kumahq/kuma/pkg/xds/sync.(*dataplaneWatchdogFactory).New.func2\n\tgithub.com/kumahq/kuma/pkg/xds/sync/dataplane_watchdog_factory.go:43\ngithub.com/kumahq/kuma/pkg/util/watchdog.(*SimpleWatchdog).onTick\n\tgithub.com/kumahq/kuma/pkg/util/watchdog/watchdog.go:70\ngithub.com/kumahq/kuma/pkg/util/watchdog.(*SimpleWatchdog).Start\n\tgithub.com/kumahq/kuma/pkg/util/watchdog/watchdog.go:40\nruntime.goexit\n\truntime/asm_arm64.s:1197"}
```

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
