### PR TITLE
chore(docs): fix typos

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -3703,7 +3703,7 @@ spec:
                           properties:
                             http:
                               description: |-
-                                LocalHTTP defines confguration of local HTTP rate limiting
+                                LocalHTTP defines configuration of local HTTP rate limiting
                                 https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter
                               properties:
                                 disabled:
@@ -3919,7 +3919,7 @@ spec:
                           properties:
                             http:
                               description: |-
-                                LocalHTTP defines confguration of local HTTP rate limiting
+                                LocalHTTP defines configuration of local HTTP rate limiting
                                 https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter
                               properties:
                                 disabled:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -3703,7 +3703,7 @@ spec:
                           properties:
                             http:
                               description: |-
-                                LocalHTTP defines confguration of local HTTP rate limiting
+                                LocalHTTP defines configuration of local HTTP rate limiting
                                 https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter
                               properties:
                                 disabled:
@@ -3919,7 +3919,7 @@ spec:
                           properties:
                             http:
                               description: |-
-                                LocalHTTP defines confguration of local HTTP rate limiting
+                                LocalHTTP defines configuration of local HTTP rate limiting
                                 https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter
                               properties:
                                 disabled:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -3723,7 +3723,7 @@ spec:
                           properties:
                             http:
                               description: |-
-                                LocalHTTP defines confguration of local HTTP rate limiting
+                                LocalHTTP defines configuration of local HTTP rate limiting
                                 https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter
                               properties:
                                 disabled:
@@ -3939,7 +3939,7 @@ spec:
                           properties:
                             http:
                               description: |-
-                                LocalHTTP defines confguration of local HTTP rate limiting
+                                LocalHTTP defines configuration of local HTTP rate limiting
                                 https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter
                               properties:
                                 disabled:

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -5127,7 +5127,7 @@ spec:
                           properties:
                             http:
                               description: |-
-                                LocalHTTP defines confguration of local HTTP rate limiting
+                                LocalHTTP defines configuration of local HTTP rate limiting
                                 https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter
                               properties:
                                 disabled:
@@ -5343,7 +5343,7 @@ spec:
                           properties:
                             http:
                               description: |-
-                                LocalHTTP defines confguration of local HTTP rate limiting
+                                LocalHTTP defines configuration of local HTTP rate limiting
                                 https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter
                               properties:
                                 disabled:

--- a/deployments/charts/kuma/crds/kuma.io_meshratelimits.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshratelimits.yaml
@@ -63,7 +63,7 @@ spec:
                           properties:
                             http:
                               description: |-
-                                LocalHTTP defines confguration of local HTTP rate limiting
+                                LocalHTTP defines configuration of local HTTP rate limiting
                                 https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter
                               properties:
                                 disabled:
@@ -279,7 +279,7 @@ spec:
                           properties:
                             http:
                               description: |-
-                                LocalHTTP defines confguration of local HTTP rate limiting
+                                LocalHTTP defines configuration of local HTTP rate limiting
                                 https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter
                               properties:
                                 disabled:

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -6879,7 +6879,7 @@ components:
                         properties:
                           http:
                             description: >-
-                              LocalHTTP defines confguration of local HTTP rate
+                              LocalHTTP defines configuration of local HTTP rate
                               limiting
 
                               https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter
@@ -7134,7 +7134,7 @@ components:
                         properties:
                           http:
                             description: >-
-                              LocalHTTP defines confguration of local HTTP rate
+                              LocalHTTP defines configuration of local HTTP rate
                               limiting
 
                               https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter

--- a/docs/generated/raw/crds/kuma.io_meshratelimits.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshratelimits.yaml
@@ -63,7 +63,7 @@ spec:
                           properties:
                             http:
                               description: |-
-                                LocalHTTP defines confguration of local HTTP rate limiting
+                                LocalHTTP defines configuration of local HTTP rate limiting
                                 https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter
                               properties:
                                 disabled:
@@ -279,7 +279,7 @@ spec:
                           properties:
                             http:
                               description: |-
-                                LocalHTTP defines confguration of local HTTP rate limiting
+                                LocalHTTP defines configuration of local HTTP rate limiting
                                 https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter
                               properties:
                                 disabled:

--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -408,7 +408,7 @@ defaults:
   skipMeshCreation: false # ENV: KUMA_DEFAULTS_SKIP_MESH_CREATION
   # If true, it skips creating the default tenant resources
   skipTenantResources: false # ENV: KUMA_DEFAULTS_SKIP_TENANT_RESOURCES
-  # If true, it creates the default routing (TrafficPermisson and TrafficRoute) resources for a new Mesh
+  # If true, it creates the default routing (TrafficPermission and TrafficRoute) resources for a new Mesh
   createMeshRoutingResources: false # ENV: KUMA_DEFAULTS_CREATE_MESH_ROUTING_RESOURCES
 # Metrics configuration
 metrics:

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -408,7 +408,7 @@ defaults:
   skipMeshCreation: false # ENV: KUMA_DEFAULTS_SKIP_MESH_CREATION
   # If true, it skips creating the default tenant resources
   skipTenantResources: false # ENV: KUMA_DEFAULTS_SKIP_TENANT_RESOURCES
-  # If true, it creates the default routing (TrafficPermisson and TrafficRoute) resources for a new Mesh
+  # If true, it creates the default routing (TrafficPermission and TrafficRoute) resources for a new Mesh
   createMeshRoutingResources: false # ENV: KUMA_DEFAULTS_CREATE_MESH_ROUTING_RESOURCES
 # Metrics configuration
 metrics:

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/meshratelimit.go
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/meshratelimit.go
@@ -47,7 +47,7 @@ type Local struct {
 	TCP  *LocalTCP  `json:"tcp,omitempty"`
 }
 
-// LocalHTTP defines confguration of local HTTP rate limiting
+// LocalHTTP defines configuration of local HTTP rate limiting
 // https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter
 type LocalHTTP struct {
 	// Define if rate limiting should be disabled.

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/schema.yaml
@@ -29,7 +29,7 @@ properties:
                   properties:
                     http:
                       description: |-
-                        LocalHTTP defines confguration of local HTTP rate limiting
+                        LocalHTTP defines configuration of local HTTP rate limiting
                         https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter
                       properties:
                         disabled:
@@ -234,7 +234,7 @@ properties:
                   properties:
                     http:
                       description: |-
-                        LocalHTTP defines confguration of local HTTP rate limiting
+                        LocalHTTP defines configuration of local HTTP rate limiting
                         https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter
                       properties:
                         disabled:

--- a/pkg/plugins/policies/meshratelimit/k8s/crd/kuma.io_meshratelimits.yaml
+++ b/pkg/plugins/policies/meshratelimit/k8s/crd/kuma.io_meshratelimits.yaml
@@ -63,7 +63,7 @@ spec:
                           properties:
                             http:
                               description: |-
-                                LocalHTTP defines confguration of local HTTP rate limiting
+                                LocalHTTP defines configuration of local HTTP rate limiting
                                 https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter
                               properties:
                                 disabled:
@@ -279,7 +279,7 @@ spec:
                           properties:
                             http:
                               description: |-
-                                LocalHTTP defines confguration of local HTTP rate limiting
+                                LocalHTTP defines configuration of local HTTP rate limiting
                                 https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter
                               properties:
                                 disabled:


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
