### PR TITLE
feat(kubernetes): add possibility to not add owner reference

### DIFF
--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -401,6 +401,10 @@ runtime:
       # RenewDeadline is the duration that the acting controlplane will retry
       # refreshing leadership before giving up. Default is 10 seconds.
       renewDeadline: 10s # ENV: KUMA_RUNTIME_KUBERNETES_LEADER_ELECTION_RENEW_DEADLINE
+    # SkipMeshOwnerReference is a flag that allows to skip adding Mesh owner reference to resources.
+    # If this is set to true, deleting a Mesh will not delete resources that belong to that Mesh.
+    # This can be useful when resources are managed in Argo CD where creation/deletion is managed there.
+    skipMeshOwnerReference: false # ENV: KUMA_RUNTIME_KUBERNETES_SKIP_MESH_OWNER_REFERENCE
   # Universal-specific configuration
   universal:
     # DataplaneCleanupAge defines how long Dataplane should be offline to be cleaned up by GC

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -401,6 +401,10 @@ runtime:
       # RenewDeadline is the duration that the acting controlplane will retry
       # refreshing leadership before giving up. Default is 10 seconds.
       renewDeadline: 10s # ENV: KUMA_RUNTIME_KUBERNETES_LEADER_ELECTION_RENEW_DEADLINE
+    # SkipMeshOwnerReference is a flag that allows to skip adding Mesh owner reference to resources.
+    # If this is set to true, deleting a Mesh will not delete resources that belong to that Mesh.
+    # This can be useful when resources are managed in Argo CD where creation/deletion is managed there.
+    skipMeshOwnerReference: false # ENV: KUMA_RUNTIME_KUBERNETES_SKIP_MESH_OWNER_REFERENCE
   # Universal-specific configuration
   universal:
     # DataplaneCleanupAge defines how long Dataplane should be offline to be cleaned up by GC

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -231,7 +231,7 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.Runtime.Kubernetes.ClientConfig.BurstQps).To(Equal(100))
 			Expect(cfg.Runtime.Kubernetes.LeaderElection.LeaseDuration.Duration).To(Equal(199 * time.Second))
 			Expect(cfg.Runtime.Kubernetes.LeaderElection.RenewDeadline.Duration).To(Equal(99 * time.Second))
-			Expect(cfg.Runtime.Kubernetes.SkipMeshOwnerReference).To(Equal(true))
+			Expect(cfg.Runtime.Kubernetes.SkipMeshOwnerReference).To(BeTrue())
 
 			Expect(cfg.Runtime.Universal.DataplaneCleanupAge.Duration).To(Equal(1 * time.Hour))
 			Expect(cfg.Runtime.Universal.VIPRefreshInterval.Duration).To(Equal(10 * time.Second))

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -231,6 +231,8 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.Runtime.Kubernetes.ClientConfig.BurstQps).To(Equal(100))
 			Expect(cfg.Runtime.Kubernetes.LeaderElection.LeaseDuration.Duration).To(Equal(199 * time.Second))
 			Expect(cfg.Runtime.Kubernetes.LeaderElection.RenewDeadline.Duration).To(Equal(99 * time.Second))
+			Expect(cfg.Runtime.Kubernetes.SkipMeshOwnerReference).To(Equal(true))
+
 			Expect(cfg.Runtime.Universal.DataplaneCleanupAge.Duration).To(Equal(1 * time.Hour))
 			Expect(cfg.Runtime.Universal.VIPRefreshInterval.Duration).To(Equal(10 * time.Second))
 
@@ -563,6 +565,7 @@ runtime:
     leaderElection:
       leaseDuration: 199s
       renewDeadline: 99s
+    skipMeshOwnerReference: true
 reports:
   enabled: false
 general:
@@ -886,6 +889,7 @@ tracing:
 				"KUMA_RUNTIME_KUBERNETES_CLIENT_CONFIG_BURST_QPS":                                          "100",
 				"KUMA_RUNTIME_KUBERNETES_LEADER_ELECTION_LEASE_DURATION":                                   "199s",
 				"KUMA_RUNTIME_KUBERNETES_LEADER_ELECTION_RENEW_DEADLINE":                                   "99s",
