### PR TITLE
test(framework/test-server): add option to succeed only after n requests

### DIFF
--- a/test/server/cmd/echo.go
+++ b/test/server/cmd/echo.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -16,6 +17,8 @@ import (
 )
 
 func newEchoHTTPCmd() *cobra.Command {
+	counters := newCounters()
+
 	args := struct {
 		ip       string
 		port     uint32
@@ -34,6 +37,14 @@ func newEchoHTTPCmd() *cobra.Command {
 				headers := request.Header
 				handleDelay(headers)
 				headers.Add("host", request.Host)
+
+				if n, id, ok := parseSucceedAfterNHeaders(headers); ok {
+					if counters.get(id) <= n {
+						writer.WriteHeader(http.StatusServiceUnavailable)
+						return
+					}
+				}
+
 				resp := &types.EchoResponse{
 					Instance: args.instance,
 					Received: types.EchoResponseReceived{
@@ -105,6 +116,37 @@ func newEchoHTTPCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&args.keyFile, "key", "./test/server/certs/server.key", "path to the server's TLS key")
 	cmd.PersistentFlags().BoolVar(&args.probes, "probes", false, "generate readiness and liveness endpoints")
 	return cmd
+}
+
+type counters struct {
+	sync.RWMutex
+	counters map[string]int
+}
+
+func newCounters() *counters {
+	return &counters{counters: map[string]int{}}
+}
+
+func (c *counters) get(hash string) int {
+	c.Lock()
+	defer c.Unlock()
+	c.counters[hash]++
+	return c.counters[hash]
+}
+
+func parseSucceedAfterNHeaders(headers http.Header) (int, string, bool) {
+	id := headers.Get("x-succeed-after-n-id")
+	if id == "" {
+		return 0, "", false
+	}
+
+	nHeader := headers.Get("x-succeed-after-n")
+	n, err := strconv.Atoi(nHeader)
+	if err != nil || n < 2 {
+		return 0, "", false
+	}
+
+	return n, id, true
 }
 
 func handleDelay(headers http.Header) {


### PR DESCRIPTION
There is currently no easy way to test MeshRetry policy with delegated gateway as current MeshRetry e2e tests are implemented on universal suites, but our framework only allows to deploy delegated gateway on kubernetes clusters.

This functionality allows test server to fail with 503 for the initial `n` request after which everything goes to normal.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - https://github.com/kumahq/kuma/issues/8746
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - There is no need

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
