### PR TITLE
feat(report): add more info in the report

### DIFF
--- a/pkg/core/runtime/builder.go
+++ b/pkg/core/runtime/builder.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/emicklei/go-restful/v3"
 	"github.com/pkg/errors"
@@ -100,7 +99,7 @@ type Builder struct {
 	tokenIssuers   builtin.TokenIssuers
 	meshCache      *mesh.Cache
 	interCpPool    *client.Pool
-	*runtimeInfo
+	RuntimeInfo
 	pgxConfigCustomizationFn config.PgxConfigCustomization
 	tenants                  multitenant.Tenants
 	apiWebServiceCustomize   []func(*restful.WebService) error
@@ -113,15 +112,11 @@ func BuilderFor(appCtx context.Context, cfg kuma_cp.Config) (*Builder, error) {
 	}
 	suffix := core.NewUUID()[0:4]
 	return &Builder{
-		cfg: cfg,
-		ext: context.Background(),
-		cam: core_ca.Managers{},
-		runtimeInfo: &runtimeInfo{
-			instanceId: fmt.Sprintf("%s-%s", hostname, suffix),
-			startTime:  time.Now(),
-			mode:       cfg.Mode,
-		},
-		appCtx: appCtx,
+		cfg:         cfg,
+		ext:         context.Background(),
+		cam:         core_ca.Managers{},
+		RuntimeInfo: NewRuntimeInfo(fmt.Sprintf("%s-%s", hostname, suffix), cfg.Mode),
+		appCtx:      appCtx,
 	}, nil
 }
 
