### PR TITLE
feat(MeshRetry): allow setting numRetries to 0 to disable retries

### DIFF
--- a/pkg/plugins/policies/meshretry/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/validator.go
@@ -89,6 +89,8 @@ func validateTCP(tcp *TCP) validators.ValidationError {
 	path := validators.RootedAt("tcp")
 	if tcp.MaxConnectAttempt == nil {
 		verr.AddViolationAt(path, validators.MustNotBeEmpty)
+	} else if *tcp.MaxConnectAttempt == 0 {
+		verr.AddViolationAt(path.Field("maxConnectAttempt"), validators.HasToBeGreaterThanZero)
 	}
 	return verr
 }

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/validator_test.go
@@ -282,6 +282,22 @@ violations:
   - field: spec.to[0].default.conf.grpc
     message: must not be empty`,
 			}),
+			Entry("0 for tcp.maxConnectAttempt", testCase{
+				inputYaml: `
+targetRef:
+  kind: Mesh
+to:
+  - targetRef:
+      kind: Mesh
+    default:
+      tcp:
+        maxConnectAttempt: 0
+`,
+				expected: `
+violations:
+  - field: spec.to[0].default.conf.tcp.maxConnectAttempt
+    message: must be greater than 0`,
+			}),
 			Entry("empty http.backOff", testCase{
 				inputYaml: `
 targetRef:

--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin_test.go
@@ -179,6 +179,27 @@ var _ = Describe("MeshRetry", func() {
 			},
 			goldenFilePrefix: "http",
 		}),
