### PR TITLE
feat(kuma-dp): add function to find default CA

### DIFF
--- a/app/kuma-dp/cmd/run.go
+++ b/app/kuma-dp/cmd/run.go
@@ -12,6 +12,7 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/app/kuma-dp/pkg/dataplane/accesslogs"
+	"github.com/kumahq/kuma/app/kuma-dp/pkg/dataplane/certificate"
 	"github.com/kumahq/kuma/app/kuma-dp/pkg/dataplane/dnsserver"
 	"github.com/kumahq/kuma/app/kuma-dp/pkg/dataplane/envoy"
 	"github.com/kumahq/kuma/app/kuma-dp/pkg/dataplane/meshmetrics"
@@ -123,6 +124,10 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 				runLog.Info("generated configurations will be stored in a temporary directory", "dir", tmpDir)
 			}
 
+			if cfg.DataplaneRuntime.SystemCaPath == "" {
+				cfg.DataplaneRuntime.SystemCaPath = certificate.GetOsCaFilePath()
+			}
+
 			if cfg.ControlPlane.CaCert == "" && cfg.ControlPlane.CaCertFile != "" {
 				cert, err := os.ReadFile(cfg.ControlPlane.CaCertFile)
 				if err != nil {
@@ -186,6 +191,7 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 				DynamicMetadata:     rootCtx.BootstrapDynamicMetadata,
 				MetricsCertPath:     cfg.DataplaneRuntime.Metrics.CertPath,
 				MetricsKeyPath:      cfg.DataplaneRuntime.Metrics.KeyPath,
+				SystemCaPath:        cfg.DataplaneRuntime.SystemCaPath,
 			})
 			if err != nil {
 				return errors.Errorf("Failed to generate Envoy bootstrap config. %v", err)

--- a/app/kuma-dp/pkg/dataplane/certificate/cert.go
+++ b/app/kuma-dp/pkg/dataplane/certificate/cert.go
@@ -1,0 +1,30 @@
+package certificate
+
+import (
+	"os"
+
+	"github.com/kumahq/kuma/pkg/core"
+)
+
+var logger = core.Log.WithName("system-certificate-selector")
+
+func GetOsCaFilePath() string {
+	// Source of CA File Paths: https://golang.org/src/crypto/x509/root_linux.go
+	certFiles := []string{
+		"/etc/ssl/certs/ca-certificates.crt",                // Debian/Ubuntu/Gentoo etc.
+		"/etc/pki/tls/certs/ca-bundle.crt",                  // Fedora/RHEL 6
+		"/etc/ssl/ca-bundle.pem",                            // OpenSUSE
+		"/etc/pki/tls/cacert.pem",                           // OpenELEC
+		"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", // CentOS/RHEL 7
+		"/etc/ssl/cert.pem",                                 // Alpine Linux
+	}
+
+	for _, cert := range certFiles {
+		if _, err := os.Stat(cert); err == nil {
+			logger.Info("using OS provided CA certificate", "certificate path", cert)
+			return cert
+		}
+	}
+	logger.Info("OS provided certificate not found")
+	return ""
+}

--- a/app/kuma-dp/pkg/dataplane/envoy/envoy.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/envoy.go
@@ -38,6 +38,7 @@ type BootstrapParams struct {
 	AccessLogSocketPath string
 	MetricsCertPath     string
 	MetricsKeyPath      string
+	SystemCaPath        string
 }
 
 type BootstrapConfigFactoryFunc func(ctx context.Context, url string, cfg kuma_dp.Config, params BootstrapParams) (*envoy_bootstrap_v3.Bootstrap, *types.KumaSidecarConfiguration, error)

--- a/app/kuma-dp/pkg/dataplane/envoy/testdata/bootstrap-request-0.golden.json
+++ b/app/kuma-dp/pkg/dataplane/envoy/testdata/bootstrap-request-0.golden.json
@@ -32,5 +32,6 @@
   "socketPath": "/tmp/metric",
   "certPath": "/tmp/cert.pem",
   "keyPath": "/tmp/key.pem"
- }
+ },
+ "systemCaPath": ""
 }

--- a/app/kuma-dp/pkg/dataplane/envoy/testdata/bootstrap-request-1.golden.json
+++ b/app/kuma-dp/pkg/dataplane/envoy/testdata/bootstrap-request-1.golden.json
@@ -31,5 +31,6 @@
   "socketPath": "/tmp/metric",
   "certPath": "",
   "keyPath": ""
- }
+ },
+ "systemCaPath": ""
 }

