### PR TITLE
ci(e2e): disable flaking tests

### DIFF
--- a/test/e2e_env/kubernetes/gateway/delegated/meshproxypatch.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshproxypatch.go
@@ -16,7 +16,8 @@ func MeshProxyPatch(config *Config) func() {
 	GinkgoHelper()
 
 	return func() {
-		It("should add a header using Lua filter", func() {
+		// Disabled because of flakes: https://github.com/kumahq/kuma/issues/9348
+		XIt("should add a header using Lua filter", func() {
 			// given
 			meshProxyPatch := fmt.Sprintf(`
 apiVersion: kuma.io/v1alpha1 

--- a/test/e2e_env/multizone/meshhttproute/test.go
+++ b/test/e2e_env/multizone/meshhttproute/test.go
@@ -25,6 +25,8 @@ func Test() {
 }
 
 func test(meshName string, meshBuilder *builders.MeshBuilder) {
+	GinkgoHelper()
+
 	BeforeAll(func() {
 		// Global
 		err := NewClusterSetup().
@@ -87,7 +89,8 @@ func test(meshName string, meshBuilder *builders.MeshBuilder) {
 		Expect(multizone.Global.DeleteMesh(meshName)).To(Succeed())
 	})
 
-	It("should use MeshHTTPRoute for cross-zone communication", func() {
+	// Disabled because of flakes: https://github.com/kumahq/kuma/issues/9346
+	XIt("should use MeshHTTPRoute for cross-zone communication", func() {
 		Expect(YamlUniversal(fmt.Sprintf(`
 type: MeshHTTPRoute
 name: route-1
@@ -127,7 +130,8 @@ spec:
 		}, "30s", "500ms").Should(Succeed())
 	})
 
-	It("should use MeshHTTPRoute for cross-zone with MeshServiceSubset", func() {
+	// Disabled because of flakes: https://github.com/kumahq/kuma/issues/9346
+	XIt("should use MeshHTTPRoute for cross-zone with MeshServiceSubset", func() {
 		Expect(YamlUniversal(fmt.Sprintf(`
 type: MeshHTTPRoute
 name: route-1

--- a/test/e2e_env/multizone/resilience/resilience_multizone_universal_postgres.go
+++ b/test/e2e_env/multizone/resilience/resilience_multizone_universal_postgres.go
@@ -164,7 +164,8 @@ func ResilienceMultizoneUniversalPostgres() {
 		}, "40s", "1s").Should(ContainSubstring("Offline"))
 	})
 
-	It("should mark zone as offline when zone control-plane is down", func() {
+	// Disabled because of flakes: https://github.com/kumahq/kuma/issues/9345
+	XIt("should mark zone as offline when zone control-plane is down", func() {
 		// given zone connected to global
 		Eventually(func() (string, error) {
 			return global.GetKumactlOptions().RunKumactlAndGetOutput("inspect", "zones")

--- a/test/e2e_env/universal/reachableservices/reachableservices.go
+++ b/test/e2e_env/universal/reachableservices/reachableservices.go
@@ -38,7 +38,8 @@ func ReachableServices() {
 		}).Should(Succeed())
 	})
 
-	It("should not be able to non reachable services", func() {
+	// Disabled because of flakiness: https://github.com/kumahq/kuma/issues/9349
+	XIt("should not be able to non reachable services", func() {
 		Consistently(func(g Gomega) {
 			// when
 			response, err := client.CollectFailure(


### PR DESCRIPTION
Following our earlier decision, I'm disabling flaking tests. When amount of disabled tests because of flakes exceed 10, we should stop other work and focus on fixing flakes.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - https://github.com/kumahq/kuma/issues/9348
  - https://github.com/kumahq/kuma/issues/9346
  - https://github.com/kumahq/kuma/issues/9345
  - https://github.com/kumahq/kuma/issues/9349
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - 🤔 

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
