### PR TITLE
test(e2e): add e2e test for MeshAccessLog with delegated gateway

### DIFF
--- a/test/e2e_env/kubernetes/gateway/delegated.go
+++ b/test/e2e_env/kubernetes/gateway/delegated.go
@@ -31,6 +31,7 @@ func Delegated() {
 			Install(Namespace(config.NamespaceOutsideMesh)).
 			Install(democlient.Install(
 				democlient.WithNamespace(config.NamespaceOutsideMesh),
+				democlient.WithService(true),
 			)).
 			Install(testserver.Install(
 				testserver.WithMesh(config.Mesh),
@@ -87,4 +88,5 @@ spec:
 	Context("MeshCircuitBreaker", delegated.CircuitBreaker(&config))
 	Context("MeshProxyPatch", delegated.MeshProxyPatch(&config))
 	Context("MeshHealthCheck", delegated.MeshHealthCheck(&config))
+	Context("MeshAccessLog", delegated.MeshAccessLog(&config))
 }

--- a/test/e2e_env/kubernetes/gateway/delegated/meshaccesslog.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshaccesslog.go
@@ -1,0 +1,141 @@
+package delegated
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/pkg/plugins/policies/meshaccesslog/api/v1alpha1"
+	"github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/client"
+	"github.com/kumahq/kuma/test/framework/envs/kubernetes"
+)
+
+func MeshAccessLog(config *Config) func() {
+	GinkgoHelper()
+
+	return func() {
+		framework.E2EAfterEach(func() {
+			Expect(framework.DeleteMeshResources(
+				kubernetes.Cluster,
+				config.Mesh,
+				v1alpha1.MeshAccessLogResourceTypeDescriptor,
+			)).To(Succeed())
+		})
+
+		It("should log incoming traffic", func() {
+			// given
+			meshAccessLog := fmt.Sprintf(`
+apiVersion: kuma.io/v1alpha1
+kind: MeshAccessLog
+metadata:
+  name: mal
+  namespace: %s
+  labels:
+    kuma.io/mesh: %s
+spec:
+  targetRef:
+    kind: Mesh
+  to:
+    - targetRef:
+        kind: Mesh
+      default:
+        backends:
+          - type: Tcp
+            tcp:
+              format:
+                type: Json
+                json:
+                  - key: Source
+                    value: '%%KUMA_SOURCE_SERVICE%%'
+                  - key: Destination
+                    value: '%%KUMA_DESTINATION_SERVICE%%'
+                  - key: Start
+                    value: '%%START_TIME(%%s)%%'
+              address: demo-client.%s.svc.cluster.local:3000
+`, config.CpNamespace, config.Mesh, config.NamespaceOutsideMesh)
+
+			Expect(framework.YamlK8s(meshAccessLog)(kubernetes.Cluster)).To(Succeed())
+
+			// when
+			Eventually(func(g Gomega) {
+				_, err := client.CollectEchoResponse(
+					kubernetes.Cluster,
+					"demo-client",
+					fmt.Sprintf("http://%s/test-server", config.KicIP),
+					client.FromKubernetesPod(config.NamespaceOutsideMesh, "demo-client"),
+				)
+				g.Expect(err).ToNot(HaveOccurred())
+			}, "30s", "1s").Should(Succeed())
+
+			// then
+			Eventually(func(g Gomega) {
+				demoClientPod, err := framework.PodOfApp(
+					kubernetes.Cluster,
+					"demo-client",
+					config.NamespaceOutsideMesh,
+				)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				logs, err := kubernetes.Cluster.GetPodLogs(demoClientPod)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(parseLogs(logs)).To(ContainElement(
+					And(
+						HaveField("Start", BeTemporally("~", time.Now(), time.Hour)),
+						HaveField("Source", fmt.Sprintf("delegated-gateway-admin_%s_svc_8444", config.Namespace)),
+						HaveField("Destination", fmt.Sprintf("test-server_%s_svc_80", config.Namespace)),
+					),
+				))
+			}, "30s", "1s").Should(Succeed())
+		})
+	}
+}
+
+type log struct {
+	Source      string
+	Destination string
+	Start       time.Time
+}
+
+func (u *log) UnmarshalJSON(b []byte) error {
+	var raw map[string]string
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+
+	if raw["Source"] == "" || raw["Destination"] == "" || raw["Start"] == "" {
+		return fmt.Errorf("missing expected fields")
+	}
+
+	timestamp, err := strconv.Atoi(raw["Start"])
+	if err != nil {
+		return err
+	}
+
+	u.Source = raw["Source"]
+	u.Destination = raw["Destination"]
+	u.Start = time.Unix(int64(timestamp), 0)
+
+	return nil
+}
+
+func parseLogs(stdout string) []log {
+	GinkgoHelper()
+
+	var logs []log
+
+	for _, line := range strings.Split(stdout, "\n") {
+		var l log
+		if err := json.Unmarshal([]byte(strings.TrimSpace(line)), &l); err != nil {
+			continue
+		}
+		logs = append(logs, l)
+	}
+
+	return logs
+}

--- a/test/framework/deployments/democlient/deployment.go
+++ b/test/framework/deployments/democlient/deployment.go
@@ -11,6 +11,7 @@ type DeploymentOpts struct {
 	Namespace        string
 	Mesh             string
 	WaitingToBeReady bool
+	Service          bool
 	PodAnnotations   map[string]string
 	NodeSelector     map[string]string
 }
@@ -60,6 +61,12 @@ func WithPodAnnotations(annotations map[string]string) DeploymentOptsFn {
 func WithNodeSelector(selector map[string]string) DeploymentOptsFn {
 	return func(opts *DeploymentOpts) {
 		opts.NodeSelector = selector
+	}
+}
+
+func WithService(service bool) DeploymentOptsFn {
+	return func(opts *DeploymentOpts) {
+		opts.Service = service
 	}
 }
 

--- a/test/framework/k8s.go
+++ b/test/framework/k8s.go
@@ -22,6 +22,15 @@ import (
 )
 
 func PodNameOfApp(cluster Cluster, name string, namespace string) (string, error) {
+	pod, err := PodOfApp(cluster, name, namespace)
+	if err != nil {
+		return "", err
+	}
+
+	return pod.Name, nil
+}
+
+func PodOfApp(cluster Cluster, name string, namespace string) (v1.Pod, error) {
 	pods, err := k8s.ListPodsE(
 		cluster.GetTesting(),
 		cluster.GetKubectlOptions(namespace),
@@ -30,12 +39,12 @@ func PodNameOfApp(cluster Cluster, name string, namespace string) (string, error
 		},
 	)
 	if err != nil {
-		return "", err
+		return v1.Pod{}, err
 	}
 	if len(pods) != 1 {
-		return "", errors.Errorf("expected %d pods, got %d", 1, len(pods))
+		return v1.Pod{}, errors.Errorf("expected %d pods, got %d", 1, len(pods))
 	}
-	return pods[0].Name, nil
+	return pods[0], nil
 }
 
 func PodIPOfApp(cluster Cluster, name string, namespace string) (string, error) {


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - https://github.com/kumahq/kuma/issues/8746
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - There is no need

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
