### PR TITLE
refactor(kds): reduce duplication in forwarding client, improve error

### DIFF
--- a/pkg/intercp/catalog/catalog.go
+++ b/pkg/intercp/catalog/catalog.go
@@ -31,10 +31,11 @@ type Catalog interface {
 	DropLeader(context.Context, Instance) error
 }
 
-var (
-	ErrNoLeader         = errors.New("leader not found")
-	ErrInstanceNotFound = errors.New("instance not found")
-)
+var ErrNoLeader = errors.New("leader not found")
+
+func ErrInstanceNotFound(id string) error {
+	return errors.Errorf("instance not found: %s", id)
+}
 
 func Leader(ctx context.Context, catalog Catalog) (Instance, error) {
 	instances, err := catalog.Instances(ctx)
@@ -59,7 +60,7 @@ func InstanceOfID(ctx context.Context, catalog Catalog, id string) (Instance, er
 			return instance, nil
 		}
 	}
-	return Instance{}, ErrInstanceNotFound
+	return Instance{}, ErrInstanceNotFound(id)
 }
 
 type InstancesByID []Instance

--- a/pkg/intercp/envoyadmin/forwarding_kds_client.go
+++ b/pkg/intercp/envoyadmin/forwarding_kds_client.go
@@ -62,91 +62,88 @@ func (f *forwardingKdsEnvoyAdminClient) PostQuit(context.Context, *core_mesh.Dat
 	panic("not implemented")
 }
 
