### PR TITLE
ci(mk): use `POSTGRES_STORE_TYPE` directly for `run/kuma-cp`

### DIFF
--- a/mk/run.mk
+++ b/mk/run.mk
@@ -24,9 +24,8 @@ networking:
 endef
 
 POSTGRES_MODE = standard
-CP_STORE = memory
-CP_ENV += KUMA_ENVIRONMENT=universal KUMA_MULTIZONE_ZONE_NAME=zone-1 KUMA_STORE_TYPE=$(CP_STORE)
-ifeq ($(CP_STORE),postgres)
+CP_ENV += KUMA_ENVIRONMENT=universal KUMA_MULTIZONE_ZONE_NAME=zone-1
+ifeq ($(KUMA_STORE_TYPE),postgres)
 CP_ENV += KUMA_STORE_POSTGRES_HOST=localhost \
 	KUMA_STORE_POSTGRES_PORT=15432 \
 	KUMA_STORE_POSTGRES_USER=kuma \
@@ -56,8 +55,8 @@ run/postgres/stop: ## Dev: stop Postgres
 	docker-compose -f $(KUMA_DIR)/test/dockerfiles/docker-compose.yaml down
 
 .PHONY: run/kuma-cp
-run/kuma-cp: $(DISTRIBUTION_FOLDER) ## Dev: Run `kuma-cp` locally (use CP_STORE=postgres to use postgres as a store and POSTGRES_MODE=tls to enabled TLS, use EXTRA_CP_ENV to add extra Kuma env vars)
-ifeq ($(CP_STORE),postgres)
+run/kuma-cp: $(DISTRIBUTION_FOLDER) ## Dev: Run `kuma-cp` locally (use KUMA_STORE_TYPE=postgres to use postgres as a store and POSTGRES_MODE=tls to enabled TLS, use EXTRA_CP_ENV to add extra Kuma env vars)
+ifeq ($(KUMA_STORE_TYPE),postgres)
 	$(CP_ENV) $(DISTRIBUTION_FOLDER)/bin/kuma-cp migrate up --log-level=debug
 endif
 	$(CP_ENV) $(DISTRIBUTION_FOLDER)/bin/kuma-cp run --log-level=debug


### PR DESCRIPTION
`CP_STORE` was unconditionally overwritten to `memory` anyway so this didn't work.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
