### PR TITLE
ci(github): use CIRCLECI_TOKEN instead of circleCIToken

### DIFF
--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -198,7 +198,7 @@ jobs:
               STATUS_CODE=$(curl -o $OUTPUT_FILE -sL -w "%{http_code}" -X $METHOD $URL \
                 --header "content-type: application/json" --header "accept: application/json" \
                 --header "x-attribution-login: ${{ github.actor }}" --header "x-attribution-actor-id: ${{ github.actor }}" \
-                --header "Circle-Token: ${{ secrets.circleCIToken }}" $DATA )
+                --header "Circle-Token: ${{ secrets.CIRCLECI_TOKEN }}" $DATA )
 
               if [[ "$STATUS_CODE" == "429" ]]; then
                 STATUS_CODE=
@@ -254,7 +254,7 @@ jobs:
             STATUS_CODE=$(curl -o $OUTPUT_FILE -sL -w "%{http_code}" -X $METHOD $URL \
               --header "content-type: application/json" --header "accept: application/json" \
               --header "x-attribution-login: ${{ github.actor }}" --header "x-attribution-actor-id: ${{ github.actor }}" \
-              --header "Circle-Token: ${{ secrets.circleCIToken }}" $DATA )
+              --header "Circle-Token: ${{ secrets.CIRCLECI_TOKEN }}" $DATA )
 
             if [ "$STATUS_CODE" == "429" ]; then
               # we are exceeding rate limit, try again later
@@ -317,7 +317,7 @@ jobs:
             STATUS_CODE=$(curl -o $OUTPUT_FILE -sL -w "%{http_code}" -X $METHOD $URL \
               --header "content-type: application/json" --header "accept: application/json" \
               --header "x-attribution-login: ${{ github.actor }}" --header "x-attribution-actor-id: ${{ github.actor }}" \
-              --header "Circle-Token: ${{ secrets.circleCIToken }}" $DATA )
+              --header "Circle-Token: ${{ secrets.CIRCLECI_TOKEN }}" $DATA )
 
             cat $OUTPUT_FILE
             rm $OUTPUT_FILE


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
