### PR TITLE
fix(kuma-cp): index generated certs by proxy type, cleanup generated egress certs (backport of #10161, #10162)

### DIFF
--- a/pkg/core/resources/apis/mesh/proxy_type.go
+++ b/pkg/core/resources/apis/mesh/proxy_type.go
@@ -1,0 +1,20 @@
+package mesh
+
+import (
+	"github.com/pkg/errors"
+
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+)
+
+func ProxyTypeFromResourceType(t core_model.ResourceType) (mesh_proto.ProxyType, error) {
+	switch t {
+	case DataplaneType:
+		return mesh_proto.DataplaneProxyType, nil
+	case ZoneIngressType:
+		return mesh_proto.IngressProxyType, nil
+	case ZoneEgressType:
+		return mesh_proto.EgressProxyType, nil
+	}
+	return "", errors.Errorf("%s does not have a corresponding proxy type", t)
+}

--- a/pkg/test/xds/secrets.go
+++ b/pkg/test/xds/secrets.go
@@ -94,11 +94,11 @@ func (ts *TestSecrets) GetAllInOne(
 	return identity, allInOne, nil
 }
 
-func (*TestSecrets) Info(model.ResourceKey) *secrets.Info {
+func (*TestSecrets) Info(mesh_proto.ProxyType, model.ResourceKey) *secrets.Info {
 	return TestSecretsInfo
 }
 
-func (*TestSecrets) Cleanup(model.ResourceKey) {
+func (*TestSecrets) Cleanup(mesh_proto.ProxyType, model.ResourceKey) {
 }
 
 var _ secrets.Secrets = &TestSecrets{}

--- a/pkg/xds/secrets/secrets_test.go
+++ b/pkg/xds/secrets/secrets_test.go
@@ -140,7 +140,7 @@ var _ = Describe("Secrets", func() {
 			Expect(ca["default"].PemCerts).ToNot(BeEmpty())
 
 			// and info is stored
-			info := secrets.Info(core_model.MetaToResourceKey(newDataplane().Meta))
+			info := secrets.Info(mesh_proto.DataplaneProxyType, core_model.MetaToResourceKey(newDataplane().Meta))
 			Expect(info.Generation).To(Equal(now))
 			Expect(info.Expiration.Unix()).To(Equal(now.Add(1 * time.Hour).Unix()))
 			Expect(info.OwnMesh.MTLS.EnabledBackend).To(Equal("ca-1"))
@@ -222,7 +222,7 @@ var _ = Describe("Secrets", func() {
 
 			It("when cert was cleaned up", func() {
 				// given
-				secrets.Cleanup(core_model.MetaToResourceKey(newDataplane().Meta))
+				secrets.Cleanup(mesh_proto.DataplaneProxyType, core_model.MetaToResourceKey(newDataplane().Meta))
 
 				// when
 				_, _, err := secrets.GetForDataPlane(context.Background(), newDataplane(), newMesh(), nil)
@@ -240,10 +240,10 @@ var _ = Describe("Secrets", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// when
-			secrets.Cleanup(core_model.MetaToResourceKey(newDataplane().Meta))
+			secrets.Cleanup(mesh_proto.DataplaneProxyType, core_model.MetaToResourceKey(newDataplane().Meta))
 
 			// then
-			Expect(secrets.Info(core_model.MetaToResourceKey(newDataplane().Meta))).To(BeNil())
+			Expect(secrets.Info(mesh_proto.DataplaneProxyType, core_model.MetaToResourceKey(newDataplane().Meta))).To(BeNil())
 		})
 	})
 
@@ -259,7 +259,7 @@ var _ = Describe("Secrets", func() {
 			Expect(ca.PemCerts).ToNot(BeEmpty())
 
 			// and info is stored
-			info := secrets.Info(core_model.MetaToResourceKey(newZoneEgress().Meta))
+			info := secrets.Info(mesh_proto.EgressProxyType, core_model.MetaToResourceKey(newZoneEgress().Meta))
 			Expect(info.Generation).To(Equal(now))
 			Expect(info.Expiration.Unix()).To(Equal(now.Add(1 * time.Hour).Unix()))
 			Expect(info.OwnMesh.MTLS.EnabledBackend).To(Equal("ca-1"))
@@ -325,7 +325,7 @@ var _ = Describe("Secrets", func() {
 
 			It("when cert was cleaned up", func() {
 				// given
-				secrets.Cleanup(core_model.MetaToResourceKey(newZoneEgress().Meta))
+				secrets.Cleanup(mesh_proto.EgressProxyType, core_model.MetaToResourceKey(newZoneEgress().Meta))
 
 				// when
 				_, _, err := secrets.GetForZoneEgress(context.Background(), newZoneEgress(), newMesh())
@@ -343,10 +343,10 @@ var _ = Describe("Secrets", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// when
-			secrets.Cleanup(core_model.MetaToResourceKey(newZoneEgress().Meta))
+			secrets.Cleanup(mesh_proto.EgressProxyType, core_model.MetaToResourceKey(newZoneEgress().Meta))
 
 			// then
-			Expect(secrets.Info(core_model.MetaToResourceKey(newZoneEgress().Meta))).To(BeNil())
+			Expect(secrets.Info(mesh_proto.EgressProxyType, core_model.MetaToResourceKey(newZoneEgress().Meta))).To(BeNil())
 		})
 	})
 })

--- a/pkg/xds/server/callbacks/dataplane_status_sink.go
+++ b/pkg/xds/server/callbacks/dataplane_status_sink.go
@@ -19,7 +19,7 @@ import (
 var sinkLog = core.Log.WithName("xds").WithName("sink")
 
 type DataplaneInsightSink interface {
-	Start(stop <-chan struct{})
+	Start(stop <-chan struct{}) // TODO error
 }
 
 type DataplaneInsightStore interface {
@@ -72,9 +72,15 @@ func (s *dataplaneInsightSink) Start(stop <-chan struct{}) {
 	var lastStoredSecretsInfo *secrets.Info
 	var generation uint32
 
+	proxyType, err := core_mesh.ProxyTypeFromResourceType(s.dataplaneType)
+	if err != nil {
+		sinkLog.Error(err, "failed to create dataplaneInsightSink")
+		return
+	}
+
 	flush := func(closing bool) {
 		dataplaneID, currentState := s.accessor.GetStatus()
-		secretsInfo := s.secrets.Info(dataplaneID)
+		secretsInfo := s.secrets.Info(proxyType, dataplaneID)
 
 		select {
 		case <-generationTicker.C:


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
