### PR TITLE
feat(k8s): opt-in to support tls for GAPI in all namespaces

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -220,6 +220,11 @@ Previously, these flags were necessary for using the Gateway API feature:
 - `--experimental-gatewayapi` flag for `kumactl install control-plane` and `kumactl install crds`
 - `experimental.gatewayAPI=true` setting in both `kumactl install control-plane` and Helm charts
 
+### TLS Secrets with Gateway API in namespace other than mesh system namespace
+
+If you use TLS secrets with Gateway API for a gateway deployed in any other namespace than mesh system namespace, set `controlPlane.supportGatewaySecretsInAllNamespaces` HELM value to true.
+This change was introduced so that control plane does not have capability to read content of secrets in all namespaces by default.
+
 ## Upgrade to `2.6.x`
 
 ### Policy

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -222,7 +222,7 @@ Previously, these flags were necessary for using the Gateway API feature:
 
 ### TLS Secrets with Gateway API in namespace other than mesh system namespace
 
-If you use TLS secrets with Gateway API for a gateway deployed in any other namespace than mesh system namespace, set `controlPlane.supportGatewaySecretsInAllNamespaces` HELM value to true.
+If you use TLS secrets with Gateway API for a builtin gateway deployed in any other namespace than mesh system namespace, set `controlPlane.supportGatewaySecretsInAllNamespaces` HELM value to true.
 This change was introduced so that control plane does not have capability to read content of secrets in all namespaces by default.
 
 ## Upgrade to `2.6.x`

--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -110,7 +110,7 @@ rules:
   - apiGroups:
     - ""
     resources:
-      - secret
+      - secrets
     verbs:
     - list
     - watch

--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -103,11 +103,17 @@ rules:
       - pods
       - configmaps
       - nodes
-      - secrets
     verbs:
       - get
       - list
       - watch
+  - apiGroups:
+    - ""
+    resources:
+      - secret
+    verbs:
+    - list
+    - watch
   - apiGroups:
       - "apps"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -7914,7 +7914,7 @@ rules:
   - apiGroups:
     - ""
     resources:
-      - secret
+      - secrets
     verbs:
     - list
     - watch

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -7907,11 +7907,17 @@ rules:
       - pods
       - configmaps
       - nodes
-      - secrets
     verbs:
       - get
       - list
       - watch
+  - apiGroups:
+    - ""
+    resources:
+      - secret
+    verbs:
+    - list
+    - watch
   - apiGroups:
       - "apps"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -323,7 +323,7 @@ controlPlane:
 
   # -- If true, then control plane can support TLS secrets for builtin gateway outside of mesh system namespace.
   # The downside is that control plane requires permission to read Secrets in all namespaces.
-  supportAllGatewaySecrets: false
+  supportGatewaySecretsInAllNamespaces: false
 
 cni:
   # -- Install Kuma with CNI instead of proxy init container

--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -321,6 +321,10 @@ controlPlane:
   containerSecurityContext:
     readOnlyRootFilesystem: true
 
+  # -- If true, then control plane can support TLS secrets for builtin gateway outside of mesh system namespace.
+  # The downside is that control plane requires permission to read Secrets in all namespaces.
+  supportAllGatewaySecrets: false
+
 cni:
   # -- Install Kuma with CNI instead of proxy init container
   enabled: false

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -7914,7 +7914,7 @@ rules:
   - apiGroups:
     - ""
     resources:
-      - secret
+      - secrets
     verbs:
     - list
     - watch

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -7907,11 +7907,17 @@ rules:
       - pods
       - configmaps
       - nodes
-      - secrets
     verbs:
       - get
       - list
       - watch
+  - apiGroups:
+    - ""
+    resources:
+      - secret
+    verbs:
+    - list
+    - watch
   - apiGroups:
       - "apps"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
@@ -55,7 +55,7 @@ rules:
   - apiGroups:
     - ""
     resources:
-      - secret
+      - secrets
     verbs:
     - list
     - watch

--- a/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
@@ -48,11 +48,17 @@ rules:
       - pods
       - configmaps
       - nodes
-      - secrets
     verbs:
       - get
       - list
       - watch
+  - apiGroups:
+    - ""
+    resources:
+      - secret
+    verbs:
+    - list
+    - watch
   - apiGroups:
       - "apps"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
@@ -55,7 +55,7 @@ rules:
   - apiGroups:
     - ""
     resources:
-      - secret
+      - secrets
     verbs:
     - list
     - watch

--- a/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
@@ -48,11 +48,17 @@ rules:
       - pods
       - configmaps
       - nodes
