### PR TITLE
test(e2e): add debug to all multizone tests

### DIFF
--- a/test/e2e_env/multizone/connectivity/cni_v2_ipv6_gateway.go
+++ b/test/e2e_env/multizone/connectivity/cni_v2_ipv6_gateway.go
@@ -41,6 +41,11 @@ func GatewayIPV6CNIV2() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(multizone.Global, meshName)
+		DebugKube(multizone.KubeZone2, meshName, namespace)
+	})
+
 	E2EAfterAll(func() {
 		Expect(multizone.KubeZone2.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(multizone.Global.DeleteMesh(meshName)).To(Succeed())

--- a/test/e2e_env/multizone/externalservices/externalservices_multizone_universal.go
+++ b/test/e2e_env/multizone/externalservices/externalservices_multizone_universal.go
@@ -135,6 +135,12 @@ routing:
 		wg.Wait()
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(global, defaultMesh)
+		DebugUniversal(zone1, defaultMesh)
+		DebugUniversal(zone2, defaultMesh)
+	})
+
 	E2EAfterEach(func() {
 		Expect(external.DismissCluster()).To(Succeed())
 		Expect(zone1.DismissCluster()).To(Succeed())

--- a/test/e2e_env/multizone/gateway/cross-mesh.go
+++ b/test/e2e_env/multizone/gateway/cross-mesh.go
@@ -105,6 +105,13 @@ func CrossMeshGatewayOnMultizone() {
 		Expect(otherZoneSetup.Setup(multizone.KubeZone2)).To(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(multizone.Global, gatewayMesh)
+		DebugUniversal(multizone.Global, gatewayOtherMesh)
+		DebugKube(multizone.KubeZone1, gatewayMesh, gatewayClientNamespaceOtherMesh, gatewayClientNamespaceSameMesh, gatewayTestNamespace)
+		DebugKube(multizone.KubeZone2, gatewayOtherMesh, gatewayClientNamespaceOtherMesh, gatewayClientNamespaceSameMesh)
+	})
+
 	E2EAfterAll(func() {
 		Expect(multizone.KubeZone1.TriggerDeleteNamespace(gatewayClientNamespaceOtherMesh)).To(Succeed())
 		Expect(multizone.KubeZone1.TriggerDeleteNamespace(gatewayClientNamespaceSameMesh)).To(Succeed())

--- a/test/e2e_env/multizone/gateway/gateway.go
+++ b/test/e2e_env/multizone/gateway/gateway.go
@@ -48,6 +48,12 @@ func GatewayHybrid() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(multizone.Global, meshName)
+		DebugUniversal(multizone.UniZone1, meshName)
+		DebugKube(multizone.KubeZone1, meshName, namespace)
+	})
+
 	E2EAfterAll(func() {
 		Expect(multizone.KubeZone1.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(multizone.UniZone1.DeleteMeshApps(meshName)).To(Succeed())

--- a/test/e2e_env/multizone/healthcheck/healthcheck.go
+++ b/test/e2e_env/multizone/healthcheck/healthcheck.go
@@ -46,6 +46,13 @@ func ApplicationOnUniversalClientOnK8s() {
 			Setup(multizone.UniZone2)
 		Expect(err).ToNot(HaveOccurred())
 	})
+
+	AfterEachFailure(func() {
+		DebugUniversal(multizone.Global, meshName)
+		DebugUniversal(multizone.UniZone2, meshName)
+		DebugKube(multizone.KubeZone1, meshName, namespace)
+	})
+
 	E2EAfterAll(func() {
 		Expect(multizone.KubeZone1.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(multizone.UniZone2.DeleteMeshApps(meshName)).To(Succeed())

--- a/test/e2e_env/multizone/inbound_communication/inbound_passthrough.go
+++ b/test/e2e_env/multizone/inbound_communication/inbound_passthrough.go
@@ -93,6 +93,13 @@ func InboundPassthrough() {
 			Setup(multizone.KubeZone1),
 		).To(Succeed())
 	})
+
+	AfterEachFailure(func() {
+		DebugUniversal(multizone.Global, mesh)
+		DebugUniversal(multizone.UniZone1, mesh)
+		DebugKube(multizone.KubeZone1, mesh, namespace)
+	})
+
 	E2EAfterAll(func() {
 		Expect(multizone.KubeZone1.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(multizone.UniZone1.DeleteMeshApps(mesh)).To(Succeed())

--- a/test/e2e_env/multizone/inbound_communication/inbound_passthrough_disabled.go
+++ b/test/e2e_env/multizone/inbound_communication/inbound_passthrough_disabled.go
@@ -81,6 +81,13 @@ func InboundPassthroughDisabled() {
 			Setup(multizone.KubeZone2),
 		).To(Succeed())
 	})
+
+	AfterEachFailure(func() {
+		DebugUniversal(multizone.Global, mesh)
+		DebugUniversal(multizone.UniZone2, mesh)
+		DebugKube(multizone.KubeZone2, mesh, namespace)
+	})
+
 	E2EAfterAll(func() {
 		Expect(multizone.KubeZone2.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(multizone.UniZone2.DeleteMeshApps(mesh)).To(Succeed())

--- a/test/e2e_env/multizone/inspect/inspect.go
+++ b/test/e2e_env/multizone/inspect/inspect.go
@@ -34,6 +34,11 @@ func Inspect() {
 		}).Should(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(multizone.Global, meshName)
+		DebugUniversal(multizone.UniZone1, meshName)
+	})
+
 	E2EAfterAll(func() {
 		Expect(multizone.UniZone1.DeleteMeshApps(meshName)).To(Succeed())
 		Expect(multizone.Global.DeleteMesh(meshName)).To(Succeed())

--- a/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid.go
+++ b/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid.go
@@ -127,6 +127,14 @@ func LocalityAwareLB() {
 			Setup(multizone.KubeZone2)).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(multizone.Global, mesh)
+		DebugUniversal(multizone.UniZone1, mesh)
+		DebugUniversal(multizone.UniZone2, mesh)
+		DebugKube(multizone.KubeZone1, mesh, namespace)
+		DebugKube(multizone.KubeZone2, mesh, namespace)
+	})
+
 	E2EAfterAll(func() {
 		Expect(multizone.UniZone1.DeleteMeshApps(mesh)).To(Succeed())
 		Expect(multizone.UniZone2.DeleteMeshApps(mesh)).To(Succeed())

--- a/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid_egress.go
+++ b/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid_egress.go
@@ -140,6 +140,13 @@ spec:
 		).To(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(multizone.Global, mesh)
+		DebugUniversal(multizone.UniZone1, mesh)
+		DebugUniversal(multizone.UniZone2, mesh)
+		DebugKube(multizone.KubeZone1, mesh, namespace)
+	})
+
 	E2EAfterAll(func() {
 		Expect(multizone.UniZone1.DeleteMeshApps(mesh)).To(Succeed())
 		Expect(multizone.UniZone2.DeleteMeshApps(mesh)).To(Succeed())

--- a/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid_gateway.go
+++ b/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid_gateway.go
@@ -132,6 +132,13 @@ conf:
 		Expect(multizone.Global.Install(meshGatewayRoute)).To(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(multizone.Global, mesh)
+		DebugUniversal(multizone.UniZone1, mesh)
+		DebugUniversal(multizone.UniZone2, mesh)
+		DebugKube(multizone.KubeZone1, mesh, namespace)
+	})
+
 	E2EAfterAll(func() {
 		Expect(multizone.UniZone1.DeleteMeshApps(mesh)).To(Succeed())
 		Expect(multizone.UniZone2.DeleteMeshApps(mesh)).To(Succeed())

--- a/test/e2e_env/multizone/localityawarelb/locality_multizone_hybrid.go
+++ b/test/e2e_env/multizone/localityawarelb/locality_multizone_hybrid.go
@@ -115,6 +115,14 @@ networking:
 			Setup(multizone.Global)).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(multizone.Global, mesh)
+		DebugUniversal(multizone.Global, meshNoZoneEgress)
+		DebugUniversal(multizone.UniZone1, mesh)
+		DebugUniversal(multizone.UniZone2, meshNoZoneEgress)
+		DebugKube(multizone.KubeZone1, mesh, namespace)
+	})
+
 	E2EAfterAll(func() {
 		Expect(multizone.UniZone1.DeleteMeshApps(mesh)).To(Succeed())
 		Expect(multizone.UniZone1.DeleteMeshApps(meshNoZoneEgress)).To(Succeed())

--- a/test/e2e_env/multizone/localityawarelb/meshloadbalancingstrategy.go
+++ b/test/e2e_env/multizone/localityawarelb/meshloadbalancingstrategy.go
@@ -63,6 +63,12 @@ networking:
 			Setup(multizone.Global)).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(multizone.Global, mesh)
+		DebugUniversal(multizone.UniZone1, mesh)
+		DebugUniversal(multizone.UniZone2, mesh)
+	})
+
 	E2EAfterAll(func() {
 		Expect(multizone.UniZone1.DeleteMeshApps(mesh)).To(Succeed())
 		Expect(multizone.UniZone2.DeleteMeshApps(mesh)).To(Succeed())

--- a/test/e2e_env/multizone/meshhttproute/test.go
+++ b/test/e2e_env/multizone/meshhttproute/test.go
@@ -79,6 +79,12 @@ func test(meshName string, meshBuilder *builders.MeshBuilder) {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(multizone.Global, meshName)
+		DebugUniversal(multizone.UniZone1, meshName)
+		DebugUniversal(multizone.UniZone2, meshName)
+	})
+
 	E2EAfterEach(func() {
 		Expect(DeleteMeshResources(multizone.Global, meshName, v1alpha1.MeshHTTPRouteResourceTypeDescriptor)).To(Succeed())
 	})

--- a/test/e2e_env/multizone/meshtcproute/test.go
+++ b/test/e2e_env/multizone/meshtcproute/test.go
@@ -68,6 +68,12 @@ func Test() {
 		)).To(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(multizone.Global, meshName)
+		DebugUniversal(multizone.UniZone1, meshName)
+		DebugUniversal(multizone.UniZone2, meshName)
+	})
+
 	E2EAfterAll(func() {
 		Expect(multizone.UniZone2.DeleteMeshApps(meshName)).To(Succeed())
 		Expect(multizone.UniZone1.DeleteMeshApps(meshName)).To(Succeed())

--- a/test/e2e_env/multizone/meshtimeout/meshtimeout.go
+++ b/test/e2e_env/multizone/meshtimeout/meshtimeout.go
@@ -44,6 +44,11 @@ func MeshTimeout() {
 		Expect(DeleteMeshResources(multizone.Global, mesh, meshretry_api.MeshRetryResourceTypeDescriptor)).To(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(multizone.Global, mesh)
+		DebugKube(multizone.KubeZone1, mesh, k8sZoneNamespace)
+	})
+
 	E2EAfterEach(func() {
 		Expect(DeleteMeshResources(multizone.Global, mesh, meshtimeout_api.MeshTimeoutResourceTypeDescriptor)).To(Succeed())
 		Expect(DeleteMeshResources(multizone.Global, mesh, meshhttproute_api.MeshHTTPRouteResourceTypeDescriptor)).To(Succeed())

--- a/test/e2e_env/multizone/meshtrafficpermission/meshtrafficpermission.go
+++ b/test/e2e_env/multizone/meshtrafficpermission/meshtrafficpermission.go
@@ -80,6 +80,12 @@ func MeshTrafficPermission() {
 		Expect(multizone.Global.Install(externalService(meshName, esIp))).To(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(multizone.Global, meshName)
+		DebugUniversal(multizone.UniZone1, meshName)
+		DebugKube(multizone.KubeZone1, meshName, namespace)
+	})
+
 	BeforeEach(func() {
 		Expect(DeleteMeshResources(multizone.Global, meshName, policies_api.MeshTrafficPermissionResourceTypeDescriptor)).To(Succeed())
 	})

--- a/test/e2e_env/multizone/ownership/ownership.go
+++ b/test/e2e_env/multizone/ownership/ownership.go
@@ -28,6 +28,11 @@ func MultizoneUniversal() {
 		).To(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(global, "default")
+		DebugUniversal(zoneUniversal, "default")
+	})
+
 	E2EAfterEach(func() {
 		Expect(zoneUniversal.DeleteKuma()).To(Succeed())
 		Expect(zoneUniversal.DismissCluster()).To(Succeed())

--- a/test/e2e_env/multizone/resilience/resilience_multizone_universal.go
+++ b/test/e2e_env/multizone/resilience/resilience_multizone_universal.go
@@ -34,6 +34,11 @@ func ResilienceMultizoneUniversal() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(global, "default")
+		DebugUniversal(zone1, "default")
+	})
+
 	E2EAfterEach(func() {
 		err := zone1.DeleteKuma()
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e_env/multizone/resilience/resilience_multizone_universal_postgres.go
+++ b/test/e2e_env/multizone/resilience/resilience_multizone_universal_postgres.go
@@ -61,6 +61,11 @@ func ResilienceMultizoneUniversalPostgres() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(global, "default")
+		DebugUniversal(zoneUniversal, "default")
+	})
+
 	E2EAfterEach(func() {
 		err := zoneUniversal.DeleteKuma()
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e_env/multizone/sync/sync.go
+++ b/test/e2e_env/multizone/sync/sync.go
@@ -35,6 +35,13 @@ func Sync() {
 			Setup(multizone.UniZone1)
 		Expect(err).ToNot(HaveOccurred())
 	})
+
+	AfterEachFailure(func() {
+		DebugUniversal(multizone.Global, meshName)
+		DebugUniversal(multizone.UniZone1, meshName)
+		DebugKube(multizone.KubeZone1, meshName, namespace)
+	})
+
 	E2EAfterAll(func() {
 		Expect(multizone.KubeZone1.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(multizone.UniZone1.DeleteMeshApps(meshName)).To(Succeed())

--- a/test/e2e_env/multizone/sync/sync_legacy.go
+++ b/test/e2e_env/multizone/sync/sync_legacy.go
@@ -80,6 +80,13 @@ func SyncLegacy() {
 		}()
 		wg.Wait()
 	})
+
+	AfterEachFailure(func() {
+		DebugUniversal(global, meshName)
+		DebugUniversal(zone1, meshName)
+		DebugUniversal(zone2, meshName)
+	})
+
 	E2EAfterAll(func() {
 		Expect(zone2.DeleteMeshApps(meshName)).To(Succeed())
 		Expect(zone2.DismissCluster()).To(Succeed())

--- a/test/e2e_env/multizone/trafficpermission/trafficpermission.go
+++ b/test/e2e_env/multizone/trafficpermission/trafficpermission.go
@@ -50,6 +50,12 @@ func TrafficPermission() {
 		Expect(DeleteMeshResources(multizone.Global, meshName, core_mesh.TrafficPermissionResourceTypeDescriptor)).To(Succeed())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(multizone.Global, meshName)
+		DebugUniversal(multizone.UniZone1, meshName)
+		DebugKube(multizone.KubeZone1, meshName, namespace)
+	})
+
 	E2EAfterAll(func() {
 		Expect(multizone.KubeZone1.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(multizone.UniZone1.DeleteMeshApps(meshName)).To(Succeed())

--- a/test/e2e_env/multizone/trafficroute/trafficroute.go
+++ b/test/e2e_env/multizone/trafficroute/trafficroute.go
@@ -64,6 +64,13 @@ func TrafficRoute() {
 			Setup(multizone.UniZone2)
 		Expect(err).ToNot(HaveOccurred())
 	})
+
+	AfterEachFailure(func() {
+		DebugUniversal(multizone.Global, meshName)
+		DebugUniversal(multizone.UniZone1, meshName)
+		DebugUniversal(multizone.UniZone2, meshName)
+	})
+
 	E2EAfterAll(func() {
 		Expect(multizone.UniZone2.DeleteMeshApps(meshName)).To(Succeed())
 		Expect(multizone.UniZone1.DeleteMeshApps(meshName)).To(Succeed())

--- a/test/e2e_env/multizone/virtualoutbound/virtualoutbound.go
+++ b/test/e2e_env/multizone/virtualoutbound/virtualoutbound.go
@@ -54,6 +54,12 @@ func virtualOutbound(meshName string, meshBuilder *builders.MeshBuilder) {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(multizone.Global, meshName)
+		DebugKube(multizone.KubeZone1, meshName, namespace)
+		DebugKube(multizone.KubeZone2, meshName, namespace)
+	})
+
 	E2EAfterAll(func() {
 		Expect(multizone.KubeZone1.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(multizone.KubeZone2.TriggerDeleteNamespace(namespace)).To(Succeed())

--- a/test/e2e_env/multizone/zonedisable/zone_disable.go
+++ b/test/e2e_env/multizone/zonedisable/zone_disable.go
@@ -75,6 +75,12 @@ func ZoneDisable() {
 		wg.Wait()
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(global, nonDefaultMesh)
+		DebugUniversal(zone1, nonDefaultMesh)
+		DebugUniversal(zone2, nonDefaultMesh)
+	})
+
 	E2EAfterEach(func() {
 		Expect(zone1.DismissCluster()).To(Succeed())
 		Expect(zone2.DismissCluster()).To(Succeed())

--- a/test/e2e_env/multizone/zoneegress/internal_services.go
+++ b/test/e2e_env/multizone/zoneegress/internal_services.go
@@ -73,6 +73,14 @@ routing:
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(multizone.Global, meshName)
+		DebugUniversal(multizone.UniZone1, meshName)
+		DebugUniversal(multizone.UniZone2, meshName)
+		DebugKube(multizone.KubeZone1, meshName, namespace)
+		DebugKube(multizone.KubeZone2, meshName, namespace)
+	})
+
 	AfterAll(func() {
 		Expect(multizone.KubeZone1.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(multizone.KubeZone2.TriggerDeleteNamespace(namespace)).To(Succeed())


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