-func (f *forwardingKdsEnvoyAdminClient) ConfigDump(ctx context.Context, proxy core_model.ResourceWithAddress, includeEds bool) ([]byte, error) {
+type MessageWithError interface {
+	GetError() string
+}
+
+func forward[T MessageWithError](
+	f *forwardingKdsEnvoyAdminClient,
+	ctx context.Context,
+	proxy core_model.ResourceWithAddress,
+	kind string,
+	fallback func(ctx context.Context, proxy core_model.ResourceWithAddress) ([]byte, error),
+	doRequest func(ctx context.Context, client mesh_proto.InterCPEnvoyAdminForwardServiceClient) (T, error),
+	handleResponse func(resp T) []byte,
+) ([]byte, error) {
 	ctx = appendTenantMetadata(ctx)
-	instanceID, err := f.globalInstanceID(ctx, core_model.ZoneOfResource(proxy), service.ConfigDumpRPC)
+	instanceID, err := f.globalInstanceID(ctx, core_model.ZoneOfResource(proxy), kind)
 	if err != nil {
 		return nil, err
 	}
 	f.logIntendedAction(proxy, instanceID)
 	if instanceID == f.instanceID {
-		return f.fallbackClient.ConfigDump(ctx, proxy, includeEds)
+		return fallback(ctx, proxy)
 	}
 	client, err := f.clientForInstanceID(ctx, instanceID)
 	if err != nil {
 		return nil, err
 	}
-	req := &mesh_proto.XDSConfigRequest{
-		ResourceType: string(proxy.Descriptor().Name),
-		ResourceName: proxy.GetMeta().GetName(),
-		ResourceMesh: proxy.GetMeta().GetMesh(),
-	}
-	resp, err := client.XDSConfig(ctx, req)
+	resp, err := doRequest(ctx, client)
 	if err != nil {
 		return nil, err
 	}
-	if resp != nil && resp.GetError() != "" {
+	if resp.GetError() != "" {
 		return nil, &ForwardKDSRequestError{reason: resp.GetError()}
 	}
-	return resp.GetConfig(), nil
+	return handleResponse(resp), nil
+}
+
+func (f *forwardingKdsEnvoyAdminClient) ConfigDump(ctx context.Context, proxy core_model.ResourceWithAddress, includeEds bool) ([]byte, error) {
+	fallback := func(ctx context.Context, proxy core_model.ResourceWithAddress) ([]byte, error) {
+		return f.fallbackClient.ConfigDump(ctx, proxy, includeEds)
+	}
+	doRequest := func(ctx context.Context, client mesh_proto.InterCPEnvoyAdminForwardServiceClient) (*mesh_proto.XDSConfigResponse, error) {
+		req := &mesh_proto.XDSConfigRequest{
+			ResourceType: string(proxy.Descriptor().Name),
+			ResourceName: proxy.GetMeta().GetName(),
+			ResourceMesh: proxy.GetMeta().GetMesh(),
+		}
+		return client.XDSConfig(ctx, req)
+	}
+	handleResponse := func(resp *mesh_proto.XDSConfigResponse) []byte { return resp.GetConfig() }
+	return forward(f, ctx, proxy, service.ConfigDumpRPC, fallback, doRequest, handleResponse)
 }
 
 func (f *forwardingKdsEnvoyAdminClient) Stats(ctx context.Context, proxy core_model.ResourceWithAddress, format mesh_proto.AdminOutputFormat) ([]byte, error) {
-	ctx = appendTenantMetadata(ctx)
-	instanceID, err := f.globalInstanceID(ctx, core_model.ZoneOfResource(proxy), service.StatsRPC)
-	if err != nil {
-		return nil, err
-	}
-	f.logIntendedAction(proxy, instanceID)
-	if instanceID == f.instanceID {
+	fallback := func(ctx context.Context, proxy core_model.ResourceWithAddress) ([]byte, error) {
 		return f.fallbackClient.Stats(ctx, proxy, format)
 	}
-	client, err := f.clientForInstanceID(ctx, instanceID)
-	if err != nil {
-		return nil, err
+	doRequest := func(ctx context.Context, client mesh_proto.InterCPEnvoyAdminForwardServiceClient) (*mesh_proto.StatsResponse, error) {
+		req := &mesh_proto.StatsRequest{
+			ResourceType: string(proxy.Descriptor().Name),
+			ResourceName: proxy.GetMeta().GetName(),
+			ResourceMesh: proxy.GetMeta().GetMesh(),
+		}
+		return client.Stats(ctx, req)
 	}
-	req := &mesh_proto.StatsRequest{
-		ResourceType: string(proxy.Descriptor().Name),
-		ResourceName: proxy.GetMeta().GetName(),
-		ResourceMesh: proxy.GetMeta().GetMesh(),
-	}
-	resp, err := client.Stats(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	if resp != nil && resp.GetError() != "" {
-		return nil, &ForwardKDSRequestError{reason: resp.GetError()}
-	}
-	return resp.GetStats(), nil
+	handleResponse := func(resp *mesh_proto.StatsResponse) []byte { return resp.GetStats() }
+	return forward(f, ctx, proxy, service.StatsRPC, fallback, doRequest, handleResponse)
 }
 
 func (f *forwardingKdsEnvoyAdminClient) Clusters(ctx context.Context, proxy core_model.ResourceWithAddress, format mesh_proto.AdminOutputFormat) ([]byte, error) {
-	ctx = appendTenantMetadata(ctx)
-	instanceID, err := f.globalInstanceID(ctx, core_model.ZoneOfResource(proxy), service.ClustersRPC)
-	if err != nil {
-		return nil, err
-	}
-	f.logIntendedAction(proxy, instanceID)
-	if instanceID == f.instanceID {
+	fallback := func(ctx context.Context, proxy core_model.ResourceWithAddress) ([]byte, error) {
 		return f.fallbackClient.Clusters(ctx, proxy, format)
 	}
-	client, err := f.clientForInstanceID(ctx, instanceID)
-	if err != nil {
-		return nil, err
+	doRequest := func(ctx context.Context, client mesh_proto.InterCPEnvoyAdminForwardServiceClient) (*mesh_proto.ClustersResponse, error) {
+		req := &mesh_proto.ClustersRequest{
+			ResourceType: string(proxy.Descriptor().Name),
+			ResourceName: proxy.GetMeta().GetName(),
+			ResourceMesh: proxy.GetMeta().GetMesh(),
+		}
+		return client.Clusters(ctx, req)
 	}
-	req := &mesh_proto.ClustersRequest{
-		ResourceType: string(proxy.Descriptor().Name),
-		ResourceName: proxy.GetMeta().GetName(),
-		ResourceMesh: proxy.GetMeta().GetMesh(),
-	}
-	resp, err := client.Clusters(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	if resp != nil && resp.GetError() != "" {
-		return nil, &ForwardKDSRequestError{reason: resp.GetError()}
-	}
-	return resp.GetClusters(), nil
+	handleResponse := func(resp *mesh_proto.ClustersResponse) []byte { return resp.GetClusters() }
+	return forward(f, ctx, proxy, service.ClustersRPC, fallback, doRequest, handleResponse)
 }
 
 func (f *forwardingKdsEnvoyAdminClient) logIntendedAction(proxy core_model.ResourceWithAddress, instanceID string) {


### PR DESCRIPTION
Adds the not found instance ID to the error.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
