### PR TITLE
ci(update-vulnerable-dependencies): pass KUMA_DIR to the script

### DIFF
--- a/mk/check.mk
+++ b/mk/check.mk
@@ -89,4 +89,4 @@ check: format/common lint ## Dev: Run code checks (go fmt, go vet, ...)
 
 .PHONY: update-vulnerable-dependencies
 update-vulnerable-dependencies:
-	@$(KUMA_DIR)/tools/ci/update-vulnerable-dependencies/update-vulnerable-dependencies.sh
+	@$(KUMA_DIR)/tools/ci/update-vulnerable-dependencies/update-vulnerable-dependencies.sh $(KUMA_DIR)

--- a/mk/check.mk
+++ b/mk/check.mk
@@ -89,4 +89,4 @@ check: format/common lint ## Dev: Run code checks (go fmt, go vet, ...)
 
 .PHONY: update-vulnerable-dependencies
 update-vulnerable-dependencies:
-	@$(KUMA_DIR)/tools/ci/update-vulnerable-dependencies/update-vulnerable-dependencies.sh $(KUMA_DIR)
+	@$(KUMA_DIR)/tools/ci/update-vulnerable-dependencies/update-vulnerable-dependencies.sh

--- a/tools/ci/update-vulnerable-dependencies/update-vulnerable-dependencies.sh
+++ b/tools/ci/update-vulnerable-dependencies/update-vulnerable-dependencies.sh
@@ -5,15 +5,13 @@ set -e
 command -v osv-scanner >/dev/null 2>&1 || { echo >&2 "osv-scanner not installed!"; exit 1; }
 command -v jq >/dev/null 2>&1 || { echo >&2 "jq not installed!"; exit 1; }
 
-KUMA_DIR=${1:-"."}
-
 for dep in $(osv-scanner --lockfile=go.mod --json | jq -c '.results[].packages[] | .package.name as $vulnerablePackage | {
   name: $vulnerablePackage,
   current: .package.version,
   fixedVersions: [.vulnerabilities[].affected[] | select(.package.name == $vulnerablePackage) | .ranges[].events |
   map(select(.fixed != null) | .fixed)] | map(select(length > 0)) } | select(.name != "github.com/kumahq/kuma")'); do
 
-  fixVersion=$(go run "$KUMA_DIR"/tools/ci/update-vulnerable-dependencies/main.go <<< "$dep")
+  fixVersion=$(go run "$(dirname -- "$0")"/main.go <<< "$dep")
 
   if [ "$fixVersion" != "null" ]; then
     package=$(jq -r .name <<< "$dep")

--- a/tools/ci/update-vulnerable-dependencies/update-vulnerable-dependencies.sh
+++ b/tools/ci/update-vulnerable-dependencies/update-vulnerable-dependencies.sh
@@ -5,13 +5,16 @@ set -e
 command -v osv-scanner >/dev/null 2>&1 || { echo >&2 "osv-scanner not installed!"; exit 1; }
 command -v jq >/dev/null 2>&1 || { echo >&2 "jq not installed!"; exit 1; }
 
+SCRIPT_PATH="${BASH_SOURCE[0]:-$0}";
+SCRIPT_DIR="$(dirname -- "$SCRIPT_PATH")"
+
 for dep in $(osv-scanner --lockfile=go.mod --json | jq -c '.results[].packages[] | .package.name as $vulnerablePackage | {
   name: $vulnerablePackage,
   current: .package.version,
   fixedVersions: [.vulnerabilities[].affected[] | select(.package.name == $vulnerablePackage) | .ranges[].events |
   map(select(.fixed != null) | .fixed)] | map(select(length > 0)) } | select(.name != "github.com/kumahq/kuma")'); do
 
-  fixVersion=$(go run "$(dirname -- "$0")"/main.go <<< "$dep")
+  fixVersion=$(go run "$SCRIPT_DIR"/main.go <<< "$dep")
 
   if [ "$fixVersion" != "null" ]; then
     package=$(jq -r .name <<< "$dep")


### PR DESCRIPTION
When this target is being called from the projects which depends on Kuma, path to `tools/ci/update-vulnerable-dependencies/main.go` is different, so script needs to take into account this root path.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - No relevant issues
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It actually fixes child repos
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Manually tested locally
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
