### PR TITLE
test(e2e): add e2e test for MeshTCPRoute with delegated gateway

### DIFF
--- a/test/e2e_env/kubernetes/gateway/delegated.go
+++ b/test/e2e_env/kubernetes/gateway/delegated.go
@@ -47,6 +47,10 @@ func Delegated() {
 				testserver.WithNamespace(config.NamespaceOutsideMesh),
 				testserver.WithName("external-service"),
 			)).
+			Install(testserver.Install(
+				testserver.WithNamespace(config.NamespaceOutsideMesh),
+				testserver.WithName("external-tcp-service"),
+			)).
 			Install(otelcollector.Install(
 				otelcollector.WithNamespace(config.NamespaceOutsideMesh),
 				otelcollector.WithIPv6(Config.IPV6),
@@ -115,4 +119,5 @@ spec:
 	Context("MeshTrace", delegated.MeshTrace(&config))
 	Context("MeshLoadBalancingStrategy", delegated.MeshLoadBalancingStrategy(&config))
 	Context("MeshAccessLog", delegated.MeshAccessLog(&config))
+	Context("MeshTCPRoute", delegated.MeshTCPRoute(&config))
 }

--- a/test/e2e_env/kubernetes/gateway/delegated/meshtcproute.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshtcproute.go
@@ -1,0 +1,111 @@
+package delegated
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/plugins/policies/meshtcproute/api/v1alpha1"
+	"github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/client"
+	"github.com/kumahq/kuma/test/framework/envs/kubernetes"
+	"github.com/kumahq/kuma/test/server/types"
+)
+
+func MeshTCPRoute(config *Config) func() {
+	GinkgoHelper()
+
+	return func() {
+		framework.E2EAfterEach(func() {
+			Expect(framework.DeleteMeshResources(
+				kubernetes.Cluster,
+				config.Mesh,
+				v1alpha1.MeshTCPRouteResourceTypeDescriptor,
+				core_mesh.ExternalServiceResourceTypeDescriptor,
+			)).To(Succeed())
+		})
+
+		It("should split traffic between internal and external services "+
+			"with mixed (tcp and http) protocols", func() {
+			// given
+			Expect(kubernetes.Cluster.Install(framework.YamlK8s(fmt.Sprintf(`
+apiVersion: kuma.io/v1alpha1
+kind: ExternalService
+metadata:
+  name: external-http-service-mtcpr
+mesh: %s
+spec:
+  tags:
+    kuma.io/service: external-http-service-mtcpr
+    kuma.io/protocol: http
+  networking:
+    # .svc.cluster.local is needed, otherwise Kubernetes will resolve this
+    # to the real IP
+    address: external-service.%s.svc.cluster.local:80
+`, config.Mesh, config.NamespaceOutsideMesh)))).To(Succeed())
+
+			Expect(kubernetes.Cluster.Install(framework.YamlK8s(fmt.Sprintf(`
+apiVersion: kuma.io/v1alpha1
+kind: ExternalService
+metadata:
+  name: external-tcp-service-mtcpr
+mesh: %s
+spec:
+  tags:
+    kuma.io/service: external-tcp-service-mtcpr
+    kuma.io/protocol: tcp
+  networking:
+    # .svc.cluster.local is needed, otherwise Kubernetes will resolve this
+    # to the real IP
+    address: external-tcp-service.%s.svc.cluster.local:80
+`, config.Mesh, config.NamespaceOutsideMesh)))).To(Succeed())
+
+			// when
+			Expect(framework.YamlK8s(fmt.Sprintf(`
+apiVersion: kuma.io/v1alpha1
+kind: MeshTCPRoute
+metadata:
+  name: mtr
+  namespace: %s
+  labels:
+    kuma.io/mesh: %s
+spec:
+  targetRef:
+    kind: MeshService
+    name: delegated-gateway-admin_%[2]s_svc_8444
+  to:
+  - targetRef:
+      kind: MeshService
+      name: test-server_%[2]s_svc_80
+    rules: 
+    - default:
+        backendRefs:
+        - kind: MeshService
+          name: test-server_%[2]s_svc_80
+        - kind: MeshService
+          name: external-http-service-mtcpr
+        - kind: MeshService
+          name: external-tcp-service-mtcpr
+`, config.CpNamespace, config.Mesh))(kubernetes.Cluster)).To(Succeed())
+
+			// then
+			Eventually(func() ([]types.EchoResponse, error) {
+				return client.CollectResponses(
+					kubernetes.Cluster,
+					"demo-client",
+					fmt.Sprintf("http://%s/test-server", config.KicIP),
+					client.FromKubernetesPod(config.NamespaceOutsideMesh, "demo-client"),
+					client.WithNumberOfRequests(10),
+					client.WithHeader("x-set-response-delay-ms", "2000"),
+					client.WithoutRetries(),
+				)
+			}, "30s", "1s").Should(ContainElements(
+				HaveField("Instance", HavePrefix("test-server")),
+				HaveField("Instance", HavePrefix("external-service")),
+				HaveField("Instance", HavePrefix("external-tcp-service")),
+			))
+		})
+	}
+}


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - https://github.com/kumahq/kuma/issues/8746
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - There is no need

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
