### PR TITLE
Revert "feat(images/kuma-init): use iptables-wrapper to use correct iptables version (backport of #9701) (#9727)"

### DIFF
--- a/mk/build.mk
+++ b/mk/build.mk
@@ -108,12 +108,6 @@ build/artifacts-$(1)-$(2)/envoy:
 build/artifacts-$(1)-$(2)/test-server:
 	$(Build_Go_Application) ./test/server
 
-.PHONY: build/artifacts-$(1)-$(2)/iptables-wrapper
-build/artifacts-$(1)-$(2)/iptables-wrapper:
-	mkdir -p $$(@)
-	[ -f $$(@)/iptables-wrapper ] && [ -f $$(@)/iptables-wrapper-installer.sh ] || \
-	curl -s --fail --location https://github.com/kumahq/iptables-wrappers/releases/download/v0.1.0/iptables-wrapper-$(1)-$(2).tar.gz | tar -C $$(@) -xz
-
 endef
 $(foreach goos,$(SUPPORTED_GOOSES),$(foreach goarch,$(SUPPORTED_GOARCHES),$(eval $(call BUILD_TARGET,$(goos),$(goarch)))))
 

--- a/mk/check.mk
+++ b/mk/check.mk
@@ -14,7 +14,7 @@ tidy:
 
 .PHONY: shellcheck
 shellcheck:
-	find . -name "*.sh" -not -path "./.git/*" -and -not -path "./build/*" -exec $(SHELLCHECK) -P SCRIPTDIR -x {} +
+	find . -name "*.sh" -not -path "./.git/*" -exec $(SHELLCHECK) -P SCRIPTDIR -x {} +
 
 .PHONY: golangci-lint
 golangci-lint: ## Dev: Runs golangci-lint linter

--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -54,7 +54,7 @@ image/kumactl/$(1): image/base/$(1) build/artifacts-linux-$(1)/kumactl ## Dev: R
 	docker build -t $$(call build_image,kumactl,$(1)) --build-arg ARCH=$(1) --platform=linux/$(1) -f $(TOOLS_DIR)/releases/dockerfiles/kumactl.Dockerfile .
 
 .PHONY: image/kuma-init/$(1)
-image/kuma-init/$(1): build/artifacts-linux-$(1)/kumactl build/artifacts-linux-$(1)/iptables-wrapper ## Dev: Rebuild `kuma-init` Docker image
+image/kuma-init/$(1): build/artifacts-linux-$(1)/kumactl ## Dev: Rebuild `kuma-init` Docker image
 	docker build -t $$(call build_image,kuma-init,$(1)) --build-arg ARCH=$(1) --platform=linux/$(1) -f $(TOOLS_DIR)/releases/dockerfiles/kuma-init.Dockerfile .
 
 .PHONY: image/kuma-cni/$(1)

--- a/tools/releases/dockerfiles/kuma-init.Dockerfile
+++ b/tools/releases/dockerfiles/kuma-init.Dockerfile
@@ -15,30 +15,8 @@ COPY /tools/releases/templates/LICENSE \
 
 COPY /tools/releases/templates/NOTICE-kumactl /kuma/NOTICE
 
-RUN adduser --system --disabled-password --group kumactl --uid 5678
-
-# As of iptables 1.8, the iptables command line clients come in two different versions/modes:
-# "legacy", which uses the kernel iptables API just like iptables 1.6 and earlier did, and
-# "nft", which translates the iptables command-line API into the kernel nftables API.
-#
-# Because they connect to two different subsystems in the kernel, you cannot mix and match
-# between them; in particular, if you are adding a new rule that needs to run either before
-# or after some existing rules (such as the system firewall rules), then you need to create
-# your rule with the same iptables mode as the other rules were created with, since otherwise
-# the ordering may not be what you expect. (eg, if you prepend a rule using the nft-based
-# client, it will still run after all rules that were added with the legacy iptables client.)
-#
-# In particular, this means that if you create a container image that will make changes to
-# iptables rules in the host network namespace, and you want that container to be able to work
-# on any host, then you need to figure out at run time which mode the host is using, and then
-# also use that mode yourself. This wrapper is designed to do that for you.
-#
-# ref. https://github.com/kubernetes-sigs/iptables-wrappers
-COPY /build/artifacts-linux-$ARCH/iptables-wrapper/iptables-wrapper-installer.sh \
-     /build/artifacts-linux-$ARCH/iptables-wrapper/iptables-wrapper \
-     /
-
-RUN /iptables-wrapper-installer.sh
+RUN update-alternatives --set iptables /usr/sbin/iptables-legacy && \
+    adduser --system --disabled-password --group kumactl --uid 5678
 
 ENTRYPOINT ["/usr/bin/kumactl"]
 CMD ["install", "transparent-proxy"]

--- a/tools/releases/dockerfiles/kuma-init.Dockerfile.dockerignore
+++ b/tools/releases/dockerfiles/kuma-init.Dockerfile.dockerignore
@@ -1,16 +1,8 @@
 *
 !build/artifacts-linux-amd64/kumactl/kumactl
 !build/artifacts-linux-arm64/kumactl/kumactl
-!build/artifacts-linux-amd64/iptables-wrapper/iptables-wrapper
-!build/artifacts-linux-amd64/iptables-wrapper/iptables-wrapper-installer.sh
-!build/artifacts-linux-arm64/iptables-wrapper/iptables-wrapper
-!build/artifacts-linux-arm64/iptables-wrapper/iptables-wrapper-installer.sh
 !build/artifacts-darwin-amd64/kumactl/kumactl
 !build/artifacts-darwin-arm64/kumactl/kumactl
-!build/artifacts-darwin-amd64/iptables-wrapper/iptables-wrapper
-!build/artifacts-darwin-amd64/iptables-wrapper/iptables-wrapper-installer.sh
-!build/artifacts-darwin-arm64/iptables-wrapper/iptables-wrapper
-!build/artifacts-darwin-arm64/iptables-wrapper/iptables-wrapper-installer.sh
 !tools/releases/templates/LICENSE
 !tools/releases/templates/NOTICE-kumactl
 !tools/releases/templates/README


### PR DESCRIPTION
This reverts commit 78a0ce054916418bb6a907a51169a8ea2503739b.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
