### PR TITLE
chore(e2e): re enable meshmetric with otel backend e2e tests

### DIFF
--- a/test/e2e_env/kubernetes/gateway/delegated/meshmetric.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshmetric.go
@@ -71,7 +71,7 @@ spec:
 						config.Mesh,
 					)),
 				))
-			}, "2m", "15s").Should(Succeed())
+			}, "3m", "5s").Should(Succeed())
 		})
 	}
 }

--- a/test/e2e_env/kubernetes/meshmetric/meshmetric.go
+++ b/test/e2e_env/kubernetes/meshmetric/meshmetric.go
@@ -609,7 +609,7 @@ func MeshMetric() {
 			)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(stdout).To(ContainSubstring("envoy_cluster_external_upstream_rq_time_bucket"))
-		}, "3m", "5s").Should(Succeed())
+		}, "2m", "5s").Should(Succeed())
 	})
 }
 

--- a/test/e2e_env/kubernetes/meshmetric/meshmetric.go
+++ b/test/e2e_env/kubernetes/meshmetric/meshmetric.go
@@ -504,7 +504,7 @@ func MeshMetric() {
 		}).Should(Succeed())
 	})
 
-	XIt("MeshMetric with OpenTelemetry enabled", func() {
+	It("MeshMetric with OpenTelemetry enabled", func() {
 		// given
 		openTelemetryCollector := otelcollector.From(kubernetes.Cluster, primaryOtelCollectorName)
 		Expect(kubernetes.Cluster.Install(MeshMetricWithOpenTelemetryBackend(mainMesh, openTelemetryCollector.CollectorEndpoint()))).To(Succeed())
@@ -518,10 +518,10 @@ func MeshMetric() {
 			)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(stdout).To(ContainSubstring("envoy_cluster_external_upstream_rq_time_bucket"))
-		}, "2m", "3s").Should(Succeed())
+		}, "3m", "5s").Should(Succeed())
 	})
 
-	XIt("MeshMetric with OpenTelemetry and usedonly/filter", func() {
+	It("MeshMetric with OpenTelemetry and usedonly/filter", func() {
 		// given
 		openTelemetryCollector := otelcollector.From(kubernetes.Cluster, primaryOtelCollectorName)
 		Expect(kubernetes.Cluster.Install(MeshMetricWithOpenTelemetryAndIncludeUnused(mainMesh, openTelemetryCollector.CollectorEndpoint()))).To(Succeed())
@@ -536,10 +536,10 @@ func MeshMetric() {
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(stdout).To(Not(ContainSubstring("envoy_cluster_client_ssl_socket_factory_upstream_context_secrets_not_ready"))) // unused
 			g.Expect(stdout).To(ContainSubstring("envoy_cluster_external_upstream_rq_time_bucket"))                                  // used
-		}, "2m", "3s").Should(Succeed())
+		}, "3m", "5s").Should(Succeed())
 	})
 
-	XIt("MeshMetric with OpenTelemetry and Prometheus enabled", func() {
+	It("MeshMetric with OpenTelemetry and Prometheus enabled", func() {
 		// given
 		openTelemetryCollector := otelcollector.From(kubernetes.Cluster, primaryOtelCollectorName)
 		testServerIp, err := PodIPOfApp(kubernetes.Cluster, "test-server-0", namespace)
@@ -565,10 +565,10 @@ func MeshMetric() {
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(stdout).ToNot(BeNil())
 			g.Expect(stdout).To(ContainSubstring("envoy_http_downstream_rq_xx"))
-		}, "2m", "3s").Should(Succeed())
+		}, "3m", "5s").Should(Succeed())
 	})
 
-	XIt("MeshMetric with multiple OpenTelemetry backends", func() {
+	It("MeshMetric with multiple OpenTelemetry backends", func() {
 		// given
 		primaryOpenTelemetryCollector := otelcollector.From(kubernetes.Cluster, primaryOtelCollectorName)
 		secondaryOpenTelemetryCollector := otelcollector.From(kubernetes.Cluster, secondaryOtelCollectorName)
@@ -593,7 +593,7 @@ func MeshMetric() {
 			)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(stdout).To(ContainSubstring("envoy_cluster_external_upstream_rq_time_bucket"))
-		}, "2m", "3s").Should(Succeed())
+		}, "3m", "5s").Should(Succeed())
 	})
 }
 

--- a/test/e2e_env/kubernetes/meshmetric/meshmetric.go
+++ b/test/e2e_env/kubernetes/meshmetric/meshmetric.go
@@ -609,7 +609,7 @@ func MeshMetric() {
 			)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(stdout).To(ContainSubstring("envoy_cluster_external_upstream_rq_time_bucket"))
-		}, "2m", "5s").Should(Succeed())
+		}, "3m", "5s").Should(Succeed())
 	})
 }
 

--- a/test/e2e_env/kubernetes/meshmetric/meshmetric.go
+++ b/test/e2e_env/kubernetes/meshmetric/meshmetric.go
@@ -5,13 +5,11 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	mads "github.com/kumahq/kuma/api/observability/v1"
 	"github.com/kumahq/kuma/pkg/plugins/policies/meshmetric/api/v1alpha1"
-	"github.com/kumahq/kuma/test/framework"
 	. "github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/framework/client"
 	"github.com/kumahq/kuma/test/framework/deployments/democlient"
@@ -312,20 +310,6 @@ func MeshMetric() {
 	})
 
 	E2EAfterEach(func() {
-		if err := k8s.RunKubectlE(kubernetes.Cluster.GetTesting(), kubernetes.Cluster.GetKubectlOptions(), "get", "pods", "-A"); err != nil {
-			framework.Logf("could not retrieve kube pods")
-		}
-		details := framework.ExtractDeploymentDetails(kubernetes.Cluster.GetTesting(), kubernetes.Cluster.GetKubectlOptions(observabilityNamespace), primaryOtelCollectorName)
-		framework.Logf("OTEL LOG collector")
-		for k, v := range details.Pods[0].Logs {
-			framework.Logf(" OTEL LOG container: %s, logs: %s", k, v)
-		}
-
-		testServerDetails := framework.ExtractDeploymentDetails(kubernetes.Cluster.GetTesting(), kubernetes.Cluster.GetKubectlOptions(namespace), "test-server-0")
-		framework.Logf("OTEL LOG test server")
-		for k, v := range testServerDetails.Pods[0].Logs {
-			framework.Logf("OTEL LOG container: %s, logs: %s", k, v)
-		}
 		Expect(DeleteMeshResources(kubernetes.Cluster, mainMesh, v1alpha1.MeshMetricResourceTypeDescriptor)).To(Succeed())
 		Expect(DeleteMeshResources(kubernetes.Cluster, secondaryMesh, v1alpha1.MeshMetricResourceTypeDescriptor)).To(Succeed())
 	})


### PR DESCRIPTION
We merged couple of fixes to OTEL in MeshMetric: 

- https://github.com/kumahq/kuma/pull/9606
- https://github.com/kumahq/kuma/pull/9623
- https://github.com/kumahq/kuma/pull/9632
- https://github.com/kumahq/kuma/pull/9636

This should make otel tests more stable

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --


> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
