### PR TITLE
feat(meshmetric): usedonly filters

### DIFF
--- a/app/kuma-dp/pkg/dataplane/meshmetrics/component.go
+++ b/app/kuma-dp/pkg/dataplane/meshmetrics/component.go
@@ -222,7 +222,7 @@ func (cf *ConfigFetcher) mapApplicationToApplicationToScrape(applications []xds.
 		Address:       cf.envoyAdminAddress,
 		Port:          cf.envoyAdminPort,
 		IsIPv6:        false,
-		QueryModifier: metrics.AggregatedQueryParametersModifier(metrics.AddPrometheusFormat, metrics.AddUsedOnlyParameter(sidecar)),
+		QueryModifier: metrics.AggregatedQueryParametersModifier(metrics.AddPrometheusFormat, metrics.AddSidecarParameters(sidecar)),
 		Mutator:       metrics.MergeClusters,
 		OtelMutator:   metrics.MergeClustersForOpenTelemetry,
 	})

--- a/app/kuma-dp/pkg/dataplane/metrics/server.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/server.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	v1alpha12 "github.com/kumahq/kuma/pkg/plugins/policies/meshmetric/api/v1alpha1"
-	"github.com/kumahq/kuma/pkg/plugins/policies/meshmetric/plugin/v1alpha1"
 	"io"
 	"math"
 	"mime"
