### PR TITLE
fix(api-server): fix trace/span ID processing in logs

### DIFF
--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -20,13 +20,13 @@ import (
 
 	"github.com/bakito/go-log-logr-adapter/adapter"
 	"github.com/emicklei/go-restful/v3"
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	http_prometheus "github.com/slok/go-http-metrics/metrics/prometheus"
 	"github.com/slok/go-http-metrics/middleware"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful"
 
 	"github.com/kumahq/kuma/pkg/api-server/authn"
-	"github.com/kumahq/kuma/pkg/api-server/customization"
 	"github.com/kumahq/kuma/pkg/api-server/filters"
 	api_server "github.com/kumahq/kuma/pkg/config/api-server"
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
@@ -42,13 +42,11 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/registry"
 	"github.com/kumahq/kuma/pkg/core/runtime"
 	"github.com/kumahq/kuma/pkg/dns/vips"
-	"github.com/kumahq/kuma/pkg/envoy/admin"
 	"github.com/kumahq/kuma/pkg/insights/globalinsight"
-	"github.com/kumahq/kuma/pkg/metrics"
+	kuma_log "github.com/kumahq/kuma/pkg/log"
 	"github.com/kumahq/kuma/pkg/plugins/authn/api-server/certs"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s"
 	secrets_k8s "github.com/kumahq/kuma/pkg/plugins/secrets/k8s"
-	"github.com/kumahq/kuma/pkg/tokens/builtin"
 	tokens_server "github.com/kumahq/kuma/pkg/tokens/builtin/server"
 	kuma_srv "github.com/kumahq/kuma/pkg/util/http/server"
 	util_prometheus "github.com/kumahq/kuma/pkg/util/prometheus"
@@ -98,20 +96,10 @@ func init() {
 }
 
 func NewApiServer(
-	resManager manager.ResourceManager,
+	rt runtime.Runtime,
 	meshContextBuilder xds_context.MeshContextBuilder,
-	wsManager customization.APIInstaller,
 	defs []model.ResourceTypeDescriptor,
 	cfg *kuma_cp.Config,
-	metrics metrics.Metrics,
-	getInstanceId func() string,
-	getClusterId func() string,
-	authenticator authn.Authenticator,
-	access runtime.Access,
-	envoyAdminClient admin.EnvoyAdminClient,
-	tokenIssuers builtin.TokenIssuers,
-	wsCustomize func(*restful.WebService) error,
-	globalInsightService globalinsight.GlobalInsightService,
 	xdsHooks []hooks.ResourceSetHook,
 ) (*ApiServer, error) {
 	serverConfig := cfg.ApiServer
@@ -119,7 +107,7 @@ func NewApiServer(
 
 	promMiddleware := middleware.New(middleware.Config{
 		Recorder: http_prometheus.NewRecorder(http_prometheus.Config{
-			Registry: metrics,
+			Registry: rt.Metrics(),
 			Prefix:   "api_server",
 		}),
 	})
@@ -131,7 +119,7 @@ func NewApiServer(
 	if cfg.ApiServer.Authn.LocalhostIsAdmin {
 		container.Filter(authn.LocalhostAuthenticator)
 	}
-	container.Filter(authenticator)
+	container.Filter(rt.APIServerAuthenticator())
 
 	cors := restful.CrossOriginResourceSharing{
 		ExposeHeaders:  []string{restful.HEADER_AccessControlAllowOrigin},
@@ -149,11 +137,20 @@ func NewApiServer(
 		Consumes(restful.MIME_JSON).
 		Produces(restful.MIME_JSON)
 
-	addResourcesEndpoints(ws, defs, resManager, cfg, access.ResourceAccess, globalInsightService, meshContextBuilder, xdsHooks)
+	addResourcesEndpoints(
+		ws,
+		defs,
+		rt.ResourceManager(),
+		cfg,
+		rt.Access().ResourceAccess,
+		rt.GlobalInsightService(),
+		meshContextBuilder,
+		xdsHooks,
+	)
 	addPoliciesWsEndpoints(ws, cfg.IsFederatedZoneCP(), cfg.ApiServer.ReadOnly, defs)
-	addInspectEndpoints(ws, cfg, meshContextBuilder, resManager)
-	addInspectEnvoyAdminEndpoints(ws, cfg, resManager, access.EnvoyAdminAccess, envoyAdminClient)
-	addZoneEndpoints(ws, resManager)
+	addInspectEndpoints(ws, cfg, meshContextBuilder, rt.ResourceManager())
+	addInspectEnvoyAdminEndpoints(ws, cfg, rt.ResourceManager(), rt.Access().EnvoyAdminAccess, rt.EnvoyAdminClient())
+	addZoneEndpoints(ws, rt.ResourceManager())
 	guiUrl := ""
 	if cfg.ApiServer.GUI.Enabled && !cfg.IsFederatedZoneCP() {
 		guiUrl = cfg.ApiServer.GUI.BasePath
@@ -166,17 +163,17 @@ func NewApiServer(
 		apiUrl = cfg.ApiServer.RootUrl
 	}
 
-	err := addConfigEndpoints(ws, access.ControlPlaneMetadataAccess, cfg)
+	err := addConfigEndpoints(ws, rt.Access().ControlPlaneMetadataAccess, cfg)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create configuration webservice")
 	}
-	if err := addIndexWsEndpoints(ws, getInstanceId, getClusterId, guiUrl); err != nil {
+	if err := addIndexWsEndpoints(ws, rt.GetInstanceId, rt.GetClusterId, guiUrl); err != nil {
 		return nil, errors.Wrap(err, "could not create index webservice")
 	}
 	addWhoamiEndpoints(ws)
 
 	ws.SetDynamicRoutes(true)
-	if err := wsCustomize(ws); err != nil {
+	if err := rt.APIWebServiceCustomize()(ws); err != nil {
 		return nil, errors.Wrap(err, "couldn't customize webservice")
 	}
 
@@ -188,10 +185,10 @@ func NewApiServer(
 	}
 	container.Add(tokens_server.NewWebservice(
 		path+"tokens",
-		tokenIssuers.DataplaneToken,
-		tokenIssuers.ZoneToken,
-		access.DataplaneTokenAccess,
-		access.ZoneTokenAccess,
+		rt.TokenIssuers().DataplaneToken,
+		rt.TokenIssuers().ZoneToken,
+		rt.Access().DataplaneTokenAccess,
+		rt.Access().ZoneTokenAccess,
 	))
 	guiPath := cfg.ApiServer.GUI.BasePath
 	if !strings.HasSuffix(guiPath, "/") {
@@ -227,7 +224,20 @@ func NewApiServer(
 		config: *serverConfig,
 	}
 
-	wsManager.Install(container)
+	container.Filter(func(request *restful.Request, response *restful.Response, chain *restful.FilterChain) {
+		request.Request = request.Request.WithContext(logr.NewContext(
+			request.Request.Context(),
+			kuma_log.AddFieldsFromCtx(
+				core.Log.WithName("rest"),
+				request.Request.Context(),
+				rt.Extensions(),
+			),
+		))
+
+		chain.ProcessFilter(request, response)
+	})
+
+	rt.APIInstaller().Install(container)
 
 	return newApiServer, nil
 }
@@ -455,7 +465,7 @@ func configureTLS(cfg api_server.ApiServerConfig) (*tls.Config, error) {
 func SetupServer(rt runtime.Runtime) error {
 	cfg := rt.Config()
 	apiServer, err := NewApiServer(
-		rt.ResourceManager(),
+		rt,
 		xds_context.NewMeshContextBuilder(
 			rt.ResourceManager(),
 			server.MeshResourceTypes(),
@@ -467,18 +477,8 @@ func SetupServer(rt runtime.Runtime) error {
 			xds_context.AnyToAnyReachableServicesGraphBuilder,
 			cfg.Experimental.SkipPersistedVIPs,
 		),
-		rt.APIInstaller(),
 		registry.Global().ObjectDescriptors(model.HasWsEnabled()),
 		&cfg,
-		rt.Metrics(),
-		rt.GetInstanceId,
-		rt.GetClusterId,
-		rt.APIServerAuthenticator(),
-		rt.Access(),
-		rt.EnvoyAdminClient(),
-		rt.TokenIssuers(),
-		rt.APIWebServiceCustomize(),
-		rt.GlobalInsightService(),
 		rt.XDS().Hooks.ResourceSetHooks(),
 	)
 	if err != nil {

--- a/pkg/core/rest/errors/error_handler.go
+++ b/pkg/core/rest/errors/error_handler.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 
 	"github.com/emicklei/go-restful/v3"
+	"github.com/go-logr/logr"
 	"go.opentelemetry.io/otel/trace"
 
 	api_server_types "github.com/kumahq/kuma/pkg/api-server/types"
-	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/access"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/resources/model/rest"
@@ -20,12 +20,12 @@ import (
 	"github.com/kumahq/kuma/pkg/core/validators"
 	"github.com/kumahq/kuma/pkg/intercp/envoyadmin"
 	kds_envoyadmin "github.com/kumahq/kuma/pkg/kds/envoyadmin"
-	kuma_log "github.com/kumahq/kuma/pkg/log"
 	"github.com/kumahq/kuma/pkg/multitenant"
 )
 
 func HandleError(ctx context.Context, response *restful.Response, err error, title string) {
-	log := kuma_log.AddFieldsFromCtx(core.Log.WithName("rest"), ctx, context.Background())
+	log := logr.FromContextOrDiscard(ctx)
+
 	var kumaErr *types.Error
 	switch {
 	case store.IsResourceNotFound(err) || errors.Is(err, &NotFound{}):

--- a/pkg/test/api_server/api_server.go
+++ b/pkg/test/api_server/api_server.go
@@ -15,7 +15,7 @@ import (
 
 func NewApiServer(cfg kuma_cp.Config, runtime runtime.Runtime) (*api_server.ApiServer, error) {
 	return api_server.NewApiServer(
-		runtime.ResourceManager(),
+		runtime,
 		context.NewMeshContextBuilder(
 			runtime.ResourceManager(),
 			server.MeshResourceTypes(),
@@ -31,18 +31,8 @@ func NewApiServer(cfg kuma_cp.Config, runtime runtime.Runtime) (*api_server.ApiS
 			context.AnyToAnyReachableServicesGraphBuilder,
 			cfg.Experimental.SkipPersistedVIPs,
 		),
-		runtime.APIInstaller(),
 		registry.Global().ObjectDescriptors(model.HasWsEnabled()),
 		&cfg,
-		runtime.Metrics(),
-		runtime.GetInstanceId,
-		runtime.GetClusterId,
-		runtime.APIServerAuthenticator(),
-		runtime.Access(),
-		runtime.EnvoyAdminClient(),
-		runtime.TokenIssuers(),
-		runtime.APIWebServiceCustomize(),
-		runtime.GlobalInsightService(),
 		runtime.XDS().Hooks.ResourceSetHooks(),
 	)
 }

--- a/pkg/test/runtime/runtime.go
+++ b/pkg/test/runtime/runtime.go
@@ -350,3 +350,7 @@ func (r *TestRuntime) TokenIssuers() tokens_builtin.TokenIssuers {
 func (r *TestRuntime) APIWebServiceCustomize() func(ws *restful.WebService) error {
 	return func(*restful.WebService) error { return nil }
 }
+
+func (r *TestRuntime) Extensions() context.Context {
+	return context.Background()
+}

--- a/pkg/test/runtime/runtime.go
+++ b/pkg/test/runtime/runtime.go
@@ -7,9 +7,11 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/emicklei/go-restful/v3"
 	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/pkg/api-server/authn"
 	"github.com/kumahq/kuma/pkg/api-server/customization"
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
 	config_core "github.com/kumahq/kuma/pkg/config/core"
@@ -33,8 +35,10 @@ import (
 	secret_store "github.com/kumahq/kuma/pkg/core/secrets/store"
 	"github.com/kumahq/kuma/pkg/dns/vips"
 	"github.com/kumahq/kuma/pkg/dp-server/server"
+	"github.com/kumahq/kuma/pkg/envoy/admin"
 	envoyadmin_access "github.com/kumahq/kuma/pkg/envoy/admin/access"
 	"github.com/kumahq/kuma/pkg/events"
+	"github.com/kumahq/kuma/pkg/insights/globalinsight"
 	"github.com/kumahq/kuma/pkg/intercp"
 	kds_context "github.com/kumahq/kuma/pkg/kds/context"
 	"github.com/kumahq/kuma/pkg/metrics"
@@ -262,4 +266,87 @@ func (d *DummyEnvoyAdminClient) ConfigDump(ctx context.Context, proxy core_model
 		out["eds"] = "eds"
 	}
 	return json.Marshal(out)
+}
+
+type TestRuntime struct {
+	core_runtime.Runtime
+	rm                   core_manager.ResourceManager
+	config               kuma_cp.Config
+	metrics              metrics.Metrics
+	apiInstaller         customization.APIInstaller
+	access               core_runtime.Access
+	tokenIssuers         tokens_builtin.TokenIssuers
+	globalInsightService globalinsight.GlobalInsightService
+}
+
+func NewTestRuntime(
+	rm core_manager.ResourceManager,
+	config kuma_cp.Config,
+	metrics metrics.Metrics,
+	apiInstaller customization.APIInstaller,
+	access core_runtime.Access,
+	tokenIssuers tokens_builtin.TokenIssuers,
+	globalInsightService globalinsight.GlobalInsightService,
+) *TestRuntime {
+	return &TestRuntime{
+		rm:                   rm,
+		config:               config,
+		metrics:              metrics,
+		apiInstaller:         apiInstaller,
+		access:               access,
+		tokenIssuers:         tokenIssuers,
+		globalInsightService: globalInsightService,
+	}
+}
+
+func (r *TestRuntime) GetInstanceId() string {
+	return "instance-id"
+}
+
+func (r *TestRuntime) GetClusterId() string {
+	return "cluster-id"
+}
+
+func (r *TestRuntime) Config() kuma_cp.Config {
+	return r.config
+}
+
+func (r *TestRuntime) ResourceManager() core_manager.ResourceManager {
+	return r.rm
+}
+
+func (r *TestRuntime) ReadOnlyResourceManager() core_manager.ReadOnlyResourceManager {
+	return r.rm
+}
+
+func (r *TestRuntime) GlobalInsightService() globalinsight.GlobalInsightService {
+	return r.globalInsightService
+}
+
+func (r *TestRuntime) EnvoyAdminClient() admin.EnvoyAdminClient {
+	return &DummyEnvoyAdminClient{}
+}
+
+func (r *TestRuntime) Metrics() metrics.Metrics {
+	return r.metrics
+}
+
+func (r *TestRuntime) APIInstaller() customization.APIInstaller {
+	return r.apiInstaller
+}
+
+func (r *TestRuntime) APIServerAuthenticator() authn.Authenticator {
+	return certs.ClientCertAuthenticator
+}
+
+func (r *TestRuntime) Access() core_runtime.Access {
+	return r.access
+}
+
+func (r *TestRuntime) TokenIssuers() tokens_builtin.TokenIssuers {
+	return r.tokenIssuers
+}
+
+func (r *TestRuntime) APIWebServiceCustomize() func(ws *restful.WebService) error {
+	return func(*restful.WebService) error { return nil }
 }


### PR DESCRIPTION
## Problem:

Currently, processing trace/span IDs before logging them (e.g., converting them to Datadog format) requires calling [`NewSpanLogValuesProcessorContext`](https://github.com/kumahq/kuma/blob/dd95f22e4e568ebeb899c187b107020a28703db5/pkg/plugins/extensions/logger/context.go#L19-L24) with the `runtime.Extensions()` context. However, this context isn't always available, particularly when [handling errors in REST endpoint handlers through `AddFieldsFromCtx`](https://github.com/kumahq/kuma/blob/dd95f22e4e568ebeb899c187b107020a28703db5/pkg/log/logger.go#L120). This inconsistency leads to the processing function being ignored.

## Proposed Solutions:

- Pass `runtime.Extensions()` Context to [`HandleError`](https://github.com/kumahq/kuma/blob/8d2eaed06c21ad74b6806ce1db837f6610dcaaee/pkg/core/rest/errors/error_handler.go#L27): While effective, this approach adds significant boilerplate code and requires disabling the `contextcheck` linter in multiple locations (see PR #10094).

- Leverage slog's Contextual Logging (ref: https://github.com/kumahq/kuma/issues/8216): This approach offers cleaner code but requires significant changes to our logging infrastructure (ones which I immediately faced when tried to do a quick POC):
  - slog lacks the concept of logger names, necessitating a custom `slog.Handler` for maintaining desired log structure.
  - We'd need to abandon using globally configured/named loggers or potentially introduce deferred logger initialization logic for slog.

## Current Solution (For This PR):

To address the issue without a major logging overhaul, this PR proposes a simpler solution:

- Pass the logger instance through the context when constructing ApiServer.
- Restore the logger from the context in `HandleError` function.

This approach, while not ideal due to the passing logger via context, effectively resolves the problem without introducing complex logging changes.

## Additional changes:

I adjusted the signature of `NewApiServer` function to accept the whole `runtime.Runtime`, which reduced significantly the amount of necessary arguments, which were attained from the `runtime.Runtime`. It makes `contextcheck` linter happy as we don't have to pass `runtime.Extensions()` context as an argument, which linter would flag as passed and not used, without realising it's not the regular context.


### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - No relevant issues
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Manually tested by running local OTEL collector and then manually triggering handlers to return error with ant without span logging processors
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - There is no need I think 🤔 

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
