### PR TITLE
test(e2e): add debug to all uni tests

### DIFF
--- a/test/e2e_env/universal/auth/dp_auth.go
+++ b/test/e2e_env/universal/auth/dp_auth.go
@@ -20,6 +20,11 @@ func DpAuth() {
 	BeforeAll(func() {
 		Expect(universal.Cluster.Install(MeshUniversal(meshName))).To(Succeed())
 	})
+
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, meshName)
+	})
+
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
 		Expect(universal.Cluster.DeleteMesh(meshName)).To(Succeed())

--- a/test/e2e_env/universal/auth/offline_auth.go
+++ b/test/e2e_env/universal/auth/offline_auth.go
@@ -92,6 +92,11 @@ dpServer:
 			Setup(universal)).To(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(universal, meshes[0])
+		DebugUniversal(universal, meshes[1])
+	})
+
 	AfterAll(func() {
 		Expect(universal.DismissCluster()).To(Succeed())
 	})

--- a/test/e2e_env/universal/compatibility/dp_compatibility.go
+++ b/test/e2e_env/universal/compatibility/dp_compatibility.go
@@ -30,6 +30,10 @@ func UniversalCompatibility() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(cluster, "default")
+	})
+
 	E2EAfterEach(func() {
 		Expect(cluster.DismissCluster()).To(Succeed())
 	})

--- a/test/e2e_env/universal/externalservices/externalservices.go
+++ b/test/e2e_env/universal/externalservices/externalservices.go
@@ -102,6 +102,10 @@ networking:
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, meshName)
+	})
+
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
 		Expect(universal.Cluster.DeleteMesh(meshName)).To(Succeed())

--- a/test/e2e_env/universal/externalservices/zoneegress_externalservices.go
+++ b/test/e2e_env/universal/externalservices/zoneegress_externalservices.go
@@ -63,6 +63,10 @@ networking:
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(cluster, "default")
+	})
+
 	E2EAfterEach(func() {
 		Expect(cluster.DismissCluster()).To(Succeed())
 	})

--- a/test/e2e_env/universal/gateway/cross-mesh.go
+++ b/test/e2e_env/universal/gateway/cross-mesh.go
@@ -78,6 +78,11 @@ func CrossMeshGatewayOnUniversal() {
 		Expect(setup.Setup(universal.Cluster)).To(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, gatewayMesh)
+		DebugUniversal(universal.Cluster, gatewayOtherMesh)
+	})
+
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(gatewayMesh)).To(Succeed())
 		Expect(universal.Cluster.DeleteMesh(gatewayMesh)).To(Succeed())

--- a/test/e2e_env/universal/gateway/gateway.go
+++ b/test/e2e_env/universal/gateway/gateway.go
@@ -40,6 +40,10 @@ func Gateway() {
 		Expect(setup.Setup(universal.Cluster)).To(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, mesh)
+	})
+
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteApp("gateway-client")).To(Succeed())
 		Expect(universal.Cluster.DeleteMeshApps(mesh)).To(Succeed())

--- a/test/e2e_env/universal/healthcheck/panic.go
+++ b/test/e2e_env/universal/healthcheck/panic.go
@@ -72,6 +72,10 @@ networking:
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, meshName)
+	})
+
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
 		for i := 7; i <= 10; i++ {

--- a/test/e2e_env/universal/healthcheck/policy.go
+++ b/test/e2e_env/universal/healthcheck/policy.go
@@ -53,6 +53,11 @@ conf:
 				Setup(universal.Cluster)
 			Expect(err).ToNot(HaveOccurred())
 		})
+
+		AfterEachFailure(func() {
+			DebugUniversal(universal.Cluster, meshName)
+		})
+
 		E2EAfterAll(func() {
 			Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
 			Expect(universal.Cluster.DeleteMesh(meshName)).To(Succeed())
@@ -138,6 +143,11 @@ conf:
 				Setup(universal.Cluster)
 			Expect(err).ToNot(HaveOccurred())
 		})
