### PR TITLE
fix(kuma-cp): clone outbound tags

### DIFF
--- a/pkg/xds/generator/outbound_proxy_generator.go
+++ b/pkg/xds/generator/outbound_proxy_generator.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	"golang.org/x/exp/maps"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/user"
 	model "github.com/kumahq/kuma/pkg/core/xds"
-	"github.com/kumahq/kuma/pkg/util/maps"
+	util_maps "github.com/kumahq/kuma/pkg/util/maps"
 	util_protocol "github.com/kumahq/kuma/pkg/util/protocol"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
@@ -471,7 +472,7 @@ func buildOutboundsWithMultipleIPs(dataplane *core_mesh.DataplaneResource, outbo
 
 	tagsToOutbounds := map[string]OutboundWithMultipleIPs{}
 	for _, outbound := range outbounds {
-		tags := outbound.GetTags()
+		tags := maps.Clone(outbound.GetTags())
 		tags[mesh_proto.ServiceTag] = outbound.GetService()
 		tagsStr := mesh_proto.SingleValueTagSet(tags).String()
 		owmi := tagsToOutbounds[tagsStr]
@@ -488,7 +489,7 @@ func buildOutboundsWithMultipleIPs(dataplane *core_mesh.DataplaneResource, outbo
 
 	// return sorted outbounds for a stable XDS config
 	var result []OutboundWithMultipleIPs
-	for _, key := range maps.SortedKeys(tagsToOutbounds) {
+	for _, key := range util_maps.SortedKeys(tagsToOutbounds) {
 		result = append(result, tagsToOutbounds[key])
 	}
 	return result


### PR DESCRIPTION
### Checklist prior to review

There was an error:
```
fatal error: concurrent map writes
  
  goroutine 11569 [running]:
  github.com/kumahq/kuma/pkg/xds/generator.buildOutboundsWithMultipleIPs(0xc00325f878, {0xc002dbca10, 0x2, 0x10?}, {0xc001d88230, 0x2, 0x307ee20?})
  	github.com/kumahq/kuma/pkg/xds/generator/outbound_proxy_generator.go:475 +0x253
```

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
