### PR TITLE
fix(transparent-proxy): stop logging all to stderr when installing tproxy

### DIFF
--- a/pkg/transparentproxy/iptables/builder/builder.go
+++ b/pkg/transparentproxy/iptables/builder/builder.go
@@ -94,8 +94,8 @@ func BuildIPTables(
 // runtimeOutput is the file (should be os.Stdout by default) where we can dump generated
 // rules for used to see and debug if something goes wrong, which can be overwritten
 // in tests to not obfuscate the other, more relevant logs
-func (r *restorer) saveIPTablesRestoreFile(f *os.File, content string) error {
-	fmt.Fprintf(r.cfg.RuntimeStdout, "# writing following contents to rules file: %s\n", f.Name())
+func (r *restorer) saveIPTablesRestoreFile(logPrefix string, f *os.File, content string) error {
+	fmt.Fprintf(r.cfg.RuntimeStdout, "%s writing following contents to rules file: %s\n", logPrefix, f.Name())
 	fmt.Fprint(r.cfg.RuntimeStdout, content)
 
 	writer := bufio.NewWriter(f)
@@ -164,36 +164,40 @@ func (r *restorer) restore(ctx context.Context) (string, error) {
 	maxRetries := pointer.Deref(r.cfg.Retry.MaxRetries)
 
 	for i := 0; i <= maxRetries; i++ {
-		fmt.Fprintf(r.cfg.RuntimeStderr, "\n# [%d/%d] ", i+1, maxRetries+1)
+		logPrefix := fmt.Sprintf("# [%d/%d]", i+1, maxRetries+1)
 
-		output, err := r.tryRestoreIPTables(ctx, r.executables, rulesFile)
+		output, err := r.tryRestoreIPTables(ctx, logPrefix, r.executables, rulesFile)
 		if err == nil {
 			return output, nil
 		}
 
 		if r.executables.fallback != nil {
-			fmt.Fprintf(r.cfg.RuntimeStderr, ", trying fallback: ")
+			fmt.Fprintf(r.cfg.RuntimeStdout, "%s trying fallback\n", logPrefix)
 
-			output, err := r.tryRestoreIPTables(ctx, r.executables.fallback, rulesFile)
+			output, err := r.tryRestoreIPTables(ctx, logPrefix, r.executables.fallback, rulesFile)
 			if err == nil {
 				return output, nil
 			}
 		}
 
 		if i < maxRetries {
-			fmt.Fprintf(r.cfg.RuntimeStderr, " will try again in %s", r.cfg.Retry.SleepBetweenReties)
+			fmt.Fprintf(
+				r.cfg.RuntimeStdout,
+				"%s will try again in %s\n",
+				logPrefix,
+				r.cfg.Retry.SleepBetweenReties,
+			)
 
 			time.Sleep(r.cfg.Retry.SleepBetweenReties)
 		}
 	}
-
-	fmt.Fprintln(r.cfg.RuntimeStderr)
 
 	return "", errors.Errorf("%s failed", r.executables.Restore.Path)
 }
 
 func (r *restorer) tryRestoreIPTables(
 	ctx context.Context,
+	logPrefix string,
 	executables *Executables,
 	rulesFile *os.File,
 ) (string, error) {
@@ -206,20 +210,31 @@ func (r *restorer) tryRestoreIPTables(
 		return "", fmt.Errorf("unable to build iptable rules: %s", err)
 	}
 
-	if err := r.saveIPTablesRestoreFile(rulesFile, rules); err != nil {
+	if err := r.saveIPTablesRestoreFile(logPrefix, rulesFile, rules); err != nil {
 		return "", fmt.Errorf("unable to save iptables restore file: %s", err)
 	}
 
-	params := buildRestoreParameters(r.cfg, rulesFile, executables.legacy)
+	params := buildRestoreParameters(r.cfg, rulesFile, executables.legacy())
 
-	fmt.Fprintf(r.cfg.RuntimeStderr, "%s %s", executables.Restore.Path, strings.Join(params, " "))
+	fmt.Fprintf(
+		r.cfg.RuntimeStdout,
+		"%s %s %s\n",
+		logPrefix,
+		executables.Restore.Path,
+		strings.Join(params, " "),
+	)
 
 	output, err := executables.Restore.exec(ctx, params...)
 	if err == nil {
 		return output.String(), nil
 	}
 
-	fmt.Fprintf(r.cfg.RuntimeStderr, " failed with error: '%s'", err)
+	fmt.Fprintf(
+		r.cfg.RuntimeStderr,
+		"%s failed with error: '%s'\n",
+		logPrefix,
+		strings.ReplaceAll(err.Error(), "\n", ""),
+	)
 
 	return "", err
 }
@@ -265,8 +280,7 @@ func RestoreIPTables(ctx context.Context, cfg config.Config) (string, error) {
 		output += ipv6Output
 	}
 
-	_, _ = cfg.RuntimeStdout.Write([]byte("\n# iptables set to diverge the traffic " +
-		"to Envoy.\n"))
+	fmt.Fprintln(cfg.RuntimeStdout, "# iptables set to diverge the traffic to Envoy")
 
 	return output, nil
 }

--- a/pkg/transparentproxy/iptables/builder/builder.go
+++ b/pkg/transparentproxy/iptables/builder/builder.go
@@ -280,7 +280,7 @@ func RestoreIPTables(ctx context.Context, cfg config.Config) (string, error) {
 		output += ipv6Output
 	}
 
-	fmt.Fprintln(cfg.RuntimeStdout, "# iptables set to diverge the traffic to Envoy")
+	fmt.Fprintln(cfg.RuntimeStdout, "# iptables set to divert the traffic to Envoy")
 
 	return output, nil
 }

--- a/pkg/transparentproxy/iptables/builder/builder_restore.go
+++ b/pkg/transparentproxy/iptables/builder/builder_restore.go
@@ -92,7 +92,7 @@ type Executables struct {
 	Save                   Executable
 	Restore                Executable
 	fallback               *Executables
-	legacy                 bool
+	mode                   string
 	foundDockerOutputChain bool
 }
 
@@ -110,7 +110,7 @@ func newExecutables(ipv6 bool, mode string) *Executables {
 		Iptables: findExecutable(iptables),
 		Save:     findExecutable(iptablesSave),
 		Restore:  findExecutable(iptablesRestore),
-		legacy:   mode == "legacy",
+		mode:     mode,
 	}
 }
 
@@ -118,6 +118,10 @@ var necessaryMatchExtensions = []string{
 	"owner",
 	"tcp",
 	"udp",
+}
+
+func (e *Executables) legacy() bool {
+	return e.mode == "legacy"
 }
 
 func (e *Executables) verify(ctx context.Context, cfg config.Config) (*Executables, error) {
@@ -132,7 +136,7 @@ func (e *Executables) verify(ctx context.Context, cfg config.Config) (*Executabl
 	}
 
 	if len(missing) > 0 {
-		return nil, errors.Errorf("couldn't find executables: [%s]", strings.Join(missing, ","))
+		return nil, errors.Errorf("couldn't find %s executables: [%s]", e.mode, strings.Join(missing, ", "))
 	}
 
 	// We always need to have access to the "nat" table


### PR DESCRIPTION
Because of the construction of the log line, where everything was located at the same line, we were not able to figure out at the beginnig of the log if it'll be successfull or not, so everything was logged in stderr. It's wrong when you have a monitoring set to watch stderr. I changed it so now the same information is placed in multiple lines and only failure is send to stderr.

Examples:

```
# kumactl is about to apply the iptables rules that will enable transparent proxying on the machine. The SSH connection may drop. If that happens, just reconnect again.
# [1/5] writing following contents to rules file: /tmp/iptables-rules-1713857949369149426.txt3315697516
* nat
-N KUMA_MESH_INBOUND
-N KUMA_MESH_OUTBOUND
-N KUMA_MESH_INBOUND_REDIRECT
-N KUMA_MESH_OUTBOUND_REDIRECT
-A PREROUTING -p tcp -j KUMA_MESH_INBOUND
-A OUTPUT -p tcp -j KUMA_MESH_OUTBOUND
-A KUMA_MESH_INBOUND -p tcp -j KUMA_MESH_INBOUND_REDIRECT
-A KUMA_MESH_OUTBOUND -s 127.0.0.6/32 -o lo -j RETURN
-A KUMA_MESH_OUTBOUND -p tcp -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
-A KUMA_MESH_OUTBOUND -p tcp -o lo -m owner ! --uid-owner 5678 -j RETURN
-A KUMA_MESH_OUTBOUND -m owner --uid-owner 5678 -j RETURN
-A KUMA_MESH_OUTBOUND -d 127.0.0.1/32 -j RETURN
-A KUMA_MESH_OUTBOUND -j KUMA_MESH_OUTBOUND_REDIRECT
-A KUMA_MESH_INBOUND_REDIRECT -p tcp -j REDIRECT --to-ports 15006
-A KUMA_MESH_OUTBOUND_REDIRECT -p tcp -j REDIRECT --to-ports 15001
COMMIT
# [1/5] /usr/sbin/iptables-nft-restore -n /tmp/iptables-rules-1713857949369149426.txt3315697516
# iptables set to diverge the traffic to Envoy
# Transparent proxy set up successfully, you can now run kuma-dp using transparent-proxy.
```

```
# kumactl is about to apply the iptables rules that will enable transparent proxying on the machine. The SSH connection may drop. If that happens, just reconnect again.
# [1/5] writing following contents to rules file: /tmp/iptables-rules-1713857756759164748.txt2242814141
* nat
-N KUMA_MESH_INBOUND
-N KUMA_MESH_OUTBOUND
-N KUMA_MESH_INBOUND_REDIRECT
-N KUMA_MESH_OUTBOUND_REDIRECT
-A PREROUTING -p tcp -j KUMA_MESH_INBOUND
-A OUTPUT -p tcp -j KUMA_MESH_OUTBOUND
-A KUMA_MESH_INBOUND -p tcp -j KUMA_MESH_INBOUND_REDIRECT
-A KUMA_MESH_OUTBOUND -s 127.0.0.6/32 -o lo -j RETURN
-A KUMA_MESH_OUTBOUND -p tcp -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
-A KUMA_MESH_OUTBOUND -p tcp -o lo -m owner ! --uid-owner 5678 -j RETURN
-A KUMA_MESH_OUTBOUND -m owner --uid-owner 5678 -j RETURN
-A KUMA_MESH_OUTBOUND -d 127.0.0.1/32 -j RETURN
-A KUMA_MESH_OUTBOUND -j KUMA_MESH_OUTBOUND_REDIRECT
-A KUMA_MESH_INBOUND_REDIRECT -p tcp -j REDIRECT --to-ports 15006
-A KUMA_MESH_OUTBOUND_REDIRECT -p tcp -j REDIRECT --to-ports 15001
COMMIT
# [1/5] /usr/sbin/iptables-nft-restore -n /tmp/iptables-rules-1713857756759164748.txt2242814141
# [1/5] failed with error: 'iptables-nft-restore: line 2 failed: Chain already exists.: exit status 1'
# [1/5] trying fallback
# [1/5] writing following contents to rules file: /tmp/iptables-rules-1713857756759164748.txt2242814141
* nat
-N KUMA_MESH_INBOUND
-N KUMA_MESH_OUTBOUND
-N KUMA_MESH_INBOUND_REDIRECT
-N KUMA_MESH_OUTBOUND_REDIRECT
-A PREROUTING -p tcp -j KUMA_MESH_INBOUND
-A OUTPUT -p tcp -j KUMA_MESH_OUTBOUND
-A KUMA_MESH_INBOUND -p tcp -j KUMA_MESH_INBOUND_REDIRECT
-A KUMA_MESH_OUTBOUND -s 127.0.0.6/32 -o lo -j RETURN
-A KUMA_MESH_OUTBOUND -p tcp -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
-A KUMA_MESH_OUTBOUND -p tcp -o lo -m owner ! --uid-owner 5678 -j RETURN
-A KUMA_MESH_OUTBOUND -m owner --uid-owner 5678 -j RETURN
-A KUMA_MESH_OUTBOUND -d 127.0.0.1/32 -j RETURN
-A KUMA_MESH_OUTBOUND -j KUMA_MESH_OUTBOUND_REDIRECT
-A KUMA_MESH_INBOUND_REDIRECT -p tcp -j REDIRECT --to-ports 15006
-A KUMA_MESH_OUTBOUND_REDIRECT -p tcp -j REDIRECT --to-ports 15001
COMMIT
# [1/5] /usr/sbin/iptables-legacy-restore --wait=5 -n /tmp/iptables-rules-1713857756759164748.txt2242814141
# [1/5] failed with error: 'iptables-restore: line 2 failed: exit status 1'
# [1/5] will try again in 2s
...
```

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - No relevant issues
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Manually tested locally
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