@@ -372,7 +367,7 @@ func (b *Builder) Build() (Runtime, error) {
 		return nil, errors.Errorf("Tenants has not been configured")
 	}
 	return &runtime{
-		RuntimeInfo: b.runtimeInfo,
+		RuntimeInfo: b.RuntimeInfo,
 		RuntimeContext: &runtimeContext{
 			cfg:                      b.cfg,
 			rm:                       b.rm,

--- a/pkg/kds/v2/client/zone_sync_test.go
+++ b/pkg/kds/v2/client/zone_sync_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/registry"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
+	core_runtime "github.com/kumahq/kuma/pkg/core/runtime"
 	kds_context "github.com/kumahq/kuma/pkg/kds/context"
 	client_v2 "github.com/kumahq/kuma/pkg/kds/v2/client"
 	sync_store_v2 "github.com/kumahq/kuma/pkg/kds/v2/store"
@@ -28,18 +29,17 @@ import (
 	"github.com/kumahq/kuma/pkg/test/grpc"
 	"github.com/kumahq/kuma/pkg/test/kds/samples"
 	"github.com/kumahq/kuma/pkg/test/kds/setup"
-	"github.com/kumahq/kuma/pkg/test/runtime"
 )
 
 var _ = Describe("Zone Delta Sync", func() {
 	zoneName := "zone-1"
 
-	runtimeInfo := runtime.TestRuntimeInfo{InstanceId: "zone-inst", Mode: config_core.Zone}
+	runtimeInfo := core_runtime.NewRuntimeInfo("zone-inst", config_core.Zone)
 	newPolicySink := func(zoneName string, resourceSyncer sync_store_v2.ResourceSyncer, cs *grpc.MockDeltaClientStream, configs map[string]bool) client_v2.KDSSyncClient {
 		return client_v2.NewKDSSyncClient(
 			core.Log.WithName("kds-sink"),
 			registry.Global().ObjectTypes(model.HasKDSFlag(model.GlobalToZoneSelector)),
-			client_v2.NewDeltaKDSStream(cs, zoneName, &runtimeInfo, ""),
+			client_v2.NewDeltaKDSStream(cs, zoneName, runtimeInfo, ""),
 			sync_store_v2.ZoneSyncCallback(context.Background(), configs, resourceSyncer, false, zoneName, nil, "kuma-system"), 0,
 		)
 	}

--- a/pkg/kds/zone/components_test.go
+++ b/pkg/kds/zone/components_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/registry"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
+	core_runtime "github.com/kumahq/kuma/pkg/core/runtime"
 	kds_client "github.com/kumahq/kuma/pkg/kds/client"
 	kds_context "github.com/kumahq/kuma/pkg/kds/context"
 	sync_store "github.com/kumahq/kuma/pkg/kds/store"
@@ -31,7 +32,6 @@ import (
 	"github.com/kumahq/kuma/pkg/test/grpc"
 	"github.com/kumahq/kuma/pkg/test/kds/samples"
 	"github.com/kumahq/kuma/pkg/test/kds/setup"
-	"github.com/kumahq/kuma/pkg/test/runtime"
 )
 
 var _ = Describe("Zone Sync", func() {
@@ -237,12 +237,12 @@ var _ = Describe("Zone Sync", func() {
 
 	Context("GlobalToZone", func() {
 		var zoneSyncer sync_store_v2.ResourceSyncer
-		runtimeInfo := runtime.TestRuntimeInfo{InstanceId: "global-inst", Mode: config_core.Global}
+		runtimeInfo := core_runtime.NewRuntimeInfo("global-inst", config_core.Global)
 		newPolicySyncClient := func(zoneName string, resourceSyncer sync_store_v2.ResourceSyncer, cs *grpc.MockDeltaClientStream, configs map[string]bool) kds_client_v2.KDSSyncClient {
 			return kds_client_v2.NewKDSSyncClient(
 				core.Log.WithName("kds-sink"),
 				registry.Global().ObjectTypes(model.HasKDSFlag(model.GlobalToZoneSelector)),
-				kds_client_v2.NewDeltaKDSStream(cs, zoneName, &runtimeInfo, ""),
+				kds_client_v2.NewDeltaKDSStream(cs, zoneName, runtimeInfo, ""),
 				sync_store_v2.ZoneSyncCallback(context.Background(), configs, resourceSyncer, false, zoneName, nil, "kuma-system"),
 				0,
 			)

--- a/pkg/test/kds/setup/client.go
+++ b/pkg/test/kds/setup/client.go
@@ -2,11 +2,11 @@ package setup
 
 import (
 	"fmt"
-	"time"
 
 	config_core "github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
+	core_runtime "github.com/kumahq/kuma/pkg/core/runtime"
 	kds_client "github.com/kumahq/kuma/pkg/kds/client"
 	kds_client_v2 "github.com/kumahq/kuma/pkg/kds/v2/client"
 	"github.com/kumahq/kuma/pkg/test/grpc"
@@ -27,10 +27,7 @@ func StartClient(clientStreams []*grpc.MockClientStream, resourceTypes []model.R
 func StartDeltaClient(clientStreams []*grpc.MockDeltaClientStream, resourceTypes []model.ResourceType, stopCh chan struct{}, cb *kds_client_v2.Callbacks) {
 	for i := 0; i < len(clientStreams); i++ {
 		clientID := fmt.Sprintf("client-%d", i)
-		runtimeInfo := &mockRuntimeInfo{
-			instanceId: fmt.Sprintf("cp-%d", i),
-			mode:       config_core.Zone,
-		}
+		runtimeInfo := core_runtime.NewRuntimeInfo(fmt.Sprintf("cp-%d", i), config_core.Zone)
 		item := clientStreams[i]
 		comp := kds_client_v2.NewKDSSyncClient(core.Log.WithName("kds").WithName(clientID), resourceTypes, kds_client_v2.NewDeltaKDSStream(item, clientID, runtimeInfo, ""), cb, 0)
 		go func() {
@@ -38,29 +35,4 @@ func StartDeltaClient(clientStreams []*grpc.MockDeltaClientStream, resourceTypes
 			_ = item.CloseSend()
 		}()
 	}
-}
-
-type mockRuntimeInfo struct {
-	instanceId string
-	mode       config_core.CpMode
-}
-
-func (m mockRuntimeInfo) GetInstanceId() string {
-	return m.instanceId
-}
-
-func (m mockRuntimeInfo) SetClusterId(clusterId string) {
-	panic("implement me")
-}
-
-func (m mockRuntimeInfo) GetClusterId() string {
-	panic("implement me")
-}
-
-func (m mockRuntimeInfo) GetStartTime() time.Time {
-	panic("implement me")
-}
-
-func (m mockRuntimeInfo) GetMode() config_core.CpMode {
-	return m.mode
 }

--- a/pkg/test/kds/setup/server.go
+++ b/pkg/test/kds/setup/server.go
@@ -34,7 +34,6 @@ import (
 	core_metrics "github.com/kumahq/kuma/pkg/metrics"
 	"github.com/kumahq/kuma/pkg/multitenant"
 	"github.com/kumahq/kuma/pkg/plugins/resources/postgres/config"
-	test_runtime "github.com/kumahq/kuma/pkg/test/runtime"
 	"github.com/kumahq/kuma/pkg/tokens/builtin"
 	"github.com/kumahq/kuma/pkg/xds/cache/mesh"
 	xds_runtime "github.com/kumahq/kuma/pkg/xds/runtime"
@@ -42,7 +41,7 @@ import (
 )
 
 type testRuntimeContext struct {
-	test_runtime.TestRuntimeInfo
+	runtime.RuntimeInfo
 	rom                      manager.ReadOnlyResourceManager
 	rm                       manager.ResourceManager
 	cfg                      kuma_cp.Config
@@ -222,12 +221,10 @@ func NewKdsServerBuilder(store store.ResourceStore) *KdsServerBuilder {
 	}
 	cfg := kuma_cp.DefaultConfig()
 	cfg.Mode = config_core.Global
+	runtimeInfo := runtime.NewRuntimeInfo("global-cp", cfg.Mode)
+	runtimeInfo.SetClusterInfo("my-cluster", time.Now())
 	rt := &testRuntimeContext{
-		TestRuntimeInfo: test_runtime.TestRuntimeInfo{
-			InstanceId: "global-cp",
-			ClusterId:  "my-cluster",
-			Mode:       cfg.Mode,
-		},
+		RuntimeInfo:              runtimeInfo,
 		rom:                      rm,
 		rm:                       rm,
 		cfg:                      cfg,
@@ -246,8 +243,8 @@ func NewKdsServerBuilder(store store.ResourceStore) *KdsServerBuilder {
 
 func (b *KdsServerBuilder) AsZone(name string) *KdsServerBuilder {
 	b.rt.cfg.Multizone.Zone.Name = name
-	b.rt.TestRuntimeInfo.InstanceId = name
 	b.rt.cfg.Mode = config_core.Zone
+	b.rt.RuntimeInfo = runtime.NewRuntimeInfo("zone-cp", b.rt.cfg.Mode)
 	return b
 }
 

--- a/pkg/test/runtime/runtime.go
+++ b/pkg/test/runtime/runtime.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"net"
 	"net/http"
-	"time"
 
 	"github.com/emicklei/go-restful/v3"
 	"github.com/pkg/errors"
@@ -14,7 +13,6 @@ import (
 	"github.com/kumahq/kuma/pkg/api-server/authn"
 	"github.com/kumahq/kuma/pkg/api-server/customization"
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
-	config_core "github.com/kumahq/kuma/pkg/config/core"
 	dp_server "github.com/kumahq/kuma/pkg/config/dp-server"
 	"github.com/kumahq/kuma/pkg/core/access"
 	config_manager "github.com/kumahq/kuma/pkg/core/config/manager"
@@ -56,35 +54,6 @@ import (
 	"github.com/kumahq/kuma/pkg/xds/secrets"
 	xds_server "github.com/kumahq/kuma/pkg/xds/server"
 )
-
-var _ core_runtime.RuntimeInfo = &TestRuntimeInfo{}
-
-type TestRuntimeInfo struct {
-	InstanceId string
-	ClusterId  string
-	StartTime  time.Time
-	Mode       config_core.CpMode
-}
-
-func (i *TestRuntimeInfo) GetMode() config_core.CpMode {
-	return i.Mode
-}
-
-func (i *TestRuntimeInfo) GetInstanceId() string {
-	return i.InstanceId
-}
-
-func (i *TestRuntimeInfo) SetClusterId(clusterId string) {
-	i.ClusterId = clusterId
-}
-
-func (i *TestRuntimeInfo) GetClusterId() string {
-	return i.ClusterId
-}
-
-func (i *TestRuntimeInfo) GetStartTime() time.Time {
-	return i.StartTime
-}
 
 func BuilderFor(appCtx context.Context, cfg kuma_cp.Config) (*core_runtime.Builder, error) {
 	if cfg.DpServer.Authn.DpProxy.Type == "" {

--- a/pkg/xds/server/callbacks/dataplane_status_tracker_test.go
+++ b/pkg/xds/server/callbacks/dataplane_status_tracker_test.go
@@ -13,9 +13,10 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/pkg/config/core"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+	core_runtime "github.com/kumahq/kuma/pkg/core/runtime"
 	. "github.com/kumahq/kuma/pkg/test/matchers"
-	test_runtime "github.com/kumahq/kuma/pkg/test/runtime"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	v3 "github.com/kumahq/kuma/pkg/util/xds/v3"
 	. "github.com/kumahq/kuma/pkg/xds/server/callbacks"
@@ -25,11 +26,11 @@ var _ = Describe("DataplaneStatusTracker", func() {
 	var tracker DataplaneStatusTracker
 	var callbacks envoy_server.Callbacks
 
-	runtimeInfo := test_runtime.TestRuntimeInfo{InstanceId: "test"}
+	runtimeInfo := core_runtime.NewRuntimeInfo("test", core.Zone)
 	var ctx context.Context
 
 	BeforeEach(func() {
-		tracker = NewDataplaneStatusTracker(&runtimeInfo, func(dataplaneType core_model.ResourceType, accessor SubscriptionStatusAccessor) DataplaneInsightSink {
+		tracker = NewDataplaneStatusTracker(runtimeInfo, func(dataplaneType core_model.ResourceType, accessor SubscriptionStatusAccessor) DataplaneInsightSink {
 			return DataplaneInsightSinkFunc(func(<-chan struct{}) {})
 		})
 		callbacks = v3.AdaptCallbacks(tracker)


### PR DESCRIPTION
- Remove `TestRuntime` as it was just unecessary complexity
- Add clusterCreationTime to easily figure when a cluster was first created (roughly)
- Add a zoneHashName to be able to easily uniquely identity the number of zones in a cluster

This should provide better metadata for understand usage

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
