### PR TITLE
chore(cni): don't redirect inbound for gateway in CNI

### DIFF
--- a/app/cni/pkg/cni/injector_linux.go
+++ b/app/cni/pkg/cni/injector_linux.go
@@ -117,13 +117,14 @@ func mapToConfig(intermediateConfig *IntermediateConfig, logWriter *bufio.Writer
 			return nil, err
 		}
 	}
-	enableIpV6, err := transparentproxy.ShouldEnableIPv6(inboundPortV6)
+
+	cfg.IPv6, err = transparentproxy.ShouldEnableIPv6(inboundPortV6)
 	if err != nil {
 		return nil, err
 	}
-	cfg.IPv6 = enableIpV6
-	redirectInbound := !isGateway
-	if redirectInbound {
+
+	cfg.Redirect.Inbound.Enabled = !isGateway
+	if cfg.Redirect.Inbound.Enabled {
 		inboundPort, err := convertToUint16("inbound port", intermediateConfig.inboundPort)
 		if err != nil {
 			return nil, err
@@ -134,23 +135,21 @@ func mapToConfig(intermediateConfig *IntermediateConfig, logWriter *bufio.Writer
 			return nil, err
 		}
 
-		cfg.Redirect.Inbound.Enabled = true
 		cfg.Redirect.Inbound.Port = inboundPort
 		cfg.Redirect.Inbound.PortIPv6 = inboundPortV6
 		cfg.Redirect.Inbound.ExcludePorts = excludedPorts
 	}
 
-	useBuiltinDNS, err := GetEnabled(intermediateConfig.builtinDNS)
+	cfg.Redirect.DNS.Enabled, err = GetEnabled(intermediateConfig.builtinDNS)
 	if err != nil {
 		return nil, err
 	}
-	if useBuiltinDNS {
+	if cfg.Redirect.DNS.Enabled {
 		builtinDnsPort, err := convertToUint16("builtin dns port", intermediateConfig.builtinDNSPort)
 		if err != nil {
 			return nil, err
 		}
 
-		cfg.Redirect.DNS.Enabled = true
 		cfg.Redirect.DNS.Port = builtinDnsPort
 		cfg.Redirect.DNS.CaptureAll = true
 		cfg.Redirect.DNS.ConntrackZoneSplit = true


### PR DESCRIPTION
`Config` has both - inbound and outbound traffic redirection enabled by default (change introduced in https://github.com/kumahq/kuma/pull/10206), which is wrong in case of gateway so `GatewayIPV6CNIV2` tests were failing (ref. https://github.com/kumahq/kuma/actions/runs/9030440854/job/24815380164)

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - No relevant issues
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - There is no need

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
