### PR TITLE
docs(MADR): add Kubernetes UX for `MeshService`

### DIFF
--- a/docs/madr/decisions/041-meshservice-kubernetes-ux.md
+++ b/docs/madr/decisions/041-meshservice-kubernetes-ux.md
@@ -47,6 +47,35 @@ including supporting named `targetPorts`.
 Note that we only support `Service.ports[].protocol: TCP`, which is also the
 default.
 
+### Headless Service with selectors
+
+In Kubernetes, a headless Service with selectors is used to create a DNS record
+for every Pod selected by the Service that points directly to the Pod's IP.
+
+To support this with Kuma, we will create a `MeshService` per Pod, each
+represented by the hostname allocated by the headless Service and the Pod
+IP as the "VIP" and single endpoint.
+
+In order to do this we need to have a list of all the Pods selected by the
+Service, which we can get by looking at `EndpointSlices`. These resources hold a
+list of endpoints, each of which has a `targetRef`. If the `targetRef` is `kind:
+Pod`, we can rely on the naming of `Dataplane` objects and directly select a
+given `Dataplane` by setting `spec.selector.dataplaneName` to the name of the
+`Pod`.
+
+```
+kind: MeshService
+spec:
+  selector:
+    dataplaneName: pod-1
+    # dataplaneTags: ...
+```
+
+#### Policy matching
+
+Note that this prevents using `kind: MeshService` to select all Pods of a
+StatefulSet. In another MADR, we will cover this use case.
+
 ### Positive Consequences
 
 * Users don't have to think about creating `MeshService`

--- a/docs/madr/decisions/041-meshservice-kubernetes-ux.md
+++ b/docs/madr/decisions/041-meshservice-kubernetes-ux.md
@@ -1,0 +1,64 @@
+# `MeshService` Kubernetes UX
+
+* Status: accepted
+
+Technical Story: #9704
+
+## Context and Problem Statement
+
+The new `MeshService` resource in Kubernetes zones maps 1-1 to Kubernetes
+`Service` resources. Additionally, users should not have to manage
+`MeshServices` directly but instead a `MeshService` should be derived directly
+from its `Service` with the possibility of users annotating the `Service`
+to control specifics.
+
+## Considered Options
+
+* CP manages `MeshService` from `Service`
+* Users have to create `MeshService`
+
+## Decision Outcome
+
+We will convert `Services` to `MeshServices` in a Kubernetes controller,
+assuming:
+
+1. The namespace is part of the mesh with `kuma.io/sidecar-injection: "true"`
+1. The `Mesh` of the `Service` or its namespace exists.
+1. The `Service` hasn't opted out via `kuma.io/ignore: "true"`
+
+### Metadata
+
+The `ownerReference` of the `MeshService` points to the `Service`.
+Labels are copied from the `Service` object to the `MeshService` object.
+
+### VIP
+
+For `MeshServices` in Kubernetes zones, we no longer create a VIP but instead
+reuse the `ClusterIP` field allocated by the Kubernetes control plane and add
+this to `status.vips` on `MeshService`.
+
+Note this happens asynchronously.
+
+### `ports`
+
+The `MeshService` ports are derived from the `ports` field on `Service`. Note
+that `meshservice_api.Port.Protocol` is derived from `ServicePort.AppProtocol`.
+
+Note that we only support `Service.ports[].protocol: TCP`, which is also the
+default.
+
+### Positive Consequences
+
+* Users don't have to think about creating `MeshService`
+* We don't need to allocate additional VIPs
+
+### Negative Consequences
+
+* None?
+
+## Pros and Cons of the Options
+
+### Manual management
+
+* Bad, because almost always the `MeshService` should be entirely derived from
+  the `Service` object

--- a/docs/madr/decisions/041-meshservice-kubernetes-ux.md
+++ b/docs/madr/decisions/041-meshservice-kubernetes-ux.md
@@ -74,6 +74,11 @@ spec:
     # dataplaneTags: ...
 ```
 
+Note that Kubernetes does not allocate a `ClusterIP` for headless services, it
+only creates a round-robin DNS record to point to PodIPs. Kuma does not
+allocate a VIP either. In a zone, users can rely on kube-dns. Cross-zone
+behavior will be covered in a subsequent MADR.
+
 #### Policy matching
 
 Note that this prevents using `kind: MeshService` to select all Pods of a

--- a/docs/madr/decisions/041-meshservice-kubernetes-ux.md
+++ b/docs/madr/decisions/041-meshservice-kubernetes-ux.md
@@ -56,6 +56,8 @@ for every Pod selected by the Service that points directly to the Pod's IP.
 To support this with Kuma, we will create a `MeshService` per Pod, each
 represented by the hostname allocated by the headless Service and the Pod
 IP as the "VIP" and single endpoint.
+The name of said `MeshServices` has the format `<service-name>-<pod-hash>`
+where the `Service` name is appropriately truncated.
 
 In order to do this we need to have a list of all the Pods selected by the
 Service, which we can get by looking at `EndpointSlices`. These resources hold a

--- a/docs/madr/decisions/041-meshservice-kubernetes-ux.md
+++ b/docs/madr/decisions/041-meshservice-kubernetes-ux.md
@@ -32,6 +32,9 @@ assuming:
 The `ownerReference` of the `MeshService` points to the `Service`.
 Labels are copied from the `Service` object to the `MeshService` object.
 
+If a `MeshService` object exists in the namespace with the same name, the
+`MeshService` won't be created and an error is bubbled up to the user.
+
 ### VIP
 
 For `MeshServices` in Kubernetes zones, we no longer create a VIP but instead
@@ -76,8 +79,8 @@ spec:
 
 Note that Kubernetes does not allocate a `ClusterIP` for headless services, it
 only creates a round-robin DNS record to point to PodIPs. Kuma does not
-allocate a VIP either. In a zone, users can rely on kube-dns. Cross-zone
-behavior will be covered in a subsequent MADR.
+allocate a VIP either. In a zone, users can rely on kube-dns. This record or
+behavior won't be exposed in anyway cross-zone.
 
 #### Policy matching
 

--- a/docs/madr/decisions/041-meshservice-kubernetes-ux.md
+++ b/docs/madr/decisions/041-meshservice-kubernetes-ux.md
@@ -66,15 +66,16 @@ In order to do this we need to have a list of all the Pods selected by the
 Service, which we can get by looking at `EndpointSlices`. These resources hold a
 list of endpoints, each of which has a `targetRef`. If the `targetRef` is `kind:
 Pod`, we can rely on the naming of `Dataplane` objects and directly select a
-given `Dataplane` by setting `spec.selector.dataplaneName` to the name of the
+given `Dataplane` by setting `spec.selector.dataplane.name` to the name of the
 `Pod`.
 
 ```
 kind: MeshService
 spec:
   selector:
