### PR TITLE
ci(github): correct DOCKER_USERNAME in provenance

### DIFF
--- a/.github/workflows/_provenance.yaml
+++ b/.github/workflows/_provenance.yaml
@@ -28,6 +28,7 @@ jobs:
       upload-assets: ${{ github.ref_type == 'tag' }}
       upload-tag-name: ${{ github.ref_name }}
       provenance-name: ${{ github.event.repository.name }}.intoto.jsonl
+      draft-release: "true"
 
   # Provenance job for all images manifests
   # SLSA generator is a reusable workflow
@@ -47,6 +48,6 @@ jobs:
     with:
       image: ${{ matrix.IMAGE }}
       digest: ${{ fromJSON(inputs.image_digests)[matrix.IMAGE] }}
+      registry-username: ${{ vars.DOCKER_USERNAME }}
     secrets:
       registry-password: ${{ secrets.DOCKER_API_KEY }}
-      registry-username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
We were using a secret instead of a variable

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