+
+		AfterEachFailure(func() {
+			DebugUniversal(universal.Cluster, meshName)
+		})
+
 		E2EAfterAll(func() {
 			Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
 			Expect(universal.Cluster.DeleteMesh(meshName)).To(Succeed())
@@ -235,6 +245,11 @@ conf:
 				Setup(universal.Cluster)
 			Expect(err).ToNot(HaveOccurred())
 		})
+
+		AfterEachFailure(func() {
+			DebugUniversal(universal.Cluster, meshName)
+		})
+
 		E2EAfterAll(func() {
 			Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
 			Expect(universal.Cluster.DeleteMesh(meshName)).To(Succeed())

--- a/test/e2e_env/universal/healthcheck/service_probes.go
+++ b/test/e2e_env/universal/healthcheck/service_probes.go
@@ -26,6 +26,10 @@ func ServiceProbes() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, meshName)
+	})
+
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
 		Expect(universal.Cluster.DeleteMesh(meshName)).To(Succeed())

--- a/test/e2e_env/universal/inspect/inspect.go
+++ b/test/e2e_env/universal/inspect/inspect.go
@@ -18,6 +18,11 @@ func Inspect() {
 			Setup(universal.Cluster)
 		Expect(err).ToNot(HaveOccurred())
 	})
+
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, meshName)
+	})
+
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
 		Expect(universal.Cluster.DeleteMesh(meshName)).To(Succeed())

--- a/test/e2e_env/universal/matching/matching.go
+++ b/test/e2e_env/universal/matching/matching.go
@@ -27,6 +27,10 @@ func Matching() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, mesh)
+	})
+
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(mesh)).To(Succeed())
 		Expect(universal.Cluster.DeleteMesh(mesh)).To(Succeed())

--- a/test/e2e_env/universal/membership/membership.go
+++ b/test/e2e_env/universal/membership/membership.go
@@ -28,10 +28,16 @@ constraints:
 	BeforeAll(func() {
 		Expect(YamlUniversal(fmt.Sprintf(mesh, meshName))(universal.Cluster)).To(Succeed())
 	})
+
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, meshName)
+	})
+
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
 		Expect(universal.Cluster.DeleteMesh(meshName)).To(Succeed())
 	})
+
 	It("should take into account membership when dp is connecting to the CP", func() {
 		// when demo client is trying to connect
 		err := DemoClientUniversal(AppModeDemoClient, meshName)(universal.Cluster)

--- a/test/e2e_env/universal/meshaccesslog/meshaccesslog.go
+++ b/test/e2e_env/universal/meshaccesslog/meshaccesslog.go
@@ -41,6 +41,11 @@ func TestPlugin() {
 			Install(MeshTrafficPermissionAllowAllUniversal(meshName)).
 			Setup(universal.Cluster)).To(Succeed())
 	})
+
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, meshName)
+	})
+
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteApp("gateway-client")).To(Succeed())
 		Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())

--- a/test/e2e_env/universal/meshfaultinjection/meshfaultinjection.go
+++ b/test/e2e_env/universal/meshfaultinjection/meshfaultinjection.go
@@ -87,6 +87,11 @@ spec:
 			Install(DemoClientUniversal("demo-client-timeout", meshName, WithTransparentProxy(true))).
 			Setup(universal.Cluster)).To(Succeed())
 	})
+
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, meshName)
+	})
+
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
 		Expect(universal.Cluster.DeleteMesh(meshName)).To(Succeed())

