### PR TITLE
fix(xds): duplicated listeners

### DIFF
--- a/pkg/xds/generator/outbound_proxy_generator_test.go
+++ b/pkg/xds/generator/outbound_proxy_generator_test.go
@@ -889,6 +889,36 @@ var _ = Describe("OutboundProxyGenerator", func() {
 `,
 			expected: "10.envoy.golden.yaml",
 		}),
+		Entry("11. service vips with outbound of multiple tags (headless service)", testCase{
+			ctx: serviceVipCtx,
+			dataplane: `
+            networking:
+              address: 10.0.0.1
+              inbound:
+              - port: 8080
+                tags:
+                  kuma.io/service: web
+              outbound:
+              - port: 80
+                address: 240.0.0.3
+                tags:
+                  kuma.io/service: backend
+              - port: 80
+                address: 10.0.0.1
+                tags:
+                  kuma.io/service: backend
+                  kuma.io/instance: instance-1
+              - port: 80
+                address: 10.0.0.2
+                tags:
+                  kuma.io/service: backend
+                  kuma.io/instance: instance-2
+              transparentProxying:
+                redirectPortOutbound: 15001
+                redirectPortInbound: 15006
+`,
+			expected: "11.envoy.golden.yaml",
+		}),
 	)
 
 	It("Add sanitized alternative cluster name for stats", func() {

--- a/pkg/xds/generator/testdata/outbound-proxy/08.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/08.envoy.golden.yaml
@@ -57,109 +57,18 @@ resources:
           idleTimeout: 0s
         explicitHttpConfig:
           http2ProtocolOptions: {}
-- name: outbound:240.0.0.0:80
-  resource:
-    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
-    address:
-      socketAddress:
-        address: 240.0.0.0
-        portValue: 80
-    bindToPort: false
-    filterChains:
-    - filters:
-      - name: envoy.filters.network.http_connection_manager
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-          commonHttpProtocolOptions:
-            idleTimeout: 0s
-          httpFilters:
-          - name: envoy.filters.http.router
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-          routeConfig:
-            name: outbound:es2
-            requestHeadersToAdd:
-            - header:
-                key: x-kuma-tags
-                value: '&kuma.io/service=web&'
-            validateClusters: false
-            virtualHosts:
-            - domains:
-              - '*'
-              name: es2
-              routes:
-              - match:
-                  prefix: /
-                route:
-                  autoHostRewrite: true
-                  timeout: 0s
-                  weightedClusters:
-                    clusters:
-                    - name: es2-b5516780eaf1ed13
-                      weight: 10
-                    - name: es2-d79214c8b3a5805b
-                      weight: 90
-          statPrefix: es2
-          streamIdleTimeout: 0s
-    metadata:
-      filterMetadata:
-        io.kuma.tags:
-          kuma.io/service: es2
-    name: outbound:240.0.0.0:80
-    trafficDirection: OUTBOUND
-- name: outbound:240.0.0.1:80
-  resource:
-    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
-    address:
-      socketAddress:
-        address: 240.0.0.1
-        portValue: 80
-    bindToPort: false
-    filterChains:
-    - filters:
-      - name: envoy.filters.network.http_connection_manager
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-          commonHttpProtocolOptions:
-            idleTimeout: 0s
-          httpFilters:
-          - name: envoy.filters.http.router
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-          routeConfig:
-            name: outbound:es2
-            requestHeadersToAdd:
-            - header:
-                key: x-kuma-tags
-                value: '&kuma.io/service=web&'
-            validateClusters: false
-            virtualHosts:
-            - domains:
-              - '*'
-              name: es2
-              routes:
-              - match:
-                  prefix: /
-                route:
-                  autoHostRewrite: true
-                  timeout: 0s
-                  weightedClusters:
-                    clusters:
-                    - name: es2-b5516780eaf1ed13
-                      weight: 10
-                    - name: es2-d79214c8b3a5805b
-                      weight: 90
-          statPrefix: es2
-          streamIdleTimeout: 0s
-    metadata:
-      filterMetadata:
-        io.kuma.tags:
-          kuma.io/service: es2
-    name: outbound:240.0.0.1:80
-    trafficDirection: OUTBOUND
 - name: outbound:240.0.0.2:80
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    additionalAddresses:
+    - address:
+        socketAddress:
+          address: 240.0.0.1
+          portValue: 80
+    - address:
+        socketAddress:
+          address: 240.0.0.0
+          portValue: 80
     address:
       socketAddress:
         address: 240.0.0.2

--- a/pkg/xds/generator/testdata/outbound-proxy/11.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/11.envoy.golden.yaml
@@ -1,0 +1,51 @@
+resources:
+- name: outbound:10.0.0.1:80
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 10.0.0.1
+        portValue: 80
+    bindToPort: false
+    filterChains:
+    - {}
+    metadata:
+      filterMetadata:
+        io.kuma.tags:
+          kuma.io/instance: instance-1
+          kuma.io/service: backend
+    name: outbound:10.0.0.1:80
+    trafficDirection: OUTBOUND
+- name: outbound:10.0.0.2:80
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 10.0.0.2
+        portValue: 80
+    bindToPort: false
+    filterChains:
+    - {}
+    metadata:
+      filterMetadata:
+        io.kuma.tags:
+          kuma.io/instance: instance-2
+          kuma.io/service: backend
+    name: outbound:10.0.0.2:80
+    trafficDirection: OUTBOUND
+- name: outbound:240.0.0.3:80
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 240.0.0.3
+        portValue: 80
+    bindToPort: false
+    filterChains:
+    - {}
+    metadata:
+      filterMetadata:
+        io.kuma.tags:
+          kuma.io/service: backend
+    name: outbound:240.0.0.3:80
+    trafficDirection: OUTBOUND


### PR DESCRIPTION
### Checklist prior to review

Fix #9006 (at least for headless services).

I've rewritten the `buildAdditionalAddresses` function. It now just groups outbound by tags and puts addresses in proper order. It's O(n) as well. I also don't get why `08` test case was not squashed to additional addresses before.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
