### PR TITLE
fix(MeshHealthCheck): isolate MeshGateway config based on hostname

### DIFF
--- a/pkg/plugins/policies/core/rules/rules.go
+++ b/pkg/plugins/policies/core/rules/rules.go
@@ -85,8 +85,13 @@ func InboundListenerHostnameFromGatewayListener(
 }
 
 type GatewayToRules struct {
+	// ByListener contains rules that are not specific to hostnames
+	// If the policy supports `GatewayListenerTagsAllowed: true`
+	// then it likely should use ByListenerAndHostname
+	ByListener map[InboundListener]Rules
+	// ByListenerAndHostname contains rules for policies that are specific to hostnames
+	// This only relevant if the policy has `GatewayListenerTagsAllowed: true`
 	ByListenerAndHostname map[InboundListenerHostname]Rules
-	ByListener            map[InboundListener]Rules
 }
 
 type GatewayRules struct {

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin.go
@@ -8,6 +8,7 @@ import (
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/matchers"
+	"github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
 	core_rules "github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
 	policies_xds "github.com/kumahq/kuma/pkg/plugins/policies/core/xds"
 	api "github.com/kumahq/kuma/pkg/plugins/policies/meshhealthcheck/api/v1alpha1"
@@ -71,15 +72,17 @@ func applyToGateways(
 	proxy *core_xds.Proxy,
 ) error {
 	for _, listenerInfo := range gateway_plugin.ExtractGatewayListeners(proxy) {
-		rules, ok := gatewayRules.ToRules.ByListener[core_rules.InboundListener{
-			Address: proxy.Dataplane.Spec.GetNetworking().Address,
-			Port:    listenerInfo.Listener.Port,
-		}]
-		if !ok {
-			continue
-		}
-		for _, listenerHostnames := range listenerInfo.ListenerHostnames {
-			for _, hostInfo := range listenerHostnames.HostInfos {
+		for _, listenerHostname := range listenerInfo.ListenerHostnames {
+			inboundListener := rules.NewInboundListenerHostname(
+				proxy.Dataplane.Spec.GetNetworking().Address,
+				listenerInfo.Listener.Port,
+				listenerHostname.Hostname,
+			)
+			rules, ok := gatewayRules.ToRules.ByListenerAndHostname[inboundListener]
+			if !ok {
+				continue
+			}
+			for _, hostInfo := range listenerHostname.HostInfos {
 				destinations := gateway_plugin.RouteDestinationsMutable(hostInfo.Entries())
 				for _, dest := range destinations {
 					clusterName, err := dest.Destination.DestinationClusterName(hostInfo.Host.Tags)

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
@@ -343,8 +343,8 @@ var _ = Describe("MeshHealthCheck", func() {
 			gatewayRoutes: []*core_mesh.MeshGatewayRouteResource{samples.BackendGatewayRoute()},
 			rules: core_rules.GatewayRules{
 				ToRules: core_rules.GatewayToRules{
-					ByListener: map[core_rules.InboundListener]core_rules.Rules{
-						{Address: "192.168.0.1", Port: 8080}: {
+					ByListenerAndHostname: map[core_rules.InboundListenerHostname]core_rules.Rules{
+						rules.NewInboundListenerHostname("192.168.0.1", 8080, "*"): {
 							{
 								Subset: core_rules.Subset{},
 								Conf: api.Conf{
@@ -437,8 +437,8 @@ var _ = Describe("MeshHealthCheck", func() {
 			},
 			rules: core_rules.GatewayRules{
 				ToRules: core_rules.GatewayToRules{
-					ByListener: map[core_rules.InboundListener]core_rules.Rules{
-						{Address: "192.168.0.1", Port: 8080}: {
+					ByListenerAndHostname: map[core_rules.InboundListenerHostname]core_rules.Rules{
+						rules.NewInboundListenerHostname("192.168.0.1", 8080, "*"): {
 							{
 								Subset: core_rules.Subset{},
 								Conf: api.Conf{
@@ -477,7 +477,7 @@ var _ = Describe("MeshHealthCheck", func() {
 								},
 							},
 						},
-						{Address: "192.168.0.1", Port: 8081}: {
+						rules.NewInboundListenerHostname("192.168.0.1", 8081, "*"): {
 							{
 								Subset: core_rules.Subset{},
 								Conf: api.Conf{

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
@@ -165,7 +165,7 @@ var _ = Describe("MeshHealthCheck", func() {
 							InitialJitter:                test.ParseDuration("13s"),
 							IntervalJitter:               test.ParseDuration("15s"),
 							IntervalJitterPercent:        pointer.To[int32](10),
-							HealthyPanicThreshold:        pointer.To[intstr.IntOrString](intstr.FromString("62.9")),
+							HealthyPanicThreshold:        pointer.To(intstr.FromString("62.9")),
 							FailTrafficOnPanic:           pointer.To(true),
 							EventLogPath:                 pointer.To("/tmp/log.txt"),
 							AlwaysLogHealthCheckFailures: pointer.To(false),


### PR DESCRIPTION
Because we have `GatewayListenerTagsAllowed: true` in validation, we must take the policies from `ByListenerAndHostname`, listener-specific rules from one policy can be clobbered by another in `ByListener`, if the listeners share a port.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x]  [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
