### PR TITLE
ci(e2e): upload junit results to gh artifacts

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -21,6 +21,7 @@ env:
   E2E_PARAM_TARGET: ${{ fromJSON(inputs.matrix).target }}
   E2E_PARAM_PARALLELISM: ${{ fromJSON(inputs.matrix).parallelism }}
   CI_TOOLS_DIR: /home/runner/work/kuma/kuma/.ci_tools
+  E2E_RUN_NAME: ${{ fromJSON(inputs.matrix).target }}-${{ fromJSON(inputs.matrix).k8sVersion }}-${{ fromJSON(inputs.matrix).cniNetworkPlugin }}-${{ fromJSON(inputs.matrix).arch }}-${{ fromJSON(inputs.matrix).parallelism }}
 jobs:
   e2e:
     timeout-minutes: 60
@@ -138,6 +139,12 @@ jobs:
             target="test/e2e"
           fi
           make ${MAKE_PARAMETERS} CI=true "${target}"
+      - name: "Archive production artifacts"
+        if: ${{ always() }}
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        with:
+          name: test-e2e-${{ env.E2E_RUN_NAME }}-${{ (github.event.pull_request.head.sha||github.sha) }}-${{ github.run_id }}
+          path: build/reports/results.xml
       - name: "CircleCI: make circleci parameters"
         if: steps.eval-params.outputs.run-type == 'circleci'
         id: circleci-gen-params

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -21,7 +21,7 @@ env:
   E2E_PARAM_TARGET: ${{ fromJSON(inputs.matrix).target }}
   E2E_PARAM_PARALLELISM: ${{ fromJSON(inputs.matrix).parallelism }}
   CI_TOOLS_DIR: /home/runner/work/kuma/kuma/.ci_tools
-  E2E_RUN_NAME: ${{ fromJSON(inputs.matrix).target }}-${{ fromJSON(inputs.matrix).k8sVersion }}-${{ fromJSON(inputs.matrix).cniNetworkPlugin }}-${{ fromJSON(inputs.matrix).arch }}-${{ fromJSON(inputs.matrix).parallelism }}
+  E2E_RUN_NAME: ${{ fromJSON(inputs.matrix).target }}_${{ fromJSON(inputs.matrix).k8sVersion }}_${{ fromJSON(inputs.matrix).cniNetworkPlugin }}_${{ fromJSON(inputs.matrix).arch }}_${{ fromJSON(inputs.matrix).parallelism }}
 jobs:
   e2e:
     timeout-minutes: 60
@@ -143,7 +143,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
-          name: test-e2e-${{ env.E2E_RUN_NAME }}-${{ (github.event.pull_request.head.sha||github.sha) }}-${{ github.run_id }}
+          name: test_e2e_${{ env.E2E_RUN_NAME }}-${{ (github.event.pull_request.head.sha||github.sha) }}-${{ github.run_id }}
           path: |
             build/reports/results.xml
             build/reports/results.json

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -144,7 +144,9 @@ jobs:
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
           name: test-e2e-${{ env.E2E_RUN_NAME }}-${{ (github.event.pull_request.head.sha||github.sha) }}-${{ github.run_id }}
-          path: build/reports/results.xml
+          path: |
+            build/reports/results.xml
+            build/reports/results.json
       - name: "CircleCI: make circleci parameters"
         if: steps.eval-params.outputs.run-type == 'circleci'
         id: circleci-gen-params

--- a/mk/test.mk
+++ b/mk/test.mk
@@ -7,7 +7,7 @@ GINKGO_UNIT_TEST_FLAGS ?= \
 
 # -race requires CGO_ENABLED=1 https://go.dev/doc/articles/race_detector and https://github.com/golang/go/issues/27089
 UNIT_TEST_ENV=$(GOENV) CGO_ENABLED=1 KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) TMPDIR=/tmp UPDATE_GOLDEN_FILES=$(UPDATE_GOLDEN_FILES) $(if $(CI),TESTCONTAINERS_RYUK_DISABLED=true,GINKGO_EDITOR_INTEGRATION=true)
-GINKGO_TEST:=$(GINKGO) $(GOFLAGS) $(LD_FLAGS) -p --keep-going --keep-separate-reports --junit-report results.xml --output-dir $(REPORTS_DIR)
+GINKGO_TEST:=$(GINKGO) $(GOFLAGS) $(LD_FLAGS) -p --keep-going --junit-report results.xml --output-dir $(REPORTS_DIR)
 
 .PHONY: test
 test: build/ebpf | $(REPORTS_DIR) ## Dev: Run tests for all modules. to include reports set `make TEST_REPORTS=1` and `make TEST_REPORTS=coverage` to include coverage. To run only some tests by set `TEST_PKG_LIST=./pkg/...` for example

--- a/mk/test.mk
+++ b/mk/test.mk
@@ -7,7 +7,7 @@ GINKGO_UNIT_TEST_FLAGS ?= \
 
 # -race requires CGO_ENABLED=1 https://go.dev/doc/articles/race_detector and https://github.com/golang/go/issues/27089
 UNIT_TEST_ENV=$(GOENV) CGO_ENABLED=1 KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) TMPDIR=/tmp UPDATE_GOLDEN_FILES=$(UPDATE_GOLDEN_FILES) $(if $(CI),TESTCONTAINERS_RYUK_DISABLED=true,GINKGO_EDITOR_INTEGRATION=true)
-GINKGO_TEST:=$(GINKGO) $(GOFLAGS) $(LD_FLAGS) -p --keep-going --junit-report results.xml --output-dir $(REPORTS_DIR)
+GINKGO_TEST:=$(GINKGO) $(GOFLAGS) $(LD_FLAGS) -p --keep-going --junit-report results.xml --json-report results.json --output-dir $(REPORTS_DIR)
 
 .PHONY: test
 test: build/ebpf | $(REPORTS_DIR) ## Dev: Run tests for all modules. to include reports set `make TEST_REPORTS=1` and `make TEST_REPORTS=coverage` to include coverage. To run only some tests by set `TEST_PKG_LIST=./pkg/...` for example


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --


> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
