### PR TITLE
chore(distribution): remove envoy version from info, allow custom envoy version 

### DIFF
--- a/mk/build.mk
+++ b/mk/build.mk
@@ -2,8 +2,7 @@ build_info_fields = \
 	version=$(BUILD_INFO_VERSION) \
 	gitTag=$(GIT_TAG) \
 	gitCommit=$(GIT_COMMIT) \
-	buildDate=$(BUILD_DATE) \
-	Envoy=$(ENVOY_VERSION)
+	buildDate=$(BUILD_DATE)
 
 build_info_ld_flags := $(foreach entry,$(build_info_fields), -X github.com/kumahq/kuma/pkg/version.$(entry))
 

--- a/mk/distribution.mk
+++ b/mk/distribution.mk
@@ -4,7 +4,7 @@ DISTRIBUTION_CONFIG_PATH ?= pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
 # OS:ARCH:COREDNS:ENVOY_FLAVOUR
 # COREDNS is always coredns(CORDNS_EXT)
 # If you don't want to include just put skip
-DISTRIBUTION_LIST ?= linux:amd64:coredns:envoy linux:arm64:coredns:envoy darwin:amd64:coredns:envoy darwin:arm64:coredns:envoy
+DISTRIBUTION_LIST ?= linux:amd64:coredns:envoy:$(ENVOY_VERSION) linux:arm64:coredns:envoy:$(ENVOY_VERSION) darwin:amd64:coredns:envoy:$(ENVOY_VERSION) darwin:arm64:coredns:envoy:$(ENVOY_VERSION)
 
 PULP_HOST ?= "https://api.pulp.konnect-prod.konghq.com"
 PULP_PACKAGE_TYPE ?= $(PROJECT_NAME)
@@ -38,7 +38,7 @@ ifneq ($(3),skip)
 endif
 
 # Package envoy
-	$(MAKE) build/artifacts-$(1)-$(2)/envoy ENVOY_EXT_$(1)_$(2)=$(subst envoy,,$(4))
+	$(MAKE) build/artifacts-$(1)-$(2)/envoy ENVOY_VERSION=$(5) ENVOY_EXT_$(1)_$(2)=$(subst envoy,,$(4))
 	cp -r build/artifacts-$(1)-$(2)/envoy/* $$@/bin
 
 	# Set permissions correctly
@@ -90,9 +90,10 @@ dist_arch = $(word 2, $(subst :, ,$(elt)))
 dist_coredns = $(word 3, $(subst :, ,$(elt)))
 dist_envoy = $(word 4, $(subst :, ,$(elt)))
 dist_envoy_alt = $(word 5, $(subst :, ,$(elt)))
+dist_envoy_version = $(word 6, $(subst :, ,$(elt)))
 dist_name = $(dist_os)-$(dist_arch)
 # Call make_distribution_target with each combination
-$(foreach elt,$(DISTRIBUTION_LIST),$(eval $(call make_distributions_target,$(dist_os),$(dist_arch),$(dist_coredns),$(dist_envoy),$(dist_envoy_alt))))
+$(foreach elt,$(DISTRIBUTION_LIST),$(eval $(call make_distributions_target,$(dist_os),$(dist_arch),$(dist_coredns),$(dist_envoy),$(dist_envoy_alt),$(dist_envoy_version))))
 ENABLED_DIST_NAMES=$(filter $(addprefix %,$(ENABLED_ARCH_OS)),$(foreach elt,$(DISTRIBUTION_LIST),$(dist_name)))
 
 # Create a main target which will call the tar.gz target for each distribution


### PR DESCRIPTION
### Checklist before review

For some specific architectures, we could allow defining a custom version of Envoy. Added a change that will enable setting the version of envoy during distribution.

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
