### PR TITLE
feat(meshmetric): disable rollup of clusters

### DIFF
--- a/app/kuma-dp/cmd/run.go
+++ b/app/kuma-dp/cmd/run.go
@@ -322,7 +322,7 @@ func getApplicationsToScrape(kumaSidecarConfiguration *types.KumaSidecarConfigur
 		IsIPv6:            false,
 		QueryModifier:     metrics.AddPrometheusFormat,
 		Mutator:           metrics.AggregatedMetricsMutator(metrics.MergeClustersForPrometheus),
-		MeshMetricMutator: metrics.AggregatedOtelMutator(metrics.MergeClustersForOpenTelemetry),
+		MeshMetricMutator: metrics.AggregatedOtelMutator(),
 	})
 	return applicationsToScrape
 }

--- a/app/kuma-dp/pkg/dataplane/meshmetrics/component.go
+++ b/app/kuma-dp/pkg/dataplane/meshmetrics/component.go
@@ -279,7 +279,7 @@ func (cf *ConfigFetcher) mapApplicationToApplicationToScrape(applications []xds.
 		Port:              cf.envoyAdminPort,
 		IsIPv6:            false,
 		QueryModifier:     metrics.AggregatedQueryParametersModifier(metrics.AddPrometheusFormat, metrics.AddSidecarParameters(sidecar)),
-		MeshMetricMutator: metrics.AggregatedOtelMutator(metrics.ProfileMutatorGenerator(sidecar), metrics.MergeClustersForOpenTelemetry),
+		MeshMetricMutator: metrics.AggregatedOtelMutator(metrics.ProfileMutatorGenerator(sidecar)),
 	})
 
 	return applicationsToScrape

--- a/app/kuma-dp/pkg/dataplane/meshmetrics/component.go
+++ b/app/kuma-dp/pkg/dataplane/meshmetrics/component.go
@@ -279,7 +279,6 @@ func (cf *ConfigFetcher) mapApplicationToApplicationToScrape(applications []xds.
 		Port:              cf.envoyAdminPort,
 		IsIPv6:            false,
 		QueryModifier:     metrics.AggregatedQueryParametersModifier(metrics.AddPrometheusFormat, metrics.AddSidecarParameters(sidecar)),
-		Mutator:           metrics.AggregatedMetricsMutator(metrics.MergeClustersForPrometheus),
 		MeshMetricMutator: metrics.AggregatedOtelMutator(metrics.ProfileMutatorGenerator(sidecar), metrics.MergeClustersForOpenTelemetry),
 	})
 

--- a/app/kuma-dp/pkg/dataplane/metrics/merge.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/merge.go
@@ -35,23 +35,6 @@ func MergeClustersForPrometheus(in map[string]*io_prometheus_client.MetricFamily
 	return nil
 }
 
-func MergeClustersForOpenTelemetry(metricFamilies map[string]*io_prometheus_client.MetricFamily) error {
-	for _, metricFamily := range metricFamilies {
-		switch {
-		case isClusterMetricFamily(metricFamily):
-			if err := handleClusterMetric(metricFamily); err != nil {
-				return err
-			}
-		case isHttpMetricFamily(metricFamily):
-			if err := handleHttpMetricFamily(metricFamily); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
 func handleClusterMetric(metricFamily *io_prometheus_client.MetricFamily) error {
 	// metricsByClusterNames returns the data in the following format:
 	// 'cluster_name' ->


### PR DESCRIPTION
closes: https://github.com/kumahq/kuma/issues/9738

Looks like it works as intended:

Querying via prometheus exposed via MeshMetric:
![image](https://github.com/kumahq/kuma/assets/2753650/4c70e0b7-0451-44f8-9119-4231591af93c)

Querying directly:
![image](https://github.com/kumahq/kuma/assets/2753650/97c71ae3-978b-46b4-a3b9-a59d8506aa37)

It needs traffic split to get the hash into the clusters:

```
apiVersion: kuma.io/v1alpha1
kind: MeshHTTPRoute
metadata:
  name: http-route-1
  namespace: kuma-system
  labels:
    kuma.io/mesh: default
spec:
  targetRef:
    kind: MeshService
    name: frontend_kuma-demo_svc_8080
  to:
    - targetRef:
        kind: MeshService
        name: backend_kuma-demo_svc_3001
      rules:
        - matches:
            - path:
                type: PathPrefix
                value: /api
          default:
            backendRefs:
              - kind: MeshServiceSubset
                name: backend_kuma-demo_svc_3001
                tags:
                  version: "1.0"
                weight: 90
              - kind: MeshServiceSubset
                name: backend_kuma-demo_svc_3001
                tags:
                  version: "2.0"
                weight: 10
```

and I used this MeshMetric:

```
apiVersion: kuma.io/v1alpha1
kind: MeshMetric
metadata:
  name: metrics-default
  namespace: kuma-system
  labels:
    kuma.io/mesh: default
spec:
  targetRef:
    kind: Mesh
  default:
    sidecar:
      profiles:
        appendProfiles:
          - name: All
    backends:
    - type: Prometheus
      prometheus:
        port: 5670
        path: "/metrics"
```

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
