### PR TITLE
fix(kuma-cp): copy annotations when adding/update k8s object

### DIFF
--- a/pkg/plugins/resources/k8s/store.go
+++ b/pkg/plugins/resources/k8s/store.go
@@ -58,7 +58,7 @@ func (s *KubernetesStore) Create(ctx context.Context, r core_model.Resource, fs 
 		return err
 	}
 
-	labels, annotations := splitLabelsAndAnnotations(opts.Labels)
+	labels, annotations := splitLabelsAndAnnotations(opts.Labels, obj.GetAnnotations())
 	obj.GetObjectMeta().SetLabels(labels)
 	obj.GetObjectMeta().SetAnnotations(annotations)
 	obj.SetMesh(opts.Mesh)
@@ -99,7 +99,7 @@ func (s *KubernetesStore) Update(ctx context.Context, r core_model.Resource, fs 
 		return errors.Wrapf(err, "failed to convert core model of type %s into k8s counterpart", r.Descriptor().Name)
 	}
 
-	labels, annotations := splitLabelsAndAnnotations(opts.Labels)
+	labels, annotations := splitLabelsAndAnnotations(opts.Labels, obj.GetAnnotations())
 	obj.GetObjectMeta().SetLabels(labels)
 	obj.GetObjectMeta().SetAnnotations(annotations)
 	obj.SetMesh(r.GetMeta().GetMesh())
@@ -237,9 +237,9 @@ func k8sNameNamespace(coreName string, scope k8s_model.Scope) (string, string, e
 
 // Kuma resource labels are generally stored on Kubernetes as labels, except "kuma.io/display-name".
 // We store it as an annotation because the resource name on k8s is limited by 253 and the label value is limited by 63.
-func splitLabelsAndAnnotations(coreLabels map[string]string) (map[string]string, map[string]string) {
+func splitLabelsAndAnnotations(coreLabels map[string]string, currentAnnotations map[string]string) (map[string]string, map[string]string) {
 	labels := maps.Clone(coreLabels)
-	annotations := map[string]string{}
+	annotations := maps.Clone(currentAnnotations)
 	if v, ok := labels[v1alpha1.DisplayName]; ok {
 		annotations[v1alpha1.DisplayName] = v
 		delete(labels, v1alpha1.DisplayName)

--- a/pkg/plugins/resources/k8s/store.go
+++ b/pkg/plugins/resources/k8s/store.go
@@ -240,6 +240,9 @@ func k8sNameNamespace(coreName string, scope k8s_model.Scope) (string, string, e
 func splitLabelsAndAnnotations(coreLabels map[string]string, currentAnnotations map[string]string) (map[string]string, map[string]string) {
 	labels := maps.Clone(coreLabels)
 	annotations := maps.Clone(currentAnnotations)
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
 	if v, ok := labels[v1alpha1.DisplayName]; ok {
 		annotations[v1alpha1.DisplayName] = v
 		delete(labels, v1alpha1.DisplayName)


### PR DESCRIPTION
### Checklist prior to review

`mesh_controller` adds `k8s.kuma.io/mesh-defaults-generated` annotations to the default resources. Lately, we've changed a bit of labels/annotations logic and we were setting an empty annotation map instead of coping the existing one. Added a change that copies existing annotations.
 
- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
