### PR TITLE
ci(github): enable image signing

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -21,8 +21,6 @@ on:
         value: ${{ jobs.build.outputs.IMAGE_MANIFESTS }}
       BINARY_ARTIFACT_DIGEST_BASE64:
         value: ${{ jobs.build.outputs.BINARY_ARTIFACT_DIGEST_BASE64 }}
-permissions:
-  contents: read
 env:
   CI_TOOLS_DIR: "/home/runner/work/kuma/kuma/.ci_tools"
   FULL_MATRIX: ${{ inputs.FULL_MATRIX }}
@@ -136,7 +134,6 @@ jobs:
           name: images_${{ matrix.image }}
           path: |
             ./build/docker/*.tar
-      # TODO Do we need to scan images for each arch?
       - name: scan amd64 image
         id: scan_image-amd64
         uses: Kong/public-shared-actions/security-actions/scan-docker-image@60c9b136104671b7091b2306c599d80fec34ae3f # v2.0.3
@@ -173,15 +170,15 @@ jobs:
         run: |
           echo "Fetching image digest for ${{ matrix.image }}"
           digest=$(regctl image digest ${{ steps.image_meta.outputs.image }})
+          echo "Got digest: $digest"
           echo "digest=${digest}" >> $GITHUB_OUTPUT
       - name: sign image
-        # TODO At the it's asking for verifying a token in a browser... Something seems off
-        if: false # ${{ fromJSON(inputs.ALLOW_PUSH) }}
+        if: ${{ fromJSON(inputs.ALLOW_PUSH) }}
         id: sign
         uses: Kong/public-shared-actions/security-actions/sign-docker-image@60c9b136104671b7091b2306c599d80fec34ae3f # v2.0.3
         with:
-          image_digest: ${{ steps.manifest_digest.outputs.digest }}
-          tags: ${{ steps.image_meta.outputs.tag }}
+          image_digest: ${{ steps.image_digest.outputs.digest }}
+          tags: ${{ steps.image_meta.outputs.image }}
           signature_registry: ${{ steps.image_meta.outputs.registry }}/notary${{ contains(steps.image_meta.outputs.tag, 'preview') && '-internal' }}
           registry_username: ${{ vars.DOCKER_USERNAME }}
           registry_password: ${{ secrets.DOCKER_API_KEY }}

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -14,6 +14,7 @@ env:
 jobs:
   test_unit:
     timeout-minutes: 20
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -10,11 +10,14 @@ concurrency:
   cancel-in-progress: true
 permissions:
   contents: read
+  id-token: write
 env:
   KUMA_DIR: "."
   CI_TOOLS_DIR: "/home/runner/work/kuma/kuma/.ci_tools"
 jobs:
   check:
+    permissions:
+      contents: read
     timeout-minutes: 15
     runs-on: ubuntu-latest
     env:
@@ -59,6 +62,8 @@ jobs:
         run: |
           echo "images=$(make images/info/release/json)" >> $GITHUB_OUTPUT
   test:
+    permissions:
+      contents: read
     needs: ["check"]
     if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
     uses: ./.github/workflows/_test.yaml
@@ -66,6 +71,9 @@ jobs:
       FULL_MATRIX: ${{ needs.check.outputs.FULL_MATRIX }}
     secrets: inherit
   build_publish:
+    permissions:
+      contents: read
+      id-token: write
     needs: ["check", "test"]
     uses: ./.github/workflows/_build_publish.yaml
     with:


### PR DESCRIPTION
More work integrating https://github.com/kumahq/kuma/pull/9169

Now we should be signing usign cosign.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
