### PR TITLE
test(e2e/framework): don't fail when deleting non-existing k8s namespace

### DIFF
--- a/test/framework/deployments/kic/kubernetes.go
+++ b/test/framework/deployments/kic/kubernetes.go
@@ -82,7 +82,7 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 }
 
 func (t *k8sDeployment) Delete(cluster framework.Cluster) error {
-	return cluster.DeleteNamespace(t.ingressNamespace)
+	return cluster.(*framework.K8sCluster).TriggerDeleteNamespace(t.ingressNamespace)
 }
 
 func (t *k8sDeployment) IP(namespace string) (string, error) {


### PR DESCRIPTION
When removing kic deployment we are removing a configured ingress namespace. There might be situation when this namespace might be already deleted during different test suite stage, so if doesn't exist, we don't have to fail during the deletion.

Updated kic deployment delete function to call `TraiggerDeleteNamespace` (which potentially might be more performant) instead of `DeleteNamespace`.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - No relevant issues
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - There is no need

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
