### PR TITLE
ci(stability): reenable flaky tests and collect cpu metrics

### DIFF
--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -106,6 +106,8 @@ jobs:
       - name: "GitHub Actions: run E2E tests"
         if: steps.eval-params.outputs.run-type == 'github'
         run: |
+          while true; do ps -eo pcpu,pmem,pid,user,args | sort -k 1 -r | head -30 >> /tmp/stats.txt ; sleep 1; done &
+          
           if [[ "${{ env.E2E_PARAM_K8S_VERSION }}" == "kindIpv6" ]]; then
             export IPV6=true
             export K8S_CLUSTER_TOOL=kind
@@ -136,6 +138,12 @@ jobs:
             target="test/e2e"
           fi
           make ${MAKE_PARAMETERS} CI=true "${target}"
+      - name: Upload cpu stats
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        with:
+          name: cpu-stats.txt
+          path: /tmp/stats.txt
+          retention-days: 7
       - name: "CircleCI: make circleci parameters"
         if: steps.eval-params.outputs.run-type == 'circleci'
         id: circleci-gen-params

--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -112,10 +112,16 @@ jobs:
           RANDOM_ID=$RANDOM
           FILENAME_K1="stats_k1_$RANDOM_ID.txt"
           FILENAME_K2="stats_k2_$RANDOM_ID.txt"
+          FILENAME_NS_K1="ns_k1_$RANDOM_ID.txt"
+          FILENAME_NS_K2="ns_k2_$RANDOM_ID.txt"
           echo "stats_filename_k1=$FILENAME_K1" >> $GITHUB_OUTPUT
           echo "stats_filename_k2=$FILENAME_K2" >> $GITHUB_OUTPUT
-          while true; do KUBECONFIG=$HOME/.kube/kind-kuma-1-config kubectl top pod -A --sort-by=cpu --context=k3d-kuma-1 | head -30 >> /tmp/$FILENAME_K1 ; echo "---" >> /tmp/$FILENAME_K1 ; sleep 1; done &
-          while true; do KUBECONFIG=$HOME/.kube/kind-kuma-2-config kubectl top pod -A --sort-by=cpu --context=k3d-kuma-2 | head -30 >> /tmp/$FILENAME_K2 ; echo "---" >> /tmp/$FILENAME_K2 ; sleep 1; done &
+          echo "ns_filename_k1=$FILENAME_NS_K1" >> $GITHUB_OUTPUT
+          echo "ns_filename_k2=$FILENAME_NS_K2" >> $GITHUB_OUTPUT
+          while true; do KUBECONFIG=$HOME/.kube/kind-kuma-1-config kubectl top pod -A --sort-by=cpu --context=k3d-kuma-1 | head -30 >> /tmp/$FILENAME_K1 ; echo "---" >> /tmp/$FILENAME_K1 ; sleep 10; done &
+          while true; do KUBECONFIG=$HOME/.kube/kind-kuma-2-config kubectl top pod -A --sort-by=cpu --context=k3d-kuma-2 | head -30 >> /tmp/$FILENAME_K2 ; echo "---" >> /tmp/$FILENAME_K2 ; sleep 10; done &
+          while true; do KUBECONFIG=$HOME/.kube/kind-kuma-1-config kubectl get namespaces --context=k3d-kuma-1 >> /tmp/$FILENAME_NS_K1 ; echo "---" >> /tmp/$FILENAME_NS_K1; sleep 10; done &
+          while true; do KUBECONFIG=$HOME/.kube/kind-kuma-2-config kubectl get namespaces --context=k3d-kuma-2 >> /tmp/$FILENAME_NS_K2 ; echo "---" >> /tmp/$FILENAME_NS_K2; sleep 10; done &
           
           if [[ "${{ env.E2E_PARAM_K8S_VERSION }}" == "kindIpv6" ]]; then
             export IPV6=true
@@ -158,6 +164,18 @@ jobs:
         with:
           name: ${{ steps.e2e.outputs.stats_filename_k2 }}
           path: /tmp/${{ steps.e2e.outputs.stats_filename_k2 }}
+          retention-days: 7
+      - name: Upload ns stats
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        with:
+          name: ${{ steps.e2e.outputs.ns_filename_k1 }}
+          path: /tmp/${{ steps.e2e.outputs.ns_filename_k1 }}
+          retention-days: 7
+      - name: Upload ns stats
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        with:
+          name: ${{ steps.e2e.outputs.ns_filename_k2 }}
+          path: /tmp/${{ steps.e2e.outputs.ns_filename_k2 }}
           retention-days: 7
       - name: "CircleCI: make circleci parameters"
         if: steps.eval-params.outputs.run-type == 'circleci'

