### PR TITLE
fix(e2e): skip meshmetric otel tests until we find why there are flaky

### DIFF
--- a/test/e2e_env/kubernetes/meshmetric/meshmetric.go
+++ b/test/e2e_env/kubernetes/meshmetric/meshmetric.go
@@ -504,7 +504,7 @@ func MeshMetric() {
 		}).Should(Succeed())
 	})
 
-	It("MeshMetric with OpenTelemetry enabled", func() {
+	XIt("MeshMetric with OpenTelemetry enabled", func() {
 		// given
 		openTelemetryCollector := otelcollector.From(kubernetes.Cluster, primaryOtelCollectorName)
 		Expect(kubernetes.Cluster.Install(MeshMetricWithOpenTelemetryBackend(mainMesh, openTelemetryCollector.CollectorEndpoint()))).To(Succeed())
@@ -521,7 +521,7 @@ func MeshMetric() {
 		}, "2m", "3s").Should(Succeed())
 	})
 
-	It("MeshMetric with OpenTelemetry and usedonly/filter", func() {
+	XIt("MeshMetric with OpenTelemetry and usedonly/filter", func() {
 		// given
 		openTelemetryCollector := otelcollector.From(kubernetes.Cluster, primaryOtelCollectorName)
 		Expect(kubernetes.Cluster.Install(MeshMetricWithOpenTelemetryAndIncludeUnused(mainMesh, openTelemetryCollector.CollectorEndpoint()))).To(Succeed())
@@ -539,7 +539,7 @@ func MeshMetric() {
 		}, "2m", "3s").Should(Succeed())
 	})
 
-	It("MeshMetric with OpenTelemetry and Prometheus enabled", func() {
+	XIt("MeshMetric with OpenTelemetry and Prometheus enabled", func() {
 		// given
 		openTelemetryCollector := otelcollector.From(kubernetes.Cluster, primaryOtelCollectorName)
 		testServerIp, err := PodIPOfApp(kubernetes.Cluster, "test-server-0", namespace)


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
