### PR TITLE
ci(check): fail CI wih `ci/force-publish` label on PRs from forks

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -35,7 +35,7 @@ jobs:
       IMAGES: ${{ steps.metadata.outputs.images }}
     steps:
       - name: "Fail when 'ci/force-publish' label is present on PRs from forks"
-        if: ${{ env.ALLOW_PUSH }} && ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+        if: ${{ env.ALLOW_PUSH && github.event.pull_request.head.repo.full_name != github.repository }}
         run: |
           echo "::error title=Label 'ci/force-publish' cannot be used on PRs from forks::To prevent accidental exposure of secrets, CI won't use repository secrets on pull requests from forks"
           exit 1

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -35,7 +35,7 @@ jobs:
       IMAGES: ${{ steps.metadata.outputs.images }}
     steps:
       - name: "Fail when 'ci/force-publish' label is present on PRs from forks"
-        if: ${{ env.ALLOW_PUSH && github.event.pull_request.head.repo.full_name != github.repository }}
+        if: ${{ fromJSON(env.ALLOW_PUSH) && github.event.pull_request.head.repo.full_name != github.repository }}
         run: |
           echo "::error title=Label 'ci/force-publish' cannot be used on PRs from forks::To prevent accidental exposure of secrets, CI won't use repository secrets on pull requests from forks"
           exit 1

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -35,7 +35,7 @@ jobs:
       IMAGES: ${{ steps.metadata.outputs.images }}
     steps:
       - name: "Fail when 'ci/force-publish' label is present on PRs from forks"
-        if: env.ALLOW_PUSH && github.event.pull_request.head.repo.full_name != github.repository
+        if: ${{ env.ALLOW_PUSH }} && ${{ github.event.pull_request.head.repo.full_name != github.repository }}
         run: |
           echo "::error title=Label 'ci/force-publish' cannot be used on PRs from forks::To prevent accidental exposure of secrets, CI won't use repository secrets on pull requests from forks"
           exit 1

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -34,6 +34,11 @@ jobs:
       BUILD: ${{ env.BUILD }}
       IMAGES: ${{ steps.metadata.outputs.images }}
     steps:
+      - name: "Fail when 'ci/force-publish' label is present on PRs from forks"
+        if: env.ALLOW_PUSH && github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          echo "::error title=Label 'ci/force-publish' cannot be used on PRs from forks::To prevent accidental exposure of secrets, CI won't use repository secrets on pull requests from forks"
+          exit 1
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           fetch-depth: 0


### PR DESCRIPTION
There is no access to secrets on a PRs from forks, so to have a quick feedback, whole workflow will immediately fail when CI will detect `ci/force-publish` label on such PRs.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - No relevant issues
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - https://github.com/kumahq/kuma/actions/runs/8537662169/job/23388720406?pr=9801
    ![image](https://github.com/kumahq/kuma/assets/11655498/06bd1fba-2289-4e52-8513-9e68f5796b4c)
    ![image](https://github.com/kumahq/kuma/assets/11655498/6681b1cd-5977-4946-8f13-df92d3337954)
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
