### PR TITLE
test(e2e): add debug kube to all kube tests

### DIFF
--- a/test/e2e_env/kubernetes/connectivity/exclude_outbound_port.go
+++ b/test/e2e_env/kubernetes/connectivity/exclude_outbound_port.go
@@ -32,6 +32,10 @@ func ExcludeOutboundPort() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, meshName, namespace)
+	})
+
 	E2EAfterAll(func() {
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(namespaceExternal)).To(Succeed())

--- a/test/e2e_env/kubernetes/container_patch/container_patch.go
+++ b/test/e2e_env/kubernetes/container_patch/container_patch.go
@@ -65,6 +65,9 @@ spec:
 			Setup(kubernetes.Cluster)
 		Expect(err).ToNot(HaveOccurred())
 	})
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, mesh, namespace)
+	})
 	E2EAfterAll(func() {
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(kubernetes.Cluster.DeleteMesh(mesh)).To(Succeed())

--- a/test/e2e_env/kubernetes/defaults/defaults.go
+++ b/test/e2e_env/kubernetes/defaults/defaults.go
@@ -18,6 +18,10 @@ func Defaults() {
 		Expect(kubernetes.Cluster.Install(MeshKubernetes(meshName))).To(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, meshName)
+	})
+
 	AfterAll(func() {
 		Expect(kubernetes.Cluster.DeleteMesh(meshName)).To(Succeed())
 	})

--- a/test/e2e_env/kubernetes/externalname-services/externalname-services.go
+++ b/test/e2e_env/kubernetes/externalname-services/externalname-services.go
@@ -46,6 +46,10 @@ spec:
 		).To(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, meshName, namespace)
+	})
+
 	E2EAfterAll(func() {
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(kubernetes.Cluster.DeleteMesh(meshName)).To(Succeed())

--- a/test/e2e_env/kubernetes/externalservices/externalservices.go
+++ b/test/e2e_env/kubernetes/externalservices/externalservices.go
@@ -48,6 +48,10 @@ spec:
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, meshName, namespace, clientNamespace)
+	})
+
 	E2EAfterAll(func() {
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(clientNamespace)).To(Succeed())
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())

--- a/test/e2e_env/kubernetes/externalservices/permissive_mtls.go
+++ b/test/e2e_env/kubernetes/externalservices/permissive_mtls.go
@@ -69,6 +69,10 @@ spec:
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, meshName, namespace, clientNamespace)
+	})
+
 	E2EAfterAll(func() {
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(clientNamespace)).To(Succeed())
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())

--- a/test/e2e_env/kubernetes/gateway/cross-mesh.go
+++ b/test/e2e_env/kubernetes/gateway/cross-mesh.go
@@ -68,6 +68,11 @@ func CrossMeshGatewayOnKubernetes() {
 		Expect(setup.Setup(kubernetes.Cluster)).To(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, gatewayMesh, gatewayTestNamespace, gatewayTestNamespace2, gatewayClientNamespaceSameMesh)
+		DebugKube(kubernetes.Cluster, gatewayOtherMesh, gatewayClientNamespaceOtherMesh)
+	})
+
 	E2EAfterAll(func() {
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(gatewayClientNamespaceOtherMesh)).To(Succeed())
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(gatewayClientNamespaceSameMesh)).To(Succeed())

--- a/test/e2e_env/kubernetes/gateway/delegated/meshaccesslog.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshaccesslog.go
@@ -48,6 +48,10 @@ func MeshAccessLog(config *Config) func() {
 			return logs
 		}
 