--- a/test/e2e_env/universal/meshhealthcheck/panic.go
+++ b/test/e2e_env/universal/meshhealthcheck/panic.go
@@ -72,6 +72,10 @@ networking:
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, meshName)
+	})
+
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
 		for i := 7; i <= 10; i++ {

--- a/test/e2e_env/universal/meshhealthcheck/policy.go
+++ b/test/e2e_env/universal/meshhealthcheck/policy.go
@@ -55,6 +55,10 @@ spec:
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		AfterEachFailure(func() {
+			DebugUniversal(universal.Cluster, meshName)
+		})
+
 		E2EAfterAll(func() {
 			Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
 			Expect(universal.Cluster.DeleteMesh(meshName)).To(Succeed())

--- a/test/e2e_env/universal/meshloadbalancingstrategy/policy.go
+++ b/test/e2e_env/universal/meshloadbalancingstrategy/policy.go
@@ -26,6 +26,10 @@ func Policy() {
 			Setup(universal.Cluster)).To(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, meshName)
+	})
+
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
 		Expect(universal.Cluster.DeleteMesh(meshName)).To(Succeed())

--- a/test/e2e_env/universal/meshproxypatch/meshproxypatch.go
+++ b/test/e2e_env/universal/meshproxypatch/meshproxypatch.go
@@ -26,6 +26,11 @@ func MeshProxyPatch() {
 			Setup(universal.Cluster)
 		Expect(err).ToNot(HaveOccurred())
 	})
+
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, mesh)
+	})
+
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(mesh)).To(Succeed())
 		Expect(universal.Cluster.DeleteMesh(mesh)).To(Succeed())

--- a/test/e2e_env/universal/meshratelimit/meshratelimit.go
+++ b/test/e2e_env/universal/meshratelimit/meshratelimit.go
@@ -69,6 +69,11 @@ spec:
 			Install(DemoClientUniversal("web", meshName, WithTransparentProxy(true))).
 			Setup(universal.Cluster)).To(Succeed())
 	})
+
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, meshName)
+	})
+
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
 		Expect(universal.Cluster.DeleteMesh(meshName)).To(Succeed())

--- a/test/e2e_env/universal/meshretry/grpc.go
+++ b/test/e2e_env/universal/meshretry/grpc.go
@@ -40,6 +40,10 @@ func GrpcRetry() {
 		}).Should(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, meshName)
+	})
+
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
 		Expect(universal.Cluster.GetKumactlOptions().RunKumactl("delete", "dataplane", "fake-echo-server", "-m", meshName)).To(Succeed())

--- a/test/e2e_env/universal/meshretry/http.go
+++ b/test/e2e_env/universal/meshretry/http.go
@@ -38,6 +38,10 @@ func HttpRetry() {
 		)).To(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, meshName)
+	})
+
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
 		Expect(universal.Cluster.DeleteMesh(meshName)).To(Succeed())

--- a/test/e2e_env/universal/meshtrafficpermission/meshtrafficpermission.go
+++ b/test/e2e_env/universal/meshtrafficpermission/meshtrafficpermission.go
@@ -39,6 +39,10 @@ func MeshTrafficPermissionUniversal() {
 		Expect(universal.Cluster.DeleteMesh(meshName)).To(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, meshName)
+	})
+
 	E2EAfterEach(func() {
 		// remove all MeshTrafficPermissions
 		items, err := universal.Cluster.GetKumactlOptions().KumactlList("meshtrafficpermissions", meshName)

--- a/test/e2e_env/universal/mtls/mtls.go
+++ b/test/e2e_env/universal/mtls/mtls.go
@@ -15,10 +15,16 @@ import (
 
 func Policy() {
 	meshName := "mtls-test"
+
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, meshName)
+	})
+
 	E2EAfterEach(func() {
 		Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
 		Expect(universal.Cluster.DeleteMesh(meshName)).To(Succeed())
 	})
+
 	curlAddr := func(addr string, fn ...client.CollectResponsesOptsFn) (string, string, error) {
 		fn = append(fn, client.WithVerbose())
 

--- a/test/e2e_env/universal/observability/applications_metrics.go
+++ b/test/e2e_env/universal/observability/applications_metrics.go
@@ -135,6 +135,13 @@ metrics:
 			Setup(universal.Cluster)
 		Expect(err).ToNot(HaveOccurred())
 	})
