### PR TITLE
feat(kuma-dp): use Envoy `--drain-strategy immediate`

### DIFF
--- a/app/kuma-dp/pkg/dataplane/envoy/envoy.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/envoy.go
@@ -116,6 +116,7 @@ func (e *Envoy) Start(stop <-chan struct{}) error {
 		"--config-path", configFile,
 		"--drain-time-s",
 		fmt.Sprintf("%d", e.opts.Config.Dataplane.DrainTime.Duration/time.Second),
+		"--drain-strategy", "immediate",
 		// "hot restart" (enabled by default) requires each Envoy instance to have
 		// `--base-id <uint32_t>` argument.
 		// it is not possible to start multiple Envoy instances on the same Linux machine

--- a/app/kuma-dp/pkg/dataplane/envoy/envoy_test.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/envoy_test.go
@@ -117,12 +117,12 @@ var _ = Describe("Envoy", func() {
 			// and
 			if runtime.GOOS == "linux" {
 				Expect(strings.TrimSpace(buf.String())).To(Equal(
-					fmt.Sprintf("--config-path %s --drain-time-s 15 --disable-hot-restart --log-level off --cpuset-threads",
+					fmt.Sprintf("--config-path %s --drain-time-s 15 --drain-strategy immediate --disable-hot-restart --log-level off --cpuset-threads",
 						expectedConfigFile)),
 				)
 			} else {
 				Expect(strings.TrimSpace(buf.String())).To(Equal(
-					fmt.Sprintf("--config-path %s --drain-time-s 15 --disable-hot-restart --log-level off",
+					fmt.Sprintf("--config-path %s --drain-time-s 15 --drain-strategy immediate --disable-hot-restart --log-level off",
 						expectedConfigFile)),
 				)
 			}
@@ -178,7 +178,7 @@ var _ = Describe("Envoy", func() {
 			Expect(err).ToNot(HaveOccurred())
 			// and
 			Expect(strings.TrimSpace(buf.String())).To(Equal(
-				fmt.Sprintf("--config-path %s --drain-time-s 15 --disable-hot-restart --log-level off --concurrency 9",
+				fmt.Sprintf("--config-path %s --drain-time-s 15 --drain-strategy immediate --disable-hot-restart --log-level off --concurrency 9",
 					expectedConfigFile)),
 			)
 		}))


### PR DESCRIPTION
There's no reason to not immediately start GOAWAYing _all_ connections.

- [x] is this ok for gateway? I think it is.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
