### PR TITLE
fix(kuma-cp): kds sync on upgrade doubles the number of policies

### DIFF
--- a/pkg/api-server/api_server_suite_test.go
+++ b/pkg/api-server/api_server_suite_test.go
@@ -154,11 +154,12 @@ func putSampleResourceIntoStore(resourceStore store.ResourceStore, name string, 
 }
 
 type testApiServerConfigurer struct {
-	store   store.ResourceStore
-	config  *config_api_server.ApiServerConfig
-	metrics func() core_metrics.Metrics
-	zone    string
-	global  bool
+	store                        store.ResourceStore
+	config                       *config_api_server.ApiServerConfig
+	metrics                      func() core_metrics.Metrics
+	zone                         string
+	global                       bool
+	disableOriginLabelValidation bool
 }
 
 func NewTestApiServerConfigurer() *testApiServerConfigurer {
@@ -188,6 +189,11 @@ func (t *testApiServerConfigurer) WithGlobal() *testApiServerConfigurer {
 
 func (t *testApiServerConfigurer) WithStore(resourceStore store.ResourceStore) *testApiServerConfigurer {
 	t.store = resourceStore
+	return t
+}
+
+func (t *testApiServerConfigurer) WithDisableOriginLabelValidation(disable bool) *testApiServerConfigurer {
+	t.disableOriginLabelValidation = disable
 	return t
 }
 
@@ -250,6 +256,8 @@ func tryStartApiServer(t *testApiServerConfigurer) (*api_server.ApiServer, kuma_
 	} else if t.global {
 		cfg.Mode = config_core.Global
 	}
+
+	cfg.Multizone.Zone.DisableOriginLabelValidation = t.disableOriginLabelValidation
 
 	resManager := manager.NewResourceManager(t.store)
 	apiServer, err := api_server.NewApiServer(

--- a/pkg/api-server/circuit_breaker_endpoints_test.go
+++ b/pkg/api-server/circuit_breaker_endpoints_test.go
@@ -57,6 +57,8 @@ var _ = Describe("CircuitBreaker Endpoints", func() {
         mesh: default
         creationTime: "2018-07-17T16:05:36.995Z"
         modificationTime: "2018-07-17T16:05:36.995Z"
+        labels:
+          kuma.io/origin: zone
         sources:
         - match:
             kuma.io/service: web

--- a/pkg/api-server/fault_injection_endpoints_test.go
+++ b/pkg/api-server/fault_injection_endpoints_test.go
@@ -57,6 +57,8 @@ var _ = Describe("FaultInjection Endpoints", func() {
         mesh: default
         creationTime: "2018-07-17T16:05:36.995Z"
         modificationTime: "2018-07-17T16:05:36.995Z"
+        labels:
+          kuma.io/origin: zone
         sources:
         - match:
             service: web

--- a/pkg/api-server/global_secret_endpoints_test.go
+++ b/pkg/api-server/global_secret_endpoints_test.go
@@ -57,6 +57,8 @@ var _ = Describe("GlobalSecret Endpoints", func() {
         name: sec-1
         creationTime: "2018-07-17T16:05:36.995Z"
         modificationTime: "2018-07-17T16:05:36.995Z"
+        labels:
+          kuma.io/origin: zone
         data: "dGVzdAo="
 `
 		It("GET should return data saved by PUT", func() {

--- a/pkg/api-server/health_check_endpoints_test.go
+++ b/pkg/api-server/health_check_endpoints_test.go
@@ -58,6 +58,8 @@ var _ = Describe("HealthCheck Endpoints", func() {
         mesh: default
         creationTime: "2018-07-17T16:05:36.995Z"
         modificationTime: "2018-07-17T16:05:36.995Z"
+        labels:
+          kuma.io/origin: zone
         sources:
         - match:
             kuma.io/service: web

--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -360,6 +360,13 @@ func (r *resourceEndpoints) createResource(
 		return
 	}
 
+	if r.federatedZone && r.descriptor.IsPluginOriginated {
+		if labels == nil {
+			labels = map[string]string{}
+		}
+		labels[mesh_proto.ResourceOriginLabel] = string(mesh_proto.ZoneResourceOrigin)
+	}
+
 	res := r.descriptor.NewObject()
 	_ = res.SetSpec(spec)
 	if err := r.resManager.Create(ctx, res, store.CreateByKey(name, meshName), store.CreateWithLabels(labels)); err != nil {

--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -360,7 +360,7 @@ func (r *resourceEndpoints) createResource(
 		return
 	}
 
-	if r.federatedZone && r.descriptor.IsPluginOriginated {
+	if r.mode == config_core.Zone {
 		if labels == nil {
 			labels = map[string]string{}
 		}

--- a/pkg/api-server/resource_endpoints_test.go
+++ b/pkg/api-server/resource_endpoints_test.go
@@ -1121,7 +1121,6 @@ var _ = Describe("Resource Endpoints on Zone, label origin", func() {
 		bytes, err := io.ReadAll(resp.Body)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(bytes).To(matchers.MatchGoldenJSON(path.Join("testdata", "resource_400onNoOriginLabel.golden.json")))
-
 	})
 
 	It("should set origin label automatically when origin validation is disabled", func() {

--- a/pkg/api-server/resource_endpoints_test.go
+++ b/pkg/api-server/resource_endpoints_test.go
@@ -18,24 +18,26 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/model/rest/unversioned"
 	rest_v1alpha1 "github.com/kumahq/kuma/pkg/core/resources/model/rest/v1alpha1"
-	"github.com/kumahq/kuma/pkg/core/resources/store"
+	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 	core_metrics "github.com/kumahq/kuma/pkg/metrics"
+	"github.com/kumahq/kuma/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/resources/memory"
 	"github.com/kumahq/kuma/pkg/test"
 	"github.com/kumahq/kuma/pkg/test/matchers"
 	test_metrics "github.com/kumahq/kuma/pkg/test/metrics"
+	"github.com/kumahq/kuma/pkg/test/resources/builders"
 )
 
 var _ = Describe("Resource Endpoints Zone", func() {
 	var apiServer *api_server.ApiServer
-	var resourceStore store.ResourceStore
+	var resourceStore core_store.ResourceStore
 	var client resourceApiClient
 	stop := func() {}
 
 	const mesh = "default"
 
 	BeforeEach(func() {
-		resourceStore = store.NewPaginationStore(memory.NewStore())
+		resourceStore = core_store.NewPaginationStore(memory.NewStore())
 		apiServer, _, stop = StartApiServer(
 			NewTestApiServerConfigurer().
 				WithStore(resourceStore).
@@ -53,7 +55,7 @@ var _ = Describe("Resource Endpoints Zone", func() {
 
 	BeforeEach(func() {
 		// create default mesh
-		err := resourceStore.Create(context.Background(), core_mesh.NewMeshResource(), store.CreateByKey(mesh, model.NoMesh))
+		err := resourceStore.Create(context.Background(), core_mesh.NewMeshResource(), core_store.CreateByKey(mesh, model.NoMesh))
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -134,7 +136,7 @@ var _ = Describe("Resource Endpoints Zone", func() {
 
 var _ = Describe("Resource Endpoints", func() {
 	var apiServer *api_server.ApiServer
-	var resourceStore store.ResourceStore
+	var resourceStore core_store.ResourceStore
 	var client resourceApiClient
 	stop := func() {}
 	var metrics core_metrics.Metrics
@@ -142,7 +144,7 @@ var _ = Describe("Resource Endpoints", func() {
 	const mesh = "default"
 
 	BeforeEach(func() {
-		resourceStore = store.NewPaginationStore(memory.NewStore())
+		resourceStore = core_store.NewPaginationStore(memory.NewStore())
 		apiServer, _, stop = StartApiServer(NewTestApiServerConfigurer().WithStore(resourceStore).WithMetrics(func() core_metrics.Metrics {
 			m, _ := core_metrics.NewMetrics("Zone")
 			metrics = m
@@ -160,7 +162,7 @@ var _ = Describe("Resource Endpoints", func() {
 
 	BeforeEach(func() {
 		// create default mesh
-		err := resourceStore.Create(context.Background(), core_mesh.NewMeshResource(), store.CreateByKey(mesh, model.NoMesh))
+		err := resourceStore.Create(context.Background(), core_mesh.NewMeshResource(), core_store.CreateByKey(mesh, model.NoMesh))
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -316,10 +318,10 @@ var _ = Describe("Resource Endpoints", func() {
 			}
 			// given three resources
 			for i := 0; i < 3; i++ {
-				err := resourceStore.Create(context.Background(), esWithTags("my-svc"), store.CreateByKey(fmt.Sprintf("dp-%02d", i), mesh))
+				err := resourceStore.Create(context.Background(), esWithTags("my-svc"), core_store.CreateByKey(fmt.Sprintf("dp-%02d", i), mesh))
 				Expect(err).NotTo(HaveOccurred())
 			}
-			err := resourceStore.Create(context.Background(), esWithTags("other-svc"), store.CreateByKey("dp-not-good", mesh))
+			err := resourceStore.Create(context.Background(), esWithTags("other-svc"), core_store.CreateByKey("dp-not-good", mesh))
 			Expect(err).NotTo(HaveOccurred())
 
 			// when ask for dataplanes with "my-svc" filter
@@ -367,10 +369,10 @@ var _ = Describe("Resource Endpoints", func() {
 			}
 			// given three resources
 			for i := 0; i < 3; i++ {
-				err := resourceStore.Create(context.Background(), dpWithService("my-svc"), store.CreateByKey(fmt.Sprintf("dp-%02d", i), mesh))
+				err := resourceStore.Create(context.Background(), dpWithService("my-svc"), core_store.CreateByKey(fmt.Sprintf("dp-%02d", i), mesh))
 				Expect(err).NotTo(HaveOccurred())
 			}
-			err := resourceStore.Create(context.Background(), dpWithService("other-svc"), store.CreateByKey("dp-not-good", mesh))
+			err := resourceStore.Create(context.Background(), dpWithService("other-svc"), core_store.CreateByKey("dp-not-good", mesh))
 			Expect(err).NotTo(HaveOccurred())
 
 			// when ask for dataplanes with "my-svc" filter
@@ -570,7 +572,7 @@ var _ = Describe("Resource Endpoints", func() {
 
 			// and then
 			resource := core_mesh.NewTrafficRouteResource()
-			err := resourceStore.Get(context.Background(), resource, store.GetByKey("new-resource", mesh))
+			err := resourceStore.Get(context.Background(), resource, core_store.GetByKey("new-resource", mesh))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(resource.Spec.Conf.Destination["path"]).To(Equal("/sample-path"))
 			Expect(resource.Meta.GetLabels()).To(Equal(map[string]string{"foo": "bar"}))
@@ -612,7 +614,7 @@ var _ = Describe("Resource Endpoints", func() {
 
 			// then
 			resource := core_mesh.NewTrafficRouteResource()
-			err := resourceStore.Get(context.Background(), resource, store.GetByKey(name, mesh))
+			err := resourceStore.Get(context.Background(), resource, core_store.GetByKey(name, mesh))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(resource.Spec.Conf.Destination["path"]).To(Equal("/update-sample-path"))
 			Expect(resource.Meta.GetLabels()).To(Equal(map[string]string{"foo": "barbar", "newlabel": "newvalue"}))
@@ -1002,8 +1004,8 @@ var _ = Describe("Resource Endpoints", func() {
 
 			// and
 			resource := core_mesh.NewTrafficRouteResource()
-			err := resourceStore.Get(context.Background(), resource, store.GetByKey(name, mesh))
-			Expect(err).To(Equal(store.ErrorResourceNotFound(resource.Descriptor().Name, name, mesh)))
+			err := resourceStore.Get(context.Background(), resource, core_store.GetByKey(name, mesh))
+			Expect(err).To(Equal(core_store.ErrorResourceNotFound(resource.Descriptor().Name, name, mesh)))
 		})
 
 		It("should delete non-existing resource", func() {
@@ -1072,4 +1074,84 @@ var _ = Describe("Resource Endpoints", func() {
 		format.MaxLength = 0
 		apiTest(inputFile, apiServer, resourceStore)
 	}, test.EntriesForFolder("resources/crud"))
+})
+
+var _ = Describe("Resource Endpoints on Zone, label origin", func() {
+	createServer := func(validateOriginLabel bool) (*api_server.ApiServer, core_store.ResourceStore, func()) {
+		store := core_store.NewPaginationStore(memory.NewStore())
+		apiServer, _, stop := StartApiServer(
+			NewTestApiServerConfigurer().
+				WithStore(store).
+				WithDisableOriginLabelValidation(!validateOriginLabel).
+				WithZone("zone-1"),
+		)
+		return apiServer, store, stop
+	}
+
+	createMesh := func(s core_store.ResourceStore, mesh string) {
+		// create default mesh
+		err := s.Create(context.Background(), core_mesh.NewMeshResource(), core_store.CreateByKey(mesh, model.NoMesh))
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	It("should return 400 when origin validation is enabled and origin label is not set", func() {
+		// given
+		apiServer, store, stop := createServer(true)
+		defer stop()
+		createMesh(store, "mesh-1")
+		client := resourceApiClient{address: apiServer.Address(), path: "/meshes/mesh-1/meshtrafficpermissions"}
+
+		// when
+		res := &rest_v1alpha1.Resource{
+			ResourceMeta: rest_v1alpha1.ResourceMeta{
+				Name: "mtp-1",
+				Mesh: "mesh-1",
+				Type: string(v1alpha1.MeshTrafficPermissionType),
+			},
+			Spec: builders.MeshTrafficPermission().
+				WithTargetRef(builders.TargetRefMesh()).
+				AddFrom(builders.TargetRefMesh(), v1alpha1.Allow).
+				Build().Spec,
+		}
+		resp := client.put(res)
+
+		// then
+		Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+		// and then
+		bytes, err := io.ReadAll(resp.Body)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(bytes).To(matchers.MatchGoldenJSON(path.Join("testdata", "resource_400onNoOriginLabel.golden.json")))
+
+	})
+
+	It("should set origin label automatically when origin validation is disabled", func() {
+		// given
+		apiServer, store, stop := createServer(false)
+		defer stop()
+		createMesh(store, "mesh-1")
+		client := resourceApiClient{address: apiServer.Address(), path: "/meshes/mesh-1/meshtrafficpermissions"}
+
+		// when
+		res := &rest_v1alpha1.Resource{
+			ResourceMeta: rest_v1alpha1.ResourceMeta{
+				Name: "mtp-1",
+				Mesh: "mesh-1",
+				Type: string(v1alpha1.MeshTrafficPermissionType),
+			},
+			Spec: builders.MeshTrafficPermission().
+				WithTargetRef(builders.TargetRefMesh()).
+				AddFrom(builders.TargetRefMesh(), v1alpha1.Allow).
+				Build().Spec,
+		}
+		resp := client.put(res)
+
+		// then
+		Expect(resp.StatusCode).To(Equal(http.StatusCreated))
+		// and then
+		actualMtp := v1alpha1.NewMeshTrafficPermissionResource()
+		Expect(store.Get(context.Background(), actualMtp, core_store.GetByKey("mtp-1", "mesh-1"))).To(Succeed())
+		Expect(actualMtp.Meta.GetLabels()).To(Equal(map[string]string{
+			mesh_proto.ResourceOriginLabel: string(mesh_proto.ZoneResourceOrigin),
+		}))
+	})
 })

--- a/pkg/api-server/secret_endpoints_test.go
+++ b/pkg/api-server/secret_endpoints_test.go
@@ -57,6 +57,8 @@ var _ = Describe("Secret Endpoints", func() {
         mesh: default
         creationTime: "2018-07-17T16:05:36.995Z"
         modificationTime: "2018-07-17T16:05:36.995Z"
+        labels:
+          kuma.io/origin: zone
         data: "dGVzdAo="
 `
 		It("GET should return data saved by PUT", func() {

--- a/pkg/api-server/testdata/resource_400onNoOriginLabel.golden.json
+++ b/pkg/api-server/testdata/resource_400onNoOriginLabel.golden.json
@@ -1,0 +1,19 @@
+{
+ "type": "/std-errors",
+ "status": 400,
+ "title": "Could not process a resource",
+ "detail": "Resource is not valid",
+ "invalid_parameters": [
+  {
+   "field": "labels[\"kuma.io/origin\"]",
+   "reason": "the origin label must be set to 'zone'"
+  }
+ ],
+ "details": "Resource is not valid",
+ "causes": [
+  {
+   "field": "labels[\"kuma.io/origin\"]",
+   "message": "the origin label must be set to 'zone'"
+  }
+ ]
+}

--- a/pkg/api-server/traffic_route_endpoints_test.go
+++ b/pkg/api-server/traffic_route_endpoints_test.go
@@ -57,6 +57,8 @@ var _ = Describe("TrafficRoute Endpoints", func() {
         mesh: default
         creationTime: "2018-07-17T16:05:36.995Z"
         modificationTime: "2018-07-17T16:05:36.995Z"
+        labels:
+          kuma.io/origin: zone
         sources:
         - match:
             kuma.io/service: web

--- a/pkg/api-server/traffic_trace_endpoints_test.go
+++ b/pkg/api-server/traffic_trace_endpoints_test.go
@@ -57,6 +57,8 @@ var _ = Describe("TrafficTrace Endpoints", func() {
         mesh: default
         creationTime: "2018-07-17T16:05:36.995Z"
         modificationTime: "2018-07-17T16:05:36.995Z"
+        labels:
+          kuma.io/origin: zone
         selectors:
         - match:
             service: backend

--- a/pkg/core/resources/model/resource.go
+++ b/pkg/core/resources/model/resource.go
@@ -402,8 +402,8 @@ func IsLocallyOriginated(mode config_core.CpMode, r Resource) bool {
 		origin, ok := ResourceOrigin(r.GetMeta())
 		return !ok || origin == mesh_proto.GlobalResourceOrigin
 	case config_core.Zone:
-		origin, ok := ResourceOrigin(r.GetMeta())
-		return !ok || origin == mesh_proto.ZoneResourceOrigin
+		origin, _ := ResourceOrigin(r.GetMeta())
+		return origin == mesh_proto.ZoneResourceOrigin
 	default:
 		return true
 	}

--- a/pkg/plugins/runtime/k8s/webhooks/defaulter.go
+++ b/pkg/plugins/runtime/k8s/webhooks/defaulter.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/registry"
 	k8s_common "github.com/kumahq/kuma/pkg/plugins/common/k8s"
@@ -19,16 +20,19 @@ type Defaulter interface {
 	Default() error
 }
 
-func DefaultingWebhookFor(scheme *runtime.Scheme, converter k8s_common.Converter) *admission.Webhook {
+func DefaultingWebhookFor(scheme *runtime.Scheme, converter k8s_common.Converter, checker ResourceAdmissionChecker) *admission.Webhook {
 	return &admission.Webhook{
 		Handler: &defaultingHandler{
-			converter: converter,
-			decoder:   admission.NewDecoder(scheme),
+			converter:                converter,
+			decoder:                  admission.NewDecoder(scheme),
+			ResourceAdmissionChecker: checker,
 		},
 	}
 }
 
 type defaultingHandler struct {
+	ResourceAdmissionChecker
+
 	converter k8s_common.Converter
 	decoder   *admission.Decoder
 }
@@ -64,6 +68,10 @@ func (h *defaultingHandler) Handle(ctx context.Context, req admission.Request) a
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 
+	if resp := h.IsOperationAllowed(req.UserInfo, resource); !resp.Allowed {
+		return resp
+	}
+
 	if resource.Descriptor().Scope == core_model.ScopeMesh {
 		labels := obj.GetLabels()
 		if _, ok := labels[metadata.KumaMeshLabel]; !ok {
@@ -71,6 +79,17 @@ func (h *defaultingHandler) Handle(ctx context.Context, req admission.Request) a
 				labels = map[string]string{}
 			}
 			labels[metadata.KumaMeshLabel] = core_model.DefaultMesh
+			obj.SetLabels(labels)
+		}
+	}
+
+	if resource.Descriptor().IsPluginOriginated && h.FederatedZone {
+		labels := obj.GetLabels()
+		if _, ok := core_model.ResourceOrigin(resource.GetMeta()); !ok {
+			if len(labels) == 0 {
+				labels = map[string]string{}
+			}
+			labels[mesh_proto.ResourceOriginLabel] = string(mesh_proto.ZoneResourceOrigin)
 			obj.SetLabels(labels)
 		}
 	}

--- a/pkg/plugins/runtime/k8s/webhooks/defaulter.go
+++ b/pkg/plugins/runtime/k8s/webhooks/defaulter.go
@@ -9,6 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/pkg/config/core"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/registry"
 	k8s_common "github.com/kumahq/kuma/pkg/plugins/common/k8s"
@@ -83,7 +84,7 @@ func (h *defaultingHandler) Handle(ctx context.Context, req admission.Request) a
 		}
 	}
 
-	if resource.Descriptor().IsPluginOriginated && h.FederatedZone {
+	if h.Mode == core.Zone {
 		labels := obj.GetLabels()
 		if _, ok := core_model.ResourceOrigin(resource.GetMeta()); !ok {
 			if len(labels) == 0 {

--- a/pkg/plugins/runtime/k8s/webhooks/resourceadmissionchecker.go
+++ b/pkg/plugins/runtime/k8s/webhooks/resourceadmissionchecker.go
@@ -1,0 +1,127 @@
+package webhooks
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/exp/slices"
+	v1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/pkg/config/core"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/version"
+)
+
+type ResourceAdmissionChecker struct {
+	AllowedUsers                 []string
+	Mode                         core.CpMode
+	FederatedZone                bool
+	DisableOriginLabelValidation bool
+}
+
+func (c *ResourceAdmissionChecker) IsOperationAllowed(userInfo authenticationv1.UserInfo, r core_model.Resource) admission.Response {
+	if c.isPrivilegedUser(c.AllowedUsers, userInfo) {
+		return admission.Allowed("")
+	}
+
+	if !c.isResourceTypeAllowed(r.Descriptor()) {
+		return c.resourceTypeIsNotAllowedResponse(r.Descriptor().Name)
+	}
+
+	if !c.isResourceAllowed(r) {
+		return c.resourceIsNotAllowedResponse()
+	}
+
+	return admission.Allowed("")
+}
+
+func (c *ResourceAdmissionChecker) isResourceTypeAllowed(d core_model.ResourceTypeDescriptor) bool {
+	if d.KDSFlags == core_model.KDSDisabledFlag {
+		return true
+	}
+	if c.Mode == core.Global && !d.KDSFlags.Has(core_model.AllowedOnGlobalSelector) {
+		return false
+	}
+	if c.FederatedZone && !d.KDSFlags.Has(core_model.AllowedOnZoneSelector) {
+		return false
+	}
+	return true
+}
+
+func (c *ResourceAdmissionChecker) isResourceAllowed(r core_model.Resource) bool {
+	if !c.FederatedZone || !r.Descriptor().IsPluginOriginated {
+		return true
+	}
+	if !c.DisableOriginLabelValidation {
+		if origin, ok := core_model.ResourceOrigin(r.GetMeta()); !ok || origin != mesh_proto.ZoneResourceOrigin {
+			return false
+		}
+	}
+	return true
+}
+
+func (c *ResourceAdmissionChecker) isPrivilegedUser(allowedUsers []string, userInfo authenticationv1.UserInfo) bool {
+	// Assume this means one of the following:
+	// - sync from another zone (rt.Config().Runtime.Kubernetes.ServiceAccountName)
+	// - GC cleanup resources due to OwnerRef. ("system:serviceaccount:kube-system:generic-garbage-collector")
+	// - storageversionmigratior
+	// Not security; protecting user from self.
+	return slices.Contains(allowedUsers, userInfo.Username)
+}
+
+func (c *ResourceAdmissionChecker) resourceIsNotAllowedResponse() admission.Response {
+	return admission.Response{
+		AdmissionResponse: v1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Status:  "Failure",
+				Message: fmt.Sprintf("Operation not allowed. Applying policies on Zone CP requires '%s' label to be set to '%s'.", mesh_proto.ResourceOriginLabel, mesh_proto.ZoneResourceOrigin),
+				Reason:  "Forbidden",
+				Code:    403,
+				Details: &metav1.StatusDetails{
+					Causes: []metav1.StatusCause{
+						{
+							Type:    "FieldValueInvalid",
+							Message: "cannot be empty",
+							Field:   "metadata.labels[kuma.io/origin]",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (c *ResourceAdmissionChecker) resourceTypeIsNotAllowedResponse(resType core_model.ResourceType) admission.Response {
+	otherCpMode := ""
+	if c.Mode == core.Zone {
+		otherCpMode = core.Global
+	} else if c.Mode == core.Global {
+		otherCpMode = core.Zone
+	}
+	return admission.Response{
+		AdmissionResponse: v1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Status: "Failure",
+				Message: fmt.Sprintf("Operation not allowed. %s resources like %s can be updated or deleted only "+
+					"from the %s control plane and not from a %s control plane.", version.Product, resType, strings.ToUpper(otherCpMode), strings.ToUpper(c.Mode)),
+				Reason: "Forbidden",
+				Code:   403,
+				Details: &metav1.StatusDetails{
+					Causes: []metav1.StatusCause{
+						{
+							Type:    "FieldValueInvalid",
+							Message: "cannot be empty",
+							Field:   "metadata.annotations[kuma.io/synced]",
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/plugins/runtime/k8s/webhooks/validation.go
+++ b/pkg/plugins/runtime/k8s/webhooks/validation.go
@@ -2,19 +2,14 @@ package webhooks
 
 import (
 	"context"
-	"fmt"
 	"net/http"
-	"strings"
 
-	"golang.org/x/exp/slices"
 	v1 "k8s.io/api/admission/v1"
-	authenticationv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_runtime "k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	"github.com/kumahq/kuma/pkg/config/core"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_registry "github.com/kumahq/kuma/pkg/core/resources/registry"
@@ -22,38 +17,29 @@ import (
 	k8s_common "github.com/kumahq/kuma/pkg/plugins/common/k8s"
 	k8s_model "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/model"
 	k8s_registry "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
-	"github.com/kumahq/kuma/pkg/version"
 )
 
 func NewValidatingWebhook(
 	converter k8s_common.Converter,
 	coreRegistry core_registry.TypeRegistry,
 	k8sRegistry k8s_registry.TypeRegistry,
-	mode core.CpMode,
-	federatedZone bool,
-	allowedUsers []string,
-	disableOriginLabelValidation bool,
+	checker ResourceAdmissionChecker,
 ) k8s_common.AdmissionValidator {
 	return &validatingHandler{
-		coreRegistry:                 coreRegistry,
-		k8sRegistry:                  k8sRegistry,
-		converter:                    converter,
-		mode:                         mode,
-		federatedZone:                federatedZone,
-		allowedUsers:                 allowedUsers,
-		disableOriginLabelValidation: disableOriginLabelValidation,
+		coreRegistry:             coreRegistry,
+		k8sRegistry:              k8sRegistry,
+		converter:                converter,
+		ResourceAdmissionChecker: checker,
 	}
 }
 
 type validatingHandler struct {
-	coreRegistry                 core_registry.TypeRegistry
-	k8sRegistry                  k8s_registry.TypeRegistry
-	converter                    k8s_common.Converter
-	decoder                      *admission.Decoder
-	mode                         core.CpMode
-	federatedZone                bool
-	allowedUsers                 []string
-	disableOriginLabelValidation bool
+	ResourceAdmissionChecker
+
+	coreRegistry core_registry.TypeRegistry
+	k8sRegistry  k8s_registry.TypeRegistry
+	converter    k8s_common.Converter
+	decoder      *admission.Decoder
 }
 
 func (h *validatingHandler) InjectDecoder(d *admission.Decoder) {
@@ -72,7 +58,7 @@ func (h *validatingHandler) Handle(ctx context.Context, req admission.Request) a
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
-	if resp := h.isOperationAllowed(req.UserInfo, coreRes); !resp.Allowed {
+	if resp := h.IsOperationAllowed(req.UserInfo, coreRes); !resp.Allowed {
 		return resp
 	}
 
@@ -127,57 +113,6 @@ func (h *validatingHandler) decode(req admission.Request) (core_model.Resource, 
 	return coreRes, k8sObj, nil
 }
 
-// Note that this func does not validate ConfigMap and Secret since this webhook does not support those
-func (h *validatingHandler) isOperationAllowed(userInfo authenticationv1.UserInfo, r core_model.Resource) admission.Response {
-	if h.isPrivilegedUser(userInfo) {
-		return admission.Allowed("")
-	}
-
-	if !h.isResourceTypeAllowed(r.Descriptor()) {
-		return resourceTypeIsNotAllowedResponse(r.Descriptor().Name, h.mode)
-	}
-
-	if !h.isResourceAllowed(r) {
-		return resourceIsNotAllowedResponse()
-	}
-
-	return admission.Allowed("")
-}
-
-func (h *validatingHandler) isPrivilegedUser(userInfo authenticationv1.UserInfo) bool {
-	// Assume this means one of the following:
-	// - sync from another zone (rt.Config().Runtime.Kubernetes.ServiceAccountName)
-	// - GC cleanup resources due to OwnerRef. ("system:serviceaccount:kube-system:generic-garbage-collector")
-	// - storageversionmigratior
-	// Not security; protecting user from self.
-	return slices.Contains(h.allowedUsers, userInfo.Username)
-}
-
-func (h *validatingHandler) isResourceTypeAllowed(d core_model.ResourceTypeDescriptor) bool {
-	if d.KDSFlags == core_model.KDSDisabledFlag {
-		return true
-	}
-	if h.mode == core.Global && !d.KDSFlags.Has(core_model.AllowedOnGlobalSelector) {
-		return false
-	}
-	if h.federatedZone && !d.KDSFlags.Has(core_model.AllowedOnZoneSelector) {
-		return false
-	}
-	return true
-}
-
-func (h *validatingHandler) isResourceAllowed(r core_model.Resource) bool {
-	if !h.federatedZone || !r.Descriptor().IsPluginOriginated {
-		return true
-	}
-	if !h.disableOriginLabelValidation {
-		if origin, ok := core_model.ResourceOrigin(r.GetMeta()); !ok || origin != mesh_proto.ZoneResourceOrigin {
-			return false
-		}
-	}
-	return true
-}
-
 func (h *validatingHandler) validateLabels(rm core_model.ResourceMeta) validators.ValidationError {
 	var verr validators.ValidationError
 	if origin, ok := core_model.ResourceOrigin(rm); ok {
@@ -186,59 +121,6 @@ func (h *validatingHandler) validateLabels(rm core_model.ResourceMeta) validator
 		}
 	}
 	return verr
-}
-
-func resourceIsNotAllowedResponse() admission.Response {
-	return admission.Response{
-		AdmissionResponse: v1.AdmissionResponse{
-			Allowed: false,
-			Result: &metav1.Status{
-				Status:  "Failure",
-				Message: fmt.Sprintf("Operation not allowed. Applying policies on Zone CP requires '%s' label to be set to '%s'.", mesh_proto.ResourceOriginLabel, mesh_proto.ZoneResourceOrigin),
-				Reason:  "Forbidden",
-				Code:    403,
-				Details: &metav1.StatusDetails{
-					Causes: []metav1.StatusCause{
-						{
-							Type:    "FieldValueInvalid",
-							Message: "cannot be empty",
-							Field:   "metadata.labels[kuma.io/origin]",
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-func resourceTypeIsNotAllowedResponse(resType core_model.ResourceType, cpMode core.CpMode) admission.Response {
-	otherCpMode := ""
-	if cpMode == core.Zone {
-		otherCpMode = core.Global
-	} else if cpMode == core.Global {
-		otherCpMode = core.Zone
-	}
-	return admission.Response{
-		AdmissionResponse: v1.AdmissionResponse{
-			Allowed: false,
-			Result: &metav1.Status{
-				Status: "Failure",
-				Message: fmt.Sprintf("Operation not allowed. %s resources like %s can be updated or deleted only "+
-					"from the %s control plane and not from a %s control plane.", version.Product, resType, strings.ToUpper(otherCpMode), strings.ToUpper(cpMode)),
-				Reason: "Forbidden",
-				Code:   403,
-				Details: &metav1.StatusDetails{
-					Causes: []metav1.StatusCause{
-						{
-							Type:    "FieldValueInvalid",
-							Message: "cannot be empty",
-							Field:   "metadata.annotations[kuma.io/synced]",
-						},
-					},
-				},
-			},
-		},
-	}
 }
 
 func (h *validatingHandler) Supports(admission.Request) bool {

--- a/pkg/plugins/runtime/k8s/webhooks/validation_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/validation_test.go
@@ -44,8 +44,13 @@ var _ = Describe("Validation", func() {
 	DescribeTable("Validation",
 		func(given testCase) {
 			// given
-			allowedUsers := []string{"system:serviceaccount:kube-system:generic-garbage-collector", "system:serviceaccount:kuma-system:kuma-control-plane"}
-			handler := webhooks.NewValidatingWebhook(converter, core_registry.Global(), k8s_registry.Global(), given.mode, given.federatedZone, allowedUsers, false)
+			checker := webhooks.ResourceAdmissionChecker{
+				AllowedUsers:                 []string{"system:serviceaccount:kube-system:generic-garbage-collector", "system:serviceaccount:kuma-system:kuma-control-plane"},
+				Mode:                         given.mode,
+				FederatedZone:                given.federatedZone,
+				DisableOriginLabelValidation: false,
+			}
+			handler := webhooks.NewValidatingWebhook(converter, core_registry.Global(), k8s_registry.Global(), checker)
 			handler.InjectDecoder(kube_admission.NewDecoder(scheme))
 			webhook := &kube_admission.Webhook{
 				Handler: handler,

--- a/test/e2e/helm/kuma_helm_upgrade_multizone.go
+++ b/test/e2e/helm/kuma_helm_upgrade_multizone.go
@@ -131,7 +131,7 @@ spec:
 	})
 
 	// Disabled due to https://github.com/kumahq/kuma/issues/9184
-	PIt("should upgrade Kuma on Zone", func() {
+	It("should upgrade Kuma on Zone", func() {
 		// when
 		err := zone.(*K8sCluster).UpgradeKuma(core.Zone,
 			WithHelmReleaseName(releaseName),


### PR DESCRIPTION
The PR makes KDS sync rely on `kuma.io/origin: zone` label. But we still want `KUMA_MULTIZONE_ZONE_DISABLE_ORIGIN_LABEL_VALIDATION: true` to disable origin label validation. That's why the PR introduces a webhook that automatically adds `kuma.io/origin: zone` after the validation.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues -- fix https://github.com/kumahq/kuma/issues/9184
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
