### PR TITLE
ci(stability): wait for kuma service to be available

### DIFF
--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -833,6 +833,8 @@ func (c *K8sCluster) VerifyKuma() error {
 		return err
 	}
 
+	k8s.WaitUntilServiceAvailable(c.GetTesting(), c.GetKubectlOptions(Config.KumaNamespace), Config.KumaServiceName, DefaultRetries, DefaultTimeout)
+
 	return nil
 }
 


### PR DESCRIPTION
Time and time again I'm seeing `no endpoints available for service \"kuma-control-plane\""` ([example](https://github.com/kumahq/kuma/actions/runs/8435507434/job/23102735001?pr=9624#step:13:1067)):

```
2024-03-26T13:06:54.0183958Z  2024-03-26T13:06:53Z logger.go:66: 2024-03-26T13:03:32.587Z	INFO	kds-delta-zone	error during callback received, sending NACK	{"kds-version": "v2", "err": "failed to create k8s resource: Internal error occurred: failed calling webhook \"mesh.defaulter.kuma-admission.kuma.io\": failed to call webhook: Post \"https://kuma-control-plane.kuma-system.svc:443/default-kuma-io-v1alpha1-mesh?timeout=10s\": no endpoints available for service \"kuma-control-plane\""...
```

this is repeated X times and eventually, after just a couple of seconds (5 in this case)

```
2024-03-26T13:06:54.0634082Z  2024-03-26T13:06:53Z logger.go:66: 2024-03-26T13:03:34.200Z	INFO	kds-delta-zone	error during callback received, sending NACK	{"kds-version": "v2", "err": "failed to create k8s resource: Internal error occurred: failed calling webhook \"mesh.defaulter.kuma-admission.kuma.io\": failed to call webhook: Post \"https://kuma-control-plane.kuma-system.svc:443/default-kuma-io-v1alpha1-mesh?timeout=10s\": no endpoints available for service
```

The test fails with

```
2024-03-26T13:06:54.0701409Z [38;5;9m[SynchronizedBeforeSuite] [FAILED] [215.769 seconds][0m
```

Let's wait for this service to be available explicitly in e2e setup and see if this helps. The `kube-controller-manager` is probably overwhelmed and needs a bit more time to run and setup endpoints.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues -- not reported
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