-    dataplaneName: pod-1
-    # dataplaneTags: ...
+    dataplane:
+      name: pod-1
+      # tags: ...
 ```
 
 Note that Kubernetes does not allocate a `ClusterIP` for headless services, it
@@ -124,10 +125,11 @@ metadata:
     kuma.io/mesh: default
 spec:
   selector:
-    dataplaneTags: # tags in Dataplane object, see below
-      app.kubernetes.io/name: redis
-      k8s.kuma.io/namespace: redis-system # added automatically
-      kuma.io/zone: east-1 # added automatically
+    dataplane:
+      tags: # tags in Dataplane object, see below
+        app.kubernetes.io/name: redis
+        k8s.kuma.io/namespace: redis-system # added automatically
+        kuma.io/zone: east-1 # added automatically
   ports:
   - port: 6739
     targetPort:

--- a/docs/madr/decisions/041-meshservice-kubernetes-ux.md
+++ b/docs/madr/decisions/041-meshservice-kubernetes-ux.md
@@ -41,8 +41,8 @@ Note this happens asynchronously.
 
 ### `ports`
 
-The `MeshService` ports are derived from the `ports` field on `Service`. Note
-that `meshservice_api.Port.Protocol` is derived from `ServicePort.AppProtocol`.
+The `MeshService` ports are derived from the `ports` field on `Service`,
+including supporting named `targetPorts`.
 
 Note that we only support `Service.ports[].protocol: TCP`, which is also the
 default.

--- a/docs/madr/decisions/041-meshservice-kubernetes-ux.md
+++ b/docs/madr/decisions/041-meshservice-kubernetes-ux.md
@@ -23,6 +23,7 @@ We will convert `Services` to `MeshServices` in a Kubernetes controller,
 assuming:
 
 1. The namespace is part of the mesh with `kuma.io/sidecar-injection: "true"`
+  or the `Service` is labelled with `kuma.io/mesh`.
 1. The `Mesh` of the `Service` or its namespace exists.
 1. The `Service` hasn't opted out via `kuma.io/ignore: "true"`
 

--- a/docs/madr/decisions/041-meshservice-kubernetes-ux.md
+++ b/docs/madr/decisions/041-meshservice-kubernetes-ux.md
@@ -31,9 +31,12 @@ assuming:
 
 The `ownerReference` of the `MeshService` points to the `Service`.
 Labels are copied from the `Service` object to the `MeshService` object.
+We also add a label `k8s.kuma.io/service-name` to the `MeshService` to easily
+filter for owner the `Service` object.
 
 If a `MeshService` object exists in the namespace with the same name, the
-`MeshService` won't be created and an error is bubbled up to the user.
+`MeshService` won't be created and an error is bubbled up to the user as an
+event on the `Service` resource.
 
 ### VIP
 
@@ -50,6 +53,9 @@ including supporting named `targetPorts`.
 
 Note that we only support `Service.ports[].protocol: TCP`, which is also the
 default. We copy `appProtocol` to the `MeshService` port entry as well.
+
+We add an event to the `Service` to indicate that there are ports not supported
+by Kuma.
 
 ### Headless Service with selectors
 

--- a/docs/madr/decisions/041-meshservice-kubernetes-ux.md
+++ b/docs/madr/decisions/041-meshservice-kubernetes-ux.md
@@ -54,9 +54,6 @@ including supporting named `targetPorts`.
 Note that we only support `Service.ports[].protocol: TCP`, which is also the
 default. We copy `appProtocol` to the `MeshService` port entry as well.
 
-We add an event to the `Service` to indicate that there are ports not supported
-by Kuma.
-
 ### Headless Service with selectors
 
 In Kubernetes, a headless Service with selectors is used to create a DNS record


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- #9704 
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
