### PR TITLE
feat(meshhttproute): set name of route action equal to hash of matches

### DIFF
--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/gateway_routes.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/gateway_routes.go
@@ -155,6 +155,7 @@ func generateEnvoyRouteEntries(host plugin_gateway.GatewayHost, toRules []ruleBy
 			slices.Sort(names)
 			entry := makeHttpRouteEntry(strings.Join(names, "_"), rule)
 
+			hashedMatches := api.HashMatches(rule.Matches)
 			// The rule matches if any of the matches is successful (it has OR
 			// semantics). That means that we have to duplicate the route table
 			// entry for each repeated match so that the rule can match any of
@@ -162,6 +163,7 @@ func generateEnvoyRouteEntries(host plugin_gateway.GatewayHost, toRules []ruleBy
 			for _, m := range rule.Matches {
 				routeEntry := entry // Shallow copy.
 				routeEntry.Match = makeRouteMatch(m)
+				routeEntry.Name = hashedMatches
 
 				switch {
 				case routeEntry.Match.ExactPath != "":

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.routes.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.routes.golden.yaml
@@ -14,6 +14,7 @@ resources:
       routes:
       - match:
           path: /to-go-dev
+        name: Frbf/SZpiW1b8rEPrn3A7c4EKGSGnefVDLJRfVGAYpE=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -27,6 +28,7 @@ resources:
               weight: 100
       - match:
           prefix: /to-go-dev/
+        name: Frbf/SZpiW1b8rEPrn3A7c4EKGSGnefVDLJRfVGAYpE=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -44,6 +46,7 @@ resources:
       routes:
       - match:
           path: /to-other-dev
+        name: lDbZlCo24LgzLwJXScqSGn9A/Cc48ZccKoWZ5to5nIE=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -57,6 +60,7 @@ resources:
               weight: 100
       - match:
           prefix: /to-other-dev/
+        name: lDbZlCo24LgzLwJXScqSGn9A/Cc48ZccKoWZ5to5nIE=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -83,6 +87,7 @@ resources:
       routes:
       - match:
           path: /wild-dev
+        name: lLLrCSPQjG+oW7yjjvonBacpsCv4C2frWuEcfTc4Eh0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -96,6 +101,7 @@ resources:
               weight: 100
       - match:
           prefix: /wild-dev/
+        name: lLLrCSPQjG+oW7yjjvonBacpsCv4C2frWuEcfTc4Eh0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -122,6 +128,7 @@ resources:
       routes:
       - match:
           path: /same-path
+        name: 9P6k3EKFpMiMvzJVQY9Pf3nMzBNDyQYY+jY7Pteyb2E=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -135,6 +142,7 @@ resources:
               weight: 100
       - match:
           path: /same-path
+        name: 9P6k3EKFpMiMvzJVQY9Pf3nMzBNDyQYY+jY7Pteyb2E=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -148,6 +156,7 @@ resources:
               weight: 100
       - match:
           prefix: /same-path/
+        name: 9P6k3EKFpMiMvzJVQY9Pf3nMzBNDyQYY+jY7Pteyb2E=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -161,6 +170,7 @@ resources:
               weight: 100
       - match:
           prefix: /same-path/
+        name: 9P6k3EKFpMiMvzJVQY9Pf3nMzBNDyQYY+jY7Pteyb2E=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -178,6 +188,7 @@ resources:
       routes:
       - match:
           path: /same-path
+        name: 9P6k3EKFpMiMvzJVQY9Pf3nMzBNDyQYY+jY7Pteyb2E=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -191,6 +202,7 @@ resources:
               weight: 100
       - match:
           prefix: /same-path/
+        name: 9P6k3EKFpMiMvzJVQY9Pf3nMzBNDyQYY+jY7Pteyb2E=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -223,6 +235,7 @@ resources:
       routes:
       - match:
           path: /first-specific-dev
+        name: gQNYHyc/dPE/PZjQV4gKRkhpSiX3E/bIyFnI1ofXI10=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -236,6 +249,7 @@ resources:
               weight: 100
       - match:
           prefix: /first-specific-dev/
+        name: gQNYHyc/dPE/PZjQV4gKRkhpSiX3E/bIyFnI1ofXI10=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -259,6 +273,7 @@ resources:
       routes:
       - match:
           path: /second-specific-dev
+        name: nyb0MrCtA579T6XitT4uZP/eGEckP1vkZryTcHaoVKQ=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -272,6 +287,7 @@ resources:
               weight: 100
       - match:
           prefix: /second-specific-dev/
+        name: nyb0MrCtA579T6XitT4uZP/eGEckP1vkZryTcHaoVKQ=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -304,6 +320,7 @@ resources:
       routes:
       - match:
           path: /first-specific-super-dev
+        name: d/A23c0dXRlfOw8QfkXzpPkNG9boGPA0TTXYc1hFODs=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -317,6 +334,7 @@ resources:
               weight: 100
       - match:
           prefix: /first-specific-super-dev/
+        name: d/A23c0dXRlfOw8QfkXzpPkNG9boGPA0TTXYc1hFODs=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -340,6 +358,7 @@ resources:
       routes:
       - match:
           path: /second-specific-super-dev
+        name: NNQerRuE8G6UEINUGa+L44MkBjQgC2dEFTBDhG5KLuQ=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -353,6 +372,7 @@ resources:
               weight: 100
       - match:
           prefix: /second-specific-super-dev/
+        name: NNQerRuE8G6UEINUGa+L44MkBjQgC2dEFTBDhG5KLuQ=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-specific.routes.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-specific.routes.golden.yaml
@@ -14,6 +14,7 @@ resources:
       routes:
       - match:
           path: /wild
+        name: B1eCmxcX/xQ44MYKsaZEU7WFqFsae8v/C/SCaDgzRS0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -27,6 +28,7 @@ resources:
               weight: 100
       - match:
           prefix: /wild/
+        name: B1eCmxcX/xQ44MYKsaZEU7WFqFsae8v/C/SCaDgzRS0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -53,6 +55,7 @@ resources:
       routes:
       - match:
           path: /go-dev
+        name: 4+68EKCHui5s6csAInUo5tlEIKluTe170NtisyhQWFQ=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -66,6 +69,7 @@ resources:
               weight: 100
       - match:
           prefix: /go-dev/
+        name: 4+68EKCHui5s6csAInUo5tlEIKluTe170NtisyhQWFQ=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway.routes.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway.routes.golden.yaml
@@ -14,6 +14,7 @@ resources:
       routes:
       - match:
           path: /wild-dev
+        name: lLLrCSPQjG+oW7yjjvonBacpsCv4C2frWuEcfTc4Eh0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -27,6 +28,7 @@ resources:
               weight: 100
       - match:
           path: /go-dev
+        name: 4+68EKCHui5s6csAInUo5tlEIKluTe170NtisyhQWFQ=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -40,6 +42,7 @@ resources:
               weight: 100
       - match:
           path: /wild
+        name: B1eCmxcX/xQ44MYKsaZEU7WFqFsae8v/C/SCaDgzRS0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -53,6 +56,7 @@ resources:
               weight: 100
       - match:
           prefix: /wild-dev/
+        name: lLLrCSPQjG+oW7yjjvonBacpsCv4C2frWuEcfTc4Eh0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -66,6 +70,7 @@ resources:
               weight: 100
       - match:
           prefix: /go-dev/
+        name: 4+68EKCHui5s6csAInUo5tlEIKluTe170NtisyhQWFQ=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -79,6 +84,7 @@ resources:
               weight: 100
       - match:
           prefix: /wild/
+        name: B1eCmxcX/xQ44MYKsaZEU7WFqFsae8v/C/SCaDgzRS0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -96,6 +102,7 @@ resources:
       routes:
       - match:
           path: /other-dev
+        name: RVX/EBgfhvvo7WfJD6AAQb6Wigywd2s44SjLyeBKRto=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -109,6 +116,7 @@ resources:
               weight: 100
       - match:
           path: /wild-dev
+        name: lLLrCSPQjG+oW7yjjvonBacpsCv4C2frWuEcfTc4Eh0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -122,6 +130,7 @@ resources:
               weight: 100
       - match:
           path: /wild
+        name: B1eCmxcX/xQ44MYKsaZEU7WFqFsae8v/C/SCaDgzRS0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -135,6 +144,7 @@ resources:
               weight: 100
       - match:
           prefix: /other-dev/
+        name: RVX/EBgfhvvo7WfJD6AAQb6Wigywd2s44SjLyeBKRto=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -148,6 +158,7 @@ resources:
               weight: 100
       - match:
           prefix: /wild-dev/
+        name: lLLrCSPQjG+oW7yjjvonBacpsCv4C2frWuEcfTc4Eh0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -161,6 +172,7 @@ resources:
               weight: 100
       - match:
           prefix: /wild/
+        name: B1eCmxcX/xQ44MYKsaZEU7WFqFsae8v/C/SCaDgzRS0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -178,6 +190,7 @@ resources:
       routes:
       - match:
           path: /wild-dev
+        name: lLLrCSPQjG+oW7yjjvonBacpsCv4C2frWuEcfTc4Eh0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -191,6 +204,7 @@ resources:
               weight: 100
       - match:
           path: /wild
+        name: B1eCmxcX/xQ44MYKsaZEU7WFqFsae8v/C/SCaDgzRS0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -204,6 +218,7 @@ resources:
               weight: 100
       - match:
           prefix: /wild-dev/
+        name: lLLrCSPQjG+oW7yjjvonBacpsCv4C2frWuEcfTc4Eh0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -217,6 +232,7 @@ resources:
               weight: 100
       - match:
           prefix: /wild/
+        name: B1eCmxcX/xQ44MYKsaZEU7WFqFsae8v/C/SCaDgzRS0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -234,6 +250,7 @@ resources:
       routes:
       - match:
           path: /wild
+        name: B1eCmxcX/xQ44MYKsaZEU7WFqFsae8v/C/SCaDgzRS0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -247,6 +264,7 @@ resources:
               weight: 100
       - match:
           prefix: /wild/
+        name: B1eCmxcX/xQ44MYKsaZEU7WFqFsae8v/C/SCaDgzRS0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -273,6 +291,7 @@ resources:
       routes:
       - match:
           path: /wild-dev
+        name: lLLrCSPQjG+oW7yjjvonBacpsCv4C2frWuEcfTc4Eh0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -286,6 +305,7 @@ resources:
               weight: 100
       - match:
           path: /go-dev
+        name: 4+68EKCHui5s6csAInUo5tlEIKluTe170NtisyhQWFQ=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -299,6 +319,7 @@ resources:
               weight: 100
       - match:
           path: /wild
+        name: B1eCmxcX/xQ44MYKsaZEU7WFqFsae8v/C/SCaDgzRS0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -312,6 +333,7 @@ resources:
               weight: 100
       - match:
           prefix: /wild-dev/
+        name: lLLrCSPQjG+oW7yjjvonBacpsCv4C2frWuEcfTc4Eh0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -325,6 +347,7 @@ resources:
               weight: 100
       - match:
           prefix: /go-dev/
+        name: 4+68EKCHui5s6csAInUo5tlEIKluTe170NtisyhQWFQ=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -338,6 +361,7 @@ resources:
               weight: 100
       - match:
           prefix: /wild/
+        name: B1eCmxcX/xQ44MYKsaZEU7WFqFsae8v/C/SCaDgzRS0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -364,6 +388,7 @@ resources:
       routes:
       - match:
           path: /wild-dev
+        name: lLLrCSPQjG+oW7yjjvonBacpsCv4C2frWuEcfTc4Eh0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -377,6 +402,7 @@ resources:
               weight: 100
       - match:
           path: /go-dev
+        name: 4+68EKCHui5s6csAInUo5tlEIKluTe170NtisyhQWFQ=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -390,6 +416,7 @@ resources:
               weight: 100
       - match:
           path: /wild
+        name: B1eCmxcX/xQ44MYKsaZEU7WFqFsae8v/C/SCaDgzRS0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -403,6 +430,7 @@ resources:
               weight: 100
       - match:
           prefix: /wild-dev/
+        name: lLLrCSPQjG+oW7yjjvonBacpsCv4C2frWuEcfTc4Eh0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -416,6 +444,7 @@ resources:
               weight: 100
       - match:
           prefix: /go-dev/
+        name: 4+68EKCHui5s6csAInUo5tlEIKluTe170NtisyhQWFQ=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -429,6 +458,7 @@ resources:
               weight: 100
       - match:
           prefix: /wild/
+        name: B1eCmxcX/xQ44MYKsaZEU7WFqFsae8v/C/SCaDgzRS0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -446,6 +476,7 @@ resources:
       routes:
       - match:
           path: /other-dev
+        name: RVX/EBgfhvvo7WfJD6AAQb6Wigywd2s44SjLyeBKRto=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -459,6 +490,7 @@ resources:
               weight: 100
       - match:
           path: /wild-dev
+        name: lLLrCSPQjG+oW7yjjvonBacpsCv4C2frWuEcfTc4Eh0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -472,6 +504,7 @@ resources:
               weight: 100
       - match:
           path: /wild
+        name: B1eCmxcX/xQ44MYKsaZEU7WFqFsae8v/C/SCaDgzRS0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -485,6 +518,7 @@ resources:
               weight: 100
       - match:
           prefix: /other-dev/
+        name: RVX/EBgfhvvo7WfJD6AAQb6Wigywd2s44SjLyeBKRto=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -498,6 +532,7 @@ resources:
               weight: 100
       - match:
           prefix: /wild-dev/
+        name: lLLrCSPQjG+oW7yjjvonBacpsCv4C2frWuEcfTc4Eh0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -511,6 +546,7 @@ resources:
               weight: 100
       - match:
           prefix: /wild/
+        name: B1eCmxcX/xQ44MYKsaZEU7WFqFsae8v/C/SCaDgzRS0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -528,6 +564,7 @@ resources:
       routes:
       - match:
           path: /wild-dev
+        name: lLLrCSPQjG+oW7yjjvonBacpsCv4C2frWuEcfTc4Eh0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -541,6 +578,7 @@ resources:
               weight: 100
       - match:
           path: /wild
+        name: B1eCmxcX/xQ44MYKsaZEU7WFqFsae8v/C/SCaDgzRS0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -554,6 +592,7 @@ resources:
               weight: 100
       - match:
           prefix: /wild-dev/
+        name: lLLrCSPQjG+oW7yjjvonBacpsCv4C2frWuEcfTc4Eh0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s
@@ -567,6 +606,7 @@ resources:
               weight: 100
       - match:
           prefix: /wild/
+        name: B1eCmxcX/xQ44MYKsaZEU7WFqFsae8v/C/SCaDgzRS0=
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           idleTimeout: 5s

--- a/pkg/plugins/runtime/gateway/route/table.go
+++ b/pkg/plugins/runtime/gateway/route/table.go
@@ -27,6 +27,7 @@ type Table struct {
 // additional processing.
 type Entry struct {
 	Route  string
+	Name   string
 	Match  Match
 	Action Action
 

--- a/pkg/plugins/runtime/gateway/route_table_generator.go
+++ b/pkg/plugins/runtime/gateway/route_table_generator.go
@@ -61,7 +61,7 @@ func GenerateVirtualHost(
 	sort.Sort(route.Sorter(routes))
 
 	for _, e := range routes {
-		routeBuilder := envoy_routes.NewRouteBuilder(envoy_common.APIV3, envoy_common.AnonymousResource).
+		routeBuilder := envoy_routes.NewRouteBuilder(envoy_common.APIV3, e.Name).
 			Configure(
 				envoy_routes.RouteMatchExactPath(e.Match.ExactPath),
 				envoy_routes.RouteMatchPrefixPath(e.Match.PrefixPath),


### PR DESCRIPTION
### Checklist prior to review

We are setting the name of a route equal to the hash of `match` for Dataplane routes but not for the gateway. This is useful when the `targetRef` is `kind: MeshHTTPRoute`. The change introduces setting RDS route names equal to the hash of the `match`.

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
