### PR TITLE
feat(xds): don't merge listeners of headless service instances

### DIFF
--- a/pkg/xds/generator/outbound_proxy_generator_test.go
+++ b/pkg/xds/generator/outbound_proxy_generator_test.go
@@ -889,6 +889,44 @@ var _ = Describe("OutboundProxyGenerator", func() {
 `,
 			expected: "10.envoy.golden.yaml",
 		}),
+		Entry("11. service vips with headless service", testCase{
+			ctx: serviceVipCtx,
+			dataplane: `
+            networking:
+              address: 10.0.0.1
+              inbound:
+              - port: 8080
+                tags:
+                  kuma.io/service: web
+              outbound:
+              - port: 18080
+                tags:
+                  kuma.io/service: backend
+              - port: 80
+                address: 240.0.0.3
+                tags:
+                  kuma.io/service: backend
+              - port: 5432
+                address: 240.0.0.4
+                tags:
+                  kuma.io/service: db
+                  kuma.io/instance: db-1
+              - port: 5432
+                address: 10.16.26.3
+                tags:
+                  kuma.io/service: db
+                  kuma.io/instance: db-1
+              - port: 5432
+                address: 10.16.31.5
+                tags:
+                  kuma.io/service: backend
+                  kuma.io/instance: db-2
+              transparentProxying:
+                redirectPortOutbound: 15001
+                redirectPortInbound: 15006
+`,
+			expected: "11.envoy.golden.yaml",
+		}),
 	)
 
 	It("Add sanitized alternative cluster name for stats", func() {

--- a/pkg/xds/generator/testdata/outbound-proxy/11.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/11.envoy.golden.yaml
@@ -1,0 +1,148 @@
+resources:
+- name: backend
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+        resourceApiVersion: V3
+    lbPolicy: MAGLEV
+    name: backend
+    transportSocket:
+      name: envoy.transport_sockets.tls
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        commonTlsContext:
+          alpnProtocols:
+          - kuma
+          combinedValidationContext:
+            defaultValidationContext:
+              matchTypedSubjectAltNames:
+              - matcher:
+                  exact: spiffe://mesh1/backend
+                sanType: URI
+            validationContextSdsSecretConfig:
+              name: mesh_ca:secret:mesh1
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+          tlsCertificateSdsSecretConfigs:
+          - name: identity_cert:secret:mesh1
+            sdsConfig:
+              ads: {}
+              resourceApiVersion: V3
+        sni: backend{mesh=mesh1}
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
+- name: backend
+  resource:
+    '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
+    clusterName: backend
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.0.1
+              portValue: 8081
+        loadBalancingWeight: 1
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              region: us
+            envoy.transport_socket_match:
+              region: us
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.0.2
+              portValue: 8082
+        loadBalancingWeight: 1
+- name: outbound:10.16.26.3:5432
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 10.16.26.3
+        portValue: 5432
+    bindToPort: false
+    filterChains:
+    - {}
+    metadata:
+      filterMetadata:
+        io.kuma.tags:
+          kuma.io/instance: db-1
+          kuma.io/service: db
+    name: outbound:10.16.26.3:5432
+    trafficDirection: OUTBOUND
+- name: outbound:10.16.31.5:5432
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    additionalAddresses:
+    - address:
+        socketAddress:
+          address: 240.0.0.3
+          portValue: 80
+    address:
+      socketAddress:
+        address: 10.16.31.5
+        portValue: 5432
+    bindToPort: false
+    filterChains:
+    - {}
+    metadata:
+      filterMetadata:
+        io.kuma.tags:
+          kuma.io/instance: db-2
+          kuma.io/service: backend
+    name: outbound:10.16.31.5:5432
+    trafficDirection: OUTBOUND
+- name: outbound:127.0.0.1:18080
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    additionalAddresses:
+    - address:
+        socketAddress:
+          address: 240.0.0.3
+          portValue: 80
+    address:
+      socketAddress:
+        address: 127.0.0.1
+        portValue: 18080
+    bindToPort: false
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: backend
+          idleTimeout: 0s
+          statPrefix: backend
+    metadata:
+      filterMetadata:
+        io.kuma.tags:
+          kuma.io/service: backend
+    name: outbound:127.0.0.1:18080
+    trafficDirection: OUTBOUND
+- name: outbound:240.0.0.4:5432
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 240.0.0.4
+        portValue: 5432
+    bindToPort: false
+    filterChains:
+    - {}
+    metadata:
+      filterMetadata:
+        io.kuma.tags:
+          kuma.io/instance: db-1
+          kuma.io/service: db
+    name: outbound:240.0.0.4:5432
+    trafficDirection: OUTBOUND


### PR DESCRIPTION
Should be part of the cause of issue 9006, but may not be complete.

xref: https://github.com/kumahq/kuma/issues/9006


### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues 
  - Described
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS 
  - Confirmed
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) 
  - Tested using unit tests and manually
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - No
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) 
  - No, this is new in 2.6.1

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
