### PR TITLE
fix(kuma-cp): validate the bandwidth strictly

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -10,7 +10,7 @@ does not have any particular instructions.
 
 ### MeshFaultInjection responseBandwidth.limit
 
-With [#10371](https://github.com/kumahq/kuma/pull/10371) we strict the validation of `responseBandwidth.limit` field in policies `MeshFaultInjection`. Policies with bad value like `-10kbps` will be rejected.
+With [#10371](https://github.com/kumahq/kuma/pull/10371) we have tightened the validation of the `responseBandwidth.limit` field in `MeshFaultInjection` policy. Policies with invalid values, such as `-10kbps`, will be rejected.
 
 ### MeshRetry tcp.MaxConnectAttempt
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ does not have any particular instructions.
 
 ## Upgrade to `2.8.x`
 
+### MeshFaultInjection responseBandwidth.limit
+
+With [#10371](https://github.com/kumahq/kuma/pull/10371) we strict the validation of `responseBandwidth.limit` field in policies `MeshFaultInjection`. Policies with bad value like `-10kbps` will be rejected.
+
 ### MeshRetry tcp.MaxConnectAttempt
 
 With [#10250](https://github.com/kumahq/kuma/pull/10250) `MeshRetry` policies with `spec.tcp.MaxConnectAttempt=0` will be rejected.

--- a/pkg/core/validators/common_validators.go
+++ b/pkg/core/validators/common_validators.go
@@ -223,7 +223,7 @@ func ValidateIntegerGreaterThan(path PathBuilder, value uint32, minValue uint32)
 	return err
 }
 
-var BandwidthRegex = regexp.MustCompile(`(\d*)\s?([GMk]?bps)`)
+var BandwidthRegex = regexp.MustCompile(`^(\d*)\s?([GMk]+bps)$`)
 
 func ValidateBandwidth(path PathBuilder, value string) ValidationError {
 	var err ValidationError

--- a/pkg/core/validators/common_validators_test.go
+++ b/pkg/core/validators/common_validators_test.go
@@ -1,0 +1,68 @@
+package validators
+
+import "testing"
+
+func TestValidateBandwidth(t *testing.T) {
+	path := []string{"path"}
+
+	tests := []struct {
+		name  string
+		input string
+		err   string
+	}{
+		{
+			name:  "sanity",
+			input: "1kbps",
+		},
+		{
+			name:  "without number",
+			input: "Mbps",
+		},
+		{
+			name:  "not exact match",
+			input: "1bpsp",
+			err: func() string {
+				e := &ValidationError{}
+				e.AddViolationAt(path, MustHaveBPSUnit)
+				return e.Error()
+			}(),
+		},
+		{
+			name:  "bps is not allowed",
+			input: "1bps",
+			err: func() string {
+				e := &ValidationError{}
+				e.AddViolationAt(path, MustHaveBPSUnit)
+				return e.Error()
+			}(),
+		},
+		{
+			name:  "float point number is not supported",
+			input: "0.1kbps",
+			err: func() string {
+				e := &ValidationError{}
+				e.AddViolationAt(path, MustHaveBPSUnit)
+				return e.Error()
+			}(),
+		},
+		{
+			name:  "not defined",
+			input: "",
+			err: func() string {
+				e := &ValidationError{}
+				e.AddViolationAt(path, MustBeDefined)
+				return e.Error()
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			actual := ValidateBandwidth(path, tt.input)
+			if actual.Error() != tt.err {
+				t.Errorf("ValidateBandwidth(%s): expected %s, actual %s", tt.input, tt.err, actual)
+			}
+		})
+	}
+}

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/validator_test.go
@@ -34,7 +34,7 @@ from:
             value: 5s
             percentage: 5
         - responseBandwidth:
-            limit: 100mbps
+            limit: 100Mbps
             percentage: 5
         - abort:
             httpStatus: 500

--- a/test/e2e_env/kubernetes/meshfaultinjection/api.go
+++ b/test/e2e_env/kubernetes/meshfaultinjection/api.go
@@ -68,7 +68,7 @@ spec:
                 value: 5s
                 percentage: 3
               responseBandwidth:
-                limit: 10mbps
+                limit: 10Mbps
                 percentage: 1
             - delay:
                 value: 11s
@@ -85,7 +85,7 @@ spec:
                 value: 5s
                 percentage: "3.2"
             - responseBandwidth:
-                limit: 10mbps
+                limit: 10Mbps
                 percentage: 1
 `, Config.KumaNamespace, meshName))(kubernetes.Cluster)).To(Succeed())
 


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
