### PR TITLE
ci(github): add provenance for images

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -209,7 +209,7 @@ jobs:
       - id: compute-digests
         run: |
           # Create an object of digests indexed by image (.e.g: {"kuma-cp": "sha256:1234", "kuma-dp": "sha256:5678" ...})
-          echo "digests=<<EOF" >> $GITHUB_OUTPUT
+          echo "digests<<EOF" >> $GITHUB_OUTPUT
           jq --slurp 'reduce .[] as $item ({}; . * $item)' ./digests/*.digest.json >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
   publish-helm:

--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -17,10 +17,10 @@ on:
         required: true
         type: string
     outputs:
-      IMAGE_MANIFESTS:
-        value: ${{ jobs.build.outputs.IMAGE_MANIFESTS }}
       BINARY_ARTIFACT_DIGEST_BASE64:
         value: ${{ jobs.build-binaries.outputs.BINARY_ARTIFACT_DIGEST_BASE64 }}
+      IMAGE_DIGESTS:
+        value: ${{ jobs.digest-images.outputs.DIGESTS }}
 permissions:
   contents: read
   id-token: write # Required for image signing
@@ -76,6 +76,7 @@ jobs:
             ./build/distributions/out/*.tar.gz
             ./build/distributions/out/*.sha256
             !./build/distributions/out/*.tar.gz.sha256
+          retention-days: ${{ github.event_name == 'pull_request' && 1 || 30 }}
       - name: publish binaries
         env:
           PULP_USERNAME: ${{ vars.PULP_USERNAME }}
@@ -86,8 +87,6 @@ jobs:
   build-images:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    outputs:
-      IMAGE_MANIFESTS: ${{ steps.image_manifests.outputs.manifests }}
     strategy:
       fail-fast: false
       matrix:
@@ -133,12 +132,6 @@ jobs:
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-container-structure-test') && !contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
         run: |
           make test/container-structure/${{ matrix.image }}
-      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
-        id: image-artifacts
-        with:
-          name: images_${{ matrix.image }}
-          path: |
-            ./build/docker/*.tar
       - name: scan amd64 image
         id: scan_image-amd64
         uses: Kong/public-shared-actions/security-actions/scan-docker-image@590c699fe824010d7d563a33cc60500d847d3f9e # v2.1.0
@@ -177,6 +170,21 @@ jobs:
           digest=$(regctl image digest ${{ steps.image_meta.outputs.image }})
           echo "Got digest: $digest"
           echo "digest=${digest}" >> $GITHUB_OUTPUT
+          echo "{\"${{matrix.image}}\": \"${digest}\"}" > ./build/docker/${{ matrix.image }}.digest.json
+      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        id: image-artifacts
+        with:
+          name: image_${{ matrix.image }}
+          path: |
+            ./build/docker/*.tar
+          retention-days: ${{ github.event_name == 'pull_request' && 1 || 30 }}
+      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        id: image-digest-artifacts
+        with:
+          name: image_${{ matrix.image }}.digest.json
+          path: |
+            ./build/docker/${{ matrix.image }}.digest.json
+          retention-days: ${{ github.event_name == 'pull_request' && 1 || 30 }}
       - name: sign image
         if: ${{ fromJSON(inputs.ALLOW_PUSH) }}
         id: sign
@@ -187,6 +195,23 @@ jobs:
           signature_registry: ${{ steps.image_meta.outputs.registry }}/notary${{ contains(steps.image_meta.outputs.tag, 'preview') && '-internal' }}
           registry_username: ${{ vars.DOCKER_USERNAME }}
           registry_password: ${{ secrets.DOCKER_API_KEY }}
+  digest-images:
+    needs: [build-images]
+    runs-on: ubuntu-latest
+    outputs:
+      DIGESTS: ${{ steps.compute-digests.outputs.digests }}
+    steps:
+      - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+        with:
+          pattern: "image_*.digest.json"
+          path: ./digests
+          merge-multiple: true
+      - id: compute-digests
+        run: |
+          # Create an object of digests indexed by image (.e.g: {"kuma-cp": "sha256:1234", "kuma-dp": "sha256:5678" ...})
+          echo "digests=<<EOF" >> $GITHUB_OUTPUT
+          jq --slurp 'reduce .[] as $item ({}; . * $item)' ./digests/*.digest.json >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
   publish-helm:
     needs: [build-images]
     timeout-minutes: 10

--- a/.github/workflows/_provenance.yaml
+++ b/.github/workflows/_provenance.yaml
@@ -42,7 +42,7 @@ jobs:
       fail-fast: true
       matrix:
         IMAGE: ${{ fromJSON(inputs.images) }}
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@07e64b653f10a80b6510f4568f685f8b7b9ea830 #v1.9.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@c747fe7769adf3656dc7d588b161cb614d7abfee # v1.10.0
     with:
       image: ${{ matrix.IMAGE }}
       digest: ${{ fromJSON(inputs.image_digests)[matrix.IMAGE] }}

--- a/.github/workflows/_provenance.yaml
+++ b/.github/workflows/_provenance.yaml
@@ -6,6 +6,14 @@ on:
         required: true
         type: string
         description: file containing hash for all compressed binary artifacts
+      images:
+        required: true
+        type: string
+        description: JSON string containing all images
+      image_digests:
+        required: true
+        type: string
+        description: JSON string containing all image digests
 permissions:
   contents: write
   id-token: write # needed for signing the images
@@ -20,3 +28,25 @@ jobs:
       upload-tag-name: ${{ github.ref_name }}
       provenance-name: ${{ github.event.repository.name }}.intoto.jsonl
       continue-on-error: true
+
+  # Provenance job for all images manifests
+  # SLSA generator is a reusable workflow
+  # pull-request event is [not supported](https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/container#supported-triggers)
+  # runs-on option is [not supported](https://github.com/orgs/community/discussions/25783)
+  # ENV option is [not supported](https://github.com/orgs/community/discussions/26671)
+  # Reusable workflow doesn't support exrernal COSIGN_REPOSITORY via input / env variable
+  # TODO:
+  #   Split provenance jobs for internal / official releases when repositories are split
+  images-provenance:
+    strategy:
+      fail-fast: true
+      matrix:
+        IMAGE: ${{ fromJSON(inputs.images) }}
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@07e64b653f10a80b6510f4568f685f8b7b9ea830 #v1.9.0
+    with:
+      image: ${{ matrix.IMAGE }}
+      digest: ${{ fromJSON(inputs.image_digests)[matrix.IMAGE] }}
+      continue-on-error: true
+    secrets:
+      registry-password: ${{ secrets.DOCKER_API_KEY }}
+      registry-username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -90,9 +90,10 @@ jobs:
       IMAGES: ${{ needs.check.outputs.IMAGES }}
     secrets: inherit
   provenance:
-    needs: ["build_publish"]
+    needs: ["check", "build_publish"]
     if: ${{ fromJSON(needs.check.outputs.BUILD) }}
     uses: ./.github/workflows/_provenance.yaml
+    secrets: inherit
     permissions:
       contents: write
       id-token: write # For using token to sign images
@@ -100,6 +101,8 @@ jobs:
       packages: write # Required for publishing provenance. Issue: https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/container#known-issues
     with:
       binary_artifacts_hashes_as_file: ${{ needs.build_publish.outputs.BINARY_ARTIFACT_DIGEST_BASE64 }}
+      images: ${{ needs.check.outputs.IMAGES }}
+      image_digests: ${{ needs.build_publish.outputs.IMAGE_DIGESTS }}
   distributions:
     needs: ["build_publish", "check", "test", "provenance"]
     timeout-minutes: 10


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