--- a/app/kuma-dp/pkg/dataplane/envoy/testdata/bootstrap-request-2.golden.json
+++ b/app/kuma-dp/pkg/dataplane/envoy/testdata/bootstrap-request-2.golden.json
@@ -30,5 +30,6 @@
   "socketPath": "/tmp/metric",
   "certPath": "",
   "keyPath": ""
- }
+ },
+ "systemCaPath": ""
 }

--- a/app/kuma-dp/pkg/dataplane/envoy/testdata/bootstrap-request-3.golden.json
+++ b/app/kuma-dp/pkg/dataplane/envoy/testdata/bootstrap-request-3.golden.json
@@ -30,5 +30,6 @@
   "socketPath": "/tmp/metric",
   "certPath": "",
   "keyPath": ""
- }
+ },
+ "systemCaPath": ""
 }

--- a/pkg/config/app/kuma-dp/config.go
+++ b/pkg/config/app/kuma-dp/config.go
@@ -209,6 +209,8 @@ type DataplaneRuntime struct {
 	Metrics Metrics `json:"metrics,omitempty"`
 	// DynamicConfiguration defines properties of dataplane dynamic configuration
 	DynamicConfiguration DynamicConfiguration `json:"dynamicConfiguration" envconfig:"kuma_dataplane_runtime_dynamic_configuration"`
+	// SystemCaPath defines path of system provided Ca
+	SystemCaPath string `json:"systemCaPath,omitempty" envconfig:"kuma_dataplane_runtime_dynamic_system_ca_path"`
 }
 
 type Metrics struct {

--- a/pkg/core/xds/metadata.go
+++ b/pkg/core/xds/metadata.go
@@ -34,6 +34,7 @@ const (
 	FieldMetricsSocketPath          = "metricsSocketPath"
 	FieldMetricsCertPath            = "metricsCertPath"
 	FieldMetricsKeyPath             = "metricsKeyPath"
+	FieldSystemCaPath               = "systemCaPath"
 )
 
 // DataplaneMetadata represents environment-specific part of a dataplane configuration.
@@ -65,6 +66,7 @@ type DataplaneMetadata struct {
 	MetricsSocketPath   string
 	MetricsCertPath     string
 	MetricsKeyPath      string
+	SystemCaPath        string
 }
 
 // GetDataplaneResource returns the underlying DataplaneResource, if present.
@@ -201,6 +203,9 @@ func DataplaneMetadataFromXdsMetadata(xdsMetadata *structpb.Struct, tmpDir strin
 	}
 	if xdsMetadata.Fields[FieldMetricsKeyPath] != nil {
 		metadata.MetricsKeyPath = xdsMetadata.Fields[FieldMetricsKeyPath].GetStringValue()
+	}
+	if xdsMetadata.Fields[FieldSystemCaPath] != nil {
+		metadata.SystemCaPath = xdsMetadata.Fields[FieldSystemCaPath].GetStringValue()
 	}
 
 	if listValue := xdsMetadata.Fields[FieldFeatures]; listValue != nil {

--- a/pkg/core/xds/metadata_test.go
+++ b/pkg/core/xds/metadata_test.go
@@ -69,6 +69,11 @@ var _ = Describe("DataplaneMetadataFromXdsMetadata", func() {
 							StringValue: "/tmp/metrics",
 						},
 					},
+					"systemCaPath": {
+						Kind: &structpb.Value_StringValue{
+							StringValue: "/etc/certs/cert.pem",
+						},
+					},
 				},
 			},
 			expected: xds.DataplaneMetadata{
@@ -77,6 +82,7 @@ var _ = Describe("DataplaneMetadataFromXdsMetadata", func() {
 				EmptyDNSPort:        8001,
 				AccessLogSocketPath: "/tmp/logs",
 				MetricsSocketPath:   "/tmp/metrics",
+				SystemCaPath:        "/etc/certs/cert.pem",
 			},
 		}),
 		Entry("should ignore dependencies version provided through metadata if version is not set at all", testCase{

--- a/pkg/xds/bootstrap/generator.go
+++ b/pkg/xds/bootstrap/generator.go
@@ -125,6 +125,7 @@ func (b *bootstrapGenerator) Generate(ctx context.Context, request types.Bootstr
 		MetricsSocketPath:   metricsSocketPath,
 		MetricsCertPath:     request.MetricsResources.CertPath,
 		MetricsKeyPath:      request.MetricsResources.KeyPath,
+		SystemCaPath:        request.SystemCaPath,
 	}
 
 	setAdminPort := func(adminPortFromResource uint32) {

--- a/pkg/xds/bootstrap/generator_test.go
+++ b/pkg/xds/bootstrap/generator_test.go
@@ -333,6 +333,41 @@ var _ = Describe("bootstrapGenerator", func() {
 			expectedConfigFile: "generator.metrics-config.kubernetes.golden.yaml",
 			hdsEnabled:         false,
 		}),
+		Entry("default config, kubernetes with custom system ca path", testCase{
+			dpAuthForProxyType: authEnabled,
+			serverConfig: func() *bootstrap_config.BootstrapServerConfig {
+				cfg := bootstrap_config.DefaultBootstrapServerConfig()
+				cfg.Params.XdsHost = "localhost"
+				cfg.Params.XdsPort = 5678
+				return cfg
+			}(),
+			dataplane: func() *core_mesh.DataplaneResource {
+				dp := defaultDataplane()
+				dp.Spec.Networking.Admin.Port = 1234
+				dp.Spec.Metrics = &mesh_proto.MetricsBackend{
+					Type: mesh_proto.MetricsPrometheusType,
+					Conf: util_proto.MustToStruct(&mesh_proto.PrometheusMetricsBackendConfig{
+						Aggregate: []*mesh_proto.PrometheusAggregateMetricsConfig{
+							{
+								Name: "app1",
+								Port: 123,
+								Path: "/stats",
+							},
+						},
+					}),
+				}
+				return dp
+			},
+			request: types.BootstrapRequest{
+				Mesh:           "mesh",
+				Name:           "name.namespace",
+				DataplaneToken: "token",
+				Version:        defaultVersion,
+				SystemCaPath:   "/etc/certs/cert.pem",
+			},
+			expectedConfigFile: "generator.system-cert-config.kubernetes.golden.yaml",
+			hdsEnabled:         false,
+		}),
 		Entry("backwards compatibility, adminPort both in bootstrapRequest and in DPP resource", testCase{ // https://github.com/kumahq/kuma/issues/4002
 			dpAuthForProxyType: authEnabled,
 			serverConfig: func() *bootstrap_config.BootstrapServerConfig {

--- a/pkg/xds/bootstrap/parameters.go
+++ b/pkg/xds/bootstrap/parameters.go
@@ -52,4 +52,5 @@ type configParameters struct {
 	Features            []string
 	IsGatewayDataplane  bool
 	Resources           types.ProxyResources
+	SystemCaPath        string
 }

--- a/pkg/xds/bootstrap/template_v3.go
+++ b/pkg/xds/bootstrap/template_v3.go
@@ -122,6 +122,7 @@ func genConfig(parameters configParameters, proxyConfig xds.Proxy, enableReloada
 					core_xds.FieldMetricsSocketPath:   util_proto.MustNewValueForStruct(parameters.MetricsSocketPath),
 					core_xds.FieldMetricsCertPath:     util_proto.MustNewValueForStruct(parameters.MetricsCertPath),
 					core_xds.FieldMetricsKeyPath:      util_proto.MustNewValueForStruct(parameters.MetricsKeyPath),
+					core_xds.FieldSystemCaPath:        util_proto.MustNewValueForStruct(parameters.SystemCaPath),
 				},
 			},
 		},

--- a/pkg/xds/bootstrap/testdata/bootstrap.gateway.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.gateway.golden.yaml
@@ -54,6 +54,7 @@ node:
     metricsCertPath: ""
     metricsKeyPath: ""
     metricsSocketPath: /tmp/kuma-mh-gateway-1.default-default.sock
+    systemCaPath: ""
     version:
       envoy:
         build: hash/1.15.0/RELEASE

--- a/pkg/xds/bootstrap/testdata/bootstrap.k8s.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.k8s.golden.yaml
@@ -45,6 +45,7 @@ node:
     metricsCertPath: ""
     metricsKeyPath: ""
     metricsSocketPath: /tmp/kuma-mh-dp-1.default-default.sock
+    systemCaPath: ""
     version:
       envoy:
         build: hash/1.15.0/RELEASE

--- a/pkg/xds/bootstrap/testdata/bootstrap.overridden.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.overridden.golden.yaml
@@ -57,6 +57,7 @@ node:
     metricsCertPath: ""
     metricsKeyPath: ""
     metricsSocketPath: /tmp/kuma-mh-dp-1.default-default.sock
+    systemCaPath: ""
     version:
       envoy:
         build: hash/1.15.0/RELEASE

--- a/pkg/xds/bootstrap/testdata/bootstrap.universal.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.universal.golden.yaml
@@ -45,6 +45,7 @@ node:
     metricsCertPath: ""
     metricsKeyPath: ""
     metricsSocketPath: /tmp/kuma-mh-dp-1-default.sock
+    systemCaPath: ""
     version:
       envoy:
         build: hash/1.15.0/RELEASE

--- a/pkg/xds/bootstrap/testdata/generator.custom-config-minimal-request.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.custom-config-minimal-request.golden.yaml
@@ -51,6 +51,7 @@ node:
     metricsCertPath: ""
     metricsKeyPath: ""
     metricsSocketPath: /tmp/kuma-mh-name.namespace-mesh.sock
+    systemCaPath: ""
     version:
       envoy:
         build: hash/1.15.0/RELEASE

--- a/pkg/xds/bootstrap/testdata/generator.custom-config.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.custom-config.golden.yaml
@@ -84,6 +84,7 @@ node:
     metricsCertPath: ""
     metricsKeyPath: ""
     metricsSocketPath: /tmp/kuma-mh-name.namespace-mesh.sock
+    systemCaPath: ""
     version:
       envoy:
         build: hash/1.15.0/RELEASE

--- a/pkg/xds/bootstrap/testdata/generator.default-config-minimal-request.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config-minimal-request.golden.yaml
@@ -39,6 +39,7 @@ node:
     metricsCertPath: ""
     metricsKeyPath: ""
     metricsSocketPath: /tmp/kuma-mh-name.namespace-mesh.sock
+    systemCaPath: ""
     version:
       envoy:
         build: hash/1.15.0/RELEASE

--- a/pkg/xds/bootstrap/testdata/generator.default-config-token-path.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config-token-path.golden.yaml
@@ -79,6 +79,7 @@ node:
     metricsCertPath: /path/cert/pem
     metricsKeyPath: /path/key/pem
     metricsSocketPath: /tmp/kuma-mh-name.namespace-mesh.sock
+    systemCaPath: ""
     version:
       envoy:
         build: hash/1.15.0/RELEASE

--- a/pkg/xds/bootstrap/testdata/generator.default-config.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config.golden.yaml
@@ -59,6 +59,7 @@ node:
     metricsCertPath: ""
     metricsKeyPath: ""
     metricsSocketPath: /tmp/kuma-mh-name.namespace-mesh.sock
+    systemCaPath: ""
     version:
       envoy:
         build: hash/1.15.0/RELEASE

--- a/pkg/xds/bootstrap/testdata/generator.default-config.kubernetes.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config.kubernetes.golden.yaml
@@ -47,6 +47,7 @@ node:
     metricsCertPath: ""
     metricsKeyPath: ""
     metricsSocketPath: /tmp/kuma-mh-name.namespace-mesh.sock
+    systemCaPath: ""
     version:
       envoy:
         build: hash/1.15.0/RELEASE

--- a/pkg/xds/bootstrap/testdata/generator.gateway.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.gateway.golden.yaml
@@ -76,6 +76,7 @@ node:
     metricsCertPath: ""
     metricsKeyPath: ""
     metricsSocketPath: /tmp/kuma-mh-name.namespace-mesh.sock
+    systemCaPath: ""
     version:
       envoy:
         build: hash/1.15.0/RELEASE

--- a/pkg/xds/bootstrap/testdata/generator.metrics-config.kubernetes.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.metrics-config.kubernetes.golden.yaml
@@ -47,6 +47,7 @@ node:
     metricsCertPath: ""
     metricsKeyPath: ""
     metricsSocketPath: /tmp/kuma-mh-name.namespace-mesh.sock
+    systemCaPath: ""
     version:
       envoy:
         build: hash/1.15.0/RELEASE

--- a/pkg/xds/bootstrap/testdata/generator.system-cert-config.kubernetes.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.system-cert-config.kubernetes.golden.yaml
@@ -47,7 +47,7 @@ node:
     metricsCertPath: ""
     metricsKeyPath: ""
     metricsSocketPath: /tmp/kuma-mh-name.namespace-mesh.sock
-    systemCaPath: ""
+    systemCaPath: /etc/certs/cert.pem
     version:
       envoy:
         build: hash/1.15.0/RELEASE
@@ -89,7 +89,7 @@ staticResources:
         - endpoint:
             address:
               socketAddress:
-                address: fd00:a123::1
+                address: localhost
                 portValue: 5678
     name: ads_cluster
     transportSocket:
@@ -101,8 +101,8 @@ staticResources:
             tlsMinimumProtocolVersion: TLSv1_2
           validationContextSdsSecretConfig:
             name: cp_validation_ctx
-        sni: fd00:a123::1
-    type: STATIC
+        sni: localhost
+    type: STRICT_DNS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
@@ -118,10 +118,10 @@ staticResources:
     validationContext:
       matchTypedSubjectAltNames:
       - matcher:
-          exact: fd00:a123::1
+          exact: localhost
         sanType: DNS
       - matcher:
-          exact: fd00:a123::1
+          exact: localhost
         sanType: IP_ADDRESS
       trustedCa:
         inlineBytes: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURNekNDQWh1Z0F3SUJBZ0lRRGhsSW5mc1hZSGFtS04rMjlxblF2ekFOQmdrcWhraUc5dzBCQVFzRkFEQVAKTVEwd0N3WURWUVFERXdScmRXMWhNQjRYRFRJeE1EUXdNakV3TWpJeU5sb1hEVE14TURNek1URXdNakl5TmxvdwpEekVOTUFzR0ExVUVBeE1FYTNWdFlUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCCkFMNEdHZytlMk83ZUExMkYwRjZ2MnJyOGoyaVZTRktlcG5adEwxNWxyQ2RzNmxxSzUwc1hXT3c4UEtacDJpaEEKWEpWVFNaekthc3lMRFRBUjlWWVFqVHBFNTI2RXp2dGR0aFNhZ2YzMlFXVyt3WTZMTXBFZGV4S09PQ3gyc2U1NQpSZDk3TDMzeVlQZmdYMTVPWWxpSFBEMDU2ampob3RITGROMmxweTcrU1REdlF5Um5YQXU3M1lrWTM3RWQ0aEk0CnQvVjZzb0h5RUdOY0RobTlwNWZCR3F6MG5qQmJRa3AybFRZNS9rajQycUI3UTZyQ00ydGJQc0VNb29lQUF3NW0KaHlZNHhqMHRQOXVjcWxVejhnYys2bzhIRE5zdDhOZUpYWmt0V24rQ095dGpyL056R2dTMjJrdlNEcGhpc0pvdApvMEZ5b0lPZEF0eEMxcXhYWFIrWHVVVUNBd0VBQWFPQmlqQ0JoekFPQmdOVkhROEJBZjhFQkFNQ0FxUXdIUVlEClZSMGxCQll3RkFZSUt3WUJCUVVIQXdFR0NDc0dBUVVGQndNQk1BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0hRWUQKVlIwT0JCWUVGS1JMa2dJelgvT2pLdzlpZGVwdVEvUk10VCtBTUNZR0ExVWRFUVFmTUIyQ0NXeHZZMkZzYUc5egpkSWNRL1FDaEl3QUFBQUFBQUFBQUFBQUFBVEFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBUHM1eUpaaG9ZbEdXCkNwQThkU0lTaXZNOC84aUJOUTNmVndQNjNmdDBFSkxNVkd1MlJGWjQvVUFKL3JVUFNHTjh4aFhTazUrMWQ1NmEKL2thSDlyWDBIYVJJSEhseEE3aVBVS3hBajQ0eDlMS21xUEhUb0wzWGxXWTFBWHp2aWNXOWQrR00yRmFRZWUrSQpsZWFxTGJ6MEFadmxudTI3MVoxQ2VhQUN1VTlHbGp1anZ5aVRURTluYUhVRXF2SGdTcFB0aWxKYWx5SjUveklsClo5RjArVVd0M1RPWU1zNWcrU0N0ME13SFROYmlzYm1ld3BjRkZKemp0Mmt2dHJjOXQ5ZGtGODF4aGNTMTl3N3EKaDFBZVAzUlJsTGw3YnY5RUFWWEVtSWF2aWgvMjlQQTNaU3krcGJZTlc3ak5KSGpNUTRoUTBFK3hjQ2F6VS9PNAp5cFdHYWFudlBnPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=

--- a/pkg/xds/bootstrap/types/bootstrap_request.go
+++ b/pkg/xds/bootstrap/types/bootstrap_request.go
@@ -20,6 +20,7 @@ type BootstrapRequest struct {
 	Workdir             string            `json:"workdir"`
 	AccessLogSocketPath string            `json:"accessLogSocketPath"`
 	MetricsResources    MetricsResources  `json:"metricsResources"`
+	SystemCaPath        string            `json:"systemCaPath"`
 }
 
 type Version struct {


### PR DESCRIPTION
xrel: https://github.com/kumahq/kuma/issues/10238

### Checklist prior to review

I added an option to propagate information about the default OS CA certificate in a bootstrap request from kuma-dp.

* a user can provide a path to the certificate when it's not a default one for the OS
* if the cert path is not provided we are scanning default paths based on the https://golang.org/src/crypto/x509/root_linux.go
* propagate the information in metadata

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
