### PR TITLE
test(_rules): add test case with httproutes with listeners on meshgateways

### DIFF
--- a/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshgateway2.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshgateway2.golden.json
@@ -1,0 +1,183 @@
+{
+ "httpMatches": [
+  {
+   "hash": "7AL18PkCPj3JAlwamTpzmVg7/sLnT8IXWtQljrRqs+4=",
+   "match": [
+    {
+     "headers": [
+      {
+       "type": "Exact",
+       "name": "foo",
+       "value": "baz"
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "hash": "tX9tfbEoFumfHilx1E5h3KWj9aB7Zbw0+bi2Mq2yRaw=",
+   "match": [
+    {
+     "headers": [
+      {
+       "type": "Exact",
+       "name": "foo",
+       "value": "bazz"
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "hash": "yM0/dbXyGi3nh/16+QCWa0maH7RkPXftZ4fkR+vFOjA=",
+   "match": [
+    {
+     "headers": [
+      {
+       "type": "Exact",
+       "name": "foo",
+       "value": "bar"
+      }
+     ]
+    }
+   ]
+  }
+ ],
+ "resource": {
+  "mesh": "default",
+  "name": "gw-1",
+  "type": "MeshGateway"
+ },
+ "rules": [
+  {
+   "fromRules": [],
+   "toRules": [
+    {
+     "conf": {
+      "rules": [
+       {
+        "matches": [
+         {
+          "headers": [
+           {
+            "type": "Exact",
+            "name": "foo",
+            "value": "baz"
+           }
+          ]
+         }
+        ],
+        "default": {
+         "backendRefs": [
+          {
+           "kind": "MeshServiceSubset",
+           "name": "backend_kuma-demo_svc_3001",
+           "tags": {
+            "version": "v0"
+           }
+          }
+         ]
+        }
+       },
+       {
+        "matches": [
+         {
+          "headers": [
+           {
+            "type": "Exact",
+            "name": "foo",
+            "value": "bar"
+           }
+          ]
+         }
+        ],
+        "default": {
+         "backendRefs": [
+          {
+           "kind": "MeshServiceSubset",
+           "name": "backend_kuma-demo_svc_3001",
+           "tags": {
+            "version": "v0"
+           }
+          }
+         ]
+        }
+       }
+      ]
+     },
+     "matchers": [],
+     "origin": [
+      {
+       "mesh": "default",
+       "name": "http-route-1",
+       "type": "MeshHTTPRoute"
+      },
+      {
+       "mesh": "default",
+       "name": "http-route-2",
+       "type": "MeshHTTPRoute"
+      },
+      {
+       "mesh": "default",
+       "name": "http-route-3",
+       "type": "MeshHTTPRoute"
+      }
+     ]
+    },
+    {
+     "conf": {
+      "rules": [
+       {
+        "matches": [
+         {
+          "headers": [
+           {
+            "type": "Exact",
+            "name": "foo",
+            "value": "bazz"
+           }
+          ]
+         }
+        ],
+        "default": {
+         "backendRefs": [
+          {
+           "kind": "MeshServiceSubset",
+           "name": "backend_kuma-demo_svc_3001",
+           "tags": {
+            "version": "v0"
+           }
+          }
+         ]
+        }
+       }
+      ],
+      "hostnames": [
+       "foo.com"
+      ]
+     },
+     "matchers": [],
+     "origin": [
+      {
+       "mesh": "default",
+       "name": "http-route-1",
+       "type": "MeshHTTPRoute"
+      },
+      {
+       "mesh": "default",
+       "name": "http-route-2",
+       "type": "MeshHTTPRoute"
+      },
+      {
+       "mesh": "default",
+       "name": "http-route-3",
+       "type": "MeshHTTPRoute"
+      }
+     ]
+    }
+   ],
+   "type": "MeshHTTPRoute",
+   "warnings": []
+  }
+ ]
+}

--- a/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshgateway2.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshgateway2.input.yaml
@@ -1,0 +1,99 @@
+# Currently the output of the rules API to not include `matchers` for listener selection which doesn't make this
+# powerful enough. Once https://github.com/kumahq/kuma/issues/9589 is resolved, we should update the output of the test
+# should include matchers for listener selection.
+#/meshes/default/meshgateways/gw-1/_rules 200
+type: Mesh
+name: default
+---
+type: MeshGateway
+name: gw-1
+mesh: default
+selectors:
+  - match:
+      kuma.io/service: gw-1
+conf:
+  listeners:
+    - port: 80
+      protocol: HTTP
+      tags:
+        listener: bar
+    - port: 81
+      protocol: HTTP
+      hostname: bar.com
+      tags:
+        listener: foo
+---
+type: MeshHTTPRoute
+name: http-route-1
+mesh: default
+spec:
+  targetRef:
+    kind: MeshGateway
+    name: gw-1
+  to:
+    - targetRef:
+        kind: Mesh
+      rules:
+        - matches:
+            - headers:
+                - type: Exact
+                  name: foo
+                  value: bar
+          default:
+            backendRefs:
+              - kind: MeshServiceSubset
+                name: backend_kuma-demo_svc_3001
+                tags:
+                  version: v0
+---
+type: MeshHTTPRoute
+name: http-route-2
+mesh: default
+spec:
+  targetRef:
+    kind: MeshGateway
+    name: gw-1
+    tags:
+      listener: foo
+  to:
+    - targetRef:
+        kind: Mesh
+      rules:
+        - matches:
+            - headers:
+                - type: Exact
+                  name: foo
+                  value: baz
+          default:
+            backendRefs:
+              - kind: MeshServiceSubset
+                name: backend_kuma-demo_svc_3001
+                tags:
+                  version: v0
+
+---
+type: MeshHTTPRoute
+name: http-route-3
+mesh: default
+spec:
+  targetRef:
+    kind: MeshGateway
+    name: gw-1
+    tags:
+      listener: foo
+  to:
+    - targetRef:
+        kind: Mesh
+      hostnames: ["foo.com"]
+      rules:
+        - matches:
+            - headers:
+                - type: Exact
+                  name: foo
+                  value: bazz
+          default:
+            backendRefs:
+              - kind: MeshServiceSubset
+                name: backend_kuma-demo_svc_3001
+                tags:
+                  version: v0


### PR DESCRIPTION
…eways

This test case is meant to be updated once selection in the matchers works correctly

ref #9589

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
