### PR TITLE
fix(postgres): add ping when creating a pool

### DIFF
--- a/pkg/plugins/common/postgres/connection.go
+++ b/pkg/plugins/common/postgres/connection.go
@@ -73,8 +73,7 @@ func ConnectToDbPgx(ctx context.Context, postgresStoreConfig config.PostgresStor
 	if err != nil {
 		return nil, err
 	}
-	err = p.Ping(ctx)
-	if err != nil {
+	if err := p.Ping(ctx); err != nil {
 		return nil, err
 	}
 	return p, nil

--- a/pkg/plugins/common/postgres/pgx_listener.go
+++ b/pkg/plugins/common/postgres/pgx_listener.go
@@ -34,7 +34,7 @@ var _ Listener = (*PgxListener)(nil)
 // NewPgxListener will create and initialize a PgxListener which will automatically connect and listen to the provided channel.
 func NewPgxListener(config postgres.PostgresStoreConfig, logger logr.Logger) (Listener, error) {
 	ctx := context.Background()
-	db, err := ConnectToDbPgx(config)
+	db, err := ConnectToDbPgx(ctx, config)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/plugins/resources/postgres/pgx_store.go
+++ b/pkg/plugins/resources/postgres/pgx_store.go
@@ -45,7 +45,8 @@ type TransactionableResourceStore interface {
 }
 
 func NewPgxStore(metrics core_metrics.Metrics, config config.PostgresStoreConfig, customizer pgx_config.PgxConfigCustomization) (TransactionableResourceStore, error) {
-	pool, err := postgres.ConnectToDbPgx(config, customizer)
+	ctx := context.Background()
+	pool, err := postgres.ConnectToDbPgx(ctx, config, customizer)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +55,7 @@ func NewPgxStore(metrics core_metrics.Metrics, config config.PostgresStoreConfig
 		roConfig := config
 		roConfig.Host = config.ReadReplica.Host
 		roConfig.Port = int(config.ReadReplica.Port)
-		roPool, err = postgres.ConnectToDbPgx(roConfig, customizer)
+		roPool, err = postgres.ConnectToDbPgx(ctx, roConfig, customizer)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This may avoid cases where the pool is not properly warmed on startup

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