--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -114,8 +114,8 @@ jobs:
           FILENAME_K2="stats_k2_$RANDOM_ID.txt"
           echo "stats_filename_k1=$FILENAME_K1" >> $GITHUB_OUTPUT
           echo "stats_filename_k2=$FILENAME_K2" >> $GITHUB_OUTPUT
-          while true; do kubectl top pod -A --sort-by=cpu --context=k3d-kuma-1 | head -30 >> /tmp/$FILENAME_K1 ; echo "---" >> /tmp/$FILENAME_K1 ; sleep 1; done &
-          while true; do kubectl top pod -A --sort-by=cpu --context=k3d-kuma-2 | head -30 >> /tmp/$FILENAME_K2 ; echo "---" >> /tmp/$FILENAME_K2 ; sleep 1; done &
+          while true; do KUBECONFIG=$HOME/.kube/kind-kuma-1-config kubectl top pod -A --sort-by=cpu --context=k3d-kuma-1 | head -30 >> /tmp/$FILENAME_K1 ; echo "---" >> /tmp/$FILENAME_K1 ; sleep 1; done &
+          while true; do KUBECONFIG=$HOME/.kube/kind-kuma-2-config kubectl top pod -A --sort-by=cpu --context=k3d-kuma-2 | head -30 >> /tmp/$FILENAME_K2 ; echo "---" >> /tmp/$FILENAME_K2 ; sleep 1; done &
           
           if [[ "${{ env.E2E_PARAM_K8S_VERSION }}" == "kindIpv6" ]]; then
             export IPV6=true

--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -104,9 +104,12 @@ jobs:
           EOF
           sudo service docker restart
       - name: "GitHub Actions: run E2E tests"
+        id: e2e
         if: steps.eval-params.outputs.run-type == 'github'
         run: |
-          while true; do ps -eo pcpu,pmem,pid,user,args | sort -k 1 -r | head -30 >> /tmp/stats.txt ; sleep 1; done &
+          FILENAME="stats$RANDOM.txt"
+          echo "stats_filename=$FILENAME" >> $GITHUB_OUTPUT
+          while true; do ps -eo pcpu,pmem,pid,user,args | sort -k 1 -r | head -30 >> /tmp/$FILENAME ; sleep 1; done &
           
           if [[ "${{ env.E2E_PARAM_K8S_VERSION }}" == "kindIpv6" ]]; then
             export IPV6=true
@@ -141,8 +144,8 @@ jobs:
       - name: Upload cpu stats
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
-          name: cpu-stats.txt
-          path: /tmp/stats.txt
+          name: ${{ steps.e2e.outputs.stats_filename }}
+          path: /tmp/${{ steps.e2e.outputs.stats_filename }}
           retention-days: 7
       - name: "CircleCI: make circleci parameters"
         if: steps.eval-params.outputs.run-type == 'circleci'

--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -103,13 +103,19 @@ jobs:
           }
           EOF
           sudo service docker restart
+      - uses: azure/setup-kubectl@v3
+        id: install
       - name: "GitHub Actions: run E2E tests"
         id: e2e
         if: steps.eval-params.outputs.run-type == 'github'
         run: |
-          FILENAME="stats$RANDOM.txt"
-          echo "stats_filename=$FILENAME" >> $GITHUB_OUTPUT
-          while true; do ps -eo pcpu,pmem,pid,user,args | tail -n +2 | sort -k 1 -r | head -30 >> /tmp/$FILENAME ; echo "---" >> /tmp/$FILENAME ; sleep 1; done &
+          RANDOM_ID=$RANDOM
+          FILENAME_K1="stats_k1_$RANDOM_ID.txt"
+          FILENAME_K2="stats_k2_$RANDOM_ID.txt"
+          echo "stats_filename_k1=$FILENAME_K1" >> $GITHUB_OUTPUT
+          echo "stats_filename_k2=$FILENAME_K2" >> $GITHUB_OUTPUT
+          while true; do kubectl top pod -A --sort-by=cpu --context=k3d-kuma-1 | head -30 >> /tmp/$FILENAME_K1 ; echo "---" >> /tmp/$FILENAME_K1 ; sleep 1; done &
+          while true; do kubectl top pod -A --sort-by=cpu --context=k3d-kuma-2 | head -30 >> /tmp/$FILENAME_K2 ; echo "---" >> /tmp/$FILENAME_K2 ; sleep 1; done &
           
           if [[ "${{ env.E2E_PARAM_K8S_VERSION }}" == "kindIpv6" ]]; then
             export IPV6=true
