### PR TITLE
ci(github): add provenance for binary artifacts

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -21,6 +21,9 @@ on:
         value: ${{ jobs.build.outputs.IMAGE_MANIFESTS }}
       BINARY_ARTIFACT_DIGEST_BASE64:
         value: ${{ jobs.build.outputs.BINARY_ARTIFACT_DIGEST_BASE64 }}
+permissions:
+  contents: read
+  id-token: write # Required for image signing
 env:
   CI_TOOLS_DIR: "/home/runner/work/kuma/kuma/.ci_tools"
   FULL_MATRIX: ${{ inputs.FULL_MATRIX }}
@@ -34,7 +37,6 @@ jobs:
     timeout-minutes: 40
     runs-on: ubuntu-latest
     outputs:
-      IMAGE_MANIFESTS: ${{ steps.image_manifests.outputs.manifests }}
       BINARY_ARTIFACT_DIGEST_BASE64: ${{ steps.inspect-binary-output.outputs.binary_artifact_digest_base64 }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -82,7 +84,7 @@ jobs:
   build-images:
     runs-on: ubuntu-latest
     outputs:
-      BINARY_ARTIFACT_DIGEST_BASE64: ${{ steps.inspect-binary-output.outputs.binary_artifact_digest_base64 }}
+      IMAGE_MANIFESTS: ${{ steps.image_manifests.outputs.manifests }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -20,7 +20,7 @@ on:
       IMAGE_MANIFESTS:
         value: ${{ jobs.build.outputs.IMAGE_MANIFESTS }}
       BINARY_ARTIFACT_DIGEST_BASE64:
-        value: ${{ jobs.build.outputs.BINARY_ARTIFACT_DIGEST_BASE64 }}
+        value: ${{ jobs.build-binaries.outputs.BINARY_ARTIFACT_DIGEST_BASE64 }}
 permissions:
   contents: read
   id-token: write # Required for image signing
@@ -65,6 +65,8 @@ jobs:
       - id: inspect-binary-output
         run: |
           for i in build/distributions/out/*.tar.gz; do echo $i; tar -tvf $i; done
+          echo "Artifact digest:"
+          cat ./build/distributions/artifact_digest_file.text
           echo "binary_artifact_digest_base64=$(cat ./build/distributions/artifact_digest_file.text)" > $GITHUB_OUTPUT
       - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         id: binary-artifacts

--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -83,6 +83,7 @@ jobs:
           make publish/pulp
   build-images:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       IMAGE_MANIFESTS: ${{ steps.image_manifests.outputs.manifests }}
     strategy:
@@ -186,6 +187,7 @@ jobs:
           registry_password: ${{ secrets.DOCKER_API_KEY }}
   publish-helm:
     needs: [build-images]
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/_provenance.yaml
+++ b/.github/workflows/_provenance.yaml
@@ -8,6 +8,9 @@ on:
         description: file containing hash for all compressed binary artifacts
 permissions:
   contents: read
+  id-token: write # needed for signing the images
+  actions: read # For getting workflow run info to build provenance
+  packages: write # Required for publishing provenance. Issue: https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/container#known-issues
 jobs:
   artifact-provenance:
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.9.0

--- a/.github/workflows/_provenance.yaml
+++ b/.github/workflows/_provenance.yaml
@@ -7,9 +7,7 @@ on:
         type: string
         description: file containing hash for all compressed binary artifacts
 permissions:
-  id-token: write # needed for signing the images
-  actions: read # For getting workflow run info to build provenance
-  packages: write # Required for publishing provenance. Issue: https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/container#known-issues
+  contents: read
 jobs:
   artifact-provenance:
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.9.0

--- a/.github/workflows/_provenance.yaml
+++ b/.github/workflows/_provenance.yaml
@@ -7,7 +7,7 @@ on:
         type: string
         description: file containing hash for all compressed binary artifacts
 permissions:
-  contents: read
+  contents: write
   id-token: write # needed for signing the images
   actions: read # For getting workflow run info to build provenance
   packages: write # Required for publishing provenance. Issue: https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/container#known-issues

--- a/.github/workflows/_provenance.yaml
+++ b/.github/workflows/_provenance.yaml
@@ -1,0 +1,21 @@
+name: Generate Provenance
+on:
+  workflow_call:
+    inputs:
+      binary_artifacts_hashes_as_file:
+        required: true
+        type: string
+        description: file containing hash for all compressed binary artifacts
+permissions:
+  contents: write
+  id-token: write # needed for signing the images
+  actions: read # For getting workflow run info to build provenance
+  packages: write # Required for publishing provenance. Issue: https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/container#known-issues
+jobs:
+  artifact-provenance:
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.9.0
+    with:
+      base64-subjects: ${{ inputs.binary_artifacts_hashes_as_file }}
+      upload-assets: ${{ github.ref_type == 'tag' }}
+      upload-tag-name: ${{ github.ref_name }}
+      continue-on-error: true

--- a/.github/workflows/_provenance.yaml
+++ b/.github/workflows/_provenance.yaml
@@ -18,4 +18,5 @@ jobs:
       base64-subjects: ${{ inputs.binary_artifacts_hashes_as_file }}
       upload-assets: ${{ github.ref_type == 'tag' }}
       upload-tag-name: ${{ github.ref_name }}
+      provenance-name: ${{ github.event.repository.name }}.intoto.jsonl
       continue-on-error: true

--- a/.github/workflows/_provenance.yaml
+++ b/.github/workflows/_provenance.yaml
@@ -7,7 +7,6 @@ on:
         type: string
         description: file containing hash for all compressed binary artifacts
 permissions:
-  contents: write
   id-token: write # needed for signing the images
   actions: read # For getting workflow run info to build provenance
   packages: write # Required for publishing provenance. Issue: https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/container#known-issues

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -37,7 +37,7 @@ jobs:
   gen_e2e_matrix:
     timeout-minutes: 2
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e-test') }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e-test') || contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
     steps:

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -37,7 +37,6 @@ jobs:
   gen_e2e_matrix:
     timeout-minutes: 2
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e-test') && !contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
     steps:
@@ -86,6 +85,10 @@ jobs:
           BASE_MATRIX_ALL='${{ env.BASE_MATRIX }}'
           if [[ "${{ inputs.FULL_MATRIX }}" != "true" ]]; then
             BASE_MATRIX_ALL=$(echo $BASE_MATRIX_ALL | jq -r '${{ env.OVERRIDE_JQ_CMD }}')
+          fi
+          # Skip e2e tests if the PR has the label "ci/skip-e2e-test" or "ci/skip-test"
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e-test') || contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}" == "true" ]]; then
+            BASE_MATRIX_ALL='{}'
           fi
 
           echo "final matrix: $BASE_MATRIX_ALL"

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -37,7 +37,7 @@ jobs:
   gen_e2e_matrix:
     timeout-minutes: 2
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e-test') || contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e-test') && !contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
     steps:

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -69,7 +69,6 @@ jobs:
     permissions:
       contents: read
     needs: ["check"]
-    if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
     uses: ./.github/workflows/_test.yaml
     with:
       FULL_MATRIX: ${{ needs.check.outputs.FULL_MATRIX }}
@@ -98,7 +97,7 @@ jobs:
     with:
       binary_artifacts_hashes_as_file: ${{ needs.build_publish.outputs.BINARY_ARTIFACT_DIGEST_BASE64 }}
   distributions:
-    needs: ["build_publish", "check", "test"]
+    needs: ["build_publish", "check", "test", "provenance"]
     timeout-minutes: 10
     if: ${{ always() }}
     runs-on: ubuntu-latest

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -11,6 +11,8 @@ concurrency:
 permissions:
   contents: read
   id-token: write # For using token to sign images
+  actions: read # For getting workflow run info to build provenance
+  packages: write # Required for publishing provenance. Issue: https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/container#known-issues
 env:
   KUMA_DIR: "."
   CI_TOOLS_DIR: "/home/runner/work/kuma/kuma/.ci_tools"
@@ -90,6 +92,9 @@ jobs:
     uses: ./.github/workflows/_provenance.yaml
     permissions:
       contents: read
+      id-token: write # For using token to sign images
+      actions: read # For getting workflow run info to build provenance
+      packages: write # Required for publishing provenance. Issue: https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/container#known-issues
     with:
       binary_artifacts_hashes_as_file: ${{ needs.build_publish.outputs.BINARY_ARTIFACT_DIGEST_BASE64 }}
   distributions:

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -85,6 +85,11 @@ jobs:
       BINARY_ARTIFACT_NAME: "binary_artifacts"
       IMAGES: ${{ needs.check.outputs.IMAGES }}
     secrets: inherit
+  provenance:
+    needs: ["build_publish"]
+    uses: ./.github/workflows/_provenance.yaml
+    with:
+      binary_artifacts_hashes_as_file: ${{ needs.build_publish.outputs.BINARY_ARTIFACT_DIGEST_BASE64 }}
   distributions:
     needs: ["build_publish", "check", "test"]
     timeout-minutes: 10

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -9,7 +9,7 @@ concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 permissions:
-  contents: read
+  contents: write # To upload assets
   id-token: write # For using token to sign images
   actions: read # For getting workflow run info to build provenance
   packages: write # Required for publishing provenance. Issue: https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/container#known-issues
@@ -91,7 +91,7 @@ jobs:
     needs: ["build_publish"]
     uses: ./.github/workflows/_provenance.yaml
     permissions:
-      contents: read
+      contents: write
       id-token: write # For using token to sign images
       actions: read # For getting workflow run info to build provenance
       packages: write # Required for publishing provenance. Issue: https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/container#known-issues

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -11,8 +11,6 @@ concurrency:
 permissions:
   contents: read
   id-token: write # For using token to sign images
-  actions: read # For getting workflow run info to build provenance
-  packages: write # Required for publishing provenance. Issue: https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/container#known-issues
 env:
   KUMA_DIR: "."
   CI_TOOLS_DIR: "/home/runner/work/kuma/kuma/.ci_tools"
@@ -91,9 +89,7 @@ jobs:
     needs: ["build_publish"]
     uses: ./.github/workflows/_provenance.yaml
     permissions:
-      actions: read
-      packages: write
-      id-token: write
+      contents: read
     with:
       binary_artifacts_hashes_as_file: ${{ needs.build_publish.outputs.BINARY_ARTIFACT_DIGEST_BASE64 }}
   distributions:

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -10,7 +10,9 @@ concurrency:
   cancel-in-progress: true
 permissions:
   contents: read
-  id-token: write
+  id-token: write # For using token to sign images
+  actions: read # For getting workflow run info to build provenance
+  packages: write # Required for publishing provenance. Issue: https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/container#known-issues
 env:
   KUMA_DIR: "."
   CI_TOOLS_DIR: "/home/runner/work/kuma/kuma/.ci_tools"
@@ -88,6 +90,10 @@ jobs:
   provenance:
     needs: ["build_publish"]
     uses: ./.github/workflows/_provenance.yaml
+    permissions:
+      actions: read
+      packages: write
+      id-token: write
     with:
       binary_artifacts_hashes_as_file: ${{ needs.build_publish.outputs.BINARY_ARTIFACT_DIGEST_BASE64 }}
   distributions:


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
