### PR TITLE
chore(GAPI): move from deprecated behavior

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/common/common.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/common/common.go
@@ -2,27 +2,18 @@ package common
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/pkg/errors"
 	kube_apierrs "k8s.io/apimachinery/pkg/api/errors"
 	kube_types "k8s.io/apimachinery/pkg/types"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
-
-	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 )
 
 const (
 	ControllerName = gatewayapi.GatewayController("gateways.kuma.io/controller")
 	HTTPRouteKind  = gatewayapi.Kind("HTTPRoute")
 )
-
-func ServiceTagForGateway(name kube_types.NamespacedName) map[string]string {
-	return map[string]string{
-		mesh_proto.ServiceTag: fmt.Sprintf("%s_%s_gateway", name.Name, name.Namespace),
-	}
-}
 
 func GetGatewayClass(ctx context.Context, client kube_client.Client, name gatewayapi.ObjectName) (*gatewayapi.GatewayClass, error) {
 	class := &gatewayapi.GatewayClass{}

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
@@ -142,19 +142,14 @@ func (r *GatewayReconciler) createOrUpdateInstance(ctx context.Context, mesh str
 		},
 	}
 
-	tags := mesh_proto.Merge(
-		common.ServiceTagForGateway(kube_client.ObjectKeyFromObject(gateway)),
-		config.Tags,
-	)
-
 	if _, err := kube_controllerutil.CreateOrUpdate(ctx, r.Client, instance, func() error {
-		if instance.Annotations == nil {
-			instance.Annotations = map[string]string{}
+		if instance.Labels == nil {
+			instance.Labels = map[string]string{}
 		}
-		instance.Annotations[metadata.KumaMeshAnnotation] = mesh
+		instance.Labels[metadata.KumaMeshAnnotation] = mesh
 
 		instance.Spec = mesh_k8s.MeshGatewayInstanceSpec{
-			Tags:                    tags,
+			Tags:                    config.Tags,
 			MeshGatewayCommonConfig: config.MeshGatewayCommonConfig,
 		}
 

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_conversion.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_conversion.go
@@ -10,7 +10,6 @@ import (
 	kube_apimeta "k8s.io/apimachinery/pkg/api/meta"
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_types "k8s.io/apimachinery/pkg/types"
-	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -18,7 +17,7 @@ import (
 	system_proto "github.com/kumahq/kuma/api/system/v1alpha1"
 	mesh_k8s "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers/gatewayapi/common"
-	referencegrants "github.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers/gatewayapi/referencegrants"
+	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers/gatewayapi/referencegrants"
 	"github.com/kumahq/kuma/pkg/util/pointer"
 )
 
@@ -241,7 +240,9 @@ func (r *GatewayReconciler) gapiToKumaGateway(
 	var kumaGateway *mesh_proto.MeshGateway
 
 	if len(listeners) > 0 {
-		match := common.ServiceTagForGateway(kube_client.ObjectKeyFromObject(gateway))
+		match := map[string]string{
+			mesh_proto.ServiceTag: fmt.Sprintf("%s_%s_svc", gateway.Name, gateway.Namespace),
+		}
 
 		kumaGateway = &mesh_proto.MeshGateway{
 			Selectors: []*mesh_proto.Selector{


### PR DESCRIPTION
Specifying `kuma.io/service` tag for `MeshGatewayInstance` is deprecated, so we shouldn't be use it when converting Gateway API resources to our internal ones.

Specifying `kuma.io/mesh` as an annotation is also deprecated, so I changed it to label in conversion to `MeshGatewayInstance`

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - No relevant issues
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Manually tested on local k3d cluster
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - There is no need

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
