### PR TITLE
ci(github): add SBOM from project

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -13,6 +13,8 @@ on:
     outputs:
       IMAGE_MANIFESTS:
         value: ${{ jobs.build.outputs.IMAGE_MANIFESTS }}
+      BINARY_ARTIFACT_DIGEST_BASE64:
+        value: ${{ jobs.build.outputs.BINARY_ARTIFACT_DIGEST_BASE64 }}
 permissions:
   contents: read
 env:
@@ -23,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       IMAGE_MANIFESTS: ${{ steps.image_manifests.outputs.manifests }}
+      BINARY_ARTIFACT_DIGEST_BASE64: ${{ steps.inspect-binary-output.outputs.binary_artifact_digest_base64 }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
@@ -60,6 +63,18 @@ jobs:
           make build
       - run: |
           make -j build/distributions
+      - id: inspect-binary-output
+        run: |
+          for i in build/distributions/out/*.tar.gz; do echo $i; tar -tvf $i; done
+          echo "binary_artifact_digest_base64=$(cat ./build/distributions/artifact_digest_file.text) > $GITHUB_OUTPUT
+      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        id: binary-artifacts
+        with:
+          name: ${{ inputs.BINARY_ARTIFACT_NAME }}
+          path: |
+            ./build/distributions/out/*.tar.gz
+            ./build/distributions/out/*.sha256
+            !./build/distributions/out/*.tar.gz.sha256
       - run: |
           make -j images
       - run: |
@@ -68,16 +83,6 @@ jobs:
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-container-structure-test') && !contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
         run: |
           make test/container-structure
-      - name: Inspect created tars
-        run: |
-          for i in build/distributions/out/*.tar.gz; do echo $i; tar -tvf $i; done
-      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
-        id: binary-artifacts
-        with:
-          name: ${{ inputs.BINARY_ARTIFACT_NAME }}
-          path: |
-            ./build/distributions/out/*.tar.gz
-            ./build/distributions/out/artifact_digest_file.text
       - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         id: image-artifacts
         with:

--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -89,8 +89,3 @@ jobs:
           MANIFESTS=$(make manifests/json/release)
           echo "Image manifests: ${MANIFESTS}"
           echo "manifests=${MANIFESTS}" >> $GITHUB_OUTPUT
-      - id: sca-project
-        uses: Kong/public-shared-actions/security-actions/sca@b0ef627fa71528272d1daa9257b71dc90246cc46
-        with:
-          dir: .
-          config: .syft.yaml

--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -27,7 +27,6 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
-
       - name: "Add matrix to .build/info to cache"
         run: |
           make build/info/short > .build-info
@@ -85,8 +84,13 @@ jobs:
           name: ${{ inputs.IMAGE_ARTIFACT_NAME }}
           path: |
             ./build/docker/*.tar
-      - id: image_manifests
+      - id: image-manifests
         run: |
           MANIFESTS=$(make manifests/json/release)
           echo "Image manifests: ${MANIFESTS}"
           echo "manifests=${MANIFESTS}" >> $GITHUB_OUTPUT
+      - id: sca-project
+        uses: Kong/public-shared-actions/security-actions/sca@b0ef627fa71528272d1daa9257b71dc90246cc46
+        with:
+          dir: .
+          config: .syft.yaml

--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -66,7 +66,7 @@ jobs:
       - id: inspect-binary-output
         run: |
           for i in build/distributions/out/*.tar.gz; do echo $i; tar -tvf $i; done
-          echo "binary_artifact_digest_base64=$(cat ./build/distributions/artifact_digest_file.text) > $GITHUB_OUTPUT
+          echo "binary_artifact_digest_base64=$(cat ./build/distributions/artifact_digest_file.text)" > $GITHUB_OUTPUT
       - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         id: binary-artifacts
         with:

--- a/.github/workflows/_publish.yaml
+++ b/.github/workflows/_publish.yaml
@@ -13,6 +13,8 @@ on:
       BINARY_ARTIFACT_NAME:
         required: true
         type: string
+permissions:
+  contents: read
 env:
   GH_OWNER: ${{ github.repository_owner }}
   GH_USER: "github-actions[bot]"

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -46,6 +46,11 @@ jobs:
           make clean
       - run: |
           make check
+      - id: sca-project
+        uses: Kong/public-shared-actions/security-actions/sca@b0ef627fa71528272d1daa9257b71dc90246cc46
+        with:
+          dir: .
+          config: .syft.yaml
   test:
     needs: ["check"]
     if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}

--- a/.syft.yaml
+++ b/.syft.yaml
@@ -1,0 +1,2 @@
+select-catalogers:
+  - +sbom-cataloger


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
