### PR TITLE
fix(jobs): jobs termination after CP restart

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/pod_status_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_status_controller.go
@@ -82,7 +82,7 @@ func (r *PodStatusReconciler) SetupWithManager(mgr kube_ctrl.Manager) error {
 
 var onlyUpdates = predicate.Funcs{
 	CreateFunc: func(event event.CreateEvent) bool {
-		return false
+		return true // we need it in case of CP restart
 	},
 	DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
 		return false


### PR DESCRIPTION
### Checklist prior to review

Fix jobs termination in case of CP missing update event (like CP restart etc.)

I tested it by applying this
```
apiVersion: batch/v1
kind: Job
metadata:
  name: pi-2
  namespace: kuma-demo
spec:
  template:
    spec:
      containers:
      - name: ubuntu
        image: ubuntu:latest
        command: [ "/bin/bash", "-c", "--" ]
        args: [ "sleep 60" ]
      restartPolicy: Never
  backoffLimit: 4
```
then scaling CP down
```
kubectl scale deployments -n kuma-system kuma-control-plane --replicas=0
```
then up
```
kubectl scale deployments -n kuma-system kuma-control-plane --replicas=1
```

without this fix, the job stays running.

I'd love write E2E test for it, but it requires CP restart so it would land in non-env tests and it would be a time-consuming test.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
