### PR TITLE
feat(meshservice): ipam

### DIFF
--- a/app/kuma-cp/cmd/run.go
+++ b/app/kuma-cp/cmd/run.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kumahq/kuma/pkg/hds"
 	"github.com/kumahq/kuma/pkg/insights"
 	"github.com/kumahq/kuma/pkg/intercp"
+	"github.com/kumahq/kuma/pkg/ipam"
 	kds_global "github.com/kumahq/kuma/pkg/kds/global"
 	kds_zone "github.com/kumahq/kuma/pkg/kds/zone"
 	mads_server "github.com/kumahq/kuma/pkg/mads/server"
@@ -143,6 +144,10 @@ func newRunCmdWithOpts(opts kuma_cmd.RunCmdOpts) *cobra.Command {
 			}
 			if err := intercp.Setup(rt); err != nil {
 				runLog.Error(err, "unable to set up Control Plane Intercommunication")
+				return err
+			}
+			if err := ipam.Setup(rt); err != nil {
+				runLog.Error(err, "unable to set up IPAM")
 				return err
 			}
 

--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -793,3 +793,11 @@ coreResources:
   enabled: # ENV: KUMA_CORE_RESOURCES_ENABLED
     - meshexternalservices
     - meshservices
+# IP address management configuration
+ipam:
+  # MeshService address management
+  meshService:
+    # CIDR for MeshService IPs
+    cidr: 241.0.0.0/8 # ENV: IPAM_MESH_SERVICE_CIDR
+    # Interval on which Kuma will allocate new IPs for MeshServices
+    allocationInterval: 5s # ENV: IPAM_MESH_SERVICE_ALLOCATION_INTERVAL

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -793,3 +793,11 @@ coreResources:
   enabled: # ENV: KUMA_CORE_RESOURCES_ENABLED
     - meshexternalservices
     - meshservices
