### PR TITLE
chore(gha): remove concurrency for build test distribute

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -5,9 +5,6 @@ on:
     tags: ["*"]
   pull_request:
     branches: ["master", "release-*"]
-concurrency:
-  group: ${{github.workflow}}-${{ github.ref_name }} # group all runs by branch or tag
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }} # only cancel previous runs on PRs, we want each commit to build on branches
 permissions:
   contents: write # To upload assets
   id-token: write # For using token to sign images


### PR DESCRIPTION
### Checklist prior to review

Removing concurrency from build-test-distribute. It does not work well for us.

![image](https://github.com/kumahq/kuma/assets/5459824/26f38479-2f89-47d5-8a3f-10b92677f5c5)

Half of commits did not run. The green tick is not real (only half of jobs actually run)
Yes, it means we will see higher queues until we have custom runners (in progress), but at least CI will be correct.

this would help https://github.com/orgs/community/discussions/12835?sort=top but it's not implemented.
also it seems to have a bug with matrix https://github.com/orgs/community/discussions/121613

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
