### PR TITLE
feat(kds): stats of kds client versions

### DIFF
--- a/pkg/kds/server/components.go
+++ b/pkg/kds/server/components.go
@@ -34,7 +34,7 @@ func New(
 	hashFn, cache := newKDSContext(log)
 	generator := reconcile.NewSnapshotGenerator(rt.ReadOnlyResourceManager(), providedTypes, filter, mapper)
 	versioner := util_xds_v3.SnapshotAutoVersioner{UUID: core.NewUUID}
-	statsCallbacks, err := util_xds.NewStatsCallbacks(rt.Metrics(), "kds")
+	statsCallbacks, err := util_xds.NewStatsCallbacks(rt.Metrics(), "kds", util_xds.NoopVersionExtractor)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kds/status/status_tracker.go
+++ b/pkg/kds/status/status_tracker.go
@@ -173,7 +173,7 @@ func (c *statusTracker) onStreamRequest(streamID int64, req DiscoveryRequestInfo
 	// infer zone
 	if state.zone == "" {
 		state.zone = node.Id
-		if err := readVersion(node.GetMetadata(), state.subscription.Version); err != nil {
+		if err := ReadVersion(node.GetMetadata(), state.subscription.Version); err != nil {
 			c.log.Error(err, "failed to extract version out of the Envoy metadata", "streamid", streamID, "metadata", node.GetMetadata())
 		}
 		go c.createStatusSink(state, c.log).Start(state.ctx, state.stop)
@@ -274,7 +274,7 @@ func (s *streamState) Close() {
 	close(s.stop)
 }
 
-func readVersion(metadata *structpb.Struct, version *system_proto.Version) error {
+func ReadVersion(metadata *structpb.Struct, version *system_proto.Version) error {
 	if metadata == nil {
 		return nil
 	}

--- a/pkg/plugins/runtime/gateway/gateway_route_generator_test.go
+++ b/pkg/plugins/runtime/gateway/gateway_route_generator_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Gateway Route", func() {
 		GinkgoHelper()
 
 		serverCtx := xds_server.NewXdsContext()
-		statsCallbacks, err := util_xds.NewStatsCallbacks(rt.Metrics(), "xds")
+		statsCallbacks, err := util_xds.NewStatsCallbacks(rt.Metrics(), "xds", util_xds.NoopVersionExtractor)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/plugins/runtime/gateway/listener_generator_test.go
+++ b/pkg/plugins/runtime/gateway/listener_generator_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Gateway Listener", func() {
 
 	Do := func(gateway string) (cache.ResourceSnapshot, error) {
 		serverCtx := xds_server.NewXdsContext()
-		statsCallbacks, err := util_xds.NewStatsCallbacks(rt.Metrics(), "xds")
+		statsCallbacks, err := util_xds.NewStatsCallbacks(rt.Metrics(), "xds", util_xds.NoopVersionExtractor)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/xds/server/components.go
+++ b/pkg/xds/server/components.go
@@ -46,7 +46,7 @@ func MeshResourceTypes() []core_model.ResourceType {
 func RegisterXDS(rt core_runtime.Runtime) error {
 	// Build common dependencies for V2 and V3 servers.
 	// We want to have same metrics (we cannot register one metric twice) and same caches for both V2 and V3.
-	statsCallbacks, err := util_xds.NewStatsCallbacks(rt.Metrics(), "xds")
+	statsCallbacks, err := util_xds.NewStatsCallbacks(rt.Metrics(), "xds", util_xds.NoopVersionExtractor)
 	if err != nil {
 		return err
 	}

--- a/pkg/xds/server/v3/reconcile_test.go
+++ b/pkg/xds/server/v3/reconcile_test.go
@@ -129,7 +129,7 @@ var _ = Describe("Reconcile", func() {
 
 			metrics, err := core_metrics.NewMetrics("Zone")
 			Expect(err).ToNot(HaveOccurred())
-			statsCallbacks, err := util_xds.NewStatsCallbacks(metrics, "xds")
+			statsCallbacks, err := util_xds.NewStatsCallbacks(metrics, "xds", util_xds.NoopVersionExtractor)
 			Expect(err).ToNot(HaveOccurred())
 
 			// setup


### PR DESCRIPTION
### Checklist prior to review

This PR adds stats of number of clients per version. For now it only works with Delta KDS, but I added this to generic stats callbacks so in the future we can add this to other DSes if we want to.

I considered just adding a dimension to `_streams_active` metric, but streams active counts all DS streams, whereas this metric only counts streams with at least one DiscoveryRequest, because version is carried in metadata of request. This should be equal, but technically _can_ be different.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
