### PR TITLE
test(MeshService): fix testdata references

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/meshservice_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/meshservice_controller_test.go
@@ -94,8 +94,8 @@ var _ = Describe("MeshServiceController", func() {
 			outputFile: "01.meshservice.yaml",
 		}),
 		Entry("with service with mesh label", testCase{
-			inputFile:  "01.resources.yaml",
-			outputFile: "01.meshservice.yaml",
+			inputFile:  "02.resources.yaml",
+			outputFile: "02.meshservice.yaml",
 		}),
 		Entry("without mesh label and sidecar injection namespace", testCase{
 			inputFile:  "03.resources.yaml",

--- a/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/02.meshservice.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/02.meshservice.yaml
@@ -1,6 +1,7 @@
 metadata:
   creationTimestamp: null
   labels:
+    k8s.kuma.io/service-name: example
     kuma.io/mesh: default
   name: example
   namespace: demo
@@ -19,7 +20,7 @@ spec:
     protocol: tcp
     targetPort: 8443
   selector: {}
-  status:
-    tls: {}
-    vips:
-    - ip: 192.168.0.1
+status:
+  tls: {}
+  vips:
+  - ip: 192.168.0.1


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
