### PR TITLE
chore(kumactl): use _overview endpoint for all entities

### DIFF
--- a/app/kumactl/cmd/export/export.go
+++ b/app/kumactl/cmd/export/export.go
@@ -3,6 +3,7 @@ package export
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -56,7 +57,7 @@ $ kumactl export --profile federation --format universal > policies.yaml
 				cmd.PrintErrln(err)
 			}
 
-			if ctx.args.profile != profileAll && ctx.args.profile != profileFederation && ctx.args.profile != profileFederationWithPolicies {
+			if !slices.Contains([]string{profileFederation, profileFederationWithPolicies, profileAll}, ctx.args.profile) {
 				return errors.New("invalid profile")
 			}
 
@@ -65,7 +66,7 @@ $ kumactl export --profile federation --format universal > policies.yaml
 				return err
 			}
 
-			if ctx.args.format != formatUniversal && ctx.args.format != formatKubernetes {
+			if !slices.Contains([]string{formatKubernetes, formatUniversal}, ctx.args.format) {
 				return errors.New("invalid format")
 			}
 

--- a/app/kumactl/pkg/resources/dataplane_overview_client.go
+++ b/app/kumactl/pkg/resources/dataplane_overview_client.go
@@ -51,7 +51,7 @@ func (d *httpDataplaneOverviewClient) List(ctx context.Context, meshName string,
 }
 
 func constructUrl(meshName string, tags map[string]string, gateway bool, ingress bool) (*url.URL, error) {
-	result, err := url.Parse(fmt.Sprintf("/meshes/%s/dataplanes+insights", meshName))
+	result, err := url.Parse(fmt.Sprintf("/meshes/%s/%s/_overview", meshName, mesh.DataplaneResourceTypeDescriptor.WsPath))
 	if err != nil {
 		return nil, err
 	}

--- a/app/kumactl/pkg/resources/dataplane_overview_client_test.go
+++ b/app/kumactl/pkg/resources/dataplane_overview_client_test.go
@@ -27,8 +27,8 @@ var _ = Describe("httpDataplaneOverviewClient", func() {
 				Client: &http.Client{
 					Transport: RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 						Expect(req.URL.String()).To(Or(
-							Equal("/meshes/default/dataplanes+insights?tag=service%3Amobile&tag=version%3Av1"),
-							Equal("/meshes/default/dataplanes+insights?tag=version%3Av1&tag=service%3Amobile"),
+							Equal("/meshes/default/dataplanes/_overview?tag=service%3Amobile&tag=version%3Av1"),
+							Equal("/meshes/default/dataplanes/_overview?tag=version%3Av1&tag=service%3Amobile"),
 						))
 
 						file, err := os.Open(filepath.Join("testdata", "list-dataplane-overviews.json"))
@@ -62,7 +62,7 @@ var _ = Describe("httpDataplaneOverviewClient", func() {
 				Client: &http.Client{
 					Transport: RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 						Expect(req.URL.String()).To(Or(
-							Equal("/meshes/default/dataplanes+insights?gateway=true"),
+							Equal("/meshes/default/dataplanes/_overview?gateway=true"),
 						))
 
 						file, err := os.Open(filepath.Join("testdata", "list-gateway-dataplane-overviews.json"))

--- a/app/kumactl/pkg/resources/zone_overview_client.go
+++ b/app/kumactl/pkg/resources/zone_overview_client.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -26,7 +27,7 @@ type httpZoneOverviewClient struct {
 }
 
 func (d *httpZoneOverviewClient) List(ctx context.Context) (*system.ZoneOverviewResourceList, error) {
-	req, err := http.NewRequest("GET", "/zones+insights", nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("/%s/_overview", system.ZoneResourceTypeDescriptor.WsPath), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/app/kumactl/pkg/resources/zoneegressoverview_client.go
+++ b/app/kumactl/pkg/resources/zoneegressoverview_client.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -26,7 +27,7 @@ type httpZoneEgressOverviewClient struct {
 }
 
 func (d *httpZoneEgressOverviewClient) List(ctx context.Context) (*mesh.ZoneEgressOverviewResourceList, error) {
-	req, err := http.NewRequest("GET", "/zoneegressoverviews", nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("/%s/_overview", mesh.ZoneEgressResourceTypeDescriptor.WsPath), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/app/kumactl/pkg/resources/zoneingress_overview_client.go
+++ b/app/kumactl/pkg/resources/zoneingress_overview_client.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -26,7 +27,7 @@ type httpZoneIngressOverviewClient struct {
 }
 
 func (d *httpZoneIngressOverviewClient) List(ctx context.Context) (*mesh.ZoneIngressOverviewResourceList, error) {
-	req, err := http.NewRequest("GET", "/zoneingresses+insights", nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("/%s/_overview", mesh.ZoneIngressResourceTypeDescriptor.WsPath), nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Stop using the older endpoints as there are better more coherent ones.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
