### PR TITLE
feat(store): update does not wipe out labels

### DIFF
--- a/pkg/core/resources/apis/meshservice/vip/allocator.go
+++ b/pkg/core/resources/apis/meshservice/vip/allocator.go
@@ -132,7 +132,7 @@ func (a *Allocator) allocateVips(ctx context.Context, kumaIpam *ipam.IPAM) error
 				},
 			}
 
-			if err := a.resManager.Update(ctx, svc, store.UpdateWithLabels(svc.GetMeta().GetLabels())); err != nil {
+			if err := a.resManager.Update(ctx, svc); err != nil {
 				msg := "could not update service with allocated Kuma VIP. Will try to update in the next allocation window"
 				if errors.Is(err, &store.ResourceConflictError{}) {
 					log.Info(msg, "cause", "conflict", "interval", a.interval)

--- a/pkg/core/resources/store/options.go
+++ b/pkg/core/resources/store/options.go
@@ -57,6 +57,7 @@ func CreateWithLabels(labels map[string]string) CreateOptionsFunc {
 type UpdateOptions struct {
 	ModificationTime time.Time
 	Labels           map[string]string
+	ModifyLabels     bool
 }
 
 func ModifiedAt(modificationTime time.Time) UpdateOptionsFunc {
@@ -68,6 +69,7 @@ func ModifiedAt(modificationTime time.Time) UpdateOptionsFunc {
 func UpdateWithLabels(labels map[string]string) UpdateOptionsFunc {
 	return func(opts *UpdateOptions) {
 		opts.Labels = labels
+		opts.ModifyLabels = true
 	}
 }
 

--- a/pkg/plugins/resources/k8s/store.go
+++ b/pkg/plugins/resources/k8s/store.go
@@ -99,7 +99,11 @@ func (s *KubernetesStore) Update(ctx context.Context, r core_model.Resource, fs 
 		return errors.Wrapf(err, "failed to convert core model of type %s into k8s counterpart", r.Descriptor().Name)
 	}
 
-	labels, annotations := splitLabelsAndAnnotations(opts.Labels, obj.GetAnnotations())
+	updateLabels := r.GetMeta().GetLabels()
+	if opts.ModifyLabels {
+		updateLabels = opts.Labels
+	}
+	labels, annotations := splitLabelsAndAnnotations(updateLabels, obj.GetAnnotations())
 	obj.GetObjectMeta().SetLabels(labels)
 	obj.GetObjectMeta().SetAnnotations(annotations)
 	obj.SetMesh(r.GetMeta().GetMesh())

--- a/pkg/plugins/resources/memory/store.go
+++ b/pkg/plugins/resources/memory/store.go
@@ -184,7 +184,9 @@ func (c *memoryStore) Update(_ context.Context, r core_model.Resource, fs ...sto
 	}
 	meta.Version = meta.Version.Next()
 	meta.ModificationTime = opts.ModificationTime
-	meta.Labels = opts.Labels
+	if opts.ModifyLabels {
+		meta.Labels = opts.Labels
+	}
 	r.SetMeta(meta)
 
 	record.Version = meta.Version

--- a/pkg/plugins/resources/postgres/pgx_store.go
+++ b/pkg/plugins/resources/postgres/pgx_store.go
@@ -159,7 +159,11 @@ func (r *pgxResourceStore) Update(ctx context.Context, resource core_model.Resou
 		return errors.Wrap(err, "failed to convert meta version to int")
 	}
 
-	labels, err := prepareLabels(opts.Labels)
+	updateLabels := resource.GetMeta().GetLabels()
+	if opts.ModifyLabels {
+		updateLabels = opts.Labels
+	}
+	labels, err := prepareLabels(updateLabels)
 	if err != nil {
 		return err
 	}

--- a/pkg/test/store/store_test_template.go
+++ b/pkg/test/store/store_test_template.go
@@ -224,6 +224,40 @@ func ExecuteStoreTests(
 				}
 			})
 
+			It("should preserve labels", func() {
+				// given
+				name := "to-be-updated.demo"
+				resource := createResource(name, "foo", "bar")
+
+				// when
+				resource.Spec.Conf.Destination["path"] = "new-path"
+				err := s.Update(context.Background(), resource)
+
+				// then
+				Expect(err).ToNot(HaveOccurred())
+
+				res := core_mesh.NewTrafficRouteResource()
+				err = s.Get(context.Background(), res, store.GetByKey(name, mesh))
+				Expect(res.Meta.GetLabels()).To(HaveKeyWithValue("foo", "bar"))
+			})
+
+			It("should delete labels", func() {
+				// given a resources in storage
+				name := "to-be-updated.demo"
+				resource := createResource(name, "foo", "bar")
+
+				// when
+				resource.Spec.Conf.Destination["path"] = "new-path"
+				err := s.Update(context.Background(), resource, store.UpdateWithLabels(map[string]string{}))
+
+				// then
+				Expect(err).ToNot(HaveOccurred())
+
+				res := core_mesh.NewTrafficRouteResource()
+				err = s.Get(context.Background(), res, store.GetByKey(name, mesh))
+				Expect(res.Meta.GetLabels()).ToNot(HaveKeyWithValue("foo", "bar"))
+			})
+
 			It("should update resource with status", func() {
 				// given
 				updated := meshservice_api.MeshServiceResource{


### PR DESCRIPTION
### Checklist prior to review

Fix #10334

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
