### PR TITLE
refactor(xds): use maps.Clone

### DIFF
--- a/pkg/xds/topology/outbound.go
+++ b/pkg/xds/topology/outbound.go
@@ -2,6 +2,7 @@ package topology
 
 import (
 	"context"
+	"maps"
 	"net"
 	"strconv"
 
@@ -118,7 +119,7 @@ func fillDataplaneOutbounds(
 		dpNetworking := dpSpec.GetNetworking()
 
 		for _, inbound := range dpNetworking.GetHealthyInbounds() {
-			inboundTags := cloneTags(inbound.GetTags())
+			inboundTags := maps.Clone(inbound.GetTags())
 			serviceName := inboundTags[mesh_proto.ServiceTag]
 			inboundInterface := dpNetworking.ToInboundInterface(inbound)
 			inboundAddress := inboundInterface.DataplaneAdvertisedIP
@@ -309,7 +310,7 @@ func fillIngressOutbounds(
 			}
 
 			// deep copy map to not modify tags in BuildRemoteEndpointMap
-			serviceTags := cloneTags(service.GetTags())
+			serviceTags := maps.Clone(service.GetTags())
 			serviceName := serviceTags[mesh_proto.ServiceTag]
 			serviceInstances := service.GetInstances()
 			locality := GetLocality(localZone, getZone(serviceTags), mesh.LocalityAwareLbEnabled())
@@ -413,7 +414,7 @@ func fillExternalServicesOutboundsThroughEgress(
 ) {
 	for _, externalService := range externalServices {
 		// deep copy map to not modify tags in ExternalService.
-		serviceTags := cloneTags(externalService.Spec.GetTags())
+		serviceTags := maps.Clone(externalService.Spec.GetTags())
 		serviceName := serviceTags[mesh_proto.ServiceTag]
 		locality := GetLocality(localZone, getZone(serviceTags), mesh.LocalityAwareLbEnabled())
 
@@ -450,7 +451,7 @@ func NewExternalServiceEndpoint(
 	tls := spec.GetNetworking().GetTls()
 	meshName := mesh.GetMeta().GetName()
 	// deep copy map to not modify tags in ExternalService.
-	tags := cloneTags(spec.GetTags())
+	tags := maps.Clone(spec.GetTags())
 
 	caCert, err := loadBytes(ctx, tls.GetCaCert(), meshName, loader)
 	if err != nil {
@@ -490,14 +491,6 @@ func NewExternalServiceEndpoint(
 		ExternalService: es,
 		Locality:        GetLocality(zone, getZone(tags), mesh.LocalityAwareLbEnabled()),
 	}, nil
-}
-
-func cloneTags(tags map[string]string) map[string]string {
-	result := map[string]string{}
-	for tag, value := range tags {
-		result[tag] = value
-	}
-	return result
 }
 
 func loadBytes(ctx context.Context, ds *v1alpha1.DataSource, mesh string, loader datasource.Loader) ([]byte, error) {


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