-      - secrets
     verbs:
       - get
       - list
       - watch
+  - apiGroups:
+    - ""
+    resources:
+      - secret
+    verbs:
+    - list
+    - watch
   - apiGroups:
       - "apps"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
@@ -55,7 +55,7 @@ rules:
   - apiGroups:
     - ""
     resources:
-      - secret
+      - secrets
     verbs:
     - list
     - watch

--- a/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
@@ -48,11 +48,17 @@ rules:
       - pods
       - configmaps
       - nodes
-      - secrets
     verbs:
       - get
       - list
       - watch
+  - apiGroups:
+    - ""
+    resources:
+      - secret
+    verbs:
+    - list
+    - watch
   - apiGroups:
       - "apps"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
@@ -55,7 +55,7 @@ rules:
   - apiGroups:
     - ""
     resources:
-      - secret
+      - secrets
     verbs:
     - list
     - watch

--- a/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
@@ -48,11 +48,17 @@ rules:
       - pods
       - configmaps
       - nodes
-      - secrets
     verbs:
       - get
       - list
       - watch
+  - apiGroups:
+    - ""
+    resources:
+      - secret
+    verbs:
+    - list
+    - watch
   - apiGroups:
       - "apps"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.tproxy-ebpf-experimental-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.tproxy-ebpf-experimental-enabled.golden.yaml
@@ -55,7 +55,7 @@ rules:
   - apiGroups:
     - ""
     resources:
-      - secret
+      - secrets
     verbs:
     - list
     - watch

--- a/app/kumactl/cmd/install/testdata/install-control-plane.tproxy-ebpf-experimental-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.tproxy-ebpf-experimental-enabled.golden.yaml
@@ -48,11 +48,17 @@ rules:
       - pods
       - configmaps
       - nodes
-      - secrets
     verbs:
       - get
       - list
       - watch
+  - apiGroups:
+    - ""
+    resources:
+      - secret
+    verbs:
+    - list
+    - watch
   - apiGroups:
       - "apps"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
@@ -65,7 +65,7 @@ rules:
   - apiGroups:
     - ""
     resources:
-      - secret
+      - secrets
     verbs:
     - list
     - watch

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
@@ -58,11 +58,17 @@ rules:
       - pods
       - configmaps
       - nodes
-      - secrets
     verbs:
       - get
       - list
       - watch
+  - apiGroups:
+    - ""
+    resources:
+      - secret
+    verbs:
+    - list
+    - watch
   - apiGroups:
       - "apps"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -7927,11 +7927,17 @@ rules:
       - pods
       - configmaps
       - nodes
-      - secrets
     verbs:
       - get
       - list
       - watch
+  - apiGroups:
+    - ""
+    resources:
+      - secret
+    verbs:
+    - list
+    - watch
   - apiGroups:
       - "apps"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -7934,7 +7934,7 @@ rules:
   - apiGroups:
     - ""
     resources:
-      - secret
+      - secrets
     verbs:
     - list
     - watch

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
@@ -55,7 +55,7 @@ rules:
   - apiGroups:
     - ""
     resources:
-      - secret
+      - secrets
     verbs:
     - list
     - watch

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
@@ -48,11 +48,17 @@ rules:
       - pods
       - configmaps
       - nodes
-      - secrets
     verbs:
       - get
       - list
       - watch
+  - apiGroups:
+    - ""
+    resources:
+      - secret
+    verbs:
+    - list
+    - watch
   - apiGroups:
       - "apps"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -65,7 +65,7 @@ rules:
   - apiGroups:
     - ""
     resources:
-      - secret
+      - secrets
     verbs:
     - list
     - watch

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -58,11 +58,17 @@ rules:
       - pods
       - configmaps
       - nodes
-      - secrets
     verbs:
       - get
       - list
       - watch
+  - apiGroups:
+    - ""
+    resources:
+      - secret
+    verbs:
+    - list
+    - watch
   - apiGroups:
       - "apps"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
@@ -55,7 +55,7 @@ rules:
   - apiGroups:
     - ""
     resources:
-      - secret
+      - secrets
     verbs:
     - list
     - watch

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
@@ -48,11 +48,17 @@ rules:
       - pods
       - configmaps
       - nodes
-      - secrets
     verbs:
       - get
       - list
       - watch
+  - apiGroups:
+    - ""
+    resources:
+      - secret
+    verbs:
+    - list
+    - watch
   - apiGroups:
       - "apps"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/doNotChangeTlsChecksum.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/doNotChangeTlsChecksum.golden.yaml
