### PR TITLE
fix(e2e): meshmetric otel flake

### DIFF
--- a/test/e2e_env/kubernetes/meshmetric/meshmetric.go
+++ b/test/e2e_env/kubernetes/meshmetric/meshmetric.go
@@ -170,7 +170,7 @@ spec:
       - type: OpenTelemetry
         openTelemetry: 
           endpoint: %s
-          refreshInterval: 10s
+          refreshInterval: 20s
 `, Config.KumaNamespace, mesh, openTelemetryEndpoint)
 	return YamlK8s(meshMetric)
 }
@@ -195,7 +195,7 @@ spec:
       - type: OpenTelemetry
         openTelemetry:
           endpoint: %s
-          refreshInterval: 10s
+          refreshInterval: 20s
 `, Config.KumaNamespace, mesh, openTelemetryEndpoint)
 	return YamlK8s(meshMetric)
 }
@@ -217,7 +217,7 @@ spec:
       - type: OpenTelemetry
         openTelemetry: 
           endpoint: %s
-          refreshInterval: 10s
+          refreshInterval: 20s
       - type: Prometheus
         prometheus: 
           port: 8080
@@ -245,11 +245,11 @@ spec:
       - type: OpenTelemetry
         openTelemetry: 
           endpoint: %s
-          refreshInterval: 10s
+          refreshInterval: 20s
       - type: OpenTelemetry
         openTelemetry:
           endpoint: %s
-          refreshInterval: 10s
+          refreshInterval: 20s
 `, Config.KumaNamespace, mesh, primaryOpenTelemetryEndpoint, secondaryOpenTelemetryEndpoint)
 	return YamlK8s(meshMetric)
 }

--- a/test/framework/deployments/otelcollector/deployment_kubernetes.go
+++ b/test/framework/deployments/otelcollector/deployment_kubernetes.go
@@ -188,7 +188,7 @@ func (k *K8SDeployment) podSpec() corev1.PodTemplateSpec {
 					Resources: corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
 							"cpu":    resource.MustParse("500m"),
-							"memory": resource.MustParse("500Mi"),
+							"memory": resource.MustParse("1000Mi"),
 						},
 					},
 					Ports: []corev1.ContainerPort{
@@ -297,21 +297,18 @@ processors:
     send_batch_size: 4096
     send_batch_max_size: 8192
   memory_limiter:
-    limit_mib: 500
-    spike_limit_mib: 400
+    limit_mib: 950
+    spike_limit_mib: 300
     check_interval: 5s
 extensions:
   zpages: {}
-  memory_ballast:
-    # Memory Ballast size should be max 1/3 to 1/2 of memory.
-    size_mib: 256
 exporters:
   debug:
     verbosity: basic
   prometheus:
     endpoint: "%s:%d"
 service:
-  extensions: [zpages, memory_ballast]
+  extensions: [zpages]
   pipelines:
     traces/1:
       receivers: [otlp]


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