+		Entry("http retry 0 numRetries", testCase{
+			resources: []core_xds.Resource{{
+				Name:     "outbound",
+				Origin:   generator.OriginOutbound,
+				Resource: httpListenerWithSimpleRoute(10001),
+			}},
+			toRules: core_rules.ToRules{
+				Rules: []*core_rules.Rule{
+					{
+						Subset: core_rules.Subset{},
+						Conf: api.Conf{
+							HTTP: &api.HTTP{
+								NumRetries:    pointer.To[uint32](0),
+								PerTryTimeout: test.ParseDuration("2s"),
+							},
+						},
+					},
+				},
+			},
+			goldenFilePrefix: "http_0_numretries",
+		}),
 		Entry("grpc retry", testCase{
 			resources: []core_xds.Resource{{
 				Name:     "outbound",
@@ -226,6 +247,30 @@ var _ = Describe("MeshRetry", func() {
 				},
 			},
 			goldenFilePrefix: "grpc",
+		}),
+		Entry("grpc retry 0 numRetries", testCase{
+			resources: []core_xds.Resource{{
+				Name:     "outbound",
+				Origin:   generator.OriginOutbound,
+				Resource: httpListenerWithSimpleRoute(10002),
+			}},
+			toRules: core_rules.ToRules{
+				Rules: []*core_rules.Rule{
+					{
+						Subset: core_rules.Subset{core_rules.Tag{
+							Key:   mesh_proto.ServiceTag,
+							Value: "grpc-service",
+						}},
+						Conf: api.Conf{
+							GRPC: &api.GRPC{
+								NumRetries:    pointer.To[uint32](0),
+								PerTryTimeout: test.ParseDuration("12s"),
+							},
+						},
+					},
+				},
+			},
+			goldenFilePrefix: "grpc_0_numretries",
 		}),
 		Entry("tcp retry", testCase{
 			resources: []core_xds.Resource{{

--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/testdata/grpc_0_numretries.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/testdata/grpc_0_numretries.listeners.golden.yaml
@@ -28,10 +28,6 @@ filterChains:
             name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
             route:
               cluster: backend
-              retryPolicy:
-                numRetries: 0
-                perTryTimeout: 12s
-                retryOn: cancelled,connect-failure,gateway-error,refused-stream,reset,resource-exhausted,unavailable
               timeout: 0s
       statPrefix: outbound_127_0_0_1_10002
 name: outbound:127.0.0.1:10002

--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/testdata/grpc_0_numretries.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/testdata/grpc_0_numretries.listeners.golden.yaml
@@ -1,0 +1,38 @@
+address:
+  socketAddress:
+    address: 127.0.0.1
+    portValue: 10002
+filterChains:
+- filters:
+  - name: envoy.filters.network.http_connection_manager
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+      httpFilters:
+      - name: envoy.filters.http.router
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+      routeConfig:
+        name: outbound:backend
+        requestHeadersToAdd:
+        - header:
+            key: x-kuma-tags
+            value: '&kuma.io/service=web&'
+        validateClusters: false
+        virtualHosts:
+        - domains:
+          - '*'
+          name: backend
+          routes:
+          - match:
+              prefix: /
+            name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
+            route:
+              cluster: backend
+              retryPolicy:
+                numRetries: 0
+                perTryTimeout: 12s
+                retryOn: cancelled,connect-failure,gateway-error,refused-stream,reset,resource-exhausted,unavailable
+              timeout: 0s
+      statPrefix: outbound_127_0_0_1_10002
+name: outbound:127.0.0.1:10002
+trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/testdata/http_0_numretries.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/testdata/http_0_numretries.listeners.golden.yaml
@@ -28,10 +28,6 @@ filterChains:
             name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
             route:
               cluster: backend
-              retryPolicy:
-                numRetries: 0
-                perTryTimeout: 2s
-                retryOn: gateway-error,connect-failure,refused-stream
               timeout: 0s
       statPrefix: outbound_127_0_0_1_10001
 name: outbound:127.0.0.1:10001

--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/testdata/http_0_numretries.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/testdata/http_0_numretries.listeners.golden.yaml
@@ -1,0 +1,38 @@
+address:
+  socketAddress:
+    address: 127.0.0.1
+    portValue: 10001
+filterChains:
+- filters:
+  - name: envoy.filters.network.http_connection_manager
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+      httpFilters:
+      - name: envoy.filters.http.router
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+      routeConfig:
+        name: outbound:backend
+        requestHeadersToAdd:
+        - header:
+            key: x-kuma-tags
+            value: '&kuma.io/service=web&'
+        validateClusters: false
+        virtualHosts:
+        - domains:
+          - '*'
+          name: backend
+          routes:
+          - match:
+              prefix: /
+            name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
+            route:
+              cluster: backend
+              retryPolicy:
+                numRetries: 0
+                perTryTimeout: 2s
+                retryOn: gateway-error,connect-failure,refused-stream
+              timeout: 0s
+      statPrefix: outbound_127_0_0_1_10001
+name: outbound:127.0.0.1:10001
+trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshretry/plugin/xds/configurer.go
+++ b/pkg/plugins/policies/meshretry/plugin/xds/configurer.go
@@ -96,11 +96,7 @@ func (c *Configurer) getRouteRetryConfig(conf *api.Conf) (*envoy_route.RetryPoli
 	}
 	switch c.Protocol {
 	case "http":
-		policy, err := genHttpRetryPolicy(conf.HTTP)
-		if err != nil {
-			return nil, err
-		}
-		return policy, nil
+		return genHttpRetryPolicy(conf.HTTP)
 	case "grpc":
 		return genGrpcRetryPolicy(conf.GRPC), nil
 	default:

--- a/pkg/plugins/policies/meshretry/plugin/xds/configurer.go
+++ b/pkg/plugins/policies/meshretry/plugin/xds/configurer.go
@@ -98,7 +98,7 @@ func (c *Configurer) getRouteRetryConfig(conf *api.Conf) (*envoy_route.RetryPoli
 	case "http":
 		return genHttpRetryPolicy(conf.HTTP)
 	case "grpc":
-		return genGrpcRetryPolicy(conf.GRPC), nil
+		return genGrpcRetryPolicy(conf.GRPC)
 	default:
 		return nil, nil
 	}
@@ -119,9 +119,9 @@ func GrpcRetryOn(conf *[]api.GRPCRetryOn) string {
 	return strings.Join(retryOn, ",")
 }
 
-func genGrpcRetryPolicy(conf *api.GRPC) *envoy_route.RetryPolicy {
+func genGrpcRetryPolicy(conf *api.GRPC) (*envoy_route.RetryPolicy, error) {
 	if conf == nil {
-		return nil
+		return nil, nil
 	}
 
 	policy := envoy_route.RetryPolicy{
@@ -133,6 +133,9 @@ func genGrpcRetryPolicy(conf *api.GRPC) *envoy_route.RetryPolicy {
 	}
 
 	if conf.NumRetries != nil {
+		if *conf.NumRetries == 0 { // If numRetries is 0 just don't configure retries
+			return nil, nil
+		}
 		policy.NumRetries = util_proto.UInt32(*conf.NumRetries)
 	}
 
@@ -156,7 +159,7 @@ func genGrpcRetryPolicy(conf *api.GRPC) *envoy_route.RetryPolicy {
 		policy.RateLimitedRetryBackOff = configureRateLimitedRetryBackOff(conf.RateLimitedBackOff)
 	}
 
-	return &policy
+	return &policy, nil
 }
 
 func genHttpRetryPolicy(conf *api.HTTP) (*envoy_route.RetryPolicy, error) {
@@ -173,6 +176,9 @@ func genHttpRetryPolicy(conf *api.HTTP) (*envoy_route.RetryPolicy, error) {
 	}
 
 	if conf.NumRetries != nil {
+		if *conf.NumRetries == 0 { // If numRetries is 0 just don't configure retries
+			return nil, nil
+		}
 		policy.NumRetries = util_proto.UInt32(*conf.NumRetries)
 	}
 


### PR DESCRIPTION
Currently if you have any retry policy inherited from anywhere you
wouldn't be able to remove the retries in a more specific policy.

This enables users to set `{grpc,http}.numRetries = 0` in a more
specific policy and remove the retry filter completely.

It also disallows `tcp.maxConnectAttempt = 0` which would create an
invalid envoy configuration.

fix https://github.com/kumahq/kuma/issues/10248

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
