### PR TITLE
ci(.github): publish slsa artifacts to cloudsmith

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -34,6 +34,7 @@ jobs:
       REGISTRY: ${{ steps.metadata.outputs.registry }}
       VERSION_NAME: ${{ steps.metadata.outputs.version }}
       NOTARY_REPOSITORY: ${{ (contains(steps.metadata.outputs.version, 'preview') && 'notary-internal') || 'notary' }}
+      CLOUDSMITH_REPOSITORY: ${{ steps.metadata.outputs.distribution_repository }}
     steps:
       - name: "Fail when 'ci/force-publish' label is present on PRs from forks"
         if: ${{ fromJSON(env.FORCE_PUBLISH_FROM_FORK) }}
@@ -75,6 +76,7 @@ jobs:
           echo "images=$(make images/info/release/json)" >> $GITHUB_OUTPUT
           echo "registry=$(make docker/info/registry)" >> $GITHUB_OUTPUT
           echo "version=$(make build/info/version)" >> $GITHUB_OUTPUT
+          echo "distribution_repository=$(make build/info/distribution/repo)" >> $GITHUB_OUTPUT
   test:
     permissions:
       contents: read
@@ -129,3 +131,64 @@ jobs:
           # so we manually check it here. An example could be found here: https://github.com/kumahq/kuma/actions/runs/7044980149
           [[ ${{ contains(needs.*.result, 'failure')|| contains(needs.*.result, 'cancelled') }} == "true" ]] && exit 1
           echo "All dependent jobs succeeded"
+        # Aggregated package for SBOMs helps avoid depending on variable asset names
+        # Easy to match and filter on file extensions produced in various distributed jobs
+      - name: "Aggregate all SBOM assets"
+        if: ${{ fromJSON(needs.check.outputs.BUILD) && (needs.check.result == 'success' || needs.build_publish.result == 'success') }}
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ github.workspace }}/security-assets/sboms
+          pattern: '*sbom.{cyclonedx,spdx}.json'
+          merge-multiple: true # When set, all matched zipped artifacts are extracted into the specified path
+          # Zip all SBOM assets for artifact types (Images, Repository scanning) produced in the jobs
+      - name: "metadata for publishing sbom assets"
+        id: sbom_publish_metadata
+        if: ${{ fromJSON(needs.check.outputs.BUILD) && (needs.check.result == 'success' || needs.build_publish.result == 'success') }}
+        run: |-
+          SBOM_PACKAGE_NAME="${{github.repository}}-sbom"
+          echo "SBOM_PACKAGE_NAME=${SBOM_PACKAGE_NAME}" >> $GITHUB_OUTPUT
+          zip -rj ${SBOM_PACKAGE_NAME} ${{ github.workspace }}/security-assets/sboms -i '*sbom.spdx.json' '*sbom.cyclonedx.json'
+      - name: "Download binary artifact provenance"
+        uses: actions/download-artifact@v4
+        if: ${{ needs.provenance.result == 'success' && github.ref_type == 'tag' }}
+        with:
+          path: ${{ github.workspace }}/security-assets/provenance
+          pattern: ${{ github.event.repository.name }}.intoto.jsonl
+          merge-multiple: true # When set, all matched zipped artifacts are extracted into the specified path
+      - name: "Inspect security assets"
+        if: ${{ fromJSON(needs.check.outputs.BUILD) }}
+        run: |-
+          ls -alR ${{github.workspace}}/security-assets
+        # Publish aggregated zip file of SBOMs to artifact regstry
+      - name: Push SBOMs assets to cloudsmith
+        id: push_sbom
+        if: ${{ fromJSON(needs.check.outputs.BUILD) && (needs.check.result == 'success' || needs.build_publish.result == 'success') }}
+        uses: cloudsmith-io/action@master
+        with:
+          api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
+          command: "push"
+          format: "raw"
+          owner: "kong"
+          repo: "${{ needs.check.outputs.CLOUDSMITH_REPOSITORY }}"
+          version: "${{ needs.check.outputs.VERSION_NAME }}"
+          file: "${{ github.workspace }}/security-assets/provenance/${{ steps.sbom_publish_metadata.outputs.SBOM_PACKAGE_NAME }}"
+          name: "${{ steps.sbom_publish_metadata.outputs.SBOM_PACKAGE_NAME }}"
+          summary: "SBOM artifacts for ${{ github.repository }}"
+          description: "SBOM artifacts for binaries built from source code and container images"
+      - name: Push Binary Provenance to cloudsmith
+        if: ${{ needs.provenance.result == 'success' && github.ref_type == 'tag' }}
+        id: push_binary_provenance
+        uses: cloudsmith-io/action@master
+        with:
+          api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
+          command: "push"
+          format: "raw"
+          owner: "kong"
+          repo: "${{ needs.check.outputs.CLOUDSMITH_REPOSITORY }}"
+          version: "${{ needs.check.outputs.VERSION_NAME }}"
+          file: "${{ github.workspace }}/security-assets/provenance/${{ github.event.repository.name }}.intoto.jsonl"
+          name: "${{ env.BINARY_PROVENANCE_PACKAGE_NAME }}"
+          summary: "Binary Artifact Provenance for ${{ github.repository }}"
+          description: "Provenance file for verifying ${{ github.repository }} binary artifacts"
+        env:
+          BINARY_PROVENANCE_PACKAGE_NAME: "${{github.repository}}-binary-provenance"

