### PR TITLE
feat(kds): add span for admin requests to zone CPs

### DIFF
--- a/pkg/envoy/admin/kds_client.go
+++ b/pkg/envoy/admin/kds_client.go
@@ -20,6 +20,7 @@ import (
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 	"github.com/kumahq/kuma/pkg/kds/service"
+	"github.com/kumahq/kuma/pkg/util/grpc"
 	util_grpc "github.com/kumahq/kuma/pkg/util/grpc"
 	"github.com/kumahq/kuma/pkg/util/k8s"
 )
@@ -42,124 +43,110 @@ func (k *kdsEnvoyAdminClient) PostQuit(context.Context, *core_mesh.DataplaneReso
 	panic("not implemented")
 }
 
-func (k *kdsEnvoyAdminClient) ConfigDump(ctx context.Context, proxy core_model.ResourceWithAddress) ([]byte, error) {
+type message interface {
+	grpc.ReverseUnaryMessage
+	GetError() string
+}
+
+func doRequest[T message]( // nolint:nonamedreturns
+	ctx context.Context,
+	resManager manager.ReadOnlyResourceManager,
+	proxy core_model.ResourceWithAddress,
+	requestType string,
+	rpcs grpc.ReverseUnaryRPCs,
+	mkMsg func(id, typ, name, mesh string) grpc.ReverseUnaryMessage,
+) (resp T, retErr error) {
+	var t T
 	zone := core_model.ZoneOfResource(proxy)
-	nameInZone, err := resNameInZone(ctx, k.resManager, proxy)
-	if err != nil {
-		return nil, &KDSTransportError{requestType: "XDSConfigRequest", reason: err.Error()}
-	}
-	reqId := core.NewUUID()
 	tenantZoneID := service.TenantZoneClientIDFromCtx(ctx, zone)
 
-	err = k.rpcs.XDSConfigDump.Send(tenantZoneID.String(), &mesh_proto.XDSConfigRequest{
-		RequestId:    reqId,
-		ResourceType: string(proxy.Descriptor().Name),
-		ResourceName: nameInZone,                // send the name which without the added prefix
-		ResourceMesh: proxy.GetMeta().GetMesh(), // should be empty for ZoneIngress/ZoneEgress
-	})
+	reqId := core.NewUUID()
+	nameInZone, err := resNameInZone(ctx, resManager, proxy)
 	if err != nil {
-		return nil, &KDSTransportError{requestType: "XDSConfigRequest", reason: err.Error()}
+		return t, &KDSTransportError{requestType: requestType, reason: err.Error()}
+	}
+	msg := mkMsg(
+		reqId,
+		string(proxy.Descriptor().Name),
+		nameInZone,                // send the name which without the added prefix
+		proxy.GetMeta().GetMesh(), // should be empty for ZoneIngress/ZoneEgress
+	)
+
+	if err = rpcs.Send(tenantZoneID.String(), msg); err != nil {
+		return t, &KDSTransportError{requestType: requestType, reason: err.Error()}
 	}
 
-	defer k.rpcs.XDSConfigDump.DeleteWatch(tenantZoneID.String(), reqId)
+	defer rpcs.DeleteWatch(tenantZoneID.String(), reqId)
 	ch := make(chan util_grpc.ReverseUnaryMessage)
-	if err := k.rpcs.XDSConfigDump.WatchResponse(tenantZoneID.String(), reqId, ch); err != nil {
-		return nil, errors.Wrapf(err, "could not watch the response")
+	if err := rpcs.WatchResponse(tenantZoneID.String(), reqId, ch); err != nil {
+		return t, errors.Wrapf(err, "could not watch the response")
 	}
 
 	select {
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return t, ctx.Err()
 	case resp := <-ch:
-		configResp, ok := resp.(*mesh_proto.XDSConfigResponse)
+		var t T
+		tResp, ok := resp.(T)
 		if !ok {
-			return nil, errors.New("invalid request type")
+			return t, errors.New("invalid request type")
 		}
-		if configResp.GetError() != "" {
-			return nil, &KDSTransportError{requestType: "XDSConfigRequest", reason: configResp.GetError()}
+		if tResp.GetError() != "" {
+			return t, &KDSTransportError{requestType: requestType, reason: tResp.GetError()}
 		}
-		return configResp.GetConfig(), nil
+		return tResp, nil
 	}
 }
 
 func (k *kdsEnvoyAdminClient) Stats(ctx context.Context, proxy core_model.ResourceWithAddress) ([]byte, error) {
-	zone := core_model.ZoneOfResource(proxy)
-	nameInZone, err := resNameInZone(ctx, k.resManager, proxy)
-	if err != nil {
-		return nil, &KDSTransportError{requestType: "StatsRequest", reason: err.Error()}
-	}
-	reqId := core.NewUUID()
-	tenantZoneId := service.TenantZoneClientIDFromCtx(ctx, zone)
-
-	err = k.rpcs.Stats.Send(tenantZoneId.String(), &mesh_proto.StatsRequest{
-		RequestId:    reqId,
-		ResourceType: string(proxy.Descriptor().Name),
-		ResourceName: nameInZone,                // send the name which without the added prefix
-		ResourceMesh: proxy.GetMeta().GetMesh(), // should be empty for ZoneIngress/ZoneEgress
-	})
-	if err != nil {
-		return nil, &KDSTransportError{requestType: "StatsRequest", reason: err.Error()}
-	}
-
-	defer k.rpcs.Stats.DeleteWatch(tenantZoneId.String(), reqId)
-	ch := make(chan util_grpc.ReverseUnaryMessage)
-	if err := k.rpcs.Stats.WatchResponse(tenantZoneId.String(), reqId, ch); err != nil {
-		return nil, errors.Wrapf(err, "could not watch the response")
-	}
-
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case resp := <-ch:
-		statsResp, ok := resp.(*mesh_proto.StatsResponse)
-		if !ok {
-			return nil, errors.New("invalid request type")
+	requestType := "StatsRequest"
+	mkMsg := func(reqId, typ, name, mesh string) grpc.ReverseUnaryMessage {
+		return &mesh_proto.StatsRequest{
+			RequestId:    reqId,
+			ResourceType: typ,
+			ResourceName: name,
+			ResourceMesh: mesh,
 		}
-		if statsResp.GetError() != "" {
-			return nil, &KDSTransportError{requestType: "StatsRequest", reason: statsResp.GetError()}
-		}
-		return statsResp.GetStats(), nil
 	}
+	resp, err := doRequest[*mesh_proto.StatsResponse](ctx, k.resManager, proxy, requestType, k.rpcs.Stats, mkMsg)
+	if err != nil {
+		return nil, err
+	}
+	return resp.GetStats(), nil
+}
+
+func (k *kdsEnvoyAdminClient) ConfigDump(ctx context.Context, proxy core_model.ResourceWithAddress) ([]byte, error) {
+	requestType := "XDSConfigRequest"
+	mkMsg := func(reqId, typ, name, mesh string) grpc.ReverseUnaryMessage {
+		return &mesh_proto.XDSConfigRequest{
+			RequestId:    reqId,
+			ResourceType: typ,
+			ResourceName: name,
+			ResourceMesh: mesh,
+		}
+	}
+	resp, err := doRequest[*mesh_proto.XDSConfigResponse](ctx, k.resManager, proxy, requestType, k.rpcs.XDSConfigDump, mkMsg)
+	if err != nil {
+		return nil, err
+	}
+	return resp.GetConfig(), nil
 }
 
 func (k *kdsEnvoyAdminClient) Clusters(ctx context.Context, proxy core_model.ResourceWithAddress) ([]byte, error) {
-	zone := core_model.ZoneOfResource(proxy)
-	nameInZone, err := resNameInZone(ctx, k.resManager, proxy)
-	if err != nil {
-		return nil, &KDSTransportError{requestType: "ClustersRequest", reason: err.Error()}
-	}
-	reqId := core.NewUUID()
-	tenantZoneID := service.TenantZoneClientIDFromCtx(ctx, zone)
-
-	err = k.rpcs.Clusters.Send(tenantZoneID.String(), &mesh_proto.ClustersRequest{
-		RequestId:    reqId,
-		ResourceType: string(proxy.Descriptor().Name),
-		ResourceName: nameInZone,                // send the name which without the added prefix
-		ResourceMesh: proxy.GetMeta().GetMesh(), // should be empty for ZoneIngress/ZoneEgress
-	})
-	if err != nil {
-		return nil, &KDSTransportError{requestType: "ClustersRequest", reason: err.Error()}
-	}
-
-	defer k.rpcs.Clusters.DeleteWatch(tenantZoneID.String(), reqId)
-	ch := make(chan util_grpc.ReverseUnaryMessage)
-	if err := k.rpcs.Clusters.WatchResponse(tenantZoneID.String(), reqId, ch); err != nil {
-		return nil, errors.Wrapf(err, "could not watch the response")
-	}
-
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case resp := <-ch:
-		clustersResp, ok := resp.(*mesh_proto.ClustersResponse)
-		if !ok {
-			return nil, errors.New("invalid request type")
+	requestType := "ClustersRequest"
+	mkMsg := func(reqId, typ, name, mesh string) grpc.ReverseUnaryMessage {
+		return &mesh_proto.ClustersRequest{
+			RequestId:    reqId,
+			ResourceType: typ,
+			ResourceName: name,
+			ResourceMesh: mesh,
 		}
-		if clustersResp.GetError() != "" {
-			return nil, &KDSTransportError{requestType: "ClustersRequest", reason: clustersResp.GetError()}
-		}
-		return clustersResp.GetClusters(), nil
 	}
+	resp, err := doRequest[*mesh_proto.ClustersResponse](ctx, k.resManager, proxy, requestType, k.rpcs.Clusters, mkMsg)
+	if err != nil {
+		return nil, err
+	}
+	return resp.GetClusters(), nil
 }
 
 func resNameInZone(


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
