### PR TITLE
test(e2e/gateway/deleaged): remove inbound MeshCircuitBreaker test case

### DIFF
--- a/test/e2e_env/kubernetes/gateway/delegated/meshcircuitbreaker.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshcircuitbreaker.go
@@ -102,28 +102,6 @@ spec:
           maxRequests: 1
           maxRetries: 1
 `, config.CpNamespace, config.Mesh)),
-			Entry("inbound circuit breaker", fmt.Sprintf(`
-apiVersion: kuma.io/v1alpha1
-kind: MeshCircuitBreaker
-metadata:
-  name: mcb-inbound-delegated
-  namespace: %s
-  labels:
-    kuma.io/mesh: %s
-spec:
-  targetRef:
-    kind: Mesh
-  from:
-    - targetRef:
-        kind: Mesh
-      default:
-        connectionLimits:
-          maxConnectionPools: 1
-          maxConnections: 1
-          maxPendingRequests: 1
-          maxRequests: 1
-          maxRetries: 1
-`, config.CpNamespace, config.Mesh)),
 		)
 	}
 }


### PR DESCRIPTION
Configuring inbound MeshCircuitBreaker is not supported for delegated gateway so this test case was wrong.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
