### PR TITLE
feat(transparent-proxy): drop all capabilities for sidecar containers

### DIFF
--- a/pkg/plugins/runtime/k8s/containers/factory.go
+++ b/pkg/plugins/runtime/k8s/containers/factory.go
@@ -129,6 +129,11 @@ func (i *DataplaneProxyFactory) NewContainer(
 		SecurityContext: &kube_core.SecurityContext{
 			RunAsUser:  &i.ContainerConfig.UID,
 			RunAsGroup: &i.ContainerConfig.GID,
+			Capabilities: &kube_core.Capabilities{
+				Drop: []kube_core.Capability{
+					"ALL",
+				},
+			},
 		},
 		LivenessProbe: &kube_core.Probe{
 			ProbeHandler: kube_core.ProbeHandler{

--- a/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
@@ -266,8 +266,11 @@ func (r *GatewayInstanceReconciler) createOrUpdateDeployment(
 			)
 
 			container.SecurityContext.AllowPrivilegeEscalation = pointer.To(false)
+			container.SecurityContext.Capabilities.Add = []kube_core.Capability{
+				"NET_BIND_SERVICE",
+			}
 
-			securityContext := &kube_core.PodSecurityContext{
+			podSecurityContext := &kube_core.PodSecurityContext{
 				Sysctls: []kube_core.Sysctl{{
 					Name:  "net.ipv4.ip_unprivileged_port_start",
 					Value: "0",
@@ -275,7 +278,7 @@ func (r *GatewayInstanceReconciler) createOrUpdateDeployment(
 			}
 
 			if fsGroup := gatewayInstance.Spec.PodTemplate.Spec.PodSecurityContext.FSGroup; fsGroup != nil {
-				securityContext.FSGroup = fsGroup
+				podSecurityContext.FSGroup = fsGroup
 			}
 
 			container.SecurityContext.ReadOnlyRootFilesystem = gatewayInstance.Spec.PodTemplate.Spec.Container.SecurityContext.ReadOnlyRootFilesystem
@@ -288,7 +291,7 @@ func (r *GatewayInstanceReconciler) createOrUpdateDeployment(
 			}
 
 			podSpec := kube_core.PodSpec{
-				SecurityContext: securityContext,
+				SecurityContext: podSecurityContext,
 				Containers:      []kube_core.Container{container},
 			}
 			podSpec.ServiceAccountName = gatewayInstance.Spec.PodTemplate.Spec.ServiceAccountName

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.01.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.01.golden.yaml
@@ -103,6 +103,9 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.02.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.02.golden.yaml
@@ -104,6 +104,9 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.03.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.03.golden.yaml
@@ -111,6 +111,9 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.04.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.04.golden.yaml
@@ -103,6 +103,9 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.05.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.05.golden.yaml
@@ -104,6 +104,9 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.06.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.06.golden.yaml
@@ -104,6 +104,9 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.07.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.07.golden.yaml
@@ -103,6 +103,9 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.08.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.08.golden.yaml
@@ -106,6 +106,9 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.09.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.09.golden.yaml
@@ -105,6 +105,9 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.10.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.10.golden.yaml
@@ -104,6 +104,9 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.11.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.11.golden.yaml
@@ -103,6 +103,9 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.12.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.12.golden.yaml
@@ -103,6 +103,9 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.13.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.13.golden.yaml
@@ -103,6 +103,9 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.14.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.14.golden.yaml
@@ -103,6 +103,9 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.15.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.15.golden.yaml
@@ -103,6 +103,9 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.16.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.16.golden.yaml
@@ -105,6 +105,9 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.17.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.17.golden.yaml
@@ -105,6 +105,9 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.18.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.18.golden.yaml
@@ -105,6 +105,9 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.19.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.19.golden.yaml
@@ -103,6 +103,9 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.20.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.20.golden.yaml
@@ -103,6 +103,9 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.21.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.21.golden.yaml
@@ -103,6 +103,9 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.22.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.22.golden.yaml
@@ -109,6 +109,9 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.23.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.23.golden.yaml
@@ -120,6 +120,9 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.24.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.24.golden.yaml
@@ -121,6 +121,9 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.25.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.25.golden.yaml
@@ -120,6 +120,9 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.26.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.26.golden.yaml
@@ -105,6 +105,9 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.27.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.27.golden.yaml
@@ -104,6 +104,9 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.28.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.28.golden.yaml
@@ -108,6 +108,9 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       privileged: false
       readOnlyRootFilesystem: true
       runAsGroup: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.29.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.29.golden.yaml
@@ -116,6 +116,9 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.30.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.30.golden.yaml
@@ -108,6 +108,9 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.31.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.31.golden.yaml
@@ -103,6 +103,9 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.32.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.32.golden.yaml
@@ -104,6 +104,9 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.33.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.33.golden.yaml
@@ -103,6 +103,9 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.01.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.01.golden.yaml
@@ -148,6 +148,9 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.02.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.02.golden.yaml
@@ -156,6 +156,9 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.03.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.03.golden.yaml
@@ -210,6 +210,9 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.04.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.04.golden.yaml
@@ -148,6 +148,9 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.05.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.05.golden.yaml
@@ -145,6 +145,9 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.06.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.06.golden.yaml
@@ -149,6 +149,9 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.07.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.07.golden.yaml
@@ -148,6 +148,9 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.08.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.08.golden.yaml
@@ -151,6 +151,9 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.09.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.09.golden.yaml
@@ -150,6 +150,9 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.10.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.10.golden.yaml
@@ -149,6 +149,9 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.11.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.11.golden.yaml
@@ -148,6 +148,9 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.12.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.12.golden.yaml
@@ -148,6 +148,9 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.13.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.13.golden.yaml
@@ -160,6 +160,9 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.14.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.14.golden.yaml
@@ -160,6 +160,9 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.15.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.15.golden.yaml
@@ -160,6 +160,9 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.16.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.16.golden.yaml
@@ -157,6 +157,9 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.17.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.17.golden.yaml
@@ -157,6 +157,9 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.18.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.18.golden.yaml
@@ -157,6 +157,9 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.19.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.19.golden.yaml
@@ -166,6 +166,9 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.20.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.20.golden.yaml
@@ -166,6 +166,9 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.21.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.21.golden.yaml
@@ -173,6 +173,9 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.22.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.22.golden.yaml
@@ -161,6 +161,9 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.23.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.23.golden.yaml
@@ -175,6 +175,9 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.24.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.24.golden.yaml
@@ -176,6 +176,9 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.25.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.25.golden.yaml
@@ -175,6 +175,9 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.26.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.26.golden.yaml
@@ -146,6 +146,9 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.27.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.27.golden.yaml
@@ -145,6 +145,9 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.28.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.28.golden.yaml
@@ -148,6 +148,9 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       privileged: false
       readOnlyRootFilesystem: true
       runAsGroup: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.29.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.29.golden.yaml
@@ -160,6 +160,9 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.30.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.30.golden.yaml
@@ -169,6 +169,9 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.31.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.31.golden.yaml
@@ -155,6 +155,9 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.32.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.32.golden.yaml
@@ -148,6 +148,9 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.33.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.33.golden.yaml
@@ -155,6 +155,9 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      capabilities:
+        drop:
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 5678
       runAsUser: 5678


### PR DESCRIPTION
fixes https://github.com/kumahq/kuma/issues/6714

Manually verified on a local OpenShift cluster and a k3d clusters. e2e tests ran at https://github.com/jijiechen/kuma/actions/runs/8323049866.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - Yes
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - Yes
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Yes
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - No need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) 
  - No

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
