### PR TITLE
chore(api-server): pass extensions context to rest endpoints

### DIFF
--- a/app/kumactl/pkg/tokens/client_test.go
+++ b/app/kumactl/pkg/tokens/client_test.go
@@ -40,6 +40,7 @@ var _ = Describe("Tokens Client", func() {
 			&zoneStaticTokenIssuer{},
 			access.NoopDpTokenAccess{},
 			zone_access.NoopZoneTokenAccess{},
+			context.Background(),
 		))
 		server = httptest.NewServer(container.ServeMux)
 	})

--- a/app/kumactl/pkg/tokens/zone_client_test.go
+++ b/app/kumactl/pkg/tokens/zone_client_test.go
@@ -39,6 +39,7 @@ var _ = Describe("Zone Egress Tokens Client", func() {
 			&zoneStaticTokenIssuer{},
 			access.NoopDpTokenAccess{},
 			zone_access.NoopZoneTokenAccess{},
+			context.Background(),
 		))
 		server = httptest.NewServer(container.ServeMux)
 	})

--- a/pkg/api-server/api_server_suite_test.go
+++ b/pkg/api-server/api_server_suite_test.go
@@ -207,6 +207,7 @@ func tryStartApiServer(t *testApiServerConfigurer) (*api_server.ApiServer, kuma_
 		func(*restful.WebService) error { return nil },
 		globalinsight.NewDefaultGlobalInsightService(t.store),
 		nil,
+		context.Background(),
 	)
 	if err != nil {
 		return nil, cfg, stop, err

--- a/pkg/api-server/authn/localhost.go
+++ b/pkg/api-server/authn/localhost.go
@@ -1,6 +1,7 @@
 package authn
 
 import (
+	"context"
 	"net"
 
 	"github.com/emicklei/go-restful/v3"
@@ -12,15 +13,17 @@ import (
 
 var log = core.Log.WithName("api-server").WithName("authn")
 
-func LocalhostAuthenticator(request *restful.Request, response *restful.Response, chain *restful.FilterChain) {
-	host, _, err := net.SplitHostPort(request.Request.RemoteAddr)
-	if err != nil {
-		rest_errors.HandleError(request.Request.Context(), response, err, "Could not parse Remote Address from the Request")
-		return
+func LocalhostAuthenticator(extensions context.Context) restful.FilterFunction {
+	return func(request *restful.Request, response *restful.Response, chain *restful.FilterChain) {
+		host, _, err := net.SplitHostPort(request.Request.RemoteAddr)
+		if err != nil {
+			rest_errors.HandleError(request.Request.Context(), extensions, response, err, "Could not parse Remote Address from the Request")
+			return
+		}
+		if host == "127.0.0.1" || host == "::1" {
+			log.V(1).Info("authenticated as admin because requests originates from the same machine")
+			request.Request = request.Request.WithContext(user.Ctx(request.Request.Context(), user.Admin.Authenticated()))
+		}
+		chain.ProcessFilter(request, response)
 	}
-	if host == "127.0.0.1" || host == "::1" {
-		log.V(1).Info("authenticated as admin because requests originates from the same machine")
-		request.Request = request.Request.WithContext(user.Ctx(request.Request.Context(), user.Admin.Authenticated()))
-	}
-	chain.ProcessFilter(request, response)
 }

--- a/pkg/api-server/authn/localhost.go
+++ b/pkg/api-server/authn/localhost.go
@@ -22,7 +22,7 @@ func LocalhostAuthenticator(extensions context.Context) restful.FilterFunction {
 		}
 		if host == "127.0.0.1" || host == "::1" {
 			log.V(1).Info("authenticated as admin because requests originates from the same machine")
-			request.Request = request.Request.WithContext(user.Ctx(request.Request.Context(), user.Admin.Authenticated()))
+			request.Request = request.Request.WithContext(user.Ctx(request.Request.Context(), user.Admin.Authenticated())) //nolint:contextcheck
 		}
 		chain.ProcessFilter(request, response)
 	}

--- a/pkg/api-server/config_ws.go
+++ b/pkg/api-server/config_ws.go
@@ -1,6 +1,8 @@
 package api_server
 
 import (
+	"context"
+
 	"github.com/emicklei/go-restful/v3"
 
 	"github.com/kumahq/kuma/pkg/config"
@@ -9,7 +11,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/user"
 )
 
-func addConfigEndpoints(ws *restful.WebService, access access.ControlPlaneMetadataAccess, cfg config.Config) error {
+func addConfigEndpoints(ws *restful.WebService, access access.ControlPlaneMetadataAccess, cfg config.Config, extensions context.Context) error {
 	cfgForDisplay, err := config.ConfigForDisplay(cfg)
 	if err != nil {
 		return err
@@ -21,7 +23,7 @@ func addConfigEndpoints(ws *restful.WebService, access access.ControlPlaneMetada
 	ws.Route(ws.GET("/config").To(func(req *restful.Request, resp *restful.Response) {
 		ctx := req.Request.Context()
 		if err := access.ValidateView(ctx, user.FromCtx(ctx)); err != nil {
-			rest_errors.HandleError(ctx, resp, err, "Access denied")
+			rest_errors.HandleError(ctx, extensions, resp, err, "Access denied")
 			return
 		}
 		resp.AddHeader("content-type", "application/json")

--- a/pkg/api-server/config_ws.go
+++ b/pkg/api-server/config_ws.go
@@ -22,7 +22,7 @@ func addConfigEndpoints(ws *restful.WebService, access access.ControlPlaneMetada
 	}
 	ws.Route(ws.GET("/config").To(func(req *restful.Request, resp *restful.Response) {
 		ctx := req.Request.Context()
-		if err := access.ValidateView(ctx, user.FromCtx(ctx)); err != nil {
+		if err := access.ValidateView(ctx, user.FromCtx(ctx)); err != nil { //nolint:contextcheck
 			rest_errors.HandleError(ctx, extensions, resp, err, "Access denied")
 			return
 		}

--- a/pkg/api-server/customization/customization_suite_test.go
+++ b/pkg/api-server/customization/customization_suite_test.go
@@ -1,6 +1,7 @@
 package customization_test
 
 import (
+	"context"
 	"net"
 	"path/filepath"
 	"testing"
@@ -92,6 +93,7 @@ func createTestApiServer(store store.ResourceStore, config *config_api_server.Ap
 		func(*restful.WebService) error { return nil },
 		globalinsight.NewDefaultGlobalInsightService(store),
 		nil,
+		context.Background(),
 	)
 	Expect(err).ToNot(HaveOccurred())
 	return apiServer

--- a/pkg/api-server/global_insight_endpoint.go
+++ b/pkg/api-server/global_insight_endpoint.go
@@ -1,6 +1,8 @@
 package api_server
 
 import (
+	"context"
+
 	"github.com/emicklei/go-restful/v3"
 
 	"github.com/kumahq/kuma/pkg/core/rest/errors"
@@ -11,6 +13,7 @@ const GlobalInsightPath = "/global-insight"
 
 type globalInsightEndpoint struct {
 	globalInsightService globalinsight.GlobalInsightService
+	extensions           context.Context
 }
 
 func (ge *globalInsightEndpoint) addEndpoint(ws *restful.WebService) {
@@ -25,12 +28,12 @@ func (ge *globalInsightEndpoint) getGlobalInsight(request *restful.Request, resp
 	ctx := request.Request.Context()
 	globalInsight, err := ge.globalInsightService.GetGlobalInsight(ctx)
 	if err != nil {
-		errors.HandleError(ctx, response, err, "Could not retrieve GlobalInsight")
+		errors.HandleError(ctx, ge.extensions, response, err, "Could not retrieve GlobalInsight")
 		return
 	}
 
 	if err = response.WriteAsJson(globalInsight); err != nil {
-		errors.HandleError(ctx, response, err, "Could not write response")
+		errors.HandleError(ctx, ge.extensions, response, err, "Could not write response")
 		return
 	}
 }

--- a/pkg/api-server/global_insights_endpoints.go
+++ b/pkg/api-server/global_insights_endpoints.go
@@ -1,6 +1,7 @@
 package api_server
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 type globalInsightsEndpoints struct {
 	resManager     manager.ResourceManager
 	resourceAccess access.ResourceAccess
+	extensions     context.Context
 }
 
 type globalInsightsStat struct {
@@ -56,7 +58,7 @@ func (r *globalInsightsEndpoints) inspectGlobalResources(request *restful.Reques
 
 		list := descriptor.NewList()
 		if err := r.resManager.List(request.Request.Context(), list); err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Could not retrieve global insights")
+			rest_errors.HandleError(request.Request.Context(), r.extensions, response, err, "Could not retrieve global insights")
 			return
 		}
 
@@ -68,6 +70,6 @@ func (r *globalInsightsEndpoints) inspectGlobalResources(request *restful.Reques
 	insights := newGlobalInsightsResponse(resources)
 
 	if err := response.WriteAsJson(insights); err != nil {
-		rest_errors.HandleError(request.Request.Context(), response, err, "Could not retrieve global insights")
+		rest_errors.HandleError(request.Request.Context(), r.extensions, response, err, "Could not retrieve global insights")
 	}
 }

--- a/pkg/api-server/inspect_endpoints.go
+++ b/pkg/api-server/inspect_endpoints.go
@@ -108,13 +108,13 @@ func inspectDataplane(
 		meshName := request.PathParameter("mesh")
 		dataplaneName := request.PathParameter("dataplane")
 
-		meshContext, err := builder.Build(ctx, meshName)
+		meshContext, err := builder.Build(ctx, meshName) //nolint:contextcheck
 		if err != nil {
 			rest_errors.HandleError(request.Request.Context(), extensions, response, err, "Could not build MeshContext")
 			return
 		}
 
-		proxy, err := getMatchedPolicies(
+		proxy, err := getMatchedPolicies( //nolint:contextcheck
 			request.Request.Context(), cfg, meshContext, core_model.ResourceKey{Mesh: meshName, Name: dataplaneName},
 		)
 		if err != nil {
@@ -149,14 +149,14 @@ func inspectGatewayDataplanes(
 		meshName := request.PathParameter("mesh")
 		gatewayName := request.PathParameter("name")
 
-		meshContext, err := builder.Build(ctx, meshName)
+		meshContext, err := builder.Build(ctx, meshName) //nolint:contextcheck
 		if err != nil {
 			rest_errors.HandleError(request.Request.Context(), extensions, response, err, "Could not build mesh context")
 			return
 		}
 
 		meshGateway := core_mesh.NewMeshGatewayResource()
-		if err := rm.Get(ctx, meshGateway, store.GetByKey(gatewayName, meshName)); err != nil {
+		if err := rm.Get(ctx, meshGateway, store.GetByKey(gatewayName, meshName)); err != nil { //nolint:contextcheck
 			rest_errors.HandleError(request.Request.Context(), extensions, response, err, "Could not find MeshGateway")
 			return
 		}
@@ -196,14 +196,14 @@ func inspectGatewayRouteDataplanes(
 		meshName := request.PathParameter("mesh")
 		gatewayRouteName := request.PathParameter("name")
 
-		meshContext, err := builder.Build(ctx, meshName)
+		meshContext, err := builder.Build(ctx, meshName) //nolint:contextcheck
 		if err != nil {
 			rest_errors.HandleError(request.Request.Context(), extensions, response, err, "Could not build mesh context")
 			return
 		}
 
 		gatewayRoute := core_mesh.NewMeshGatewayRouteResource()
-		if err := rm.Get(ctx, gatewayRoute, store.GetByKey(gatewayRouteName, meshName)); err != nil {
+		if err := rm.Get(ctx, gatewayRoute, store.GetByKey(gatewayRouteName, meshName)); err != nil { //nolint:contextcheck
 			rest_errors.HandleError(request.Request.Context(), extensions, response, err, "Could not find MeshGatewayRoute")
 			return
 		}
@@ -215,7 +215,7 @@ func inspectGatewayRouteDataplanes(
 				continue
 			}
 			key := core_model.MetaToResourceKey(dp.GetMeta())
-			proxy, err := getMatchedPolicies(request.Request.Context(), cfg, meshContext, key)
+			proxy, err := getMatchedPolicies(request.Request.Context(), cfg, meshContext, key) //nolint:contextcheck
 			if err != nil {
 				rest_errors.HandleError(request.Request.Context(), extensions, response, err, "Could not generate listener info")
 				return
@@ -264,7 +264,7 @@ func inspectPolicies(
 		meshName := request.PathParameter("mesh")
 		policyName := request.PathParameter("name")
 
-		meshContext, err := builder.Build(ctx, meshName)
+		meshContext, err := builder.Build(ctx, meshName) //nolint:contextcheck
 		if err != nil {
 			rest_errors.HandleError(request.Request.Context(), extensions, response, err, "Could not list Dataplanes")
 			return
@@ -278,7 +278,7 @@ func inspectPolicies(
 				Mesh: dpKey.Mesh,
 				Name: dpKey.Name,
 			}
-			proxy, err := getMatchedPolicies(request.Request.Context(), cfg, meshContext, dpKey)
+			proxy, err := getMatchedPolicies(request.Request.Context(), cfg, meshContext, dpKey) //nolint:contextcheck
 			if err != nil {
 				rest_errors.HandleError(request.Request.Context(), extensions, response, err, fmt.Sprintf("Could not get MatchedPolicies for %v", dpKey))
 				return
@@ -572,13 +572,13 @@ func inspectRulesAttachment(
 		meshName := request.PathParameter("mesh")
 		dataplaneName := request.PathParameter("dataplane")
 
-		meshContext, err := builder.Build(ctx, meshName)
+		meshContext, err := builder.Build(ctx, meshName) //nolint:contextcheck
 		if err != nil {
 			rest_errors.HandleError(request.Request.Context(), extensions, response, err, "Could not build MeshContext")
 			return
 		}
 
-		proxy, err := getMatchedPolicies(
+		proxy, err := getMatchedPolicies( //nolint:contextcheck
 			ctx, cfg, meshContext, core_model.ResourceKey{Mesh: meshName, Name: dataplaneName},
 		)
 		if err != nil {

--- a/pkg/api-server/inspect_envoy_admin_endpoints.go
+++ b/pkg/api-server/inspect_envoy_admin_endpoints.go
@@ -48,7 +48,7 @@ func addInspectEnvoyAdminEndpoints(
 	}
 	ws.Route(
 		ws.GET("/meshes/{mesh}/dataplanes/{dataplane}/{type}").
-			To(cl.inspectDataplaneAdmin()).
+			To(cl.inspectDataplaneAdmin()). //nolint:contextcheck
 			Doc("inspect dataplane configuration and stats").
 			Param(ws.PathParameter("mesh", "mesh name").DataType("string")).
 			Param(ws.PathParameter("dataplane", "dataplane name").DataType("string")).
@@ -56,7 +56,7 @@ func addInspectEnvoyAdminEndpoints(
 	)
 	ws.Route(
 		ws.GET("/zoneingresses/{zoneingress}/{type}").
-			To(cl.inspectZoneIngressAdmin(cfg.Mode, cfg.Multizone.Zone.Name)).
+			To(cl.inspectZoneIngressAdmin(cfg.Mode, cfg.Multizone.Zone.Name)). //nolint:contextcheck
 			Doc("inspect zone ingresses XDS configuration").
 			Produces("application/json").
 			Param(ws.PathParameter("zoneingress", "zoneingress name").DataType("string")).
@@ -64,7 +64,7 @@ func addInspectEnvoyAdminEndpoints(
 	)
 	ws.Route(
 		ws.GET("/zoneegresses/{zoneegress}/{type}").
-			To(cl.inspectZoneEgressAdmin(cfg.Mode, cfg.Multizone.Zone.Name)).
+			To(cl.inspectZoneEgressAdmin(cfg.Mode, cfg.Multizone.Zone.Name)). //nolint:contextcheck
 			Doc("inspect zone egresses XDS configuration").
 			Produces("application/json").
 			Param(ws.PathParameter("zoneegress", "zoneegress name").DataType("string")).

--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -301,24 +301,26 @@ func addResourcesEndpoints(
 					return fmt.Sprintf("%s.%s:%d", svc, cfg.DNSServer.Domain, cfg.DNSServer.ServiceVipPort)
 				},
 			}
-			ep.addCreateOrUpdateEndpoint(ws, "/meshes/{mesh}/"+definition.WsPath)
-			ep.addDeleteEndpoint(ws, "/meshes/{mesh}/"+definition.WsPath)
-			ep.addFindEndpoint(ws, "/meshes/{mesh}/"+definition.WsPath)
-			ep.addListEndpoint(ws, "/meshes/{mesh}/"+definition.WsPath)
-			ep.addListEndpoint(ws, "/"+definition.WsPath) // listing all resources in all meshes
+			ep.addCreateOrUpdateEndpoint(ws, "/meshes/{mesh}/"+definition.WsPath) //nolint:contextcheck
+			ep.addDeleteEndpoint(ws, "/meshes/{mesh}/"+definition.WsPath)         //nolint:contextcheck
+			ep.addFindEndpoint(ws, "/meshes/{mesh}/"+definition.WsPath)           //nolint:contextcheck
+			ep.addListEndpoint(ws, "/meshes/{mesh}/"+definition.WsPath)           //nolint:contextcheck
+			// listing all resources in all meshes
+			ep.addListEndpoint(ws, "/"+definition.WsPath) //nolint:contextcheck
 		default:
 			switch definition.Scope {
 			case model.ScopeMesh:
-				endpoints.addCreateOrUpdateEndpoint(ws, "/meshes/{mesh}/"+definition.WsPath)
-				endpoints.addDeleteEndpoint(ws, "/meshes/{mesh}/"+definition.WsPath)
-				endpoints.addFindEndpoint(ws, "/meshes/{mesh}/"+definition.WsPath)
-				endpoints.addListEndpoint(ws, "/meshes/{mesh}/"+definition.WsPath)
-				endpoints.addListEndpoint(ws, "/"+definition.WsPath) // listing all resources in all meshes
+				endpoints.addCreateOrUpdateEndpoint(ws, "/meshes/{mesh}/"+definition.WsPath) //nolint:contextcheck
+				endpoints.addDeleteEndpoint(ws, "/meshes/{mesh}/"+definition.WsPath)         //nolint:contextcheck
+				endpoints.addFindEndpoint(ws, "/meshes/{mesh}/"+definition.WsPath)           //nolint:contextcheck
+				endpoints.addListEndpoint(ws, "/meshes/{mesh}/"+definition.WsPath)           //nolint:contextcheck
+				// listing all resources in all meshes
+				endpoints.addListEndpoint(ws, "/"+definition.WsPath) //nolint:contextcheck
 			case model.ScopeGlobal:
-				endpoints.addCreateOrUpdateEndpoint(ws, "/"+definition.WsPath)
-				endpoints.addDeleteEndpoint(ws, "/"+definition.WsPath)
-				endpoints.addFindEndpoint(ws, "/"+definition.WsPath)
-				endpoints.addListEndpoint(ws, "/"+definition.WsPath)
+				endpoints.addCreateOrUpdateEndpoint(ws, "/"+definition.WsPath) //nolint:contextcheck
+				endpoints.addDeleteEndpoint(ws, "/"+definition.WsPath)         //nolint:contextcheck
+				endpoints.addFindEndpoint(ws, "/"+definition.WsPath)           //nolint:contextcheck
+				endpoints.addListEndpoint(ws, "/"+definition.WsPath)           //nolint:contextcheck
 			}
 		}
 	}

--- a/pkg/api-server/service_insight_endpoints.go
+++ b/pkg/api-server/service_insight_endpoints.go
@@ -35,14 +35,14 @@ func (s *serviceInsightEndpoints) findResource(request *restful.Request, respons
 	service := request.PathParameter("service")
 	meshName, err := s.meshFromRequest(request)
 	if err != nil {
-		rest_errors.HandleError(request.Request.Context(), response, err, "Failed to retrieve Mesh")
+		rest_errors.HandleError(request.Request.Context(), s.extensions, response, err, "Failed to retrieve Mesh")
 		return
 	}
 
 	serviceInsight := mesh.NewServiceInsightResource()
 	err = s.resManager.Get(request.Request.Context(), serviceInsight, store.GetBy(insights.ServiceInsightKey(meshName)))
 	if err != nil {
-		rest_errors.HandleError(request.Request.Context(), response, err, "Could not retrieve a resource")
+		rest_errors.HandleError(request.Request.Context(), s.extensions, response, err, "Could not retrieve a resource")
 	} else {
 		stat := serviceInsight.Spec.Services[service]
 		if stat == nil {
@@ -73,14 +73,14 @@ func (s *serviceInsightEndpoints) addListEndpoint(ws *restful.WebService, pathPr
 func (s *serviceInsightEndpoints) listResources(request *restful.Request, response *restful.Response) {
 	meshName, err := s.meshFromRequest(request)
 	if err != nil {
-		rest_errors.HandleError(request.Request.Context(), response, err, "Failed to retrieve Mesh")
+		rest_errors.HandleError(request.Request.Context(), s.extensions, response, err, "Failed to retrieve Mesh")
 		return
 	}
 
 	serviceInsightList := &mesh.ServiceInsightResourceList{}
 	err = s.resManager.List(request.Request.Context(), serviceInsightList, store.ListByMesh(meshName))
 	if err != nil {
-		rest_errors.HandleError(request.Request.Context(), response, err, "Could not retrieve resources")
+		rest_errors.HandleError(request.Request.Context(), s.extensions, response, err, "Could not retrieve resources")
 		return
 	}
 
@@ -92,7 +92,7 @@ func (s *serviceInsightEndpoints) listResources(request *restful.Request, respon
 			f = strings.ToLower(strings.TrimSpace(f))
 			i, exists := v1alpha1.ServiceInsight_Service_Type_value[f]
 			if !exists {
-				rest_errors.HandleError(request.Request.Context(), response, rest_errors.NewBadRequestError("unsupported service type"), "Invalid response type")
+				rest_errors.HandleError(request.Request.Context(), s.extensions, response, rest_errors.NewBadRequestError("unsupported service type"), "Invalid response type")
 				return
 			}
 			filterMap[v1alpha1.ServiceInsight_Service_Type(i)] = struct{}{}
@@ -112,12 +112,12 @@ func (s *serviceInsightEndpoints) listResources(request *restful.Request, respon
 	}
 
 	if err := s.paginateResources(request, &restList); err != nil {
-		rest_errors.HandleError(request.Request.Context(), response, err, "Could not paginate resources")
+		rest_errors.HandleError(request.Request.Context(), s.extensions, response, err, "Could not paginate resources")
 		return
 	}
 
 	if err := response.WriteAsJson(restList); err != nil {
-		rest_errors.HandleError(request.Request.Context(), response, err, "Could not list resources")
+		rest_errors.HandleError(request.Request.Context(), s.extensions, response, err, "Could not list resources")
 	}
 }
 

--- a/pkg/api-server/zones_ws.go
+++ b/pkg/api-server/zones_ws.go
@@ -19,7 +19,7 @@ type Zones []Zone
 
 func addZoneEndpoints(ws *restful.WebService, resManager manager.ResourceManager, extensions context.Context) {
 	ws.Route(ws.GET("/status/zones").To(func(request *restful.Request, response *restful.Response) {
-		zoneOverviews, err := fetchOverviews(resManager, request.Request.Context())
+		zoneOverviews, err := fetchOverviews(resManager, request.Request.Context()) //nolint:contextcheck
 		if err != nil {
 			rest_errors.HandleError(request.Request.Context(), extensions, response, err, "Could not retrieve a zone overview")
 			return

--- a/pkg/api-server/zones_ws.go
+++ b/pkg/api-server/zones_ws.go
@@ -17,11 +17,11 @@ type Zone struct {
 
 type Zones []Zone
 
-func addZoneEndpoints(ws *restful.WebService, resManager manager.ResourceManager) {
+func addZoneEndpoints(ws *restful.WebService, resManager manager.ResourceManager, extensions context.Context) {
 	ws.Route(ws.GET("/status/zones").To(func(request *restful.Request, response *restful.Response) {
 		zoneOverviews, err := fetchOverviews(resManager, request.Request.Context())
 		if err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Could not retrieve a zone overview")
+			rest_errors.HandleError(request.Request.Context(), extensions, response, err, "Could not retrieve a zone overview")
 			return
 		}
 

--- a/pkg/core/rest/errors/error_handler.go
+++ b/pkg/core/rest/errors/error_handler.go
@@ -24,8 +24,8 @@ import (
 	"github.com/kumahq/kuma/pkg/multitenant"
 )
 
-func HandleError(ctx context.Context, response *restful.Response, err error, title string) {
-	log := kuma_log.AddFieldsFromCtx(core.Log.WithName("rest"), ctx, context.Background())
+func HandleError(ctx, extensions context.Context, response *restful.Response, err error, title string) {
+	log := kuma_log.AddFieldsFromCtx(core.Log.WithName("rest"), ctx, extensions)
 	var kumaErr *types.Error
 	switch {
 	case store.IsResourceNotFound(err) || errors.Is(err, &NotFound{}):

--- a/pkg/mads/server/server.go
+++ b/pkg/mads/server/server.go
@@ -126,7 +126,13 @@ func SetupServer(rt core_runtime.Runtime) error {
 
 	if config.VersionIsEnabled(mads.API_V1) {
 		log.Info("MADS v1 is enabled")
-		svc := mads_v1.NewService(config, rm, log.WithValues("apiVersion", mads.API_V1), rt.MeshCache())
+		svc := mads_v1.NewService(
+			config,
+			rm,
+			log.WithValues("apiVersion", mads.API_V1),
+			rt.MeshCache(),
+			rt.Extensions(),
+		)
 		httpServices = append(httpServices, svc)
 	}
 

--- a/pkg/mads/server/server_test.go
+++ b/pkg/mads/server/server_test.go
@@ -2,6 +2,7 @@ package server_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"net/http"
 
@@ -52,6 +53,10 @@ func (t *testRuntime) Metrics() metrics.Metrics {
 
 func (t *testRuntime) MeshCache() *mesh.Cache {
 	return t.meshCache
+}
+
+func (t *testRuntime) Extensions() context.Context {
+	return context.Background()
 }
 
 var _ = Describe("MADS Server", func() {

--- a/pkg/mads/v1/service/http.go
+++ b/pkg/mads/v1/service/http.go
@@ -71,14 +71,14 @@ func (s *service) handleDiscovery(req *restful.Request, res *restful.Response) {
 			s.log.V(1).Info("no update needed")
 			res.WriteHeader(http.StatusNotModified)
 		} else {
-			rest_errors.HandleError(req.Request.Context(), res, err, "Could not fetch MonitoringAssignments")
+			rest_errors.HandleError(req.Request.Context(), s.extensions, res, err, "Could not fetch MonitoringAssignments")
 		}
 		return
 	}
 
 	marshaller := &jsonpb.Marshaler{OrigName: true}
 	if err := marshaller.Marshal(res, discoveryRes); err != nil {
-		rest_errors.HandleError(req.Request.Context(), res, err, "Could write DiscoveryResponse")
+		rest_errors.HandleError(req.Request.Context(), s.extensions, res, err, "Could write DiscoveryResponse")
 		return
 	}
 }

--- a/pkg/mads/v1/service/service.go
+++ b/pkg/mads/v1/service/service.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"context"
+
 	"github.com/go-logr/logr"
 
 	"github.com/kumahq/kuma/pkg/config/mads"
@@ -11,12 +13,19 @@ import (
 )
 
 type service struct {
-	server Server
-	config *mads.MonitoringAssignmentServerConfig
-	log    logr.Logger
+	server     Server
+	config     *mads.MonitoringAssignmentServerConfig
+	log        logr.Logger
+	extensions context.Context
 }
 
-func NewService(config *mads.MonitoringAssignmentServerConfig, rm core_manager.ReadOnlyResourceManager, log logr.Logger, meshCache *mesh.Cache) *service {
+func NewService(
+	config *mads.MonitoringAssignmentServerConfig,
+	rm core_manager.ReadOnlyResourceManager,
+	log logr.Logger,
+	meshCache *mesh.Cache,
+	extensions context.Context,
+) *service {
 	hasher, cache := NewXdsContext(log)
 	generator := NewSnapshotGenerator(rm, meshCache)
 	versioner := NewVersioner()
@@ -35,8 +44,9 @@ func NewService(config *mads.MonitoringAssignmentServerConfig, rm core_manager.R
 	srv := NewServer(cache, callbacks)
 
 	return &service{
-		server: srv,
-		config: config,
-		log:    log,
+		server:     srv,
+		config:     config,
+		log:        log,
+		extensions: extensions,
 	}
 }

--- a/pkg/mads/v1/service_test.go
+++ b/pkg/mads/v1/service_test.go
@@ -57,7 +57,7 @@ var _ = Describe("MADS http service", func() {
 		cfg.AssignmentRefreshInterval = config_types.Duration{Duration: refreshInterval}
 		cfg.DefaultFetchTimeout = config_types.Duration{Duration: defaultFetchTimeout}
 
-		svc := service.NewService(cfg, resManager, logr.Discard(), nil)
+		svc := service.NewService(cfg, resManager, logr.Discard(), nil, context.Background())
 
 		ws := new(restful.WebService)
 		svc.RegisterRoutes(ws)

--- a/pkg/plugins/authn/api-server/tokens/authenticator.go
+++ b/pkg/plugins/authn/api-server/tokens/authenticator.go
@@ -24,17 +24,17 @@ func UserTokenAuthenticator(validator issuer.UserTokenValidator, extensions cont
 			return
 		}
 		authnHeader := request.Request.Header.Get("authorization")
-		if user.FromCtx(request.Request.Context()).Name == user.Anonymous.Name && // do not overwrite existing user
+		if user.FromCtx(request.Request.Context()).Name == user.Anonymous.Name && //nolint:contextcheck // do not overwrite existing user
 			authnHeader != "" &&
 			strings.HasPrefix(authnHeader, bearerPrefix) {
 			token := strings.TrimPrefix(authnHeader, bearerPrefix)
-			u, err := validator.Validate(request.Request.Context(), token)
+			u, err := validator.Validate(request.Request.Context(), token) //nolint:contextcheck
 			if err != nil {
 				rest_errors.HandleError(request.Request.Context(), extensions, response, &rest_errors.Unauthenticated{}, "Invalid authentication data")
 				log.Info("authentication rejected", "reason", err.Error())
 				return
 			}
-			request.Request = request.Request.WithContext(user.Ctx(request.Request.Context(), u.Authenticated()))
+			request.Request = request.Request.WithContext(user.Ctx(request.Request.Context(), u.Authenticated())) //nolint:contextcheck
 		}
 		chain.ProcessFilter(request, response)
 	}

--- a/pkg/plugins/authn/api-server/tokens/authenticator.go
+++ b/pkg/plugins/authn/api-server/tokens/authenticator.go
@@ -1,6 +1,7 @@
 package tokens
 
 import (
+	"context"
 	"strings"
 
 	"github.com/emicklei/go-restful/v3"
@@ -16,7 +17,7 @@ const bearerPrefix = "Bearer "
 
 var log = core.Log.WithName("plugins").WithName("authn").WithName("api-server").WithName("tokens")
 
-func UserTokenAuthenticator(validator issuer.UserTokenValidator) authn.Authenticator {
+func UserTokenAuthenticator(validator issuer.UserTokenValidator, extensions context.Context) authn.Authenticator {
 	return func(request *restful.Request, response *restful.Response, chain *restful.FilterChain) {
 		if authn.SkipAuth(request) {
 			chain.ProcessFilter(request, response)
@@ -29,7 +30,7 @@ func UserTokenAuthenticator(validator issuer.UserTokenValidator) authn.Authentic
 			token := strings.TrimPrefix(authnHeader, bearerPrefix)
 			u, err := validator.Validate(request.Request.Context(), token)
 			if err != nil {
-				rest_errors.HandleError(request.Request.Context(), response, &rest_errors.Unauthenticated{}, "Invalid authentication data")
+				rest_errors.HandleError(request.Request.Context(), extensions, response, &rest_errors.Unauthenticated{}, "Invalid authentication data")
 				log.Info("authentication rejected", "reason", err.Error())
 				return
 			}

--- a/pkg/plugins/authn/api-server/tokens/plugin.go
+++ b/pkg/plugins/authn/api-server/tokens/plugin.go
@@ -64,7 +64,7 @@ func (c *plugin) NewAuthenticator(context plugins.PluginContext) (authn.Authenti
 		),
 	)
 	c.isInitialised = true
-	return UserTokenAuthenticator(validator), nil
+	return UserTokenAuthenticator(validator, context.Extensions()), nil
 }
 
 func (c *plugin) BeforeBootstrap(*plugins.MutablePluginContext, plugins.PluginConfig) error {
@@ -94,7 +94,7 @@ func (c *plugin) AfterBootstrap(context *plugins.MutablePluginContext, config pl
 			return err
 		}
 	}
-	webService := server.NewWebService(tokenIssuer, accessFn(context))
+	webService := server.NewWebService(tokenIssuer, accessFn(context), context.Extensions())
 	context.APIManager().Add(webService)
 	return nil
 }

--- a/pkg/plugins/authn/api-server/tokens/ws/ws_test.go
+++ b/pkg/plugins/authn/api-server/tokens/ws/ws_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Auth Tokens WS", func() {
 		)
 
 		Expect(signingKeyManager.CreateDefaultSigningKey(context.Background())).To(Succeed())
-		ws := server.NewWebService(tokenIssuer, &noopGenerateUserTokenAccess{})
+		ws := server.NewWebService(tokenIssuer, &noopGenerateUserTokenAccess{}, context.Background())
 
 		container := restful.NewContainer()
 		container.Add(ws)
@@ -124,7 +124,7 @@ var _ = Describe("Auth Tokens WS", func() {
 
 	It("should throw an error when issuer is disabled", func() {
 		container := restful.NewContainer()
-		ws := server.NewWebService(issuer.DisabledIssuer{}, &noopGenerateUserTokenAccess{})
+		ws := server.NewWebService(issuer.DisabledIssuer{}, &noopGenerateUserTokenAccess{}, context.Background())
 		container.Add(ws)
 		srv := httptest.NewServer(container)
 

--- a/pkg/test/api_server/api_server.go
+++ b/pkg/test/api_server/api_server.go
@@ -44,5 +44,6 @@ func NewApiServer(cfg kuma_cp.Config, runtime runtime.Runtime) (*api_server.ApiS
 		runtime.APIWebServiceCustomize(),
 		runtime.GlobalInsightService(),
 		runtime.XDS().Hooks.ResourceSetHooks(),
+		runtime.Extensions(),
 	)
 }

--- a/pkg/tokens/builtin/server/webservice_test.go
+++ b/pkg/tokens/builtin/server/webservice_test.go
@@ -53,6 +53,7 @@ var _ = Describe("Dataplane Token Webservice", func() {
 			&zoneStaticTokenIssuer{},
 			&access.NoopDpTokenAccess{},
 			&zone_access.NoopZoneTokenAccess{},
+			context.Background(),
 		)
 
 		container := restful.NewContainer()


### PR DESCRIPTION
When using `AddFieldFromCtx` in `HandleError` function we were passing fresh, empty context. Because of that whenever logger had custom `FromSpanLogValuesProcessorContext` passed, it was ignored. Now we are passing runtime extension context to all endpoint handlers which then are using `HandleError`, which allows us to provide in example mapper of OTEL trace ids to Datadog.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - https://github.com/Kong/mink-charts/issues/1096
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - There is no need

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
