### PR TITLE
feat(meshtrafficpermission): support from MeshGateway

### DIFF
--- a/pkg/plugins/policies/core/matchers/dataplane.go
+++ b/pkg/plugins/policies/core/matchers/dataplane.go
@@ -71,7 +71,7 @@ func MatchedPolicies(rType core_model.ResourceType, dpp *core_mesh.DataplaneReso
 		sort.Sort(ByTargetRef(ps))
 	}
 
-	fr, err := core_rules.BuildFromRules(matchedPoliciesByInbound)
+	fr, err := core_rules.BuildFromRules(matchedPoliciesByInbound, resources.Gateways().Items)
 	if err != nil {
 		warnings = append(warnings, fmt.Sprintf("couldn't create From rules: %s", err.Error()))
 	}

--- a/pkg/plugins/policies/core/matchers/egress.go
+++ b/pkg/plugins/policies/core/matchers/egress.go
@@ -7,6 +7,7 @@ import (
 
 	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	core_rules "github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
@@ -35,16 +36,16 @@ func EgressMatchedPolicies(rType core_model.ResourceType, tags map[string]string
 
 	var fr core_rules.FromRules
 	var err error
-
+	gateways := resources.Gateways().Items
 	// in case the policy support
 	switch {
 	case isFrom && isTo:
 		// we needed a strategy to choose what rules to apply on zone egress when a policy supports both "to" and "from".
 		// Picking "from" rules works for us today, because there is only MeshFaultInjection policy that has both "to"
 		// and "from" and is applied on zone egress. In the future, we might want to move the strategy down to the policy plugins.
-		fr, err = processFromRules(tags, policies)
+		fr, err = processFromRules(tags, policies, gateways)
 	case isFrom:
-		fr, err = processFromRules(tags, policies)
+		fr, err = processFromRules(tags, policies, gateways)
 	case isTo:
 		fr, err = processToRules(tags, policies)
 	}
@@ -62,6 +63,7 @@ func EgressMatchedPolicies(rType core_model.ResourceType, tags map[string]string
 func processFromRules(
 	tags map[string]string,
 	rl core_model.ResourceList,
+	gateways []*core_mesh.MeshGatewayResource,
 ) (core_rules.FromRules, error) {
 	matchedPolicies := []core_model.Resource{}
 
@@ -77,7 +79,7 @@ func processFromRules(
 
 	return core_rules.BuildFromRules(map[core_rules.InboundListener][]core_model.Resource{
 		{}: matchedPolicies, // egress always has only 1 listener, so we can use empty key
-	})
+	}, gateways)
 }
 
 // It's not natural for zone egress to have 'to' policies. It doesn't make sense to target
@@ -117,7 +119,10 @@ func processFromRules(
 //	        disabled: true
 //
 // that's why processToRules() method produces FromRules for the Egress.
-func processToRules(tags map[string]string, rl core_model.ResourceList) (core_rules.FromRules, error) {
+func processToRules(
+	tags map[string]string,
+	rl core_model.ResourceList,
+) (core_rules.FromRules, error) {
 	var matchedPolicies []core_model.Resource
 
 	for _, policy := range rl.GetItems() {
@@ -152,8 +157,8 @@ func processToRules(tags map[string]string, rl core_model.ResourceList) (core_ru
 				policy.GetMeta())...)
 		}
 	}
-
-	rules, err := core_rules.BuildRules(toList)
+	// MeshGateway as a To doesn't make sense so we can pass empty list
+	rules, err := core_rules.BuildRules(toList, []*core_mesh.MeshGatewayResource{})
 	if err != nil {
 		return core_rules.FromRules{}, err
 	}

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/fromrules/03.dataplane.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/fromrules/03.dataplane.yaml
@@ -1,0 +1,14 @@
+type: Dataplane
+mesh: mesh-1
+name: dp-1
+networking:
+  address: 1.1.1.1
+  inbound:
+    - port: 8080
+      tags:
+        kuma.io/service: web
+        version: v1
+    - port: 8081
+      tags:
+        kuma.io/service: web
+        version: v3

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/fromrules/03.golden.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/fromrules/03.golden.yaml
@@ -1,0 +1,1 @@
+Rules: null

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/fromrules/03.golden.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/fromrules/03.golden.yaml
@@ -1,1 +1,163 @@
-Rules: null
+Rules:
+  1.1.1.1:8080:
+  - Conf:
+      action: AllowWithShadowDeny
+    Origin:
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-1
+      type: MeshTrafficPermission
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-3
+      type: MeshTrafficPermission
+    Subset:
+    - Key: kuma.io/service
+      Not: false
+      Value: orders
+  - Conf:
+      action: Allow
+    Origin:
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-1
+      type: MeshTrafficPermission
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-3
+      type: MeshTrafficPermission
+    Subset:
+    - Key: kuma.io/service
+      Not: false
+      Value: backend
+  - Conf:
+      action: Allow
+    Origin:
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-3
+      type: MeshTrafficPermission
+    Subset:
+    - Key: kuma.io/service
+      Not: true
+      Value: backend
+    - Key: kuma.io/service
+      Not: true
+      Value: orders
+  1.1.1.1:8081:
+  - Conf:
+      action: Deny
+    Origin:
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-2
+      type: MeshTrafficPermission
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-3
+      type: MeshTrafficPermission
+    Subset:
+    - Key: kuma.io/service
+      Not: false
+      Value: other-gateway
+    - Key: kuma.io/version
+      Not: false
+      Value: v2
+  - Conf:
+      action: Deny
+    Origin:
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-2
+      type: MeshTrafficPermission
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-3
+      type: MeshTrafficPermission
+    Subset:
+    - Key: kuma.io/service
+      Not: false
+      Value: edge-gateway
+    - Key: kuma.io/version
+      Not: false
+      Value: v2
+  - Conf:
+      action: Allow
+    Origin:
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-3
+      type: MeshTrafficPermission
+    Subset:
+    - Key: kuma.io/service
+      Not: true
+      Value: edge-gateway
+    - Key: kuma.io/service
+      Not: true
+      Value: other-gateway
+    - Key: kuma.io/version
+      Not: false
+      Value: v2
+  - Conf:
+      action: Allow
+    Origin:
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-3
+      type: MeshTrafficPermission
+    Subset:
+    - Key: kuma.io/service
+      Not: false
+      Value: other-gateway
+    - Key: kuma.io/version
+      Not: true
+      Value: v2
+  - Conf:
+      action: Deny
+    Origin:
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-2
+      type: MeshTrafficPermission
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-3
+      type: MeshTrafficPermission
+    Subset:
+    - Key: kuma.io/service
+      Not: false
+      Value: edge-gateway
+    - Key: kuma.io/version
+      Not: true
+      Value: v2
+  - Conf:
+      action: Allow
+    Origin:
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-3
+      type: MeshTrafficPermission
+    Subset:
+    - Key: kuma.io/service
+      Not: true
+      Value: edge-gateway
+    - Key: kuma.io/service
+      Not: true
+      Value: other-gateway
+    - Key: kuma.io/version
+      Not: true
+      Value: v2

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/fromrules/03.policies.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/fromrules/03.policies.yaml
@@ -1,0 +1,82 @@
+type: MeshTrafficPermission
+mesh: mesh-1
+name: mtp-1
+spec:
+  targetRef:
+    kind: MeshServiceSubset
+    name: web
+    tags:
+      version: v1
+  from:
+    - targetRef:
+        kind: MeshService
+        name: backend
+      default:
+        action: Allow
+    - targetRef:
+        kind: MeshService
+        name: orders
+      default:
+        action: AllowWithShadowDeny
+---
+type: MeshTrafficPermission
+mesh: mesh-1
+name: mtp-2
+spec:
+  targetRef:
+    kind: MeshServiceSubset
+    name: web
+    tags:
+      version: v3
+  from:
+    - targetRef:
+        kind: MeshGateway
+        name: gateway-1
+      default:
+        action: Deny
+---
+type: MeshTrafficPermission
+mesh: mesh-1
+name: mtp-3
+spec:
+  targetRef:
+    kind: Mesh
+  from:
+    - targetRef:
+        kind: Mesh
+      default:
+        action: Allow
+---
+type: MeshGateway
+mesh: mesh-1
+name: gateway-1
+selectors:
+  - match:
+      kuma.io/service: edge-gateway
+  - match:
+      kuma.io/service: other-gateway
+      kuma.io/version: v2
+conf:
+  listeners:
+    - port: 8080
+      protocol: HTTP
+      tags:
+        listener: one
+    - port: 8081
+      protocol: HTTP
+      tags:
+        listener: two
+    - port: 8082
+      protocol: HTTP
+      tags:
+        listener: three
+    - port: 8083
+      protocol: HTTP
+      hostname: four-hostname-1
+      tags:
+        listener: four-hostname-1
+    - port: 8083
+      protocol: HTTP
+      hostname: four-hostname-2
+      tags:
+        listener: four-hostname-2

--- a/pkg/plugins/policies/core/rules/rules_test.go
+++ b/pkg/plugins/policies/core/rules/rules_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/yaml"
 
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/model/rest"
 	core_rules "github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
@@ -15,6 +16,7 @@ import (
 	meshtrafficpermission_api "github.com/kumahq/kuma/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/test"
 	"github.com/kumahq/kuma/pkg/test/matchers"
+	test_samples "github.com/kumahq/kuma/pkg/test/resources/samples"
 	util_yaml "github.com/kumahq/kuma/pkg/util/yaml"
 )
 
@@ -340,8 +342,13 @@ var _ = Describe("Rules", func() {
 					policiesByInbound := map[core_rules.InboundListener][]core_model.Resource{
 						listener: policies,
 					}
+
+					gateways := []*core_mesh.MeshGatewayResource{
+						test_samples.GatewayResource(),
+					}
+
 					// when
-					return core_rules.BuildFromRules(policiesByInbound)
+					return core_rules.BuildFromRules(policiesByInbound, gateways)
 				})
 			},
 			test.EntriesForFolder("rules/from"),

--- a/pkg/plugins/policies/core/rules/testdata/rules/from/mesh-gateway.golden.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/rules/from/mesh-gateway.golden.yaml
@@ -1,0 +1,26 @@
+Rules:
+  127.0.0.1:80:
+  - Conf:
+      action: Allow
+    Origin:
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-1
+      type: MeshTrafficPermission
+    Subset:
+    - Key: kuma.io/service
+      Not: false
+      Value: sample-gateway
+  - Conf:
+      action: Deny
+    Origin:
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-1
+      type: MeshTrafficPermission
+    Subset:
+    - Key: kuma.io/service
+      Not: true
+      Value: sample-gateway

--- a/pkg/plugins/policies/core/rules/testdata/rules/from/mesh-gateway.input.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/rules/from/mesh-gateway.input.yaml
@@ -1,0 +1,17 @@
+# MeshTrafficPermission with MeshGateway
+type: MeshTrafficPermission
+mesh: mesh-1
+name: mtp-1
+spec:
+  targetRef:
+    kind: Mesh
+  from:
+    - targetRef:
+        kind: Mesh
+      default:
+        action: Deny
+    - targetRef:
+        kind: MeshGateway
+        name: sample-gateway
+      default:
+        action: Allow

--- a/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/validator.go
@@ -39,6 +39,7 @@ func validateFrom(from []From) validators.ValidationError {
 				common_api.MeshSubset,
 				common_api.MeshService,
 				common_api.MeshServiceSubset,
+				common_api.MeshGateway,
 			},
 		}))
 

--- a/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/validator_test.go
@@ -52,6 +52,11 @@ from:
         version: v1
     default:
       action: Deny
+  - targetRef:
+      kind: MeshGateway
+      name: edge-gateway
+    default:
+      action: Deny
 `),
 			Entry("allow MeshSubset at top-level targetRef", `
 targetRef:


### PR DESCRIPTION
### Checklist prior to review

When using `MeshGateway` as the `from.kind`, we didn't map it for subsets. Additionally, `MeshGateway` kind uses the name of a gateway, so to make it work with `MeshTrafficPermission` we need to map matched dataplanes to services. I didn't add support for `MeshGateway` for `to` because I think there is no reason to target `MeshGateway`s from the mesh. Also, the single-match policy (`MeshTrace`) has no support for it either.

The matching of the `MeshGateway` to services:
1. Find `MeshGateway` resource with the name provided in `from.name`
2. Get all selectors and for each create a new `targetRef` with tags from selector
3. Each `targetRef` map to subset

1st commit shows the failing unit test with `from.kind: MeshGateway`
2nd commit shows the change required to make it work and the changed test file
3rd commit adds E2E test 

- [X] [Link to relevant issue][1] as well as docs and UI issues -- fix: https://github.com/kumahq/kuma/issues/9185
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
