### PR TITLE
test(e2e): fix number of policies on upgrade

### DIFF
--- a/test/e2e/helm/kuma_helm_upgrade_multizone.go
+++ b/test/e2e/helm/kuma_helm_upgrade_multizone.go
@@ -132,7 +132,7 @@ spec:
 			n, err := numberOfPolicies(zoneK8s)
 			g.Expect(err).ToNot(HaveOccurred())
 			return n
-		}, "30s", "1s").Should(Equal(1))
+		}, "30s", "1s").Should(Equal(3))
 	})
 
 	It("should sync DPPs from Zone to Global", func() {
@@ -204,7 +204,7 @@ spec:
 			policiesZone, err := numberOfPolicies(zoneK8s)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			g.Expect(policiesGlobal).To(And(Equal(policiesZone), Equal(1)))
+			g.Expect(policiesGlobal).To(And(Equal(policiesZone), Equal(3)))
 
 			dppsGlobal, err := numberOfDPPs(global)
 			g.Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
### Checklist prior to review

We changed `version.yaml`. No we upgrade from version that has default mesh timeout for dpps and gateway. Then if we added a synced one, it's 3, not 1. 

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
