### PR TITLE
test(e2e): add e2e test for MeshLoadBalancingStrategy with delegated gateway

### DIFF
--- a/test/e2e_env/kubernetes/gateway/delegated.go
+++ b/test/e2e_env/kubernetes/gateway/delegated.go
@@ -37,6 +37,8 @@ func Delegated() {
 				testserver.WithMesh(config.Mesh),
 				testserver.WithNamespace(config.Namespace),
 				testserver.WithName("test-server"),
+				testserver.WithStatefulSet(true),
+				testserver.WithReplicas(3),
 			)).
 			Install(testserver.Install(
 				testserver.WithNamespace(config.NamespaceOutsideMesh),
@@ -100,4 +102,5 @@ spec:
 	Context("MeshHTTPRoute", delegated.MeshHTTPRoute(&config))
 	Context("MeshTimeout", delegated.MeshTimeout(&config))
 	Context("MeshMetric", delegated.MeshMetric(&config))
+	Context("MeshLoadBalancingStrategy", delegated.MeshLoadBalancingStrategy(&config))
 }

--- a/test/e2e_env/kubernetes/gateway/delegated/meshloadbalancingstrategy.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshloadbalancingstrategy.go
@@ -1,0 +1,78 @@
+package delegated
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1"
+	"github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/client"
+	"github.com/kumahq/kuma/test/framework/envs/kubernetes"
+)
+
+func MeshLoadBalancingStrategy(config *Config) func() {
+	GinkgoHelper()
+
+	return func() {
+		framework.E2EAfterEach(func() {
+			Expect(framework.DeleteMeshResources(
+				kubernetes.Cluster,
+				config.Mesh,
+				v1alpha1.MeshLoadBalancingStrategyResourceTypeDescriptor,
+			)).To(Succeed())
+		})
+
+		It("should use ring hash load balancing strategy", func() {
+			Eventually(func(g Gomega) {
+				responses, err := client.CollectResponsesByInstance(
+					kubernetes.Cluster,
+					"demo-client",
+					fmt.Sprintf("http://%s/test-server", config.KicIP),
+					client.FromKubernetesPod(config.NamespaceOutsideMesh, "demo-client"),
+				)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(responses).To(HaveLen(3))
+			}, "30s", "500ms").Should(Succeed())
+
+			Expect(framework.YamlK8s(fmt.Sprintf(`
+kind: MeshLoadBalancingStrategy
+apiVersion: kuma.io/v1alpha1
+metadata:
+  name: ring-hash
+  namespace: %s
+  labels:
+    kuma.io/mesh: %s
+spec:
+  targetRef:
+    kind: MeshService
+    name: delegated-gateway-admin_%[2]s_svc_8444
+  to:
+    - targetRef:
+        kind: MeshService
+        name: test-server_%[2]s_svc_80
+      default:
+        loadBalancer:
+          type: RingHash
+          ringHash:
+            hashPolicies:
+              - type: Header
+                header:
+                  name: x-header
+`, config.CpNamespace, config.Mesh))(kubernetes.Cluster)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				responses, err := client.CollectResponsesByInstance(
+					kubernetes.Cluster,
+					"demo-client",
+					fmt.Sprintf("http://%s/test-server", config.KicIP),
+					client.FromKubernetesPod(config.NamespaceOutsideMesh, "demo-client"),
+					client.WithHeader("x-header", "value"),
+				)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(responses).To(HaveLen(1))
+			}, "30s", "500ms").Should(Succeed())
+		})
+	}
+}


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - https://github.com/kumahq/kuma/issues/8746
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - There is no need

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword