### PR TITLE
fix(kuma-cp): filter out old dangling zone resources in global (backport of #10245)

### DIFF
--- a/pkg/kds/global/components.go
+++ b/pkg/kds/global/components.go
@@ -299,11 +299,15 @@ func Callbacks(s sync_store.ResourceSyncer, k8sStore bool, kubeFactory resources
 			}
 
 			return s.Sync(rs, sync_store.PrefilterBy(func(r model.Resource) bool {
-				if !supportsHashSuffixes {
-					// todo: remove in 2 releases after 2.6.x
-					return strings.HasPrefix(r.GetMeta().GetName(), fmt.Sprintf("%s.", clusterName))
-				}
-				return r.GetMeta().GetLabels()[mesh_proto.ZoneTag] == clusterName
+				// Assuming the global CP was updated first, the prefix check is only necessary
+				// if the client doesn't have `supportsHashSuffixes`.
+				// But maybe some prefixed resources were previously synced, we
+				// can filter them and the zone won't sync them again.
+				// When we are further from this migration we can remove this
+				// check.
+				hasOldStylePrefix := strings.HasPrefix(r.GetMeta().GetName(), fmt.Sprintf("%s.", clusterName))
+				hasZoneLabel := r.GetMeta().GetLabels()[mesh_proto.ZoneTag] == clusterName
+				return hasOldStylePrefix || hasZoneLabel
 			}), sync_store.Zone(clusterName))
 		},
 	}

--- a/pkg/kds/v2/store/sync.go
+++ b/pkg/kds/v2/store/sync.go
@@ -364,11 +364,15 @@ func GlobalSyncCallback(
 			}
 
 			return syncer.Sync(ctx, upstream, PrefilterBy(func(r model.Resource) bool {
-				if !supportsHashSuffixes {
-					// todo: remove in 2 releases after 2.6.x
-					return strings.HasPrefix(r.GetMeta().GetName(), fmt.Sprintf("%s.", upstream.ControlPlaneId))
-				}
-				return r.GetMeta().GetLabels()[mesh_proto.ZoneTag] == upstream.ControlPlaneId
+				// Assuming the global CP was updated first, the prefix check is only necessary
+				// if the client doesn't have `supportsHashSuffixes`.
+				// But maybe some prefixed resources were previously synced, we
+				// can filter them and the zone won't sync them again.
+				// When we are further from this migration we can remove this
+				// check.
+				hasOldStylePrefix := strings.HasPrefix(r.GetMeta().GetName(), fmt.Sprintf("%s.", upstream.ControlPlaneId))
+				hasZoneLabel := r.GetMeta().GetLabels()[mesh_proto.ZoneTag] == upstream.ControlPlaneId
+				return hasOldStylePrefix || hasZoneLabel
 			}), Zone(upstream.ControlPlaneId))
 		},
 	}


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
