### PR TITLE
fix(helm): missing postgres tls mode when it is set to verifyNone

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone-universal-on-k8s.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone-universal-on-k8s.golden.yaml
@@ -156,6 +156,8 @@ spec:
               value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtraces,meshtrafficpermissions"
             - name: KUMA_STORE_POSTGRES_PORT
               value: "5432"
+            - name: KUMA_STORE_POSTGRES_TLS_MODE
+              value: "disable"
             - name: KUMA_STORE_TYPE
               value: "postgres"
           args:
@@ -200,6 +202,8 @@ spec:
               value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtraces,meshtrafficpermissions"
             - name: KUMA_STORE_POSTGRES_PORT
               value: "5432"
+            - name: KUMA_STORE_POSTGRES_TLS_MODE
+              value: "disable"
             - name: KUMA_STORE_TYPE
               value: "postgres"
             - name: KUMA_INTER_CP_CATALOG_INSTANCE_ADDRESS

--- a/deployments/charts/kuma/templates/_helpers.tpl
+++ b/deployments/charts/kuma/templates/_helpers.tpl
@@ -376,6 +376,8 @@ env:
 - name: KUMA_MULTIZONE_GLOBAL_KDS_TLS_KEY_FILE
   value: /var/run/secrets/kuma.io/kds-server-tls-cert/tls.key
 {{- end }}
+- name: KUMA_STORE_POSTGRES_TLS_MODE
+  value: {{ .Values.postgres.tls.mode }}
 {{- if or (eq .Values.postgres.tls.mode "verifyCa") (eq .Values.postgres.tls.mode "verifyFull") }}
 {{- if empty .Values.postgres.tls.caSecretName }}
 {{ fail "if mode is 'verifyCa' or 'verifyFull' then you must provide .Values.postgres.tls.caSecretName" }}
@@ -390,8 +392,6 @@ env:
 - name: KUMA_STORE_POSTGRES_TLS_CA_PATH
   value: /var/run/secrets/kuma.io/postgres-tls-cert/ca.crt
 {{- end }}
-- name: KUMA_STORE_POSTGRES_TLS_MODE
-  value: {{ .Values.postgres.tls.mode }}
 {{- if .Values.postgres.tls.disableSSLSNI }}
 - name: KUMA_STORE_POSTGRES_TLS_DISABLE_SSLSNI
   value: {{ .Values.postgres.tls.disableSSLSNI }}

--- a/pkg/plugins/runtime/k8s/controllers/testdata/04.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/04.dataplane.yaml
@@ -31,8 +31,8 @@ spec:
       tags:
         kuma.io/service: test-app_playground_svc_80
     transparentProxying:
-      ipFamilyMode: DualStack
       directAccessServices:
       - '*'
+      ipFamilyMode: DualStack
       redirectPortInbound: 15006
       redirectPortOutbound: 15001

--- a/pkg/plugins/runtime/k8s/controllers/testdata/05.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/05.dataplane.yaml
@@ -31,9 +31,9 @@ spec:
       tags:
         kuma.io/service: test-app_playground_svc_80
     transparentProxying:
-      ipFamilyMode: DualStack
       directAccessServices:
       - test-app_playground_svc_80
       - test-app_playground_svc_443
+      ipFamilyMode: DualStack
       redirectPortInbound: 15006
       redirectPortOutbound: 15001

--- a/pkg/plugins/runtime/k8s/controllers/testdata/24.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/24.dataplane.yaml
@@ -18,6 +18,6 @@ spec:
         kuma.io/zone: zone-1
         version: "0.1"
     transparentProxying:
+      ipFamilyMode: IPv4
       redirectPortInbound: 15006
       redirectPortOutbound: 15001
-      ipFamilyMode: IPv4

--- a/pkg/plugins/runtime/k8s/controllers/testdata/25.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/25.dataplane.yaml
@@ -18,6 +18,6 @@ spec:
         kuma.io/zone: zone-1
         version: "0.1"
     transparentProxying:
+      ipFamilyMode: IPv4
       redirectPortInbound: 15006
       redirectPortOutbound: 15001
-      ipFamilyMode: IPv4

--- a/pkg/xds/generator/testdata/transparent-proxy/05.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/transparent-proxy/05.envoy.golden.yaml
@@ -1,111 +1,111 @@
 resources:
