### PR TITLE
perf(k8s): ignore serviceless pods from vips list

### DIFF
--- a/pkg/dns/vips_allocator.go
+++ b/pkg/dns/vips_allocator.go
@@ -352,6 +352,9 @@ func (d *VIPsAllocator) buildVirtualOutboundMeshView(
 			if inbound.State == mesh_proto.Dataplane_Networking_Inbound_Ignored {
 				continue
 			}
+			if inbound.Port == mesh_proto.TCPPortReserved {
+				continue
+			}
 			if d.serviceVipEnabled {
 				errs = multierr.Append(errs, addDefault(outboundSet, inbound.GetService(), 0))
 			}

--- a/test/e2e_env/kubernetes/inspect/inspect.go
+++ b/test/e2e_env/kubernetes/inspect/inspect.go
@@ -68,7 +68,6 @@ func Inspect() {
 		stdout, err := kubernetes.Cluster.GetKumactlOptions().RunKumactlAndGetOutput("inspect", "dataplane", "-m", meshName, dataplaneName, "--type=config-dump")
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(stdout).To(ContainSubstring(fmt.Sprintf(`"name": "demo-client_%s_svc"`, nsName)))
 		Expect(stdout).To(ContainSubstring(`"name": "inbound:passthrough:ipv4"`))
 		Expect(stdout).To(ContainSubstring(`"name": "inbound:passthrough:ipv6"`))
 		Expect(stdout).To(ContainSubstring(`"name": "kuma:envoy:admin"`))


### PR DESCRIPTION
### Checklist prior to review

Instead of https://github.com/kumahq/kuma/pull/9896

Do not include serviceless pods into vips list. Those are not adressable anyways, so we can save unnecessary XDS changes.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
