### PR TITLE
feat(MeshService): add events when generating from Kubernetes Service

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/meshservice_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/meshservice_controller.go
@@ -32,6 +32,12 @@ import (
 )
 
 const (
+	// CreatedMeshServiceReason is added to an event when
+	// a new MeshService is successfully created.
+	CreatedMeshServiceReason = "CreatedMeshService"
+	// UpdatedMeshServiceReason is added to an event when
+	// an existing MeshService is successfully updated.
+	UpdatedMeshServiceReason = "UpdatedMeshService"
 	// FailedToGenerateMeshServiceReason is added to an event when
 	// a MeshService cannot be generated.
 	FailedToGenerateMeshServiceReason = "FailedToGenerateMeshService"
@@ -161,7 +167,12 @@ func (r *MeshServiceReconciler) Reconcile(ctx context.Context, req kube_ctrl.Req
 	if err != nil {
 		return kube_ctrl.Result{}, err
 	}
-
+	switch operationResult {
+	case kube_controllerutil.OperationResultCreated:
+		r.EventRecorder.Eventf(svc, kube_core.EventTypeNormal, CreatedMeshServiceReason, "Created Kuma MeshService: %s", ms.Name)
+	case kube_controllerutil.OperationResultUpdated:
+		r.EventRecorder.Eventf(svc, kube_core.EventTypeNormal, UpdatedMeshServiceReason, "Updated Kuma MeshService: %s", ms.Name)
+	}
 	log.V(1).Info("mesh service reconciled", "result", operationResult)
 	return kube_ctrl.Result{}, nil
 }

--- a/pkg/plugins/runtime/k8s/controllers/meshservice_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/meshservice_controller.go
@@ -8,9 +8,10 @@ import (
 	"github.com/pkg/errors"
 	kube_core "k8s.io/api/core/v1"
 	kube_apierrs "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_runtime "k8s.io/apimachinery/pkg/runtime"
 	kube_types "k8s.io/apimachinery/pkg/types"
+	kube_record "k8s.io/client-go/tools/record"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -30,9 +31,16 @@ import (
 	"github.com/kumahq/kuma/pkg/util/pointer"
 )
 
+const (
+	// FailedToGenerateMeshServiceReason is added to an event when
+	// a MeshService cannot be generated.
+	FailedToGenerateMeshServiceReason = "FailedToGenerateMeshService"
+)
+
 // MeshServiceReconciler reconciles a MeshService object
 type MeshServiceReconciler struct {
 	kube_client.Client
+	kube_record.EventRecorder
 	Log    logr.Logger
 	Scheme *kube_runtime.Scheme
 }
@@ -101,16 +109,22 @@ func (r *MeshServiceReconciler) Reconcile(ctx context.Context, req kube_ctrl.Req
 			Namespace: svc.GetNamespace(),
 		},
 	}
-	if err := kube_controllerutil.SetOwnerReference(svc, ms, r.Scheme); err != nil {
-		return kube_ctrl.Result{}, errors.Wrap(err, "could not set owner reference")
-	}
 
 	operationResult, err := kube_controllerutil.CreateOrUpdate(ctx, r.Client, ms, func() error {
+		if ms.ObjectMeta.GetGeneration() != 0 {
+			if owners := ms.GetOwnerReferences(); len(owners) == 0 || owners[0].UID != svc.GetUID() {
+				r.EventRecorder.Eventf(
+					svc, kube_core.EventTypeWarning, FailedToGenerateMeshServiceReason, "MeshService already exists and isn't owned by Service",
+				)
+				return errors.Errorf("MeshService already exists and isn't owned by Service")
+			}
+		}
 		ms.ObjectMeta.Labels = maps.Clone(svc.GetLabels())
 		if ms.ObjectMeta.Labels == nil {
 			ms.ObjectMeta.Labels = map[string]string{}
 		}
 		ms.ObjectMeta.Labels[mesh_proto.MeshTag] = mesh
+		ms.ObjectMeta.Labels[metadata.KumaSerivceName] = svc.GetName()
 		if ms.Spec == nil {
 			ms.Spec = &meshservice_api.MeshService{}
 		}
@@ -138,6 +152,9 @@ func (r *MeshServiceReconciler) Reconcile(ctx context.Context, req kube_ctrl.Req
 			{
 				IP: svc.Spec.ClusterIP,
 			},
+		}
+		if err := kube_controllerutil.SetOwnerReference(svc, ms, r.Scheme); err != nil {
+			return errors.Wrap(err, "could not set owner reference")
 		}
 		return nil
 	})

--- a/pkg/plugins/runtime/k8s/controllers/meshservice_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/meshservice_controller_test.go
@@ -12,6 +12,7 @@ import (
 	kube_core "k8s.io/api/core/v1"
 	kube_errors "k8s.io/apimachinery/pkg/api/errors"
 	kube_types "k8s.io/apimachinery/pkg/types"
+	kube_record "k8s.io/client-go/tools/record"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 	kube_client_fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -62,9 +63,10 @@ var _ = Describe("MeshServiceController", func() {
 				Build()
 
 			reconciler = &MeshServiceReconciler{
-				Client: kubeClient,
-				Log:    logr.Discard(),
-				Scheme: k8sClientScheme,
+				Client:        kubeClient,
+				Log:           logr.Discard(),
+				Scheme:        k8sClientScheme,
+				EventRecorder: kube_record.NewFakeRecorder(10),
 			}
 
 			key := kube_types.NamespacedName{

--- a/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/01.meshservice.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/01.meshservice.yaml
@@ -1,6 +1,7 @@
 metadata:
   creationTimestamp: null
   labels:
+    k8s.kuma.io/service-name: example
     kuma.io/mesh: default
   name: example
   namespace: demo

--- a/pkg/plugins/runtime/k8s/metadata/annotations.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations.go
@@ -115,6 +115,9 @@ const (
 	KumaInitFirst = "kuma.io/init-first"
 	// KumaWaitForDataplaneReady allows to specify if the application sidecar should be hold until Envoy is ready
 	KumaWaitForDataplaneReady = "kuma.io/wait-for-dataplane-ready"
+
+	// KumaServiceName points to the Service that a MeshService is derived from
+	KumaSerivceName = "k8s.kuma.io/service-name"
 )
 
 var PodAnnotationDeprecations = []Deprecation{

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -142,9 +142,10 @@ func addServiceReconciler(mgr kube_ctrl.Manager) error {
 
 func addMeshServiceReconciler(mgr kube_ctrl.Manager) error {
 	reconciler := &k8s_controllers.MeshServiceReconciler{
-		Client: mgr.GetClient(),
-		Log:    core.Log.WithName("controllers").WithName("MeshService"),
-		Scheme: mgr.GetScheme(),
+		Client:        mgr.GetClient(),
+		Log:           core.Log.WithName("controllers").WithName("MeshService"),
+		Scheme:        mgr.GetScheme(),
+		EventRecorder: mgr.GetEventRecorderFor("k8s.kuma.io/mesh-service-generator"),
 	}
 	return reconciler.SetupWithManager(mgr)
 }


### PR DESCRIPTION
Also sets `k8s.kuma.io/service-name`

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
