### PR TITLE
docs(MADR): `warnings` field in the Resource API responses

### DIFF
--- a/docs/madr/decisions/041-resource-api-warnings.md
+++ b/docs/madr/decisions/041-resource-api-warnings.md
@@ -1,0 +1,64 @@
+# Introduce Warnings for Resource API
+
+- Status: accepted
+
+## Context and Problem Statement
+
+Resource API implements CRUDL operations for Kuma resources (policies, configs, etc.).
+If resource is correct it returns `200 OK` or `201 Created`. 
+If there is a validation error it returns `400 Bad Request`.
+Today we're missing a way to return the information on deprecated fields or values.
+
+Kubernetes implements similar functionality using the ValidatingWebhook. 
+The [AdmissionResponse schema](https://kubernetes.io/docs/reference/config-api/apiserver-admission.v1/#admission-k8s-io-v1-AdmissionResponse) has a `warnings` field:
+
+> warnings is a list of warning messages to return to the requesting API client. 
+> Warning messages describe a problem the client making the API request should correct or be aware of. 
+> Limit warnings to 120 characters if possible. 
+> Warnings over 256 characters and large numbers of warnings may be truncated.
+
+and `kubectl apply` outputs them to stderr:
+
+```bash
+$ kubectl apply -f policy.yaml
+Warning: the field "X" is deprecated, please consider using "Y"
+meshtimeout.kuma.io/timeout-global created
+```
+
+## Considered options
+
+- Introduce a `warnings` field to the successful 200 and 201 responses.
+
+## Decision Outcome
+
+- Introduce a `warnings` field to the successful 200 and 201 responses.
+
+## Implementation
+
+The `response` list for Resource API should be updated:
+
+```yaml
+responses:
+  '200':
+    description: Updated
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            warnings:
+              type: array
+              items:
+                type: string
+  '201':
+    description: Created
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            warnings:
+              type: array
+              items:
+                type: string
+```


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
