### PR TITLE
fix(kuma-dp): fix starting infinite otel exporters in kuma dp

### DIFF
--- a/app/kuma-dp/pkg/dataplane/meshmetrics/component.go
+++ b/app/kuma-dp/pkg/dataplane/meshmetrics/component.go
@@ -157,10 +157,7 @@ func (cf *ConfigFetcher) reconfigureBackends(ctx context.Context, openTelemetryB
 	for backendName, backend := range openTelemetryBackends {
 		// backend already running, in the future we can reconfigure it here
 		if cf.runningBackends[backendName] != nil {
-			err := cf.reconfigureBackendIfNeeded(ctx, backendName, backend)
-			if err != nil {
-				return err
-			}
+			return cf.reconfigureBackendIfNeeded(ctx, backendName, backend)
 		}
 		// start backend as it is not running yet
 		exporter, err := startExporter(ctx, backend, cf.openTelemetryProducer, backendName)

--- a/app/kuma-dp/pkg/dataplane/meshmetrics/component.go
+++ b/app/kuma-dp/pkg/dataplane/meshmetrics/component.go
@@ -157,7 +157,11 @@ func (cf *ConfigFetcher) reconfigureBackends(ctx context.Context, openTelemetryB
 	for backendName, backend := range openTelemetryBackends {
 		// backend already running, in the future we can reconfigure it here
 		if cf.runningBackends[backendName] != nil {
-			return cf.reconfigureBackendIfNeeded(ctx, backendName, backend)
+			err := cf.reconfigureBackendIfNeeded(ctx, backendName, backend)
+			if err != nil {
+				return err
+			}
+			continue
 		}
 		// start backend as it is not running yet
 		exporter, err := startExporter(ctx, backend, cf.openTelemetryProducer, backendName)


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
