### PR TITLE
fix(GAPI/MeshHTTPRoute): trim "/" path match suffix when converting HTTPRoute

### DIFF
--- a/pkg/plugins/policies/meshhttproute/xds/configurer.go
+++ b/pkg/plugins/policies/meshhttproute/xds/configurer.go
@@ -119,7 +119,25 @@ func (c RoutesConfigurer) routePathMatch(match api.PathMatch) []*envoy_route.Rou
 			}}
 		}
 		// This case forces us to create two different envoy matches to
-		// replicate the "path-separated prefixes only" semantics
+		// replicate the "path-separated prefixes only" semantics.
+		//
+		// It needs to be replicated instead of using envoy's native
+		// `path_separated_prefix` (https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-routematch-path-separated-prefix)
+		// because of an edge case, when if we want to drop the prefix:
+		//
+		//   ```
+		//   - match:
+		//       path_separated_prefix: "/prefix"
+		//     route:
+		//       prefix_rewrite: "/"
+		//   ```
+		//
+		// results in the rewrites:
+		//
+		//   * `/prefix` -> `/`
+		//   * `/prefix/path` -> `//path`
+		//
+		// ref. https://github.com/envoyproxy/envoy/issues/23130
 		trimmed := strings.TrimSuffix(match.Value, "/")
 		return []*envoy_route.RouteMatch{{
 			PathSpecifier: &envoy_route.RouteMatch_Path{

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/mesh_http_route_conversion.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/mesh_http_route_conversion.go
@@ -192,6 +192,21 @@ func (r *HTTPRouteReconciler) gapiToKumaMeshMatch(gapiMatch gatewayapi.HTTPRoute
 		Value: *gapiMatch.Path.Value,
 	}
 
+	// Matches based on a URL path prefix split by `/`. Matching is
+	// case-sensitive and done on a path element by element basis. A
+	// path element refers to the list of labels in the path split by
+	// the `/` separator. When specified, a trailing `/` is ignored.
+	//
+	// For example, the paths `/abc`, `/abc/`, and `/abc/def` would all match
+	// the prefix `/abc`, but the path `/abcd` would not.
+	//
+	// ref. https://github.com/kubernetes-sigs/gateway-api/blob/50091d071226d4ab2dbdb115ae65e27cf3fd5b85/apis/v1/httproute_types.go#L357-L367
+	//
+	// Necessary as MehHTTPRoute validator won't allow value with trailing `/`
+	if match.Path.Type == v1alpha1.PathPrefix && match.Path.Value != "/" {
+		match.Path.Value = strings.TrimSuffix(match.Path.Value, "/")
+	}
+
 	for _, gapiHeader := range gapiMatch.Headers {
 		header := common_api.HeaderMatch{
 			Type: pointer.To(common_api.HeaderMatchType(*gapiHeader.Type)),


### PR DESCRIPTION
Matches based on a URL path prefix split by `/`. Matching is case-sensitive and done on a path element by element basis. A path element refers to the list of labels in the path split by the `/` separator. When specified, a trailing `/` is ignored.

For example, the paths `/abc`, `/abc/`, and `/abc/def` would all match the prefix `/abc`, but the path `/abcd` would not.

ref. https://github.com/kubernetes-sigs/gateway-api/blob/50091d071226d4ab2dbdb115ae65e27cf3fd5b85/apis/v1/httproute_types.go#L357-L367

Necessary as MehHTTPRoute validator won't allow value with trailing `/`

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - No relevant issues
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Manually tested
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - There is no need

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
