### PR TITLE
feat(k8s): add `experimental.sidecarContainers` to Helm chart

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -696,6 +696,9 @@ experimental:
     programsSourcePath: /kuma/ebpf
   # -- If false, it uses legacy API for resource synchronization
   deltaKds: true
+  # -- If true, enable native Kubernetes sidecars. This requires at least
+  # Kubernetes v1.29
+  sidecarContainers: false
 
 # Postgres' settings for universal control plane on k8s
 postgres:

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -206,6 +206,7 @@ A Helm chart for the Kuma Control Plane
 | experimental.ebpf.tcAttachIface | string | `""` | Name of the network interface which TC programs should be attached to, we'll try to automatically determine it if empty |
 | experimental.ebpf.programsSourcePath | string | `"/kuma/ebpf"` | Path where compiled eBPF programs which will be installed can be found |
 | experimental.deltaKds | bool | `true` | If false, it uses legacy API for resource synchronization |
+| experimental.sidecarContainers | bool | `false` | If true, enable native Kubernetes sidecars. This requires at least Kubernetes v1.29 |
 | postgres.port | string | `"5432"` | Postgres port, password should be provided as a secret reference in "controlPlane.secrets" with the Env value "KUMA_STORE_POSTGRES_PASSWORD". Example: controlPlane:   secrets:     - Secret: postgres-postgresql       Key: postgresql-password       Env: KUMA_STORE_POSTGRES_PASSWORD |
 | postgres.tls.mode | string | `"disable"` | Mode of TLS connection. Available values are: "disable", "verifyNone", "verifyCa", "verifyFull" |
 | postgres.tls.disableSSLSNI | bool | `false` | Whether to disable SNI the postgres `sslsni` option. |

--- a/deployments/charts/kuma/templates/_helpers.tpl
+++ b/deployments/charts/kuma/templates/_helpers.tpl
@@ -269,6 +269,10 @@ env:
 - name: KUMA_EXPERIMENTAL_GATEWAY_API
   value: "true"
 {{- end }}
+{{- if .Values.experimental.sidecarContainers }}
+- name: KUMA_EXPERIMENTAL_SIDECAR_CONTAINERS
+  value: "true"
+{{- end }}
 {{- if .Values.cni.enabled }}
 - name: KUMA_RUNTIME_KUBERNETES_NODE_TAINT_CONTROLLER_ENABLED
   value: "true"

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -696,6 +696,9 @@ experimental:
     programsSourcePath: /kuma/ebpf
   # -- If false, it uses legacy API for resource synchronization
   deltaKds: true
+  # -- If true, enable native Kubernetes sidecars. This requires at least
+  # Kubernetes v1.29
+  sidecarContainers: false
 
 # Postgres' settings for universal control plane on k8s
 postgres:

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -696,6 +696,9 @@ experimental:
     programsSourcePath: /kuma/ebpf
   # -- If false, it uses legacy API for resource synchronization
   deltaKds: true
+  # -- If true, enable native Kubernetes sidecars. This requires at least
+  # Kubernetes v1.29
+  sidecarContainers: false
 
 # Postgres' settings for universal control plane on k8s
 postgres:


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
