### PR TITLE
ci(github): only run provenance on tags

### DIFF
--- a/.github/workflows/_provenance.yaml
+++ b/.github/workflows/_provenance.yaml
@@ -27,7 +27,6 @@ jobs:
       upload-assets: ${{ github.ref_type == 'tag' }}
       upload-tag-name: ${{ github.ref_name }}
       provenance-name: ${{ github.event.repository.name }}.intoto.jsonl
-      continue-on-error: true
 
   # Provenance job for all images manifests
   # SLSA generator is a reusable workflow
@@ -46,7 +45,6 @@ jobs:
     with:
       image: ${{ matrix.IMAGE }}
       digest: ${{ fromJSON(inputs.image_digests)[matrix.IMAGE] }}
-      continue-on-error: true
     secrets:
       registry-password: ${{ secrets.DOCKER_API_KEY }}
       registry-username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -91,7 +91,7 @@ jobs:
     secrets: inherit
   provenance:
     needs: ["check", "build_publish"]
-    if: ${{ fromJSON(needs.check.outputs.BUILD) }}
+    if: ${{ github.ref_type == 'tag' }}
     uses: ./.github/workflows/_provenance.yaml
     secrets: inherit
     permissions:


### PR DESCRIPTION
### Checklist prior to review

Provenance can only work on tags which is tough for testing but an harsh reality.
We now only make it run on tags and will push test tags to try it out

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
