### PR TITLE
fix(GatewayAPI): only enqueue Gateway reconciliations from routes if parent is a Gateway

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
@@ -181,6 +181,14 @@ func gatewaysForRoute(l logr.Logger) kube_handler.MapFunc {
 
 		var requests []kube_reconcile.Request
 		for _, parentRef := range route.Spec.ParentRefs {
+			if parentRef.Group != nil && *parentRef.Group != gatewayapi.GroupName {
+				continue
+			}
+
+			if parentRef.Kind != nil && *parentRef.Kind != "Gateway" {
+				continue
+			}
+
 			namespace := route.Namespace
 			if parentRef.Namespace != nil {
 				namespace = string(*parentRef.Namespace)
@@ -350,6 +358,14 @@ func (r *GatewayReconciler) SetupWithManager(mgr kube_ctrl.Manager) error {
 		var names []string
 
 		for _, parentRef := range route.Spec.ParentRefs {
+			if parentRef.Group != nil && *parentRef.Group != gatewayapi.GroupName {
+				continue
+			}
+
+			if parentRef.Kind != nil && *parentRef.Kind != "Gateway" {
+				continue
+			}
+
 			namespace := route.Namespace
 			if parentRef.Namespace != nil {
 				namespace = string(*parentRef.Namespace)

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
@@ -181,6 +181,7 @@ func gatewaysForRoute(l logr.Logger) kube_handler.MapFunc {
 
 		var requests []kube_reconcile.Request
 		for _, parentRef := range route.Spec.ParentRefs {
+			// parentRef.Group & Kind won't be nil as they have a default value
 			if *parentRef.Group != gatewayapi.GroupName || *parentRef.Kind != "Gateway" {
 				continue
 			}
@@ -354,6 +355,7 @@ func (r *GatewayReconciler) SetupWithManager(mgr kube_ctrl.Manager) error {
 		var names []string
 
 		for _, parentRef := range route.Spec.ParentRefs {
+			// parentRef.Group & Kind won't be nil as they have a default value
 			if *parentRef.Group != gatewayapi.GroupName || *parentRef.Kind != "Gateway" {
 				continue
 			}

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
@@ -181,11 +181,7 @@ func gatewaysForRoute(l logr.Logger) kube_handler.MapFunc {
 
 		var requests []kube_reconcile.Request
 		for _, parentRef := range route.Spec.ParentRefs {
-			if parentRef.Group != nil && *parentRef.Group != gatewayapi.GroupName {
-				continue
-			}
-
-			if parentRef.Kind != nil && *parentRef.Kind != "Gateway" {
+			if *parentRef.Group != gatewayapi.GroupName || *parentRef.Kind != "Gateway" {
 				continue
 			}
 
@@ -358,11 +354,7 @@ func (r *GatewayReconciler) SetupWithManager(mgr kube_ctrl.Manager) error {
 		var names []string
 
 		for _, parentRef := range route.Spec.ParentRefs {
-			if parentRef.Group != nil && *parentRef.Group != gatewayapi.GroupName {
-				continue
-			}
-
-			if parentRef.Kind != nil && *parentRef.Kind != "Gateway" {
+			if *parentRef.Group != gatewayapi.GroupName || *parentRef.Kind != "Gateway" {
 				continue
 			}
 


### PR DESCRIPTION
For example, in GAMMA, the parentRef can also be a Service.
Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
