### PR TITLE
fix(kuma-dp): pass proper context in meshmetric component

### DIFF
--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -103,8 +103,6 @@ jobs:
           }
           EOF
           sudo service docker restart
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
       - name: "GitHub Actions: run E2E tests"
         if: steps.eval-params.outputs.run-type == 'github'
         run: |

--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -103,6 +103,8 @@ jobs:
           }
           EOF
           sudo service docker restart
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
       - name: "GitHub Actions: run E2E tests"
         if: steps.eval-params.outputs.run-type == 'github'
         run: |

--- a/app/kuma-dp/cmd/run.go
+++ b/app/kuma-dp/cmd/run.go
@@ -368,6 +368,7 @@ func setupObservability(kumaSidecarConfiguration *types.KumaSidecarConfiguration
 			kumaSidecarConfiguration.Networking.Address,
 			bootstrap.GetAdmin().GetAddress().GetSocketAddress().GetPortValue(),
 			bootstrap.GetAdmin().GetAddress().GetSocketAddress().GetAddress(),
+			cfg.Dataplane.DrainTime.Duration,
 		),
 	)
 

--- a/app/kuma-dp/pkg/dataplane/meshmetrics/component.go
+++ b/app/kuma-dp/pkg/dataplane/meshmetrics/component.go
@@ -68,7 +68,7 @@ func (cf *ConfigFetcher) Start(stop <-chan struct{}) error {
 		"socketPath", fmt.Sprintf("unix://%s", cf.socketPath),
 	)
 
-	ctx := context.Background()
+	ctx, ctxCancel := context.WithCancel(context.Background())
 
 	for {
 		select {
@@ -92,6 +92,7 @@ func (cf *ConfigFetcher) Start(stop <-chan struct{}) error {
 			}
 		case <-stop:
 			logger.Info("stopping Dynamic Mesh Metrics Configuration Scraper")
+			ctxCancel()
 			return nil
 		}
 	}

--- a/app/kuma-dp/pkg/dataplane/meshmetrics/component.go
+++ b/app/kuma-dp/pkg/dataplane/meshmetrics/component.go
@@ -72,10 +72,8 @@ func (cf *ConfigFetcher) Start(stop <-chan struct{}) error {
 
 	ctx, ctxCancel := context.WithCancel(context.Background())
 	go func() {
-		select {
-		case <-stop:
-			ctxCancel()
-		}
+		<-stop
+		ctxCancel()
 	}()
 
 	for {


### PR DESCRIPTION
Fixes: #8963

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
