### PR TITLE
feat(postgres): add ability to configure TLS cipher suites

### DIFF
--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -121,6 +121,7 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.Store.Postgres.TLS.KeyPath).To(Equal("/path/to/key"))
 			Expect(cfg.Store.Postgres.TLS.CAPath).To(Equal("/path/to/rootCert"))
 			Expect(cfg.Store.Postgres.TLS.DisableSSLSNI).To(BeTrue())
+			Expect(cfg.Store.Postgres.TLS.CipherSuites).To(Equal([]string{"TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_AES_256_GCM_SHA384"}))
 
 			Expect(cfg.Store.Postgres.ReadReplica.Host).To(Equal("ro.host"))
 			Expect(cfg.Store.Postgres.ReadReplica.Port).To(Equal(uint(35432)))
@@ -404,6 +405,7 @@ store:
       keyPath: /path/to/key
       caPath: /path/to/rootCert
       disableSSLSNI: true
+      cipherSuites: ["TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_AES_256_GCM_SHA384"]
     readReplica:
       host: ro.host
       port: 35432
@@ -780,6 +782,7 @@ tracing:
 				"KUMA_STORE_POSTGRES_TLS_KEY_PATH":                                                         "/path/to/key",
 				"KUMA_STORE_POSTGRES_TLS_CA_PATH":                                                          "/path/to/rootCert",
 				"KUMA_STORE_POSTGRES_TLS_DISABLE_SSLSNI":                                                   "true",
+				"KUMA_STORE_POSTGRES_TLS_CIPHER_SUITES":                                                    "TLS_RSA_WITH_AES_128_CBC_SHA,TLS_AES_256_GCM_SHA384",
 				"KUMA_STORE_POSTGRES_MAX_LIST_QUERY_ELEMENTS":                                              "111",
 				"KUMA_STORE_POSTGRES_READ_REPLICA_HOST":                                                    "ro.host",
 				"KUMA_STORE_POSTGRES_READ_REPLICA_PORT":                                                    "35432",

--- a/pkg/config/plugins/resources/postgres/config.go
+++ b/pkg/config/plugins/resources/postgres/config.go
@@ -163,6 +163,8 @@ type TLSPostgresStoreConfig struct {
 	CAPath string `json:"caPath" envconfig:"kuma_store_postgres_tls_ca_path"`
 	// Whether to disable SNI the postgres `sslsni` option.
 	DisableSSLSNI bool `json:"disableSSLSNI" envconfig:"kuma_store_postgres_tls_disable_sslsni"`
+	// CipherSuites defines the list of ciphers to use
+	CipherSuites []string `json:"cipherSuites" envconfig:"kuma_store_postgres_tls_cipher_suites"`
 }
 
 func (s TLSPostgresStoreConfig) Validate() error {

--- a/pkg/plugins/common/postgres/connection.go
+++ b/pkg/plugins/common/postgres/connection.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 
 	config "github.com/kumahq/kuma/pkg/config/plugins/resources/postgres"
+	config_types "github.com/kumahq/kuma/pkg/config/types"
 	pgx_config "github.com/kumahq/kuma/pkg/plugins/resources/postgres/config"
 )
 
@@ -66,6 +67,13 @@ func ConnectToDbPgx(postgresStoreConfig config.PostgresStoreConfig, customizers 
 
 	if err != nil {
 		return nil, err
+	}
+	if configuredSuites := postgresStoreConfig.TLS.CipherSuites; configuredSuites != nil {
+		suites, err := config_types.TLSCiphers(configuredSuites)
+		if err != nil {
+			return nil, err
+		}
+		pgxConfig.ConnConfig.TLSConfig.CipherSuites = suites
 	}
 
 	return pgxpool.NewWithConfig(context.Background(), pgxConfig)


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