@@ -55,7 +55,7 @@ rules:
   - apiGroups:
     - ""
     resources:
-      - secret
+      - secrets
     verbs:
     - list
     - watch

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/doNotChangeTlsChecksum.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/doNotChangeTlsChecksum.golden.yaml
@@ -48,11 +48,17 @@ rules:
       - pods
       - configmaps
       - nodes
-      - secrets
     verbs:
       - get
       - list
       - watch
+  - apiGroups:
+    - ""
+    resources:
+      - secret
+    verbs:
+    - list
+    - watch
   - apiGroups:
       - "apps"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
@@ -55,7 +55,7 @@ rules:
   - apiGroups:
     - ""
     resources:
-      - secret
+      - secrets
     verbs:
     - list
     - watch

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
@@ -48,11 +48,17 @@ rules:
       - pods
       - configmaps
       - nodes
-      - secrets
     verbs:
       - get
       - list
       - watch
+  - apiGroups:
+    - ""
+    resources:
+      - secret
+    verbs:
+    - list
+    - watch
   - apiGroups:
       - "apps"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
@@ -72,7 +72,7 @@ rules:
   - apiGroups:
     - ""
     resources:
-      - secret
+      - secrets
     verbs:
     - list
     - watch

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
@@ -65,11 +65,17 @@ rules:
       - pods
       - configmaps
       - nodes
-      - secrets
     verbs:
       - get
       - list
       - watch
+  - apiGroups:
+    - ""
+    resources:
+      - secret
+    verbs:
+    - list
+    - watch
   - apiGroups:
       - "apps"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
@@ -69,7 +69,7 @@ rules:
   - apiGroups:
     - ""
     resources:
-      - secret
+      - secrets
     verbs:
     - list
     - watch

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
@@ -62,11 +62,17 @@ rules:
       - pods
       - configmaps
       - nodes
-      - secrets
     verbs:
       - get
       - list
       - watch
+  - apiGroups:
+    - ""
+    resources:
+      - secret
+    verbs:
+    - list
+    - watch
   - apiGroups:
       - "apps"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
@@ -123,11 +123,17 @@ rules:
       - pods
       - configmaps
       - nodes
-      - secrets
     verbs:
       - get
       - list
       - watch
+  - apiGroups:
+    - ""
+    resources:
+      - secret
+    verbs:
+    - list
+    - watch
   - apiGroups:
       - "apps"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
@@ -130,7 +130,7 @@ rules:
   - apiGroups:
     - ""
     resources:
-      - secret
+      - secrets
     verbs:
     - list
     - watch

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix5978.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix5978.golden.yaml
@@ -75,7 +75,7 @@ rules:
   - apiGroups:
     - ""
     resources:
-      - secret
+      - secrets
     verbs:
     - list
     - watch

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix5978.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix5978.golden.yaml
@@ -68,11 +68,17 @@ rules:
       - pods
       - configmaps
       - nodes
-      - secrets
     verbs:
       - get
       - list
       - watch
+  - apiGroups:
+    - ""
+    resources:
+      - secret
+    verbs:
+    - list
+    - watch
   - apiGroups:
       - "apps"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix7724.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix7724.golden.yaml
@@ -51,11 +51,17 @@ rules:
       - pods
       - configmaps
       - nodes
-      - secrets
     verbs:
       - get
       - list
       - watch
+  - apiGroups:
+    - ""
+    resources:
+      - secret
+    verbs:
+    - list
+    - watch
   - apiGroups:
       - "apps"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix7724.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix7724.golden.yaml
@@ -58,7 +58,7 @@ rules:
   - apiGroups:
     - ""
     resources:
-      - secret
+      - secrets
     verbs:
     - list
     - watch

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix7824.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix7824.golden.yaml
@@ -90,7 +90,7 @@ rules:
   - apiGroups:
     - ""
     resources:
-      - secret
+      - secrets
     verbs:
     - list
     - watch

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix7824.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix7824.golden.yaml
@@ -83,11 +83,17 @@ rules:
       - pods
       - configmaps
       - nodes
-      - secrets
     verbs:
       - get
       - list
       - watch
+  - apiGroups:
+    - ""
+    resources:
+      - secret
+    verbs:
+    - list
+    - watch
   - apiGroups:
       - "apps"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/minReadySeconds.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/minReadySeconds.golden.yaml
@@ -55,7 +55,7 @@ rules:
   - apiGroups:
     - ""
     resources:
