### PR TITLE
fix(kuma-cp): fix for mads adding dataplanes with empty client id to snapshots for specific client id

### DIFF
--- a/pkg/mads/v1/generator/meshmetrics.go
+++ b/pkg/mads/v1/generator/meshmetrics.go
@@ -12,6 +12,8 @@ import (
 	"github.com/kumahq/kuma/pkg/util/pointer"
 )
 
+const DefaultKumaClientId = "_kuma-default-client"
+
 func Generate(meshMetricToDataplane map[*v1alpha1.Conf]*core_mesh.DataplaneResource, clientId string) ([]*core_xds.Resource, error) {
 	var resources []*core_xds.Resource
 
@@ -22,7 +24,7 @@ func Generate(meshMetricToDataplane map[*v1alpha1.Conf]*core_mesh.DataplaneResou
 			}
 			prometheusEndpoint := backend.Prometheus
 
-			if pointer.Deref(prometheusEndpoint.ClientId) != "" && pointer.Deref(prometheusEndpoint.ClientId) != clientId {
+			if pointer.DerefOr(prometheusEndpoint.ClientId, DefaultKumaClientId) != clientId {
 				continue
 			}
 

--- a/pkg/mads/v1/reconcile/snapshot_generator.go
+++ b/pkg/mads/v1/reconcile/snapshot_generator.go
@@ -22,8 +22,6 @@ import (
 
 var log = core.Log.WithName("mads").WithName("v1").WithName("reconcile")
 
-const DefaultKumaClientId = "_kuma-default-client"
-
 func NewSnapshotGenerator(resourceManager core_manager.ReadOnlyResourceManager, resourceGenerator generator.ResourceGenerator, meshCache *mesh.Cache) *SnapshotGenerator {
 	return &SnapshotGenerator{
 		resourceManager:   resourceManager,
@@ -76,7 +74,7 @@ func (s *SnapshotGenerator) GenerateSnapshot(ctx context.Context) (map[string]ut
 		if err != nil {
 			return nil, err
 		}
-		resourcesPerClientId[DefaultKumaClientId] = createSnapshot(resources)
+		resourcesPerClientId[meshmetrics_generator.DefaultKumaClientId] = createSnapshot(resources)
 	} else {
 		for clientId, meshes := range meshesWithMeshMetrics {
 			meshMetricConfToDataplanes, err := s.getMatchingDataplanes(ctx, meshes)
@@ -110,7 +108,7 @@ func (s *SnapshotGenerator) getMeshesWithMeshMetrics(ctx context.Context) (map[s
 		for _, backend := range *meshMetric.Spec.Default.Backends { // can backends be nil?
 			// match against client ID or fallback to "" when specified by user
 			if backend.Type == v1alpha1.PrometheusBackendType {
-				client := pointer.DerefOr(backend.Prometheus.ClientId, DefaultKumaClientId)
+				client := pointer.DerefOr(backend.Prometheus.ClientId, meshmetrics_generator.DefaultKumaClientId)
 				clientToMeshes[client] = append(clientToMeshes[client], meshName)
 			}
 		}

--- a/pkg/mads/v1/reconcile/snapshot_generator_test.go
+++ b/pkg/mads/v1/reconcile/snapshot_generator_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kumahq/kuma/pkg/dns/vips"
 	mads_cache "github.com/kumahq/kuma/pkg/mads/v1/cache"
 	mads_generator "github.com/kumahq/kuma/pkg/mads/v1/generator"
+	meshmetrics_generator "github.com/kumahq/kuma/pkg/mads/v1/generator"
 	. "github.com/kumahq/kuma/pkg/mads/v1/reconcile"
 	"github.com/kumahq/kuma/pkg/metrics"
 	// to match custom policy resource type like you need to register them manually in tests
@@ -158,7 +159,7 @@ var _ = Describe("snapshotGenerator", func() {
 			},
 			Entry("no Meshes, no Dataplanes, no MeshMetrics", testCase{
 				expectedSnapshots: map[string]v3.Snapshot{
-					DefaultKumaClientId: mads_cache.NewSnapshot("", nil),
+					meshmetrics_generator.DefaultKumaClientId: mads_cache.NewSnapshot("", nil),
 				},
 			}),
 			Entry("no Meshes with Prometheus enabled, no MeshMetrics", testCase{
@@ -176,7 +177,7 @@ var _ = Describe("snapshotGenerator", func() {
 						Build(),
 				},
 				expectedSnapshots: map[string]v3.Snapshot{
-					DefaultKumaClientId: mads_cache.NewSnapshot("", nil),
+					meshmetrics_generator.DefaultKumaClientId: mads_cache.NewSnapshot("", nil),
 				},
 			}),
 			Entry("Mesh with Prometheus enabled but no Dataplanes, no MeshMetrics", testCase{
@@ -214,7 +215,7 @@ var _ = Describe("snapshotGenerator", func() {
 						Build(),
 				},
 				expectedSnapshots: map[string]v3.Snapshot{
-					DefaultKumaClientId: mads_cache.NewSnapshot("", nil),
+					meshmetrics_generator.DefaultKumaClientId: mads_cache.NewSnapshot("", nil),
 				},
 			}),
 			Entry("Mesh with Prometheus enabled and some Dataplanes, no MeshMetrics", testCase{
@@ -269,7 +270,7 @@ var _ = Describe("snapshotGenerator", func() {
 						Build(),
 				},
 				expectedSnapshots: map[string]v3.Snapshot{
-					DefaultKumaClientId: snapshotWithTwoAssignments,
+					meshmetrics_generator.DefaultKumaClientId: snapshotWithTwoAssignments,
 				},
 			}),
 			Entry("no Meshes with Prometheus enabled, MeshMetric with Prometheus enabled for all nodes", testCase{
@@ -316,7 +317,7 @@ var _ = Describe("snapshotGenerator", func() {
 					},
 				},
 				expectedSnapshots: map[string]v3.Snapshot{
-					DefaultKumaClientId: meshMetricSnapshot,
+					meshmetrics_generator.DefaultKumaClientId: meshMetricSnapshot,
 				},
 			}),
 			Entry("no Meshes with Prometheus enabled, MeshMetric with Prometheus enabled for node 1", testCase{
@@ -455,7 +456,7 @@ var _ = Describe("snapshotGenerator", func() {
 							}},
 						},
 					}),
-					DefaultKumaClientId: mads_cache.NewSnapshot("", map[string]envoy_types.Resource{
+					meshmetrics_generator.DefaultKumaClientId: mads_cache.NewSnapshot("", map[string]envoy_types.Resource{
 						"/meshes/default/dataplanes/backend-01": &observability_v1.MonitoringAssignment{
 							Mesh:    "default",
 							Service: "backend",
@@ -654,6 +655,136 @@ var _ = Describe("snapshotGenerator", func() {
 								Labels: map[string]string{
 									"kuma_io_service":  "backend-02",
 									"kuma_io_services": ",backend-02,",
+								},
+							}},
+						},
+						"/meshes/default/dataplanes/backend-03": &observability_v1.MonitoringAssignment{
+							Mesh:    "default",
+							Service: "backend-03",
+							Targets: []*observability_v1.MonitoringAssignment_Target{{
+								Name:        "backend-03",
+								Address:     "192.168.0.3:1234",
+								MetricsPath: "/custom",
+								Scheme:      "http",
+								Labels: map[string]string{
+									"kuma_io_service":  "backend-03",
+									"kuma_io_services": ",backend-03,",
+								},
+							}},
+						},
+					}),
+				},
+			}),
+			Entry("no Meshes with Prometheus enabled, multiple MeshMetrics with Prometheus and merging", testCase{
+				meshes: []*core_mesh.MeshResource{
+					{
+						Meta: &test_model.ResourceMeta{
+							Name: "default",
+						},
+						Spec: &mesh_proto.Mesh{},
+					},
+				},
+				dataplanes: []*core_mesh.DataplaneResource{
+					builders.Dataplane().
+						WithName("backend-01").
+						WithInboundOfTags(mesh_proto.ServiceTag, "backend-01").
+						WithServices("backend-01").
+						WithAddress("192.168.0.1").
+						Build(),
+					builders.Dataplane().
+						WithName("backend-02").
+						WithInboundOfTags(mesh_proto.ServiceTag, "backend-02").
+						WithAddress("192.168.0.2").
+						Build(),
+					builders.Dataplane().
+						WithName("backend-03").
+						WithInboundOfTags(mesh_proto.ServiceTag, "backend-03").
+						WithAddress("192.168.0.3").
+						Build(),
+				},
+				meshMetrics: []*v1alpha1.MeshMetricResource{
+					{
+						Meta: &test_model.ResourceMeta{
+							Name: "default",
+							Mesh: "default",
+						},
+						Spec: &v1alpha1.MeshMetric{
+							TargetRef: common_api.TargetRef{
+								Kind: common_api.Mesh,
+							},
+							Default: v1alpha1.Conf{
+								Backends: &[]v1alpha1.Backend{
+									{
+										Type: v1alpha1.PrometheusBackendType,
+										Prometheus: &v1alpha1.PrometheusBackend{
+											ClientId: &node1Id,
+											Port:     1234,
+											Path:     "/custom",
+											Tls: &v1alpha1.PrometheusTls{
+												Mode: v1alpha1.Disabled,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Meta: &test_model.ResourceMeta{
+							Name: "override",
+							Mesh: "default",
+						},
+						Spec: &v1alpha1.MeshMetric{
+							TargetRef: common_api.TargetRef{
+								Kind: common_api.MeshService,
+								Name: "backend-02",
+							},
+							Default: v1alpha1.Conf{
+								Backends: &[]v1alpha1.Backend{
+									{
+										Type: v1alpha1.PrometheusBackendType,
+										Prometheus: &v1alpha1.PrometheusBackend{
+											Port: 5678,
+											Path: "/other",
+											Tls: &v1alpha1.PrometheusTls{
+												Mode: v1alpha1.ProvidedTLS,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				expectedSnapshots: map[string]v3.Snapshot{
+					meshmetrics_generator.DefaultKumaClientId: mads_cache.NewSnapshot("", map[string]envoy_types.Resource{
+						"/meshes/default/dataplanes/backend-02": &observability_v1.MonitoringAssignment{
+							Mesh:    "default",
+							Service: "backend-02",
+							Targets: []*observability_v1.MonitoringAssignment_Target{{
+								Name:        "backend-02",
+								Address:     "192.168.0.2:5678",
+								MetricsPath: "/other",
+								Scheme:      "https",
+								Labels: map[string]string{
+									"kuma_io_service":  "backend-02",
+									"kuma_io_services": ",backend-02,",
+								},
+							}},
+						},
+					}),
+					node1Id: mads_cache.NewSnapshot("", map[string]envoy_types.Resource{
+						"/meshes/default/dataplanes/backend-01": &observability_v1.MonitoringAssignment{
+							Mesh:    "default",
+							Service: "backend-01",
+							Targets: []*observability_v1.MonitoringAssignment_Target{{
+								Name:        "backend-01",
+								Address:     "192.168.0.1:1234",
+								MetricsPath: "/custom",
+								Scheme:      "http",
+								Labels: map[string]string{
+									"kuma_io_service":  "backend-01",
+									"kuma_io_services": ",backend-01,",
 								},
 							}},
 						},

--- a/pkg/mads/v1/reconcile/snapshot_generator_test.go
+++ b/pkg/mads/v1/reconcile/snapshot_generator_test.go
@@ -675,7 +675,7 @@ var _ = Describe("snapshotGenerator", func() {
 					}),
 				},
 			}),
-			Entry("no Meshes with Prometheus enabled, multiple MeshMetrics with Prometheus and merging", testCase{
+			Entry("no Meshes with Prometheus enabled, MeshMetric targeting Mesh with override for backend-02 with Prometheus metrics backend", testCase{
 				meshes: []*core_mesh.MeshResource{
 					{
 						Meta: &test_model.ResourceMeta{

--- a/pkg/mads/v1/service/components.go
+++ b/pkg/mads/v1/service/components.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
 	mads_generator "github.com/kumahq/kuma/pkg/mads/v1/generator"
+	meshmetrics_generator "github.com/kumahq/kuma/pkg/mads/v1/generator"
 	mads_reconcile "github.com/kumahq/kuma/pkg/mads/v1/reconcile"
 	util_watchdog "github.com/kumahq/kuma/pkg/util/watchdog"
 	util_xds "github.com/kumahq/kuma/pkg/util/xds"
@@ -46,7 +47,7 @@ func (r *restReconcilerCallbacks) OnFetchRequest(ctx context.Context, request ut
 
 	knownClients := r.reconciler.KnownClientIds()
 	if !knownClients[node.Id] {
-		node.Id = mads_reconcile.DefaultKumaClientId
+		node.Id = meshmetrics_generator.DefaultKumaClientId
 	}
 
 	if r.reconciler.NeedsReconciliation(node) {


### PR DESCRIPTION


Fixes: #9628

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
