### PR TITLE
feat(metrics): add error type to nack metric

### DIFF
--- a/pkg/util/xds/stats_callbacks.go
+++ b/pkg/util/xds/stats_callbacks.go
@@ -17,9 +17,9 @@ var statsLogger = core.Log.WithName("stats-callbacks")
 
 const (
 	ConfigInFlightThreshold = 100_000
-	failedCallingWebhook = "failed calling webhook"
-	userErrorType = "user"
-	otherErrorType = "other"
+	failedCallingWebhook    = "failed calling webhook"
+	userErrorType           = "user"
+	otherErrorType          = "other"
 )
 
 type VersionExtractor = func(metadata *structpb.Struct) string

--- a/pkg/util/xds/stats_callbacks.go
+++ b/pkg/util/xds/stats_callbacks.go
@@ -20,6 +20,7 @@ const (
 	failedCallingWebhook    = "failed calling webhook"
 	userErrorType           = "user"
 	otherErrorType          = "other"
+	noErrorType             = "no_error"
 )
 
 type VersionExtractor = func(metadata *structpb.Struct) string
@@ -167,7 +168,7 @@ func (s *statsCallbacks) OnStreamRequest(streamID int64, request DiscoveryReques
 	if request.HasErrors() {
 		s.requestsReceivedMetric.WithLabelValues(request.GetTypeUrl(), "NACK", classifyError(request.ErrorMsg())).Inc()
 	} else {
-		s.requestsReceivedMetric.WithLabelValues(request.GetTypeUrl(), "ACK").Inc()
+		s.requestsReceivedMetric.WithLabelValues(request.GetTypeUrl(), "ACK", noErrorType).Inc()
 	}
 
 	if configTime, exists := s.takeConfigTimeFromQueue(request.VersionInfo()); exists {
@@ -222,7 +223,7 @@ func (s *statsCallbacks) OnStreamDeltaRequest(streamID int64, request DeltaDisco
 	if request.HasErrors() {
 		s.requestsReceivedMetric.WithLabelValues(request.GetTypeUrl(), "NACK", classifyError(request.ErrorMsg())).Inc()
 	} else {
-		s.requestsReceivedMetric.WithLabelValues(request.GetTypeUrl(), "ACK").Inc()
+		s.requestsReceivedMetric.WithLabelValues(request.GetTypeUrl(), "ACK", noErrorType).Inc()
 	}
 
 	// Delta only has an initial version, therefore we need to change the key to nodeID and typeURL.

--- a/pkg/util/xds/stats_callbacks.go
+++ b/pkg/util/xds/stats_callbacks.go
@@ -2,6 +2,7 @@ package xds
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"time"
 
@@ -14,7 +15,12 @@ import (
 
 var statsLogger = core.Log.WithName("stats-callbacks")
 
-const ConfigInFlightThreshold = 100_000
+const (
+	ConfigInFlightThreshold = 100_000
+	failedCallingWebhook = "failed calling webhook"
+	userErrorType = "user"
+	otherErrorType = "other"
+)
 
 type VersionExtractor = func(metadata *structpb.Struct) string
 
@@ -89,7 +95,7 @@ func NewStatsCallbacks(metrics prometheus.Registerer, dsType string, versionExtr
 	stats.requestsReceivedMetric = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: dsType + "_requests_received",
 		Help: "Number of confirmations requests from a client",
-	}, []string{"type_url", "confirmation"})
+	}, []string{"type_url", "confirmation", "error_type"})
 	if err := metrics.Register(stats.requestsReceivedMetric); err != nil {
 		return nil, err
 	}
@@ -159,7 +165,7 @@ func (s *statsCallbacks) OnStreamRequest(streamID int64, request DiscoveryReques
 	}
 
 	if request.HasErrors() {
-		s.requestsReceivedMetric.WithLabelValues(request.GetTypeUrl(), "NACK").Inc()
+		s.requestsReceivedMetric.WithLabelValues(request.GetTypeUrl(), "NACK", classifyError(request.ErrorMsg())).Inc()
 	} else {
 		s.requestsReceivedMetric.WithLabelValues(request.GetTypeUrl(), "ACK").Inc()
 	}
@@ -214,7 +220,7 @@ func (s *statsCallbacks) OnStreamDeltaRequest(streamID int64, request DeltaDisco
 	}
 
 	if request.HasErrors() {
-		s.requestsReceivedMetric.WithLabelValues(request.GetTypeUrl(), "NACK").Inc()
+		s.requestsReceivedMetric.WithLabelValues(request.GetTypeUrl(), "NACK", classifyError(request.ErrorMsg())).Inc()
 	} else {
 		s.requestsReceivedMetric.WithLabelValues(request.GetTypeUrl(), "ACK").Inc()
 	}
@@ -228,4 +234,12 @@ func (s *statsCallbacks) OnStreamDeltaRequest(streamID int64, request DeltaDisco
 
 func (s *statsCallbacks) OnStreamDeltaResponse(_ int64, _ DeltaDiscoveryRequest, response DeltaDiscoveryResponse) {
 	s.responsesSentMetric.WithLabelValues(response.GetTypeUrl()).Inc()
+}
+
+func classifyError(error string) string {
+	if strings.Contains(error, failedCallingWebhook) {
+		return userErrorType
+	} else {
+		return otherErrorType
+	}
 }


### PR DESCRIPTION
needed for hosted project

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