+		framework.AfterEachFailure(func() {
+			framework.DebugKube(kubernetes.Cluster, config.Mesh, config.Namespace, config.ObservabilityDeploymentName)
+		})
+
 		framework.E2EAfterEach(func() {
 			Expect(framework.DeleteMeshResources(
 				kubernetes.Cluster,

--- a/test/e2e_env/kubernetes/gateway/delegated/meshcircuitbreaker.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshcircuitbreaker.go
@@ -30,6 +30,10 @@ func CircuitBreaker(config *Config) func() {
 			)).To(Succeed())
 		})
 
+		framework.AfterEachFailure(func() {
+			framework.DebugKube(kubernetes.Cluster, config.Mesh, config.Namespace, config.ObservabilityDeploymentName)
+		})
+
 		framework.E2EAfterEach(func() {
 			Expect(framework.DeleteMeshResources(
 				kubernetes.Cluster,

--- a/test/e2e_env/kubernetes/gateway/delegated/meshhealthcheck.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshhealthcheck.go
@@ -57,6 +57,10 @@ spec:
 				To(Succeed())
 		})
 
+		framework.AfterEachFailure(func() {
+			framework.DebugKube(kubernetes.Cluster, config.Mesh, config.Namespace, config.ObservabilityDeploymentName)
+		})
+
 		framework.E2EAfterEach(func() {
 			Expect(framework.DeleteMeshResources(
 				kubernetes.Cluster,

--- a/test/e2e_env/kubernetes/gateway/delegated/meshhttproute.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshhttproute.go
@@ -17,6 +17,10 @@ func MeshHTTPRoute(config *Config) func() {
 	GinkgoHelper()
 
 	return func() {
+		framework.AfterEachFailure(func() {
+			framework.DebugKube(kubernetes.Cluster, config.Mesh, config.Namespace, config.ObservabilityDeploymentName)
+		})
+
 		framework.E2EAfterEach(func() {
 			Expect(framework.DeleteMeshResources(
 				kubernetes.Cluster,

--- a/test/e2e_env/kubernetes/gateway/delegated/meshloadbalancingstrategy.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshloadbalancingstrategy.go
@@ -16,6 +16,10 @@ func MeshLoadBalancingStrategy(config *Config) func() {
 	GinkgoHelper()
 
 	return func() {
+		framework.AfterEachFailure(func() {
+			framework.DebugKube(kubernetes.Cluster, config.Mesh, config.Namespace, config.ObservabilityDeploymentName)
+		})
+
 		framework.E2EAfterEach(func() {
 			Expect(framework.DeleteMeshResources(
 				kubernetes.Cluster,

--- a/test/e2e_env/kubernetes/gateway/delegated/meshmetric.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshmetric.go
@@ -43,6 +43,10 @@ spec:
 `, config.CpNamespace, config.Mesh, otelEndpoint))
 		}
 
+		framework.AfterEachFailure(func() {
+			framework.DebugKube(kubernetes.Cluster, config.Mesh, config.Namespace, config.ObservabilityDeploymentName)
+		})
+
 		framework.E2EAfterEach(func() {
 			Expect(framework.DeleteMeshResources(
 				kubernetes.Cluster,

--- a/test/e2e_env/kubernetes/gateway/delegated/meshretry.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshretry.go
@@ -36,6 +36,10 @@ spec:
           retryOn: ["503"]
 `, config.CpNamespace, config.Mesh)
 
+		framework.AfterEachFailure(func() {
+			framework.DebugKube(kubernetes.Cluster, config.Mesh, config.Namespace, config.ObservabilityDeploymentName)
+		})
+
 		framework.E2EAfterEach(func() {
 			Expect(framework.DeleteMeshResources(
 				kubernetes.Cluster,

--- a/test/e2e_env/kubernetes/gateway/delegated/meshtcproute.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshtcproute.go
@@ -18,6 +18,10 @@ func MeshTCPRoute(config *Config) func() {
 	GinkgoHelper()
 
 	return func() {
+		framework.AfterEachFailure(func() {
+			framework.DebugKube(kubernetes.Cluster, config.Mesh, config.Namespace, config.ObservabilityDeploymentName)
+		})
+
 		framework.E2EAfterEach(func() {
 			Expect(framework.DeleteMeshResources(
 				kubernetes.Cluster,

--- a/test/e2e_env/kubernetes/gateway/delegated/meshtimeout.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshtimeout.go
@@ -32,6 +32,10 @@ func MeshTimeout(config *Config) func() {
 			)).To(Succeed())
 		})
 
+		framework.AfterEachFailure(func() {
+			framework.DebugKube(kubernetes.Cluster, config.Mesh, config.Namespace, config.ObservabilityDeploymentName)
+		})
+
 		framework.E2EAfterEach(func() {
 			Expect(framework.DeleteMeshResources(
 				kubernetes.Cluster,

--- a/test/e2e_env/kubernetes/gateway/delegated/meshtrace.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshtrace.go
@@ -46,6 +46,10 @@ spec:
 			observabilityClient = observability.From(config.ObservabilityDeploymentName, kubernetes.Cluster)
 		})
 
+		framework.AfterEachFailure(func() {
+			framework.DebugKube(kubernetes.Cluster, config.Mesh, config.Namespace, config.ObservabilityDeploymentName)
+		})
+
 		framework.E2EAfterEach(func() {
 			Expect(framework.DeleteMeshResources(
 				kubernetes.Cluster,

--- a/test/e2e_env/kubernetes/gateway/gateway.go
+++ b/test/e2e_env/kubernetes/gateway/gateway.go
@@ -130,6 +130,10 @@ type: system.kuma.io/secret
 		}, "30s", "1s").Should(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, meshName, namespace, clientNamespace)
+	})
+
 	E2EAfterAll(func() {
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(clientNamespace)).To(Succeed())

--- a/test/e2e_env/kubernetes/gateway/gatewayapi.go
+++ b/test/e2e_env/kubernetes/gateway/gatewayapi.go
@@ -66,6 +66,10 @@ spec:
 		Expect(setup.Setup(kubernetes.Cluster)).To(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, meshName, namespace, externalServicesNamespace)
+	})
+
 	E2EAfterAll(func() {
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(externalServicesNamespace)).To(Succeed())

--- a/test/e2e_env/kubernetes/gateway/mtls.go
+++ b/test/e2e_env/kubernetes/gateway/mtls.go
@@ -93,6 +93,10 @@ type: system.kuma.io/secret
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, meshName, namespace, clientNamespace)
+	})
+
 	E2EAfterAll(func() {
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(clientNamespace)).To(Succeed())

--- a/test/e2e_env/kubernetes/gateway/resources.go
+++ b/test/e2e_env/kubernetes/gateway/resources.go
@@ -103,6 +103,10 @@ spec:
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, meshName, namespace, waitingClientNamespace, curlingClientNamespace)
+	})
+
 	E2EAfterAll(func() {
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(waitingClientNamespace)).To(Succeed())

--- a/test/e2e_env/kubernetes/graceful/change_service.go
+++ b/test/e2e_env/kubernetes/graceful/change_service.go
@@ -111,6 +111,10 @@ func ChangeService() {
 		)).To(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, mesh, namespace)
+	})
+
 	E2EAfterAll(func() {
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(kubernetes.Cluster.DeleteMesh(mesh)).To(Succeed())

--- a/test/e2e_env/kubernetes/graceful/eviction.go
+++ b/test/e2e_env/kubernetes/graceful/eviction.go
@@ -21,6 +21,10 @@ func Eviction() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, meshName, nsName)
+	})
+
 	E2EAfterAll(func() {
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(nsName)).To(Succeed())
 		Expect(kubernetes.Cluster.DeleteMesh(meshName)).To(Succeed())

--- a/test/e2e_env/kubernetes/graceful/graceful.go
+++ b/test/e2e_env/kubernetes/graceful/graceful.go
@@ -125,6 +125,10 @@ spec:
 		Expect(DeleteMeshResources(kubernetes.Cluster, mesh, core_mesh.RetryResourceTypeDescriptor)).To(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, mesh, namespace)
+	})
+
 	E2EAfterAll(func() {
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(kubernetes.Cluster.DeleteMesh(mesh)).To(Succeed())

--- a/test/e2e_env/kubernetes/graceful/wait_for_envoy.go
+++ b/test/e2e_env/kubernetes/graceful/wait_for_envoy.go
@@ -28,6 +28,10 @@ func WaitForEnvoyReady() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, meshName, namespace)
+	})
+
 	E2EAfterAll(func() {
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(kubernetes.Cluster.DeleteMesh(meshName)).To(Succeed())

--- a/test/e2e_env/kubernetes/healthcheck/virtual_probes.go
+++ b/test/e2e_env/kubernetes/healthcheck/virtual_probes.go
@@ -26,6 +26,11 @@ func VirtualProbes() {
 			Setup(kubernetes.Cluster)
 		Expect(err).To(Succeed())
 	})
+
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, mesh, namespace)
+	})
+
 	E2EAfterAll(func() {
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(kubernetes.Cluster.DeleteMesh(mesh)).To(Succeed())

--- a/test/e2e_env/kubernetes/inspect/inspect.go
+++ b/test/e2e_env/kubernetes/inspect/inspect.go
@@ -42,6 +42,10 @@ func Inspect() {
 		)).To(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, meshName, nsName)
+	})
+
 	E2EAfterAll(func() {
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(nsName)).To(Succeed())
 		Expect(kubernetes.Cluster.DeleteMesh(meshName)).To(Succeed())

--- a/test/e2e_env/kubernetes/jobs/jobs.go
+++ b/test/e2e_env/kubernetes/jobs/jobs.go
@@ -10,63 +10,79 @@ import (
 )
 
 func Jobs() {
-	It("should terminate jobs without mTLS", func() {
+	Context("plaintext", func() {
 		const namespace = "jobs"
 		const mesh = "jobs"
 
-		E2EDeferCleanup(func() {
+		BeforeAll(func() {
+			err := NewClusterSetup().
+				Install(NamespaceWithSidecarInjection(namespace)).
+				Install(MeshKubernetes(mesh)).
+				Install(testserver.Install(
+					testserver.WithNamespace(namespace),
+					testserver.WithMesh(mesh),
+				)).
+				Setup(kubernetes.Cluster)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterEachFailure(func() {
+			DebugKube(kubernetes.Cluster, mesh, namespace)
+		})
+
+		AfterAll(func() {
 			Expect(kubernetes.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
 			Expect(kubernetes.Cluster.DeleteMesh(mesh)).To(Succeed())
 		})
 
-		err := NewClusterSetup().
-			Install(NamespaceWithSidecarInjection(namespace)).
-			Install(MeshKubernetes(mesh)).
-			Install(testserver.Install(
-				testserver.WithNamespace(namespace),
-				testserver.WithMesh(mesh),
-			)).
-			Setup(kubernetes.Cluster)
-		Expect(err).ToNot(HaveOccurred())
+		It("should terminate jobs", func() {
+			// when
+			err := kubernetes.Cluster.Install(DemoClientJobK8s(namespace, mesh, "test-server_jobs_svc_80.mesh"))
 
-		// when
-		err = kubernetes.Cluster.Install(DemoClientJobK8s(namespace, mesh, "test-server_jobs_svc_80.mesh"))
+			// then CP terminates the job by sending /quitquitquit to Envoy Admin and verifies connection using self-signed certs
+			Expect(err).ToNot(HaveOccurred())
 
-		// then CP terminates the job by sending /quitquitquit to Envoy Admin and verifies connection using self-signed certs
-		Expect(err).ToNot(HaveOccurred())
-
-		// and Dataplane object is deleted
-		Eventually(func(g Gomega) {
-			out, err := kubernetes.Cluster.GetKumactlOptions().RunKumactlAndGetOutput("get", "dataplanes", "--mesh", mesh)
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(out).ToNot(ContainSubstring("demo-job-client"))
-		}, "30s", "1s").Should(Succeed())
+			// and Dataplane object is deleted
+			Eventually(func(g Gomega) {
+				out, err := kubernetes.Cluster.GetKumactlOptions().RunKumactlAndGetOutput("get", "dataplanes", "--mesh", mesh)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(out).ToNot(ContainSubstring("demo-job-client"))
+			}, "30s", "1s").Should(Succeed())
+		})
 	})
 
-	It("should terminate jobs with mTLS", func() {
+	Context("mTLS", func() {
 		const namespace = "jobs-mtls"
 		const mesh = "jobs-mtls"
 
-		E2EDeferCleanup(func() {
+		BeforeAll(func() {
+			err := NewClusterSetup().
+				Install(NamespaceWithSidecarInjection(namespace)).
+				Install(MTLSMeshKubernetes(mesh)).
+				Install(MeshTrafficPermissionAllowAllKubernetes(mesh)).
+				Install(testserver.Install(
+					testserver.WithNamespace(namespace),
+					testserver.WithMesh(mesh),
+				)).
+				Setup(kubernetes.Cluster)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterEachFailure(func() {
+			DebugKube(kubernetes.Cluster, mesh, namespace)
+		})
+
+		AfterAll(func() {
 			Expect(kubernetes.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
 			Expect(kubernetes.Cluster.DeleteMesh(mesh)).To(Succeed())
 		})
 
-		err := NewClusterSetup().
-			Install(NamespaceWithSidecarInjection(namespace)).
-			Install(MTLSMeshKubernetes(mesh)).
-			Install(MeshTrafficPermissionAllowAllKubernetes(mesh)).
-			Install(testserver.Install(
-				testserver.WithNamespace(namespace),
-				testserver.WithMesh(mesh),
-			)).
-			Setup(kubernetes.Cluster)
-		Expect(err).ToNot(HaveOccurred())
+		It("should terminate jobs", func() {
+			// when
+			err := kubernetes.Cluster.Install(DemoClientJobK8s(namespace, mesh, "test-server_jobs-mtls_svc_80.mesh"))
 
-		// when
-		err = kubernetes.Cluster.Install(DemoClientJobK8s(namespace, mesh, "test-server_jobs-mtls_svc_80.mesh"))
-
-		// then CP terminates the job by sending /quitquitquit to Envoy Admin and verifies connection using mTLS certs
-		Expect(err).ToNot(HaveOccurred())
+			// then CP terminates the job by sending /quitquitquit to Envoy Admin and verifies connection using mTLS certs
+			Expect(err).ToNot(HaveOccurred())
+		})
 	})
 }

--- a/test/e2e_env/kubernetes/jobs/jobs.go
+++ b/test/e2e_env/kubernetes/jobs/jobs.go
@@ -49,7 +49,7 @@ func Jobs() {
 				g.Expect(out).ToNot(ContainSubstring("demo-job-client"))
 			}, "30s", "1s").Should(Succeed())
 		})
-	})
+	}, Ordered)
 
 	Context("mTLS", func() {
 		const namespace = "jobs-mtls"
@@ -84,5 +84,5 @@ func Jobs() {
 			// then CP terminates the job by sending /quitquitquit to Envoy Admin and verifies connection using mTLS certs
 			Expect(err).ToNot(HaveOccurred())
 		})
-	})
+	}, Ordered)
 }

--- a/test/e2e_env/kubernetes/k8s_api_bypass/k8s_api_bypass.go
+++ b/test/e2e_env/kubernetes/k8s_api_bypass/k8s_api_bypass.go
@@ -46,6 +46,10 @@ spec:
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, meshName, namespace)
+	})
+
 	E2EAfterAll(func() {
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(kubernetes.Cluster.DeleteMesh(meshName)).To(Succeed())

--- a/test/e2e_env/kubernetes/kic/kong_ingress.go
+++ b/test/e2e_env/kubernetes/kic/kong_ingress.go
@@ -63,6 +63,10 @@ func KICKubernetes() {
 		kicIP = ip
 	})
 
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, mesh, namespace)
+	})
+
 	E2EAfterAll(func() {
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(namespaceOutsideMesh)).To(Succeed())

--- a/test/e2e_env/kubernetes/membership/membership.go
+++ b/test/e2e_env/kubernetes/membership/membership.go
@@ -38,6 +38,12 @@ spec:
 			Setup(kubernetes.Cluster)
 		Expect(err).ToNot(HaveOccurred())
 	})
+
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, mesh1, ns1)
+		DebugKube(kubernetes.Cluster, mesh2, ns2)
+	})
+
 	E2EAfterAll(func() {
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(ns1)).To(Succeed())
 		Expect(kubernetes.Cluster.DeleteMesh(mesh1)).To(Succeed())

--- a/test/e2e_env/kubernetes/meshcircuitbreaker/api.go
+++ b/test/e2e_env/kubernetes/meshcircuitbreaker/api.go
@@ -29,6 +29,10 @@ func API() {
 		)).To(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, meshName, Config.KumaNamespace)
+	})
+
 	E2EAfterEach(func() {
 		Expect(DeleteMeshResources(kubernetes.Cluster, meshName, v1alpha1.MeshCircuitBreakerResourceTypeDescriptor)).To(Succeed())
 	})

--- a/test/e2e_env/kubernetes/meshcircuitbreaker/meshcircuitbreaker.go
+++ b/test/e2e_env/kubernetes/meshcircuitbreaker/meshcircuitbreaker.go
@@ -42,6 +42,10 @@ func MeshCircuitBreaker() {
 		)).To(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, mesh, namespace)
+	})
+
 	E2EAfterEach(func() {
 		Expect(DeleteMeshResources(kubernetes.Cluster, mesh,
 			v1alpha1.MeshCircuitBreakerResourceTypeDescriptor,

--- a/test/e2e_env/kubernetes/meshfaultinjection/api.go
+++ b/test/e2e_env/kubernetes/meshfaultinjection/api.go
@@ -22,6 +22,10 @@ func API() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, meshName, Config.KumaNamespace)
+	})
+
 	E2EAfterEach(func() {
 		Expect(DeleteMeshResources(kubernetes.Cluster, meshName, v1alpha1.MeshFaultInjectionResourceTypeDescriptor)).To(Succeed())
 	})

--- a/test/e2e_env/kubernetes/meshhealthcheck/api.go
+++ b/test/e2e_env/kubernetes/meshhealthcheck/api.go
@@ -22,6 +22,10 @@ func API() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, meshName, Config.KumaNamespace)
+	})
+
 	E2EAfterEach(func() {
 		Expect(
 			DeleteMeshResources(kubernetes.Cluster, meshName, v1alpha1.MeshHealthCheckResourceTypeDescriptor),

--- a/test/e2e_env/kubernetes/meshhttproute/test.go
+++ b/test/e2e_env/kubernetes/meshhttproute/test.go
@@ -40,6 +40,10 @@ func Test() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, meshName, namespace)
+	})
+
 	E2EAfterEach(func() {
 		Expect(DeleteMeshResources(kubernetes.Cluster, meshName, v1alpha1.MeshHTTPRouteResourceTypeDescriptor)).To(Succeed())
 		Expect(DeleteMeshResources(kubernetes.Cluster, meshName, core_mesh.ExternalServiceResourceTypeDescriptor)).To(Succeed())

--- a/test/e2e_env/kubernetes/meshmetric/meshmetric.go
+++ b/test/e2e_env/kubernetes/meshmetric/meshmetric.go
@@ -379,6 +379,11 @@ func MeshMetric() {
 		}
 	})
 
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, mainMesh, namespace, observabilityNamespace)
+		DebugKube(kubernetes.Cluster, secondaryMesh, secondaryOpenTelemetryCollectorNamespace)
+	})
+
 	E2EAfterEach(func() {
 		Expect(DeleteMeshResources(kubernetes.Cluster, mainMesh, v1alpha1.MeshMetricResourceTypeDescriptor)).To(Succeed())
 		Expect(DeleteMeshResources(kubernetes.Cluster, secondaryMesh, v1alpha1.MeshMetricResourceTypeDescriptor)).To(Succeed())

--- a/test/e2e_env/kubernetes/meshproxypatch/meshproxypatch.go
+++ b/test/e2e_env/kubernetes/meshproxypatch/meshproxypatch.go
@@ -35,6 +35,10 @@ func MeshProxyPatch() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, meshName, namespace)
+	})
+
 	E2EAfterEach(func() {
 		Expect(DeleteMeshResources(kubernetes.Cluster, meshName, v1alpha1.MeshProxyPatchResourceTypeDescriptor)).To(Succeed())
 	})

