### PR TITLE
test(e2e): add e2e test for MeshTrace with delegated gateway

### DIFF
--- a/test/e2e_env/kubernetes/gateway/delegated.go
+++ b/test/e2e_env/kubernetes/gateway/delegated.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	"github.com/kumahq/kuma/test/framework/deployments/kic"
+	"github.com/kumahq/kuma/test/framework/deployments/observability"
 	"github.com/kumahq/kuma/test/framework/deployments/otelcollector"
 	"github.com/kumahq/kuma/test/framework/deployments/testserver"
 	"github.com/kumahq/kuma/test/framework/envs/kubernetes"
@@ -17,11 +18,12 @@ import (
 
 func Delegated() {
 	config := delegated.Config{
-		Namespace:            "delegated-gateway",
-		NamespaceOutsideMesh: "delegated-gateway-outside-mesh",
-		Mesh:                 "delegated-gateway",
-		KicIP:                "",
-		CpNamespace:          Config.KumaNamespace,
+		Namespace:                   "delegated-gateway",
+		NamespaceOutsideMesh:        "delegated-gateway-outside-mesh",
+		Mesh:                        "delegated-gateway",
+		KicIP:                       "",
+		CpNamespace:                 Config.KumaNamespace,
+		ObservabilityDeploymentName: "observability-delegated-meshtrace",
 	}
 
 	BeforeAll(func() {
@@ -45,6 +47,11 @@ func Delegated() {
 			Install(otelcollector.Install(
 				otelcollector.WithNamespace(config.NamespaceOutsideMesh),
 				otelcollector.WithIPv6(Config.IPV6),
+			)).
+			Install(observability.Install(
+				config.ObservabilityDeploymentName,
+				observability.WithNamespace(config.NamespaceOutsideMesh),
+				observability.WithComponents(observability.JaegerComponent),
 			)).
 			Install(kic.KongIngressController(
 				kic.WithName("delegated"),
@@ -91,6 +98,8 @@ spec:
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(config.NamespaceOutsideMesh)).
 			To(Succeed())
 		Expect(kubernetes.Cluster.DeleteMesh(config.Mesh)).To(Succeed())
+		Expect(kubernetes.Cluster.DeleteDeployment(config.ObservabilityDeploymentName)).
+			To(Succeed())
 	})
 
 	Context("MeshCircuitBreaker", delegated.CircuitBreaker(&config))
@@ -100,4 +109,5 @@ spec:
 	Context("MeshHTTPRoute", delegated.MeshHTTPRoute(&config))
 	Context("MeshTimeout", delegated.MeshTimeout(&config))
 	Context("MeshMetric", delegated.MeshMetric(&config))
+	Context("MeshTrace", delegated.MeshTrace(&config))
 }

--- a/test/e2e_env/kubernetes/gateway/delegated/common.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/common.go
@@ -1,9 +1,10 @@
 package delegated
 
 type Config struct {
-	Namespace            string
-	NamespaceOutsideMesh string
-	Mesh                 string
-	KicIP                string
-	CpNamespace          string
+	Namespace                   string
+	NamespaceOutsideMesh        string
+	Mesh                        string
+	KicIP                       string
+	CpNamespace                 string
+	ObservabilityDeploymentName string
 }

--- a/test/e2e_env/kubernetes/gateway/delegated/meshtrace.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshtrace.go
@@ -1,0 +1,80 @@
+package delegated
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/pkg/plugins/policies/meshtrace/api/v1alpha1"
+	"github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/client"
+	"github.com/kumahq/kuma/test/framework/deployments/observability"
+	"github.com/kumahq/kuma/test/framework/envs/kubernetes"
+)
+
+func MeshTrace(config *Config) func() {
+	GinkgoHelper()
+
+	return func() {
+		var observabilityClient observability.Observability
+
+		meshTrace := func(zipkinUrl string) framework.InstallFunc {
+			return framework.YamlK8s(fmt.Sprintf(`
+apiVersion: kuma.io/v1alpha1
+kind: MeshTrace
+metadata:
+  name: trace-all
+  namespace: %s
+  labels:
+    kuma.io/mesh: %s
+spec:
+  targetRef:
+    kind: Mesh
+  default:
+    tags:
+      - name: team
+        literal: core
+    backends:
+      - type: Zipkin
+        zipkin:
+          url: %s
+`, config.CpNamespace, config.Mesh, zipkinUrl))
+		}
+
+		BeforeAll(func() {
+			observabilityClient = observability.From(config.ObservabilityDeploymentName, kubernetes.Cluster)
+		})
+
+		framework.E2EAfterEach(func() {
+			Expect(framework.DeleteMeshResources(
+				kubernetes.Cluster,
+				config.Mesh,
+				v1alpha1.MeshTraceResourceTypeDescriptor,
+			)).To(Succeed())
+		})
+
+		It("should emit traces to jaeger", func() {
+			// given MeshTrace and with tracing backend
+			Expect(kubernetes.Cluster.Install(meshTrace(observabilityClient.ZipkinCollectorURL()))).
+				To(Succeed())
+
+			Eventually(func(g Gomega) {
+				_, err := client.CollectEchoResponse(
+					kubernetes.Cluster,
+					"demo-client",
+					fmt.Sprintf("http://%s/test-server", config.KicIP),
+					client.FromKubernetesPod(config.NamespaceOutsideMesh, "demo-client"),
+				)
+				g.Expect(err).ToNot(HaveOccurred())
+				srvs, err := observabilityClient.TracedServices()
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(srvs).To(Equal([]string{
+					fmt.Sprintf("delegated-gateway-admin_%s_svc_8444", config.Mesh),
+					"jaeger-query",
+					fmt.Sprintf("test-server_%s_svc_80", config.Mesh),
+				}))
+			}, "30s", "1s").Should(Succeed())
+		})
+	}
+}


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - https://github.com/kumahq/kuma/issues/8746
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - There is no need

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
