### PR TITLE
chore(kuma-cp): define fake USR2 signal for windows

### DIFF
--- a/pkg/core/alias.go
+++ b/pkg/core/alias.go
@@ -26,7 +26,7 @@ var (
 		gracefulCtx, gracefulCancel := context.WithCancel(context.Background())
 		ctx, cancel := context.WithCancel(context.Background())
 		c := make(chan os.Signal, 3)
-		signal.Notify(c, syscall.SIGINT, syscall.SIGTERM, syscall.SIGUSR2)
+		signal.Notify(c, handledSignals...)
 		usr2Notify := make(chan struct{}, 1)
 		go func() {
 			logger := Log.WithName("runtime")
@@ -50,7 +50,7 @@ var (
 						os.Exit(1)
 					}
 					numberOfStopSignals++
-				case syscall.SIGUSR2:
+				case usr2:
 					select {
 					case usr2Notify <- struct{}{}:
 					default:

--- a/pkg/core/signals.go
+++ b/pkg/core/signals.go
@@ -1,0 +1,11 @@
+//go:build !windows
+package core
+
+import (
+	"os"
+	"syscall"
+)
+
+var handledSignals = []os.Signal{syscall.SIGINT, syscall.SIGTERM, syscall.SIGUSR2}
+
+var usr2 os.Signal = syscall.SIGUSR2

--- a/pkg/core/signals.go
+++ b/pkg/core/signals.go
@@ -1,4 +1,5 @@
 //go:build !windows
+
 package core
 
 import (

--- a/pkg/core/signals_windows.go
+++ b/pkg/core/signals_windows.go
@@ -1,0 +1,20 @@
+package core
+
+import (
+	"os"
+	"syscall"
+)
+
+var handledSignals = []os.Signal{syscall.SIGINT, syscall.SIGTERM, usr2}
+
+// "syscall" doesn't define a fake USR2 for us...
+type usr2Signal struct {
+}
+
+func (usr2Signal) String() string {
+	return "user defined signal 2"
+}
+
+func (usr2Signal) Signal() {}
+
+var usr2 os.Signal = usr2Signal{}


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