-      - secret
+      - secrets
     verbs:
     - list
     - watch

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/minReadySeconds.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/minReadySeconds.golden.yaml
@@ -48,11 +48,17 @@ rules:
       - pods
       - configmaps
       - nodes
-      - secrets
     verbs:
       - get
       - list
       - watch
+  - apiGroups:
+    - ""
+    resources:
+      - secret
+    verbs:
+    - list
+    - watch
   - apiGroups:
       - "apps"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/securityContext.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/securityContext.golden.yaml
@@ -55,7 +55,7 @@ rules:
   - apiGroups:
     - ""
     resources:
-      - secret
+      - secrets
     verbs:
     - list
     - watch

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/securityContext.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/securityContext.golden.yaml
@@ -48,11 +48,17 @@ rules:
       - pods
       - configmaps
       - nodes
-      - secrets
     verbs:
       - get
       - list
       - watch
+  - apiGroups:
+    - ""
+    resources:
+      - secret
+    verbs:
+    - list
+    - watch
   - apiGroups:
       - "apps"
     resources:

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -94,7 +94,7 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.admissionServerPort | int | `5443` | Define a new server port for the admission controller. Recommended to set in combination with hostNetwork to prevent multiple port bindings on the same port (like Calico in AWS EKS). |
 | controlPlane.podSecurityContext | object | `{"runAsNonRoot":true}` | Security context at the pod level for control plane. |
 | controlPlane.containerSecurityContext | object | `{"readOnlyRootFilesystem":true}` | Security context at the container level for control plane. |
-| controlPlane.supportAllGatewaySecrets | bool | `false` | If true, then control plane can support TLS secrets for builtin gateway outside of mesh system namespace. The downside is that control plane requires permission to read Secrets in all namespaces. |
+| controlPlane.supportGatewaySecretsInAllNamespaces | bool | `false` | If true, then control plane can support TLS secrets for builtin gateway outside of mesh system namespace. The downside is that control plane requires permission to read Secrets in all namespaces. |
 | cni.enabled | bool | `false` | Install Kuma with CNI instead of proxy init container |
 | cni.chained | bool | `false` | Install CNI in chained mode |
 | cni.netDir | string | `"/etc/cni/multus/net.d"` | Set the CNI install directory |

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -94,6 +94,7 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.admissionServerPort | int | `5443` | Define a new server port for the admission controller. Recommended to set in combination with hostNetwork to prevent multiple port bindings on the same port (like Calico in AWS EKS). |
 | controlPlane.podSecurityContext | object | `{"runAsNonRoot":true}` | Security context at the pod level for control plane. |
 | controlPlane.containerSecurityContext | object | `{"readOnlyRootFilesystem":true}` | Security context at the container level for control plane. |
+| controlPlane.supportAllGatewaySecrets | bool | `false` | If true, then control plane can support TLS secrets for builtin gateway outside of mesh system namespace. The downside is that control plane requires permission to read Secrets in all namespaces. |
 | cni.enabled | bool | `false` | Install Kuma with CNI instead of proxy init container |
 | cni.chained | bool | `false` | Install CNI in chained mode |
 | cni.netDir | string | `"/etc/cni/multus/net.d"` | Set the CNI install directory |

--- a/deployments/charts/kuma/templates/_helpers.tpl
+++ b/deployments/charts/kuma/templates/_helpers.tpl
@@ -299,6 +299,10 @@ env:
 {{- end }}
 - name: KUMA_PLUGIN_POLICIES_ENABLED
   value: {{ include "kuma.pluginPoliciesEnabled" . | quote }}
+{{- if .Values.controlPlane.supportGatewaySecretsInAllNamespaces }}
+- name: KUMA_RUNTIME_KUBERNETES_SUPPORT_GATEWAY_SECRETS_IN_ALL_NAMESPACES
+  value: true
+{{- end }}
 {{- end }}
 
 {{- define "kuma.controlPlane.tls.general.caSecretName" -}}

--- a/deployments/charts/kuma/templates/cp-rbac.yaml
+++ b/deployments/charts/kuma/templates/cp-rbac.yaml
@@ -29,11 +29,20 @@ rules:
       - pods
       - configmaps
       - nodes
+{{- if .Values.controlPlane.supportAllGatewaySecrets }}
       - secrets
+{{- end }}
     verbs:
       - get
       - list
       - watch
+  - apiGroups:
+    - ""
+    resources:
+      - secret
+    verbs:
+    - list
+    - watch
   - apiGroups:
       - "apps"
     resources:

