### PR TITLE
fix(gateway): support `inlineString` in TLS certificates

### DIFF
--- a/pkg/plugins/runtime/gateway/filter_chain_generator.go
+++ b/pkg/plugins/runtime/gateway/filter_chain_generator.go
@@ -167,6 +167,8 @@ func generateCertificateSecret(
 		// to disambiguate when the certificate is provided as
 		// inline data.
 		tlsSecret.Name = names.GetSecretName("cert."+string(ktype), "inline", names.Join(hostnames...))
+	case *system_proto.DataSource_InlineString:
+		tlsSecret.Name = names.GetSecretName("cert."+string(ktype), "inlineString", names.Join(hostnames...))
 	default:
 		return nil, errors.Errorf("unsupported datasource type %T", d)
 	}

--- a/pkg/plugins/runtime/gateway/filter_chain_generator.go
+++ b/pkg/plugins/runtime/gateway/filter_chain_generator.go
@@ -156,16 +156,15 @@ func generateCertificateSecret(
 	// Generate a name to deterministically identify this secret. We
 	// want the same datasource to end up with the same name so that when
 	// resources are de-duplicated, we ony have to send the secret once.
+	// Since a host can have multiple certificates with
+	// different key types, we need to use the key type
+	// to disambiguate.
 	switch d := secret.GetType().(type) {
 	case *system_proto.DataSource_File:
 		tlsSecret.Name = names.GetSecretName("cert."+string(ktype), "file", d.File)
 	case *system_proto.DataSource_Secret:
 		tlsSecret.Name = names.GetSecretName("cert."+string(ktype), "secret", d.Secret)
 	case *system_proto.DataSource_Inline:
-		// Since a host can have multiple certificates with
-		// different key types, we need to use the key type
-		// to disambiguate when the certificate is provided as
-		// inline data.
 		tlsSecret.Name = names.GetSecretName("cert."+string(ktype), "inline", names.Join(hostnames...))
 	case *system_proto.DataSource_InlineString:
 		tlsSecret.Name = names.GetSecretName("cert."+string(ktype), "inlineString", names.Join(hostnames...))


### PR DESCRIPTION
I think this was just overlooked. `LoadSecret` handles this so there's no reason not to support it, also tested manually just in case.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