@@ -144,8 +150,14 @@ jobs:
       - name: Upload cpu stats
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
-          name: ${{ steps.e2e.outputs.stats_filename }}
-          path: /tmp/${{ steps.e2e.outputs.stats_filename }}
+          name: ${{ steps.e2e.outputs.stats_filename_k1 }}
+          path: /tmp/${{ steps.e2e.outputs.stats_filename_k1 }}
+          retention-days: 7
+      - name: Upload cpu stats
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        with:
+          name: ${{ steps.e2e.outputs.stats_filename_k2 }}
+          path: /tmp/${{ steps.e2e.outputs.stats_filename_k2 }}
           retention-days: 7
       - name: "CircleCI: make circleci parameters"
         if: steps.eval-params.outputs.run-type == 'circleci'

--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -109,7 +109,7 @@ jobs:
         run: |
           FILENAME="stats$RANDOM.txt"
           echo "stats_filename=$FILENAME" >> $GITHUB_OUTPUT
-          while true; do ps -eo pcpu,pmem,pid,user,args | sort -k 1 -r | head -30 >> /tmp/$FILENAME ; sleep 1; done &
+          while true; do ps -eo pcpu,pmem,pid,user,args | tail -n +2 | sort -k 1 -r | head -30 >> /tmp/$FILENAME ; echo "---" >> /tmp/$FILENAME ; sleep 1; done &
           
           if [[ "${{ env.E2E_PARAM_K8S_VERSION }}" == "kindIpv6" ]]; then
             export IPV6=true

--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -42,7 +42,6 @@ PORT_PREFIX := $$(($(patsubst 300-%,300+%-1,$(KIND_CLUSTER_NAME:kuma%=300%))))
 K3D_NETWORK_CNI ?= flannel
 K3D_CLUSTER_CREATE_OPTS ?= -i rancher/k3s:$(CI_K3S_VERSION) \
 	--k3s-arg '--disable=traefik@server:0' \
-	--k3s-arg '--disable=metrics-server@server:0' \
 	--k3s-arg '--disable=servicelb@server:0' \
     --volume '$(subst @,\@,$(TOP)/$(KUMA_DIR))/test/framework/deployments:/tmp/deployments@server:0' \
 	--network kind \

--- a/test/e2e_env/kubernetes/meshmetric/meshmetric.go
+++ b/test/e2e_env/kubernetes/meshmetric/meshmetric.go
@@ -504,7 +504,7 @@ func MeshMetric() {
 		}).Should(Succeed())
 	})
 
-	XIt("MeshMetric with OpenTelemetry enabled", func() {
+	It("MeshMetric with OpenTelemetry enabled", func() {
 		// given
 		openTelemetryCollector := otelcollector.From(kubernetes.Cluster, primaryOtelCollectorName)
 		Expect(kubernetes.Cluster.Install(MeshMetricWithOpenTelemetryBackend(mainMesh, openTelemetryCollector.CollectorEndpoint()))).To(Succeed())
@@ -521,7 +521,7 @@ func MeshMetric() {
 		}, "2m", "3s").Should(Succeed())
 	})
 
-	XIt("MeshMetric with OpenTelemetry and usedonly/filter", func() {
+	It("MeshMetric with OpenTelemetry and usedonly/filter", func() {
 		// given
 		openTelemetryCollector := otelcollector.From(kubernetes.Cluster, primaryOtelCollectorName)
 		Expect(kubernetes.Cluster.Install(MeshMetricWithOpenTelemetryAndIncludeUnused(mainMesh, openTelemetryCollector.CollectorEndpoint()))).To(Succeed())
@@ -539,7 +539,7 @@ func MeshMetric() {
 		}, "2m", "3s").Should(Succeed())
 	})
 
-	XIt("MeshMetric with OpenTelemetry and Prometheus enabled", func() {
+	It("MeshMetric with OpenTelemetry and Prometheus enabled", func() {
 		// given
 		openTelemetryCollector := otelcollector.From(kubernetes.Cluster, primaryOtelCollectorName)
 		testServerIp, err := PodIPOfApp(kubernetes.Cluster, "test-server-0", namespace)


### PR DESCRIPTION
just testing 

xref: https://github.com/kumahq/kuma/issues/5873

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