--- a/deployments/charts/kuma/templates/cp-rbac.yaml
+++ b/deployments/charts/kuma/templates/cp-rbac.yaml
@@ -29,7 +29,7 @@ rules:
       - pods
       - configmaps
       - nodes
-{{- if .Values.controlPlane.supportAllGatewaySecrets }}
+{{- if .Values.controlPlane.supportGatewaySecretsInAllNamespaces }}
       - secrets
 {{- end }}
     verbs:

--- a/deployments/charts/kuma/templates/cp-rbac.yaml
+++ b/deployments/charts/kuma/templates/cp-rbac.yaml
@@ -39,7 +39,7 @@ rules:
   - apiGroups:
     - ""
     resources:
-      - secret
+      - secrets
     verbs:
     - list
     - watch

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -323,7 +323,7 @@ controlPlane:
 
   # -- If true, then control plane can support TLS secrets for builtin gateway outside of mesh system namespace.
   # The downside is that control plane requires permission to read Secrets in all namespaces.
-  supportAllGatewaySecrets: false
+  supportGatewaySecretsInAllNamespaces: false
 
 cni:
   # -- Install Kuma with CNI instead of proxy init container

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -321,6 +321,10 @@ controlPlane:
   containerSecurityContext:
     readOnlyRootFilesystem: true
 
+  # -- If true, then control plane can support TLS secrets for builtin gateway outside of mesh system namespace.
+  # The downside is that control plane requires permission to read Secrets in all namespaces.
+  supportAllGatewaySecrets: false
+
 cni:
   # -- Install Kuma with CNI instead of proxy init container
   enabled: false

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -323,7 +323,7 @@ controlPlane:
 
   # -- If true, then control plane can support TLS secrets for builtin gateway outside of mesh system namespace.
   # The downside is that control plane requires permission to read Secrets in all namespaces.
-  supportAllGatewaySecrets: false
+  supportGatewaySecretsInAllNamespaces: false
 
 cni:
   # -- Install Kuma with CNI instead of proxy init container

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -321,6 +321,10 @@ controlPlane:
   containerSecurityContext:
     readOnlyRootFilesystem: true
 
+  # -- If true, then control plane can support TLS secrets for builtin gateway outside of mesh system namespace.
+  # The downside is that control plane requires permission to read Secrets in all namespaces.
+  supportAllGatewaySecrets: false
+
 cni:
   # -- Install Kuma with CNI instead of proxy init container
   enabled: false

--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -405,6 +405,9 @@ runtime:
     # If this is set to true, deleting a Mesh will not delete resources that belong to that Mesh.
     # This can be useful when resources are managed in Argo CD where creation/deletion is managed there.
     skipMeshOwnerReference: false # ENV: KUMA_RUNTIME_KUBERNETES_SKIP_MESH_OWNER_REFERENCE
+    # If true, then control plane can support TLS secrets for builtin gateway outside of mesh system namespace.
+    # The downside is that control plane requires permission to read Secrets in all namespaces.
+    supportAllGatewaySecrets: false # ENV: KUMA_RUNTIME_KUBERNETES_SUPPORT_ALL_GATEWAY_SECRETS
   # Universal-specific configuration
   universal:
     # DataplaneCleanupAge defines how long Dataplane should be offline to be cleaned up by GC

--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -407,7 +407,7 @@ runtime:
     skipMeshOwnerReference: false # ENV: KUMA_RUNTIME_KUBERNETES_SKIP_MESH_OWNER_REFERENCE
     # If true, then control plane can support TLS secrets for builtin gateway outside of mesh system namespace.
     # The downside is that control plane requires permission to read Secrets in all namespaces.
-    supportAllGatewaySecrets: false # ENV: KUMA_RUNTIME_KUBERNETES_SUPPORT_ALL_GATEWAY_SECRETS
+    supportGatewaySecretsInAllNamespaces: false # ENV: KUMA_RUNTIME_KUBERNETES_SUPPORT_GATEWAY_SECRETS_IN_ALL_NAMESPACES
   # Universal-specific configuration
   universal:
     # DataplaneCleanupAge defines how long Dataplane should be offline to be cleaned up by GC

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -405,6 +405,9 @@ runtime:
     # If this is set to true, deleting a Mesh will not delete resources that belong to that Mesh.
     # This can be useful when resources are managed in Argo CD where creation/deletion is managed there.
     skipMeshOwnerReference: false # ENV: KUMA_RUNTIME_KUBERNETES_SKIP_MESH_OWNER_REFERENCE
