### PR TITLE
chore(demo): remove tags from meshgatewayinstance

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-demo.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-demo.defaults.golden.yaml
@@ -106,7 +106,7 @@ spec:
       protocol: HTTP
   selectors:
   - match:
-      kuma.io/service: demo-app_gateway
+      kuma.io/service: demo-app-gateway_kuma-demo_svc
 ---
 apiVersion: kuma.io/v1alpha1
 kind: MeshGatewayInstance

--- a/app/kumactl/cmd/install/testdata/install-demo.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-demo.defaults.golden.yaml
@@ -116,8 +116,6 @@ metadata:
 spec:
   replicas: 1
   serviceType: LoadBalancer
-  tags:
-    kuma.io/service: demo-app_gateway
 ---
 apiVersion: kuma.io/v1alpha1
 kind: MeshHTTPRoute

--- a/app/kumactl/cmd/install/testdata/install-demo.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-demo.overrides.golden.yaml
@@ -106,7 +106,7 @@ spec:
       protocol: HTTP
   selectors:
   - match:
-      kuma.io/service: demo-app_gateway
+      kuma.io/service: demo-app-gateway_kuma-demo_svc
 ---
 apiVersion: kuma.io/v1alpha1
 kind: MeshGatewayInstance

--- a/app/kumactl/cmd/install/testdata/install-demo.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-demo.overrides.golden.yaml
@@ -116,8 +116,6 @@ metadata:
 spec:
   replicas: 1
   serviceType: LoadBalancer
-  tags:
-    kuma.io/service: demo-app_gateway
 ---
 apiVersion: kuma.io/v1alpha1
 kind: MeshHTTPRoute

--- a/app/kumactl/data/install/k8s/demo/gateway.yaml
+++ b/app/kumactl/data/install/k8s/demo/gateway.yaml
@@ -13,7 +13,7 @@ spec:
       protocol: HTTP
   selectors:
   - match:
-      kuma.io/service: demo-app_gateway
+      kuma.io/service: demo-app-gateway_kuma-demo_svc
 ---
 apiVersion: kuma.io/v1alpha1
 kind: MeshHTTPRoute

--- a/app/kumactl/data/install/k8s/demo/gateway.yaml
+++ b/app/kumactl/data/install/k8s/demo/gateway.yaml
@@ -48,5 +48,3 @@ metadata:
 spec:
   replicas: 1
   serviceType: LoadBalancer
-  tags:
-    kuma.io/service: demo-app_gateway


### PR DESCRIPTION
### Checklist prior to review

It's deprecated to use kuma.io/service tag in MeshGatewayInstance

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
