### PR TITLE
chore(deps): use `errors.Join` instead of `github.com/hashicorp/go-multierror`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -78,6 +78,9 @@ linters-settings:
         - github.com/ghodss/yaml:
             recommendations:
               - sigs.k8s.io/yaml
+        - github.com/hashicorp/go-multierror:
+            recommandations:
+              - errors
         - gopkg.in/yaml.v2:
             recommendations:
               - sigs.k8s.io/yaml

--- a/app/kumactl/pkg/output/table/printer.go
+++ b/app/kumactl/pkg/output/table/printer.go
@@ -1,9 +1,8 @@
 package table
 
 import (
+	"errors"
 	"io"
-
-	"github.com/hashicorp/go-multierror"
 )
 
 type Printer interface {
@@ -33,7 +32,7 @@ func (p *Table) Print(data interface{}, out io.Writer) error {
 			var err error
 			row, err = p.RowForItem(i, data)
 			if err != nil {
-				allErr = multierror.Append(allErr, err)
+				allErr = errors.Join(allErr, err)
 			}
 		}
 		if row == nil {

--- a/go.mod
+++ b/go.mod
@@ -27,9 +27,9 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/gruntwork-io/terratest v0.46.13
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hoisie/mustache v0.0.0-20160804235033-6375acf62c69
 	github.com/jackc/pgx/v5 v5.5.5
+	github.com/josephburnett/jd/v2 v2.0.0-20230813234251-7b2e87c80934
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/kennygrant/sanitize v1.2.4
 	github.com/lib/pq v1.10.9
@@ -68,7 +68,6 @@ require (
 	golang.org/x/net v0.24.0
 	golang.org/x/sys v0.19.0
 	golang.org/x/text v0.14.0
-	golang.org/x/time v0.5.0 // indirect
 	gonum.org/v1/gonum v0.15.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20240227224415-6ceb2ff114de
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240401170217-c3f982113cda
@@ -90,8 +89,6 @@ require (
 	sigs.k8s.io/gateway-api v1.0.1-0.20240229112436-da26d60306e1
 	sigs.k8s.io/yaml v1.4.0
 )
-
-require github.com/josephburnett/jd/v2 v2.0.0-20230813234251-7b2e87c80934
 
 require (
 	dario.cat/mergo v1.0.0 // indirect
@@ -147,6 +144,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1 // indirect
 	github.com/gruntwork-io/go-commons v0.8.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/homeport/dyff v1.6.0 // indirect
 	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect
@@ -215,6 +213,7 @@ require (
 	golang.org/x/oauth2 v0.18.0 // indirect
 	golang.org/x/sync v0.6.0 // indirect
 	golang.org/x/term v0.19.0 // indirect
+	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/tools v0.17.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect

--- a/pkg/core/runtime/runtime.go
+++ b/pkg/core/runtime/runtime.go
@@ -2,11 +2,11 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
 	"github.com/emicklei/go-restful/v3"
-	"github.com/hashicorp/go-multierror"
 
 	"github.com/kumahq/kuma/pkg/api-server/authn"
 	api_server "github.com/kumahq/kuma/pkg/api-server/customization"
@@ -320,12 +320,12 @@ func (rc *runtimeContext) Tenants() multitenant.Tenants {
 
 func (rc *runtimeContext) APIWebServiceCustomize() func(*restful.WebService) error {
 	return func(ws *restful.WebService) error {
-		err := &multierror.Error{}
+		var err error
 
 		for _, apiWebServiceCustomize := range rc.apiWebServiceCustomize {
-			err = multierror.Append(err, apiWebServiceCustomize(ws))
+			err = errors.Join(err, apiWebServiceCustomize(ws))
 		}
 
-		return err.ErrorOrNil()
+		return err
 	}
 }


### PR DESCRIPTION
### Checklist prior to review

Replace errors.Join instead of github.com/hashicorp/go-multierror . It avoid using hashicorp dependencies. 

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
