### PR TITLE
fix(kds): fix updating metric of kds client version

### DIFF
--- a/pkg/util/xds/stats_callbacks.go
+++ b/pkg/util/xds/stats_callbacks.go
@@ -151,18 +151,9 @@ func (s *statsCallbacks) OnStreamClosed(streamID int64) {
 	}
 }
 
-func (s *statsCallbacks) OnStreamRequest(streamID int64, request DiscoveryRequest) error {
+func (s *statsCallbacks) OnStreamRequest(_ int64, request DiscoveryRequest) error {
 	if request.VersionInfo() == "" {
 		return nil // It's initial DiscoveryRequest to ask for resources. It's neither ACK nor NACK.
-	}
-
-	if ver := s.versionExtractor(request.Metadata()); ver != "" {
-		s.Lock()
-		if _, ok := s.versionsForStream[streamID]; !ok {
-			s.versionsForStream[streamID] = ver
-			s.versionsMetric.WithLabelValues(ver).Inc()
-		}
-		s.Unlock()
 	}
 
 	if request.HasErrors() {
@@ -185,7 +176,16 @@ func (s *statsCallbacks) takeConfigTimeFromQueue(configVersion string) (time.Tim
 	return generatedTime, ok
 }
 
-func (s *statsCallbacks) OnStreamResponse(_ int64, _ DiscoveryRequest, response DiscoveryResponse) {
+func (s *statsCallbacks) OnStreamResponse(streamID int64, request DiscoveryRequest, response DiscoveryResponse) {
+	if ver := s.versionExtractor(request.Metadata()); ver != "" {
+		s.Lock()
+		if _, ok := s.versionsForStream[streamID]; !ok {
+			s.versionsForStream[streamID] = ver
+			s.versionsMetric.WithLabelValues(ver).Inc()
+		}
+		s.Unlock()
+	}
+
 	s.responsesSentMetric.WithLabelValues(response.GetTypeUrl()).Inc()
 }
 
@@ -206,18 +206,9 @@ func (s *statsCallbacks) OnDeltaStreamClosed(streamID int64) {
 	}
 }
 
-func (s *statsCallbacks) OnStreamDeltaRequest(streamID int64, request DeltaDiscoveryRequest) error {
+func (s *statsCallbacks) OnStreamDeltaRequest(_ int64, request DeltaDiscoveryRequest) error {
 	if request.GetResponseNonce() == "" {
 		return nil // It's initial DiscoveryRequest to ask for resources. It's neither ACK nor NACK.
-	}
-
-	if ver := s.versionExtractor(request.Metadata()); ver != "" {
-		s.Lock()
-		if _, ok := s.versionsForStream[streamID]; !ok {
-			s.versionsForStream[streamID] = ver
-			s.versionsMetric.WithLabelValues(ver).Inc()
-		}
-		s.Unlock()
 	}
 
 	if request.HasErrors() {
@@ -233,7 +224,16 @@ func (s *statsCallbacks) OnStreamDeltaRequest(streamID int64, request DeltaDisco
 	return nil
 }
 
-func (s *statsCallbacks) OnStreamDeltaResponse(_ int64, _ DeltaDiscoveryRequest, response DeltaDiscoveryResponse) {
+func (s *statsCallbacks) OnStreamDeltaResponse(streamID int64, request DeltaDiscoveryRequest, response DeltaDiscoveryResponse) {
+	if ver := s.versionExtractor(request.Metadata()); ver != "" {
+		s.Lock()
+		if _, ok := s.versionsForStream[streamID]; !ok {
+			s.versionsForStream[streamID] = ver
+			s.versionsMetric.WithLabelValues(ver).Inc()
+		}
+		s.Unlock()
+	}
+
 	s.responsesSentMetric.WithLabelValues(response.GetTypeUrl()).Inc()
 }
 

--- a/pkg/util/xds/stats_callbacks_test.go
+++ b/pkg/util/xds/stats_callbacks_test.go
@@ -111,10 +111,13 @@ var _ = Describe("Stats callbacks", func() {
 				VersionInfo: "123",
 				Node:        node,
 			}
-			err := adaptedCallbacks.OnStreamRequest(streamId, req)
+			resp := &envoy_discovery.DiscoveryResponse{
+				TypeUrl:     resource.RouteType,
+				VersionInfo: "123",
+			}
+			adaptedCallbacks.OnStreamResponse(context.Background(), streamId, req, resp)
 
 			// then
-			Expect(err).ToNot(HaveOccurred())
 			Expect(test_metrics.FindMetric(metrics, "xds_client_versions", "version", "1.0.0").GetGauge().GetValue()).To(Equal(1.0))
 
 			// when
@@ -293,10 +296,13 @@ var _ = Describe("Stats callbacks", func() {
 				Node:          node,
 				ResponseNonce: "1",
 			}
-			err := adaptedCallbacks.OnStreamDeltaRequest(streamId, req)
+			resp := &envoy_discovery.DeltaDiscoveryResponse{
+				TypeUrl:           resource.RouteType,
+				SystemVersionInfo: "123",
+			}
+			adaptedCallbacks.OnStreamDeltaResponse(streamId, req, resp)
 
 			// then
-			Expect(err).ToNot(HaveOccurred())
 			Expect(test_metrics.FindMetric(metrics, "delta_xds_client_versions", "version", "1.0.0").GetGauge().GetValue()).To(Equal(1.0))
 
 			// when


### PR DESCRIPTION
We were updating metric in `OnStreamRequest` method, problem is that in case of Global this is run after sending discovery request to zone not after receiving one from zone. We need to update this metric in `OnStreamResponse` where we have original request from zone with metadata

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
