### PR TITLE
feat(policy): add possibility to configure multiple opentelemetry backends

### DIFF
--- a/app/kuma-dp/pkg/dataplane/meshmetrics/component.go
+++ b/app/kuma-dp/pkg/dataplane/meshmetrics/component.go
@@ -162,7 +162,7 @@ func (cf *ConfigFetcher) reconfigureBackends(openTelemetryBackends map[string]*x
 
 func (cf *ConfigFetcher) shutdownBackendsRemovedFromConfig(openTelemetryBackends map[string]*xds.OpenTelemetryBackend) error {
 	var backendsToRemove []string
-	for backendName, _ := range cf.runningBackends {
+	for backendName := range cf.runningBackends {
 		// backend still configured in policy
 		if openTelemetryBackends[backendName] != nil {
 			continue

--- a/app/kuma-dp/pkg/dataplane/meshmetrics/component.go
+++ b/app/kuma-dp/pkg/dataplane/meshmetrics/component.go
@@ -150,6 +150,7 @@ func (cf *ConfigFetcher) reconfigureBackends(openTelemetryBackends map[string]*x
 		if cf.runningBackends[backendName] != nil {
 			continue
 		}
+		// start backend as it is not running yet
 		exporter, err := startExporter(backend, cf.openTelemetryProducer, backendName)
 		if err != nil {
 			return err

--- a/pkg/core/xds/sockets.go
+++ b/pkg/core/xds/sockets.go
@@ -22,8 +22,8 @@ func MeshMetricsDynamicConfigurationSocketName(workdir string) string {
 	return socketName(filepath.Join(workdir, "kuma-mesh-metric-config"))
 }
 
-func OpenTelemetrySocketName(workdir string) string {
-	return socketName(filepath.Join(workdir, "kuma-open-telemetry"))
+func OpenTelemetrySocketName(workdir string, backendName string) string {
+	return socketName(filepath.Join(workdir, "kuma-otel-"+backendName))
 }
 
 func socketName(s string) string {

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin.go
@@ -66,18 +66,17 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 	removeResourcesConfiguredByMesh(rs, listeners.Prometheus, clusters.Prometheus)
 
 	prometheusBackends := filterPrometheusBackends(conf.Backends)
-	// TODO multiple backends of the same type support. Issue: https://github.com/kumahq/kuma/issues/8942
-	openTelemetryBackend := firstOpenTelemetryBackend(conf.Backends)
+	openTelemetryBackends := filterOpenTelemetryBackends(conf.Backends)
 
 	err := configurePrometheus(rs, proxy, prometheusBackends)
 	if err != nil {
 		return err
 	}
-	err = configureOpenTelemetry(rs, proxy, openTelemetryBackend)
+	err = configureOpenTelemetry(rs, proxy, openTelemetryBackends)
 	if err != nil {
 		return err
 	}
-	err = configureDynamicDPPConfig(rs, proxy, conf, prometheusBackends, openTelemetryBackend)
+	err = configureDynamicDPPConfig(rs, proxy, conf, prometheusBackends, openTelemetryBackends)
 	if err != nil {
 		return err
 	}
@@ -131,19 +130,32 @@ func configurePrometheus(rs *core_xds.ResourceSet, proxy *core_xds.Proxy, promet
 	return nil
 }
 
-func configureOpenTelemetry(rs *core_xds.ResourceSet, proxy *core_xds.Proxy, openTelemetryBackend *api.OpenTelemetryBackend) error {
+func configureOpenTelemetry(rs *core_xds.ResourceSet, proxy *core_xds.Proxy, openTelemetryBackends []*api.OpenTelemetryBackend) error {
+	for _, openTelemetryBackend := range openTelemetryBackends {
+		err := configureOpenTelemetryBackend(rs, proxy, openTelemetryBackend)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func configureOpenTelemetryBackend(rs *core_xds.ResourceSet, proxy *core_xds.Proxy, openTelemetryBackend *api.OpenTelemetryBackend) error {
 	if openTelemetryBackend == nil {
 		return nil
 	}
 	endpoint := endpointForOpenTelemetry(openTelemetryBackend.Endpoint)
+	backendName := backendNameFrom(openTelemetryBackend.Endpoint)
 
 	configurer := &plugin_xds.OpenTelemetryConfigurer{
 		Endpoint:     endpoint,
-		ListenerName: "_kuma:metrics:opentelemetry",
-		ClusterName:  "_kuma:metrics:opentelemetry:collector",
+		ListenerName: envoy_names.GetOpenTelemetryListenerName(backendName),
+		ClusterName:  envoy_names.GetOpenTelemetryClusterName(backendName),
+		SocketName:   core_xds.OpenTelemetrySocketName(proxy.Metadata.WorkDir, backendName),
+		ApiVersion:   proxy.APIVersion,
 	}
 
-	cluster, err := configurer.ConfigureCluster(proxy)
+	cluster, err := configurer.ConfigureCluster(proxy.Dataplane.IsIPv6())
 	if err != nil {
 		return err
 	}
@@ -153,7 +165,7 @@ func configureOpenTelemetry(rs *core_xds.ResourceSet, proxy *core_xds.Proxy, ope
 		Resource: cluster,
 	})
 
-	listener, err := configurer.ConfigureListener(proxy)
+	listener, err := configurer.ConfigureListener()
 	if err != nil {
 		return err
 	}
@@ -166,7 +178,7 @@ func configureOpenTelemetry(rs *core_xds.ResourceSet, proxy *core_xds.Proxy, ope
 	return nil
 }
 
-func configureDynamicDPPConfig(rs *core_xds.ResourceSet, proxy *core_xds.Proxy, conf api.Conf, prometheusBackends []*api.PrometheusBackend, openTelemetryBackend *api.OpenTelemetryBackend) error {
+func configureDynamicDPPConfig(rs *core_xds.ResourceSet, proxy *core_xds.Proxy, conf api.Conf, prometheusBackends []*api.PrometheusBackend, openTelemetryBackend []*api.OpenTelemetryBackend) error {
 	configurer := &plugin_xds.DppConfigConfigurer{
 		ListenerName: DynamicConfigListenerName,
 		DpConfig:     createDynamicConfig(conf, proxy, prometheusBackends, openTelemetryBackend),
@@ -200,7 +212,7 @@ func EnvoyMetricsFilter(sidecar *api.Sidecar) url.Values {
 	return values
 }
 
-func createDynamicConfig(conf api.Conf, proxy *core_xds.Proxy, prometheusBackends []*api.PrometheusBackend, openTelemetryBackend *api.OpenTelemetryBackend) plugin_xds.MeshMetricDpConfig {
+func createDynamicConfig(conf api.Conf, proxy *core_xds.Proxy, prometheusBackends []*api.PrometheusBackend, openTelemetryBackends []*api.OpenTelemetryBackend) plugin_xds.MeshMetricDpConfig {
 	var applications []plugin_xds.Application
 	for _, app := range pointer.Deref(conf.Applications) {
 		applications = append(applications, plugin_xds.Application{
@@ -217,11 +229,13 @@ func createDynamicConfig(conf api.Conf, proxy *core_xds.Proxy, prometheusBackend
 			Type: string(api.PrometheusBackendType),
 		})
 	}
-	if openTelemetryBackend != nil {
+	for _, backend := range openTelemetryBackends {
+		backendName := backendNameFrom(backend.Endpoint)
 		backends = append(backends, plugin_xds.Backend{
 			Type: string(api.OpenTelemetryBackendType),
+			Name: &backendName,
 			OpenTelemetry: &plugin_xds.OpenTelemetryBackend{
-				Endpoint: core_xds.OpenTelemetrySocketName(proxy.Metadata.WorkDir),
+				Endpoint: core_xds.OpenTelemetrySocketName(proxy.Metadata.WorkDir, backendName),
 			},
 		})
 	}
@@ -250,13 +264,14 @@ func endpointForOpenTelemetry(endpoint string) *core_xds.Endpoint {
 	}
 }
 
-func firstOpenTelemetryBackend(backends *[]api.Backend) *api.OpenTelemetryBackend {
+func filterOpenTelemetryBackends(backends *[]api.Backend) []*api.OpenTelemetryBackend {
+	var openTelemetryBackends []*api.OpenTelemetryBackend
 	for _, backend := range pointer.Deref(backends) {
 		if backend.Type == api.OpenTelemetryBackendType && backend.OpenTelemetry != nil {
-			return backend.OpenTelemetry
+			openTelemetryBackends = append(openTelemetryBackends, backend.OpenTelemetry)
 		}
 	}
-	return nil
+	return openTelemetryBackends
 }
 
 func filterPrometheusBackends(backends *[]api.Backend) []*api.PrometheusBackend {
@@ -267,4 +282,8 @@ func filterPrometheusBackends(backends *[]api.Backend) []*api.PrometheusBackend 
 		}
 	}
 	return prometheusBackends
+}
+
+func backendNameFrom(endpoint string) string {
+	return strings.Split(endpoint, ":")[0]
 }

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin.go
@@ -285,5 +285,5 @@ func filterPrometheusBackends(backends *[]api.Backend) []*api.PrometheusBackend 
 }
 
 func backendNameFrom(endpoint string) string {
-	return strings.Split(endpoint, ":")[0]
+	return strings.ReplaceAll(endpoint, ":", "")
 }

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin_test.go
@@ -268,5 +268,46 @@ var _ = Describe("MeshMetric", func() {
 				).
 				Build(),
 		}),
+		Entry("multiple_otel", testCase{
+			proxy: xds_builders.Proxy().
+				WithDataplane(samples.DataplaneBackendBuilder()).
+				WithMetadata(&xds.DataplaneMetadata{WorkDir: "/tmp", MetricsSocketPath: "/tmp/kuma-metrics-backend-default.sock"}).
+				WithPolicies(xds_builders.MatchedPolicies().
+					WithSingleItemPolicy(api.MeshMetricType, core_rules.SingleItemRules{
+						Rules: []*core_rules.Rule{
+							{
+								Subset: []core_rules.Tag{},
+								Conf: api.Conf{
+									Sidecar: &api.Sidecar{
+										Regex:         pointer.To("http.*"),
+										IncludeUnused: pointer.To(false),
+									},
+									Applications: &[]api.Application{
+										{
+											Path: pointer.To("/metrics"),
+											Port: 8080,
+										},
+									},
+									Backends: &[]api.Backend{
+										{
+											Type: api.OpenTelemetryBackendType,
+											OpenTelemetry: &api.OpenTelemetryBackend{
+												Endpoint: "otel-collector.observability.svc:4317",
+											},
+										},
+										{
+											Type: api.OpenTelemetryBackendType,
+											OpenTelemetry: &api.OpenTelemetryBackend{
+												Endpoint: "second-collector.observability.svc:4317",
+											},
+										},
+									},
+								},
+							},
+						},
+					}),
+				).
+				Build(),
+		}),
 	)
 })

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/basic.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/basic.listeners.golden.yaml
@@ -22,7 +22,7 @@ resources:
               routes:
               - directResponse:
                   body:
-                    inlineString: '{"observability":{"metrics":{"applications":[{"path":"/metrics","port":8080,"address":""}],"backends":[{"type":"Prometheus"}],"sidecar":{"regex":"http.*","includeUnused":false}}}}'
+                    inlineString: '{"observability":{"metrics":{"applications":[{"path":"/metrics","port":8080,"address":""}],"backends":[{"type":"Prometheus","name":null}],"sidecar":{"regex":"http.*","includeUnused":false}}}}'
                   status: 200
                 match:
                   prefix: /

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/default.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/default.listeners.golden.yaml
@@ -22,7 +22,7 @@ resources:
               routes:
               - directResponse:
                   body:
-                    inlineString: '{"observability":{"metrics":{"applications":[{"name":"test-app","path":"/metrics","port":8080,"address":""}],"backends":[{"type":"Prometheus"}]}}}'
+                    inlineString: '{"observability":{"metrics":{"applications":[{"name":"test-app","path":"/metrics","port":8080,"address":""}],"backends":[{"type":"Prometheus","name":null}]}}}'
                   status: 200
                 match:
                   prefix: /

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/multiple_otel.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/multiple_otel.clusters.golden.yaml
@@ -1,12 +1,12 @@
 resources:
-- name: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc
+- name: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc4317
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    altStatName: _kuma_metrics_opentelemetry_cluster_otel-collector_observability_svc
+    altStatName: _kuma_metrics_opentelemetry_cluster_otel-collector_observability_svc4317
     connectTimeout: 5s
     dnsLookupFamily: V4_ONLY
     loadAssignment:
-      clusterName: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc
+      clusterName: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc4317
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -14,21 +14,21 @@ resources:
               socketAddress:
                 address: otel-collector.observability.svc
                 portValue: 4317
-    name: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc
+    name: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc4317
     type: STRICT_DNS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         explicitHttpConfig:
           http2ProtocolOptions: {}
-- name: _kuma:metrics:opentelemetry:cluster:second-collector.observability.svc
+- name: _kuma:metrics:opentelemetry:cluster:second-collector.observability.svc4317
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    altStatName: _kuma_metrics_opentelemetry_cluster_second-collector_observability_svc
+    altStatName: _kuma_metrics_opentelemetry_cluster_second-collector_observability_svc4317
     connectTimeout: 5s
     dnsLookupFamily: V4_ONLY
     loadAssignment:
-      clusterName: _kuma:metrics:opentelemetry:cluster:second-collector.observability.svc
+      clusterName: _kuma:metrics:opentelemetry:cluster:second-collector.observability.svc4317
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -36,7 +36,7 @@ resources:
               socketAddress:
                 address: second-collector.observability.svc
                 portValue: 4317
-    name: _kuma:metrics:opentelemetry:cluster:second-collector.observability.svc
+    name: _kuma:metrics:opentelemetry:cluster:second-collector.observability.svc4317
     type: STRICT_DNS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/multiple_otel.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/multiple_otel.clusters.golden.yaml
@@ -1,12 +1,12 @@
 resources:
-- name: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc4317
+- name: _kuma:metrics:opentelemetry:otel-collector.observability.svc4317
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    altStatName: _kuma_metrics_opentelemetry_cluster_otel-collector_observability_svc4317
+    altStatName: _kuma_metrics_opentelemetry_otel-collector_observability_svc4317
     connectTimeout: 5s
     dnsLookupFamily: V4_ONLY
     loadAssignment:
-      clusterName: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc4317
+      clusterName: _kuma:metrics:opentelemetry:otel-collector.observability.svc4317
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -14,21 +14,21 @@ resources:
               socketAddress:
                 address: otel-collector.observability.svc
                 portValue: 4317
-    name: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc4317
+    name: _kuma:metrics:opentelemetry:otel-collector.observability.svc4317
     type: STRICT_DNS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         explicitHttpConfig:
           http2ProtocolOptions: {}
-- name: _kuma:metrics:opentelemetry:cluster:second-collector.observability.svc4317
+- name: _kuma:metrics:opentelemetry:second-collector.observability.svc4317
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    altStatName: _kuma_metrics_opentelemetry_cluster_second-collector_observability_svc4317
+    altStatName: _kuma_metrics_opentelemetry_second-collector_observability_svc4317
     connectTimeout: 5s
     dnsLookupFamily: V4_ONLY
     loadAssignment:
-      clusterName: _kuma:metrics:opentelemetry:cluster:second-collector.observability.svc4317
+      clusterName: _kuma:metrics:opentelemetry:second-collector.observability.svc4317
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -36,7 +36,7 @@ resources:
               socketAddress:
                 address: second-collector.observability.svc
                 portValue: 4317
-    name: _kuma:metrics:opentelemetry:cluster:second-collector.observability.svc4317
+    name: _kuma:metrics:opentelemetry:second-collector.observability.svc4317
     type: STRICT_DNS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/multiple_otel.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/multiple_otel.clusters.golden.yaml
@@ -21,3 +21,25 @@ resources:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         explicitHttpConfig:
           http2ProtocolOptions: {}
+- name: _kuma:metrics:opentelemetry:cluster:second-collector.observability.svc
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    altStatName: _kuma_metrics_opentelemetry_cluster_second-collector_observability_svc
+    connectTimeout: 5s
+    dnsLookupFamily: V4_ONLY
+    loadAssignment:
+      clusterName: _kuma:metrics:opentelemetry:cluster:second-collector.observability.svc
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: second-collector.observability.svc
+                portValue: 4317
+    name: _kuma:metrics:opentelemetry:cluster:second-collector.observability.svc
+    type: STRICT_DNS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/multiple_otel.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/multiple_otel.listeners.golden.yaml
@@ -22,7 +22,7 @@ resources:
               routes:
               - directResponse:
                   body:
-                    inlineString: '{"observability":{"metrics":{"applications":[{"path":"/metrics","port":8080,"address":""}],"backends":[{"type":"OpenTelemetry","name":"otel-collector.observability.svc","openTelemetry":{"endpoint":"/tmp/kuma-otel-otel-collector.observability.svc.sock"}}]}}}'
+                    inlineString: '{"observability":{"metrics":{"applications":[{"path":"/metrics","port":8080,"address":""}],"backends":[{"type":"OpenTelemetry","name":"otel-collector.observability.svc","openTelemetry":{"endpoint":"/tmp/kuma-otel-otel-collector.observability.svc.sock"}},{"type":"OpenTelemetry","name":"second-collector.observability.svc","openTelemetry":{"endpoint":"/tmp/kuma-otel-second-collector.observability.svc.sock"}}],"sidecar":{"regex":"http.*","includeUnused":false}}}}'
                   status: 200
                 match:
                   prefix: /
@@ -60,3 +60,35 @@ resources:
                   cluster: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc
           statPrefix: _kuma_metrics_opentelemetry_listener_otel-collector_observability_svc
     name: _kuma:metrics:opentelemetry:listener:otel-collector.observability.svc
+- name: _kuma:metrics:opentelemetry:listener:second-collector.observability.svc
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      pipe:
+        path: /tmp/kuma-otel-second-collector.observability.svc.sock
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          httpFilters:
+          - name: envoy.filters.http.grpc_stats
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+              emitFilterState: true
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          routeConfig:
+            validateClusters: false
+            virtualHosts:
+            - domains:
+              - '*'
+              name: _kuma:metrics:opentelemetry:listener:second-collector.observability.svc
+              routes:
+              - match:
+                  prefix: /
+                route:
+                  cluster: _kuma:metrics:opentelemetry:cluster:second-collector.observability.svc
+          statPrefix: _kuma_metrics_opentelemetry_listener_second-collector_observability_svc
+    name: _kuma:metrics:opentelemetry:listener:second-collector.observability.svc

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/multiple_otel.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/multiple_otel.listeners.golden.yaml
@@ -28,7 +28,7 @@ resources:
                   prefix: /
           statPrefix: _kuma_dynamicconfig_observability
     name: _kuma:dynamicconfig:observability
-- name: _kuma:metrics:opentelemetry:listener:otel-collector.observability.svc4317
+- name: _kuma:metrics:opentelemetry:otel-collector.observability.svc4317
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener
     address:
@@ -52,15 +52,15 @@ resources:
             virtualHosts:
             - domains:
               - '*'
-              name: _kuma:metrics:opentelemetry:listener:otel-collector.observability.svc4317
+              name: _kuma:metrics:opentelemetry:otel-collector.observability.svc4317
               routes:
               - match:
                   prefix: /
                 route:
-                  cluster: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc4317
-          statPrefix: _kuma_metrics_opentelemetry_listener_otel-collector_observability_svc4317
-    name: _kuma:metrics:opentelemetry:listener:otel-collector.observability.svc4317
-- name: _kuma:metrics:opentelemetry:listener:second-collector.observability.svc4317
+                  cluster: _kuma:metrics:opentelemetry:otel-collector.observability.svc4317
+          statPrefix: _kuma_metrics_opentelemetry_otel-collector_observability_svc4317
+    name: _kuma:metrics:opentelemetry:otel-collector.observability.svc4317
+- name: _kuma:metrics:opentelemetry:second-collector.observability.svc4317
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener
     address:
@@ -84,11 +84,11 @@ resources:
             virtualHosts:
             - domains:
               - '*'
-              name: _kuma:metrics:opentelemetry:listener:second-collector.observability.svc4317
+              name: _kuma:metrics:opentelemetry:second-collector.observability.svc4317
               routes:
               - match:
                   prefix: /
                 route:
-                  cluster: _kuma:metrics:opentelemetry:cluster:second-collector.observability.svc4317
-          statPrefix: _kuma_metrics_opentelemetry_listener_second-collector_observability_svc4317
-    name: _kuma:metrics:opentelemetry:listener:second-collector.observability.svc4317
+                  cluster: _kuma:metrics:opentelemetry:second-collector.observability.svc4317
+          statPrefix: _kuma_metrics_opentelemetry_second-collector_observability_svc4317
+    name: _kuma:metrics:opentelemetry:second-collector.observability.svc4317

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/multiple_otel.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/multiple_otel.listeners.golden.yaml
@@ -22,18 +22,18 @@ resources:
               routes:
               - directResponse:
                   body:
-                    inlineString: '{"observability":{"metrics":{"applications":[{"path":"/metrics","port":8080,"address":""}],"backends":[{"type":"OpenTelemetry","name":"otel-collector.observability.svc","openTelemetry":{"endpoint":"/tmp/kuma-otel-otel-collector.observability.svc.sock"}},{"type":"OpenTelemetry","name":"second-collector.observability.svc","openTelemetry":{"endpoint":"/tmp/kuma-otel-second-collector.observability.svc.sock"}}],"sidecar":{"regex":"http.*","includeUnused":false}}}}'
+                    inlineString: '{"observability":{"metrics":{"applications":[{"path":"/metrics","port":8080,"address":""}],"backends":[{"type":"OpenTelemetry","name":"otel-collector.observability.svc4317","openTelemetry":{"endpoint":"/tmp/kuma-otel-otel-collector.observability.svc4317.sock"}},{"type":"OpenTelemetry","name":"second-collector.observability.svc4317","openTelemetry":{"endpoint":"/tmp/kuma-otel-second-collector.observability.svc4317.sock"}}],"sidecar":{"regex":"http.*","includeUnused":false}}}}'
                   status: 200
                 match:
                   prefix: /
           statPrefix: _kuma_dynamicconfig_observability
     name: _kuma:dynamicconfig:observability
-- name: _kuma:metrics:opentelemetry:listener:otel-collector.observability.svc
+- name: _kuma:metrics:opentelemetry:listener:otel-collector.observability.svc4317
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener
     address:
       pipe:
-        path: /tmp/kuma-otel-otel-collector.observability.svc.sock
+        path: /tmp/kuma-otel-otel-collector.observability.svc4317.sock
     filterChains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -52,20 +52,20 @@ resources:
             virtualHosts:
             - domains:
               - '*'
-              name: _kuma:metrics:opentelemetry:listener:otel-collector.observability.svc
+              name: _kuma:metrics:opentelemetry:listener:otel-collector.observability.svc4317
               routes:
               - match:
                   prefix: /
                 route:
-                  cluster: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc
-          statPrefix: _kuma_metrics_opentelemetry_listener_otel-collector_observability_svc
-    name: _kuma:metrics:opentelemetry:listener:otel-collector.observability.svc
-- name: _kuma:metrics:opentelemetry:listener:second-collector.observability.svc
+                  cluster: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc4317
+          statPrefix: _kuma_metrics_opentelemetry_listener_otel-collector_observability_svc4317
+    name: _kuma:metrics:opentelemetry:listener:otel-collector.observability.svc4317
+- name: _kuma:metrics:opentelemetry:listener:second-collector.observability.svc4317
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener
     address:
       pipe:
-        path: /tmp/kuma-otel-second-collector.observability.svc.sock
+        path: /tmp/kuma-otel-second-collector.observability.svc4317.sock
     filterChains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -84,11 +84,11 @@ resources:
             virtualHosts:
             - domains:
               - '*'
-              name: _kuma:metrics:opentelemetry:listener:second-collector.observability.svc
+              name: _kuma:metrics:opentelemetry:listener:second-collector.observability.svc4317
               routes:
               - match:
                   prefix: /
                 route:
-                  cluster: _kuma:metrics:opentelemetry:cluster:second-collector.observability.svc
-          statPrefix: _kuma_metrics_opentelemetry_listener_second-collector_observability_svc
-    name: _kuma:metrics:opentelemetry:listener:second-collector.observability.svc
+                  cluster: _kuma:metrics:opentelemetry:cluster:second-collector.observability.svc4317
+          statPrefix: _kuma_metrics_opentelemetry_listener_second-collector_observability_svc4317
+    name: _kuma:metrics:opentelemetry:listener:second-collector.observability.svc4317

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/multiple_prometheus.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/multiple_prometheus.listeners.golden.yaml
@@ -22,7 +22,7 @@ resources:
               routes:
               - directResponse:
                   body:
-                    inlineString: '{"observability":{"metrics":{"applications":[{"path":"/metrics","port":8080,"address":""}],"backends":[{"type":"Prometheus"}],"sidecar":{"regex":"http.*","includeUnused":false}}}}'
+                    inlineString: '{"observability":{"metrics":{"applications":[{"path":"/metrics","port":8080,"address":""}],"backends":[{"type":"Prometheus","name":null}],"sidecar":{"regex":"http.*","includeUnused":false}}}}'
                   status: 200
                 match:
                   prefix: /

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/openTelemetry.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/openTelemetry.clusters.golden.yaml
@@ -1,12 +1,12 @@
 resources:
-- name: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc
+- name: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc4317
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    altStatName: _kuma_metrics_opentelemetry_cluster_otel-collector_observability_svc
+    altStatName: _kuma_metrics_opentelemetry_cluster_otel-collector_observability_svc4317
     connectTimeout: 5s
     dnsLookupFamily: V4_ONLY
     loadAssignment:
-      clusterName: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc
+      clusterName: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc4317
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -14,7 +14,7 @@ resources:
               socketAddress:
                 address: otel-collector.observability.svc
                 portValue: 4317
-    name: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc
+    name: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc4317
     type: STRICT_DNS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/openTelemetry.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/openTelemetry.clusters.golden.yaml
@@ -1,12 +1,12 @@
 resources:
-- name: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc4317
+- name: _kuma:metrics:opentelemetry:otel-collector.observability.svc4317
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    altStatName: _kuma_metrics_opentelemetry_cluster_otel-collector_observability_svc4317
+    altStatName: _kuma_metrics_opentelemetry_otel-collector_observability_svc4317
     connectTimeout: 5s
     dnsLookupFamily: V4_ONLY
     loadAssignment:
-      clusterName: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc4317
+      clusterName: _kuma:metrics:opentelemetry:otel-collector.observability.svc4317
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -14,7 +14,7 @@ resources:
               socketAddress:
                 address: otel-collector.observability.svc
                 portValue: 4317
-    name: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc4317
+    name: _kuma:metrics:opentelemetry:otel-collector.observability.svc4317
     type: STRICT_DNS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/openTelemetry.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/openTelemetry.listeners.golden.yaml
@@ -28,7 +28,7 @@ resources:
                   prefix: /
           statPrefix: _kuma_dynamicconfig_observability
     name: _kuma:dynamicconfig:observability
-- name: _kuma:metrics:opentelemetry:listener:otel-collector.observability.svc4317
+- name: _kuma:metrics:opentelemetry:otel-collector.observability.svc4317
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener
     address:
@@ -52,11 +52,11 @@ resources:
             virtualHosts:
             - domains:
               - '*'
-              name: _kuma:metrics:opentelemetry:listener:otel-collector.observability.svc4317
+              name: _kuma:metrics:opentelemetry:otel-collector.observability.svc4317
               routes:
               - match:
                   prefix: /
                 route:
-                  cluster: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc4317
-          statPrefix: _kuma_metrics_opentelemetry_listener_otel-collector_observability_svc4317
-    name: _kuma:metrics:opentelemetry:listener:otel-collector.observability.svc4317
+                  cluster: _kuma:metrics:opentelemetry:otel-collector.observability.svc4317
+          statPrefix: _kuma_metrics_opentelemetry_otel-collector_observability_svc4317
+    name: _kuma:metrics:opentelemetry:otel-collector.observability.svc4317

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/openTelemetry.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/openTelemetry.listeners.golden.yaml
@@ -22,18 +22,18 @@ resources:
               routes:
               - directResponse:
                   body:
-                    inlineString: '{"observability":{"metrics":{"applications":[{"path":"/metrics","port":8080,"address":""}],"backends":[{"type":"OpenTelemetry","name":"otel-collector.observability.svc","openTelemetry":{"endpoint":"/tmp/kuma-otel-otel-collector.observability.svc.sock"}}]}}}'
+                    inlineString: '{"observability":{"metrics":{"applications":[{"path":"/metrics","port":8080,"address":""}],"backends":[{"type":"OpenTelemetry","name":"otel-collector.observability.svc4317","openTelemetry":{"endpoint":"/tmp/kuma-otel-otel-collector.observability.svc4317.sock"}}]}}}'
                   status: 200
                 match:
                   prefix: /
           statPrefix: _kuma_dynamicconfig_observability
     name: _kuma:dynamicconfig:observability
-- name: _kuma:metrics:opentelemetry:listener:otel-collector.observability.svc
+- name: _kuma:metrics:opentelemetry:listener:otel-collector.observability.svc4317
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener
     address:
       pipe:
-        path: /tmp/kuma-otel-otel-collector.observability.svc.sock
+        path: /tmp/kuma-otel-otel-collector.observability.svc4317.sock
     filterChains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -52,11 +52,11 @@ resources:
             virtualHosts:
             - domains:
               - '*'
-              name: _kuma:metrics:opentelemetry:listener:otel-collector.observability.svc
+              name: _kuma:metrics:opentelemetry:listener:otel-collector.observability.svc4317
               routes:
               - match:
                   prefix: /
                 route:
-                  cluster: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc
-          statPrefix: _kuma_metrics_opentelemetry_listener_otel-collector_observability_svc
-    name: _kuma:metrics:opentelemetry:listener:otel-collector.observability.svc
+                  cluster: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc4317
+          statPrefix: _kuma_metrics_opentelemetry_listener_otel-collector_observability_svc4317
+    name: _kuma:metrics:opentelemetry:listener:otel-collector.observability.svc4317

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/otel_and_prometheus.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/otel_and_prometheus.clusters.golden.yaml
@@ -14,14 +14,14 @@ resources:
                 path: /tmp/kuma-metrics-backend-default.sock
     name: _kuma:metrics:hijacker
     type: STATIC
-- name: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc
+- name: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc4317
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    altStatName: _kuma_metrics_opentelemetry_cluster_otel-collector_observability_svc
+    altStatName: _kuma_metrics_opentelemetry_cluster_otel-collector_observability_svc4317
     connectTimeout: 5s
     dnsLookupFamily: V4_ONLY
     loadAssignment:
-      clusterName: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc
+      clusterName: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc4317
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -29,7 +29,7 @@ resources:
               socketAddress:
                 address: otel-collector.observability.svc
                 portValue: 4317
-    name: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc
+    name: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc4317
     type: STRICT_DNS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/otel_and_prometheus.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/otel_and_prometheus.clusters.golden.yaml
@@ -14,14 +14,14 @@ resources:
                 path: /tmp/kuma-metrics-backend-default.sock
     name: _kuma:metrics:hijacker
     type: STATIC
-- name: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc4317
+- name: _kuma:metrics:opentelemetry:otel-collector.observability.svc4317
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    altStatName: _kuma_metrics_opentelemetry_cluster_otel-collector_observability_svc4317
+    altStatName: _kuma_metrics_opentelemetry_otel-collector_observability_svc4317
     connectTimeout: 5s
     dnsLookupFamily: V4_ONLY
     loadAssignment:
-      clusterName: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc4317
+      clusterName: _kuma:metrics:opentelemetry:otel-collector.observability.svc4317
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -29,7 +29,7 @@ resources:
               socketAddress:
                 address: otel-collector.observability.svc
                 portValue: 4317
-    name: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc4317
+    name: _kuma:metrics:opentelemetry:otel-collector.observability.svc4317
     type: STRICT_DNS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/otel_and_prometheus.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/otel_and_prometheus.clusters.golden.yaml
@@ -14,14 +14,14 @@ resources:
                 path: /tmp/kuma-metrics-backend-default.sock
     name: _kuma:metrics:hijacker
     type: STATIC
-- name: _kuma:metrics:opentelemetry:collector
+- name: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    altStatName: _kuma_metrics_opentelemetry_collector
+    altStatName: _kuma_metrics_opentelemetry_cluster_otel-collector_observability_svc
     connectTimeout: 5s
     dnsLookupFamily: V4_ONLY
     loadAssignment:
-      clusterName: _kuma:metrics:opentelemetry:collector
+      clusterName: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -29,7 +29,7 @@ resources:
               socketAddress:
                 address: otel-collector.observability.svc
                 portValue: 4317
-    name: _kuma:metrics:opentelemetry:collector
+    name: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc
     type: STRICT_DNS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/otel_and_prometheus.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/otel_and_prometheus.listeners.golden.yaml
@@ -22,18 +22,18 @@ resources:
               routes:
               - directResponse:
                   body:
-                    inlineString: '{"observability":{"metrics":{"applications":[{"path":"/metrics","port":8080,"address":""}],"backends":[{"type":"Prometheus","name":null},{"type":"OpenTelemetry","name":"otel-collector.observability.svc","openTelemetry":{"endpoint":"/tmp/kuma-otel-otel-collector.observability.svc.sock"}}],"sidecar":{"regex":"http.*","includeUnused":false}}}}'
+                    inlineString: '{"observability":{"metrics":{"applications":[{"path":"/metrics","port":8080,"address":""}],"backends":[{"type":"Prometheus","name":null},{"type":"OpenTelemetry","name":"otel-collector.observability.svc4317","openTelemetry":{"endpoint":"/tmp/kuma-otel-otel-collector.observability.svc4317.sock"}}],"sidecar":{"regex":"http.*","includeUnused":false}}}}'
                   status: 200
                 match:
                   prefix: /
           statPrefix: _kuma_dynamicconfig_observability
     name: _kuma:dynamicconfig:observability
-- name: _kuma:metrics:opentelemetry:listener:otel-collector.observability.svc
+- name: _kuma:metrics:opentelemetry:listener:otel-collector.observability.svc4317
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener
     address:
       pipe:
-        path: /tmp/kuma-otel-otel-collector.observability.svc.sock
+        path: /tmp/kuma-otel-otel-collector.observability.svc4317.sock
     filterChains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -52,14 +52,14 @@ resources:
             virtualHosts:
             - domains:
               - '*'
-              name: _kuma:metrics:opentelemetry:listener:otel-collector.observability.svc
+              name: _kuma:metrics:opentelemetry:listener:otel-collector.observability.svc4317
               routes:
               - match:
                   prefix: /
                 route:
-                  cluster: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc
-          statPrefix: _kuma_metrics_opentelemetry_listener_otel-collector_observability_svc
-    name: _kuma:metrics:opentelemetry:listener:otel-collector.observability.svc
+                  cluster: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc4317
+          statPrefix: _kuma_metrics_opentelemetry_listener_otel-collector_observability_svc4317
+    name: _kuma:metrics:opentelemetry:listener:otel-collector.observability.svc4317
 - name: _kuma:metrics:prometheus:default-backend
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/otel_and_prometheus.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/otel_and_prometheus.listeners.golden.yaml
@@ -28,7 +28,7 @@ resources:
                   prefix: /
           statPrefix: _kuma_dynamicconfig_observability
     name: _kuma:dynamicconfig:observability
-- name: _kuma:metrics:opentelemetry:listener:otel-collector.observability.svc4317
+- name: _kuma:metrics:opentelemetry:otel-collector.observability.svc4317
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener
     address:
@@ -52,14 +52,14 @@ resources:
             virtualHosts:
             - domains:
               - '*'
-              name: _kuma:metrics:opentelemetry:listener:otel-collector.observability.svc4317
+              name: _kuma:metrics:opentelemetry:otel-collector.observability.svc4317
               routes:
               - match:
                   prefix: /
                 route:
-                  cluster: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc4317
-          statPrefix: _kuma_metrics_opentelemetry_listener_otel-collector_observability_svc4317
-    name: _kuma:metrics:opentelemetry:listener:otel-collector.observability.svc4317
+                  cluster: _kuma:metrics:opentelemetry:otel-collector.observability.svc4317
+          statPrefix: _kuma_metrics_opentelemetry_otel-collector_observability_svc4317
+    name: _kuma:metrics:opentelemetry:otel-collector.observability.svc4317
 - name: _kuma:metrics:prometheus:default-backend
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/otel_and_prometheus.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/otel_and_prometheus.listeners.golden.yaml
@@ -22,18 +22,18 @@ resources:
               routes:
               - directResponse:
                   body:
-                    inlineString: '{"observability":{"metrics":{"applications":[{"path":"/metrics","port":8080,"address":""}],"backends":[{"type":"Prometheus"},{"type":"OpenTelemetry","openTelemetry":{"endpoint":"/tmp/kuma-open-telemetry.sock"}}],"sidecar":{"regex":"http.*","includeUnused":false}}}}'
+                    inlineString: '{"observability":{"metrics":{"applications":[{"path":"/metrics","port":8080,"address":""}],"backends":[{"type":"Prometheus","name":null},{"type":"OpenTelemetry","name":"otel-collector.observability.svc","openTelemetry":{"endpoint":"/tmp/kuma-otel-otel-collector.observability.svc.sock"}}],"sidecar":{"regex":"http.*","includeUnused":false}}}}'
                   status: 200
                 match:
                   prefix: /
           statPrefix: _kuma_dynamicconfig_observability
     name: _kuma:dynamicconfig:observability
-- name: _kuma:metrics:opentelemetry
+- name: _kuma:metrics:opentelemetry:listener:otel-collector.observability.svc
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener
     address:
       pipe:
-        path: /tmp/kuma-open-telemetry.sock
+        path: /tmp/kuma-otel-otel-collector.observability.svc.sock
     filterChains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -52,14 +52,14 @@ resources:
             virtualHosts:
             - domains:
               - '*'
-              name: _kuma:metrics:opentelemetry
+              name: _kuma:metrics:opentelemetry:listener:otel-collector.observability.svc
               routes:
               - match:
                   prefix: /
                 route:
-                  cluster: _kuma:metrics:opentelemetry:collector
-          statPrefix: _kuma_metrics_opentelemetry
-    name: _kuma:metrics:opentelemetry
+                  cluster: _kuma:metrics:opentelemetry:cluster:otel-collector.observability.svc
+          statPrefix: _kuma_metrics_opentelemetry_listener_otel-collector_observability_svc
+    name: _kuma:metrics:opentelemetry:listener:otel-collector.observability.svc
 - name: _kuma:metrics:prometheus:default-backend
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/provided_tls.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/provided_tls.listeners.golden.yaml
@@ -22,7 +22,7 @@ resources:
               routes:
               - directResponse:
                   body:
-                    inlineString: '{"observability":{"metrics":{"applications":null,"backends":[{"type":"Prometheus"}]}}}'
+                    inlineString: '{"observability":{"metrics":{"applications":null,"backends":[{"type":"Prometheus","name":null}]}}}'
                   status: 200
                 match:
                   prefix: /

--- a/pkg/plugins/policies/meshmetric/plugin/xds/dpp_config_configurer.go
+++ b/pkg/plugins/policies/meshmetric/plugin/xds/dpp_config_configurer.go
@@ -59,6 +59,7 @@ type Application struct {
 
 type Backend struct {
 	Type          string                `json:"type"`
+	Name          *string               `json:"name"`
 	OpenTelemetry *OpenTelemetryBackend `json:"openTelemetry,omitempty"`
 }
 

--- a/pkg/xds/envoy/names/resource_names.go
+++ b/pkg/xds/envoy/names/resource_names.go
@@ -66,11 +66,11 @@ func GetMetricsHijackerClusterName() string {
 }
 
 func GetOpenTelemetryListenerName(backendName string) string {
-	return Join("_kuma", "metrics", "opentelemetry", "listener", backendName)
+	return Join("_kuma", "metrics", "opentelemetry", backendName)
 }
 
 func GetOpenTelemetryClusterName(backendName string) string {
-	return Join("_kuma", "metrics", "opentelemetry", "cluster", backendName)
+	return Join("_kuma", "metrics", "opentelemetry", backendName)
 }
 
 func GetPrometheusListenerName() string {

--- a/pkg/xds/envoy/names/resource_names.go
+++ b/pkg/xds/envoy/names/resource_names.go
@@ -65,6 +65,14 @@ func GetMetricsHijackerClusterName() string {
 	return Join("kuma", "metrics", "hijacker")
 }
 
+func GetOpenTelemetryListenerName(backendName string) string {
+	return Join("_kuma", "metrics", "opentelemetry", "listener", backendName)
+}
+
+func GetOpenTelemetryClusterName(backendName string) string {
+	return Join("_kuma", "metrics", "opentelemetry", "cluster", backendName)
+}
+
 func GetPrometheusListenerName() string {
 	return Join("kuma", "metrics", "prometheus")
 }

--- a/test/e2e_env/kubernetes/meshmetric/meshmetric.go
+++ b/test/e2e_env/kubernetes/meshmetric/meshmetric.go
@@ -225,14 +225,41 @@ spec:
 	return YamlK8s(meshMetric)
 }
 
+func MeshMetricWithMultipleOpenTelemetryBackends(mesh, primaryOpenTelemetryEndpoint string, secondaryOpenTelemetryEndpoint string) InstallFunc {
+	meshMetric := fmt.Sprintf(`
+apiVersion: kuma.io/v1alpha1
+kind: MeshMetric
+metadata:
+  name: otel-metrics
+  namespace: %s
+  labels:
+    kuma.io/mesh: %s
+spec:
+  targetRef:
+    kind: Mesh
+  default:
+    backends:
+      - type: OpenTelemetry
+        openTelemetry: 
+          endpoint: %s
+      - type: OpenTelemetry
+        openTelemetry:
+          endpoint: %s
+`, Config.KumaNamespace, mesh, primaryOpenTelemetryEndpoint, secondaryOpenTelemetryEndpoint)
+	return YamlK8s(meshMetric)
+}
+
 func MeshMetric() {
 	const (
-		namespace              = "meshmetric"
-		observabilityNamespace = "observability"
-		mainMesh               = "main-metrics-mesh"
-		mainPrometheusId       = "main-prometheus"
-		secondaryMesh          = "secondary-metrics-mesh"
-		secondaryPrometheusId  = "secondary-prometheus"
+		namespace                                = "meshmetric"
+		mainMesh                                 = "main-metrics-mesh"
+		mainPrometheusId                         = "main-prometheus"
+		secondaryMesh                            = "secondary-metrics-mesh"
+		secondaryPrometheusId                    = "secondary-prometheus"
+		observabilityNamespace                   = "observability"
+		secondaryOpenTelemetryCollectorNamespace = "secondary-otel"
+		primaryOtelCollectorName                 = "otel-collector"
+		secondaryOtelCollectorName               = "secondary-otel-collector"
 	)
 
 	BeforeAll(func() {
@@ -241,11 +268,19 @@ func MeshMetric() {
 			Install(MeshKubernetes(secondaryMesh)).
 			Install(NamespaceWithSidecarInjection(namespace)).
 			Install(Namespace(observabilityNamespace)).
+			Install(Namespace(secondaryOpenTelemetryCollectorNamespace)).
 			Install(otelcollector.Install(
+				otelcollector.WithName(primaryOtelCollectorName),
 				otelcollector.WithNamespace(observabilityNamespace),
 				otelcollector.WithIPv6(Config.IPV6),
 			)).
 			Install(democlient.Install(democlient.WithNamespace(observabilityNamespace))).
+			Install(otelcollector.Install(
+				otelcollector.WithName(secondaryOtelCollectorName),
+				otelcollector.WithNamespace(secondaryOpenTelemetryCollectorNamespace),
+				otelcollector.WithIPv6(Config.IPV6),
+			)).
+			Install(democlient.Install(democlient.WithNamespace(secondaryOpenTelemetryCollectorNamespace))).
 			Setup(kubernetes.Cluster)
 		Expect(err).To(Succeed())
 
@@ -464,7 +499,7 @@ func MeshMetric() {
 
 	It("MeshMetric with OpenTelemetry enabled", func() {
 		// given
-		openTelemetryCollector := otelcollector.From(kubernetes.Cluster)
+		openTelemetryCollector := otelcollector.From(kubernetes.Cluster, primaryOtelCollectorName)
 		Expect(kubernetes.Cluster.Install(MeshMetricWithOpenTelemetryBackend(mainMesh, openTelemetryCollector.CollectorEndpoint()))).To(Succeed())
 
 		// then
@@ -481,7 +516,7 @@ func MeshMetric() {
 
 	It("MeshMetric with OpenTelemetry and usedonly/filter", func() {
 		// given
-		openTelemetryCollector := otelcollector.From(kubernetes.Cluster)
+		openTelemetryCollector := otelcollector.From(kubernetes.Cluster, primaryOtelCollectorName)
 		Expect(kubernetes.Cluster.Install(MeshMetricWithOpenTelemetryAndIncludeUnused(mainMesh, openTelemetryCollector.CollectorEndpoint()))).To(Succeed())
 
 		// then
@@ -499,7 +534,7 @@ func MeshMetric() {
 
 	It("MeshMetric with OpenTelemetry and Prometheus enabled", func() {
 		// given
-		openTelemetryCollector := otelcollector.From(kubernetes.Cluster)
+		openTelemetryCollector := otelcollector.From(kubernetes.Cluster, primaryOtelCollectorName)
 		testServerIp, err := PodIPOfApp(kubernetes.Cluster, "test-server-0", namespace)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(kubernetes.Cluster.Install(MeshMetricWithOpenTelemetryAndPrometheusBackend(mainMesh, openTelemetryCollector.CollectorEndpoint()))).To(Succeed())
@@ -523,6 +558,34 @@ func MeshMetric() {
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(stdout).ToNot(BeNil())
 			g.Expect(stdout).To(ContainSubstring("envoy_http_downstream_rq_xx"))
+		}, "2m", "3s").Should(Succeed())
+	})
+
+	It("MeshMetric with multiple OpenTelemetry backends", func() {
+		// given
+		primaryOpenTelemetryCollector := otelcollector.From(kubernetes.Cluster, primaryOtelCollectorName)
+		secondaryOpenTelemetryCollector := otelcollector.From(kubernetes.Cluster, secondaryOtelCollectorName)
+		Expect(kubernetes.Cluster.Install(MeshMetricWithMultipleOpenTelemetryBackends(mainMesh, primaryOpenTelemetryCollector.CollectorEndpoint(), secondaryOpenTelemetryCollector.CollectorEndpoint()))).To(Succeed())
+
+		// then
+		Eventually(func(g Gomega) {
+			// primary collector
+			stdout, _, err := client.CollectResponse(
+				kubernetes.Cluster, "demo-client", primaryOpenTelemetryCollector.ExporterEndpoint(),
+				client.FromKubernetesPod(observabilityNamespace, "demo-client"),
+				client.WithVerbose(),
+			)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(stdout).To(ContainSubstring("envoy_cluster_external_upstream_rq_time_bucket"))
+
+			// secondary collector
+			stdout, _, err = client.CollectResponse(
+				kubernetes.Cluster, "demo-client", secondaryOpenTelemetryCollector.ExporterEndpoint(),
+				client.FromKubernetesPod(secondaryOpenTelemetryCollectorNamespace, "demo-client"),
+				client.WithVerbose(),
+			)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(stdout).To(ContainSubstring("envoy_cluster_external_upstream_rq_time_bucket"))
 		}, "2m", "3s").Should(Succeed())
 	})
 }

--- a/test/framework/deployments/otelcollector/deployment_kubernetes.go
+++ b/test/framework/deployments/otelcollector/deployment_kubernetes.go
@@ -14,6 +14,7 @@ import (
 )
 
 type K8SDeployment struct {
+	name               string
 	namespace          string
 	image              string
 	waitingToBeReady   bool
@@ -24,7 +25,7 @@ type K8SDeployment struct {
 var _ Deployment = &K8SDeployment{}
 
 func (k *K8SDeployment) Name() string {
-	return DeploymentName
+	return k.name
 }
 
 func (k *K8SDeployment) Deploy(cluster framework.Cluster) error {
@@ -57,6 +58,11 @@ func (k *K8SDeployment) ExporterEndpoint() string {
 
 func newK8sDeployment() *K8SDeployment {
 	return &K8SDeployment{}
+}
+
+func (k *K8SDeployment) WithName(name string) *K8SDeployment {
+	k.name = name
+	return k
 }
 
 func (k *K8SDeployment) WithNamespace(namespace string) *K8SDeployment {


### PR DESCRIPTION


Fixes: #8942

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
