### PR TITLE
feat(meshmetric): filter out internal clusters

### DIFF
--- a/app/kuma-dp/pkg/dataplane/metrics/profiles.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/profiles.go
@@ -185,8 +185,8 @@ var basicProfileLabels = []selectorFunction{
 }
 
 func ProfileMutatorGenerator(sidecar *v1alpha1.Sidecar) PrometheusMutator {
-	effectiveSelectors := []selectorFunction{alwaysSelect}       // default is All
-	effectiveLabelsSelectors := []selectorFunction{alwaysSelect} // default is All
+	effectiveSelectors := basicProfile             // default is Basic
+	effectiveLabelsSelectors := basicProfileLabels // default is Basic
 	profile := v1alpha1.BasicProfileName
 	if sidecar != nil && sidecar.Profiles != nil && sidecar.Profiles.AppendProfiles != nil && len(*sidecar.Profiles.AppendProfiles) == 1 {
 		profile = (*sidecar.Profiles.AppendProfiles)[0].Name

--- a/app/kuma-dp/pkg/dataplane/metrics/profiles.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/profiles.go
@@ -7,6 +7,7 @@ import (
 	io_prometheus_client "github.com/prometheus/client_model/go"
 
 	"github.com/kumahq/kuma/pkg/plugins/policies/meshmetric/api/v1alpha1"
+	"github.com/kumahq/kuma/pkg/xds/envoy/names"
 )
 
 type (
@@ -152,10 +153,39 @@ var basicProfile = []selectorFunction{
 	// end of dashboards
 }
 
+var basicProfileLabels = []selectorFunction{
+	selectorToFilterFunction(v1alpha1.Selector{
+		Type:  v1alpha1.ExactSelectorType,
+		Match: names.GetAdsClusterName(),
+	}),
+	selectorToFilterFunction(v1alpha1.Selector{
+		Type:  v1alpha1.ExactSelectorType,
+		Match: names.GetAccessLogSinkClusterName(),
+	}),
+	selectorToFilterFunction(v1alpha1.Selector{
+		Type:  v1alpha1.ExactSelectorType,
+		Match: names.GetEnvoyAdminClusterName(),
+	}),
+	selectorToFilterFunction(v1alpha1.Selector{
+		Type:  v1alpha1.ExactSelectorType,
+		Match: names.GetMetricsHijackerClusterName(),
+	}),
+	selectorToFilterFunction(v1alpha1.Selector{
+		Type:  v1alpha1.PrefixSelectorType,
+		Match: names.GetOpenTelemetryClusterPrefix(),
+	}),
+	selectorToFilterFunction(v1alpha1.Selector{
+		Type:  v1alpha1.PrefixSelectorType,
+		Match: names.GetTracingClusterPrefix(),
+	}),
+}
+
 func ProfileMutatorGenerator(sidecar *v1alpha1.Sidecar) PrometheusMutator {
-	effectiveSelectors := []selectorFunction{alwaysSelect} // default is All
+	effectiveSelectors := []selectorFunction{alwaysSelect}       // default is All
+	effectiveLabelsSelectors := []selectorFunction{alwaysSelect} // default is All
+	profile := v1alpha1.BasicProfileName
 	if sidecar != nil && sidecar.Profiles != nil && sidecar.Profiles.AppendProfiles != nil && len(*sidecar.Profiles.AppendProfiles) == 1 {
-		profile := (*sidecar.Profiles.AppendProfiles)[0].Name
+		profile = (*sidecar.Profiles.AppendProfiles)[0].Name
 		switch profile {
 		case v1alpha1.AllProfileName:
 			effectiveSelectors = []selectorFunction{alwaysSelect}
@@ -163,6 +193,7 @@ func ProfileMutatorGenerator(sidecar *v1alpha1.Sidecar) PrometheusMutator {
 			effectiveSelectors = []selectorFunction{neverSelect}
 		case v1alpha1.BasicProfileName:
 			effectiveSelectors = basicProfile
+			effectiveLabelsSelectors = basicProfileLabels
 		}
 		logger.V(1).Info("selected profile", "name", profile)
 	}
@@ -198,6 +229,31 @@ func ProfileMutatorGenerator(sidecar *v1alpha1.Sidecar) PrometheusMutator {
 				}
 			}
 
+			// filter out internal clusters
+			// only activate this on basic profile so there is no overhead on other profiles
+			if profile == v1alpha1.BasicProfileName {
+				var metrics []*io_prometheus_client.Metric
+				for _, m := range metricFamily.Metric {
+					includeMetric := true
+					for _, l := range m.Label {
+						if metricFromInternalCluster(l, effectiveLabelsSelectors) {
+							includeMetric = false
+							break
+						}
+					}
+					if includeMetric {
+						metrics = append(metrics, m)
+					}
+				}
+
+				// if after cleaning there is no metrics remove this metric family
+				if len(metrics) == 0 {
+					include = false
+				} else {
+					metricFamily.Metric = metrics
+				}
+			}
+
 			if !include {
 				delete(in, key)
 			}
@@ -205,6 +261,15 @@ func ProfileMutatorGenerator(sidecar *v1alpha1.Sidecar) PrometheusMutator {
 
 		return nil
 	}
+}
+
+func metricFromInternalCluster(l *io_prometheus_client.LabelPair, effectiveLabelsSelectors []selectorFunction) bool {
+	for _, selector := range effectiveLabelsSelectors {
+		if l.GetName() == EnvoyClusterLabelName && selector(l.GetValue()) {
+			return true
+		}
+	}
+	return false
 }
 
 func selectorToFilterFunction(selector v1alpha1.Selector) selectorFunction {

--- a/app/kuma-dp/pkg/dataplane/metrics/profiles.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/profiles.go
@@ -155,6 +155,10 @@ var basicProfile = []selectorFunction{
 
 var basicProfileLabels = []selectorFunction{
 	selectorToFilterFunction(v1alpha1.Selector{
+		Type:  v1alpha1.PrefixSelectorType,
+		Match: names.GetInternalClusterNamePrefix(),
+	}),
+	selectorToFilterFunction(v1alpha1.Selector{
 		Type:  v1alpha1.ExactSelectorType,
 		Match: names.GetAdsClusterName(),
 	}),

--- a/app/kuma-dp/pkg/dataplane/metrics/testdata/profiles/dashboards.in
+++ b/app/kuma-dp/pkg/dataplane/metrics/testdata/profiles/dashboards.in
@@ -1,5 +1,9 @@
 # TYPE envoy_cluster_external_upstream_rq_xx counter
 envoy_cluster_external_upstream_rq_xx{envoy_cluster_name="example"} 1
+envoy_cluster_external_upstream_rq_xx{envoy_cluster_name="ads_cluster"} 2
+
+# TYPE envoy_cluster_assignment_timeout_received counter
+envoy_cluster_assignment_timeout_received{envoy_cluster_name="ads_cluster"} 1
 
 # TYPE envoy_cluster_health_check_attempt counter
 envoy_cluster_health_check_attempt{envoy_cluster_name="example"} 1

--- a/app/kuma-dp/pkg/dataplane/metrics/testdata/profiles/exclude.yaml
+++ b/app/kuma-dp/pkg/dataplane/metrics/testdata/profiles/exclude.yaml
@@ -7,6 +7,8 @@ targetRef:
 default:
   sidecar:
     profiles:
+      appendProfiles:
+        - name: All
       exclude:
         - type: Regex
           match: "envoy_rbac.*"

--- a/pkg/xds/bootstrap/template_v3.go
+++ b/pkg/xds/bootstrap/template_v3.go
@@ -26,6 +26,7 @@ import (
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	clusters_v3 "github.com/kumahq/kuma/pkg/xds/envoy/clusters/v3"
+	"github.com/kumahq/kuma/pkg/xds/envoy/names"
 	"github.com/kumahq/kuma/pkg/xds/envoy/tls"
 )
 
@@ -37,8 +38,8 @@ func RegisterBootstrapCluster(c string) string {
 }
 
 var (
-	adsClusterName           = RegisterBootstrapCluster("ads_cluster")
-	accessLogSinkClusterName = RegisterBootstrapCluster("access_log_sink")
+	adsClusterName           = RegisterBootstrapCluster(names.GetAdsClusterName())
+	accessLogSinkClusterName = RegisterBootstrapCluster(names.GetAccessLogSinkClusterName())
 )
 
 func genConfig(parameters configParameters, proxyConfig xds.Proxy, enableReloadableTokens bool) (*envoy_bootstrap_v3.Bootstrap, error) {

--- a/pkg/xds/envoy/names/resource_names.go
+++ b/pkg/xds/envoy/names/resource_names.go
@@ -65,6 +65,10 @@ func GetMetricsHijackerClusterName() string {
 	return Join("kuma", "metrics", "hijacker")
 }
 
+func GetInternalClusterNamePrefix() string {
+	return "_"
+}
+
 func GetAdsClusterName() string {
 	return "ads_cluster"
 }

--- a/pkg/xds/envoy/names/resource_names.go
+++ b/pkg/xds/envoy/names/resource_names.go
@@ -65,12 +65,24 @@ func GetMetricsHijackerClusterName() string {
 	return Join("kuma", "metrics", "hijacker")
 }
 
+func GetAdsClusterName() string {
+	return "ads_cluster"
+}
+
+func GetAccessLogSinkClusterName() string {
+	return "access_log_sink"
+}
+
 func GetOpenTelemetryListenerName(backendName string) string {
 	return Join("_kuma", "metrics", "opentelemetry", backendName)
 }
 
+func GetOpenTelemetryClusterPrefix() string {
+	return Join("_kuma", "metrics", "opentelemetry")
+}
+
 func GetOpenTelemetryClusterName(backendName string) string {
-	return Join("_kuma", "metrics", "opentelemetry", backendName)
+	return Join(GetOpenTelemetryClusterPrefix(), backendName)
 }
 
 func GetPrometheusListenerName() string {
@@ -81,8 +93,12 @@ func GetAdminListenerName() string {
 	return Join("kuma", "envoy", "admin")
 }
 
+func GetTracingClusterPrefix() string {
+	return Join("tracing")
+}
+
 func GetTracingClusterName(backendName string) string {
-	return Join("tracing", backendName)
+	return Join(GetTracingClusterPrefix(), backendName)
 }
 
 func GetDNSListenerName() string {

--- a/test/e2e_env/kubernetes/gateway/delegated/meshmetric.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshmetric.go
@@ -31,6 +31,10 @@ spec:
   targetRef:
     kind: Mesh
   default:
+    sidecar:
+      profiles:
+        appendProfiles:
+          - name: All
     backends:
       - type: OpenTelemetry
         openTelemetry: 

--- a/test/e2e_env/kubernetes/meshmetric/meshmetric.go
+++ b/test/e2e_env/kubernetes/meshmetric/meshmetric.go
@@ -31,6 +31,10 @@ spec:
   targetRef:
     kind: Mesh
   default:
+    sidecar:
+      profiles:
+        appendProfiles:
+          - name: All
     backends:
       - type: Prometheus
         prometheus: 
@@ -90,6 +94,10 @@ spec:
   targetRef:
     kind: Mesh
   default:
+    sidecar:
+      profiles:
+        appendProfiles:
+          - name: All
     backends:
       - type: Prometheus
         prometheus: 
@@ -122,6 +130,10 @@ spec:
   targetRef:
     kind: Mesh
   default:
+    sidecar:
+      profiles:
+        appendProfiles:
+          - name: All
     backends:
       - type: Prometheus
         prometheus: 
@@ -148,6 +160,10 @@ spec:
     kind: MeshService
     name: %s
   default:
+    sidecar:
+      profiles:
+        appendProfiles:
+          - name: All
     backends:
       - type: Prometheus
         prometheus: 
@@ -173,6 +189,10 @@ spec:
   targetRef:
     kind: Mesh
   default:
+    sidecar:
+      profiles:
+        appendProfiles:
+          - name: All
     applications:
       - name: "%s"
         path: "%s"
@@ -201,6 +221,10 @@ spec:
   targetRef:
     kind: Mesh
   default:
+    sidecar:
+      profiles:
+        appendProfiles:
+          - name: All
     backends:
       - type: OpenTelemetry
         openTelemetry: 
@@ -223,6 +247,10 @@ spec:
   targetRef:
     kind: Mesh
   default:
+    sidecar:
+      profiles:
+        appendProfiles:
+          - name: All
     sidecar:
       regex: .*upstream.*
       includeUnused: false
@@ -248,6 +276,10 @@ spec:
   targetRef:
     kind: Mesh
   default:
+    sidecar:
+      profiles:
+        appendProfiles:
+          - name: All
     backends:
       - type: OpenTelemetry
         openTelemetry: 
@@ -276,6 +308,10 @@ spec:
   targetRef:
     kind: Mesh
   default:
+    sidecar:
+      profiles:
+        appendProfiles:
+          - name: All
     backends:
       - type: OpenTelemetry
         openTelemetry: 


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues -- closes https://github.com/kumahq/kuma/issues/9739
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
