### PR TITLE
feat(kuma-cp): do not set mesh owner reference on synced resources

### DIFF
--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -306,6 +306,7 @@ func addValidators(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter k8s
 		Client:       client,
 		Validator:    manager.NewSecretValidator(rt.CaManagers(), rt.ResourceStore()),
 		UnsafeDelete: rt.Config().Store.UnsafeDelete,
+		CpMode:       rt.Config().Mode,
 	}
 	mgr.GetWebhookServer().Register("/validate-v1-secret", &kube_webhook.Admission{Handler: secretValidator})
 
@@ -354,6 +355,7 @@ func addMutators(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter k8s_c
 		Scheme:                 mgr.GetScheme(),
 		Decoder:                kube_admission.NewDecoder(mgr.GetScheme()),
 		SkipMeshOwnerReference: rt.Config().Runtime.Kubernetes.SkipMeshOwnerReference,
+		CpMode:                 rt.Config().Mode,
 	}
 	mgr.GetWebhookServer().Register("/owner-reference-kuma-io-v1alpha1", &kube_webhook.Admission{Handler: ownerRefMutator})
 

--- a/pkg/plugins/runtime/k8s/webhooks/secret_validator_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/secret_validator_test.go
@@ -13,6 +13,8 @@ import (
 	kube_admission "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/yaml"
 
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	config_core "github.com/kumahq/kuma/pkg/config/core"
 	secrets_manager "github.com/kumahq/kuma/pkg/core/secrets/manager"
 	core_validators "github.com/kumahq/kuma/pkg/core/validators"
 	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/webhooks"
@@ -51,6 +53,22 @@ var _ = Describe("ServiceValidator", func() {
 		}
 		err = k8sClient.Create(context.Background(), secret)
 		Expect(err).ToNot(HaveOccurred())
+
+		secret = &kube_core.Secret{
+			ObjectMeta: kube_meta.ObjectMeta{
+				Name:      "synced-secret",
+				Namespace: "default",
+				Labels: map[string]string{
+					mesh_proto.ResourceOriginLabel: string(mesh_proto.GlobalResourceOrigin),
+				},
+			},
+			Data: map[string][]byte{
+				"value": []byte("dGVzdAo="),
+			},
+			Type: "system.kuma.io/secret",
+		}
+		err = k8sClient.Create(context.Background(), secret)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
@@ -66,6 +84,7 @@ var _ = Describe("ServiceValidator", func() {
 				Client:       k8sClient,
 				Validator:    &testSecretValidator{},
 				UnsafeDelete: given.unsafeDelete,
+				CpMode:       config_core.Zone,
 			}
 			admissionReview := admissionv1.AdmissionReview{}
 			err := yaml.Unmarshal([]byte(given.request), &admissionReview)
@@ -495,6 +514,28 @@ var _ = Describe("ServiceValidator", func() {
             allowed: true
             status:
               code: 200
+              metadata: {}
+            uid: ""`,
+		}),
+		Entry("should allow deleting synced secret", testCase{
+			request: `
+            apiVersion: admission.k8s.io/v1
+            kind: AdmissionReview
+            request:
+              uid: 12345
+              kind:
+                group: ""
+                kind: Secret
+                version: v1
+              name: synced-secret
+              namespace: default
+              operation: DELETE
+`,
+			expected: `
+            allowed: true
+            status:
+              code: 200
+              message: ignore. It's synced resource.
               metadata: {}
             uid: ""`,
 		}),


### PR DESCRIPTION
### Checklist prior to review

I investigated KDS NACKs in E2E tests and all of them are caused by mesh owner reference.
What is interesting is that we don't set Mesh owner reference on Universal (because we go directly thorough store, not resource manager), that's why the only NACKs we saw were from Kube zones.

Setting mesh owner reference caused the following problems:
* Policy is synced before mesh - fails because mesh is not present so we cannot set an owner
* Resource not found on delete - fails because resource was first deleted by owner mechanism

Additionally, I disabled secret delete validation on synced resources. This also caused a race when you delete Secret before Mesh. It was also only applied on Kube because of same reasons (store vs manager).

After this change, I see 0 NACKs on KDS in the multizone suite.

Also, first I tried ordering resources over KDS, but not waiting for ACK resulted races as well. I think it's just more correct to trust the source of truth (other CP that manages resource).

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
