### PR TITLE
chore(kuma-cp): have readiness probe be dependent of server health

### DIFF
--- a/app/kuma-cp/cmd/run.go
+++ b/app/kuma-cp/cmd/run.go
@@ -86,7 +86,7 @@ func newRunCmdWithOpts(opts kuma_cmd.RunCmdOpts) *cobra.Command {
 
 			if limit, _ := os.CurrentFileLimit(); limit < minOpenFileLimit {
 				runLog.Info("for better performance, raise the open file limit",
-					"minimim-open-files", minOpenFileLimit)
+					"minimum-open-files", minOpenFileLimit)
 			}
 
 			if err := mads_server.SetupServer(rt); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,6 @@ require (
 	github.com/sethvargo/go-retry v0.2.4
 	github.com/shopspring/decimal v1.3.1
 	github.com/slok/go-http-metrics v0.11.0
-	github.com/soheilhy/cmux v0.1.5
 	github.com/spf13/cobra v1.8.0
 	github.com/spiffe/go-spiffe/v2 v2.1.7
 	github.com/testcontainers/testcontainers-go v0.29.1

--- a/go.sum
+++ b/go.sum
@@ -420,8 +420,6 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/slok/go-http-metrics v0.11.0 h1:ABJUpekCZSkQT1wQrFvS4kGbhea/w6ndFJaWJeh3zL0=
 github.com/slok/go-http-metrics v0.11.0/go.mod h1:ZGKeYG1ET6TEJpQx18BqAJAvxw9jBAZXCHU7bWQqqAc=
-github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=
-github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/spf13/afero v1.3.3/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY520V4=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.5.1 h1:R+kOtfhWQE6TVQzY+4D7wJLBgkdVasCEFxSUBYBYIlA=
@@ -549,7 +547,6 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=

--- a/pkg/api-server/auth_test.go
+++ b/pkg/api-server/auth_test.go
@@ -58,17 +58,14 @@ var _ = Describe("Auth test", func() {
 		Expect(http2.ConfigureMTLS(httpsClientWithoutCerts, certPath, "", "")).To(Succeed())
 
 		// wait for both http and https server
-		Eventually(func() bool {
+		Eventually(func(g Gomega) {
 			resp, err := httpsClient.Get(fmt.Sprintf("https://localhost:%d/secrets", httpsPort))
-			if err != nil || resp.StatusCode != 200 {
-				return false
-			}
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(resp).To(HaveHTTPStatus(200))
 			resp, err = http.Get(fmt.Sprintf("http://localhost:%d/secrets", httpPort))
-			if err != nil || resp.StatusCode != 200 {
-				return false
-			}
-			return true
-		}, "5s", "100ms").Should(BeTrue())
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(resp).To(HaveHTTPStatus(200))
+		}, "5s", "100ms").Should(Succeed())
 	})
 
 	AfterEach(func() {

--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/bakito/go-log-logr-adapter/adapter"
@@ -49,6 +50,7 @@ import (
 	secrets_k8s "github.com/kumahq/kuma/pkg/plugins/secrets/k8s"
 	"github.com/kumahq/kuma/pkg/tokens/builtin"
 	tokens_server "github.com/kumahq/kuma/pkg/tokens/builtin/server"
+	kuma_srv "github.com/kumahq/kuma/pkg/util/http/server"
 	util_prometheus "github.com/kumahq/kuma/pkg/util/prometheus"
 	"github.com/kumahq/kuma/pkg/version"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
@@ -58,8 +60,10 @@ import (
 var log = core.Log.WithName("api-server")
 
 type ApiServer struct {
-	mux    *http.ServeMux
-	config api_server.ApiServerConfig
+	mux        *http.ServeMux
+	config     api_server.ApiServerConfig
+	httpReady  atomic.Bool
+	httpsReady atomic.Bool
 }
 
 func (a *ApiServer) NeedLeaderElection() bool {
@@ -326,19 +330,44 @@ func ShouldBeReadOnly(kdsFlag model.KDSFlagType, cfg *kuma_cp.Config) bool {
 	return false
 }
 
+func (a *ApiServer) Ready() bool {
+	return a.httpReady.Load() && a.httpsReady.Load()
+}
+
 func (a *ApiServer) Start(stop <-chan struct{}) error {
 	errChan := make(chan error)
 
 	var httpServer, httpsServer *http.Server
 	if a.config.HTTP.Enabled {
-		httpServer = a.startHttpServer(errChan)
+		httpServer = &http.Server{
+			ReadHeaderTimeout: time.Second,
+			Addr:              net.JoinHostPort(a.config.HTTP.Interface, strconv.FormatUint(uint64(a.config.HTTP.Port), 10)),
+			Handler:           a.mux,
+			ErrorLog:          adapter.ToStd(log),
+		}
+		if err := kuma_srv.StartServer(log, httpServer, &a.httpReady, errChan); err != nil {
+			return err
+		}
+	} else {
+		a.httpReady.Store(true)
 	}
 	if a.config.HTTPS.Enabled {
-		var err error
-		httpsServer, err = a.startHttpsServer(errChan)
+		tlsConfig, err := configureTLS(a.config)
 		if err != nil {
 			return err
 		}
+		httpsServer = &http.Server{
+			ReadHeaderTimeout: time.Second,
+			Addr:              net.JoinHostPort(a.config.HTTPS.Interface, strconv.FormatUint(uint64(a.config.HTTPS.Port), 10)),
+			Handler:           a.mux,
+			TLSConfig:         tlsConfig,
+			ErrorLog:          adapter.ToStd(log),
+		}
+		if err := kuma_srv.StartServer(log, httpsServer, &a.httpsReady, errChan); err != nil {
+			return err
+		}
+	} else {
+		a.httpsReady.Store(true)
 	}
 	select {
 	case <-stop:
@@ -355,80 +384,29 @@ func (a *ApiServer) Start(stop <-chan struct{}) error {
 	return nil
 }
 
-func (a *ApiServer) startHttpServer(errChan chan error) *http.Server {
-	server := &http.Server{
-		ReadHeaderTimeout: time.Second,
-		Addr:              net.JoinHostPort(a.config.HTTP.Interface, strconv.FormatUint(uint64(a.config.HTTP.Port), 10)),
-		Handler:           a.mux,
-		ErrorLog:          adapter.ToStd(log),
+func configureTLS(cfg api_server.ApiServerConfig) (*tls.Config, error) {
+	cert, err := tls.LoadX509KeyPair(cfg.HTTPS.TlsCertFile, cfg.HTTPS.TlsKeyFile)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to load TLS certificate")
 	}
-
-	go func() {
-		err := server.ListenAndServe()
-		if err != nil {
-			switch err {
-			case http.ErrServerClosed:
-				log.Info("shutting down server")
-			default:
-				log.Error(err, "could not start an HTTP Server")
-				errChan <- err
-			}
-		}
-	}()
-	log.Info("starting", "interface", a.config.HTTP.Interface, "port", a.config.HTTP.Port)
-	return server
-}
-
-func (a *ApiServer) startHttpsServer(errChan chan error) (*http.Server, error) {
 	tlsConfig := &tls.Config{
-		MinVersion: tls.VersionTLS12, // to pass gosec (in practice it's always set after.
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12, // to pass gosec (in practice it's always set after.
 	}
-	var err error
-	tlsConfig.MinVersion, err = config_types.TLSVersion(a.config.HTTPS.TlsMinVersion)
+	tlsConfig.MinVersion, err = config_types.TLSVersion(cfg.HTTPS.TlsMinVersion)
 	if err != nil {
 		return nil, err
 	}
-	tlsConfig.CipherSuites, err = config_types.TLSCiphers(a.config.HTTPS.TlsCipherSuites)
+	tlsConfig.CipherSuites, err = config_types.TLSCiphers(cfg.HTTPS.TlsCipherSuites)
 	if err != nil {
 		return nil, err
 	}
-
-	err = configureMTLS(tlsConfig, a.config)
-	if err != nil {
-		return nil, err
-	}
-
-	server := &http.Server{
-		ReadHeaderTimeout: time.Second,
-		Addr:              net.JoinHostPort(a.config.HTTPS.Interface, strconv.FormatUint(uint64(a.config.HTTPS.Port), 10)),
-		Handler:           a.mux,
-		TLSConfig:         tlsConfig,
-		ErrorLog:          adapter.ToStd(log),
-	}
-
-	go func() {
-		err := server.ListenAndServeTLS(a.config.HTTPS.TlsCertFile, a.config.HTTPS.TlsKeyFile)
-		if err != nil {
-			switch err {
-			case http.ErrServerClosed:
-				log.Info("shutting down server")
-			default:
-				log.Error(err, "could not start an HTTPS Server")
-				errChan <- err
-			}
-		}
-	}()
-	log.Info("starting", "interface", a.config.HTTPS.Interface, "port", a.config.HTTPS.Port, "tls", true)
-	return server, nil
-}
-
-func configureMTLS(tlsConfig *tls.Config, cfg api_server.ApiServerConfig) error {
 	clientCertPool := x509.NewCertPool()
 	if cfg.Auth.ClientCertsDir != "" {
 		log.Info("loading client certificates")
 		files, err := os.ReadDir(cfg.Auth.ClientCertsDir)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		for _, file := range files {
 			if file.IsDir() {
@@ -442,20 +420,20 @@ func configureMTLS(tlsConfig *tls.Config, cfg api_server.ApiServerConfig) error 
 			path := filepath.Join(cfg.Auth.ClientCertsDir, file.Name())
 			caCert, err := os.ReadFile(path)
 			if err != nil {
-				return errors.Wrapf(err, "could not read certificate %q", path)
+				return nil, errors.Wrapf(err, "could not read certificate %q", path)
 			}
 			if !clientCertPool.AppendCertsFromPEM(caCert) {
-				return errors.Errorf("failed to load PEM client certificate from %q", path)
+				return nil, errors.Errorf("failed to load PEM client certificate from %q", path)
 			}
 		}
 	}
 	if cfg.HTTPS.TlsCaFile != "" {
 		file, err := os.ReadFile(cfg.HTTPS.TlsCaFile)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if !clientCertPool.AppendCertsFromPEM(file) {
-			return errors.Errorf("failed to load PEM client certificate from %q", cfg.HTTPS.TlsCaFile)
+			return nil, errors.Errorf("failed to load PEM client certificate from %q", cfg.HTTPS.TlsCaFile)
 		}
 	}
 
@@ -465,7 +443,7 @@ func configureMTLS(tlsConfig *tls.Config, cfg api_server.ApiServerConfig) error 
 	} else if cfg.Authn.Type == certs.PluginName {
 		tlsConfig.ClientAuth = tls.VerifyClientCertIfGiven // client certs are required only for some endpoints when using admin client cert
 	}
-	return nil
+	return tlsConfig, nil
 }
 
 func SetupServer(rt runtime.Runtime) error {

--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -372,6 +372,8 @@ func (a *ApiServer) Start(stop <-chan struct{}) error {
 	select {
 	case <-stop:
 		log.Info("stopping down API Server")
+		a.httpReady.Store(false)
+		a.httpsReady.Store(false)
 		if httpServer != nil {
 			return httpServer.Shutdown(context.Background())
 		}

--- a/pkg/diagnostics/components.go
+++ b/pkg/diagnostics/components.go
@@ -7,6 +7,7 @@ import (
 func SetupServer(rt core_runtime.Runtime) error {
 	return rt.Add(
 		&diagnosticsServer{
+			isReady: rt.Ready,
 			config:  rt.Config().Diagnostics,
 			metrics: rt.Metrics(),
 		},

--- a/pkg/dp-server/server/server.go
+++ b/pkg/dp-server/server/server.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/bakito/go-log-logr-adapter/adapter"
+	"github.com/pkg/errors"
 	http_prometheus "github.com/slok/go-http-metrics/metrics/prometheus"
 	"github.com/slok/go-http-metrics/middleware"
 	"github.com/slok/go-http-metrics/middleware/std"
@@ -37,6 +40,7 @@ type DpServer struct {
 	grpcServer     *grpc.Server
 	filter         Filter
 	promMiddleware middleware.Middleware
+	ready          atomic.Bool
 }
 
 var _ component.Component = &DpServer{}
@@ -72,9 +76,17 @@ func NewDpServer(config dp_server.DpServerConfig, metrics metrics.Metrics, filte
 	}
 }
 
+func (d *DpServer) Ready() bool {
+	return d.ready.Load()
+}
+
 func (d *DpServer) Start(stop <-chan struct{}) error {
 	var err error
-	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12} // To make gosec pass this is always set after
+	cert, err := tls.LoadX509KeyPair(d.config.TlsCertFile, d.config.TlsKeyFile)
+	if err != nil {
+		return errors.Wrap(err, "failed to load TLS certificate")
+	}
+	tlsConfig := &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS12} // To make gosec happy
 	if tlsConfig.MinVersion, err = config_types.TLSVersion(d.config.TlsMinVersion); err != nil {
 		return err
 	}
@@ -91,27 +103,34 @@ func (d *DpServer) Start(stop <-chan struct{}) error {
 		TLSConfig:         tlsConfig,
 		ErrorLog:          adapter.ToStd(log),
 	}
+	l, err := net.Listen("tcp", server.Addr)
+	if err != nil {
+		return err
+	}
 
 	errChan := make(chan error)
 
 	go func() {
 		defer close(errChan)
-		if err := server.ListenAndServeTLS(d.config.TlsCertFile, d.config.TlsKeyFile); err != nil {
-			if err != http.ErrServerClosed {
+		d.ready.Store(true)
+		if err := server.ServeTLS(l, d.config.TlsCertFile, d.config.TlsKeyFile); err != nil {
+			if errors.Is(err, http.ErrServerClosed) {
+				log.Info("terminated normally")
+			} else {
 				log.Error(err, "terminated with an error")
 				errChan <- err
-				return
 			}
 		}
-		log.Info("terminated normally")
 	}()
 	log.Info("starting", "interface", "0.0.0.0", "port", d.config.Port, "tls", true)
 
 	select {
 	case <-stop:
 		log.Info("stopping")
+		d.ready.Store(false)
 		return server.Shutdown(context.Background())
 	case err := <-errChan:
+		d.ready.Store(false)
 		return err
 	}
 }

--- a/pkg/intercp/server/server.go
+++ b/pkg/intercp/server/server.go
@@ -4,8 +4,10 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"github.com/pkg/errors"
 	"net"
 	"net/http"
+	"sync/atomic"
 	"time"
 
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
@@ -31,6 +33,7 @@ type InterCpServer struct {
 	config     intercp.InterCpServerConfig
 	grpcServer *grpc.Server
 	instanceId string
+	ready      atomic.Bool
 }
 
 var _ component.Component = &InterCpServer{}
@@ -85,6 +88,10 @@ func New(
 	}, nil
 }
 
+func (d *InterCpServer) Ready() bool {
+	return d.ready.Load()
+}
+
 func (d *InterCpServer) Start(stop <-chan struct{}) error {
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", d.config.Port))
 	if err != nil {
@@ -95,27 +102,29 @@ func (d *InterCpServer) Start(stop <-chan struct{}) error {
 		d.instanceId,
 	)
 
+	log.Info("starting", "interface", "0.0.0.0", "port", d.config.Port, "tls", true)
 	errChan := make(chan error)
 	go func() {
 		defer close(errChan)
+		d.ready.Store(true)
 		if err := d.grpcServer.Serve(lis); err != nil {
-			if err != http.ErrServerClosed {
+			if !errors.Is(err, http.ErrServerClosed) {
 				log.Error(err, "terminated with an error")
 				errChan <- err
-				return
 			}
 		}
-		log.Info("terminated normally")
+		log.Info("shutting down server")
 	}()
-	log.Info("starting", "interface", "0.0.0.0", "port", d.config.Port, "tls", true)
 
 	select {
 	case <-stop:
 		log.Info("stopping gracefully")
+		d.ready.Store(false)
 		d.grpcServer.GracefulStop()
 		log.Info("stopped")
 		return nil
 	case err := <-errChan:
+		d.ready.Store(false)
 		return err
 	}
 }

--- a/pkg/intercp/server/server.go
+++ b/pkg/intercp/server/server.go
@@ -4,12 +4,12 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"github.com/pkg/errors"
 	"net"
 	"net/http"
 	"sync/atomic"
 	"time"
 
+	"github.com/pkg/errors"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"

--- a/pkg/mads/server/server.go
+++ b/pkg/mads/server/server.go
@@ -1,11 +1,11 @@
 package server
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
-	"net"
 	"net/http"
-	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/bakito/go-log-logr-adapter/adapter"
@@ -13,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 	http_prometheus "github.com/slok/go-http-metrics/metrics/prometheus"
 	"github.com/slok/go-http-metrics/middleware"
-	"github.com/soheilhy/cmux"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	config_core "github.com/kumahq/kuma/pkg/config/core"
@@ -25,6 +24,7 @@ import (
 	"github.com/kumahq/kuma/pkg/mads"
 	mads_v1 "github.com/kumahq/kuma/pkg/mads/v1/service"
 	core_metrics "github.com/kumahq/kuma/pkg/metrics"
+	kuma_srv "github.com/kumahq/kuma/pkg/util/http/server"
 	util_prometheus "github.com/kumahq/kuma/pkg/util/prometheus"
 )
 
@@ -36,6 +36,7 @@ type muxServer struct {
 	httpServices []HttpService
 	config       *mads_config.MonitoringAssignmentServerConfig
 	metrics      core_metrics.Metrics
+	ready        atomic.Bool
 	mesh_proto.UnimplementedMultiplexServiceServer
 }
 
@@ -65,23 +66,18 @@ func (s *muxServer) createHttpServicesHandler() http.Handler {
 	return container
 }
 
-func (s *muxServer) Start(stop <-chan struct{}) error {
-	l, err := net.Listen("tcp", fmt.Sprintf(":%d", s.config.Port))
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err := l.Close(); err != nil {
-			log.Error(err, "unable to close the listener")
-		}
-	}()
+func (s *muxServer) Ready() bool {
+	return s.ready.Load()
+}
 
+func (s *muxServer) Start(stop <-chan struct{}) error {
+	var tlsConfig *tls.Config
 	if s.config.TlsEnabled {
 		cert, err := tls.LoadX509KeyPair(s.config.TlsCertFile, s.config.TlsKeyFile)
 		if err != nil {
 			return errors.Wrap(err, "failed to load TLS certificate")
 		}
-		tlsConfig := &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS12} // To make gosec happy
+		tlsConfig = &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS12} // To make gosec happy
 		if tlsConfig.MinVersion, err = config_types.TLSVersion(s.config.TlsMinVersion); err != nil {
 			return err
 		}
@@ -91,55 +87,25 @@ func (s *muxServer) Start(stop <-chan struct{}) error {
 		if tlsConfig.CipherSuites, err = config_types.TLSCiphers(s.config.TlsCipherSuites); err != nil {
 			return err
 		}
-		l = tls.NewListener(l, tlsConfig)
 	}
-	m := cmux.New(l)
-
-	httpL := m.Match(cmux.Any())
+	errChan := make(chan error)
 	httpS := &http.Server{
+		Addr:              fmt.Sprintf(":%d", s.config.Port),
 		ReadHeaderTimeout: time.Second,
+		TLSConfig:         tlsConfig,
 		Handler:           s.createHttpServicesHandler(),
 		ErrorLog:          adapter.ToStd(log),
 	}
-	errChanHttp := make(chan error)
-	go func() {
-		defer close(errChanHttp)
-		if err := httpS.Serve(httpL); err != nil {
-			switch err {
-			case cmux.ErrServerClosed:
-				log.Info("shutting down an HTTP Server")
-			default:
-				log.Error(err, "could not start an HTTP Server")
-				errChanHttp <- err
-			}
-		}
-	}()
-
-	errChan := make(chan error)
-	go func() {
-		defer close(errChan)
-		err := m.Serve()
-		if err != nil {
-			if strings.Contains(err.Error(), "use of closed network connection") {
-				log.Info("shutting down a mux server")
-			} else {
-				log.Error(err, "could not start a mux Server")
-				errChan <- err
-			}
-		}
-	}()
-
-	log.Info("starting", "interface", "0.0.0.0", "port", s.config.Port)
-
-	defer m.Close()
-
+	if err := kuma_srv.StartServer(log, httpS, &s.ready, errChan); err != nil {
+		return err
+	}
 	select {
 	case <-stop:
 		log.Info("stopping gracefully")
-		return nil
-	case err := <-errChanHttp:
-		return err
+		s.ready.Store(false)
+		return httpS.Shutdown(context.Background())
 	case err := <-errChan:
+		s.ready.Store(false)
 		return err
 	}
 }

--- a/pkg/mads/server/server_test.go
+++ b/pkg/mads/server/server_test.go
@@ -119,13 +119,13 @@ var _ = Describe("MADS Server", func() {
 		request.Header.Add("Content-Type", "application/json")
 		request.Header.Add("Accept", "application/json")
 
-		Eventually(func() bool {
+		Eventually(func(g Gomega) {
 			response, err := client.Do(request)
-			ok := err == nil && response.StatusCode == 200
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).To(HaveHTTPStatus(200))
 			if response != nil {
 				Expect(response.Body.Close()).To(Succeed())
 			}
-			return ok
-		}, "10s", "100ms").Should(BeTrue())
+		}, "10s", "100ms").Should(Succeed())
 	})
 })

--- a/pkg/test/kds/setup/server.go
+++ b/pkg/test/kds/setup/server.go
@@ -189,6 +189,15 @@ func (t *testRuntimeContext) APIWebServiceCustomize() func(*restful.WebService) 
 	return func(*restful.WebService) error { return nil }
 }
 
+func (t *testRuntimeContext) Ready() bool {
+	for _, c := range t.components {
+		if rc, ok := c.(component.ReadyComponent); ok && !rc.Ready() {
+			return false
+		}
+	}
+	return true
+}
+
 func (t *testRuntimeContext) Add(c ...component.Component) error {
 	t.components = append(t.components, c...)
 	return nil

--- a/pkg/util/http/server/server.go
+++ b/pkg/util/http/server/server.go
@@ -1,0 +1,36 @@
+package server
+
+import (
+	"crypto/tls"
+	"errors"
+	"net"
+	"net/http"
+	"sync/atomic"
+
+	"github.com/go-logr/logr"
+)
+
+func StartServer(log logr.Logger, server *http.Server, ready *atomic.Bool, errChan chan error) error {
+	l := log.WithValues("tls", server.TLSConfig != nil, "interface", server.Addr)
+	listener, err := net.Listen("tcp", server.Addr)
+	if err != nil {
+		return err
+	}
+	if server.TLSConfig != nil {
+		listener = tls.NewListener(listener, server.TLSConfig)
+	}
+
+	go func() {
+		ready.Store(true)
+		if err := server.Serve(listener); err != nil {
+			if errors.Is(err, http.ErrServerClosed) {
+				l.Info("shutting down server")
+			} else {
+				l.Error(err, "could not start server")
+				errChan <- err
+			}
+		}
+	}()
+	l.Info("starting server")
+	return nil
+}

--- a/pkg/util/http/server/server.go
+++ b/pkg/util/http/server/server.go
@@ -20,6 +20,7 @@ func StartServer(log logr.Logger, server *http.Server, ready *atomic.Bool, errCh
 		listener = tls.NewListener(listener, server.TLSConfig)
 	}
 
+	l.Info("starting server")
 	go func() {
 		ready.Store(true)
 		if err := server.Serve(listener); err != nil {
@@ -31,6 +32,5 @@ func StartServer(log logr.Logger, server *http.Server, ready *atomic.Bool, errCh
 			}
 		}
 	}()
-	l.Info("starting server")
 	return nil
 }


### PR DESCRIPTION
- Abstract some common http startup code.
- Add a ReadyComponent interface and implement it for api-server,dp-server,intercp and mads
- Use this readyComponent to return CP readiness in `/ready` probe

This should avoid sending requests to a server that's going down or sending requests too early when the server starts.

part of #1001

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