+				"KUMA_RUNTIME_KUBERNETES_SKIP_MESH_OWNER_REFERENCE":                                        "true",
 				"KUMA_RUNTIME_UNIVERSAL_DATAPLANE_CLEANUP_AGE":                                             "1h",
 				"KUMA_RUNTIME_UNIVERSAL_VIP_REFRESH_INTERVAL":                                              "10s",
 				"KUMA_GENERAL_TLS_CERT_FILE":                                                               "/tmp/cert",

--- a/pkg/config/plugins/runtime/k8s/config.go
+++ b/pkg/config/plugins/runtime/k8s/config.go
@@ -149,6 +149,10 @@ type KubernetesRuntimeConfig struct {
 	ClientConfig ClientConfig `json:"clientConfig"`
 	// Kubernetes leader election configuration
 	LeaderElection LeaderElection `json:"leaderElection"`
+	// SkipMeshOwnerReference is a flag that allows to skip adding Mesh owner reference to resources.
+	// If this is set to true, deleting a Mesh will not delete resources that belong to that Mesh.
+	// This can be useful when resources are managed in Argo CD where creation/deletion is managed there.
+	SkipMeshOwnerReference bool `json:"skipMeshOwnerReference" envconfig:"kuma_runtime_kubernetes_skip_mesh_owner_reference"`
 }
 
 type ControllersConcurrency struct {

--- a/pkg/config/plugins/runtime/k8s/testdata/default-config.golden.yaml
+++ b/pkg/config/plugins/runtime/k8s/testdata/default-config.golden.yaml
@@ -79,3 +79,4 @@ nodeTaintController:
   cniNamespace: kube-system
   enabled: false
 serviceAccountName: system:serviceaccount:kuma-system:kuma-control-plane
+skipMeshOwnerReference: false

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -353,11 +353,12 @@ func addMutators(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter k8s_c
 	}
 
 	ownerRefMutator := &k8s_webhooks.OwnerReferenceMutator{
-		Client:       mgr.GetClient(),
-		CoreRegistry: core_registry.Global(),
-		K8sRegistry:  k8s_registry.Global(),
-		Scheme:       mgr.GetScheme(),
-		Decoder:      kube_admission.NewDecoder(mgr.GetScheme()),
+		Client:                 mgr.GetClient(),
+		CoreRegistry:           core_registry.Global(),
+		K8sRegistry:            k8s_registry.Global(),
+		Scheme:                 mgr.GetScheme(),
+		Decoder:                kube_admission.NewDecoder(mgr.GetScheme()),
+		SkipMeshOwnerReference: rt.Config().Runtime.Kubernetes.SkipMeshOwnerReference,
 	}
 	mgr.GetWebhookServer().Register("/owner-reference-kuma-io-v1alpha1", &kube_webhook.Admission{Handler: ownerRefMutator})
 

--- a/pkg/plugins/runtime/k8s/webhooks/owner_reference_mutator_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/owner_reference_mutator_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	admissionv1 "k8s.io/api/admission/v1"

--- a/pkg/plugins/runtime/k8s/webhooks/owner_reference_mutator_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/owner_reference_mutator_test.go
@@ -4,62 +4,55 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	admissionv1 "k8s.io/api/admission/v1"
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_runtime "k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	kube_admission "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	core_registry "github.com/kumahq/kuma/pkg/core/resources/registry"
-	mesh_k8s "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/api/v1alpha1"
-	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/model"
 	k8s_registry "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
 	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/webhooks"
 )
 
 var _ = Describe("OwnerReferenceMutator", func() {
-	createWebhook := func() webhook.AdmissionHandler {
-		return &webhooks.OwnerReferenceMutator{
-			Client:       k8sClient,
-			CoreRegistry: core_registry.Global(),
-			K8sRegistry:  k8s_registry.Global(),
-			Decoder:      decoder,
-			Scheme:       scheme,
-		}
-	}
-
-	createRequest := func(obj model.KubernetesObject, raw []byte) kube_admission.Request {
-		return kube_admission.Request{
-			AdmissionRequest: admissionv1.AdmissionRequest{
-				UID: "12345",
-				Object: kube_runtime.RawExtension{
-					Raw: raw,
-				},
-				Kind: kube_meta.GroupVersionKind{
-					Group:   obj.GetObjectKind().GroupVersionKind().Group,
-					Version: obj.GetObjectKind().GroupVersionKind().Version,
-					Kind:    obj.GetObjectKind().GroupVersionKind().Kind,
-				},
-			},
-		}
-	}
-
 	type testCase struct {
-		inputObject     string
-		expectedPatch   string
-		expectedMessage string
+		inputObject            string
+		expectedPatch          string
+		expectedMessage        string
+		skipMeshOwnerReference bool
+		ownerId                kube_meta.Object
 	}
 	DescribeTable("should add owner reference to resource owned by Mesh",
 		func(given testCase) {
-			tr := &mesh_k8s.TrafficRoute{}
-			err := json.Unmarshal([]byte(given.inputObject), tr)
-			Expect(err).ToNot(HaveOccurred())
-
-			wh := createWebhook()
-			r := wh.Handle(context.Background(), createRequest(tr, []byte(given.inputObject)))
+			if given.ownerId == nil {
+				given.ownerId = defaultMesh
+			}
+			k8sGroupVersionKind := kube_meta.GroupVersionKind{}
+			Expect(json.Unmarshal([]byte(given.inputObject), &k8sGroupVersionKind)).To(Succeed())
+			wh := &webhooks.OwnerReferenceMutator{
+				Client:                 k8sClient,
+				CoreRegistry:           core_registry.Global(),
+				K8sRegistry:            k8s_registry.Global(),
+				Decoder:                decoder,
+				Scheme:                 scheme,
+				SkipMeshOwnerReference: given.skipMeshOwnerReference,
+			}
+			req := kube_admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UID: "12345",
+					Object: kube_runtime.RawExtension{
+						Raw: []byte(given.inputObject),
+					},
+					Kind: kube_meta.GroupVersionKind{
+						Group:   k8sGroupVersionKind.Group,
+						Version: k8sGroupVersionKind.Version,
+						Kind:    k8sGroupVersionKind.Kind,
+					},
+				},
+			}
+			r := wh.Handle(context.Background(), req)
 			if given.expectedMessage != "" {
 				Expect(r.Result.Message).To(Equal(given.expectedMessage))
 			} else {
@@ -68,7 +61,7 @@ var _ = Describe("OwnerReferenceMutator", func() {
 			if given.expectedPatch != "" {
 				patch, err := json.Marshal(r.Patches)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(string(patch)).To(MatchJSON(fmt.Sprintf(given.expectedPatch, defaultMesh.GetUID())))
+				Expect(string(patch)).To(MatchJSON(fmt.Sprintf(given.expectedPatch, given.ownerId.GetUID())))
 			} else {
 				Expect(r.Patches).To(BeNil())
 			}
@@ -141,10 +134,8 @@ var _ = Describe("OwnerReferenceMutator", func() {
             }`,
 			expectedMessage: "ignored. MeshService has a reference for Service",
 		}),
-	)
-
-	It("should add owner reference to resource owned by Dataplane", func() {
-		inputObject := `
+		Entry("should add owner reference to resource owned by Dataplane", testCase{
+			inputObject: `
             {
               "apiVersion": "kuma.io/v1alpha1",
               "kind": "DataplaneInsight",
@@ -154,25 +145,8 @@ var _ = Describe("OwnerReferenceMutator", func() {
                 "name": "dp-1",
                 "creationTimestamp": null
               }
-            }`
-		dpInsight := &mesh_k8s.DataplaneInsight{}
-		err := json.Unmarshal([]byte(inputObject), dpInsight)
-		Expect(err).ToNot(HaveOccurred())
-
-		dp := &mesh_k8s.Dataplane{
-			ObjectMeta: kube_meta.ObjectMeta{
-				Name:      "dp-1",
-				Namespace: "default",
-			},
-			Mesh: "default",
-		}
-		err = k8sClient.Create(context.Background(), dp)
-		Expect(err).ToNot(HaveOccurred())
-
-		wh := createWebhook()
-		r := wh.Handle(context.Background(), createRequest(dpInsight, []byte(inputObject)))
-
-		expectedPatch := fmt.Sprintf(`
+            }`,
+			expectedPatch: `
             [
               {
                 "op": "add",
@@ -186,9 +160,52 @@ var _ = Describe("OwnerReferenceMutator", func() {
                   }
                 ]
               }
-            ]`, dp.GetUID())
-		patch, err := json.Marshal(r.Patches)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(string(patch)).To(MatchJSON(expectedPatch))
-	})
+            ]`,
+			ownerId: dp1,
+		}),
+		Entry("should add owner reference to resource owned by Dataplane even with SkipMeshOwnerReference", testCase{
+			inputObject: `
+            {
+              "apiVersion": "kuma.io/v1alpha1",
+              "kind": "DataplaneInsight",
+              "mesh": "default",
+              "metadata": {
+                "namespace": "default",
+                "name": "dp-1",
+                "creationTimestamp": null
+              }
+            }`,
+			expectedPatch: `
+            [
+              {
+                "op": "add",
+                "path": "/metadata/ownerReferences",
+                "value": [
+                  {
+                    "apiVersion": "kuma.io/v1alpha1",
+                    "kind": "Dataplane",
+                    "name": "dp-1",
+                    "uid": "%s"
+                  }
+                ]
+              }
+            ]`,
+			ownerId:                dp1,
+			skipMeshOwnerReference: true,
+		}),
+		Entry("should ignore mesh owner reference", testCase{
+			inputObject: `
+            {
+              "apiVersion": "kuma.io/v1alpha1",
+              "kind": "TrafficRoute",
+              "metadata": {
+                "namespace": "example",
+                "name": "empty",
+                "creationTimestamp": null
+              }
+            }`,
+			skipMeshOwnerReference: true,
+			expectedMessage:        "ignored. Configuration setup to ignore Mesh owner reference.",
+		}),
+	)
 })

--- a/pkg/plugins/runtime/k8s/webhooks/webhook_suite_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/webhook_suite_test.go
@@ -27,7 +27,18 @@ var (
 	testEnv     *envtest.Environment
 	k8sClient   client.Client
 	scheme      *kube_runtime.Scheme
-	defaultMesh *mesh_k8s.Mesh
+	defaultMesh = &mesh_k8s.Mesh{
+		ObjectMeta: kube_meta.ObjectMeta{
+			Name: "default",
+		},
+	}
+	dp1 = &mesh_k8s.Dataplane{
+		ObjectMeta: kube_meta.ObjectMeta{
+			Name:      "dp-1",
+			Namespace: "default",
+		},
+		Mesh: "default",
+	}
 )
 
 var _ = BeforeSuite(func() {
@@ -52,13 +63,9 @@ var _ = BeforeSuite(func() {
 	Expect(k8sClient).ToNot(BeNil())
 
 	// create default mesh
-	defaultMesh = &mesh_k8s.Mesh{
-		ObjectMeta: kube_meta.ObjectMeta{
-			Name: "default",
-		},
-	}
 	err = k8sClient.Create(context.Background(), defaultMesh)
 	Expect(err).ToNot(HaveOccurred())
+	Expect(k8sClient.Create(context.Background(), dp1)).To(Succeed())
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
Introduce a new config flag to not add ownerReference to resources.

This is useful when using argoCD which will refuse deleting resources if they have an ownerReference

Fix #9541

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
