### PR TITLE
ci(lint): don't accidentally append to non-zero length slices

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,7 @@ linters:
     - whitespace
     - nosprintfhostport
     - loggercheck
+    - makezero
 
 run:
   skip-files:

--- a/api/common/v1alpha1/ref.go
+++ b/api/common/v1alpha1/ref.go
@@ -99,7 +99,7 @@ type BackendRefHash string
 func (in BackendRef) Hash() BackendRefHash {
 	keys := maps.Keys(in.Tags)
 	sort.Strings(keys)
-	orderedTags := make([]string, len(keys))
+	orderedTags := make([]string, 0, len(keys))
 	for _, k := range keys {
 		orderedTags = append(orderedTags, fmt.Sprintf("%s=%s", k, in.Tags[k]))
 	}

--- a/app/kumactl/cmd/install/install_observability.go
+++ b/app/kumactl/cmd/install/install_observability.go
@@ -39,7 +39,7 @@ func newInstallObservability(pctx *kumactl_cmd.RootContext) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			combinedResources := make([]data.File, len(metrics)+len(logging)+len(tracing))
+			combinedResources := make([]data.File, 0, len(metrics)+len(logging)+len(tracing))
 			combinedResources = append(combinedResources, metrics...)
 			combinedResources = append(combinedResources, logging...)
 			combinedResources = append(combinedResources, tracing...)


### PR DESCRIPTION
### Checklist prior to review

I was running github actions to run linter [makezero](https://github.com/ashanbrown/makezero) for top github golang repos.

see issues https://github.com/alingse/go-linter-runner/issues/1

and the github actions output https://github.com/alingse/go-linter-runner/actions/runs/9242968813/job/25426482280 

```
====================================================================================================
append to slice `orderedTags` with non-zero initialized length at https://github.com/kumahq/kuma/blob/master/api/common/v1alpha1/ref.go#L104:17
append to slice `combinedResources` with non-zero initialized length at https://github.com/kumahq/kuma/blob/master/app/kumactl/cmd/install/install_observability.go#L43:24
append to slice `combinedResources` with non-zero initialized length at https://github.com/kumahq/kuma/blob/master/app/kumactl/cmd/install/install_observability.go#L44:24
append to slice `combinedResources` with non-zero initialized length at https://github.com/kumahq/kuma/blob/master/app/kumactl/cmd/install/install_observability.go#L45:24
====================================================================================================
```


<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
