### PR TITLE
fix{meshloadbalancingstrategy): configure bultiin gateway

### DIFF
--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
@@ -187,12 +187,6 @@ func (p plugin) configureGateway(
 			continue
 		}
 
-		meshConf := core_rules.ComputeConf[api.Conf](rules, core_rules.MeshSubset())
-
-		if err := p.configureListener(listener, gatewayRoutes, meshConf); err != nil {
-			return err
-		}
-
 		for _, listenerHostnames := range listenerInfo.ListenerHostnames {
 			for _, hostInfo := range listenerHostnames.HostInfos {
 				destinations := gateway_plugin.RouteDestinationsMutable(hostInfo.Entries())
@@ -211,6 +205,10 @@ func (p plugin) configureGateway(
 					if localityConf == nil {
 						continue
 					}
+					if err := p.configureListener(listener, gatewayRoutes, localityConf); err != nil {
+						return err
+					}
+
 					if err := p.configureCluster(cluster, *localityConf); err != nil {
 						return err
 					}

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
@@ -190,6 +190,7 @@ func (p plugin) configureGateway(
 		for _, listenerHostnames := range listenerInfo.ListenerHostnames {
 			for _, hostInfo := range listenerHostnames.HostInfos {
 				destinations := gateway_plugin.RouteDestinationsMutable(hostInfo.Entries())
+				configuredServices := map[string]bool{}
 				for _, dest := range destinations {
 					clusterName, err := dest.Destination.DestinationClusterName(hostInfo.Host.Tags)
 					if err != nil {
@@ -205,8 +206,11 @@ func (p plugin) configureGateway(
 					if localityConf == nil {
 						continue
 					}
-					if err := p.configureListener(listener, gatewayRoutes, localityConf); err != nil {
-						return err
+					if _, ok := configuredServices[serviceName]; !ok {
+						if err := p.configureListener(listener, gatewayRoutes, localityConf); err != nil {
+							return err
+						}
+						configuredServices[serviceName] = true
 					}
 
 					if err := p.configureCluster(cluster, *localityConf); err != nil {

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
@@ -308,7 +308,7 @@ func (p plugin) configureListener(
 			default:
 				return errors.Errorf("unexpected RouteSpecifer %T", r)
 			}
-	
+
 			hpc := &xds.HashPolicyConfigurer{HashPolicies: *hashPolicy}
 			for _, vh := range routeConfig.VirtualHosts {
 				for _, route := range vh.Routes {

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
@@ -1225,7 +1225,7 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 				Items: []*core_mesh.MeshGatewayResource{samples.GatewayResource()},
 			}
 			resources.MeshLocalResources[core_mesh.MeshGatewayRouteType] = &core_mesh.MeshGatewayRouteResourceList{
-				Items: []*core_mesh.MeshGatewayRouteResource{samples.BackendGatewayRoute()},
+				Items: []*core_mesh.MeshGatewayRouteResource{samples.BackendGatewayRoute(), samples.BackendGatewaySecondRoute()},
 			}
 
 			xdsCtx := *xds_builders.Context().

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/basic.gateway.routes.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/basic.gateway.routes.golden.yaml
@@ -22,11 +22,6 @@ resources:
             terminal: true
           - connectionProperties:
               sourceIp: true
-          - queryParameter:
-              name: queryparam
-            terminal: true
-          - connectionProperties:
-              sourceIp: true
           idleTimeout: 5s
           weightedClusters:
             clusters:
@@ -41,11 +36,6 @@ resources:
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           hashPolicy:
-          - queryParameter:
-              name: queryparam
-            terminal: true
-          - connectionProperties:
-              sourceIp: true
           - queryParameter:
               name: queryparam
             terminal: true

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/basic.gateway.routes.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/basic.gateway.routes.golden.yaml
@@ -13,10 +13,39 @@ resources:
       name: '*'
       routes:
       - match:
+          path: /another
+        route:
+          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+          hashPolicy:
+          - queryParameter:
+              name: queryparam
+            terminal: true
+          - connectionProperties:
+              sourceIp: true
+          - queryParameter:
+              name: queryparam
+            terminal: true
+          - connectionProperties:
+              sourceIp: true
+          idleTimeout: 5s
+          weightedClusters:
+            clusters:
+            - name: backend-d230d75c0fcb71dc
+              requestHeadersToAdd:
+              - header:
+                  key: x-kuma-tags
+                  value: '&k8s.io/az=test&&k8s.io/node=node1&&k8s.io/region=test&&kuma.io/service=sample-gateway&'
+              weight: 1
+      - match:
           path: /
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
           hashPolicy:
+          - queryParameter:
+              name: queryparam
+            terminal: true
+          - connectionProperties:
+              sourceIp: true
           - queryParameter:
               name: queryparam
             terminal: true

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware.gateway.routes.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware.gateway.routes.golden.yaml
@@ -13,6 +13,19 @@ resources:
       name: '*'
       routes:
       - match:
+          path: /another
+        route:
+          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+          idleTimeout: 5s
+          weightedClusters:
+            clusters:
+            - name: backend-d230d75c0fcb71dc
+              requestHeadersToAdd:
+              - header:
+                  key: x-kuma-tags
+                  value: '&k8s.io/az=test&&k8s.io/node=node1&&k8s.io/region=test&&kuma.io/service=sample-gateway&'
+              weight: 1
+      - match:
           path: /
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/no-cross-zone.gateway.routes.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/no-cross-zone.gateway.routes.golden.yaml
@@ -13,6 +13,19 @@ resources:
       name: '*'
       routes:
       - match:
+          path: /another
+        route:
+          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+          idleTimeout: 5s
+          weightedClusters:
+            clusters:
+            - name: backend-d230d75c0fcb71dc
+              requestHeadersToAdd:
+              - header:
+                  key: x-kuma-tags
+                  value: '&k8s.io/az=test&&k8s.io/node=node1&&k8s.io/region=test&&kuma.io/service=sample-gateway&'
+              weight: 1
+      - match:
           path: /
         route:
           clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR

--- a/pkg/test/resources/samples/gateway_samples.go
+++ b/pkg/test/resources/samples/gateway_samples.go
@@ -15,6 +15,14 @@ func BackendGatewayRoute() *core_mesh.MeshGatewayRouteResource {
 		Build()
 }
 
+func BackendGatewaySecondRoute() *core_mesh.MeshGatewayRouteResource {
+	return builders.GatewayRoute().
+		WithName("sample-gateway-route-second").
+		WithGateway("sample-gateway").
+		WithExactMatchHttpRoute("/another", "backend").
+		Build()
+}
+
 func BackendGatewayTCPRoute() *core_mesh.MeshGatewayRouteResource {
 	return builders.GatewayRoute().
 		WithName("sample-tcp-gateway-route").

--- a/test/e2e_env/kubernetes/gateway/delegated/meshloadbalancingstrategy.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshloadbalancingstrategy.go
@@ -34,7 +34,7 @@ func MeshLoadBalancingStrategy(config *Config) func() {
 				)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(responses).To(HaveLen(3))
-			}, "30s", "1s").Should(Succeed())
+			}, "30s", "500ms").Should(Succeed())
 
 			Expect(framework.YamlK8s(fmt.Sprintf(`
 kind: MeshLoadBalancingStrategy
@@ -72,7 +72,7 @@ spec:
 				)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(responses).To(HaveLen(1))
-			}, "30s", "1s", MustPassRepeatedly(5)).Should(Succeed())
+			}, "30s", "500ms").Should(Succeed())
 		})
 	}
 }

--- a/test/e2e_env/kubernetes/gateway/delegated/meshloadbalancingstrategy.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshloadbalancingstrategy.go
@@ -34,7 +34,7 @@ func MeshLoadBalancingStrategy(config *Config) func() {
 				)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(responses).To(HaveLen(3))
-			}, "30s", "500ms").Should(Succeed())
+			}, "30s", "1s").Should(Succeed())
 
 			Expect(framework.YamlK8s(fmt.Sprintf(`
 kind: MeshLoadBalancingStrategy
@@ -72,7 +72,7 @@ spec:
 				)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(responses).To(HaveLen(1))
-			}, "30s", "500ms").Should(Succeed())
+			}, "30s", "1s", MustPassRepeatedly(5)).Should(Succeed())
 		})
 	}
 }

--- a/test/e2e_env/kubernetes/gateway/gateway.go
+++ b/test/e2e_env/kubernetes/gateway/gateway.go
@@ -551,7 +551,7 @@ spec:
                 header:
                   name: x-header
 `, Config.KumaNamespace, meshName)
-		routes :=httpRoute("test-server-mlbs", "/mlbs", "test-server-mlbs_simple-gateway_svc_80")
+		routes := httpRoute("test-server-mlbs", "/mlbs", "test-server-mlbs_simple-gateway_svc_80")
 
 		BeforeAll(func() {
 			err := NewClusterSetup().

--- a/test/e2e_env/kubernetes/gateway/gateway.go
+++ b/test/e2e_env/kubernetes/gateway/gateway.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	meshretry_api "github.com/kumahq/kuma/pkg/plugins/policies/meshretry/api/v1alpha1"
+	"github.com/kumahq/kuma/test/framework"
 	. "github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/framework/client"
 	"github.com/kumahq/kuma/test/framework/deployments/testserver"
@@ -521,6 +522,87 @@ spec:
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(response.ResponseCode).To(Equal(429))
 			}, "30s", "1s").Should(Succeed())
+		})
+	})
+
+	Context("MeshLoadBalancingStrategy", func() {
+		mlbs := fmt.Sprintf(`
+kind: MeshLoadBalancingStrategy
+apiVersion: kuma.io/v1alpha1
+metadata:
+  name: ring-hash
+  namespace: %s
+  labels:
+    kuma.io/mesh: %s
+spec:
+  targetRef:
+    kind: MeshGateway
+    name: simple-gateway
+  to:
+    - targetRef:
+        kind: MeshService
+        name: test-server-mlbs_%[2]s_svc_80
+      default:
+        loadBalancer:
+          type: RingHash
+          ringHash:
+            hashPolicies:
+              - type: Header
+                header:
+                  name: x-header
+`, Config.KumaNamespace, meshName)
+		routes :=httpRoute("test-server-mlbs", "/mlbs", "test-server-mlbs_simple-gateway_svc_80")
+
+		BeforeAll(func() {
+			err := NewClusterSetup().
+				Install(testserver.Install(
+					testserver.WithMesh(meshName),
+					testserver.WithNamespace(namespace),
+					testserver.WithName("test-server-mlbs"),
+					testserver.WithStatefulSet(true),
+					testserver.WithReplicas(3),
+				)).
+				Install(YamlK8s(routes...)).
+				Setup(kubernetes.Cluster)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterAll(func() {
+			err := NewClusterSetup().
+				Install(DeleteYamlK8s(routes...)).
+				Install(DeleteYamlK8s(mlbs)).
+				Setup(kubernetes.Cluster)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should route to only one instance", func() {
+			Eventually(func(g Gomega) {
+				responses, err := client.CollectResponsesByInstance(
+					kubernetes.Cluster, "demo-client",
+					"http://simple-gateway.simple-gateway:8080/mlbs",
+					client.WithHeader("host", "example.kuma.io"),
+					client.FromKubernetesPod(clientNamespace, "demo-client"),
+					client.WithHeader("x-header", "value"),
+				)
+
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(responses).To(HaveLen(3))
+			}, "30s", "1s").Should(Succeed())
+
+			Expect(framework.YamlK8s(mlbs)(kubernetes.Cluster)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				responses, err := client.CollectResponsesByInstance(
+					kubernetes.Cluster, "demo-client",
+					"http://simple-gateway.simple-gateway:8080/mlbs",
+					client.WithHeader("host", "example.kuma.io"),
+					client.FromKubernetesPod(clientNamespace, "demo-client"),
+					client.WithHeader("x-header", "value"),
+				)
+
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(responses).To(HaveLen(1))
+			}, "30s", "1s").MustPassRepeatedly(5).Should(Succeed())
 		})
 	})
 


### PR DESCRIPTION
### Checklist prior to review

While checking the MeshLoadBalancingStrategy I noticed the builtin gateway is not configured when using targetRef to, `MeshService`. It was caused by a condition that we were trying to get configuration using MeshSubset from `MeshService`.

```
meshConf := core_rules.ComputeConf[api.Conf](rules, core_rules.MeshSubset())
```
which returns nil because a subset of a specific service cannot have all services.

* use per-service configuration and configure listener once to avoid duplicate configuration
* allow more than one filter chain (gateway might have more)
* added E2E test


- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