-  - name: inbound:passthrough:ipv4
-    resource:
-      '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-      altStatName: inbound_passthrough_ipv4
-      connectTimeout: 5s
-      lbPolicy: CLUSTER_PROVIDED
-      name: inbound:passthrough:ipv4
-      type: ORIGINAL_DST
-      upstreamBindConfig:
-        sourceAddress:
-          address: 127.0.0.6
-          portValue: 0
-  - name: inbound:passthrough:ipv6
-    resource:
-      '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-      altStatName: inbound_passthrough_ipv6
-      connectTimeout: 5s
-      lbPolicy: CLUSTER_PROVIDED
-      name: inbound:passthrough:ipv6
-      type: ORIGINAL_DST
-      upstreamBindConfig:
-        sourceAddress:
-          address: ::6
-          portValue: 0
-  - name: outbound:passthrough:ipv4
-    resource:
-      '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-      altStatName: outbound_passthrough_ipv4
-      connectTimeout: 5s
-      lbPolicy: CLUSTER_PROVIDED
-      name: outbound:passthrough:ipv4
-      type: ORIGINAL_DST
-  - name: outbound:passthrough:ipv6
-    resource:
-      '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-      altStatName: outbound_passthrough_ipv6
-      connectTimeout: 5s
-      lbPolicy: CLUSTER_PROVIDED
-      name: outbound:passthrough:ipv6
-      type: ORIGINAL_DST
-  - name: inbound:passthrough:ipv4
-    resource:
-      '@type': type.googleapis.com/envoy.config.listener.v3.Listener
-      address:
-        socketAddress:
-          address: 0.0.0.0
-          portValue: 15006
-      enableReusePort: false
-      filterChains:
-        - filters:
-            - name: envoy.filters.network.tcp_proxy
-              typedConfig:
-                '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-                cluster: inbound:passthrough:ipv4
-                statPrefix: inbound_passthrough_ipv4
-      name: inbound:passthrough:ipv4
-      trafficDirection: INBOUND
-      useOriginalDst: true
-  - name: inbound:passthrough:ipv6
-    resource:
-      '@type': type.googleapis.com/envoy.config.listener.v3.Listener
-      address:
-        socketAddress:
-          address: '::'
-          portValue: 15066
-      enableReusePort: false
-      filterChains:
-        - filters:
-            - name: envoy.filters.network.tcp_proxy
-              typedConfig:
-                '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-                cluster: inbound:passthrough:ipv6
-                statPrefix: inbound_passthrough_ipv6
-      name: inbound:passthrough:ipv6
-      trafficDirection: INBOUND
-      useOriginalDst: true
-  - name: outbound:passthrough:ipv4
-    resource:
-      '@type': type.googleapis.com/envoy.config.listener.v3.Listener
-      address:
-        socketAddress:
-          address: 0.0.0.0
-          portValue: 15001
-      filterChains:
-        - filters:
-            - name: envoy.filters.network.tcp_proxy
-              typedConfig:
-                '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-                cluster: outbound:passthrough:ipv4
-                statPrefix: outbound_passthrough_ipv4
-      name: outbound:passthrough:ipv4
-      trafficDirection: OUTBOUND
-      useOriginalDst: true
-  - name: outbound:passthrough:ipv6
-    resource:
-      '@type': type.googleapis.com/envoy.config.listener.v3.Listener
-      address:
-        socketAddress:
-          address: '::'
-          portValue: 15001
-      filterChains:
-        - filters:
-            - name: envoy.filters.network.tcp_proxy
-              typedConfig:
-                '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-                cluster: outbound:passthrough:ipv6
-                statPrefix: outbound_passthrough_ipv6
-      name: outbound:passthrough:ipv6
-      trafficDirection: OUTBOUND
-      useOriginalDst: true
+- name: inbound:passthrough:ipv4
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    altStatName: inbound_passthrough_ipv4
+    connectTimeout: 5s
+    lbPolicy: CLUSTER_PROVIDED
+    name: inbound:passthrough:ipv4
+    type: ORIGINAL_DST
+    upstreamBindConfig:
+      sourceAddress:
+        address: 127.0.0.6
+        portValue: 0
+- name: inbound:passthrough:ipv6
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    altStatName: inbound_passthrough_ipv6
+    connectTimeout: 5s
+    lbPolicy: CLUSTER_PROVIDED
+    name: inbound:passthrough:ipv6
+    type: ORIGINAL_DST
+    upstreamBindConfig:
+      sourceAddress:
+        address: ::6
+        portValue: 0
+- name: outbound:passthrough:ipv4
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    altStatName: outbound_passthrough_ipv4
+    connectTimeout: 5s
+    lbPolicy: CLUSTER_PROVIDED
+    name: outbound:passthrough:ipv4
+    type: ORIGINAL_DST
+- name: outbound:passthrough:ipv6
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    altStatName: outbound_passthrough_ipv6
+    connectTimeout: 5s
+    lbPolicy: CLUSTER_PROVIDED
+    name: outbound:passthrough:ipv6
+    type: ORIGINAL_DST
+- name: inbound:passthrough:ipv4
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 0.0.0.0
+        portValue: 15006
+    enableReusePort: false
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: inbound:passthrough:ipv4
+          statPrefix: inbound_passthrough_ipv4
+    name: inbound:passthrough:ipv4
+    trafficDirection: INBOUND
+    useOriginalDst: true
+- name: inbound:passthrough:ipv6
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: '::'
+        portValue: 15066
+    enableReusePort: false
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: inbound:passthrough:ipv6
+          statPrefix: inbound_passthrough_ipv6
+    name: inbound:passthrough:ipv6
+    trafficDirection: INBOUND
+    useOriginalDst: true
+- name: outbound:passthrough:ipv4
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 0.0.0.0
+        portValue: 15001
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: outbound:passthrough:ipv4
+          statPrefix: outbound_passthrough_ipv4
+    name: outbound:passthrough:ipv4
+    trafficDirection: OUTBOUND
+    useOriginalDst: true
+- name: outbound:passthrough:ipv6
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: '::'
+        portValue: 15001
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: outbound:passthrough:ipv6
+          statPrefix: outbound_passthrough_ipv6
+    name: outbound:passthrough:ipv6
+    trafficDirection: OUTBOUND
+    useOriginalDst: true


### PR DESCRIPTION
In helm, when `Values.postgres.tls.mode is verifyNone or disable`, key `KUMA_STORE_POSTGRES_TLS_MODE` is not getting added, causing kuma-cp to take the default which is "disable".

Few testcases might fail, as with this change when `Values.postgres.tls.mode=disable`, `KUMA_STORE_POSTGRES_TLS_MODE=disable` will be added , where as earlier the env variable was omitted.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
