### PR TITLE
fix(kds): change version label for kds_clint_versions metric

### DIFF
--- a/pkg/util/xds/stats_callbacks.go
+++ b/pkg/util/xds/stats_callbacks.go
@@ -126,7 +126,7 @@ func NewStatsCallbacks(metrics prometheus.Registerer, dsType string, versionExtr
 	stats.versionsMetric = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: dsType + "_client_versions",
 		Help: "Number of clients for each version. It only counts connections where they sent at least one request",
-	}, []string{"version"})
+	}, []string{"client_version"})
 	if err := metrics.Register(stats.versionsMetric); err != nil {
 		return nil, err
 	}

--- a/pkg/util/xds/stats_callbacks_test.go
+++ b/pkg/util/xds/stats_callbacks_test.go
@@ -118,13 +118,13 @@ var _ = Describe("Stats callbacks", func() {
 			adaptedCallbacks.OnStreamResponse(context.Background(), streamId, req, resp)
 
 			// then
-			Expect(test_metrics.FindMetric(metrics, "xds_client_versions", "version", "1.0.0").GetGauge().GetValue()).To(Equal(1.0))
+			Expect(test_metrics.FindMetric(metrics, "xds_client_versions", "client_version", "1.0.0").GetGauge().GetValue()).To(Equal(1.0))
 
 			// when
 			adaptedCallbacks.OnStreamClosed(streamId, node)
 
 			// then
-			Expect(test_metrics.FindMetric(metrics, "xds_client_versions", "version", "1.0.0").GetGauge().GetValue()).To(Equal(0.0))
+			Expect(test_metrics.FindMetric(metrics, "xds_client_versions", "client_version", "1.0.0").GetGauge().GetValue()).To(Equal(0.0))
 		})
 
 		It("should track NACK", func() {
@@ -303,7 +303,7 @@ var _ = Describe("Stats callbacks", func() {
 			adaptedCallbacks.OnStreamDeltaResponse(streamId, req, resp)
 
 			// then
-			Expect(test_metrics.FindMetric(metrics, "delta_xds_client_versions", "version", "1.0.0").GetGauge().GetValue()).To(Equal(1.0))
+			Expect(test_metrics.FindMetric(metrics, "delta_xds_client_versions", "client_version", "1.0.0").GetGauge().GetValue()).To(Equal(1.0))
 
 			// when
 			adaptedCallbacks.OnDeltaStreamClosed(streamId, node)


### PR DESCRIPTION
this metric label can collide with automatically added label `version` which results with invalid version label looking like: `$cp-version,$client-version` for example when using datadog

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --




<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