--- a/test/e2e_env/kubernetes/meshratelimit/api.go
+++ b/test/e2e_env/kubernetes/meshratelimit/api.go
@@ -22,6 +22,10 @@ func API() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, meshName, Config.KumaNamespace)
+	})
+
 	E2EAfterEach(func() {
 		Expect(DeleteMeshResources(kubernetes.Cluster, meshName, v1alpha1.MeshRateLimitResourceTypeDescriptor)).To(Succeed())
 	})

--- a/test/e2e_env/kubernetes/meshretry/api.go
+++ b/test/e2e_env/kubernetes/meshretry/api.go
@@ -29,6 +29,10 @@ func API() {
 		)).To(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, meshName, Config.KumaNamespace)
+	})
+
 	E2EAfterEach(func() {
 		Expect(DeleteMeshResources(kubernetes.Cluster, meshName, v1alpha1.MeshRetryResourceTypeDescriptor)).To(Succeed())
 	})

--- a/test/e2e_env/kubernetes/meshtcproute/test.go
+++ b/test/e2e_env/kubernetes/meshtcproute/test.go
@@ -55,6 +55,10 @@ func Test() {
 		).To(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, meshName, namespace)
+	})
+
 	E2EAfterEach(func() {
 		Expect(DeleteMeshResources(
 			kubernetes.Cluster,

--- a/test/e2e_env/kubernetes/meshtimeout/meshtimeout.go
+++ b/test/e2e_env/kubernetes/meshtimeout/meshtimeout.go
@@ -44,6 +44,10 @@ func MeshTimeout() {
 		)).To(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, mesh, namespace)
+	})
+
 	E2EAfterAll(func() {
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(kubernetes.Cluster.DeleteMesh(mesh)).To(Succeed())

--- a/test/e2e_env/kubernetes/meshtrafficpermission/api.go
+++ b/test/e2e_env/kubernetes/meshtrafficpermission/api.go
@@ -22,6 +22,10 @@ func API() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, meshName, Config.KumaNamespace)
+	})
+
 	E2EAfterEach(func() {
 		Expect(DeleteMeshResources(kubernetes.Cluster, meshName, v1alpha1.MeshTrafficPermissionResourceTypeDescriptor)).To(Succeed())
 	})

