### PR TITLE
fix(gatewayapi): validate presence of all required Gateway API resources

### DIFF
--- a/pkg/plugins/runtime/k8s/plugin_gateway.go
+++ b/pkg/plugins/runtime/k8s/plugin_gateway.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
+	"golang.org/x/exp/maps"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
@@ -16,23 +17,47 @@ import (
 	k8s_common "github.com/kumahq/kuma/pkg/plugins/common/k8s"
 	k8s_registry "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
 	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/containers"
-	controllers "github.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers"
+	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers"
 	gatewayapi_controllers "github.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers/gatewayapi"
 	k8s_webhooks "github.com/kumahq/kuma/pkg/plugins/runtime/k8s/webhooks"
 )
 
-func gatewayAPICRDsPresent(mgr kube_ctrl.Manager) bool {
-	gk := schema.GroupKind{
-		Group: gatewayapi.SchemeGroupVersion.Group,
-		Kind:  "Gateway",
+var requiredGatewayCRDs = map[string]string{
+	"GatewayClass":   gatewayCRDNameWithGroupKindAndVersion("GatewayClass"),
+	"Gateway":        gatewayCRDNameWithGroupKindAndVersion("Gateway"),
+	"HTTPRoute":      gatewayCRDNameWithGroupKindAndVersion("HTTPRoute"),
+	"ReferenceGrant": gatewayCRDNameWithGroupKindAndVersion("ReferenceGrant"),
+}
+
+func gatewayCRDNameWithGroupKindAndVersion(name string) string {
+	return fmt.Sprintf(
+		"%s.%s/%s",
+		name,
+		gatewayapi.GroupVersion.Group,
+		gatewayapi.GroupVersion.Version,
+	)
+}
+
+func gatewayAPICRDsPresent(mgr kube_ctrl.Manager) (bool, []string) {
+	var missing []string
+
+	for kind, fullName := range requiredGatewayCRDs {
+		gk := schema.GroupKind{
+			Group: gatewayapi.GroupVersion.Group,
+			Kind:  kind,
+		}
+
+		mappings, _ := mgr.GetClient().RESTMapper().RESTMappings(
+			gk,
+			gatewayapi.GroupVersion.Version,
+		)
+
+		if len(mappings) == 0 {
+			missing = append(missing, fullName)
+		}
 	}
 
-	mappings, _ := mgr.GetClient().RESTMapper().RESTMappings(
-		gk,
-		gatewayapi.SchemeGroupVersion.Version,
-	)
-
-	return len(mappings) > 0
+	return len(missing) == 0, missing
 }
 
 func meshGatewayCRDsPresent() bool {
@@ -100,8 +125,22 @@ func addGatewayReconcilers(mgr kube_ctrl.Manager, rt core_runtime.Runtime, conve
 }
 
 func addGatewayAPIReconcillers(mgr kube_ctrl.Manager, rt core_runtime.Runtime, proxyFactory *containers.DataplaneProxyFactory) error {
-	if !gatewayAPICRDsPresent(mgr) {
-		log.Info("[WARNING] GatewayAPI CRDs are not registered. Disabling support")
+	if ok, missingGatewayCRDs := gatewayAPICRDsPresent(mgr); !ok {
+		if len(requiredGatewayCRDs) != len(missingGatewayCRDs) {
+			// Logging this as error as in such case there is possibility that user is expecting
+			// Gateway API support to work, but might be unaware that some (not all) CRDs are
+			// missing. Such scenario might occur when old version of CRDs is installed with
+			// missing ReferenceGrant.
+			log.Error(
+				errors.New("only subset of required GatewayAPI CRDs registered"),
+				"disabling support for GatewayAPI",
+				"required", maps.Values(requiredGatewayCRDs),
+				"missing", missingGatewayCRDs,
+			)
+		} else {
+			log.Info("[WARNING] GatewayAPI CRDs are not registered. Disabling support")
+		}
+
 		return nil
 	}
 


### PR DESCRIPTION
Existing check of presence for only `Gateway` resource is insufficient in situation when some (not all) of the Gateway API CRDs are missing (i.e. package with CRDs was installed before `ReferenceGrant` was added), which causes CP to start throwing lot of errors:

```
controller-runtime.source.EventHandler	if kind is a CRD, it should be installed before calling Start	{"kind": "ReferenceGrant.gateway.networking.k8s.io", "error": "no matches for kind \"ReferenceGrant\" in version \"gateway.networking.k8s.io/v1beta1\""}
```

This is the simplest solution as we could also verify if `ReferenceGrant` is present, and if not to disable cross-mesh references, but it would be unnecesarily complex, especially in situation when Gateway API is GA and contains `ReferenceGrant` in `v1`.

Closes: https://github.com/kumahq/kuma/issues/10074

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - https://github.com/kumahq/kuma/issues/10074
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Manually tested on local k3d cluster
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
