### PR TITLE
test(e2e): add e2e test for MeshRetry with delegated gateway

### DIFF
--- a/test/e2e_env/kubernetes/gateway/delegated.go
+++ b/test/e2e_env/kubernetes/gateway/delegated.go
@@ -87,4 +87,5 @@ spec:
 	Context("MeshCircuitBreaker", delegated.CircuitBreaker(&config))
 	Context("MeshProxyPatch", delegated.MeshProxyPatch(&config))
 	Context("MeshHealthCheck", delegated.MeshHealthCheck(&config))
+	Context("MeshRetry", delegated.MeshRetry(&config))
 }

--- a/test/e2e_env/kubernetes/gateway/delegated/meshretry.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshretry.go
@@ -1,0 +1,86 @@
+package delegated
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/pkg/plugins/policies/meshretry/api/v1alpha1"
+	"github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/client"
+	"github.com/kumahq/kuma/test/framework/envs/kubernetes"
+)
+
+func MeshRetry(config *Config) func() {
+	GinkgoHelper()
+
+	return func() {
+		meshRetryPolicy := fmt.Sprintf(`
+apiVersion: kuma.io/v1alpha1
+kind: MeshRetry
+metadata:
+  name: mr
+  namespace: %s
+  labels:
+    kuma.io/mesh: %s
+spec:
+  targetRef:
+    kind: Mesh
+  to:
+    - targetRef:
+        kind: Mesh
+      default:
+        http:
+          numRetries: 6
+          retryOn: ["503"]
+`, config.CpNamespace, config.Mesh)
+
+		framework.E2EAfterEach(func() {
+			Expect(framework.DeleteMeshResources(
+				kubernetes.Cluster,
+				config.Mesh,
+				v1alpha1.MeshRetryResourceTypeDescriptor,
+			)).To(Succeed())
+		})
+
+		It("should retry on HTTP connection failure", func() {
+			// Given no MeshRetry policies
+			Expect(framework.DeleteMeshResources(
+				kubernetes.Cluster,
+				config.Mesh,
+				v1alpha1.MeshRetryResourceTypeDescriptor,
+			)).To(Succeed())
+
+			// then
+			Eventually(func(g Gomega) {
+				response, err := client.CollectFailure(
+					kubernetes.Cluster,
+					"demo-client",
+					fmt.Sprintf("http://%s/test-server", config.KicIP),
+					client.FromKubernetesPod(config.NamespaceOutsideMesh, "demo-client"),
+					client.WithHeader("x-succeed-after-n", "100"),
+					client.WithHeader("x-succeed-after-n-id", "1"),
+				)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(response.ResponseCode).To(Equal(503))
+			}, "1m", "1s", MustPassRepeatedly(5)).Should(Succeed())
+
+			// and when a MeshRetry policy is applied
+			Expect(framework.YamlK8s(meshRetryPolicy)(kubernetes.Cluster)).To(Succeed())
+
+			// then
+			Eventually(func(g Gomega) {
+				_, err := client.CollectEchoResponse(
+					kubernetes.Cluster,
+					"demo-client",
+					fmt.Sprintf("http://%s/test-server", config.KicIP),
+					client.FromKubernetesPod(config.NamespaceOutsideMesh, "demo-client"),
+					client.WithHeader("x-succeed-after-n", "5"),
+					client.WithHeader("x-succeed-after-n-id", "2"),
+				)
+				g.Expect(err).ToNot(HaveOccurred())
+			}, "1m", "1s", MustPassRepeatedly(5)).Should(Succeed())
+		})
+	}
+}

--- a/test/e2e_env/kubernetes/gateway/delegated/meshretry.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshretry.go
@@ -44,7 +44,7 @@ spec:
 			)).To(Succeed())
 		})
 
-		It("should retry on HTTP connection failure", func() {
+		It("should retry on HTTP 503", func() {
 			// Given no MeshRetry policies
 			Expect(framework.DeleteMeshResources(
 				kubernetes.Cluster,


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - https://github.com/kumahq/kuma/issues/8746
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - There is no need

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