--- a/test/e2e_env/kubernetes/observability/applications_metrics.go
+++ b/test/e2e_env/kubernetes/observability/applications_metrics.go
@@ -143,6 +143,12 @@ func ApplicationsMetrics() {
 			Setup(kubernetes.Cluster)
 		Expect(err).To(Succeed())
 	})
+
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, mesh, namespace)
+		DebugKube(kubernetes.Cluster, meshNoAggregate)
+	})
+
 	E2EAfterAll(func() {
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(kubernetes.Cluster.DeleteMesh(mesh)).To(Succeed())

--- a/test/e2e_env/kubernetes/observability/meshtrace.go
+++ b/test/e2e_env/kubernetes/observability/meshtrace.go
@@ -55,6 +55,11 @@ func PluginTest() {
 		obsClient = obs.From(obsDeployment, kubernetes.Cluster)
 		Expect(err).ToNot(HaveOccurred())
 	})
+
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, mesh, ns, obsNs)
+	})
+
 	E2EAfterAll(func() {
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(ns)).To(Succeed())
 		Expect(kubernetes.Cluster.DeleteMesh(mesh)).To(Succeed())

--- a/test/e2e_env/kubernetes/observability/tracing.go
+++ b/test/e2e_env/kubernetes/observability/tracing.go
@@ -66,6 +66,11 @@ func Tracing() {
 		Expect(err).ToNot(HaveOccurred())
 		obsClient = obs.From(obsDeployment, kubernetes.Cluster)
 	})
