### PR TITLE
build(version): fix detection if latest patch isn't 0

### DIFF
--- a/tools/releases/version.sh
+++ b/tools/releases/version.sh
@@ -35,7 +35,7 @@ function base_branch_name() {
   highestMinorVersionTag=$(git tag -l --sort -version:refname | head -n 1  | awk -F'.' '{print $1"."$2}')
   currentBranch=$(git rev-parse --abbrev-ref HEAD 2> /dev/null || echo "no-branch")
   # On master the closest tag is 2.0.0 so we are setting dev for master
-  if [[ ${describe} =~ ^v?[1-9]*\.[0-9]*\.0 && ${describe} =~ ^${highestMinorVersionTag} ]]
+  if [[ ${describe} =~ ^v?[1-9]*\.[0-9]*\.[0-9]* && ${describe} =~ ^${highestMinorVersionTag} ]]
   then
     echo "master"
   # If we are on the release branch use the branch name


### PR DESCRIPTION
I'm getting `make dev/tools` installed in `release-2.7` on `master`. I don't see why this logic should require vX.Y.0 in particular.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
