### PR TITLE
fix(kds): skip error on context cancelled

### DIFF
--- a/pkg/kds/global/components.go
+++ b/pkg/kds/global/components.go
@@ -114,7 +114,7 @@ func Setup(rt runtime.Runtime) error {
 
 	onGlobalToZoneSyncConnect := mux.OnGlobalToZoneSyncConnectFunc(func(stream mesh_proto.KDSSyncService_GlobalToZoneSyncServer, errChan chan error) {
 		zoneID, err := util.ClientIDFromIncomingCtx(stream.Context())
-		if err != nil && !errors.Is(err, context.Canceled) {
+		if err != nil {
 			select {
 			case errChan <- err:
 			default:
@@ -151,7 +151,7 @@ func Setup(rt runtime.Runtime) error {
 
 	onZoneToGlobalSyncConnect := mux.OnZoneToGlobalSyncConnectFunc(func(stream mesh_proto.KDSSyncService_ZoneToGlobalSyncServer, errChan chan error) {
 		zoneID, err := util.ClientIDFromIncomingCtx(stream.Context())
-		if err != nil && !errors.Is(err, context.Canceled) {
+		if err != nil {
 			select {
 			case errChan <- err:
 			default:

--- a/pkg/kds/global/components.go
+++ b/pkg/kds/global/components.go
@@ -125,8 +125,10 @@ func Setup(rt runtime.Runtime) error {
 		log := kdsDeltaGlobalLog.WithValues("peer-id", zoneID)
 		log = kuma_log.AddFieldsFromCtx(log, stream.Context(), rt.Extensions())
 		log.Info("Global To Zone new session created")
-		err = createZoneIfAbsent(stream.Context(), log, zoneID, rt.ResourceManager())
-		if err != nil && !errors.Is(err, context.Canceled) {
+		if err := createZoneIfAbsent(stream.Context(), log, zoneID, rt.ResourceManager()); err != nil {
+			if errors.Is(err, context.Canceled) {
+				return
+			}
 			err = errors.Wrap(err, "Global CP could not create a zone")
 			select {
 			case errChan <- err:

--- a/pkg/kds/global/components.go
+++ b/pkg/kds/global/components.go
@@ -138,8 +138,7 @@ func Setup(rt runtime.Runtime) error {
 			return
 		}
 
-		err = kdsServerV2.GlobalToZoneSync(stream)
-		if err != nil && !errors.Is(err, context.Canceled) {
+		if err := kdsServerV2.GlobalToZoneSync(stream); err != nil && !errors.Is(err, context.Canceled) {
 			select {
 			case errChan <- err:
 			default:

--- a/pkg/kds/zone/components.go
+++ b/pkg/kds/zone/components.go
@@ -2,6 +2,7 @@ package zone
 
 import (
 	"context"
+
 	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"


### PR DESCRIPTION
We are changing this because with context cancelled we will log it as error, that is irrelevant since we are logging it on info level later on

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
