### PR TITLE
fix(MeshTCPRoute): allow MeshGateway listener tags

### DIFF
--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/validator.go
@@ -28,6 +28,7 @@ func validateTop(targetRef common_api.TargetRef) validators.ValidationError {
 				common_api.MeshService,
 				common_api.MeshServiceSubset,
 			},
+			GatewayListenerTagsAllowed: true,
 		},
 	)
 }

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/validator_test.go
@@ -112,13 +112,15 @@ to:
     kind: MeshService
     name: backend
 `),
-		Entry("accepts MeshGateway targeted route", `
+		Entry("accepts MeshGateway with listener tags targeted route", `
 type: MeshTCPRoute
 mesh: mesh-1
 name: route-1
 targetRef:
   kind: MeshGateway
   name: edge
+  tags:
+    port: 6000
 to:
 - targetRef:
     kind: Mesh


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
