### PR TITLE
fix(kumactl): npe when creating new core resources

### DIFF
--- a/pkg/core/resources/apis/donothingresource/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/donothingresource/api/v1alpha1/zz_generated.resource.go
@@ -135,7 +135,7 @@ var DoNothingResourceResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	IsExperimental:      false,
 	SingularDisplayName: "Do Nothing Resource",
 	PluralDisplayName:   "Do Nothing Resources",
-	IsPluginOriginated:  false,
+	IsPluginOriginated:  true,
 	IsTargetRefBased:    false,
 	HasToTargetRef:      false,
 	HasFromTargetRef:    false,

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/zz_generated.resource.go
@@ -135,7 +135,7 @@ var MeshServiceResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	IsExperimental:      false,
 	SingularDisplayName: "Mesh Service",
 	PluralDisplayName:   "Mesh Services",
-	IsPluginOriginated:  false,
+	IsPluginOriginated:  true,
 	IsTargetRefBased:    false,
 	HasToTargetRef:      false,
 	HasFromTargetRef:    false,

--- a/tools/policy-gen/generator/cmd/core_resource.go
+++ b/tools/policy-gen/generator/cmd/core_resource.go
@@ -175,7 +175,7 @@ var {{.Name}}ResourceTypeDescriptor = model.ResourceTypeDescriptor{
 		IsExperimental: false,
 		SingularDisplayName: "{{.SingularDisplayName}}",
 		PluralDisplayName: "{{.PluralDisplayName}}",
-		IsPluginOriginated: {{.IsPolicy}},
+		IsPluginOriginated: true,
 		IsTargetRefBased: {{.IsPolicy}},
 		HasToTargetRef: {{.HasTo}},
 		HasFromTargetRef: {{.HasFrom}},


### PR DESCRIPTION
Without `IsPluginOriginated` the deserialization expects a `ProtoMessage`:

```
$ kumactl apply -f meshservice.yaml
panic: interface conversion: *v1alpha1.MeshService is not protoreflect.ProtoMessage: missing method ProtoReflect

goroutine 1 [running]:
github.com/kumahq/kuma/pkg/core/resources/model/rest/unversioned.(*Resource).UnmarshalJSON(0xc000086180, {0xc000925400, 0x3f, 0x200})
	github.com/kumahq/kuma/pkg/core/resources/model/rest/unversioned/resource.go:72 +0xc9
encoding/json.(*decodeState).object(0xc000379068, {0x266e2c0?, 0xc0002ffa90?, 0xc000999408?})
	encoding/json/decode.go:604 +0x6cc
encoding/json.(*decodeState).value(0xc000379068, {0x266e2c0?, 0xc0002ffa90?, 0xc000999458?})
	encoding/json/decode.go:374 +0x3e
encoding/json.(*decodeState).unmarshal(0xc000379068, {0x266e2c0?, 0xc0002ffa90?})
	encoding/json/decode.go:181 +0x133
encoding/json.(*Decoder).Decode(0xc000379040, {0x266e2c0, 0xc0002ffa90})
	encoding/json/stream.go:73 +0x179
sigs.k8s.io/yaml.jsonUnmarshal({0x45220c0?, 0xc000879470}, {0x298ef20, 0xc000086180}, {0x0, 0x0, 0x0?})
	sigs.k8s.io/yaml@v1.4.0/yaml.go:94 +0xf6
sigs.k8s.io/yaml.unmarshal({0xc000a87200?, 0xd?, 0x0?}, {0x298ef20, 0xc000086180}, 0x0?, {0x0, 0x0, 0x0})
	sigs.k8s.io/yaml@v1.4.0/yaml.go:77 +0x18f
sigs.k8s.io/yaml.Unmarshal(...)
	sigs.k8s.io/yaml@v1.4.0/yaml.go:56
github.com/kumahq/kuma/pkg/core/resources/model/rest.glob..func1({0xc000a87200?, 0x4570ba0?, 0xc000894df8?}, {0x298ef20?, 0xc000086180?})
	github.com/kumahq/kuma/pkg/core/resources/model/rest/unmarshaller.go:21 +0x32
github.com/kumahq/kuma/pkg/core/resources/model/rest.(*unmarshaler).Unmarshal(0x61b6ca0, {0xc000a87200, _, _}, {{0x2d6234e, 0xb}, {0x4570ba0, 0x61cfeb0}, {0x4574dd0, 0x6231b80}, ...})
	github.com/kumahq/kuma/pkg/core/resources/model/rest/unmarshaller.go:82 +0x2f4
github.com/kumahq/kuma/pkg/core/resources/model/rest.(*unmarshaler).UnmarshalCore(0x61b6ca0, {0xc000a87200, 0x33, 0x40})
	github.com/kumahq/kuma/pkg/core/resources/model/rest/unmarshaller.go:54 +0x1ff
github.com/kumahq/kuma/app/kumactl/cmd/apply.NewApplyCmd.func1(0xc000ef6600, {0x0?, 0x0?, 0x0?})
	github.com/kumahq/kuma/app/kumactl/cmd/apply/apply.go:114 +0x51d
github.com/kumahq/kuma/app/kumactl/pkg/errors.FormatErrorWrapper.func1(0xc000ea1300?, {0xc000844560?, 0x4?, 0x2d55a0e?})
	github.com/kumahq/kuma/app/kumactl/pkg/errors/formatter.go:14 +0x1c
github.com/spf13/cobra.(*Command).execute(0xc000ef6600, {0xc000844540, 0x2, 0x2})
	github.com/spf13/cobra@v1.8.0/command.go:983 +0xabc
github.com/spf13/cobra.(*Command).ExecuteC(0xc000ef6300)
	github.com/spf13/cobra@v1.8.0/command.go:1115 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.8.0/command.go:1039
github.com/kumahq/kuma/app/kumactl/cmd.Execute()
	github.com/kumahq/kuma/app/kumactl/cmd/root.go:113 +0x18
main.main()
	github.com/kumahq/kuma/app/kumactl/main.go:6 +0xf
```

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
