### PR TITLE
chore(kds): add tenantID to 'received NACK' log message

### DIFF
--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -92,7 +92,7 @@ func newZapLoggerTo(destWriter io.Writer, level LogLevel, opts ...zap.Option) *z
 		WithOptions(opts...)
 }
 
-const tenantLoggerKey = "tenantID"
+const TenantLoggerKey = "tenantID"
 
 // AddFieldsFromCtx will check if provided context contain tracing span and
 // if the span is currently recording. If so, it will call spanLogValuesProcessor
@@ -105,7 +105,7 @@ func AddFieldsFromCtx(
 	extensions context.Context,
 ) logr.Logger {
 	if tenantId, ok := multitenant.TenantFromCtx(ctx); ok {
-		logger = logger.WithValues(tenantLoggerKey, tenantId)
+		logger = logger.WithValues(TenantLoggerKey, tenantId)
 	}
 
 	return addSpanValuesToLogger(logger, ctx, extensions)


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
