### PR TITLE
feat(kubectl): support specifying profile name when installing control planes

### DIFF
--- a/app/kumactl/cmd/install/context/install_control_plane_context.go
+++ b/app/kumactl/cmd/install/context/install_control_plane_context.go
@@ -128,13 +128,13 @@ func DefaultInstallCpContext() InstallCpContext {
 				return loadedFileList, err
 			}
 
-			return useProfileValues(loadedFileList, args.ValuesProfile)
+			return UseProfileValues(loadedFileList, args.ValuesProfile)
 		},
 		HELMValuesPrefix: "",
 	}
 }
 
-func useProfileValues(loadedFileList data.FileList, profile string) (data.FileList, error) {
+func UseProfileValues(loadedFileList data.FileList, profile string) (data.FileList, error) {
 	if profile == "" || profile == "demo" {
 		return loadedFileList, nil
 	}

--- a/app/kumactl/cmd/install/context/install_control_plane_context.go
+++ b/app/kumactl/cmd/install/context/install_control_plane_context.go
@@ -2,11 +2,13 @@ package context
 
 import (
 	"fmt"
+
+	"golang.org/x/exp/slices"
+
 	"github.com/kumahq/kuma/deployments"
 	"github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/pkg/util/data"
 	kuma_version "github.com/kumahq/kuma/pkg/version"
-	"golang.org/x/exp/slices"
 )
 
 type InstallControlPlaneArgs struct {

--- a/app/kumactl/cmd/install/context/install_control_plane_context_test.go
+++ b/app/kumactl/cmd/install/context/install_control_plane_context_test.go
@@ -1,14 +1,17 @@
 package context
 
 import (
-	"github.com/kumahq/kuma/pkg/util/data"
+	"strings"
+
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"strings"
+
+	"github.com/kumahq/kuma/pkg/util/data"
 )
 
 var _ = Describe("Override profile values", func() {
-
 	It("should apply profile values and remove default values.yaml", func() {
 		loadedFiles := createFiles("values.production.yaml", "values.yaml")
 		files, err := UseProfileValues(loadedFiles, "production")

--- a/app/kumactl/cmd/install/context/install_control_plane_context_test.go
+++ b/app/kumactl/cmd/install/context/install_control_plane_context_test.go
@@ -1,0 +1,70 @@
+package context
+
+import (
+	"github.com/kumahq/kuma/pkg/util/data"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"strings"
+)
+
+var _ = Describe("Override profile values", func() {
+
+	It("should apply profile values and remove default values.yaml", func() {
+		loadedFiles := createFiles("values.production.yaml", "values.yaml")
+		files, err := useProfileValues(loadedFiles, "production")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(files).To(HaveLen(1))
+		Expect(files[0].Name).To(Equal("values.yaml"))
+		Expect(files[0].FullPath).To(Equal("values.yaml"))
+		Expect(string(files[0].Data)).To(Equal("values.production.yaml"))
+	})
+
+	It("should use default values.yaml when use demo profile", func() {
+		loadedFiles := createFiles("values.yaml", "templates/config.yaml")
+		files, err := useProfileValues(loadedFiles, "demo")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(files).To(HaveLen(2))
+		Expect(files[0].Name).To(Equal("values.yaml"))
+		Expect(string(files[0].Data)).To(Equal("values.yaml"))
+	})
+
+	It("should keep values.yaml when use empty profile", func() {
+		loadedFiles := createFiles("values.yaml")
+		files, err := useProfileValues(loadedFiles, "demo")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(files).To(HaveLen(1))
+		Expect(files[0].Name).To(Equal("values.yaml"))
+		Expect(string(files[0].Data)).To(Equal("values.yaml"))
+	})
+
+	It("should keep default values.yaml when profile does not exist", func() {
+		loadedFiles := createFiles("values.yaml")
+		files, err := useProfileValues(loadedFiles, "default")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(files).To(HaveLen(1))
+		Expect(files[0].Name).To(Equal("values.yaml"))
+	})
+})
+
+func createFiles(relativePaths ...string) []data.File {
+	var loaded []data.File
+	for _, p := range relativePaths {
+		loaded = append(loaded, createFile(p))
+	}
+	return loaded
+}
+
+func createFile(relativePath string) data.File {
+	dirName := "/fake/path/"
+	name := relativePath
+	lastIdxOfSlash := strings.LastIndex(relativePath, "/")
+	if lastIdxOfSlash > -1 {
+		name = relativePath[lastIdxOfSlash+1:]
+	}
+
+	return data.File{
+		Data:     []byte(name),
+		Name:     name,
+		FullPath: dirName + relativePath,
+	}
+}

--- a/app/kumactl/cmd/install/context/install_control_plane_context_test.go
+++ b/app/kumactl/cmd/install/context/install_control_plane_context_test.go
@@ -11,7 +11,7 @@ var _ = Describe("Override profile values", func() {
 
 	It("should apply profile values and remove default values.yaml", func() {
 		loadedFiles := createFiles("values.production.yaml", "values.yaml")
-		files, err := useProfileValues(loadedFiles, "production")
+		files, err := UseProfileValues(loadedFiles, "production")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(files).To(HaveLen(1))
 		Expect(files[0].Name).To(Equal("values.yaml"))
@@ -21,7 +21,7 @@ var _ = Describe("Override profile values", func() {
 
 	It("should use default values.yaml when use demo profile", func() {
 		loadedFiles := createFiles("values.yaml", "templates/config.yaml")
-		files, err := useProfileValues(loadedFiles, "demo")
+		files, err := UseProfileValues(loadedFiles, "demo")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(files).To(HaveLen(2))
 		Expect(files[0].Name).To(Equal("values.yaml"))
@@ -30,7 +30,7 @@ var _ = Describe("Override profile values", func() {
 
 	It("should keep values.yaml when use empty profile", func() {
 		loadedFiles := createFiles("values.yaml")
-		files, err := useProfileValues(loadedFiles, "demo")
+		files, err := UseProfileValues(loadedFiles, "demo")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(files).To(HaveLen(1))
 		Expect(files[0].Name).To(Equal("values.yaml"))
@@ -39,7 +39,7 @@ var _ = Describe("Override profile values", func() {
 
 	It("should keep default values.yaml when profile does not exist", func() {
 		loadedFiles := createFiles("values.yaml")
-		files, err := useProfileValues(loadedFiles, "default")
+		files, err := UseProfileValues(loadedFiles, "default")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(files).To(HaveLen(1))
 		Expect(files[0].Name).To(Equal("values.yaml"))

--- a/app/kumactl/cmd/install/context/suite_test.go
+++ b/app/kumactl/cmd/install/context/suite_test.go
@@ -1,0 +1,11 @@
+package context
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/pkg/test"
+)
+
+func TestInstall(t *testing.T) {
+	test.RunSpecs(t, "kubectl install Suite")
+}

--- a/app/kumactl/cmd/install/install_control_plane.go
+++ b/app/kumactl/cmd/install/install_control_plane.go
@@ -294,6 +294,7 @@ This command requires that the KUBECONFIG environment is set`,
 	cmd.Flags().BoolVar(&args.WithoutKubernetesConnection, "without-kubernetes-connection", false, "install without connection to Kubernetes cluster. This can be used for initial Kuma installation, but not for upgrades")
 	cmd.Flags().StringSliceVarP(&args.ValueFiles, "values", "f", []string{}, "specify values in a YAML file or '-' for stdin. This is similar to `helm template <chart> -f ...`")
 	cmd.Flags().StringArrayVar(&args.Values, "set", []string{}, "set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2), This is similar to `helm template <chart> --set ...` to use set-file or set-string just use helm instead")
+	cmd.Flags().StringVar(&args.ValuesProfile, "profile", args.ValuesProfile, "specify the builtin default values file to be used, supported values are: demo, production")
 	cmd.Flags().StringArrayVar(&args.SkipKinds, "skip-kinds", []string{}, "INTERNAL: A list of kubernetes kinds to not generate (useful, to ignore CRDs for example)")
 	if err := cmd.Flags().MarkHidden("skip-kinds"); err != nil {
 		panic(err.Error())

--- a/deployments/charts/kuma/templates/_helpers.tpl
+++ b/deployments/charts/kuma/templates/_helpers.tpl
@@ -217,6 +217,8 @@ env:
   value: "false"
 - name: KUMA_API_SERVER_READ_ONLY
   value: "true"
+- name: KUMA_API_SERVER_CORS_ALLOWED_DOMAINS
+  value: {{ join " " .Values.controlPlane.apiServer.coresAllowedDomains | quote }}
 - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_PORT
   value: {{ .Values.controlPlane.admissionServerPort | default "5443" | quote }}
 - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR

--- a/deployments/charts/kuma/templates/egress-hpa.yaml
+++ b/deployments/charts/kuma/templates/egress-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.egress.autoscaling.enabled }}
+{{- if and .Values.egress.enabled .Values.egress.autoscaling.enabled }}
 {{ if .Capabilities.APIVersions.Has "autoscaling/v2" }}
 apiVersion: "autoscaling/v2"
 {{ else }}

--- a/deployments/charts/kuma/templates/egress-pdb.yaml
+++ b/deployments/charts/kuma/templates/egress-pdb.yaml
@@ -1,4 +1,4 @@
-{{ if $.Values.egress.podDisruptionBudget.enabled }}
+{{ if and .Values.egress.enabled .Values.egress.podDisruptionBudget.enabled }}
 {{ if .Capabilities.APIVersions.Has "policy/v1" }}
 apiVersion: policy/v1
 {{ else if .Capabilities.APIVersions.Has "policy/v1beta1" }}

--- a/deployments/charts/kuma/templates/ingress-hpa.yaml
+++ b/deployments/charts/kuma/templates/ingress-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.autoscaling.enabled }}
+{{- if and .Values.ingress.enabled .Values.ingress.autoscaling.enabled }}
 {{ if .Capabilities.APIVersions.Has "autoscaling/v2" }}
 apiVersion: "autoscaling/v2"
 {{ else }}

--- a/deployments/charts/kuma/templates/ingress-pdb.yaml
+++ b/deployments/charts/kuma/templates/ingress-pdb.yaml
@@ -1,4 +1,4 @@
-{{ if $.Values.ingress.podDisruptionBudget.enabled }}
+{{ if and .Values.ingress.enabled .Values.ingress.podDisruptionBudget.enabled }}
 {{ if .Capabilities.APIVersions.Has "policy/v1" }}
 apiVersion: policy/v1
 {{ else if .Capabilities.APIVersions.Has "policy/v1beta1" }}

--- a/deployments/charts/kuma/values.production.yaml
+++ b/deployments/charts/kuma/values.production.yaml
@@ -45,6 +45,11 @@ controlPlane:
   # -- Only used in `zone` mode
   kdsGlobalAddress: ""
 
+  apiServer:
+    coresAllowedDomains:
+      - "https://localhost:5678"
+      - "http://localhost:5678"
+
   # -- Number of replicas of the Kuma CP. Ignored when autoscaling is enabled
   replicas: 2
 

--- a/deployments/charts/kuma/values.production.yaml
+++ b/deployments/charts/kuma/values.production.yaml
@@ -1,0 +1,759 @@
+global:
+  image:
+    # -- Default registry for all Kuma Images
+    registry: "docker.io/kumahq"
+    # -- The default tag for all Kuma images, which itself defaults to .Chart.AppVersion
+    tag:
+  # -- Add `imagePullSecrets` to all the service accounts used for Kuma components
+  imagePullSecrets: []
+
+# -- Whether to patch the target namespace with the system label
+patchSystemNamespace: true
+
+installCrdsOnUpgrade:
+  # -- Whether install new CRDs before upgrade (if any were introduced with the new version of Kuma)
+  enabled: true
+  # -- The `imagePullSecrets` to attach to the Service Account running CRD installation.
+  # This field will be deprecated in a future release, please use .global.imagePullSecrets
+  imagePullSecrets: []
+
+# -- Whether to disable all helm hooks
+noHelmHooks: false
+
+# -- Whether to restart control-plane by calculating a new checksum for the secret
+restartOnSecretChange: true
+
+controlPlane:
+  # -- Environment that control plane is run in, useful when running universal global control plane on k8s
+  environment: "kubernetes"
+
+  # -- Labels to add to resources in addition to default labels
+  extraLabels: {}
+
+  # -- Kuma CP log level: one of off,info,debug
+  logLevel: "info"
+
+  # -- Kuma CP log output path: Defaults to /dev/stdout
+  logOutputPath: ""
+
+  # -- Kuma CP modes: one of zone,global
+  mode: "zone"
+
+  # -- (string) Kuma CP zone, if running multizone
+  zone:
+
+  # -- Only used in `zone` mode
+  kdsGlobalAddress: ""
+
+  # -- Number of replicas of the Kuma CP. Ignored when autoscaling is enabled
+  replicas: 2
+
+  # -- Minimum number of seconds for which a newly created pod should be ready for it to be considered available.
+  minReadySeconds: 0
+
+  # -- Annotations applied only to the `Deployment` resource
+  deploymentAnnotations: {}
+
+  # -- Annotations applied only to the `Pod` resource
+  podAnnotations: {}
+
+  # Horizontal Pod Autoscaling configuration
+  autoscaling:
+    # -- Whether to enable Horizontal Pod Autoscaling, which requires the [Metrics Server](https://github.com/kubernetes-sigs/metrics-server) in the cluster
+    enabled: true
+
+    # -- The minimum CP pods to allow
+    minReplicas: 2
+    # -- The max CP pods to scale to
+    maxReplicas: 5
+
+    # -- For clusters that don't support autoscaling/v2, autoscaling/v1 is used
+    targetCPUUtilizationPercentage: 50
+    # -- For clusters that do support autoscaling/v2, use metrics
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 50
+      - type: Resource
+        resource:
+          name: memory
+          target:
+            type: Utilization
+            averageUtilization: 50
+
+  # -- Node selector for the Kuma Control Plane pods
+  nodeSelector:
+    kubernetes.io/os: linux
+
+  # -- Tolerations for the Kuma Control Plane pods
+  tolerations: []
+
+  podDisruptionBudget:
+    # -- Whether to create a pod disruption budget
+    enabled: true
+    # -- The maximum number of unavailable pods allowed by the budget
+    maxUnavailable: 1
+
+  # -- Affinity placement rule for the Kuma Control Plane pods.
+  # This is rendered as a template, so you can reference other helm variables or includes.
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            # These match the selector labels used on the deployment.
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - '{{ include "kuma.name" . }}'
+              - key: app.kubernetes.io/instance
+                operator: In
+                values:
+                  - '{{ .Release.Name }}'
+              - key: app
+                operator: In
+                values:
+                  - '{{ include "kuma.name" . }}-control-plane'
+          topologyKey: kubernetes.io/hostname
+
+  # -- Topology spread constraints rule for the Kuma Control Plane pods.
+  # This is rendered as a template, so you can use variables to generate match labels.
+  topologySpreadConstraints:
+
+  # -- Failure policy of the mutating webhook implemented by the Kuma Injector component
+  injectorFailurePolicy: Fail
+
+  service:
+    apiServer:
+      http:
+        # -- Port on which Http api server Service is exposed on Node for service of type NodePort
+        nodePort: 30681
+      https:
+        # -- Port on which Https api server Service is exposed on Node for service of type NodePort
+        nodePort: 30682
+
+    # -- Whether to create a service resource.
+    enabled: true
+
+    # -- (string) Optionally override of the Kuma Control Plane Service's name
+    name:
+
+    # -- Service type of the Kuma Control Plane
+    type: ClusterIP
+
+    # -- Annotations to put on the Kuma Control Plane
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "5680"
+
+  # Kuma API and GUI ingress settings. Useful if you want to expose the
+  # API and GUI of Kuma outside the k8s cluster.
+  ingress:
+    # -- Install K8s Ingress resource that exposes GUI and API
+    enabled: false
+    # -- IngressClass defines which controller will implement the resource
+    ingressClassName:
+    # -- Ingress hostname
+    hostname:
+    # -- Map of ingress annotations.
+    annotations: {}
+    # -- Ingress path.
+    path: /
+    # -- Each path in an Ingress is required to have a corresponding path type. (ImplementationSpecific/Exact/Prefix)
+    pathType: ImplementationSpecific
+    # -- Port from kuma-cp to use to expose API and GUI. Switch to 5682 to expose TLS port
+    servicePort: 5681
+
+  globalZoneSyncService:
+    # -- Whether to create a k8s service for the global zone sync
+    # service. It will only be created when enabled and deploying the global
+    # control plane.
+    enabled: true
+    # -- Service type of the Global-zone sync
+    type: LoadBalancer
+    # -- (string) Optionally specify IP to be used by cloud provider when configuring load balancer
+    loadBalancerIP:
+    # -- Optionally specify allowed source ranges that can access the load balancer
+    loadBalancerSourceRanges: []
+    # -- Additional annotations to put on the Global Zone Sync Service
+    annotations: { }
+    # -- Port on which Global Zone Sync Service is exposed on Node for service of type NodePort
+    nodePort: 30685
+    # -- Port on which Global Zone Sync Service is exposed
+    port: 5685
+    # -- Protocol of the Global Zone Sync service port
+    protocol: grpc
+
+  defaults:
+    # -- Whether to skip creating the default Mesh
+    skipMeshCreation: false
+
+  # -- Whether to automountServiceAccountToken for cp. Optionally set to false
+  automountServiceAccountToken: true
+
+  # -- Optionally override the resource spec
+  resources:
+    requests:
+       cpu: 1000m
+       memory: 1024Mi
+    limits:
+       cpu: 1000m
+       memory: 1024Mi
+
+  # -- Pod lifecycle settings (useful for adding a preStop hook, when
+  # using AWS ALB or NLB)
+  lifecycle: {}
+
+  # -- Number of seconds to wait before force killing the pod. Make sure to
+  # update this if you add a preStop hook.
+  terminationGracePeriodSeconds: 30
+
+  # TLS for various servers
+  tls:
+    general:
+      # -- Secret that contains tls.crt, tls.key [and ca.crt when no
+      # controlPlane.tls.general.caSecretName specified] for protecting
+      # Kuma in-cluster communication
+      secretName: ""
+      # -- Secret that contains ca.crt that was used to sign cert for protecting
+      # Kuma in-cluster communication (ca.crt present in this secret
+      # have precedence over the one provided in the controlPlane.tls.general.secretName)
+      caSecretName: ""
+      # -- Base64 encoded CA certificate (the same as in controlPlane.tls.general.secret#ca.crt)
+      caBundle: ""
+    apiServer:
+      # -- Secret that contains tls.crt, tls.key for protecting Kuma API on HTTPS
+      secretName: ""
+      # -- Secret that contains list of .pem certificates that can access admin endpoints of Kuma API on HTTPS
+      clientCertsSecretName: ""
+    # - if not creating the global control plane, then do nothing
+    # - if secretName is empty and create is false, then do nothing
+    # - if secretName is non-empty and create is false, then use the secret made outside of helm with the name secretName
+    # - if secretName is empty and create is true, then create a secret with a default name and use it
+    # - if secretName is non-empty and create is true, then create the secret using the provided name
+    kdsGlobalServer:
+      # -- Name of the K8s TLS Secret resource. If you set this and don't set
+      # create=true, you have to create the secret manually.
+      secretName: ""
+      # -- Whether to create the TLS secret in helm.
+      create: false
+      # -- The TLS certificate to offer.
+      cert: ""
+      # -- The TLS key to use.
+      key: ""
+    # - if not creating the zonal control plane, then do nothing
+    # - if secretName is empty and create is false, then do nothing
+    # - if secretName is non-empty and create is false, then use the secret made outside of helm with the name secretName
+    # - if secretName is empty and create is true, then create a secret with a default name and use it
+    # - if secretName is non-empty and create is true, then create the secret using the provided name
+    kdsZoneClient:
+      # -- Name of the K8s Secret resource that contains ca.crt which was
+      # used to sign the certificate of KDS Global Server. If you set this
+      # and don't set create=true, you have to create the secret manually.
+      secretName: ""
+      # -- Whether to create the TLS secret in helm.
+      create: false
+      # -- CA bundle that was used to sign the certificate of KDS Global Server.
+      cert: ""
+      # -- If true, TLS cert of the server is not verified.
+      skipVerify: false
+
+  # -- Annotations to add for Control Plane's Service Account
+  serviceAccountAnnotations: { }
+
+  image:
+    # -- Kuma CP ImagePullPolicy
+    pullPolicy: IfNotPresent
+    # -- Kuma CP image repository
+    repository: "kuma-cp"
+    # -- Kuma CP Image tag. When not specified, the value is copied from global.tag
+    tag:
+
+  # -- (object with { Env: string, Secret: string, Key: string }) Secrets to add as environment variables,
+  # where `Env` is the name of the env variable,
+  # `Secret` is the name of the Secret,
+  # and `Key` is the key of the Secret value to use
+  secrets:
+  #  someSecret:
+  #    Secret: some-secret
+  #    Key: secret_key
+  #    Env: SOME_SECRET
+
+  # -- Additional environment variables that will be passed to the control plane
+  envVars: { }
+
+  # -- Additional config maps to mount into the control plane, with optional inline values
+  extraConfigMaps: [ ]
+#    - name: extra-config
+#      mountPath: /etc/extra-config
+#      readOnly: true
+#      values:
+#        extra-config-key: |
+#          extra-config-value
+
+  # -- (object with { name: string, mountPath: string, readOnly: string }) Additional secrets to mount into the control plane,
+  # where `Env` is the name of the env variable,
+  # `Secret` is the name of the Secret,
+  # and `Key` is the key of the Secret value to use
+  extraSecrets:
+  #  extraConfig:
+  #    name: extra-config
+  #    mountPath: /etc/extra-config
+  #    readOnly: true
+
+  webhooks:
+    validator:
+      # -- Additional rules to apply on Kuma validator webhook. Useful when building custom policy on top of Kuma.
+      additionalRules: ""
+    ownerReference:
+      # -- Additional rules to apply on Kuma owner reference webhook. Useful when building custom policy on top of Kuma.
+      additionalRules: ""
+
+  # -- Specifies if the deployment should be started in hostNetwork mode.
+  hostNetwork: false
+  # -- Define a new server port for the admission controller. Recommended to set in combination with
+  # hostNetwork to prevent multiple port bindings on the same port (like Calico in AWS EKS).
+  admissionServerPort: 5443
+
+  # -- Security context at the pod level for control plane.
+  podSecurityContext:
+    runAsNonRoot: true
+
+  # -- Security context at the container level for control plane.
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+
+  # -- If true, then control plane can support TLS secrets for builtin gateway outside of mesh system namespace.
+  # The downside is that control plane requires permission to read Secrets in all namespaces.
+  supportGatewaySecretsInAllNamespaces: false
+
+cni:
+  # -- Install Kuma with CNI instead of proxy init container
+  enabled: false
+  # -- Install CNI in chained mode
+  chained: false
+  # -- Set the CNI install directory
+  netDir: /etc/cni/multus/net.d
+  # -- Set the CNI bin directory
+  binDir: /var/lib/cni/bin
+  # -- Set the CNI configuration name
+  confName: kuma-cni.conf
+  # -- CNI log level: one of off,info,debug
+  logLevel: info
+  # -- Node Selector for the CNI pods
+  nodeSelector:
+    kubernetes.io/os: linux
+  # -- Tolerations for the CNI pods
+  tolerations: []
+  # -- Additional pod annotations
+  podAnnotations: { }
+  # -- Set the CNI namespace
+  namespace: kube-system
+
+  image:
+    # -- CNI image repository
+    repository: "kuma-cni"
+    # -- CNI image tag - defaults to .Chart.AppVersion
+    tag:
+    # -- CNI image pull policy
+    imagePullPolicy: IfNotPresent
+
+  # -- it's only useful in tests to trigger a possible race condition
+  delayStartupSeconds: 0
+
+  # -- use new CNI (experimental)
+  experimental:
+    imageEbpf:
+      # -- CNI experimental eBPF image registry
+      registry: "docker.io/kumahq"
+      # -- CNI experimental eBPF image repository
+      repository: "merbridge"
+      # -- CNI experimental eBPF image tag
+      tag: "0.8.5"
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+    limits:
+      cpu: 100m
+      memory: 100Mi
+
+  # -- Security context at the pod level for cni
+  podSecurityContext: {}
+
+  # -- Security context at the container level for cni
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+    runAsNonRoot: false
+    runAsUser: 0
+    runAsGroup: 0
+
+dataPlane:
+  # -- If true, then turn on CoreDNS query logging
+  dnsLogging: false
+  image:
+    # -- The Kuma DP image repository
+    repository: "kuma-dp"
+    # -- Kuma DP ImagePullPolicy
+    pullPolicy: IfNotPresent
+    # -- Kuma DP Image Tag. When not specified, the value is copied from global.tag
+    tag:
+
+  initImage:
+    # -- The Kuma DP init image repository
+    repository: "kuma-init"
+    # -- Kuma DP init image tag When not specified, the value is copied from global.tag
+    tag:
+
+ingress:
+  # -- If true, it deploys Ingress for cross cluster communication
+  enabled: false
+
+  # -- Labels to add to resources, in addition to default labels
+  extraLabels: {}
+
+  # -- Time for which old listener will still be active as draining
+  drainTime: 30s
+
+  # -- Number of replicas of the Ingress. Ignored when autoscaling is enabled.
+  replicas: 2
+
+  # -- Log level for ingress (available values: off|info|debug)
+  logLevel: info
+
+  # -- Define the resources to allocate to mesh ingress
+  resources:
+    requests:
+      cpu: 1000m
+      memory: 1024Mi
+    limits:
+      cpu: 1000m
+      memory: 1024Mi
+
+  # -- Pod lifecycle settings (useful for adding a preStop hook, when
+  # using AWS ALB or NLB)
+  lifecycle: {}
+
+  # -- Number of seconds to wait before force killing the pod. Make sure to
+  # update this if you add a preStop hook.
+  terminationGracePeriodSeconds: 40
+
+  # Horizontal Pod Autoscaling configuration
+  autoscaling:
+    # -- Whether to enable Horizontal Pod Autoscaling, which requires the [Metrics Server](https://github.com/kubernetes-sigs/metrics-server) in the cluster
+    enabled: true
+
+    # -- The minimum CP pods to allow
+    minReplicas: 2
+    # -- The max CP pods to scale to
+    maxReplicas: 5
+
+    # -- For clusters that don't support autoscaling/v2, autoscaling/v1 is used
+    targetCPUUtilizationPercentage: 50
+    # -- For clusters that do support autoscaling/v2, use metrics
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 50
+      - type: Resource
+        resource:
+          name: memory
+          target:
+            type: Utilization
+            averageUtilization: 50
+
+  service:
+    # -- Whether to create a Service resource.
+    enabled: true
+    # -- Service type of the Ingress
+    type: LoadBalancer
+    # -- (string) Optionally specify IP to be used by cloud provider when configuring load balancer
+    loadBalancerIP:
+    # -- Additional annotations to put on the Ingress service
+    annotations: { }
+    # -- Port on which Ingress is exposed
+    port: 10001
+    # -- Port on which service is exposed on Node for service of type NodePort
+    nodePort:
+  # -- Additional pod annotations (deprecated favor `podAnnotations`)
+  annotations: { }
+  # -- Additional pod annotations
+  podAnnotations: { }
+  # -- Node Selector for the Ingress pods
+  nodeSelector:
+    kubernetes.io/os: linux
+  # -- Tolerations for the Ingress pods
+  tolerations: []
+  podDisruptionBudget:
+    # -- Whether to create a pod disruption budget
+    enabled: true
+    # -- The maximum number of unavailable pods allowed by the budget
+    maxUnavailable: 1
+
+  # -- Affinity placement rule for the Kuma Ingress pods
+  # This is rendered as a template, so you can reference other helm variables
+  # or includes.
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            # These match the selector labels used on the deployment.
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - '{{ include "kuma.name" . }}'
+              - key: app.kubernetes.io/instance
+                operator: In
+                values:
+                  - '{{ .Release.Name }}'
+              - key: app
+                operator: In
+                values:
+                  - kuma-ingress
+          topologyKey: kubernetes.io/hostname
+
+  # -- Topology spread constraints rule for the Kuma Mesh Ingress pods.
+  # This is rendered as a template, so you can use variables to generate match labels.
+  topologySpreadConstraints:
+
+  # -- Security context at the pod level for ingress
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 5678
+    runAsGroup: 5678
+
+  # -- Security context at the container level for ingress
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+
+  # -- Annotations to add for Control Plane's Service Account
+  serviceAccountAnnotations: { }
+  # -- Whether to automountServiceAccountToken for cp. Optionally set to false
+  automountServiceAccountToken: true
+
+egress:
+  # -- If true, it deploys Egress for cross cluster communication
+  enabled: false
+  # -- Labels to add to resources, in addition to the default labels.
+  extraLabels: {}
+  # -- Time for which old listener will still be active as draining
+  drainTime: 30s
+  # -- Number of replicas of the Egress. Ignored when autoscaling is enabled.
+  replicas: 1
+
+  # -- Log level for egress (available values: off|info|debug)
+  logLevel: info
+
+  # Horizontal Pod Autoscaling configuration
+  autoscaling:
+    # -- Whether to enable Horizontal Pod Autoscaling, which requires the [Metrics Server](https://github.com/kubernetes-sigs/metrics-server) in the cluster
+    enabled: true
+
+    # -- The minimum CP pods to allow
+    minReplicas: 2
+    # -- The max CP pods to scale to
+    maxReplicas: 5
+
+    # -- For clusters that don't support autoscaling/v2, autoscaling/v1 is used
+    targetCPUUtilizationPercentage: 50
+    # -- For clusters that do support autoscaling/v2, use metrics
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 50
+  resources:
+    requests:
+      cpu: 1000m
+      memory: 1024Mi
+    limits:
+      cpu: 1000m
+      memory: 1024Mi
+
+  service:
+    # -- Whether to create the service object
+    enabled: true
+    # -- Service type of the Egress
+    type: ClusterIP
+    # -- (string) Optionally specify IP to be used by cloud provider when configuring load balancer
+    loadBalancerIP:
+    # -- Additional annotations to put on the Egress service
+    annotations: { }
+    # -- Port on which Egress is exposed
+    port: 10002
+    # -- Port on which service is exposed on Node for service of type NodePort
+    nodePort:
+  # -- Additional pod annotations (deprecated favor `podAnnotations`)
+  annotations: { }
+  # -- Additional pod annotations
+  podAnnotations: { }
+  # -- Node Selector for the Egress pods
+  nodeSelector:
+    kubernetes.io/os: linux
+  # -- Tolerations for the Egress pods
+  tolerations: []
+  podDisruptionBudget:
+    # -- Whether to create a pod disruption budget
+    enabled: true
+    # -- The maximum number of unavailable pods allowed by the budget
+    maxUnavailable: 1
+
+  # -- Affinity placement rule for the Kuma Egress pods.
+  # This is rendered as a template, so you can reference other helm variables or includes.
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            # These match the selector labels used on the deployment.
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - '{{ include "kuma.name" . }}'
+              - key: app.kubernetes.io/instance
+                operator: In
+                values:
+                  - '{{ .Release.Name }}'
+              - key: app
+                operator: In
+                values:
+                  - kuma-egress
+          topologyKey: kubernetes.io/hostname
+
+  # -- Topology spread constraints rule for the Kuma Egress pods.
+  # This is rendered as a template, so you can use variables to generate match labels.
+  topologySpreadConstraints:
+
+  # -- Security context at the pod level for egress
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 5678
+    runAsGroup: 5678
+
+  # -- Security context at the container level for egress
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+
+  # -- Annotations to add for Control Plane's Service Account
+  serviceAccountAnnotations: { }
+  # -- Whether to automountServiceAccountToken for cp. Optionally set to false
+  automountServiceAccountToken: true
+
+kumactl:
+  image:
+    # -- The kumactl image repository
+    repository: kumactl
+    # -- The kumactl image tag. When not specified, the value is copied from global.tag
+    tag:
+
+kubectl:
+  image:
+    # -- The kubectl image registry
+    registry: docker.io
+    # -- The kubectl image repository
+    repository: bitnami/kubectl
+    # -- The kubectl image tag
+    tag: "1.27.5"
+hooks:
+  # -- Node selector for the HELM hooks
+  nodeSelector:
+    kubernetes.io/os: linux
+  # -- Tolerations for the HELM hooks
+  tolerations: []
+  # -- Security context at the pod level for crd/webhook/ns
+  podSecurityContext:
+    runAsNonRoot: true
+
+  # -- Security context at the container level for crd/webhook/ns
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+
+  # -- ebpf-cleanup hook needs write access to the root filesystem to clean ebpf programs
+  # Changing below values will potentially break ebpf cleanup completely,
+  # so be cautious when doing so.
+  ebpfCleanup:
+    # -- Security context at the pod level for crd/webhook/cleanup-ebpf
+    podSecurityContext:
+      runAsNonRoot: false
+    # -- Security context at the container level for crd/webhook/cleanup-ebpf
+    containerSecurityContext:
+      readOnlyRootFilesystem: false
+
+experimental:
+  # Configuration for the experimental ebpf mode for transparent proxy
+  ebpf:
+    # -- If true, ebpf will be used instead of using iptables to install/configure transparent proxy
+    enabled: false
+    # -- Name of the environmental variable which will contain the IP address of a pod
+    instanceIPEnvVarName: INSTANCE_IP
+    # -- Path where BPF file system should be mounted
+    bpffsPath: /sys/fs/bpf
+    # -- Host's cgroup2 path
+    cgroupPath: /sys/fs/cgroup
+    # -- Name of the network interface which TC programs should be attached to, we'll try to automatically determine it if empty
+    tcAttachIface: ""
+    # -- Path where compiled eBPF programs which will be installed can be found
+    programsSourcePath: /tmp/kuma-ebpf
+  # -- If false, it uses legacy API for resource synchronization
+  deltaKds: true
+  # -- If true, enable native Kubernetes sidecars. This requires at least
+  # Kubernetes v1.29
+  sidecarContainers: false
+
+# Postgres' settings for universal control plane on k8s
+postgres:
+  # -- Postgres port, password should be provided as a secret reference in "controlPlane.secrets"
+  # with the Env value "KUMA_STORE_POSTGRES_PASSWORD".
+  # Example:
+  # controlPlane:
+  #   secrets:
+  #     - Secret: postgres-postgresql
+  #       Key: postgresql-password
+  #       Env: KUMA_STORE_POSTGRES_PASSWORD
+  port: "5432"
+  # TLS settings
+  tls:
+    # -- Mode of TLS connection. Available values are: "disable", "verifyNone", "verifyCa", "verifyFull"
+    mode: disable # ENV: KUMA_STORE_POSTGRES_TLS_MODE
+    # -- Whether to disable SNI the postgres `sslsni` option.
+    disableSSLSNI: false # ENV: KUMA_STORE_POSTGRES_TLS_DISABLE_SSLSNI
+    # -- Secret name that contains the ca.crt
+    caSecretName:
+    # -- Secret name that contains the client tls.crt, tls.key
+    secretName:
+
+# @ignored for helm-docs
+plugins:
+  resources:
+    meshservices: true
+  policies:
+    meshaccesslogs: true
+    meshcircuitbreakers: true
+    meshfaultinjections: true
+    meshhealthchecks: true
+    meshhttproutes: true
+    meshloadbalancingstrategies: true
+    meshmetrics: true
+    meshproxypatches: true
+    meshratelimits: true
+    meshretries: true
+    meshtcproutes: true
+    meshtimeouts: true
+    meshtraces: true
+    meshtrafficpermissions: true

--- a/deployments/charts/kuma/values.production.yaml
+++ b/deployments/charts/kuma/values.production.yaml
@@ -575,6 +575,12 @@ egress:
           name: cpu
           target:
             type: Utilization
+          averageUtilization: 50
+      - type: Resource
+        resource:
+          name: memory
+          target:
+            type: Utilization
             averageUtilization: 50
   resources:
     requests:

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -45,6 +45,10 @@ controlPlane:
   # -- Only used in `zone` mode
   kdsGlobalAddress: ""
 
+  apiServer:
+    coresAllowedDomains:
+      - '.*'
+
   # -- Number of replicas of the Kuma CP. Ignored when autoscaling is enabled
   replicas: 1
 


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues 
  - N/A
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS 
  - Confirmed
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) 
  - Tested with unit tests and manual tests
  - Don't forget `ci/` labels to run additional/fewer tests
    - [x] Done
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? 
  - No
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) 
  - No

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

Two features are included:
- Added the ability to specify a profile name that has been supported by a builtin `values.{profile}.yaml`.
- Provided a `production` profile for Kuma so that:
  - resources claims are generally higher than the default `demo` proifle
  - make resource requests/limits to be identical so that pod will be `guaranteed` on clusters
  - autoscalling is open
  - pod disruption budgets are open

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
