### PR TITLE
ci(github): add registry to provenance

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -16,6 +16,15 @@ on:
       IMAGES:
         required: true
         type: string
+      REGISTRY:
+        required: true
+        type: string
+      VERSION_NAME:
+        required: true
+        type: string
+      NOTARY_REPOSITORY:
+        required: true
+        type: string
     outputs:
       BINARY_ARTIFACT_DIGEST_BASE64:
         value: ${{ jobs.build-binaries.outputs.BINARY_ARTIFACT_DIGEST_BASE64 }}
@@ -117,11 +126,7 @@ jobs:
       - id: image_meta
         run: |
           echo "Extracting image meta for ${{ matrix.image }}"
-          registry=$(make docker/info/registry)
-          tag=$(make build/info/version)
-          echo "tag=${tag}" >> $GITHUB_OUTPUT
-          echo "registry=${registry}" >> $GITHUB_OUTPUT
-          echo "image=${registry}/${{ matrix.image }}:${tag}" >> $GITHUB_OUTPUT
+          echo "image=${{ inputs.REGISTRY }}/${{ matrix.image }}:${{ inputs.VERSION_NAME }}" >> $GITHUB_OUTPUT
           # Add matrix to .build/info to cache
           make build/info/short > .build-info
       - run: |
@@ -192,7 +197,7 @@ jobs:
         with:
           image_digest: ${{ steps.image_digest.outputs.digest }}
           tags: ${{ steps.image_meta.outputs.image }}
-          signature_registry: ${{ steps.image_meta.outputs.registry }}/notary${{ contains(steps.image_meta.outputs.tag, 'preview') && '-internal' }}
+          signature_registry: ${{ inputs.REGISTRY }}/${{inputs.NOTARY_REPOSITORY}}
           registry_username: ${{ vars.DOCKER_USERNAME }}
           registry_password: ${{ secrets.DOCKER_API_KEY }}
   digest-images:

--- a/.github/workflows/_provenance.yaml
+++ b/.github/workflows/_provenance.yaml
@@ -2,18 +2,26 @@ name: Generate Provenance
 on:
   workflow_call:
     inputs:
-      binary_artifacts_hashes_as_file:
+      BINARY_ARTIFACTS_HASH_AS_FILE:
         required: true
         type: string
         description: file containing hash for all compressed binary artifacts
-      images:
+      IMAGES:
         required: true
         type: string
-        description: JSON string containing all images
-      image_digests:
+        description: JSON string containing all IMAGES
+      IMAGE_DIGESTS:
         required: true
         type: string
         description: JSON string containing all image digests
+      REGISTRY:
+        required: true
+        type: string
+        description: registry name
+      NOTARY_REPOSITORY:
+        required: true
+        type: string
+        description: notary repository
 permissions:
   contents: write
   id-token: write # needed for signing the images
@@ -24,7 +32,7 @@ jobs:
     # need to use non hash version because of: https://github.com/slsa-framework/slsa-github-generator/issues/3498
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.10.0
     with:
-      base64-subjects: ${{ inputs.binary_artifacts_hashes_as_file }}
+      base64-subjects: ${{ inputs.BINARY_ARTIFACTS_HASH_AS_FILE }}
       upload-assets: ${{ github.ref_type == 'tag' }}
       upload-tag-name: ${{ github.ref_name }}
       provenance-name: ${{ github.event.repository.name }}.intoto.jsonl
@@ -42,12 +50,13 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        IMAGE: ${{ fromJSON(inputs.images) }}
+        IMAGE: ${{ fromJSON(inputs.IMAGES) }}
     # need to use non hash version because of: https://github.com/slsa-framework/slsa-github-generator/issues/3498
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.10.0
     with:
       image: ${{ matrix.IMAGE }}