+    # If true, then control plane can support TLS secrets for builtin gateway outside of mesh system namespace.
+    # The downside is that control plane requires permission to read Secrets in all namespaces.
+    supportAllGatewaySecrets: false # ENV: KUMA_RUNTIME_KUBERNETES_SUPPORT_ALL_GATEWAY_SECRETS
   # Universal-specific configuration
   universal:
     # DataplaneCleanupAge defines how long Dataplane should be offline to be cleaned up by GC

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -407,7 +407,7 @@ runtime:
     skipMeshOwnerReference: false # ENV: KUMA_RUNTIME_KUBERNETES_SKIP_MESH_OWNER_REFERENCE
     # If true, then control plane can support TLS secrets for builtin gateway outside of mesh system namespace.
     # The downside is that control plane requires permission to read Secrets in all namespaces.
-    supportAllGatewaySecrets: false # ENV: KUMA_RUNTIME_KUBERNETES_SUPPORT_ALL_GATEWAY_SECRETS
+    supportGatewaySecretsInAllNamespaces: false # ENV: KUMA_RUNTIME_KUBERNETES_SUPPORT_GATEWAY_SECRETS_IN_ALL_NAMESPACES
   # Universal-specific configuration
   universal:
     # DataplaneCleanupAge defines how long Dataplane should be offline to be cleaned up by GC

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -232,7 +232,7 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.Runtime.Kubernetes.LeaderElection.LeaseDuration.Duration).To(Equal(199 * time.Second))
 			Expect(cfg.Runtime.Kubernetes.LeaderElection.RenewDeadline.Duration).To(Equal(99 * time.Second))
 			Expect(cfg.Runtime.Kubernetes.SkipMeshOwnerReference).To(BeTrue())
-			Expect(cfg.Runtime.Kubernetes.SupportAllGatewaySecrets).To(BeTrue())
+			Expect(cfg.Runtime.Kubernetes.SupportGatewaySecretsInAllNamespaces).To(BeTrue())
 
 			Expect(cfg.Runtime.Universal.DataplaneCleanupAge.Duration).To(Equal(1 * time.Hour))
 			Expect(cfg.Runtime.Universal.VIPRefreshInterval.Duration).To(Equal(10 * time.Second))
@@ -568,7 +568,7 @@ runtime:
       leaseDuration: 199s
       renewDeadline: 99s
     skipMeshOwnerReference: true
-    supportAllGatewaySecrets: true
+    supportGatewaySecretsInAllNamespaces: true
 reports:
   enabled: false
 general:
@@ -895,7 +895,7 @@ tracing:
 				"KUMA_RUNTIME_KUBERNETES_LEADER_ELECTION_LEASE_DURATION":                                   "199s",
 				"KUMA_RUNTIME_KUBERNETES_LEADER_ELECTION_RENEW_DEADLINE":                                   "99s",
 				"KUMA_RUNTIME_KUBERNETES_SKIP_MESH_OWNER_REFERENCE":                                        "true",
-				"KUMA_RUNTIME_KUBERNETES_SUPPORT_ALL_GATEWAY_SECRETS":                                      "true",
+				"KUMA_RUNTIME_KUBERNETES_SUPPORT_GATEWAY_SECRETS_IN_ALL_NAMESPACES":                        "true",
 				"KUMA_RUNTIME_UNIVERSAL_DATAPLANE_CLEANUP_AGE":                                             "1h",
 				"KUMA_RUNTIME_UNIVERSAL_VIP_REFRESH_INTERVAL":                                              "10s",
 				"KUMA_GENERAL_TLS_CERT_FILE":                                                               "/tmp/cert",

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -232,6 +232,7 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.Runtime.Kubernetes.LeaderElection.LeaseDuration.Duration).To(Equal(199 * time.Second))
 			Expect(cfg.Runtime.Kubernetes.LeaderElection.RenewDeadline.Duration).To(Equal(99 * time.Second))
 			Expect(cfg.Runtime.Kubernetes.SkipMeshOwnerReference).To(BeTrue())
+			Expect(cfg.Runtime.Kubernetes.SupportAllGatewaySecrets).To(BeTrue())
 
 			Expect(cfg.Runtime.Universal.DataplaneCleanupAge.Duration).To(Equal(1 * time.Hour))
 			Expect(cfg.Runtime.Universal.VIPRefreshInterval.Duration).To(Equal(10 * time.Second))
@@ -567,6 +568,7 @@ runtime:
       leaseDuration: 199s
       renewDeadline: 99s
     skipMeshOwnerReference: true
+    supportAllGatewaySecrets: true
 reports:
   enabled: false
 general:
