### PR TITLE
chore(e2e): added suffix to e2e test resource delegated

### DIFF
--- a/test/e2e_env/kubernetes/gateway/delegated/meshcircuitbreaker.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshcircuitbreaker.go
@@ -84,7 +84,7 @@ func CircuitBreaker(config *Config) func() {
 apiVersion: kuma.io/v1alpha1
 kind: MeshCircuitBreaker
 metadata:
-  name: mcb-outbound
+  name: mcb-outbound-delegated
   namespace: %s
   labels:
     kuma.io/mesh: %s
@@ -106,7 +106,7 @@ spec:
 apiVersion: kuma.io/v1alpha1
 kind: MeshCircuitBreaker
 metadata:
-  name: mcb-inbound
+  name: mcb-inbound-delegated
   namespace: %s
   labels:
     kuma.io/mesh: %s

--- a/test/e2e_env/kubernetes/gateway/delegated/meshloadbalancingstrategy.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshloadbalancingstrategy.go
@@ -40,7 +40,7 @@ func MeshLoadBalancingStrategy(config *Config) func() {
 kind: MeshLoadBalancingStrategy
 apiVersion: kuma.io/v1alpha1
 metadata:
-  name: ring-hash
+  name: ring-hash-delegated
   namespace: %s
   labels:
     kuma.io/mesh: %s

--- a/test/e2e_env/kubernetes/gateway/delegated/meshmetric.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshmetric.go
@@ -23,7 +23,7 @@ func MeshMetric(config *Config) func() {
 apiVersion: kuma.io/v1alpha1
 kind: MeshMetric
 metadata:
-  name: otel-metrics
+  name: otel-metrics-delegated
   namespace: %s
   labels:
     kuma.io/mesh: %s

--- a/test/e2e_env/kubernetes/gateway/delegated/meshproxypatch.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshproxypatch.go
@@ -23,7 +23,7 @@ func MeshProxyPatch(config *Config) func() {
 apiVersion: kuma.io/v1alpha1 
 kind: MeshProxyPatch
 metadata:
-  name: backend-lua-filter
+  name: backend-lua-filter-delegated
   namespace: %s
   labels:
     kuma.io/mesh: %s

--- a/test/e2e_env/kubernetes/gateway/delegated/meshretry.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshretry.go
@@ -20,7 +20,7 @@ func MeshRetry(config *Config) func() {
 apiVersion: kuma.io/v1alpha1
 kind: MeshRetry
 metadata:
-  name: mr
+  name: mr-delegated
   namespace: %s
   labels:
     kuma.io/mesh: %s

--- a/test/e2e_env/kubernetes/gateway/delegated/meshtimeout.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshtimeout.go
@@ -83,7 +83,7 @@ func MeshTimeout(config *Config) func() {
 apiVersion: kuma.io/v1alpha1
 kind: MeshTimeout
 metadata:
-  name: mt1
+  name: mt1-delegated
   namespace: %s
   labels:
     kuma.io/mesh: %s
@@ -102,7 +102,7 @@ spec:
 apiVersion: kuma.io/v1alpha1
 kind: MeshTimeout
 metadata:
-  name: mt1
+  name: mt1-delegated
   namespace: %s
   labels:
     kuma.io/mesh: %s

--- a/test/e2e_env/kubernetes/gateway/delegated/meshtrace.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshtrace.go
@@ -24,7 +24,7 @@ func MeshTrace(config *Config) func() {
 apiVersion: kuma.io/v1alpha1
 kind: MeshTrace
 metadata:
-  name: trace-all
+  name: trace-all-delegated
   namespace: %s
   labels:
     kuma.io/mesh: %s


### PR DESCRIPTION
### Checklist prior to review

Some policies have the same name but are in different meshes. That might cause one policy to override another because all are applied in the same namespace. This might cause tests to be flaky. Added suffix to resource names for delegated tests.

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
