### PR TITLE
fix(kuma-cp): change the "direction" of the diff in inspect shadow responses

### DIFF
--- a/api/openapi/specs/api.yaml
+++ b/api/openapi/specs/api.yaml
@@ -93,7 +93,7 @@ paths:
           name: include
           description: |
             An array of extra fields to include in the response. When `include=diff` the server computes a diff in JSONPatch format
-            between the XDS config returned in 'xds' and the current proxy XDS config.
+            between the current proxy XDS config and the config returned in the 'xds' field.
           schema:
             type: array
             items:

--- a/api/openapi/types/zz_generated.api.go
+++ b/api/openapi/types/zz_generated.api.go
@@ -164,7 +164,7 @@ type GetMeshesMeshDataplanesNameConfigParams struct {
 	Shadow *bool `form:"shadow,omitempty" json:"shadow,omitempty"`
 
 	// Include An array of extra fields to include in the response. When `include=diff` the server computes a diff in JSONPatch format
-	// between the XDS config returned in 'xds' and the current proxy XDS config.
+	// between the current proxy XDS config and the config returned in the 'xds' field.
 	Include *[]GetMeshesMeshDataplanesNameConfigParamsInclude `form:"include,omitempty" json:"include,omitempty"`
 }
 

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -105,8 +105,8 @@ paths:
             An array of extra fields to include in the response. When
             `include=diff` the server computes a diff in JSONPatch format
 
-            between the XDS config returned in 'xds' and the current proxy XDS
-            config.
+            between the current proxy XDS config and the config returned in the
+            'xds' field.
           schema:
             type: array
             items:

--- a/docs/madr/decisions/040-transition-to-new-policies.md
+++ b/docs/madr/decisions/040-transition-to-new-policies.md
@@ -64,9 +64,10 @@ Add a query parameter `shadow=true`:
 
 when `shadow=true` is set, the response will take policies with `kuma.io/effect: shadow` label into account.
 
-For visualization in GUI it would be nice to include the diff between the shadow XDS config and the current XDS config.
-When `include=diff` query parameter is set the response includes a JSONPatch that can be applied to the returned XDS config to get the current proxy XDS config.
-For `shadow=false&include=diff` the server should return an empty JSONPatch diff alongside the current XDS config.
+For visualization in GUI it would be nice to include the diff between the current XDS config and the shadow XDS config.
+When `include=diff` query parameter is set the response includes the diff in a JSONPatch format.
+The config in response `xds` filed is always a result of JSONPatch diff from `diff` field applied to the current XDS config.
+So when the query is `shadow=false&include=diff` the server should return an empty JSONPatch diff alongside the current XDS config.
 
 OpenAPI spec for new endpoints:
 

--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -726,7 +726,7 @@ func (r *resourceEndpoints) configForProxy() restful.RouteFunction {
 				rest_errors.HandleError(ctx, response, err, "Failed to inspect current proxy config")
 				return
 			}
-			diff, err := inspect.Diff(config, currentConfig)
+			diff, err := inspect.Diff(currentConfig, config)
 			if err != nil {
 				rest_errors.HandleError(ctx, response, err, "Failed to compute diff")
 				return

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/proxyconfig_shadow-true_diff.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/proxyconfig_shadow-true_diff.golden.json
@@ -3,32 +3,32 @@
   {
    "op": "test",
    "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/connectTimeout",
-   "value": "5s"
+   "value": "10s"
   },
   {
    "op": "remove",
-   "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/connectTimeout",
-   "value": "5s"
-  },
-  {
-   "op": "add",
    "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/connectTimeout",
    "value": "10s"
   },
   {
+   "op": "add",
+   "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/connectTimeout",
+   "value": "5s"
+  },
+  {
    "op": "test",
    "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:127.0.0.1:8080/filterChains/0/filters/0/typedConfig/idleTimeout",
-   "value": "322s"
+   "value": "7200s"
   },
   {
    "op": "remove",
    "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:127.0.0.1:8080/filterChains/0/filters/0/typedConfig/idleTimeout",
-   "value": "322s"
+   "value": "7200s"
   },
   {
    "op": "add",
    "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:127.0.0.1:8080/filterChains/0/filters/0/typedConfig/idleTimeout",
-   "value": "7200s"
+   "value": "322s"
   }
  ],
  "xds": {


### PR DESCRIPTION
Previously the following invariant took place in the `_config` endpoint:
```
${response.diff} apply to ${response.xds} results in ${current_proxy_config}
```

this PR changes the invariant to:

```
${response.diff} apply to ${current_proxy_config} results in ${response.xds}
```

that way users see a list of changes that are going to be applied to current configs if they switch "shadow" mode to normal one.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
