### PR TITLE
test(e2e): remove legacy KDS job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,9 +36,6 @@ parameters:
   e2e_param_cniNetworkPlugin:
     type: string
     default: flannel
-  e2e_param_legacyKDS:
-    type: boolean
-    default: false
 # See https://circleci.com/docs/2.0/configuration-reference/#commands-requires-version-21.
 commands:
   install_build_tools:
@@ -265,10 +262,6 @@ jobs:
         description: The CNI networking plugin to use [flannel | calico]
         type: string
         default: flannel
-      legacyKDS:
-        description: if should run tests with new implementation of KDS
-        type: boolean
-        default: false
     executor:
       name: vm-<< parameters.arch >>
     parallelism: << parameters.parallelism >>
@@ -285,7 +278,6 @@ jobs:
               - {equal: [calico, << parameters.cniNetworkPlugin >>]}
               - {equal: [kindIpv6, << parameters.k8sVersion >>]}
               - {equal: [arm64, << parameters.arch >>]}
-              - {equal: [true, << parameters.legacyKDS >>]}
               - {equal: [<< pipeline.parameters.first_k8s_version >>, << parameters.k8sVersion >>]}
           steps:
             - halt_non_priority_job
@@ -362,10 +354,6 @@ jobs:
               export MAKE_PARAMETERS="-j2"
             fi
 
-            if [[ "<< parameters.legacyKDS >>" == true ]]; then
-              export KUMA_LEGACY_KDS=true
-            fi
-
             if [[ "<< parameters.target >>" == "" ]]; then
               export GINKGO_E2E_LABEL_FILTERS="job-$CIRCLE_NODE_INDEX"
             fi
@@ -403,9 +391,6 @@ jobs:
         description: The CNI networking plugin to use [flannel | calico]
         type: string
         default: flannel
-      legacyKDS:
-        description: if should run tests with new implementation of KDS
-        type: boolean
     executor:
       name: vm-<< parameters.arch >>
     parallelism: << parameters.parallelism >>
@@ -469,10 +454,6 @@ jobs:
               export MAKE_PARAMETERS="-j1"
             else
               export MAKE_PARAMETERS="-j2"
-            fi
-
-            if [[ "<< parameters.legacyKDS >>" == true ]]; then
-              export KUMA_LEGACY_KDS=true
             fi
 
             if [[ "<< parameters.target >>" == "" ]]; then
@@ -625,16 +606,6 @@ workflows:
               arch: [amd64, arm64]
           requires: [build, go_cache-<< matrix.arch >>]
       - e2e:
-          name: << matrix.target >>:<< matrix.arch >>-<< matrix.k8sVersion >>-legacy-kds
-          matrix:
-            alias: legacy-kds
-            parameters:
-              k8sVersion: [<< pipeline.parameters.last_k8s_version >>]
-              target: [multizone]
-              arch: [amd64]
-              legacyKDS: [true]
-          requires: [build, go_cache-amd64]
-      - e2e:
           name: << matrix.target >>:<< matrix.arch >>-<< matrix.k8sVersion >>-calico
           matrix:
             alias: calico
@@ -661,6 +632,5 @@ workflows:
           k8sVersion: << pipeline.parameters.e2e_param_k8sVersion >>
           target: << pipeline.parameters.e2e_param_target >>
           arch: << pipeline.parameters.e2e_param_arch >>
-          legacyKDS: << pipeline.parameters.e2e_param_legacyKDS >>
           cniNetworkPlugin: << pipeline.parameters.e2e_param_cniNetworkPlugin >>
           parallelism: << pipeline.parameters.e2e_param_parallelism >>

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -221,7 +221,6 @@ jobs:
                 "arch": ["amd64"],
                 "parallelism": [4],
                 "cniNetworkPlugin": ["flannel"],
