### PR TITLE
fix(kuma-cp): fix long polling issues in mads

### DIFF
--- a/pkg/mads/v1/reconcile/interfaces.go
+++ b/pkg/mads/v1/reconcile/interfaces.go
@@ -8,8 +8,9 @@ import (
 
 // Reconciler re-computes configuration for a given node.
 type Reconciler interface {
-	Reconcile(context.Context, *envoy_core.Node) error
+	Reconcile(context.Context) error
 	// NeedsReconciliation checks if there is a valid configuration snapshot already present
 	// for a given node
 	NeedsReconciliation(node *envoy_core.Node) bool
+	KnownClientIds() map[string]bool
 }

--- a/pkg/mads/v1/reconcile/reconciler.go
+++ b/pkg/mads/v1/reconcile/reconciler.go
@@ -2,6 +2,7 @@ package reconcile
 
 import (
 	"context"
+	"sync"
 
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_cache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
@@ -9,36 +10,59 @@ import (
 	util_xds_v3 "github.com/kumahq/kuma/pkg/util/xds/v3"
 )
 
-func NewReconciler(hasher envoy_cache.NodeHash, cache util_xds_v3.SnapshotCache,
-	generator util_xds_v3.SnapshotGenerator, versioner util_xds_v3.SnapshotVersioner,
-) Reconciler {
+func NewReconciler(hasher envoy_cache.NodeHash, cache util_xds_v3.SnapshotCache, generator *SnapshotGenerator, versioner util_xds_v3.SnapshotVersioner) Reconciler {
 	return &reconciler{
-		hasher:    hasher,
-		cache:     cache,
-		generator: generator,
-		versioner: versioner,
+		hasher:              hasher,
+		cache:               cache,
+		generator:           generator,
+		versioner:           versioner,
+		knownClientIds:      map[string]bool{},
+		knownClientIdsMutex: &sync.Mutex{},
 	}
 }
 
 type reconciler struct {
-	hasher    envoy_cache.NodeHash
-	cache     util_xds_v3.SnapshotCache
-	generator util_xds_v3.SnapshotGenerator
-	versioner util_xds_v3.SnapshotVersioner
+	hasher              envoy_cache.NodeHash
+	cache               util_xds_v3.SnapshotCache
+	generator           *SnapshotGenerator
+	versioner           util_xds_v3.SnapshotVersioner
+	knownClientIds      map[string]bool
+	knownClientIdsMutex *sync.Mutex
 }
 
-func (r *reconciler) Reconcile(ctx context.Context, node *envoy_core.Node) error {
-	newSnapshot, err := r.generator.GenerateSnapshot(ctx, node)
+func (r *reconciler) KnownClientIds() map[string]bool {
+	r.knownClientIdsMutex.Lock()
+	defer r.knownClientIdsMutex.Unlock()
+	knownClientIds := make(map[string]bool, len(r.knownClientIds))
+	for k, v := range r.knownClientIds {
+		knownClientIds[k] = v
+	}
+	return knownClientIds
+}
+
+func (r *reconciler) Reconcile(ctx context.Context) error {
+	newSnapshotPerClient, err := r.generator.GenerateSnapshot(ctx)
 	if err != nil {
 		return err
 	}
-	if err := newSnapshot.Consistent(); err != nil {
-		return err
+	knownClients := map[string]bool{}
+	for clientId, newSnapshot := range newSnapshotPerClient {
+		knownClients[clientId] = true
+		if err := newSnapshot.Consistent(); err != nil {
+			return err
+		}
+		old, _ := r.cache.GetSnapshot(clientId)
+		newSnapshot = r.versioner.Version(newSnapshot, old)
+		err := r.cache.SetSnapshot(clientId, newSnapshot)
+		if err != nil {
+			return err
+		}
 	}
-	id := r.hasher.ID(node)
-	old, _ := r.cache.GetSnapshot(id)
-	newSnapshot = r.versioner.Version(newSnapshot, old)
-	return r.cache.SetSnapshot(id, newSnapshot)
+
+	r.knownClientIdsMutex.Lock()
+	r.knownClientIds = knownClients
+	r.knownClientIdsMutex.Unlock()
+	return nil
 }
 
 func (r *reconciler) NeedsReconciliation(node *envoy_core.Node) bool {

--- a/pkg/mads/v1/reconcile/reconciler.go
+++ b/pkg/mads/v1/reconcile/reconciler.go
@@ -2,6 +2,7 @@ package reconcile
 
 import (
 	"context"
+	"maps"
 	"sync"
 
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -33,11 +34,7 @@ type reconciler struct {
 func (r *reconciler) KnownClientIds() map[string]bool {
 	r.knownClientIdsMutex.Lock()
 	defer r.knownClientIdsMutex.Unlock()
-	knownClientIds := make(map[string]bool, len(r.knownClientIds))
-	for k, v := range r.knownClientIds {
-		knownClientIds[k] = v
-	}
-	return knownClientIds
+	return maps.Clone(r.knownClientIds)
 }
 
 func (r *reconciler) Reconcile(ctx context.Context) error {

--- a/pkg/mads/v1/reconcile/snapshot_generator.go
+++ b/pkg/mads/v1/reconcile/snapshot_generator.go
@@ -2,6 +2,7 @@ package reconcile
 
 import (
 	"context"
+
 	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/core"

--- a/pkg/mads/v1/reconcile/snapshot_generator.go
+++ b/pkg/mads/v1/reconcile/snapshot_generator.go
@@ -2,8 +2,6 @@ package reconcile
 
 import (
 	"context"
-
-	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/core"
@@ -16,28 +14,31 @@ import (
 	meshmetrics_generator "github.com/kumahq/kuma/pkg/mads/v1/generator"
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/matchers"
 	"github.com/kumahq/kuma/pkg/plugins/policies/meshmetric/api/v1alpha1"
+	"github.com/kumahq/kuma/pkg/util/pointer"
 	util_xds_v3 "github.com/kumahq/kuma/pkg/util/xds/v3"
 	"github.com/kumahq/kuma/pkg/xds/cache/mesh"
 )
 
 var log = core.Log.WithName("mads").WithName("v1").WithName("reconcile")
 
-func NewSnapshotGenerator(resourceManager core_manager.ReadOnlyResourceManager, resourceGenerator generator.ResourceGenerator, meshCache *mesh.Cache) util_xds_v3.SnapshotGenerator {
-	return &snapshotGenerator{
+const DefaultKumaClientId = "_kuma-default-client"
+
+func NewSnapshotGenerator(resourceManager core_manager.ReadOnlyResourceManager, resourceGenerator generator.ResourceGenerator, meshCache *mesh.Cache) *SnapshotGenerator {
+	return &SnapshotGenerator{
 		resourceManager:   resourceManager,
 		resourceGenerator: resourceGenerator,
 		meshCache:         meshCache,
 	}
 }
 
-type snapshotGenerator struct {
+type SnapshotGenerator struct {
 	resourceManager   core_manager.ReadOnlyResourceManager
 	resourceGenerator generator.ResourceGenerator
 	meshCache         *mesh.Cache
 }
 
-func (s *snapshotGenerator) GenerateSnapshot(ctx context.Context, node *envoy_core.Node) (util_xds_v3.Snapshot, error) {
-	meshesWithMeshMetrics, err := s.getMeshesWithMeshMetrics(ctx, node.Id)
+func (s *SnapshotGenerator) GenerateSnapshot(ctx context.Context) (map[string]util_xds_v3.Snapshot, error) {
+	meshesWithMeshMetrics, err := s.getMeshesWithMeshMetrics(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -52,6 +53,7 @@ func (s *snapshotGenerator) GenerateSnapshot(ctx context.Context, node *envoy_co
 	}
 
 	var resources []*core_xds.Resource
+	resourcesPerClientId := map[string]util_xds_v3.Snapshot{}
 	if len(meshesWithMeshMetrics) == 0 {
 		dataplanes, err := s.getDataplanes(ctx, meshes)
 		if err != nil {
@@ -73,45 +75,50 @@ func (s *snapshotGenerator) GenerateSnapshot(ctx context.Context, node *envoy_co
 		if err != nil {
 			return nil, err
 		}
+		resourcesPerClientId[DefaultKumaClientId] = createSnapshot(resources)
 	} else {
-		meshMetricConfToDataplanes, err := s.getMatchingDataplanes(ctx, meshesWithMeshMetrics)
-		if err != nil {
-			return nil, err
-		}
+		for clientId, meshes := range meshesWithMeshMetrics {
+			meshMetricConfToDataplanes, err := s.getMatchingDataplanes(ctx, meshes)
+			if err != nil {
+				return nil, err
+			}
 
-		resources, err = meshmetrics_generator.Generate(meshMetricConfToDataplanes, node.Id)
-		if err != nil {
-			return nil, err
+			resources, err = meshmetrics_generator.Generate(meshMetricConfToDataplanes, clientId)
+			if err != nil {
+				return nil, err
+			}
+			resourcesPerClientId[clientId] = createSnapshot(resources)
 		}
 	}
 
-	return mads_v1_cache.NewSnapshot("", core_xds.ResourceList(resources).ToIndex()), nil
+	return resourcesPerClientId, nil
 }
 
-func (s *snapshotGenerator) getMeshesWithMeshMetrics(ctx context.Context, clientId string) ([]string, error) {
+func (s *SnapshotGenerator) getMeshesWithMeshMetrics(ctx context.Context) (map[string][]string, error) {
 	meshMetricsList := v1alpha1.MeshMetricResourceList{}
 	if err := s.resourceManager.List(ctx, &meshMetricsList); err != nil {
 		return nil, err
 	}
 
-	var meshToMeshMetrics []string
+	clientToMeshes := map[string][]string{}
 	for _, meshMetric := range meshMetricsList.Items {
 		if meshMetric.Spec.Default.Backends == nil {
 			continue
 		}
+		meshName := meshMetric.GetMeta().GetMesh()
 		for _, backend := range *meshMetric.Spec.Default.Backends { // can backends be nil?
 			// match against client ID or fallback to "" when specified by user
-			if backend.Type == v1alpha1.PrometheusBackendType && (backend.Prometheus.ClientId == nil || *backend.Prometheus.ClientId == clientId || *backend.Prometheus.ClientId == "") {
-				meshName := meshMetric.GetMeta().GetMesh()
-				meshToMeshMetrics = append(meshToMeshMetrics, meshName)
+			if backend.Type == v1alpha1.PrometheusBackendType {
+				client := pointer.DerefOr(backend.Prometheus.ClientId, DefaultKumaClientId)
+				clientToMeshes[client] = append(clientToMeshes[client], meshName)
 			}
 		}
 	}
 
-	return meshToMeshMetrics, nil
+	return clientToMeshes, nil
 }
 
-func (s *snapshotGenerator) getMatchingDataplanes(ctx context.Context, meshesWithMeshMetrics []string) (map[*v1alpha1.Conf]*core_mesh.DataplaneResource, error) {
+func (s *SnapshotGenerator) getMatchingDataplanes(ctx context.Context, meshesWithMeshMetrics []string) (map[*v1alpha1.Conf]*core_mesh.DataplaneResource, error) {
 	meshMetricConfToDataplanes := map[*v1alpha1.Conf]*core_mesh.DataplaneResource{}
 	for _, meshName := range meshesWithMeshMetrics {
 		meshContext, err := s.meshCache.GetMeshContext(ctx, meshName)
@@ -134,7 +141,7 @@ func (s *snapshotGenerator) getMatchingDataplanes(ctx context.Context, meshesWit
 	return meshMetricConfToDataplanes, nil
 }
 
-func (s *snapshotGenerator) getMeshesWithPrometheusEnabled(ctx context.Context) ([]*core_mesh.MeshResource, error) {
+func (s *SnapshotGenerator) getMeshesWithPrometheusEnabled(ctx context.Context) ([]*core_mesh.MeshResource, error) {
 	meshList := &core_mesh.MeshResourceList{}
 	if err := s.resourceManager.List(ctx, meshList); err != nil {
 		return nil, err
@@ -149,7 +156,7 @@ func (s *snapshotGenerator) getMeshesWithPrometheusEnabled(ctx context.Context) 
 	return meshes, nil
 }
 
-func (s *snapshotGenerator) getDataplanes(ctx context.Context, meshes []*core_mesh.MeshResource) ([]*core_mesh.DataplaneResource, error) {
+func (s *SnapshotGenerator) getDataplanes(ctx context.Context, meshes []*core_mesh.MeshResource) ([]*core_mesh.DataplaneResource, error) {
 	dataplanes := make([]*core_mesh.DataplaneResource, 0)
 	for _, mesh := range meshes {
 		dataplaneList := &core_mesh.DataplaneResourceList{}
@@ -161,7 +168,7 @@ func (s *snapshotGenerator) getDataplanes(ctx context.Context, meshes []*core_me
 	return dataplanes, nil
 }
 
-func (s *snapshotGenerator) getMeshGateways(ctx context.Context, meshes []*core_mesh.MeshResource) ([]*core_mesh.MeshGatewayResource, error) {
+func (s *SnapshotGenerator) getMeshGateways(ctx context.Context, meshes []*core_mesh.MeshResource) ([]*core_mesh.MeshGatewayResource, error) {
 	meshGateways := make([]*core_mesh.MeshGatewayResource, 0)
 	for _, mesh := range meshes {
 		meshGatewayList := &core_mesh.MeshGatewayResourceList{}
@@ -171,4 +178,8 @@ func (s *snapshotGenerator) getMeshGateways(ctx context.Context, meshes []*core_
 		meshGateways = append(meshGateways, meshGatewayList.Items...)
 	}
 	return meshGateways, nil
+}
+
+func createSnapshot(resources []*core_xds.Resource) *mads_v1_cache.Snapshot {
+	return mads_v1_cache.NewSnapshot("", core_xds.ResourceList(resources).ToIndex())
 }

--- a/pkg/mads/v1/reconcile/snapshot_generator_test.go
+++ b/pkg/mads/v1/reconcile/snapshot_generator_test.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"time"
 
-	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_types "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -31,6 +30,7 @@ import (
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
 	"github.com/kumahq/kuma/pkg/test/resources/samples"
 	"github.com/kumahq/kuma/pkg/util/proto"
+	v3 "github.com/kumahq/kuma/pkg/util/xds/v3"
 	"github.com/kumahq/kuma/pkg/xds/cache/mesh"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	"github.com/kumahq/kuma/pkg/xds/server"
@@ -42,7 +42,6 @@ var _ = Describe("snapshotGenerator", func() {
 		var resourceManager core_manager.ResourceManager
 		var store core_store.ResourceStore
 		node1Id := "one"
-		node2Id := "two"
 		snapshotWithTwoAssignments := mads_cache.NewSnapshot("", map[string]envoy_types.Resource{
 			"/meshes/demo/dataplanes/backend-02": &observability_v1.MonitoringAssignment{
 				Mesh:    "demo",
@@ -102,11 +101,10 @@ var _ = Describe("snapshotGenerator", func() {
 		})
 
 		type testCase struct {
-			meshes           []*core_mesh.MeshResource
-			meshMetrics      []*v1alpha1.MeshMetricResource
-			dataplanes       []*core_mesh.DataplaneResource
-			expectedForNode1 *mads_cache.Snapshot
-			expectedForNode2 *mads_cache.Snapshot
+			meshes            []*core_mesh.MeshResource
+			meshMetrics       []*v1alpha1.MeshMetricResource
+			dataplanes        []*core_mesh.DataplaneResource
+			expectedSnapshots map[string]v3.Snapshot
 		}
 
 		DescribeTable("",
@@ -130,8 +128,6 @@ var _ = Describe("snapshotGenerator", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				ctx := context.Background()
-				node1 := corev3.Node{Id: node1Id}
-				node2 := corev3.Node{Id: node2Id}
 				for _, mesh := range given.meshes {
 					// when
 					err := resourceManager.Create(ctx, mesh, core_store.CreateBy(core_model.MetaToResourceKey(mesh.GetMeta())))
@@ -154,22 +150,16 @@ var _ = Describe("snapshotGenerator", func() {
 				// given
 				snapshotter := NewSnapshotGenerator(resourceManager, mads_generator.MonitoringAssignmentsGenerator{}, cache)
 				// when
-				snapshot, err := snapshotter.GenerateSnapshot(context.Background(), &node1)
+				snapshotPerClient, err := snapshotter.GenerateSnapshot(context.Background())
 				// then
 				Expect(err).ToNot(HaveOccurred())
 				// and
-				Expect(snapshot).To(Equal(given.expectedForNode1))
-
-				// when
-				snapshot2, err := snapshotter.GenerateSnapshot(context.Background(), &node2)
-				// then
-				Expect(err).ToNot(HaveOccurred())
-				// and
-				Expect(snapshot2).To(Equal(given.expectedForNode2))
+				Expect(snapshotPerClient).To(Equal(given.expectedSnapshots))
 			},
 			Entry("no Meshes, no Dataplanes, no MeshMetrics", testCase{
-				expectedForNode1: mads_cache.NewSnapshot("", nil),
-				expectedForNode2: mads_cache.NewSnapshot("", nil),
+				expectedSnapshots: map[string]v3.Snapshot{
+					DefaultKumaClientId: mads_cache.NewSnapshot("", nil),
+				},
 			}),
 			Entry("no Meshes with Prometheus enabled, no MeshMetrics", testCase{
 				meshes: []*core_mesh.MeshResource{
@@ -185,8 +175,9 @@ var _ = Describe("snapshotGenerator", func() {
 						WithName("backend-01").
 						Build(),
 				},
-				expectedForNode1: mads_cache.NewSnapshot("", nil),
-				expectedForNode2: mads_cache.NewSnapshot("", nil),
+				expectedSnapshots: map[string]v3.Snapshot{
+					DefaultKumaClientId: mads_cache.NewSnapshot("", nil),
+				},
 			}),
 			Entry("Mesh with Prometheus enabled but no Dataplanes, no MeshMetrics", testCase{
 				meshes: []*core_mesh.MeshResource{
@@ -222,8 +213,9 @@ var _ = Describe("snapshotGenerator", func() {
 						WithName("backend-01").
 						Build(),
 				},
-				expectedForNode1: mads_cache.NewSnapshot("", nil),
-				expectedForNode2: mads_cache.NewSnapshot("", nil),
+				expectedSnapshots: map[string]v3.Snapshot{
+					DefaultKumaClientId: mads_cache.NewSnapshot("", nil),
+				},
 			}),
 			Entry("Mesh with Prometheus enabled and some Dataplanes, no MeshMetrics", testCase{
 				meshes: []*core_mesh.MeshResource{
@@ -276,11 +268,9 @@ var _ = Describe("snapshotGenerator", func() {
 						}).
 						Build(),
 				},
-				// TODO: generate this resource map on the fly using the mads/v1/generator pkg
-				expectedForNode1: snapshotWithTwoAssignments,
-				// The pre-MeshMetric "mesh.metrics" code configures all prometheus clients (recognized as nodes here)
-				// the same way, that's why we have the same assignments for both nodes
-				expectedForNode2: snapshotWithTwoAssignments,
+				expectedSnapshots: map[string]v3.Snapshot{
+					DefaultKumaClientId: snapshotWithTwoAssignments,
+				},
 			}),
 			Entry("no Meshes with Prometheus enabled, MeshMetric with Prometheus enabled for all nodes", testCase{
 				meshes: []*core_mesh.MeshResource{
@@ -325,8 +315,9 @@ var _ = Describe("snapshotGenerator", func() {
 						},
 					},
 				},
-				expectedForNode1: meshMetricSnapshot,
-				expectedForNode2: meshMetricSnapshot,
+				expectedSnapshots: map[string]v3.Snapshot{
+					DefaultKumaClientId: meshMetricSnapshot,
+				},
 			}),
 			Entry("no Meshes with Prometheus enabled, MeshMetric with Prometheus enabled for node 1", testCase{
 				meshes: []*core_mesh.MeshResource{
@@ -371,25 +362,118 @@ var _ = Describe("snapshotGenerator", func() {
 						},
 					},
 				},
-				expectedForNode1: mads_cache.NewSnapshot("", map[string]envoy_types.Resource{
-					"/meshes/default/dataplanes/backend-01": &observability_v1.MonitoringAssignment{
-						Mesh:    "default",
-						Service: "backend",
-						Targets: []*observability_v1.MonitoringAssignment_Target{{
-							Name:        "backend-01",
-							Address:     "192.168.0.1:1234",
-							MetricsPath: "/custom",
-							Scheme:      "http",
-							Labels: map[string]string{
-								"env":              "intg",
-								"envs":             ",intg,",
-								"kuma_io_service":  "backend",
-								"kuma_io_services": ",backend,",
-							},
-						}},
+				expectedSnapshots: map[string]v3.Snapshot{
+					node1Id: mads_cache.NewSnapshot("", map[string]envoy_types.Resource{
+						"/meshes/default/dataplanes/backend-01": &observability_v1.MonitoringAssignment{
+							Mesh:    "default",
+							Service: "backend",
+							Targets: []*observability_v1.MonitoringAssignment_Target{{
+								Name:        "backend-01",
+								Address:     "192.168.0.1:1234",
+								MetricsPath: "/custom",
+								Scheme:      "http",
+								Labels: map[string]string{
+									"env":              "intg",
+									"envs":             ",intg,",
+									"kuma_io_service":  "backend",
+									"kuma_io_services": ",backend,",
+								},
+							}},
+						},
+					}),
+				},
+			}),
+			Entry("no Meshes with Prometheus enabled, MeshMetric with Prometheus enabled for node 1 and default client for rest", testCase{
+				meshes: []*core_mesh.MeshResource{
+					{
+						Meta: &test_model.ResourceMeta{
+							Name: "default",
+						},
+						Spec: &mesh_proto.Mesh{},
 					},
-				}),
-				expectedForNode2: mads_cache.NewSnapshot("", nil),
+				},
+				dataplanes: []*core_mesh.DataplaneResource{
+					samples.DataplaneBackendBuilder().
+						WithName("backend-01").
+						WithInboundOfTags(mesh_proto.ServiceTag, "backend", "env", "intg").
+						Build(),
+				},
+				meshMetrics: []*v1alpha1.MeshMetricResource{
+					{
+						Meta: &test_model.ResourceMeta{
+							Name: "default",
+							Mesh: "default",
+						},
+						Spec: &v1alpha1.MeshMetric{
+							TargetRef: common_api.TargetRef{
+								Kind: common_api.Mesh,
+							},
+							Default: v1alpha1.Conf{
+								Backends: &[]v1alpha1.Backend{
+									{
+										Type: v1alpha1.PrometheusBackendType,
+										Prometheus: &v1alpha1.PrometheusBackend{
+											ClientId: &node1Id,
+											Port:     1234,
+											Path:     "/custom",
+											Tls: &v1alpha1.PrometheusTls{
+												Mode: v1alpha1.Disabled,
+											},
+										},
+									},
+									{
+										Type: v1alpha1.PrometheusBackendType,
+										Prometheus: &v1alpha1.PrometheusBackend{
+											Port: 1234,
+											Path: "/custom",
+											Tls: &v1alpha1.PrometheusTls{
+												Mode: v1alpha1.Disabled,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				expectedSnapshots: map[string]v3.Snapshot{
+					node1Id: mads_cache.NewSnapshot("", map[string]envoy_types.Resource{
+						"/meshes/default/dataplanes/backend-01": &observability_v1.MonitoringAssignment{
+							Mesh:    "default",
+							Service: "backend",
+							Targets: []*observability_v1.MonitoringAssignment_Target{{
+								Name:        "backend-01",
+								Address:     "192.168.0.1:1234",
+								MetricsPath: "/custom",
+								Scheme:      "http",
+								Labels: map[string]string{
+									"env":              "intg",
+									"envs":             ",intg,",
+									"kuma_io_service":  "backend",
+									"kuma_io_services": ",backend,",
+								},
+							}},
+						},
+					}),
+					DefaultKumaClientId: mads_cache.NewSnapshot("", map[string]envoy_types.Resource{
+						"/meshes/default/dataplanes/backend-01": &observability_v1.MonitoringAssignment{
+							Mesh:    "default",
+							Service: "backend",
+							Targets: []*observability_v1.MonitoringAssignment_Target{{
+								Name:        "backend-01",
+								Address:     "192.168.0.1:1234",
+								MetricsPath: "/custom",
+								Scheme:      "http",
+								Labels: map[string]string{
+									"kuma_io_service":  "backend",
+									"kuma_io_services": ",backend,",
+									"env":              "intg",
+									"envs":             ",intg,",
+								},
+							}},
+						},
+					}),
+				},
 			}),
 			Entry("no Meshes with Prometheus enabled, MeshMetric with Prometheus for some dataplanes", testCase{
 				meshes: []*core_mesh.MeshResource{
@@ -442,23 +526,24 @@ var _ = Describe("snapshotGenerator", func() {
 						},
 					},
 				},
-				expectedForNode1: mads_cache.NewSnapshot("", map[string]envoy_types.Resource{
-					"/meshes/default/dataplanes/backend-01": &observability_v1.MonitoringAssignment{
-						Mesh:    "default",
-						Service: "backend-01",
-						Targets: []*observability_v1.MonitoringAssignment_Target{{
-							Name:        "backend-01",
-							Address:     "192.168.0.1:1234",
-							MetricsPath: "/custom",
-							Scheme:      "http",
-							Labels: map[string]string{
-								"kuma_io_service":  "backend-01",
-								"kuma_io_services": ",backend-01,",
-							},
-						}},
-					},
-				}),
-				expectedForNode2: mads_cache.NewSnapshot("", nil),
+				expectedSnapshots: map[string]v3.Snapshot{
+					node1Id: mads_cache.NewSnapshot("", map[string]envoy_types.Resource{
+						"/meshes/default/dataplanes/backend-01": &observability_v1.MonitoringAssignment{
+							Mesh:    "default",
+							Service: "backend-01",
+							Targets: []*observability_v1.MonitoringAssignment_Target{{
+								Name:        "backend-01",
+								Address:     "192.168.0.1:1234",
+								MetricsPath: "/custom",
+								Scheme:      "http",
+								Labels: map[string]string{
+									"kuma_io_service":  "backend-01",
+									"kuma_io_services": ",backend-01,",
+								},
+							}},
+						},
+					}),
+				},
 			}),
 			Entry("no Meshes with Prometheus enabled, multiple MeshMetrics with Prometheus and merging", testCase{
 				meshes: []*core_mesh.MeshResource{
@@ -542,51 +627,52 @@ var _ = Describe("snapshotGenerator", func() {
 						},
 					},
 				},
-				expectedForNode1: mads_cache.NewSnapshot("", map[string]envoy_types.Resource{
-					"/meshes/default/dataplanes/backend-01": &observability_v1.MonitoringAssignment{
-						Mesh:    "default",
-						Service: "backend-01",
-						Targets: []*observability_v1.MonitoringAssignment_Target{{
-							Name:        "backend-01",
-							Address:     "192.168.0.1:1234",
-							MetricsPath: "/custom",
-							Scheme:      "http",
-							Labels: map[string]string{
-								"kuma_io_service":  "backend-01",
-								"kuma_io_services": ",backend-01,",
-							},
-						}},
-					},
-					"/meshes/default/dataplanes/backend-02": &observability_v1.MonitoringAssignment{
-						Mesh:    "default",
-						Service: "backend-02",
-						Targets: []*observability_v1.MonitoringAssignment_Target{{
-							Name:        "backend-02",
-							Address:     "192.168.0.2:5678",
-							MetricsPath: "/other",
-							Scheme:      "https",
-							Labels: map[string]string{
-								"kuma_io_service":  "backend-02",
-								"kuma_io_services": ",backend-02,",
-							},
-						}},
-					},
-					"/meshes/default/dataplanes/backend-03": &observability_v1.MonitoringAssignment{
-						Mesh:    "default",
-						Service: "backend-03",
-						Targets: []*observability_v1.MonitoringAssignment_Target{{
-							Name:        "backend-03",
-							Address:     "192.168.0.3:1234",
-							MetricsPath: "/custom",
-							Scheme:      "http",
-							Labels: map[string]string{
-								"kuma_io_service":  "backend-03",
-								"kuma_io_services": ",backend-03,",
-							},
-						}},
-					},
-				}),
-				expectedForNode2: mads_cache.NewSnapshot("", nil),
+				expectedSnapshots: map[string]v3.Snapshot{
+					node1Id: mads_cache.NewSnapshot("", map[string]envoy_types.Resource{
+						"/meshes/default/dataplanes/backend-01": &observability_v1.MonitoringAssignment{
+							Mesh:    "default",
+							Service: "backend-01",
+							Targets: []*observability_v1.MonitoringAssignment_Target{{
+								Name:        "backend-01",
+								Address:     "192.168.0.1:1234",
+								MetricsPath: "/custom",
+								Scheme:      "http",
+								Labels: map[string]string{
+									"kuma_io_service":  "backend-01",
+									"kuma_io_services": ",backend-01,",
+								},
+							}},
+						},
+						"/meshes/default/dataplanes/backend-02": &observability_v1.MonitoringAssignment{
+							Mesh:    "default",
+							Service: "backend-02",
+							Targets: []*observability_v1.MonitoringAssignment_Target{{
+								Name:        "backend-02",
+								Address:     "192.168.0.2:5678",
+								MetricsPath: "/other",
+								Scheme:      "https",
+								Labels: map[string]string{
+									"kuma_io_service":  "backend-02",
+									"kuma_io_services": ",backend-02,",
+								},
+							}},
+						},
+						"/meshes/default/dataplanes/backend-03": &observability_v1.MonitoringAssignment{
+							Mesh:    "default",
+							Service: "backend-03",
+							Targets: []*observability_v1.MonitoringAssignment_Target{{
+								Name:        "backend-03",
+								Address:     "192.168.0.3:1234",
+								MetricsPath: "/custom",
+								Scheme:      "http",
+								Labels: map[string]string{
+									"kuma_io_service":  "backend-03",
+									"kuma_io_services": ",backend-03,",
+								},
+							}},
+						},
+					}),
+				},
 			}),
 		)
 	})

--- a/pkg/mads/v1/service/components.go
+++ b/pkg/mads/v1/service/components.go
@@ -20,7 +20,7 @@ import (
 	"github.com/kumahq/kuma/pkg/xds/cache/mesh"
 )
 
-func NewSnapshotGenerator(rm core_manager.ReadOnlyResourceManager, meshCache *mesh.Cache) util_xds_v3.SnapshotGenerator {
+func NewSnapshotGenerator(rm core_manager.ReadOnlyResourceManager, meshCache *mesh.Cache) *mads_reconcile.SnapshotGenerator {
 	return mads_reconcile.NewSnapshotGenerator(rm, mads_generator.MonitoringAssignmentsGenerator{}, meshCache)
 }
 
@@ -28,9 +28,7 @@ func NewVersioner() util_xds_v3.SnapshotVersioner {
 	return util_xds_v3.SnapshotAutoVersioner{UUID: core.NewUUID}
 }
 
-func NewReconciler(hasher envoy_cache.NodeHash, cache util_xds_v3.SnapshotCache,
-	generator util_xds_v3.SnapshotGenerator, versioner util_xds_v3.SnapshotVersioner,
-) mads_reconcile.Reconciler {
+func NewReconciler(hasher envoy_cache.NodeHash, cache util_xds_v3.SnapshotCache, generator *mads_reconcile.SnapshotGenerator, versioner util_xds_v3.SnapshotVersioner) mads_reconcile.Reconciler {
 	return mads_reconcile.NewReconciler(hasher, cache, generator, versioner)
 }
 
@@ -46,13 +44,11 @@ func (r *restReconcilerCallbacks) OnFetchRequest(ctx context.Context, request ut
 		return errors.Errorf("expecting a v3 Node, got: %v", nodei)
 	}
 
-	// TODO we need to reconcile on demand because if we us MeshMetric we will only reconcile in watchdog for single client
-	// that send request first because of watchdog callback implementation: pkg/util/xds/v3/watchdog_callbacks.go:48
-	// Moreover grpc sotw server is never used in real world scenario so we probably need to thing of different syncing cache mechanism
-	// if performance of ondemand reconcile will turn out to be poor.
-	// Also we probably can remove sync tracker since it will run and recompute MADS response that won't be used
-	// Issue: https://github.com/kumahq/kuma/issues/8764
-	return r.reconciler.Reconcile(ctx, node)
+	knownClients := r.reconciler.KnownClientIds()
+	if !knownClients[node.Id] {
+		node.Id = mads_reconcile.DefaultKumaClientId
+	}
+	return nil
 }
 
 func (r *restReconcilerCallbacks) OnFetchResponse(request util_xds.DiscoveryRequest, response util_xds.DiscoveryResponse) {
@@ -71,7 +67,7 @@ func NewSyncTracker(reconciler mads_reconcile.Reconciler, refresh time.Duration,
 			},
 			OnTick: func(context.Context) error {
 				log.V(1).Info("on tick")
-				return reconciler.Reconcile(ctx, node)
+				return reconciler.Reconcile(ctx)
 			},
 			OnError: func(err error) {
 				log.Error(err, "OnTick() failed")

--- a/pkg/mads/v1/service/components.go
+++ b/pkg/mads/v1/service/components.go
@@ -48,6 +48,10 @@ func (r *restReconcilerCallbacks) OnFetchRequest(ctx context.Context, request ut
 	if !knownClients[node.Id] {
 		node.Id = mads_reconcile.DefaultKumaClientId
 	}
+
+	if r.reconciler.NeedsReconciliation(node) {
+		return r.reconciler.Reconcile(ctx)
+	}
 	return nil
 }
 

--- a/pkg/mads/v1/service_test.go
+++ b/pkg/mads/v1/service_test.go
@@ -415,6 +415,8 @@ var _ = Describe("MADS http service", func() {
 
 			// and given the same version
 			discoveryReq.VersionInfo = discoveryRes.VersionInfo
+			// simulate restarted prometheus
+			discoveryReq.Node.Id = "new-prome"
 			reqBytes, err = pbMarshaller.MarshalToString(&discoveryReq)
 			Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
Fixes: #9508

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
