### PR TITLE
test(e2e): add debug information on failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,9 +369,6 @@ jobs:
       - store_artifacts:
           name: "Store logs"
           path: /tmp/e2e
-      - store_artifacts:
-          name: debug-dir
-          path: /tmp/e2e-debug
   e2e_testing:
     parameters:
       k8sVersion:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,6 +369,9 @@ jobs:
       - store_artifacts:
           name: "Store logs"
           path: /tmp/e2e
+      - store_artifacts:
+          name: debug-dir
+          path: /tmp/e2e-debug
   e2e_testing:
     parameters:
       k8sVersion:

--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -143,6 +143,7 @@ jobs:
         if: always()
         with:
           name: e2e-debug-${{ env.E2E_PARAM_TARGET }}
+          if-no-files-found: ignore
           path: |
             /tmp/e2e-debug/
           retention-days: ${{ github.event_name == 'pull_request' && 1 || 30 }}

--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -139,6 +139,12 @@ jobs:
             target="test/e2e"
           fi
           make ${MAKE_PARAMETERS} CI=true "${target}"
+      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        with:
+          name: e2e-debug-${{ env.E2E_PARAM_TARGET }}
+          path: |
+            /tmp/e2e-debug/
+          retention-days: ${{ github.event_name == 'pull_request' && 1 || 30 }}
       - name: "CircleCI: make circleci parameters"
         if: steps.eval-params.outputs.run-type == 'circleci'
         id: circleci-gen-params

--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -140,6 +140,7 @@ jobs:
           fi
           make ${MAKE_PARAMETERS} CI=true "${target}"
       - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        if: always()
         with:
           name: e2e-debug-${{ env.E2E_PARAM_TARGET }}
           path: |

--- a/test/e2e_env/kubernetes/connectivity/headless_services.go
+++ b/test/e2e_env/kubernetes/connectivity/headless_services.go
@@ -69,6 +69,10 @@ func HeadlessServices() {
 		Expect(kubernetes.Cluster.Install(YamlK8sObject(headlessSvc))).To(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, meshName, namespace)
+	})
+
 	E2EAfterAll(func() {
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(kubernetes.Cluster.DeleteMesh(meshName)).To(Succeed())

--- a/test/e2e_env/kubernetes/gateway/gatewayapi.go
+++ b/test/e2e_env/kubernetes/gateway/gatewayapi.go
@@ -181,11 +181,8 @@ spec:
 			address = net.JoinHostPort(GatewayIP(gatewayName), "10080")
 			Expect(WaitPodsAvailable(namespace, gatewayName)(kubernetes.Cluster)).To(Succeed())
 		})