+# IP address management configuration
+ipam:
+  # MeshService address management
+  meshService:
+    # CIDR for MeshService IPs
+    cidr: 241.0.0.0/8 # ENV: IPAM_MESH_SERVICE_CIDR
+    # Interval on which Kuma will allocate new IPs for MeshServices
+    allocationInterval: 5s # ENV: IPAM_MESH_SERVICE_ALLOCATION_INTERVAL

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -372,6 +372,9 @@ var _ = Describe("Config loader", func() {
 
 			Expect(cfg.Proxy.Gateway.GlobalDownstreamMaxConnections).To(BeNumerically("==", 1))
 			Expect(cfg.EventBus.BufferSize).To(Equal(uint(30)))
+
+			Expect(cfg.IPAM.MeshService.CIDR).To(Equal("251.0.0.0/8"))
+			Expect(cfg.IPAM.MeshService.AllocationInterval.Duration).To(Equal(7 * time.Second))
 		},
 		Entry("from config file", testCase{
 			envVars: map[string]string{},
@@ -748,6 +751,10 @@ tracing:
   openTelemetry:
     enabled: true
     endpoint: collector:4317
+ipam:
+  meshService:
+    cidr: 251.0.0.0/8
+    allocationInterval: 7s
 `,
 		}),
 		Entry("from env variables", testCase{
@@ -1026,6 +1033,8 @@ tracing:
 				"KUMA_EVENT_BUS_BUFFER_SIZE":                                                               "30",
 				"KUMA_PLUGIN_POLICIES_ENABLED":                                                             "meshaccesslog,meshcircuitbreaker",
 				"KUMA_CORE_RESOURCES_ENABLED":                                                              "meshservice",
+				"KUMA_IPAM_MESH_SERVICE_CIDR":                                                              "251.0.0.0/8",
+				"KUMA_IPAM_MESH_SERVICE_ALLOCATION_INTERVAL":                                               "7s",
 			},
 			yamlFileConfig: "",
 		}),

--- a/pkg/core/resources/apis/meshservice/vip/allocator.go
+++ b/pkg/core/resources/apis/meshservice/vip/allocator.go
@@ -1,0 +1,146 @@
+package vip
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"github.com/Nordix/simple-ipam/pkg/ipam"
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/kumahq/kuma/pkg/core"
+	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
+	"github.com/kumahq/kuma/pkg/core/resources/manager"
+	"github.com/kumahq/kuma/pkg/core/resources/store"
+	"github.com/kumahq/kuma/pkg/core/runtime/component"
+	"github.com/kumahq/kuma/pkg/core/user"
+	core_metrics "github.com/kumahq/kuma/pkg/metrics"
+)
+
+// Allocator manages IPs for MeshServices.
+// Each time allocator starts it initiates the IPAM based on existing MeshServices
+// We don't free addresses explicitly, but we always allocate next free IP to avoid a problem when we
+// 1) Remove Service A with IP X
+// 2) Add new Service B that gets IP X
+// 3) Clients that were sending the traffic to A now sends the traffic to B for brief amount of time
+// IPAM is kept in memory to avoid state management, so technically this problem can still happen when leader changes
+// However, leader should not change before TTL of a DNS that serves this VIP.
+//
+// It's technically possible to allocate all addresses by creating and removing services in the loop.
+// However, CIDR has range of 16M addresses, after that the component will just restart.
+type Allocator struct {
+	logger     logr.Logger
+	cidr       string
+	interval   time.Duration
+	metric     prometheus.Summary
+	resManager manager.ResourceManager
+}
+
+var _ component.Component = &Allocator{}
+
+func NewAllocator(
+	logger logr.Logger,
+	metrics core_metrics.Metrics,
+	resManager manager.ResourceManager,
+	cidr string,
+	interval time.Duration,
+) (*Allocator, error) {
+	metric := prometheus.NewSummary(prometheus.SummaryOpts{
+		Name:       "component_ms_vip_allocator",
+		Help:       "Summary of Inter CP Heartbeat component interval",
+		Objectives: core_metrics.DefaultObjectives,
+	})
+	if err := metrics.Register(metric); err != nil {
+		return nil, err
+	}
+
+	return &Allocator{
+		logger:     logger,
+		resManager: resManager,
+		cidr:       cidr,
+		interval:   interval,
+		metric:     metric,
+	}, nil
+}
+
+func (a *Allocator) Start(stop <-chan struct{}) error {
+	ticker := time.NewTicker(a.interval)
+	ctx := user.Ctx(context.Background(), user.ControlPlane)
+
+	kumaIpam, err := a.initIpam(ctx)
+	if err != nil {
+		return err
+	}
+
+	for {
+		select {
+		case <-ticker.C:
+			start := core.Now()
+			if err := a.allocateVips(ctx, kumaIpam); err != nil {
+				return err
+			}
+			a.metric.Observe(float64(core.Now().Sub(start).Milliseconds()))
+		case <-stop:
+			a.logger.Info("stopping")
+			return nil
+		}
+	}
+}
+
+func (a *Allocator) NeedLeaderElection() bool {
+	return true
+}
+
+func (a *Allocator) initIpam(ctx context.Context) (*ipam.IPAM, error) {
+	newIPAM, err := ipam.New(a.cidr)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not allocate IPAM of CIDR %s", a.cidr)
+	}
+
+	services := &meshservice_api.MeshServiceResourceList{}
+	if err := a.resManager.List(ctx, services); err != nil {
+		return nil, errors.Wrap(err, "could not list mesh services for initialization of ipam")
+	}
+	for _, service := range services.Items {
+		for _, vip := range service.Status.VIPs {
+			_ = newIPAM.Reserve(net.ParseIP(vip.IP)) // ignore error for outside of range
+		}
+	}
+
+	return newIPAM, nil
+}
+
+func (a *Allocator) allocateVips(ctx context.Context, kumaIpam *ipam.IPAM) error {
+	services := &meshservice_api.MeshServiceResourceList{}
+	if err := a.resManager.List(ctx, services); err != nil {
+		return errors.Wrap(err, "could not list mesh services for ip allocation")
+	}
+
+	for _, svc := range services.Items {
+		if len(svc.Status.VIPs) == 0 {
+			log := a.logger.WithValues("service", svc.Meta.GetName(), "mesh", svc.Meta.GetMesh())
+			ip, err := kumaIpam.Allocate()
+			if err != nil {
+				return errors.Wrapf(err, "could not allocate the address for svc %s", svc.Meta.GetName())
+			}
+			log.Info("allocating IP for a service", "ip", ip.String())
+			svc.Status.VIPs = []meshservice_api.VIP{
+				{
+					IP: ip.String(),
+				},
+			}
+
+			if err := a.resManager.Update(ctx, svc); err != nil {
+				msg := "could not update service with allocated Kuma VIP. Will try to update in the next allocation window"
+				if errors.Is(err, &store.ResourceConflictError{}) {
+					log.Info(msg, "cause", "conflict", "interval", a.interval)
+				} else {
+					log.Error(err, msg, "interval", a.interval)
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/core/resources/apis/meshservice/vip/allocator.go
+++ b/pkg/core/resources/apis/meshservice/vip/allocator.go
@@ -81,7 +81,7 @@ func (a *Allocator) Start(stop <-chan struct{}) error {
 			if err := a.allocateVips(ctx, kumaIpam); err != nil {
 				return err
 			}
-			a.metric.Observe(float64(time.Now().Sub(start).Milliseconds()))
+			a.metric.Observe(float64(time.Since(start).Milliseconds()))
 		case <-stop:
 			a.logger.Info("stopping")
 			return nil

--- a/pkg/core/resources/apis/meshservice/vip/allocator_test.go
+++ b/pkg/core/resources/apis/meshservice/vip/allocator_test.go
@@ -1,0 +1,92 @@
+package vip
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
+	"github.com/kumahq/kuma/pkg/core/resources/manager"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/core/resources/store"
+	core_metrics "github.com/kumahq/kuma/pkg/metrics"
+	"github.com/kumahq/kuma/pkg/plugins/resources/memory"
+	test_metrics "github.com/kumahq/kuma/pkg/test/metrics"
+	"github.com/kumahq/kuma/pkg/test/resources/samples"
+)
+
+var _ = Describe("VIP Allocator", func() {
+	var stopCh chan struct{}
+	var resManager manager.ResourceManager
+	var metrics core_metrics.Metrics
+
+	BeforeEach(func() {
+		m, err := core_metrics.NewMetrics("")
+		Expect(err).ToNot(HaveOccurred())
+		metrics = m
+		resManager = manager.NewResourceManager(memory.NewStore())
+		allocator, err := NewAllocator(logr.Discard(), m, resManager, "241.0.0.0/8", 50*time.Millisecond)
+		Expect(err).ToNot(HaveOccurred())
+		stopCh = make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			Expect(allocator.Start(stopCh)).To(Succeed())
+		}()
+
+		Expect(samples.MeshDefaultBuilder().Create(resManager)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		close(stopCh)
+	})
+
+	vipOfMeshService := func(name string) string {
+		ms := meshservice_api.NewMeshServiceResource()
+		err := resManager.Get(context.Background(), ms, store.GetByKey(name, model.DefaultMesh))
+		Expect(err).ToNot(HaveOccurred())
+		if len(ms.Status.VIPs) == 0 {
+			return ""
+		}
+		return ms.Status.VIPs[0].IP
+	}
+
+	It("should allocate vip for service without vip", func() {
+		// when
+		err := samples.MeshServiceBackendBuilder().WithoutVIP().Create(resManager)
+		Expect(err).ToNot(HaveOccurred())
+
+		// then
+		Eventually(func(g Gomega) {
+			g.Expect(vipOfMeshService("backend")).Should(Equal("241.0.0.0"))
+		}, "10s", "100ms").Should(Succeed())
+	})
+
+	It("should not reuse IPs", func() {
+		// given
+		err := samples.MeshServiceBackendBuilder().WithoutVIP().Create(resManager)
+		Expect(err).ToNot(HaveOccurred())
+		Eventually(func(g Gomega) {
+			g.Expect(vipOfMeshService("backend")).Should(Equal("241.0.0.0"))
+		}, "10s", "100ms").Should(Succeed())
+
+		// when resource is reapplied
+		err = resManager.Delete(context.Background(), meshservice_api.NewMeshServiceResource(), store.DeleteByKey("backend", model.DefaultMesh))
+		Expect(err).ToNot(HaveOccurred())
+		err = samples.MeshServiceBackendBuilder().WithoutVIP().Create(resManager)
+		Expect(err).ToNot(HaveOccurred())
+
+		// then
+		Eventually(func(g Gomega) {
+			g.Expect(vipOfMeshService("backend")).Should(Equal("241.0.0.1"))
+		}, "10s", "100ms").Should(Succeed())
+	})
+
+	It("should emit metric", func() {
+		Eventually(func(g Gomega) {
+			g.Expect(test_metrics.FindMetric(metrics, "component_ms_vip_allocator")).ToNot(BeNil())
+		}, "10s", "100ms").Should(Succeed())
+	})
+})

--- a/pkg/core/resources/apis/meshservice/vip/suite_test.go
+++ b/pkg/core/resources/apis/meshservice/vip/suite_test.go
@@ -1,0 +1,11 @@
+package vip_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/pkg/test"
+)
+
+func TestVIP(t *testing.T) {
+	test.RunSpecs(t, "MeshService VIP Suite")
+}

--- a/pkg/ipam/components.go
+++ b/pkg/ipam/components.go
@@ -3,6 +3,7 @@ package ipam
 import (
 	"slices"
 
+	config_core "github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/vip"
 	"github.com/kumahq/kuma/pkg/core/runtime"
@@ -10,10 +11,14 @@ import (
 )
 
 func Setup(rt runtime.Runtime) error {
-	if !slices.Contains(rt.Config().CoreResources.Enabled, "meshservice") {
+	if rt.GetMode() == config_core.Global {
 		return nil
 	}
 	logger := core.Log.WithName("meshservice").WithName("vips").WithName("allocator")
+	if !slices.Contains(rt.Config().CoreResources.Enabled, "meshservices") {
+		logger.Info("MeshService is not enabled. Not enabling VIP allocator for MeshService.")
+		return nil
+	}
 	allocator, err := vip.NewAllocator(
 		logger,
 		rt.Metrics(),

--- a/pkg/ipam/components.go
+++ b/pkg/ipam/components.go
@@ -1,0 +1,33 @@
+package ipam
+
+import (
+	"slices"
+
+	"github.com/kumahq/kuma/pkg/core"
+	"github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/vip"
+	"github.com/kumahq/kuma/pkg/core/runtime"
+	"github.com/kumahq/kuma/pkg/core/runtime/component"
+)
+
+func Setup(rt runtime.Runtime) error {
+	if !slices.Contains(rt.Config().CoreResources.Enabled, "meshservice") {
+		return nil
+	}
+	logger := core.Log.WithName("meshservice").WithName("vips").WithName("allocator")
+	allocator, err := vip.NewAllocator(
+		logger,
+		rt.Metrics(),
+		rt.ResourceManager(),
+		rt.Config().IPAM.MeshService.CIDR,
+		rt.Config().IPAM.MeshService.AllocationInterval.Duration,
+	)
+	if err != nil {
+		return err
+	}
+	return rt.Add(component.NewResilientComponent(
+		logger,
+		allocator,
+		rt.Config().General.ResilientComponentBaseBackoff.Duration,
+		rt.Config().General.ResilientComponentMaxBackoff.Duration,
+	))
+}

--- a/pkg/ipam/components.go
+++ b/pkg/ipam/components.go
@@ -16,7 +16,7 @@ func Setup(rt runtime.Runtime) error {
 	}
 	logger := core.Log.WithName("meshservice").WithName("vips").WithName("allocator")
 	if !slices.Contains(rt.Config().CoreResources.Enabled, "meshservices") {
-		logger.Info("MeshService is not enabled. Not enabling VIP allocator for MeshService.")
+		logger.Info("MeshService is not enabled. Skip starting VIP allocator for MeshService.")
 		return nil
 	}
 	allocator, err := vip.NewAllocator(

--- a/pkg/test/resources/builders/meshservice_builder.go
+++ b/pkg/test/resources/builders/meshservice_builder.go
@@ -1,0 +1,88 @@
+package builders
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/core/resources/store"
+	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
+)
+
+type MeshServiceBuilder struct {
+	res *v1alpha1.MeshServiceResource
+}
+
+func MeshService() *MeshServiceBuilder {
+	return &MeshServiceBuilder{
+		res: &v1alpha1.MeshServiceResource{
+			Meta: &test_model.ResourceMeta{
+				Mesh: core_model.DefaultMesh,
+				Name: "backend",
+			},
+			Spec:   &v1alpha1.MeshService{},
+			Status: &v1alpha1.MeshServiceStatus{},
+		},
+	}
+}
+
+func (m *MeshServiceBuilder) WithName(name string) *MeshServiceBuilder {
+	m.res.Meta.(*test_model.ResourceMeta).Name = name
+	return m
+}
+
+func (m *MeshServiceBuilder) WithMesh(mesh string) *MeshServiceBuilder {
+	m.res.Meta.(*test_model.ResourceMeta).Mesh = mesh
+	return m
+}
+
+func (m *MeshServiceBuilder) WithDataplaneTagsSelector(selector map[string]string) *MeshServiceBuilder {
+	m.res.Spec.Selector = v1alpha1.Selector{
+		DataplaneTags: selector,
+	}
+	return m
+}
+
+func (m *MeshServiceBuilder) AddIntPort(port, target uint32, protocol core_mesh.Protocol) *MeshServiceBuilder {
+	m.res.Spec.Ports = append(m.res.Spec.Ports, v1alpha1.Port{
+		Port: port,
+		TargetPort: intstr.IntOrString{
+			Type:   intstr.Int,
+			IntVal: int32(target),
+		},
+		Protocol: protocol,
+	})
+	return m
+}
+
+func (m *MeshServiceBuilder) WithKumaVIP(vip string) *MeshServiceBuilder {
+	m.res.Status.VIPs = []v1alpha1.VIP{
+		{
+			IP: vip,
+		},
+	}
+	return m
+}
+
+func (m *MeshServiceBuilder) WithoutVIP() *MeshServiceBuilder {
+	m.res.Status.VIPs = []v1alpha1.VIP{}
+	return m
+}
+
+func (m *MeshServiceBuilder) Build() *v1alpha1.MeshServiceResource {
+	if err := m.res.Validate(); err != nil {
+		panic(err)
+	}
+	return m.res
+}
+
+func (m *MeshServiceBuilder) Create(s store.ResourceStore) error {
+	return s.Create(context.Background(), m.Build(), store.CreateBy(m.Key()))
+}
+
+func (m *MeshServiceBuilder) Key() core_model.ResourceKey {
+	return core_model.MetaToResourceKey(m.res.GetMeta())
+}

--- a/pkg/test/resources/samples/meshservice_samples.go
+++ b/pkg/test/resources/samples/meshservice_samples.go
@@ -1,0 +1,20 @@
+package samples
+
+import (
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
+	"github.com/kumahq/kuma/pkg/test/resources/builders"
+)
+
+func MeshServiceBackendBuilder() *builders.MeshServiceBuilder {
+	return builders.MeshService().
+		WithDataplaneTagsSelector(map[string]string{
+			mesh_proto.ServiceTag: "backend",
+		}).
+		WithKumaVIP("240.0.0.1").
+		AddIntPort(builders.FirstInboundPort, builders.FirstInboundPort, "http")
+}
+
+func MeshServiceBackend() *v1alpha1.MeshServiceResource {
+	return MeshServiceBackendBuilder().Build()
+}


### PR DESCRIPTION
### Checklist prior to review

IPAM part of the implementation decided in [MADR 046](https://github.com/kumahq/kuma/blob/master/docs/madr/decisions/046-meshservice-hostname-vips.md).

Still unit tests. Will create e2e tests once we have hostname generator to actually check that we can communicate over DNS -> VIP.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
