### PR TITLE
chore(cleanup): remove deprecated dpServer.auth

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -36,6 +36,10 @@ Migration step:
 3. Deploy the gateway and verify if traffic works correctly.
 4. Remove the old resources.
 
+### Configuration option `KUMA_DP_SERVER_AUTH_*`, `dpServer.auth.*` was removed
+
+The option to configure authentication was deprecated and has been removed in release `2.7.x`. If you are still using `KUMA_DP_SERVER_AUTH_*` environment variables or `dpServer.auth.*` configuration, please migrate your configuration to use `dpServer.authn` before upgrade.
+
 ## Upgrade to `2.6.x`
 
 ### Policy

--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -568,12 +568,6 @@ dpServer:
   # Tokens e2e tests, which started flaking a lot after introducing explicit
   # 1s timeout)
   readHeaderTimeout: 5s # ENV: KUMA_DP_SERVER_READ_HEADER_TIMEOUT
-  # Auth defines an authentication configuration for the DP Server
-  # DEPRECATED: use "authn" section.
-  auth:
-    # Type of authentication. Available values: "serviceAccountToken", "dpToken", "none".
-    # If empty, autoconfigured based on the environment - "serviceAccountToken" on Kubernetes, "dpToken" on Universal.
-    type: "" # ENV: KUMA_DP_SERVER_AUTH_TYPE
   # Authn defines an authentication configuration for the DP Server
   authn:
     # Configuration for data plane proxy authentication.

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -568,12 +568,6 @@ dpServer:
   # Tokens e2e tests, which started flaking a lot after introducing explicit
   # 1s timeout)
   readHeaderTimeout: 5s # ENV: KUMA_DP_SERVER_READ_HEADER_TIMEOUT
-  # Auth defines an authentication configuration for the DP Server
-  # DEPRECATED: use "authn" section.
-  auth:
-    # Type of authentication. Available values: "serviceAccountToken", "dpToken", "none".
-    # If empty, autoconfigured based on the environment - "serviceAccountToken" on Kubernetes, "dpToken" on Universal.
-    type: "" # ENV: KUMA_DP_SERVER_AUTH_TYPE
   # Authn defines an authentication configuration for the DP Server
   authn:
     # Configuration for data plane proxy authentication.

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -306,7 +306,6 @@ var _ = Describe("Config loader", func() {
 
 			Expect(cfg.DpServer.TlsCertFile).To(Equal("/test/path"))
 			Expect(cfg.DpServer.TlsKeyFile).To(Equal("/test/path/key"))
-			Expect(cfg.DpServer.Auth.Type).To(Equal("dpToken"))
 			Expect(cfg.DpServer.Authn.DpProxy.Type).To(Equal("dpToken"))
 			Expect(cfg.DpServer.Authn.DpProxy.DpToken.EnableIssuer).To(BeFalse())
 			Expect(cfg.DpServer.Authn.DpProxy.DpToken.Validator.UseSecrets).To(BeFalse())
@@ -646,8 +645,6 @@ dpServer:
   tlsCipherSuites: ["TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_AES_256_GCM_SHA384"]
   readHeaderTimeout: 11s
   port: 9876
-  auth:
-    type: dpToken
   authn:
     dpProxy:
       type: dpToken
@@ -949,8 +946,6 @@ tracing:
 				"KUMA_DP_SERVER_TLS_MAX_VERSION":                                                           "TLSv1_3",
 				"KUMA_DP_SERVER_TLS_CIPHER_SUITES":                                                         "TLS_RSA_WITH_AES_128_CBC_SHA,TLS_AES_256_GCM_SHA384",
 				"KUMA_DP_SERVER_READ_HEADER_TIMEOUT":                                                       "11s",
-				"KUMA_DP_SERVER_AUTH_TYPE":                                                                 "dpToken",
-				"KUMA_DP_SERVER_AUTH_USE_TOKEN_PATH":                                                       "true",
 				"KUMA_DP_SERVER_AUTHN_DP_PROXY_TYPE":                                                       "dpToken",
 				"KUMA_DP_SERVER_AUTHN_DP_PROXY_DP_TOKEN_ENABLE_ISSUER":                                     "false",
 				"KUMA_DP_SERVER_AUTHN_DP_PROXY_DP_TOKEN_VALIDATOR_USE_SECRETS":                             "false",

--- a/pkg/core/bootstrap/autoconfig.go
+++ b/pkg/core/bootstrap/autoconfig.go
@@ -52,14 +52,6 @@ func autoconfigureGeneral(cfg *kuma_cp.Config) error {
 }
 
 func autoconfigureDpServerAuth(cfg *kuma_cp.Config) {
-	if cfg.DpServer.Auth.Type == "" {
-		switch cfg.Environment {
-		case config_core.KubernetesEnvironment:
-			cfg.DpServer.Auth.Type = dp_server.DpServerAuthServiceAccountToken
-		case config_core.UniversalEnvironment:
-			cfg.DpServer.Auth.Type = dp_server.DpServerAuthDpToken
-		}
-	}
 	if cfg.DpServer.Authn.DpProxy.Type == "" {
 		switch cfg.Environment {
 		case config_core.KubernetesEnvironment:
@@ -75,10 +67,6 @@ func autoconfigureDpServerAuth(cfg *kuma_cp.Config) {
 		case config_core.UniversalEnvironment:
 			cfg.DpServer.Authn.ZoneProxy.Type = dp_server.DpServerAuthZoneToken
 		}
-	}
-	// backwards compatibility https://github.com/kumahq/kuma/issues/6138
-	if cfg.DpServer.Auth.UseTokenPath {
-		cfg.DpServer.Authn.EnableReloadableTokens = cfg.DpServer.Auth.UseTokenPath
 	}
 }
 

--- a/pkg/test/runtime/runtime.go
+++ b/pkg/test/runtime/runtime.go
@@ -81,8 +81,10 @@ func (i *TestRuntimeInfo) GetStartTime() time.Time {
 }
 
 func BuilderFor(appCtx context.Context, cfg kuma_cp.Config) (*core_runtime.Builder, error) {
-	if cfg.DpServer.Auth.Type == "" { // for test, autoconfigure to dp token
+	if cfg.DpServer.Authn.DpProxy.Type == "" {
 		cfg.DpServer.Authn.DpProxy.Type = dp_server.DpServerAuthDpToken
+	}
+	if cfg.DpServer.Authn.ZoneProxy.Type == "" {
 		cfg.DpServer.Authn.ZoneProxy.Type = dp_server.DpServerAuthZoneToken
 	}
 	builder, err := core_runtime.BuilderFor(appCtx, cfg)


### PR DESCRIPTION
### Checklist prior to review

- [ ] [Link to relevant issue][1] as well as docs and UI issues -- fix: [#6138](https://github.com/kumahq/kuma/issues/6138)
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
