### PR TITLE
fix(policy): fix otel endpoint validation for meshmetric

### DIFF
--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/validator.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/asaskevich/govalidator"
 
@@ -128,8 +129,14 @@ func validateBackend(backends *[]Backend) validators.ValidationError {
 		case OpenTelemetryBackendType:
 			if backend.OpenTelemetry == nil {
 				verr.AddViolationAt(path.Field("openTelemetry"), validators.MustBeDefined)
-			} else if !govalidator.IsURL(backend.OpenTelemetry.Endpoint) {
-				verr.AddViolationAt(path.Field("openTelemetry").Field("endpoint"), "must be a valid url")
+			} else {
+				endpoint := backend.OpenTelemetry.Endpoint
+				if !govalidator.IsURL(endpoint) {
+					verr.AddViolationAt(path.Field("openTelemetry").Field("endpoint"), "must be a valid url")
+				}
+				if strings.HasPrefix(endpoint, "http://") || strings.HasPrefix(endpoint, "https://") {
+					verr.AddViolationAt(path.Field("openTelemetry").Field("endpoint"), "must not use schema")
+				}
 			}
 		default:
 			verr.AddViolationAt(path, "unrecognized type")

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/validator_test.go
@@ -42,6 +42,9 @@ default:
         path: /metrics
         tls:
           mode: "ProvidedTLS"
+    - type: OpenTelemetry
+      openTelemetry:
+        endpoint: otel-collector:4778
 `),
 	)
 
@@ -195,6 +198,25 @@ default:
     - type: OpenTelemetry
       openTelemetry:
         endpoint: "asdasd123"
+`),
+		ErrorCase(
+			"invalid url",
+			validators.Violation{
+				Field:   "spec.default.backends.backend[0].openTelemetry.endpoint",
+				Message: "must not use schema",
+			},
+			`
+type: MeshMetric
+mesh: mesh-1
+name: metrics-1
+targetRef:
+  kind: MeshService
+  name: svc-1
+default:
+  backends:
+    - type: OpenTelemetry
+      openTelemetry:
+        endpoint: "http://endpoint:8023"
 `),
 		ErrorCase(
 			"undefined openTelemetry backend when type is OpenTelemetry",


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
