### PR TITLE
fix(policy): don't set empty kuma.io service when using MeshHTTPRoute

### DIFF
--- a/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshhttproute.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshhttproute.golden.json
@@ -122,13 +122,18 @@
       {
        "key": "kuma.io/service",
        "not": false,
-       "value": ""
+       "value": "backend_kuma-demo_svc_3001"
       }
      ],
      "origin": [
       {
        "mesh": "default",
        "name": "on-route",
+       "type": "MeshTimeout"
+      },
+      {
+       "mesh": "default",
+       "name": "on-service",
        "type": "MeshTimeout"
       }
      ]
@@ -141,6 +146,11 @@
      },
      "matchers": [
       {
+       "key": "__rule-matches-hash__",
+       "not": true,
+       "value": "P6k5V5Y/QDNzTnF1vr7gY33PAAoDt+H+DtspboMfNMs="
+      },
+      {
        "key": "kuma.io/service",
        "not": false,
        "value": "backend_kuma-demo_svc_3001"
@@ -150,6 +160,32 @@
       {
        "mesh": "default",
        "name": "on-service",
+       "type": "MeshTimeout"
+      }
+     ]
+    },
+    {
+     "conf": {
+      "http": {
+       "requestTimeout": "15s"
+      }
+     },
+     "matchers": [
+      {
+       "key": "__rule-matches-hash__",
+       "not": false,
+       "value": "P6k5V5Y/QDNzTnF1vr7gY33PAAoDt+H+DtspboMfNMs="
+      },
+      {
+       "key": "kuma.io/service",
+       "not": true,
+       "value": "backend_kuma-demo_svc_3001"
+      }
+     ],
+     "origin": [
+      {
+       "mesh": "default",
+       "name": "on-route",
        "type": "MeshTimeout"
       }
      ]

--- a/pkg/plugins/policies/core/rules/rules.go
+++ b/pkg/plugins/policies/core/rules/rules.go
@@ -366,15 +366,27 @@ func buildToList(p core_model.Resource, httpRoutes []core_model.Resource) ([]cor
 		for _, mhrRule := range mhrRules.Rules {
 			matchesHash := v1alpha1.HashMatches(mhrRule.Matches)
 			for _, to := range policyWithTo.GetToList() {
-				rv = append(rv, &artificialPolicyItem{
-					targetRef: common_api.TargetRef{
+				var targetRef common_api.TargetRef
+				switch mhrRules.TargetRef.Kind {
+				case common_api.Mesh, common_api.MeshSubset:
+					targetRef = common_api.TargetRef{
+						Kind: common_api.MeshSubset,
+						Tags: map[string]string{
+							RuleMatchesHashTag: matchesHash,
+						},
+					}
+				default:
+					targetRef = common_api.TargetRef{
 						Kind: common_api.MeshServiceSubset,
 						Name: mhrRules.TargetRef.Name,
 						Tags: map[string]string{
 							RuleMatchesHashTag: matchesHash,
 						},
-					},
-					conf: to.GetDefault(),
+					}
+				}
+				rv = append(rv, &artificialPolicyItem{
+					targetRef: targetRef,
+					conf:      to.GetDefault(),
 				})
 			}
 		}

--- a/pkg/plugins/policies/core/rules/testdata/rules/to/to-with-mesh-http-route.golden.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/rules/to/to-with-mesh-http-route.golden.yaml
@@ -12,6 +12,3 @@ Rules:
   - Key: __rule-matches-hash__
     Not: false
     Value: JNNc6//C3P17nUsOJm5f4kqG+U3v8pXhS0od9C3+oss=
-  - Key: kuma.io/service
-    Not: false
-    Value: ""

--- a/pkg/plugins/policies/core/rules/testdata/rules/to/to-with-mesh-http-route.golden.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/rules/to/to-with-mesh-http-route.golden.yaml
@@ -1,0 +1,17 @@
+Rules:
+- Conf:
+    http:
+      requestTimeout: 15s
+  Origin:
+  - creationTime: "0001-01-01T00:00:00Z"
+    mesh: default
+    modificationTime: "0001-01-01T00:00:00Z"
+    name: override
+    type: MeshTimeout
+  Subset:
+  - Key: __rule-matches-hash__
+    Not: false
+    Value: JNNc6//C3P17nUsOJm5f4kqG+U3v8pXhS0od9C3+oss=
+  - Key: kuma.io/service
+    Not: false
+    Value: ""

--- a/pkg/plugins/policies/core/rules/testdata/rules/to/to-with-mesh-http-route.input.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/rules/to/to-with-mesh-http-route.input.yaml
@@ -1,0 +1,34 @@
+# MeshTimeout targeting MeshHTTPRoute and MeshHTTPRoute shouldn't have empty kuma.io/service
+type: MeshTimeout
+name: override
+mesh: default
+spec:
+  targetRef:
+    kind: MeshHTTPRoute
+    name: http-route-1
+  to:
+    - targetRef:
+        kind: Mesh
+      default:
+        http:
+          requestTimeout: 15s
+---
+type: MeshHTTPRoute
+mesh: default
+name: http-route-1
+spec:
+  targetRef:
+    kind: MeshGateway
+    name: sample-gateway
+  to:
+    - targetRef:
+        kind: Mesh
+      rules:
+        - matches:
+            - path:
+                type: Exact
+                value: /
+          default:
+            backendRefs:
+              - kind: MeshService
+                name: test-service


### PR DESCRIPTION
### Checklist prior to review

#### Problem
When policy targets `MeshHTTPRoute` with `to.kind: Mesh` we are creating an artificial object that has a tag with a hashed value of a matcher from `MeshHTTPRoute`. By default, we are creating it as a `MeshServiceSubset` which by default has `kuma.io/service` with an empty value. That works well for policies that have `to.kind: MeshService/MeshServiceSubset` but not for `Mesh/MeshSubset`. Later we cannot match the subset because `kuma.io/service: ""` is set. This change checks the kind and sets the correct value.

The best to review by commits 
1st shows the issue
2nd implementation
3rd shows the file


- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
