### PR TITLE
ci(update): make it possible to pass additional options to osv-scanner

### DIFF
--- a/.github/workflows/update-insecure-dependencies.yaml
+++ b/.github/workflows/update-insecure-dependencies.yaml
@@ -19,6 +19,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
   update-insecure-dependencies:
+    env:
+      OSV_SCANNER_ADDITIONAL_OPTS: ""
     timeout-minutes: 20
     needs:
       - build-matrix
@@ -44,7 +46,7 @@ jobs:
       - name: "Prepare commit body - before"
         id: prepare_commit_body_before
         run: |
-          SCAN_OUTPUT_BEFORE=$(osv-scanner --lockfile=go.mod | tr "+" "|" | awk 'NR>3 {print last} {last=$0}' || true)
+          SCAN_OUTPUT_BEFORE=$(osv-scanner $OSV_SCANNER_ADDITIONAL_OPTS --lockfile=go.mod | tr "+" "|" | awk 'NR>3 {print last} {last=$0}' || true)
           echo "SCAN_OUTPUT_BEFORE<<EOF" >> $GITHUB_ENV
           echo "$SCAN_OUTPUT_BEFORE" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
@@ -55,7 +57,7 @@ jobs:
       - name: "Prepare commit body - after"
         id: prepare_commit_body_after
         run: |
-          SCAN_OUTPUT_AFTER=$(osv-scanner --lockfile=go.mod | tr "+" "|" | awk 'NR>3 {print last} {last=$0}' || true)
+          SCAN_OUTPUT_AFTER=$(osv-scanner $OSV_SCANNER_ADDITIONAL_OPTS --lockfile=go.mod | tr "+" "|" | awk 'NR>3 {print last} {last=$0}' || true)
           echo "SCAN_OUTPUT_AFTER<<EOF" >> $GITHUB_ENV
           echo "$SCAN_OUTPUT_AFTER" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV

--- a/tools/ci/update-vulnerable-dependencies/update-vulnerable-dependencies.sh
+++ b/tools/ci/update-vulnerable-dependencies/update-vulnerable-dependencies.sh
@@ -8,7 +8,7 @@ command -v jq >/dev/null 2>&1 || { echo >&2 "jq not installed!"; exit 1; }
 SCRIPT_PATH="${BASH_SOURCE[0]:-$0}";
 SCRIPT_DIR="$(dirname -- "$SCRIPT_PATH")"
 
-for dep in $(osv-scanner --lockfile=go.mod --json | jq -c '.results[].packages[] | .package.name as $vulnerablePackage | {
+for dep in $(osv-scanner "$OSV_SCANNER_ADDITIONAL_OPTS" --lockfile=go.mod --json | jq -c '.results[].packages[] | .package.name as $vulnerablePackage | {
   name: $vulnerablePackage,
   current: .package.version,
   fixedVersions: [.vulnerabilities[].affected[] | select(.package.name == $vulnerablePackage) | .ranges[].events |


### PR DESCRIPTION
Need to pass additional arg in parent project.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