-                "legacyKDS": [false]
               },
               "test_e2e_env": {
                 "target": ["kubernetes", "universal", "multizone"],
@@ -229,7 +228,6 @@ jobs:
                 "arch": ["amd64"],
                 "parallelism": [1],
                 "cniNetworkPlugin": ["flannel"],
-                "legacyKDS": [false],
                 "exclude":[
                   {"target": "kubernetes", "k8sVersion":"kind"},
                   {"target": "multizone", "k8sVersion":"kind"},
@@ -237,7 +235,6 @@ jobs:
                   {"target":"universal", "k8sVersion":"${{ env.K8S_MAX_VERSION }}"}
                 ],
                 "include":[
-                  {"legacyKDS": true, "k8sVersion": "${{ env.K8S_MAX_VERSION }}", "target": "multizone", "arch": "amd64"},
                   {"k8sVersion": "${{ env.K8S_MAX_VERSION }}", "target": "multizone", "arch": "arm64"},
                   {"k8sVersion": "${{ env.K8S_MAX_VERSION }}", "target": "kubernetes", "arch": "arm64"},
                   {"k8sVersion": "${{ env.K8S_MAX_VERSION }}", "target": "universal", "arch": "arm64"},

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -17,7 +17,6 @@ env:
   E2E_PARAM_K8S_VERSION: ${{ fromJSON(inputs.matrix).k8sVersion }}
   E2E_PARAM_CNI_NETWORK_PLUGIN: ${{ fromJSON(inputs.matrix).cniNetworkPlugin }}
   E2E_PARAM_ARCH: ${{ fromJSON(inputs.matrix).arch }}
-  E2E_PARAM_LEGACY_KDS: ${{ fromJSON(inputs.matrix).legacyKDS }}
   E2E_PARAM_TARGET: ${{ fromJSON(inputs.matrix).target }}
   E2E_PARAM_PARALLELISM: ${{ fromJSON(inputs.matrix).parallelism }}
   CI_TOOLS_DIR: /home/runner/work/kuma/kuma/.ci_tools
@@ -122,10 +121,6 @@ jobs:
             export MAKE_PARAMETERS="-j1"
           else
             export MAKE_PARAMETERS="-j2"
-          fi
-
-          if [[ "${{ env.E2E_PARAM_LEGACY_KDS }}" == "true" ]]; then
-            export KUMA_LEGACY_KDS=true
           fi
 
           if [[ "${{ env.E2E_PARAM_TARGET }}" == "" ]]; then

--- a/test/e2e_env/multizone/meshtimeout/meshtimeout.go
+++ b/test/e2e_env/multizone/meshtimeout/meshtimeout.go
@@ -121,10 +121,6 @@ spec:
 	})
 
 	It("should apply MeshTimeout policy on Zone CP", func() {
-		if Config.KumaLegacyKDS {
-			Skip("applying policies on zone CP is not available for legacy KDS")
-			return
-		}
 		Eventually(func(g Gomega) {
 			start := time.Now()
 			_, err := framework_client.CollectEchoResponse(

--- a/test/e2e_env/multizone/sync/sync.go
+++ b/test/e2e_env/multizone/sync/sync.go
@@ -57,19 +57,15 @@ func Sync() {
 			g.Expect(result.Spec.Subscriptions).ToNot(BeEmpty())
 			globalSub := result.Spec.Subscriptions[0]
 			g.Expect(globalSub.GlobalInstanceId).ToNot(BeEmpty())
-			if !Config.KumaLegacyKDS {
-				g.Expect(globalSub.ZoneInstanceId).ToNot(BeEmpty())
-			}
+			g.Expect(globalSub.ZoneInstanceId).ToNot(BeEmpty())
 
 			zoneResult := &system.ZoneInsightResource{}
 			api.FetchResource(g, multizone.KubeZone1, zoneResult, "", multizone.KubeZone1.ZoneName())
 			g.Expect(zoneResult.Spec.Subscriptions).ToNot(BeEmpty())
 			zoneSub := zoneResult.Spec.Subscriptions[0]
-			if !Config.KumaLegacyKDS {
-				// Check that this is the other side of the connection
-				g.Expect(zoneSub.GlobalInstanceId).To(Equal(globalSub.GlobalInstanceId))
-				g.Expect(zoneSub.ZoneInstanceId).To(Equal(globalSub.ZoneInstanceId))
-			}
+			// Check that this is the other side of the connection
+			g.Expect(zoneSub.GlobalInstanceId).To(Equal(globalSub.GlobalInstanceId))
+			g.Expect(zoneSub.ZoneInstanceId).To(Equal(globalSub.ZoneInstanceId))
 		}, "1m", "1s").Should(Succeed())
 	})
 

--- a/test/framework/config.go
+++ b/test/framework/config.go
@@ -59,7 +59,6 @@ type E2eConfig struct {
 	KumaCpConfig                  KumaCpConfig      `json:"kumaCpConfig,omitempty" envconfig:"KUMA_CP_CONFIG"`
 	UniversalE2ELogsPath          string            `json:"universalE2ELogsPath,omitempty" envconfig:"UNIVERSAL_E2E_LOGS_PATH"`
 	CleanupLogsOnSuccess          bool              `json:"cleanupLogsOnSuccess,omitempty" envconfig:"CLEANUP_LOGS_ON_SUCCESS"`
-	KumaLegacyKDS                 bool              `json:"kumaLegacyKDS,omitempty" envconfig:"KUMA_LEGACY_KDS"`
 	VersionsYamlPath              string            `json:"versionsYamlPath,omitempty" envconfig:"VERSIONS_YAML_PATH"`
 
 	SuiteConfig SuiteConfig `json:"suites,omitempty"`
@@ -146,13 +145,6 @@ func (c E2eConfig) AutoConfigure() error {
 
 	if Config.IPV6 && Config.CIDR == "" {
 		Config.CIDR = "fd00:fd00::/64"
-	}
-
-	if Config.KumaLegacyKDS {
-		Config.KumaCpConfig.Multizone.KubeZone1.Envs["KUMA_EXPERIMENTAL_KDS_DELTA_ENABLED"] = "false"
-		Config.KumaCpConfig.Multizone.KubeZone2.Envs["KUMA_EXPERIMENTAL_KDS_DELTA_ENABLED"] = "false"
-		Config.KumaCpConfig.Multizone.UniZone1.Envs["KUMA_EXPERIMENTAL_KDS_DELTA_ENABLED"] = "false"
-		Config.KumaCpConfig.Multizone.UniZone2.Envs["KUMA_EXPERIMENTAL_KDS_DELTA_ENABLED"] = "false"
 	}
 
 	Config.Arch = runtime.GOARCH
@@ -261,7 +253,6 @@ var defaultConf = E2eConfig{
 	ZoneIngressApp:       "kuma-ingress",
 	UniversalE2ELogsPath: path.Join(os.TempDir(), "e2e"),
 	CleanupLogsOnSuccess: false,
-	KumaLegacyKDS:        false,
 }
 
 func init() {


### PR DESCRIPTION
The new implementation will be on by default so remove the logic where `KumaLegacyKDS == true`.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- https://github.com/kumahq/kuma/issues/9075
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
