### PR TITLE
fix(gatewayapi): don't add HTTPRoute status if Kuma isn't the controller

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -140,6 +140,7 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 
 	notAcceptedConditions := map[gatewayapi.ParentReference]string{}
 
+	var kumaRefs []gatewayapi.ParentReference
 	// Convert GAPI parent refs into selectors
 	for i, ref := range route.Spec.ParentRefs {
 		refAttachment, err := attachment.EvaluateParentRefAttachment(ctx, r.Client, route.Spec.Hostnames, &routeNs, ref)
@@ -187,6 +188,8 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 			}
 			notAcceptedConditions[ref] = reason
 		}
+
+		kumaRefs = append(kumaRefs, ref)
 	}
 
 	meshRoutes, meshRouteConditions, err := r.gapiToMeshRouteSpecs(ctx, mesh, route, services)
@@ -194,7 +197,7 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 		return nil, nil, nil, err
 	}
 
-	for _, ref := range route.Spec.ParentRefs {
+	for _, ref := range kumaRefs {
 		var refConditions []kube_meta.Condition
 		switch {
 		case *ref.Kind == "Gateway" && *ref.Group == gatewayapi.GroupName:


### PR DESCRIPTION
We were accidentally setting a status for Kuma.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
