### PR TITLE
fix(GatewayAPI): make MeshHTTPRoute conversion port redirect gapi conformant

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/mesh_http_route_conversion.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/mesh_http_route_conversion.go
@@ -298,13 +298,26 @@ func (r *HTTPRouteReconciler) gapiToKumaMeshFilter(
 			path = &meshPath
 		}
 
+		port := (*v1alpha1.PortNumber)(redirect.Port)
+		if redirect.Scheme != nil && redirect.Port == nil {
+			// See https://github.com/kubernetes-sigs/gateway-api/pull/1880
+			// this would have been a breaking change for MeshGateway, so handle
+			// it here.
+			switch *redirect.Scheme {
+			case "http":
+				port = (*v1alpha1.PortNumber)(pointer.To(int32(80)))
+			case "https":
+				port = (*v1alpha1.PortNumber)(pointer.To(int32(443)))
+			}
+		}
+
 		return v1alpha1.Filter{
 			Type: v1alpha1.RequestRedirectType,
 			RequestRedirect: &v1alpha1.RequestRedirect{
 				Scheme:     redirect.Scheme,
 				Hostname:   (*v1alpha1.PreciseHostname)(redirect.Hostname),
 				Path:       path,
-				Port:       (*v1alpha1.PortNumber)(redirect.Port),
+				Port:       port,
 				StatusCode: redirect.StatusCode,
 			},
 		}, nil, true


### PR DESCRIPTION
According to https://github.com/kubernetes-sigs/gateway-api/pull/1880

> When empty, the redirect port MUST be derived using the following rules: //
> * If redirect scheme is not-empty, the redirect port MUST be the well-known
>   port associated with the redirect scheme. Specifically "http" to port 80
>   and "https" to port 443. If the redirect scheme does not have a
>   well-known port, the listener port of the Gateway SHOULD be used.
> * If redirect scheme is empty, the redirect port MUST be the Gateway
>   Listener port.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - No relevant issues
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Manually tested
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - There is no need

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