-      digest: ${{ fromJSON(inputs.image_digests)[matrix.IMAGE] }}
+      digest: ${{ fromJSON(inputs.IMAGE_DIGESTS)[matrix.IMAGE] }}
+      provenance-registry: ${{ inputs.REGISTRY }}/${{ inputs.NOTARY_REPOSITORY }}
       registry-username: ${{ vars.DOCKER_USERNAME }}
     secrets:
       registry-password: ${{ secrets.DOCKER_API_KEY }}

--- a/.github/workflows/_provenance.yaml
+++ b/.github/workflows/_provenance.yaml
@@ -54,9 +54,8 @@ jobs:
     # need to use non hash version because of: https://github.com/slsa-framework/slsa-github-generator/issues/3498
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.10.0
     with:
-      image: ${{ matrix.IMAGE }}
+      image: ${{ inputs.REGISTRY }}/${{ matrix.IMAGE }}
       digest: ${{ fromJSON(inputs.IMAGE_DIGESTS)[matrix.IMAGE] }}
-      provenance-registry: ${{ inputs.REGISTRY }}/${{ inputs.NOTARY_REPOSITORY }}
       registry-username: ${{ vars.DOCKER_USERNAME }}
     secrets:
       registry-password: ${{ secrets.DOCKER_API_KEY }}

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -34,6 +34,9 @@ jobs:
       ALLOW_PUSH: ${{ env.ALLOW_PUSH }}
       BUILD: ${{ env.BUILD }}
       IMAGES: ${{ steps.metadata.outputs.images }}
+      REGISTRY: ${{ steps.metadata.outputs.registry }}
+      VERSION_NAME: ${{ steps.metadata.outputs.version }}
+      NOTARY_REPOSITORY: ${{ (contains(steps.metadata.outputs.version, 'preview') && 'notary-internal') || 'notary' }}
     steps:
       - name: "Fail when 'ci/force-publish' label is present on PRs from forks"
         if: ${{ fromJSON(env.FORCE_PUBLISH_FROM_FORK) }}
@@ -73,6 +76,8 @@ jobs:
       - id: metadata
         run: |
           echo "images=$(make images/info/release/json)" >> $GITHUB_OUTPUT
+          echo "registry=$(make docker/info/registry)" >> $GITHUB_OUTPUT
+          echo "version=$(make build/info/version)" >> $GITHUB_OUTPUT
   test:
     permissions:
       contents: read
@@ -94,6 +99,9 @@ jobs:
       IMAGE_ARTIFACT_NAME: "image_artifacts"
       BINARY_ARTIFACT_NAME: "binary_artifacts"
       IMAGES: ${{ needs.check.outputs.IMAGES }}
+      REGISTRY: ${{ needs.check.outputs.REGISTRY }}
+      NOTARY_REPOSITORY: ${{ needs.check.outputs.NOTARY_REPOSITORY }}
+      VERSION_NAME: ${{ needs.build_publish.outputs.VERSION_NAME }}
     secrets: inherit
   provenance:
     needs: ["check", "build_publish"]
@@ -106,9 +114,11 @@ jobs:
       actions: read # For getting workflow run info to build provenance
       packages: write # Required for publishing provenance. Issue: https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/container#known-issues
     with:
-      binary_artifacts_hashes_as_file: ${{ needs.build_publish.outputs.BINARY_ARTIFACT_DIGEST_BASE64 }}
-      images: ${{ needs.check.outputs.IMAGES }}
-      image_digests: ${{ needs.build_publish.outputs.IMAGE_DIGESTS }}
+      BINARY_ARTIFACTS_HASH_AS_FILE: ${{ needs.build_publish.outputs.BINARY_ARTIFACT_DIGEST_BASE64 }}
+      IMAGES: ${{ needs.check.outputs.IMAGES }}
+      REGISTRY: ${{ needs.check.outputs.REGISTRY }}
+      NOTARY_REPOSITORY: ${{ needs.check.outputs.NOTARY_REPOSITORY }}
+      IMAGE_DIGESTS: ${{ needs.build_publish.outputs.IMAGE_DIGESTS }}
   distributions:
     needs: ["build_publish", "check", "test", "provenance"]
     timeout-minutes: 10


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
