### PR TITLE
build(shell): use env in shebang

### DIFF
--- a/mk/dependencies/clang-format.sh
+++ b/mk/dependencies/clang-format.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
@@ -7,7 +7,7 @@ VERSION="13.0.0"
 CLANG_FORMAT=${OUTPUT_DIR}/clang-format
 # No arm64 linux so let's do a dummy script
 if [ "${ARCH}" == "arm64" ] && [ "${OS}" == "linux" ]; then
-  printf "#!/bin/bash\necho clang-format not suported on arm linux" > "${CLANG_FORMAT}"
+  printf "#!/usr/bin/env bash\necho clang-format not suported on arm linux" > "${CLANG_FORMAT}"
   chmod u+x "${CLANG_FORMAT}"
   exit
 fi

--- a/mk/dependencies/container-structure-test.sh
+++ b/mk/dependencies/container-structure-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/mk/dependencies/deps.lock
+++ b/mk/dependencies/deps.lock
@@ -1,1 +1,1 @@
-e92868cfb776c1710a3c9e621f3f009aae4cbcaa
+04dfcff6cde9b0ab2e20a1bcf0adb525af1ec86d

--- a/mk/dependencies/etcd.sh
+++ b/mk/dependencies/etcd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/mk/dependencies/go-deps.sh
+++ b/mk/dependencies/go-deps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/mk/dependencies/golangci-lint.sh
+++ b/mk/dependencies/golangci-lint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 OUTPUT_BIN_DIR=$1/bin

--- a/mk/dependencies/hadolint.sh
+++ b/mk/dependencies/hadolint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/mk/dependencies/helm.sh
+++ b/mk/dependencies/helm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/mk/dependencies/k3d.sh
+++ b/mk/dependencies/k3d.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/mk/dependencies/kind.sh
+++ b/mk/dependencies/kind.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/mk/dependencies/kubebuilder.sh
+++ b/mk/dependencies/kubebuilder.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/mk/dependencies/kubernetes.sh
+++ b/mk/dependencies/kubernetes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/mk/dependencies/protoc.sh
+++ b/mk/dependencies/protoc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/mk/dependencies/shellcheck.sh
+++ b/mk/dependencies/shellcheck.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/tools/ci/has_label.sh
+++ b/tools/ci/has_label.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 LABEL_TO_CHECK="$1"
 # CIRCLE_PULL_REQUEST looks like: https://github.com/kumahq/kuma/pull/2949 the api is at: https://api.github.com/kumahq/kuma/pulls/2949

--- a/tools/ci/needs_backporting.sh
+++ b/tools/ci/needs_backporting.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -Ee -o pipefail
 

--- a/tools/dev/install-dev-tools.sh
+++ b/tools/dev/install-dev-tools.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/tools/policy-gen/crd-extract-openapi.sh
+++ b/tools/policy-gen/crd-extract-openapi.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit
 set -o pipefail

--- a/tools/policy-gen/generate-policy-config.sh
+++ b/tools/policy-gen/generate-policy-config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/tools/policy-gen/generate-policy-defaults.sh
+++ b/tools/policy-gen/generate-policy-defaults.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/tools/policy-gen/generate-policy-helm.sh
+++ b/tools/policy-gen/generate-policy-helm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o pipefail
 set -o nounset

--- a/tools/policy-gen/generate-policy-import.sh
+++ b/tools/policy-gen/generate-policy-import.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 GO_MODULE=$1

--- a/tools/postgres/certs/generate.sh
+++ b/tools/postgres/certs/generate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 openssl genrsa -out rootCA.key 4096
 openssl req -x509 -new -nodes -key rootCA.key -sha256 -days 10024 -out rootCA.crt -subj "/C=US/ST=CA/O=MyOrg, Inc./CN=kuma-ca"
 

--- a/tools/postgres/wait-for-postgres.sh
+++ b/tools/postgres/wait-for-postgres.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 while ! nc -z localhost "$1"; do sleep 1; done;


### PR DESCRIPTION
We should use the user's preferred version of `bash` found by looking in `$PATH`.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
