### PR TITLE
fix(gatewayapi): reconcile HTTPRoutes when relevant Services change

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -354,7 +354,7 @@ func routesForService(l logr.Logger, client kube_client.Client) kube_handler.Map
 		if err := client.List(ctx, &routes, kube_client.MatchingFields{
 			servicesOfRouteField: kube_client.ObjectKeyFromObject(svc).String(),
 		}); err != nil {
-			l.Error(nil, "unexpected error listing HTTPRoutes")
+			l.Error(err, "unexpected error listing HTTPRoutes")
 			return nil
 		}
 

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -338,7 +338,76 @@ func routesForGrant(l logr.Logger, client kube_client.Client) kube_handler.MapFu
 	}
 }
 
+// routesForService returns a function that calculates which HTTPRoutes might
+// be affected by changes in a Service.
+func routesForService(l logr.Logger, client kube_client.Client) kube_handler.MapFunc {
+	l = l.WithName("service-to-routes-mapper")
+
+	return func(ctx context.Context, obj kube_client.Object) []kube_reconcile.Request {
+		svc, ok := obj.(*kube_core.Service)
+		if !ok {
+			l.Error(nil, "unexpected error converting object to Service", "typ", reflect.TypeOf(obj))
+			return nil
+		}
+
+		var routes gatewayapi.HTTPRouteList
+		if err := client.List(ctx, &routes, kube_client.MatchingFields{
+			servicesOfRouteField: kube_client.ObjectKeyFromObject(svc).String(),
+		}); err != nil {
+			l.Error(nil, "unexpected error listing HTTPRoutes")
+			return nil
+		}
+
+		var requests []kube_reconcile.Request
+		for i := range routes.Items {
+			requests = append(requests, kube_reconcile.Request{
+				NamespacedName: kube_client.ObjectKeyFromObject(&routes.Items[i]),
+			})
+		}
+		return requests
+	}
+}
+
+const (
+	servicesOfRouteField = ".metadata.services"
+)
+
 func (r *HTTPRouteReconciler) SetupWithManager(mgr kube_ctrl.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayapi.HTTPRoute{}, servicesOfRouteField, func(obj kube_client.Object) []string {
+		route := obj.(*gatewayapi.HTTPRoute)
+
+		var names []string
+
+		for _, rule := range route.Spec.Rules {
+			var allBackendRefs []gatewayapi.BackendObjectReference
+			for _, backendRef := range rule.BackendRefs {
+				allBackendRefs = append(allBackendRefs, backendRef.BackendObjectReference)
+			}
+			for _, filter := range rule.Filters {
+				if filter.Type == gatewayapi_v1.HTTPRouteFilterRequestMirror {
+					allBackendRefs = append(allBackendRefs, filter.RequestMirror.BackendRef)
+				}
+			}
+			for _, backendRef := range allBackendRefs {
+				if string(*backendRef.Group) != kube_core.SchemeGroupVersion.Group || *backendRef.Kind != "Service" {
+					continue
+				}
+
+				namespace := route.Namespace
+				if backendRef.Namespace != nil {
+					namespace = string(*backendRef.Namespace)
+				}
+				names = append(
+					names,
+					kube_types.NamespacedName{Namespace: namespace, Name: string(backendRef.Name)}.String(),
+				)
+			}
+		}
+
+		return names
+	}); err != nil {
+		return err
+	}
 	return kube_ctrl.NewControllerManagedBy(mgr).
 		For(&gatewayapi.HTTPRoute{}).
 		Watches(
@@ -348,6 +417,10 @@ func (r *HTTPRouteReconciler) SetupWithManager(mgr kube_ctrl.Manager) error {
 		Watches(
 			&gatewayapi.ReferenceGrant{},
 			kube_handler.EnqueueRequestsFromMapFunc(routesForGrant(r.Log, r.Client)),
+		).
+		Watches(
+			&kube_core.Service{},
+			kube_handler.EnqueueRequestsFromMapFunc(routesForService(r.Log, r.Client)),
 		).
 		Complete(r)
 }


### PR DESCRIPTION
This is important if an HTTPRoute references a Service that didn't initially exist but then is created, we need to reconvert to MeshHTTPRoute and update status.
The PR adds an index on HTTPRoutes to the Services they care about to make it cheaper to queue reconciliation for HTTPRoutes when a Service changes.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
