### PR TITLE
chore(workflow): add bash function to compare semvers

### DIFF
--- a/tools/ci/update-vulnerable-dependencies.sh
+++ b/tools/ci/update-vulnerable-dependencies.sh
@@ -57,7 +57,7 @@ for dep in $(osv-scanner --lockfile=go.mod --json | jq -c '.results[].packages[]
         exit 1
     fi
     # Do not downgrade in order to fix the vulnerability
-    if [[ $(compare_versions currentMajor currentMinor currentPatch fixMajor fixMinor fixPatch) -eq -1]]; then
+    if [[ $(compare_versions "$currentMajor" "$currentMinor" "$currentPatch" "$fixMajor" "$fixMinor" "$fixPatch") -eq -1 ]]; then
       package=$(jq -r .name <<< "$dep")
       if [[ "$package" == "stdlib" ]]; then
         yq -i e ".parameters.go_version.default = \"$version\"" .circleci/config.yml

--- a/tools/ci/update-vulnerable-dependencies.sh
+++ b/tools/ci/update-vulnerable-dependencies.sh
@@ -5,6 +5,41 @@ set -e
 command -v osv-scanner >/dev/null 2>&1 || { echo >&2 "osv-scanner not installed!"; exit 1; }
 command -v jq >/dev/null 2>&1 || { echo >&2 "jq not installed!"; exit 1; }
 
+compare_versions() {
+    local majorV1=$1
+    local minorV1=$2
+    local patchV1=$3
+    local majorV2=$4
+    local minorV2=$5
+    local patchV2=$6
+
+    if ((majorV1 < majorV2)); then
+        echo -1
+        return
+    elif ((majorV1 > majorV2)); then
+        echo 1
+        return
+    fi
+
+    if ((minorV1 < minorV2)); then
+        echo -1
+        return
+    elif ((minorV1 > minorV2)); then
+        echo 1
+        return
+    fi
+
+    if ((patchV1 < patchV2)); then
+        echo -1
+        return
+    elif ((patchV1 > patchV2)); then
+        echo 1
+        return
+    else
+        echo 0
+    fi
+}
+
 for dep in $(osv-scanner --lockfile=go.mod --json | jq -c '.results[].packages[] | .package.name as $vulnerablePackage | {
   name: $vulnerablePackage,
   current: .package.version,
@@ -22,7 +57,7 @@ for dep in $(osv-scanner --lockfile=go.mod --json | jq -c '.results[].packages[]
         exit 1
     fi
     # Do not downgrade in order to fix the vulnerability
-    if ((currentMajor <= fixMajor)) && ((currentMinor <= fixMinor)) && ((currentPatch <= fixPatch)); then
+    if [[ $(compare_versions currentMajor currentMinor currentPatch fixMajor fixMinor fixPatch) -eq -1]]; then
       package=$(jq -r .name <<< "$dep")
       if [[ "$package" == "stdlib" ]]; then
         yq -i e ".parameters.go_version.default = \"$version\"" .circleci/config.yml


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