@@ -24,6 +22,8 @@ import (
 
 	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/runtime/component"
+	v1alpha12 "github.com/kumahq/kuma/pkg/plugins/policies/meshmetric/api/v1alpha1"
+	"github.com/kumahq/kuma/pkg/plugins/policies/meshmetric/plugin/v1alpha1"
 )
 
 var (
@@ -75,14 +75,14 @@ func AddPrometheusFormat(queryParameters url.Values) url.Values {
 func AddUsedOnlyParameter(sidecar *v1alpha12.Sidecar) func(queryParameters url.Values) url.Values {
 	values := v1alpha1.EnvoyMetricsFilter(sidecar)
 
-	return func (queryParameters url.Values) url.Values {
+	return func(queryParameters url.Values) url.Values {
 		queryParameters.Set("filter", values.Get("filter"))
 		queryParameters.Set("usedonly", values.Get("usedonly"))
 		return queryParameters
 	}
 }
 
-func AggregatedQueryParametersModifier(modifiers... QueryParametersModifier) QueryParametersModifier {
+func AggregatedQueryParametersModifier(modifiers ...QueryParametersModifier) QueryParametersModifier {
 	return func(queryParameters url.Values) url.Values {
 		q := queryParameters
 		for _, m := range modifiers {

--- a/app/kuma-dp/pkg/dataplane/metrics/server.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/server.go
@@ -72,7 +72,7 @@ func AddPrometheusFormat(queryParameters url.Values) url.Values {
 	return queryParameters
 }
 
-func AddUsedOnlyParameter(sidecar *v1alpha12.Sidecar) func(queryParameters url.Values) url.Values {
+func AddSidecarParameters(sidecar *v1alpha12.Sidecar) func(queryParameters url.Values) url.Values {
 	values := v1alpha1.EnvoyMetricsFilter(sidecar)
 
 	return func(queryParameters url.Values) url.Values {

--- a/app/kuma-dp/pkg/dataplane/metrics/server_test.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/server_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"github.com/kumahq/kuma/pkg/plugins/policies/meshmetric/api/v1alpha1"
 	"io"
 	"net/http"
 	"net/url"
@@ -11,6 +12,9 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/common/expfmt"
 )
+
+var regex = "abc"
+var includeUnused = true
 
 var _ = Describe("Rewriting the metrics URL", func() {
 	type testCase struct {
@@ -46,6 +50,23 @@ var _ = Describe("Rewriting the metrics URL", func() {
 			adminPort:     80,
 			expected:      "http://127.0.0.1:80/stats",
 			queryModifier: RemoveQueryParameters,
+		}),
+		Entry("add usedonly and filter parameters", testCase{
+			address:       "127.0.0.1",
+			input:         "http://foo/bar?one=two&three=four",
+			adminPort:     80,
+			expected:      "http://127.0.0.1:80/stats?filter=abc&one=two&three=four&usedonly=",
+			queryModifier: AddUsedOnlyParameter(&v1alpha1.Sidecar{
+				Regex:         &regex,
+				IncludeUnused: &includeUnused,
+			}),
+		}),
+		Entry("add default usedonly parameter", testCase{
+			address:       "127.0.0.1",
+			input:         "http://foo/bar?one=two&three=four",
+			adminPort:     80,
+			expected:      "http://127.0.0.1:80/stats?filter=&one=two&three=four&usedonly=",
+			queryModifier: AddUsedOnlyParameter(nil),
 		}),
 	)
 })

--- a/app/kuma-dp/pkg/dataplane/metrics/server_test.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/server_test.go
@@ -1,7 +1,6 @@
 package metrics
 
 import (
-	"github.com/kumahq/kuma/pkg/plugins/policies/meshmetric/api/v1alpha1"
 	"io"
 	"net/http"
 	"net/url"
@@ -11,10 +10,14 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/common/expfmt"
+
+	"github.com/kumahq/kuma/pkg/plugins/policies/meshmetric/api/v1alpha1"
 )
 
-var regex = "abc"
-var includeUnused = true
+var (
+	regex         = "abc"
+	includeUnused = true
+)
 
 var _ = Describe("Rewriting the metrics URL", func() {
 	type testCase struct {
@@ -52,10 +55,10 @@ var _ = Describe("Rewriting the metrics URL", func() {
 			queryModifier: RemoveQueryParameters,
 		}),
 		Entry("add usedonly and filter parameters", testCase{
-			address:       "127.0.0.1",
-			input:         "http://foo/bar?one=two&three=four",
-			adminPort:     80,
-			expected:      "http://127.0.0.1:80/stats?filter=abc&one=two&three=four&usedonly=",
+			address:   "127.0.0.1",
+			input:     "http://foo/bar?one=two&three=four",
+			adminPort: 80,
+			expected:  "http://127.0.0.1:80/stats?filter=abc&one=two&three=four&usedonly=",
 			queryModifier: AddUsedOnlyParameter(&v1alpha1.Sidecar{
 				Regex:         &regex,
 				IncludeUnused: &includeUnused,

--- a/app/kuma-dp/pkg/dataplane/metrics/server_test.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/server_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Rewriting the metrics URL", func() {
 			input:     "http://foo/bar?one=two&three=four",
 			adminPort: 80,
 			expected:  "http://127.0.0.1:80/stats?filter=abc&one=two&three=four&usedonly=",
-			queryModifier: AddUsedOnlyParameter(&v1alpha1.Sidecar{
+			queryModifier: AddSidecarParameters(&v1alpha1.Sidecar{
 				Regex:         &regex,
 				IncludeUnused: &includeUnused,
 			}),
@@ -69,7 +69,7 @@ var _ = Describe("Rewriting the metrics URL", func() {
 			input:         "http://foo/bar?one=two&three=four",
 			adminPort:     80,
 			expected:      "http://127.0.0.1:80/stats?filter=&one=two&three=four&usedonly=",
-			queryModifier: AddUsedOnlyParameter(nil),
+			queryModifier: AddSidecarParameters(nil),
 		}),
 	)
 })

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/validator_test.go
@@ -20,7 +20,7 @@ targetRef:
 default:
   sidecar:
     regex: "http2_.*"
-    usedOnly: true
+    includeUnused: true
   applications:
     - path: "metrics/prometheus"
       port: 8888
@@ -107,7 +107,7 @@ targetRef:
 default:
   sidecar:
     regex: "())(!("
-    usedOnly: true
+    includeUnused: true
 `),
 		ErrorCase(
 			"invalid url",

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/basic.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/basic.listeners.golden.yaml
@@ -22,7 +22,7 @@ resources:
               routes:
               - directResponse:
                   body:
-                    inlineString: '{"observability":{"metrics":{"applications":[{"path":"/metrics","port":8080,"address":""}],"backends":[{"type":"Prometheus"}]}}}'
+                    inlineString: '{"observability":{"metrics":{"applications":[{"path":"/metrics","port":8080,"address":""}],"backends":[{"type":"Prometheus"}],"sidecar":{"regex":"http.*","includeUnused":false}}}}'
                   status: 200
                 match:
                   prefix: /
@@ -56,7 +56,7 @@ resources:
                   prefix: /metrics
                 route:
                   cluster: _kuma:metrics:hijacker
-                  prefixRewrite: /?filter=http.*&usedonly
+                  prefixRewrite: /filter=http.%2A&usedonly=
           statPrefix: _kuma_metrics_prometheus_default-backend
     name: _kuma:metrics:prometheus:default-backend
     trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/default.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/default.listeners.golden.yaml
@@ -56,7 +56,7 @@ resources:
                   prefix: /metrics
                 route:
                   cluster: _kuma:metrics:hijacker
-                  prefixRewrite: /?usedonly
+                  prefixRewrite: /usedonly=
           statPrefix: _kuma_metrics_prometheus_default-backend
     name: _kuma:metrics:prometheus:default-backend
     trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/multiple_prometheus.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/multiple_prometheus.listeners.golden.yaml
@@ -22,7 +22,7 @@ resources:
               routes:
               - directResponse:
                   body:
-                    inlineString: '{"observability":{"metrics":{"applications":[{"path":"/metrics","port":8080,"address":""}],"backends":[{"type":"Prometheus"}]}}}'
+                    inlineString: '{"observability":{"metrics":{"applications":[{"path":"/metrics","port":8080,"address":""}],"backends":[{"type":"Prometheus"}],"sidecar":{"regex":"http.*","includeUnused":false}}}}'
                   status: 200
                 match:
                   prefix: /
@@ -56,7 +56,7 @@ resources:
                   prefix: /metrics
                 route:
                   cluster: _kuma:metrics:hijacker
-                  prefixRewrite: /?filter=http.*&usedonly
+                  prefixRewrite: /filter=http.%2A&usedonly=
           statPrefix: _kuma_metrics_prometheus_first-backend
     name: _kuma:metrics:prometheus:first-backend
     trafficDirection: INBOUND
@@ -88,7 +88,7 @@ resources:
                   prefix: /metrics
                 route:
                   cluster: _kuma:metrics:hijacker
-                  prefixRewrite: /?filter=http.*&usedonly
+                  prefixRewrite: /filter=http.%2A&usedonly=
           statPrefix: _kuma_metrics_prometheus_second-backend
     name: _kuma:metrics:prometheus:second-backend
     trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/otel_and_prometheus.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/otel_and_prometheus.listeners.golden.yaml
@@ -22,7 +22,7 @@ resources:
               routes:
               - directResponse:
                   body:
-                    inlineString: '{"observability":{"metrics":{"applications":[{"path":"/metrics","port":8080,"address":""}],"backends":[{"type":"Prometheus"},{"type":"OpenTelemetry","openTelemetry":{"endpoint":"/tmp/kuma-open-telemetry.sock"}}]}}}'
+                    inlineString: '{"observability":{"metrics":{"applications":[{"path":"/metrics","port":8080,"address":""}],"backends":[{"type":"Prometheus"},{"type":"OpenTelemetry","openTelemetry":{"endpoint":"/tmp/kuma-open-telemetry.sock"}}],"sidecar":{"regex":"http.*","includeUnused":false}}}}'
                   status: 200
                 match:
                   prefix: /
@@ -88,7 +88,7 @@ resources:
                   prefix: /metrics
                 route:
                   cluster: _kuma:metrics:hijacker
-                  prefixRewrite: /?filter=http.*&usedonly
+                  prefixRewrite: /filter=http.%2A&usedonly=
           statPrefix: _kuma_metrics_prometheus_default-backend
     name: _kuma:metrics:prometheus:default-backend
     trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/provided_tls.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/provided_tls.listeners.golden.yaml
@@ -58,7 +58,7 @@ resources:
                   prefix: /metrics
                 route:
                   cluster: _kuma:metrics:hijacker
-                  prefixRewrite: /?usedonly
+                  prefixRewrite: /usedonly=
           statPrefix: _kuma_metrics_prometheus_default-backend
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -79,7 +79,7 @@ resources:
                   prefix: /metrics
                 route:
                   cluster: _kuma:metrics:hijacker
-                  prefixRewrite: /?usedonly
+                  prefixRewrite: /usedonly=
           statPrefix: _kuma_metrics_prometheus_default-backend
       transportSocket:
         name: envoy.transport_sockets.tls

--- a/pkg/plugins/policies/meshmetric/plugin/xds/dpp_config_configurer.go
+++ b/pkg/plugins/policies/meshmetric/plugin/xds/dpp_config_configurer.go
@@ -2,8 +2,8 @@ package xds
 
 import (
 	"encoding/json"
-
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+	"github.com/kumahq/kuma/pkg/plugins/policies/meshmetric/api/v1alpha1"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	envoy_listeners "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
 	v3 "github.com/kumahq/kuma/pkg/xds/envoy/listeners/v3"
@@ -44,8 +44,9 @@ type Observability struct {
 }
 
 type Metrics struct {
-	Applications []Application `json:"applications"`
-	Backends     []Backend     `json:"backends"`
+	Applications []Application     `json:"applications"`
+	Backends     []Backend         `json:"backends"`
+	Sidecar      *v1alpha1.Sidecar `json:"sidecar,omitempty"`
 }
 
 type Application struct {

--- a/pkg/plugins/policies/meshmetric/plugin/xds/dpp_config_configurer.go
+++ b/pkg/plugins/policies/meshmetric/plugin/xds/dpp_config_configurer.go
@@ -2,6 +2,7 @@ package xds
 
 import (
 	"encoding/json"
+
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/plugins/policies/meshmetric/api/v1alpha1"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"

--- a/test/e2e_env/kubernetes/meshmetric/meshmetric.go
+++ b/test/e2e_env/kubernetes/meshmetric/meshmetric.go
@@ -492,7 +492,7 @@ func MeshMetric() {
 			)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(stdout).To(Not(ContainSubstring("envoy_cluster_client_ssl_socket_factory_upstream_context_secrets_not_ready"))) // unused
-			g.Expect(stdout).To(ContainSubstring("envoy_cluster_external_upstream_rq_time_bucket")) // used
+			g.Expect(stdout).To(ContainSubstring("envoy_cluster_external_upstream_rq_time_bucket"))                                  // used
 		}, "2m", "3s").Should(Succeed())
 	})
 


### PR DESCRIPTION
closes https://github.com/kumahq/kuma/issues/8926

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
