### PR TITLE
ci(github): fix provenance to use version for action

### DIFF
--- a/.github/workflows/_provenance.yaml
+++ b/.github/workflows/_provenance.yaml
@@ -21,7 +21,8 @@ permissions:
   packages: write # Required for publishing provenance. Issue: https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/container#known-issues
 jobs:
   artifact-provenance:
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@c747fe7769adf3656dc7d588b161cb614d7abfee # v1.10.0
+    # need to use non hash version because of: https://github.com/slsa-framework/slsa-github-generator/issues/3498
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.10.0
     with:
       base64-subjects: ${{ inputs.binary_artifacts_hashes_as_file }}
       upload-assets: ${{ github.ref_type == 'tag' }}
@@ -41,7 +42,8 @@ jobs:
       fail-fast: true
       matrix:
         IMAGE: ${{ fromJSON(inputs.images) }}
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@c747fe7769adf3656dc7d588b161cb614d7abfee # v1.10.0
+    # need to use non hash version because of: https://github.com/slsa-framework/slsa-github-generator/issues/3498
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.10.0
     with:
       image: ${{ matrix.IMAGE }}
       digest: ${{ fromJSON(inputs.image_digests)[matrix.IMAGE] }}


### PR DESCRIPTION
Because of https://github.com/slsa-framework/slsa-github-generator/issues/3498 we can't use hash in the action so we use version instead

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
