### PR TITLE
ci(mk): fix postgres target

### DIFF
--- a/mk/run.mk
+++ b/mk/run.mk
@@ -49,11 +49,11 @@ KUMA_CP_ADDRESS ?= grpcs://localhost:5678
 
 .PHONY: run/postgres/start
 run/postgres/start: ## Dev: start Postgres for Control Plane with initial schema (Use POSTGRES_MODE=tls to enable TLS)
-	$(CP_ENV) POSTGRES_MODE=$(POSTGRES_MODE) docker-compose -f $(TOOLS_DIR)/postgres/docker-compose.yaml up -d --build
+	$(CP_ENV) POSTGRES_MODE=$(POSTGRES_MODE) docker-compose -f $(KUMA_DIR)/test/dockerfiles/docker-compose.yaml up -d --build
 
 .PHONY: run/postgres/stop
 run/postgres/stop: ## Dev: stop Postgres
-	docker-compose -f $(TOOLS_DIR)/postgres/docker-compose.yaml down
+	docker-compose -f $(KUMA_DIR)/test/dockerfiles/docker-compose.yaml down
 
 .PHONY: run/kuma-cp
 run/kuma-cp: $(DISTRIBUTION_FOLDER) ## Dev: Run `kuma-cp` locally (use CP_STORE=postgres to use postgres as a store and POSTGRES_MODE=tls to enabled TLS, use EXTRA_CP_ENV to add extra Kuma env vars)

--- a/test/dockerfiles/docker-compose.yaml
+++ b/test/dockerfiles/docker-compose.yaml
@@ -3,6 +3,7 @@ services:
   db:
     build:
       context: .
+      dockerfile: postgres.dockerfile
       args:
         MODE: ${POSTGRES_MODE:-standard}
     restart: always


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

> Changelog: skip
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