--- a/mk/distribution.mk
+++ b/mk/distribution.mk
@@ -107,6 +107,10 @@ endif
 build/distributions/out: $(patsubst %,build/distributions/out/$(DISTRIBUTION_TARGET_NAME)-%.tar.gz,$(ENABLED_DIST_NAMES))
 	cd $@; sha256sum *.tar.gz > $(DISTRIBUTION_TARGET_NAME).sha256
 
+.PHONY: build/info/distribution/repo
+build/info/distribution/repo:
+	@echo $(PULP_PACKAGE_TYPE)-binaries-$(PULP_DIST_VERSION)
+
 # Create a main target which will publish to pulp each to the tar.gz built
 .PHONY: publish/pulp ## Publish to pulp all enabled distributions
 publish/pulp: $(addprefix publish/pulp/$(DISTRIBUTION_TARGET_NAME)-,$(ENABLED_DIST_NAMES))

--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -19,7 +19,10 @@ KUMA_IMAGES = $(call build_image,$(IMAGES_RELEASE) $(IMAGES_TEST))
 export DOCKER_BUILDKIT := 1
 
 # add targets to build images for each arch
-# $(1) - GOOS to build for
+# $(1) - GOARCH to build for
+# (TODO): Donot hardcode "linux" platform for images
+# (TODO): May be support other image platforms using argument
+
 define IMAGE_TARGETS_BY_ARCH
 .PHONY: image/static/$(1)
 image/static/$(1): ## Dev: Rebuild `kuma-static` Docker image
@@ -65,8 +68,9 @@ $(foreach goarch,$(SUPPORTED_GOARCHES),$(eval $(call IMAGE_TARGETS_BY_ARCH,$(goa
 
 # add targets to generate docker/{save,load,tag,push} for each supported ARCH
 # add targets to build images for each arch
-# $(1) - GOOS to build for
+# $(1) - Imae Name to build for
 # $(2) - GOARCH to build for
+# (TODO): Support image platform in output file names
 define DOCKER_TARGETS_BY_ARCH
 .PHONY: docker/save/$(1)/$(2)
 docker/save/$(1)/$(2):


### PR DESCRIPTION
# Summary

- Source JIRA: https://konghq.atlassian.net/browse/SEC-1106
- Downloads SLSA workflow run assets from various jobs in CI using `glob` pattern on file extensions
-  Upload the below cloudsmith packages in RAW package format:
   - SBOMs: `<repo>-sbom` - Aggregated ZIP file with all SBOMs for image artifacts and Source Code from which binary was built
   - Binary Provenance: `<repo>-binary-provenance` - ZIP file containing provenance for binary verification

# Out of Scope:
- Image provenance is automatically published as image signature and no RAW artifact is produced.
- SCA / Vulnerability reports are not uploaded / exposed to customers.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
