### PR TITLE
test(MeshService): improve golden files in controller

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/meshservice_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/meshservice_controller_test.go
@@ -10,7 +10,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	kube_core "k8s.io/api/core/v1"
-	kube_errors "k8s.io/apimachinery/pkg/api/errors"
 	kube_types "k8s.io/apimachinery/pkg/types"
 	kube_record "k8s.io/client-go/tools/record"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
@@ -80,14 +79,9 @@ var _ = Describe("MeshServiceController", func() {
 			// then
 			Expect(err).ToNot(HaveOccurred())
 
-			ms := &meshservice_k8s.MeshService{}
-			actual := []byte("{}")
-			err = kubeClient.Get(context.Background(), key, ms)
-			if !kube_errors.IsNotFound(err) {
-				actual, err = yaml.Marshal(ms)
-				Expect(err).ToNot(HaveOccurred())
-			}
-			Expect(actual).To(MatchGoldenYAML("testdata", "meshservice", given.outputFile))
+			mss := &meshservice_k8s.MeshServiceList{}
+			Expect(kubeClient.List(context.Background(), mss)).To(Succeed())
+			Expect(yaml.Marshal(mss)).To(MatchGoldenYAML("testdata", "meshservice", given.outputFile))
 		},
 		Entry("with service in sidecar injection namespace", testCase{
 			inputFile:  "01.resources.yaml",

--- a/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/01.meshservice.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/01.meshservice.yaml
@@ -1,26 +1,28 @@
-metadata:
-  creationTimestamp: null
-  labels:
-    k8s.kuma.io/service-name: example
-    kuma.io/mesh: default
-  name: example
-  namespace: demo
-  ownerReferences:
-  - apiVersion: v1
-    kind: Service
+items:
+- metadata:
+    creationTimestamp: null
+    labels:
+      k8s.kuma.io/service-name: example
+      kuma.io/mesh: default
     name: example
-    uid: ""
-  resourceVersion: "1"
-spec:
-  ports:
-  - port: 80
-    protocol: http
-    targetPort: 8080
-  - port: 443
-    protocol: tcp
-    targetPort: 8443
-  selector: {}
-status:
-  tls: {}
-  vips:
-  - ip: 192.168.0.1
+    namespace: demo
+    ownerReferences:
+    - apiVersion: v1
+      kind: Service
+      name: example
+      uid: ""
+    resourceVersion: "1"
+  spec:
+    ports:
+    - port: 80
+      protocol: http
+      targetPort: 8080
+    - port: 443
+      protocol: tcp
+      targetPort: 8443
+    selector: {}
+  status:
+    tls: {}
+    vips:
+    - ip: 192.168.0.1
+metadata: {}

--- a/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/02.meshservice.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/02.meshservice.yaml
@@ -1,26 +1,28 @@
-metadata:
-  creationTimestamp: null
-  labels:
-    k8s.kuma.io/service-name: example
-    kuma.io/mesh: default
-  name: example
-  namespace: demo
-  ownerReferences:
-  - apiVersion: v1
-    kind: Service
+items:
+- metadata:
+    creationTimestamp: null
+    labels:
+      k8s.kuma.io/service-name: example
+      kuma.io/mesh: default
     name: example
-    uid: ""
-  resourceVersion: "1"
-spec:
-  ports:
-  - port: 80
-    protocol: http
-    targetPort: 8080
-  - port: 443
-    protocol: tcp
-    targetPort: 8443
-  selector: {}
-status:
-  tls: {}
-  vips:
-  - ip: 192.168.0.1
+    namespace: demo
+    ownerReferences:
+    - apiVersion: v1
+      kind: Service
+      name: example
+      uid: ""
+    resourceVersion: "1"
+  spec:
+    ports:
+    - port: 80
+      protocol: http
+      targetPort: 8080
+    - port: 443
+      protocol: tcp
+      targetPort: 8443
+    selector: {}
+  status:
+    tls: {}
+    vips:
+    - ip: 192.168.0.1
+metadata: {}

--- a/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/03.meshservice.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/03.meshservice.yaml
@@ -1,1 +1,2 @@
-{}
+items: []
+metadata: {}

--- a/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/04.meshservice.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/04.meshservice.yaml
@@ -1,1 +1,2 @@
-{}
+items: []
+metadata: {}

--- a/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/05.meshservice.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/05.meshservice.yaml
@@ -1,1 +1,2 @@
-{}
+items: null
+metadata: {}


### PR DESCRIPTION
Allows checking the state of all MeshServices

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
