### PR TITLE
test(e2e): enable skipped delegated gateway tests

### DIFF
--- a/test/e2e_env/kubernetes/gateway/delegated.go
+++ b/test/e2e_env/kubernetes/gateway/delegated.go
@@ -109,7 +109,7 @@ spec:
 			To(Succeed())
 	})
 
-	XContext("MeshCircuitBreaker", delegated.CircuitBreaker(&config))
+	Context("MeshCircuitBreaker", delegated.CircuitBreaker(&config))
 	Context("MeshProxyPatch", delegated.MeshProxyPatch(&config))
 	Context("MeshHealthCheck", delegated.MeshHealthCheck(&config))
 	Context("MeshRetry", delegated.MeshRetry(&config))
@@ -119,5 +119,5 @@ spec:
 	Context("MeshTrace", delegated.MeshTrace(&config))
 	Context("MeshLoadBalancingStrategy", delegated.MeshLoadBalancingStrategy(&config))
 	Context("MeshAccessLog", delegated.MeshAccessLog(&config))
-	XContext("MeshTCPRoute", delegated.MeshTCPRoute(&config))
+	Context("MeshTCPRoute", delegated.MeshTCPRoute(&config))
 }

--- a/test/e2e_env/kubernetes/gateway/delegated.go
+++ b/test/e2e_env/kubernetes/gateway/delegated.go
@@ -119,5 +119,5 @@ spec:
 	Context("MeshTrace", delegated.MeshTrace(&config))
 	Context("MeshLoadBalancingStrategy", delegated.MeshLoadBalancingStrategy(&config))
 	Context("MeshAccessLog", delegated.MeshAccessLog(&config))
-	Context("MeshTCPRoute", delegated.MeshTCPRoute(&config))
+	XContext("MeshTCPRoute", delegated.MeshTCPRoute(&config))
 }

--- a/test/e2e_env/kubernetes/gateway/delegated/meshproxypatch.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshproxypatch.go
@@ -16,8 +16,7 @@ func MeshProxyPatch(config *Config) func() {
 	GinkgoHelper()
 
 	return func() {
-		// Disabled because of flakes: https://github.com/kumahq/kuma/issues/9348
-		XIt("should add a header using Lua filter", func() {
+		It("should add a header using Lua filter", func() {
 			// given
 			meshProxyPatch := fmt.Sprintf(`
 apiVersion: kuma.io/v1alpha1 

--- a/test/e2e_env/kubernetes/gateway/delegated/meshtcproute.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshtcproute.go
@@ -34,11 +34,11 @@ func MeshTCPRoute(config *Config) func() {
 apiVersion: kuma.io/v1alpha1
 kind: ExternalService
 metadata:
-  name: external-http-service-mtcpr
+  name: external-http-service-mtcprd
 mesh: %s
 spec:
   tags:
-    kuma.io/service: external-http-service-mtcpr
+    kuma.io/service: external-http-service-mtcprd
     kuma.io/protocol: http
   networking:
     # .svc.cluster.local is needed, otherwise Kubernetes will resolve this
@@ -50,11 +50,11 @@ spec:
 apiVersion: kuma.io/v1alpha1
 kind: ExternalService
 metadata:
-  name: external-tcp-service-mtcpr
+  name: external-tcp-service-mtcprd
 mesh: %s
 spec:
   tags:
-    kuma.io/service: external-tcp-service-mtcpr
+    kuma.io/service: external-tcp-service-mtcprd
     kuma.io/protocol: tcp
   networking:
     # .svc.cluster.local is needed, otherwise Kubernetes will resolve this
@@ -85,9 +85,9 @@ spec:
         - kind: MeshService
           name: test-server_%[2]s_svc_80
         - kind: MeshService
-          name: external-http-service-mtcpr
+          name: external-http-service-mtcprd
         - kind: MeshService
-          name: external-tcp-service-mtcpr
+          name: external-tcp-service-mtcprd
 `, config.CpNamespace, config.Mesh))(kubernetes.Cluster)).To(Succeed())
 
 			// then


### PR DESCRIPTION
### Checklist prior to review

@lukidzi found why we had so many flakes in e2e tests
https://github.com/kumahq/kuma/pull/9937

With this change, we can reenable MeshProxyPatch (it was a name conflict). Fix #9378 Fix #9348.
As well as circuit breaker (there was no issue for it).

Added ci/run-full-matrix to run this a bunch of times before we merge.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
