### PR TITLE
test(e2e): add e2e test for MeshHTTPRoute with delegated gateway

### DIFF
--- a/test/e2e_env/kubernetes/gateway/delegated.go
+++ b/test/e2e_env/kubernetes/gateway/delegated.go
@@ -37,6 +37,10 @@ func Delegated() {
 				testserver.WithNamespace(config.Namespace),
 				testserver.WithName("test-server"),
 			)).
+			Install(testserver.Install(
+				testserver.WithNamespace(config.NamespaceOutsideMesh),
+				testserver.WithName("external-service"),
+			)).
 			Install(kic.KongIngressController(
 				kic.WithName("delegated"),
 				kic.WithNamespace(config.Namespace),
@@ -88,4 +92,5 @@ spec:
 	Context("MeshProxyPatch", delegated.MeshProxyPatch(&config))
 	Context("MeshHealthCheck", delegated.MeshHealthCheck(&config))
 	Context("MeshRetry", delegated.MeshRetry(&config))
+	Context("MeshHTTPRoute", delegated.MeshHTTPRoute(&config))
 }

--- a/test/e2e_env/kubernetes/gateway/delegated/meshhttproute.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshhttproute.go
@@ -1,0 +1,107 @@
+package delegated
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
+	"github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/client"
+	"github.com/kumahq/kuma/test/framework/envs/kubernetes"
+)
+
+func MeshHTTPRoute(config *Config) func() {
+	GinkgoHelper()
+
+	return func() {
+		framework.E2EAfterEach(func() {
+			Expect(framework.DeleteMeshResources(
+				kubernetes.Cluster,
+				config.Mesh,
+				v1alpha1.MeshHTTPRouteResourceTypeDescriptor,
+			)).To(Succeed())
+
+			Expect(framework.DeleteMeshResources(
+				kubernetes.Cluster,
+				config.Mesh,
+				core_mesh.ExternalServiceResourceTypeDescriptor,
+			)).To(Succeed())
+		})
+
+		It("should split traffic between internal and external services", func() {
+			// given
+			Expect(framework.YamlK8s(fmt.Sprintf(`
+apiVersion: kuma.io/v1alpha1
+kind: ExternalService
+metadata:
+  name: external-service-mhr
+mesh: %s
+spec:
+  tags:
+    kuma.io/service: external-service-mhr
+    kuma.io/protocol: http
+  networking:
+    address: external-service.%s.svc.cluster.local:80 # .svc.cluster.local is needed, otherwise Kubernetes will resolve this to the real IP
+`, config.Mesh, config.NamespaceOutsideMesh))(kubernetes.Cluster)).To(Succeed())
+
+			// when
+			Expect(framework.YamlK8s(fmt.Sprintf(`
+apiVersion: kuma.io/v1alpha1
+kind: MeshHTTPRoute
+metadata:
+  name: mhr
+  namespace: %s
+  labels:
+    kuma.io/mesh: %[2]s
+spec:
+  targetRef:
+    kind: MeshService
+    name: delegated-gateway-admin_%[2]s_svc_8444
+  to:
+    - targetRef:
+        kind: MeshService
+        name: test-server_%[2]s_svc_80
+      rules: 
+        - matches:
+            - path: 
+                type: PathPrefix
+                value: /
+          default:
+            backendRefs:
+              - kind: MeshService
+                name: test-server_%[2]s_svc_80
+                weight: 50
+              - kind: MeshService
+                name: external-service-mhr
+                weight: 50
+`, config.CpNamespace, config.Mesh))(kubernetes.Cluster)).To(Succeed())
+
+			// then receive responses from 'test-server_meshhttproute_svc_80'
+			Eventually(func(g Gomega) {
+				response, err := client.CollectEchoResponse(
+					kubernetes.Cluster,
+					"demo-client",
+					fmt.Sprintf("http://%s/test-server", config.KicIP),
+					client.FromKubernetesPod(config.NamespaceOutsideMesh, "demo-client"),
+				)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(response.Instance).To(HavePrefix("test-server"))
+			}, "30s", "1s").Should(Succeed())
+
+			// and then receive responses from 'external-service'
+			Eventually(func(g Gomega) {
+				response, err := client.CollectEchoResponse(
+					kubernetes.Cluster,
+					"demo-client",
+					fmt.Sprintf("http://%s/test-server", config.KicIP),
+					client.FromKubernetesPod(config.NamespaceOutsideMesh, "demo-client"),
+				)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(response.Instance).To(HavePrefix("external-service"))
+			}, "30s", "1s").Should(Succeed())
+		})
+	}
+}


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - https://github.com/kumahq/kuma/issues/8746
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - There is no need

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