+
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, mesh, ns, obsNs)
+	})
+
 	E2EAfterAll(func() {
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(ns)).To(Succeed())
 		Expect(kubernetes.Cluster.DeleteMesh(mesh)).To(Succeed())

--- a/test/e2e_env/kubernetes/reachableservices/reachableservices.go
+++ b/test/e2e_env/kubernetes/reachableservices/reachableservices.go
@@ -39,6 +39,10 @@ func ReachableServices() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, meshName, namespace)
+	})
+
 	E2EAfterAll(func() {
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(kubernetes.Cluster.DeleteMesh(meshName)).To(Succeed())

--- a/test/e2e_env/kubernetes/trafficlog/tcp_logging.go
+++ b/test/e2e_env/kubernetes/trafficlog/tcp_logging.go
@@ -132,6 +132,10 @@ spec:
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		AfterEachFailure(func() {
+			DebugKube(kubernetes.Cluster, meshName, trafficNamespace, tcpSinkNamespace)
+		})
+
 		E2EAfterAll(func() {
 			Expect(kubernetes.Cluster.TriggerDeleteNamespace(trafficNamespace)).To(Succeed())
 			Expect(kubernetes.Cluster.TriggerDeleteNamespace(tcpSinkNamespace)).To(Succeed())

--- a/test/e2e_env/kubernetes/virtualoutbound/virtualoutbound.go
+++ b/test/e2e_env/kubernetes/virtualoutbound/virtualoutbound.go
@@ -31,6 +31,10 @@ func VirtualOutbound() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugKube(kubernetes.Cluster, meshName, namespace)
+	})
+
 	E2EAfterAll(func() {
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(kubernetes.Cluster.DeleteMesh(meshName)).To(Succeed())


### PR DESCRIPTION
### Checklist prior to review

Add debug kube invocation to all kube tests. It's only kubernetes, not universal and not multizone yet

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