-		AfterAll(func() {
-			// debug information to track "could not get a LoadBalancer IP of the Gateway" flake.
-			Expect(k8s.RunKubectlE(kubernetes.Cluster.GetTesting(), kubernetes.Cluster.GetKubectlOptions(namespace), "get", "gateway", "-oyaml")).To(Succeed())
-			Expect(k8s.RunKubectlE(kubernetes.Cluster.GetTesting(), kubernetes.Cluster.GetKubectlOptions(namespace), "get", "service", "-oyaml")).To(Succeed())
-			Expect(k8s.RunKubectlE(kubernetes.Cluster.GetTesting(), kubernetes.Cluster.GetKubectlOptions(namespace), "get", "pods", "-oyaml")).To(Succeed())
+		AfterEachFailure(func() {
+			DebugKube(kubernetes.Cluster, meshName, namespace)
 		})
 		E2EAfterAll(func() {
 			Expect(k8s.RunKubectlE(kubernetes.Cluster.GetTesting(), kubernetes.Cluster.GetKubectlOptions(namespace), "delete", "gateway", gatewayName)).To(Succeed())

--- a/test/e2e_env/multizone/connectivity/connectivity.go
+++ b/test/e2e_env/multizone/connectivity/connectivity.go
@@ -49,6 +49,14 @@ func Connectivity() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(multizone.Global, meshName)
+		DebugUniversal(multizone.UniZone1, meshName)
+		DebugUniversal(multizone.UniZone2, meshName)
+		DebugKube(multizone.KubeZone1, meshName, namespace)
+		DebugKube(multizone.KubeZone2, meshName, namespace)
+	})
+
 	E2EAfterAll(func() {
 		Expect(multizone.KubeZone1.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(multizone.KubeZone2.TriggerDeleteNamespace(namespace)).To(Succeed())

--- a/test/e2e_env/multizone/connectivity/connectivity.go
+++ b/test/e2e_env/multizone/connectivity/connectivity.go
@@ -72,6 +72,7 @@ func Connectivity() {
 
 	DescribeTable("client from Kubernetes",
 		func(given testCase) {
+			Expect(true).To(BeFalse())
 			Eventually(func(g Gomega) {
 				response, err := client.CollectEchoResponse(multizone.KubeZone1, "demo-client", given.address,
 					client.FromKubernetesPod(meshName, "demo-client"),

--- a/test/e2e_env/multizone/connectivity/connectivity.go
+++ b/test/e2e_env/multizone/connectivity/connectivity.go
@@ -72,7 +72,6 @@ func Connectivity() {
 
 	DescribeTable("client from Kubernetes",
 		func(given testCase) {
-			Expect(true).To(BeFalse())
 			Eventually(func(g Gomega) {
 				response, err := client.CollectEchoResponse(multizone.KubeZone1, "demo-client", given.address,
 					client.FromKubernetesPod(meshName, "demo-client"),

--- a/test/e2e_env/universal/grpc/grpc.go
+++ b/test/e2e_env/universal/grpc/grpc.go
@@ -35,6 +35,10 @@ func GRPC() {
 			Setup(universal.Cluster)).To(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, meshName)
+	})
+
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
 		Expect(universal.Cluster.DeleteMesh(meshName)).To(Succeed())

--- a/test/e2e_env/universal/grpc/grpc.go
+++ b/test/e2e_env/universal/grpc/grpc.go
@@ -46,7 +46,6 @@ func GRPC() {
 
 	It("should emit stats from the server", func() {
 		Eventually(func(g Gomega) {
-			Expect(true).To(BeFalse())
 			stdout, _, err := client.CollectResponse(
 				universal.Cluster, "test-server", "http://localhost:9901/stats?format=prometheus",
 			)

--- a/test/e2e_env/universal/grpc/grpc.go
+++ b/test/e2e_env/universal/grpc/grpc.go
@@ -46,6 +46,7 @@ func GRPC() {
 
 	It("should emit stats from the server", func() {
 		Eventually(func(g Gomega) {
+			Expect(true).To(BeFalse())
 			stdout, _, err := client.CollectResponse(
 				universal.Cluster, "test-server", "http://localhost:9901/stats?format=prometheus",
 			)

--- a/test/framework/config.go
+++ b/test/framework/config.go
@@ -63,6 +63,7 @@ type E2eConfig struct {
 	CleanupLogsOnSuccess              bool              `json:"cleanupLogsOnSuccess,omitempty" envconfig:"CLEANUP_LOGS_ON_SUCCESS"`
 	VersionsYamlPath                  string            `json:"versionsYamlPath,omitempty" envconfig:"VERSIONS_YAML_PATH"`
 	KumaExperimentalSidecarContainers bool              `json:"kumaSidecarContainers,omitempty" envconfig:"KUMA_EXPERIMENTAL_SIDECAR_CONTAINERS"`
+	DebugDir                          string            `json:"debugDir" envconfig:"KUMA_DEBUG_DIR"`
 
 	SuiteConfig SuiteConfig `json:"suites,omitempty"`
 }
@@ -261,6 +262,7 @@ var defaultConf = E2eConfig{
 	UniversalE2ELogsPath:              path.Join(os.TempDir(), "e2e"),
 	CleanupLogsOnSuccess:              false,
 	KumaExperimentalSidecarContainers: false,
+	DebugDir:                          path.Join(os.TempDir(), "e2e-debug"),
 }
 
 func init() {

--- a/test/framework/debug.go
+++ b/test/framework/debug.go
@@ -26,7 +26,7 @@ func DebugUniversal(cluster Cluster, mesh string) {
 	Expect(err).ToNot(HaveOccurred())
 
 	exportFilePath := filepath.Join(Config.DebugDir, fmt.Sprintf("%s-export-%s", cluster.Name(), uuid.New().String()))
-	Expect(os.WriteFile(exportFilePath, []byte(out), 0o755)).To(Succeed())
+	Expect(os.WriteFile(exportFilePath, []byte(out), 0o600)).To(Succeed())
 	Logf("saving export of cluster %q for mesh %q to a file %q", cluster.Name(), mesh, exportFilePath)
 }
 
@@ -39,7 +39,7 @@ func DebugKube(cluster Cluster, mesh string, namespace string) {
 	Expect(err).ToNot(HaveOccurred())
 
 	exportFilePath := filepath.Join(Config.DebugDir, fmt.Sprintf("%s-namespace-%s-%s", cluster.Name(), namespace, uuid.New().String()))
-	Expect(os.WriteFile(exportFilePath, []byte(out), 0o755)).To(Succeed())
+	Expect(os.WriteFile(exportFilePath, []byte(out), 0o600)).To(Succeed())
 	Logf("saving state of the namespace %q of cluster %q to a file %q", namespace, cluster.Name(), exportFilePath)
 
 	kumactlOpts := *cluster.GetKumactlOptions() // copy to not override fields globally
@@ -48,12 +48,12 @@ func DebugKube(cluster Cluster, mesh string, namespace string) {
 	Expect(err).ToNot(HaveOccurred())
 
 	exportFilePath = filepath.Join(Config.DebugDir, fmt.Sprintf("%s-export-%s", cluster.Name(), uuid.New().String()))
-	Expect(os.WriteFile(exportFilePath, []byte(out), 0o755)).To(Succeed())
+	Expect(os.WriteFile(exportFilePath, []byte(out), 0o600)).To(Succeed())
 	Logf("saving export of cluster %q for mesh %q to a file %q", cluster.Name(), mesh, exportFilePath)
 }
 
 func ensureDebugDir() {
-	err := os.MkdirAll(Config.DebugDir, 0755)
+	err := os.MkdirAll(Config.DebugDir, 0o755)
 	if err == nil || os.IsNotExist(err) {
 		return
 	}

--- a/test/framework/debug.go
+++ b/test/framework/debug.go
@@ -1,0 +1,28 @@
+package framework
+
+import (
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	. "github.com/onsi/gomega"
+)
+
+// DebugUniversal prints state of the cluster. Useful in case of failure.
+// Ideas what we can add
+// * XDS / Stats / Clusters of all DPPs (ideally in form of command that we can use on prod as well)
+//
+// In case we get into limits of massive logs on stdout. We can save it to file, print file names and upload the files on CI as artifacts.
+func DebugUniversal(cluster Cluster, mesh string) {
+	Logf("printing debug information of cluster %q for mesh %q", cluster.Name(), mesh)
+	// we don't have command to print policies for given mesh, so it's better to print all than none.
+	out, err := cluster.GetKumactlOptions().RunKumactlAndGetOutput("export", "--profile", "all")
+	Expect(err).ToNot(HaveOccurred())
+	Logf(out)
+}
+
+func DebugKube(cluster Cluster, mesh string, namespace string) {
+	Logf("printing debug information of cluster %q for mesh %q and namespace %q", cluster.Name(), mesh, namespace)
+	err := k8s.RunKubectlE(cluster.GetTesting(), cluster.GetKubectlOptions(namespace), "get", "all", "-oyaml")
+	Expect(err).ToNot(HaveOccurred())
+	out, err := cluster.GetKumactlOptions().RunKumactlAndGetOutput("export", "--profile", "all")
+	Expect(err).ToNot(HaveOccurred())
+	Logf(out)
+}

--- a/test/framework/debug.go
+++ b/test/framework/debug.go
@@ -14,8 +14,7 @@ import (
 // DebugUniversal prints state of the cluster. Useful in case of failure.
 // Ideas what we can add
 // * XDS / Stats / Clusters of all DPPs (ideally in form of command that we can use on prod as well)
-//
-// In case we get into limits of massive logs on stdout. We can save it to file, print file names and upload the files on CI as artifacts.
+// * CP logs (although we print this already on failure)
 func DebugUniversal(cluster Cluster, mesh string) {
 	ensureDebugDir()
 	Logf("printing debug information of cluster %q for mesh %q", cluster.Name(), mesh)

--- a/test/framework/debug.go
+++ b/test/framework/debug.go
@@ -1,7 +1,13 @@
 package framework
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/google/uuid"
 	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/logger"
 	. "github.com/onsi/gomega"
 )
 
@@ -11,18 +17,45 @@ import (
 //
 // In case we get into limits of massive logs on stdout. We can save it to file, print file names and upload the files on CI as artifacts.
 func DebugUniversal(cluster Cluster, mesh string) {
+	ensureDebugDir()
 	Logf("printing debug information of cluster %q for mesh %q", cluster.Name(), mesh)
 	// we don't have command to print policies for given mesh, so it's better to print all than none.
-	out, err := cluster.GetKumactlOptions().RunKumactlAndGetOutput("export", "--profile", "all")
+	kumactlOpts := *cluster.GetKumactlOptions()
+	kumactlOpts.Verbose = false
+	out, err := kumactlOpts.RunKumactlAndGetOutput("export", "--profile", "all")
 	Expect(err).ToNot(HaveOccurred())
-	Logf(out)
+
+	exportFilePath := filepath.Join(Config.DebugDir, fmt.Sprintf("%s-export-%s", cluster.Name(), uuid.New().String()))
+	Expect(os.WriteFile(exportFilePath, []byte(out), 0o755)).To(Succeed())
+	Logf("saving export of cluster %q for mesh %q to a file %q", cluster.Name(), mesh, exportFilePath)
 }
 
 func DebugKube(cluster Cluster, mesh string, namespace string) {
+	ensureDebugDir()
 	Logf("printing debug information of cluster %q for mesh %q and namespace %q", cluster.Name(), mesh, namespace)
-	err := k8s.RunKubectlE(cluster.GetTesting(), cluster.GetKubectlOptions(namespace), "get", "all", "-oyaml")
+	kubeOptions := *cluster.GetKubectlOptions(namespace) // copy to not override fields globally
+	kubeOptions.Logger = logger.Discard                  // to not print on stdout
+	out, err := k8s.RunKubectlAndGetOutputE(cluster.GetTesting(), &kubeOptions, "get", "all", "-oyaml")
 	Expect(err).ToNot(HaveOccurred())
-	out, err := cluster.GetKumactlOptions().RunKumactlAndGetOutput("export", "--profile", "all")
+
+	exportFilePath := filepath.Join(Config.DebugDir, fmt.Sprintf("%s-namespace-%s-%s", cluster.Name(), namespace, uuid.New().String()))
+	Expect(os.WriteFile(exportFilePath, []byte(out), 0o755)).To(Succeed())
+	Logf("saving state of the namespace %q of cluster %q to a file %q", namespace, cluster.Name(), exportFilePath)
+
+	kumactlOpts := *cluster.GetKumactlOptions() // copy to not override fields globally
+	kumactlOpts.Verbose = false                 // to not print on stdout
+	out, err = kumactlOpts.RunKumactlAndGetOutput("export", "--profile", "all")
 	Expect(err).ToNot(HaveOccurred())
-	Logf(out)
+
+	exportFilePath = filepath.Join(Config.DebugDir, fmt.Sprintf("%s-export-%s", cluster.Name(), uuid.New().String()))
+	Expect(os.WriteFile(exportFilePath, []byte(out), 0o755)).To(Succeed())
+	Logf("saving export of cluster %q for mesh %q to a file %q", cluster.Name(), mesh, exportFilePath)
+}
+
+func ensureDebugDir() {
+	err := os.MkdirAll(Config.DebugDir, 0755)
+	if err == nil || os.IsNotExist(err) {
+		return
+	}
+	Expect(err).ToNot(HaveOccurred())
 }

--- a/test/framework/ginkgo.go
+++ b/test/framework/ginkgo.go
@@ -25,6 +25,15 @@ func doIfNoSkipCleanup(fn func()) func() {
 	}
 }
 
+func AfterEachFailure(fn func()) bool {
+	return ginkgo.AfterEach(func() {
+		if !ginkgo.CurrentSpecReport().Failed() {
+			return
+		}
+		fn()
+	})
+}
+
 func E2EAfterEach(fn func()) bool {
 	return ginkgo.AfterEach(doIfNoSkipCleanup(fn))
 }


### PR DESCRIPTION
### Checklist prior to review

A new strategy to help us debug flakes.

One of the problem with flakes is that we don't have enough information. In case of failure, we should preserve as much as we can. I introduced a new block that we could add to every test
```
	AfterEachFailure(func() {
		DebugKube(kubernetes.Cluster, meshName, namespace)
	})
```
Then we can gradually add more stuff to the implementation.
I only added one invocation of it as an example. If we accept this PR, I'll add it to all tests.

We need this in each test because we need to execute it before the test cleans up namespace and mesh.

We already have CP logs after the whole suite fails, no need to print this again.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
