### PR TITLE
chore(api-server): remove duplicate error checking logic

### DIFF
--- a/pkg/api-server/index_endpoints.go
+++ b/pkg/api-server/index_endpoints.go
@@ -18,9 +18,6 @@ func addIndexWsEndpoints(ws *restful.WebService, getInstanceId func() string, ge
 
 	var instanceId string
 	var clusterId string
-	if err != nil {
-		return err
-	}
 	ws.Route(ws.GET("/").
 		Metadata(authn.MetadataAuthKey, authn.MetadataAuthSkip).
 		To(func(req *restful.Request, resp *restful.Response) {


### PR DESCRIPTION
### Checklist prior to review

- [x] [Link to relevant issue][1] as well as docs and UI issues --
  - None
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
  - There is no need

> Changelog: skip

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