+
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, mesh)
+		DebugUniversal(universal.Cluster, meshNoAggregate)
+		DebugUniversal(universal.Cluster, meshWithLocalhostBound)
+	})
+
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(mesh)).To(Succeed())
 		Expect(universal.Cluster.DeleteMesh(mesh)).To(Succeed())

--- a/test/e2e_env/universal/observability/meshtrace.go
+++ b/test/e2e_env/universal/observability/meshtrace.go
@@ -58,6 +58,10 @@ func PluginTest() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, mesh)
+	})
+
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteApp("gateway-client")).To(Succeed())
 		Expect(universal.Cluster.DeleteMeshApps(mesh)).To(Succeed())

--- a/test/e2e_env/universal/observability/metrics.go
+++ b/test/e2e_env/universal/observability/metrics.go
@@ -55,6 +55,11 @@ func PrometheusMetrics() {
 			Setup(universal.Cluster)
 		Expect(err).ToNot(HaveOccurred())
 	})
+
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, mesh)
+	})
+
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(mesh)).To(Succeed())
 		Expect(universal.Cluster.DeleteMesh(mesh)).To(Succeed())

--- a/test/e2e_env/universal/observability/tracing.go
+++ b/test/e2e_env/universal/observability/tracing.go
@@ -55,6 +55,10 @@ func Tracing() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, mesh)
+	})
+
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(mesh)).To(Succeed())
 		Expect(universal.Cluster.DeleteMesh(mesh)).To(Succeed())

--- a/test/e2e_env/universal/projectedsatoken/psat_universal.go
+++ b/test/e2e_env/universal/projectedsatoken/psat_universal.go
@@ -23,6 +23,10 @@ func ProjectedServiceAccountToken() {
 			Setup(universal)).To(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(universal, "default")
+	})
+
 	E2EAfterEach(func() {
 		Expect(universal.DismissCluster()).To(Succeed())
 	})

--- a/test/e2e_env/universal/proxytemplate/proxy_template.go
+++ b/test/e2e_env/universal/proxytemplate/proxy_template.go
@@ -31,6 +31,11 @@ func ProxyTemplate() {
 			Setup(universal.Cluster)
 		Expect(err).ToNot(HaveOccurred())
 	})
+
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, mesh)
+	})
+
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(mesh)).To(Succeed())
 		Expect(universal.Cluster.DeleteMesh(mesh)).To(Succeed())

--- a/test/e2e_env/universal/ratelimit/ratelimit.go
+++ b/test/e2e_env/universal/ratelimit/ratelimit.go
@@ -45,6 +45,11 @@ conf:
 			Install(TrafficPermissionUniversal(meshName)).
 			Setup(universal.Cluster)).To(Succeed())
 	})
+
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, meshName)
+	})
+
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
 		Expect(universal.Cluster.DeleteMesh(meshName)).To(Succeed())

--- a/test/e2e_env/universal/reachableservices/reachableservices.go
+++ b/test/e2e_env/universal/reachableservices/reachableservices.go
@@ -22,6 +22,10 @@ func ReachableServices() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, meshName)
+	})
+
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
 		Expect(universal.Cluster.DeleteMesh(meshName)).To(Succeed())

--- a/test/e2e_env/universal/resilience/leader_election_postgres.go
+++ b/test/e2e_env/universal/resilience/leader_election_postgres.go
@@ -35,6 +35,11 @@ func LeaderElectionPostgres() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(zone1, "default")
+		DebugUniversal(zone2, "default")
+	})
+
 	E2EAfterEach(func() {
 		err := zone1.DeleteKuma()
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e_env/universal/resilience/resilience.go
+++ b/test/e2e_env/universal/resilience/resilience.go
@@ -28,6 +28,10 @@ func ResilienceUniversal() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(universal, "default")
+	})
+
 	E2EAfterEach(func() {
 		Expect(universal.DeleteKuma()).To(Succeed())
 		Expect(universal.DismissCluster()).To(Succeed())

--- a/test/e2e_env/universal/retry/retry.go
+++ b/test/e2e_env/universal/retry/retry.go
@@ -30,6 +30,10 @@ func Policy() {
 		}).Should(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, meshName)
+	})
+
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
 		Expect(universal.Cluster.GetKumactlOptions().RunKumactl("delete", "dataplane", "fake-echo-server", "-m", meshName)).To(Succeed())