@@ -893,6 +895,7 @@ tracing:
 				"KUMA_RUNTIME_KUBERNETES_LEADER_ELECTION_LEASE_DURATION":                                   "199s",
 				"KUMA_RUNTIME_KUBERNETES_LEADER_ELECTION_RENEW_DEADLINE":                                   "99s",
 				"KUMA_RUNTIME_KUBERNETES_SKIP_MESH_OWNER_REFERENCE":                                        "true",
+				"KUMA_RUNTIME_KUBERNETES_SUPPORT_ALL_GATEWAY_SECRETS":                                      "true",
 				"KUMA_RUNTIME_UNIVERSAL_DATAPLANE_CLEANUP_AGE":                                             "1h",
 				"KUMA_RUNTIME_UNIVERSAL_VIP_REFRESH_INTERVAL":                                              "10s",
 				"KUMA_GENERAL_TLS_CERT_FILE":                                                               "/tmp/cert",

--- a/pkg/config/plugins/runtime/k8s/config.go
+++ b/pkg/config/plugins/runtime/k8s/config.go
@@ -153,6 +153,9 @@ type KubernetesRuntimeConfig struct {
 	// If this is set to true, deleting a Mesh will not delete resources that belong to that Mesh.
 	// This can be useful when resources are managed in Argo CD where creation/deletion is managed there.
 	SkipMeshOwnerReference bool `json:"skipMeshOwnerReference" envconfig:"kuma_runtime_kubernetes_skip_mesh_owner_reference"`
+	// If true, then control plane can support TLS secrets for builtin gateway outside of mesh system namespace.
+	// The downside is that control plane requires permission to read Secrets in all namespaces.
+	SupportAllGatewaySecrets bool `json:"supportAllGatewaySecrets" envconfig:"KUMA_RUNTIME_KUBERNETES_SUPPORT_ALL_GATEWAY_SECRETS"`
 }
 
 type ControllersConcurrency struct {

--- a/pkg/config/plugins/runtime/k8s/config.go
+++ b/pkg/config/plugins/runtime/k8s/config.go
@@ -155,7 +155,7 @@ type KubernetesRuntimeConfig struct {
 	SkipMeshOwnerReference bool `json:"skipMeshOwnerReference" envconfig:"kuma_runtime_kubernetes_skip_mesh_owner_reference"`
 	// If true, then control plane can support TLS secrets for builtin gateway outside of mesh system namespace.
 	// The downside is that control plane requires permission to read Secrets in all namespaces.
-	SupportAllGatewaySecrets bool `json:"supportAllGatewaySecrets" envconfig:"KUMA_RUNTIME_KUBERNETES_SUPPORT_ALL_GATEWAY_SECRETS"`
+	SupportGatewaySecretsInAllNamespaces bool `json:"supportGatewaySecretsInAllNamespaces" envconfig:"kuma_runtime_kubernetes_support_gateway_secrets_in_all_namespaces"`
 }
 
 type ControllersConcurrency struct {

--- a/pkg/config/plugins/runtime/k8s/testdata/default-config.golden.yaml
+++ b/pkg/config/plugins/runtime/k8s/testdata/default-config.golden.yaml
@@ -80,3 +80,4 @@ nodeTaintController:
   enabled: false
 serviceAccountName: system:serviceaccount:kuma-system:kuma-control-plane
 skipMeshOwnerReference: false
+supportGatewaySecretsInAllNamespaces: false

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/secret_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/secret_controller.go
@@ -17,15 +17,15 @@ import (
 // Whenever Secret is used for TLS termination in Gateway API, we copy this to system namespace.
 // Secret is created in GatewayController, SecretController updates and deletes the secret.
 type SecretController struct {
-	Log                      logr.Logger
-	Client                   kube_client.Client
-	SystemNamespace          string
-	SupportAllGatewaySecrets bool
+	Log                                  logr.Logger
+	Client                               kube_client.Client
+	SystemNamespace                      string
+	SupportGatewaySecretsInAllNamespaces bool
 }
 
 func (r *SecretController) Reconcile(ctx context.Context, req kube_ctrl.Request) (kube_ctrl.Result, error) {
-	if !r.SupportAllGatewaySecrets && req.Namespace != r.SystemNamespace {
-		r.Log.V(1).Info("ignoring reconcile because SupportAllGatewaySecrets is disabled", "req", req)
+	if !r.SupportGatewaySecretsInAllNamespaces && req.Namespace != r.SystemNamespace {
+		r.Log.V(1).Info("ignoring reconcile because SupportGatewaySecretsInAllNamespaces is disabled", "req", req)
 		return kube_ctrl.Result{}, nil
 	}
 	r.Log.Info("reconcile", "req", req)

--- a/pkg/plugins/runtime/k8s/plugin_gateway.go
+++ b/pkg/plugins/runtime/k8s/plugin_gateway.go
@@ -140,9 +140,10 @@ func addGatewayAPIReconcillers(mgr kube_ctrl.Manager, rt core_runtime.Runtime, p
 	}
 
 	secretController := &gatewayapi_controllers.SecretController{
-		Log:             core.Log.WithName("controllers").WithName("secret"),
-		Client:          mgr.GetClient(),
-		SystemNamespace: rt.Config().Store.Kubernetes.SystemNamespace,
+		Log:                      core.Log.WithName("controllers").WithName("secret"),
+		Client:                   mgr.GetClient(),
+		SystemNamespace:          rt.Config().Store.Kubernetes.SystemNamespace,
+		SupportAllGatewaySecrets: rt.Config().Runtime.Kubernetes.SupportAllGatewaySecrets,
 	}
 	if err := secretController.SetupWithManager(mgr); err != nil {
 		return errors.Wrap(err, "could not setup Secret reconciler")

--- a/pkg/plugins/runtime/k8s/plugin_gateway.go
+++ b/pkg/plugins/runtime/k8s/plugin_gateway.go
@@ -140,10 +140,10 @@ func addGatewayAPIReconcillers(mgr kube_ctrl.Manager, rt core_runtime.Runtime, p
 	}
 
 	secretController := &gatewayapi_controllers.SecretController{
-		Log:                      core.Log.WithName("controllers").WithName("secret"),
-		Client:                   mgr.GetClient(),
-		SystemNamespace:          rt.Config().Store.Kubernetes.SystemNamespace,
-		SupportAllGatewaySecrets: rt.Config().Runtime.Kubernetes.SupportAllGatewaySecrets,
+		Log:                                  core.Log.WithName("controllers").WithName("secret"),
+		Client:                               mgr.GetClient(),
+		SystemNamespace:                      rt.Config().Store.Kubernetes.SystemNamespace,
+		SupportGatewaySecretsInAllNamespaces: rt.Config().Runtime.Kubernetes.SupportGatewaySecretsInAllNamespaces,
 	}
 	if err := secretController.SetupWithManager(mgr); err != nil {
 		return errors.Wrap(err, "could not setup Secret reconciler")

--- a/test/framework/envs/kubernetes/env.go
+++ b/test/framework/envs/kubernetes/env.go
@@ -26,7 +26,9 @@ func SetupAndGetState() []byte {
 	kumaOptions := append(
 		[]framework.KumaDeploymentOption{
 			framework.WithEgress(),
-			framework.WithHelmOpt("controlPlane.supportGatewaySecretsInAllNamespaces", "true"), // needed for test/e2e_env/kubernetes/gateway/gatewayapi.go:470
+			framework.WithCtlOpts(map[string]string{
+				"--set": "controlPlane.supportGatewaySecretsInAllNamespaces=true", // needed for test/e2e_env/kubernetes/gateway/gatewayapi.go:470
+			}),
 		},
 		framework.KumaDeploymentOptionsFromConfig(framework.Config.KumaCpConfig.Standalone.Kubernetes)...,
 	)

--- a/test/framework/envs/kubernetes/env.go
+++ b/test/framework/envs/kubernetes/env.go
@@ -24,7 +24,10 @@ func SetupAndGetState() []byte {
 	)).To(Succeed())
 
 	kumaOptions := append(
-		[]framework.KumaDeploymentOption{framework.WithEgress()},
+		[]framework.KumaDeploymentOption{
+			framework.WithEgress(),
+			framework.WithHelmOpt("controlPlane.supportGatewaySecretsInAllNamespaces", "true"), // needed for test/e2e_env/kubernetes/gateway/gatewayapi.go:470
+		},
 		framework.KumaDeploymentOptionsFromConfig(framework.Config.KumaCpConfig.Standalone.Kubernetes)...,
 	)
 	if framework.Config.KumaExperimentalSidecarContainers {


### PR DESCRIPTION
### Checklist prior to review

Fix #9947

Provide get permissions for Secrets as opt-in. This comes at the cost that if you want to use gateway API Gateway with TLS in namespace other than system, you need to set `supportAllGatewaySecrets` to true.

We can still list and watch all the secrets in the cluster. We cannot get the content of them though. This is needed for SecretController to run. The only alternative is to try to run another Kubernetes Manager with restricted access to a namespace, but that's hard to manage.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