--- a/test/e2e_env/universal/timeout/meshtimeout.go
+++ b/test/e2e_env/universal/timeout/meshtimeout.go
@@ -33,6 +33,10 @@ func PluginTest() {
 		}).Should(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, meshName)
+	})
+
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
 		Expect(universal.Cluster.DeleteMesh(meshName)).To(Succeed())

--- a/test/e2e_env/universal/timeout/timeout.go
+++ b/test/e2e_env/universal/timeout/timeout.go
@@ -33,6 +33,11 @@ func Policy() {
 			return universal.Cluster.GetKumactlOptions().RunKumactl("delete", "meshtimeout", "--mesh", meshName, "mesh-timeout-all-"+meshName)
 		}).Should(Succeed())
 	})
+
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, meshName)
+	})
+
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
 		Expect(universal.Cluster.DeleteMesh(meshName)).To(Succeed())

--- a/test/e2e_env/universal/trafficlog/tcp_logging.go
+++ b/test/e2e_env/universal/trafficlog/tcp_logging.go
@@ -60,6 +60,10 @@ destinations:
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		AfterEachFailure(func() {
+			DebugUniversal(universal.Cluster, meshName)
+		})
+
 		E2EAfterAll(func() {
 			Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
 			Expect(universal.Cluster.DeleteApp(AppModeTcpSink)).To(Succeed())

--- a/test/e2e_env/universal/trafficpermission/traffic_permission.go
+++ b/test/e2e_env/universal/trafficpermission/traffic_permission.go
@@ -21,6 +21,10 @@ func TrafficPermission() {
 			Setup(universal.Cluster)).To(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, meshName)
+	})
+
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
 		Expect(universal.Cluster.DeleteMesh(meshName)).To(Succeed())

--- a/test/e2e_env/universal/trafficroute/traffic_route.go
+++ b/test/e2e_env/universal/trafficroute/traffic_route.go
@@ -50,6 +50,10 @@ func TrafficRoute() {
 		esHttpHostPort = net.JoinHostPort(universal.Cluster.GetApp("route-es-http").GetContainerName(), "80")
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, meshName)
+	})
+
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
 		Expect(universal.Cluster.DeleteMesh(meshName)).To(Succeed())

--- a/test/e2e_env/universal/transparentproxy/transparent_proxy.go
+++ b/test/e2e_env/universal/transparentproxy/transparent_proxy.go
@@ -25,6 +25,11 @@ func TransparentProxy() {
 			Setup(universal.Cluster)
 		Expect(err).ToNot(HaveOccurred())
 	})
+
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, mesh)
+	})
+
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(mesh)).To(Succeed())
 		Expect(universal.Cluster.DeleteMesh(mesh)).To(Succeed())

--- a/test/e2e_env/universal/virtualoutbound/virtualoutbound_universal.go
+++ b/test/e2e_env/universal/virtualoutbound/virtualoutbound_universal.go
@@ -24,6 +24,10 @@ func VirtualOutbound() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, meshName)
+	})
+
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
 		Expect(universal.Cluster.DeleteMesh(meshName)).To(Succeed())

--- a/test/e2e_env/universal/zoneegress/external_services.go
+++ b/test/e2e_env/universal/zoneegress/external_services.go
@@ -96,6 +96,10 @@ func ExternalServices() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, meshName)
+	})
+
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
 		Expect(universal.Cluster.DeleteMesh(meshName)).To(Succeed())


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
