### PR TITLE
feat(MeshService): support mTLS

### DIFF
--- a/pkg/plugins/policies/core/xds/meshroute/listeners.go
+++ b/pkg/plugins/policies/core/xds/meshroute/listeners.go
@@ -74,13 +74,13 @@ func CollectServices(
 			if outbound.GetAddress() == proxy.Dataplane.Spec.GetNetworking().GetAddress() {
 				continue
 			}
-			ms, ok := meshCtx.MeshServiceByName[outbound.BackendRef.Name]
+			ms, ok := meshCtx.MeshServiceIdentity[outbound.BackendRef.Name]
 			if !ok {
 				// we want to ignore service which is not found. Logging might be excessive here.
 				// We don't have other mechanism to bubble up warnings yet.
 				continue
 			}
-			port, ok := ms.FindPort(outbound.BackendRef.Port)
+			port, ok := ms.Resource.FindPort(outbound.BackendRef.Port)
 			if !ok {
 				continue
 			}
@@ -91,11 +91,11 @@ func CollectServices(
 			dests = append(dests, DestinationService{
 				Outbound:    oface,
 				Protocol:    protocol,
-				ServiceName: ms.DestinationName(outbound.BackendRef.Port),
+				ServiceName: ms.Resource.DestinationName(outbound.BackendRef.Port),
 				BackendRef: common_api.BackendRef{
 					TargetRef: common_api.TargetRef{
 						Kind: common_api.MeshService,
-						Name: ms.GetMeta().GetName(),
+						Name: ms.Resource.GetMeta().GetName(),
 					},
 					Port: &port.Port,
 				},
@@ -140,16 +140,18 @@ func makeSplit(
 		if pointer.DerefOr(ref.Weight, 1) == 0 {
 			continue
 		}
+		var meshServiceName string
 		if ref.Port != nil { // in this case, reference real MeshService instead of kuma.io/service tag
-			ms, ok := meshCtx.MeshServiceByName[ref.Name]
+			ms, ok := meshCtx.MeshServiceIdentity[ref.Name]
 			if !ok {
 				continue
 			}
-			port, ok := ms.FindPort(*ref.Port)
+			meshServiceName = ms.Resource.GetMeta().GetName()
+			port, ok := ms.Resource.FindPort(*ref.Port)
 			if !ok {
 				continue
 			}
-			service = ms.DestinationName(*ref.Port)
+			service = ms.Resource.DestinationName(*ref.Port)
 			protocol = port.Protocol // todo(jakubdyszkiewicz): do we need to default to TCP or will this be done by MeshService defaulter?
 		} else {
 			service = ref.Name
@@ -204,7 +206,11 @@ func makeSplit(
 			clusterBuilder.WithMesh(mesh)
 		}
 
-		servicesAcc.Add(clusterBuilder.Build())
+		if len(meshServiceName) > 0 {
+			servicesAcc.AddMeshService(meshServiceName, clusterBuilder.Build())
+		} else {
+			servicesAcc.Add(clusterBuilder.Build())
+		}
 	}
 
 	return split

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
@@ -125,7 +125,12 @@ var _ = Describe("MeshHTTPRoute", func() {
 					WithTarget("192.168.0.4").
 					WithPort(8084).
 					WithWeight(1).
-					WithTags(mesh_proto.ServiceTag, "backend", mesh_proto.ProtocolTag, core_mesh.ProtocolHTTP, "region", "us"))
+					WithTags(mesh_proto.ServiceTag, "backend", mesh_proto.ProtocolTag, core_mesh.ProtocolHTTP, "app", "backend")).
+				AddEndpoint("backend_svc_80", xds_builders.Endpoint().
+					WithTarget("192.168.0.5").
+					WithPort(8084).
+					WithWeight(1).
+					WithTags(mesh_proto.ServiceTag, "other-backend", mesh_proto.ProtocolTag, core_mesh.ProtocolHTTP, "app", "backend"))
 			meshSvc := meshservice_api.MeshServiceResource{
 				Meta: &test_model.ResourceMeta{Name: "backend", Mesh: "default"},
 				Spec: &meshservice_api.MeshService{

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
@@ -119,7 +119,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 		}()),
 		Entry("default-meshservice", func() outboundsTestCase {
 			outboundTargets := xds_builders.EndpointMap().
-				AddEndpoint("backend_svc_8084", xds_builders.Endpoint().
+				AddEndpoint("backend_svc_80", xds_builders.Endpoint().
 					WithTarget("192.168.0.4").
 					WithPort(8084).
 					WithWeight(1).

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
@@ -19,6 +19,7 @@ import (
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/secrets/cipher"
 	secret_manager "github.com/kumahq/kuma/pkg/core/secrets/manager"
 	secret_store "github.com/kumahq/kuma/pkg/core/secrets/store"
@@ -39,6 +40,7 @@ import (
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	"github.com/kumahq/kuma/pkg/xds/cache/cla"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
+	envoy "github.com/kumahq/kuma/pkg/xds/envoy"
 )
 
 func getResource(resourceSet *core_xds.ResourceSet, typ envoy_resource.Type) []byte {
@@ -146,11 +148,13 @@ var _ = Describe("MeshHTTPRoute", func() {
 			}
 			return outboundsTestCase{
 				xdsContext: *xds_builders.Context().
+					WithMesh(builders.Mesh().WithBuiltinMTLSBackend("builtin").WithEnabledMTLSBackend("builtin")).
 					WithEndpointMap(outboundTargets).
 					WithResources(resources).
 					AddServiceProtocol("backend_svc_80", core_mesh.ProtocolHTTP).
 					Build(),
 				proxy: xds_builders.Proxy().
+					WithSecretsTracker(envoy.NewSecretsTracker(core_model.DefaultMesh, nil)).
 					WithDataplane(samples.DataplaneWebBuilder().
 						AddOutbound(builders.Outbound().
 							WithAddress("10.0.0.1").

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.clusters.golden.yaml
@@ -20,6 +20,9 @@ resources:
               - matcher:
                   exact: spiffe://default/backend
                 sanType: URI
+              - matcher:
+                  exact: spiffe://default/other-backend
+                sanType: URI
             validationContextSdsSecretConfig:
               name: mesh_ca:secret:default
               sdsConfig:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.clusters.golden.yaml
@@ -18,7 +18,7 @@ resources:
             defaultValidationContext:
               matchTypedSubjectAltNames:
               - matcher:
-                  exact: spiffe://default/backend_svc_80
+                  exact: spiffe://default/backend
                 sanType: URI
             validationContextSdsSecretConfig:
               name: mesh_ca:secret:default

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.clusters.golden.yaml
@@ -7,6 +7,30 @@ resources:
         ads: {}
         resourceApiVersion: V3
     name: backend_svc_80
+    transportSocket:
+      name: envoy.transport_sockets.tls
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        commonTlsContext:
+          alpnProtocols:
+          - kuma
+          combinedValidationContext:
+            defaultValidationContext:
+              matchTypedSubjectAltNames:
+              - matcher:
+                  exact: spiffe://default/backend_svc_80
+                sanType: URI
+            validationContextSdsSecretConfig:
+              name: mesh_ca:secret:default
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+          tlsCertificateSdsSecretConfigs:
+          - name: identity_cert:secret:default
+            sdsConfig:
+              ads: {}
+              resourceApiVersion: V3
+        sni: backend{mesh=default}
     type: EDS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.endpoints.golden.yaml
@@ -14,8 +14,22 @@ resources:
         metadata:
           filterMetadata:
             envoy.lb:
+              app: backend
               kuma.io/protocol: http
-              region: us
             envoy.transport_socket_match:
+              app: backend
               kuma.io/protocol: http
-              region: us
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.0.5
+              portValue: 8084
+        loadBalancingWeight: 1
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              app: backend
+              kuma.io/protocol: http
+            envoy.transport_socket_match:
+              app: backend
+              kuma.io/protocol: http

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.endpoints.golden.yaml
@@ -3,3 +3,19 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
     clusterName: backend_svc_80
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.0.4
+              portValue: 8084
+        loadBalancingWeight: 1
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              kuma.io/protocol: http
+              region: us
+            envoy.transport_socket_match:
+              kuma.io/protocol: http
+              region: us

--- a/pkg/test/xds/builders/context_builder.go
+++ b/pkg/test/xds/builders/context_builder.go
@@ -2,12 +2,12 @@ package builders
 
 import (
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/test/resources/builders"
 	"github.com/kumahq/kuma/pkg/test/resources/samples"
 	"github.com/kumahq/kuma/pkg/test/xds"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
+	"github.com/kumahq/kuma/pkg/xds/topology"
 )
 
 type ContextBuilder struct {
@@ -21,7 +21,7 @@ func Context() *ContextBuilder {
 				Resource:            samples.MeshDefault(),
 				EndpointMap:         map[core_xds.ServiceName][]core_xds.Endpoint{},
 				ServicesInformation: map[string]*xds_context.ServiceInformation{},
-				MeshServiceByName:   map[string]*meshservice_api.MeshServiceResource{},
+				MeshServiceIdentity: map[string]topology.MeshServiceIdentity{},
 			},
 			ControlPlane: &xds_context.ControlPlaneContext{
 				CLACache: &xds.DummyCLACache{OutboundTargets: map[core_xds.ServiceName][]core_xds.Endpoint{}},
@@ -33,9 +33,9 @@ func Context() *ContextBuilder {
 }
 
 func (mc *ContextBuilder) Build() *xds_context.Context {
-	for _, ms := range mc.res.Mesh.Resources.MeshServices().Items {
-		mc.res.Mesh.MeshServiceByName[ms.GetMeta().GetName()] = ms
-	}
+	mc.res.Mesh.MeshServiceIdentity = topology.BuildMeshServiceIdentityMap(
+		mc.res.Mesh.Resources.MeshServices().Items, mc.res.Mesh.EndpointMap,
+	)
 	return mc.res
 }
 

--- a/pkg/xds/context/context.go
+++ b/pkg/xds/context/context.go
@@ -7,10 +7,10 @@ import (
 	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/datasource"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/xds/envoy"
 	"github.com/kumahq/kuma/pkg/xds/secrets"
+	"github.com/kumahq/kuma/pkg/xds/topology"
 )
 
 type Context struct {
@@ -63,7 +63,7 @@ type MeshContext struct {
 	Resource                    *core_mesh.MeshResource
 	Resources                   Resources
 	DataplanesByName            map[string]*core_mesh.DataplaneResource
-	MeshServiceByName           map[string]*meshservice_api.MeshServiceResource
+	MeshServiceIdentity         map[string]topology.MeshServiceIdentity
 	EndpointMap                 xds.EndpointMap
 	ExternalServicesEndpointMap xds.EndpointMap
 	CrossMeshEndpoints          map[xds.MeshName]xds.EndpointMap

--- a/pkg/xds/envoy/clusters/configurers.go
+++ b/pkg/xds/envoy/clusters/configurers.go
@@ -36,6 +36,20 @@ func ClientSideMTLS(tracker core_xds.SecretsTracker, mesh *core_mesh.MeshResourc
 	})
 }
 
+func ClientSideMultiIdentitiesMTLS(tracker core_xds.SecretsTracker, mesh *core_mesh.MeshResource, upstreamTLSReady bool, tags []envoy_tags.Tags, identities []string) ClusterBuilderOpt {
+	return ClusterBuilderOptFunc(func(builder *ClusterBuilder) {
+		builder.AddConfigurer(&v3.ClientSideMTLSConfigurer{
+			SecretsTracker:   tracker,
+			UpstreamMesh:     mesh,
+			UpstreamService:  "*",
+			LocalMesh:        mesh,
+			Tags:             tags,
+			UpstreamTLSReady: upstreamTLSReady,
+			VerifyIdentities: identities,
+		})
+	})
+}
+
 func CrossMeshClientSideMTLS(tracker core_xds.SecretsTracker, localMesh *core_mesh.MeshResource, upstreamMesh *core_mesh.MeshResource, upstreamService string, upstreamTLSReady bool, tags []envoy_tags.Tags) ClusterBuilderOpt {
 	return ClusterBuilderOptFunc(func(builder *ClusterBuilder) {
 		builder.AddConfigurer(&v3.ClientSideMTLSConfigurer{

--- a/pkg/xds/envoy/clusters/v3/client_side_mtls_configurer.go
+++ b/pkg/xds/envoy/clusters/v3/client_side_mtls_configurer.go
@@ -22,6 +22,7 @@ type ClientSideMTLSConfigurer struct {
 	LocalMesh        *core_mesh.MeshResource
 	Tags             []tags.Tags
 	UpstreamTLSReady bool
+	VerifyIdentities []string
 }
 
 var _ ClusterConfigurer = &ClientSideTLSConfigurer{}
@@ -79,7 +80,11 @@ func (c *ClientSideMTLSConfigurer) createTransportSocket(sni string) (*envoy_cor
 	ca := c.SecretsTracker.RequestCa(c.UpstreamMesh.GetMeta().GetName())
 	identity := c.SecretsTracker.RequestIdentityCert()
 
-	tlsContext, err := envoy_tls.CreateUpstreamTlsContext(identity, ca, c.UpstreamService, sni)
+	var verifyIdentities []string
+	if c.VerifyIdentities != nil {
+		verifyIdentities = c.VerifyIdentities
+	}
+	tlsContext, err := envoy_tls.CreateUpstreamTlsContext(identity, ca, c.UpstreamService, sni, verifyIdentities)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/xds/envoy/tls/v3/tls_test.go
+++ b/pkg/xds/envoy/tls/v3/tls_test.go
@@ -114,6 +114,7 @@ var _ = Describe("CreateUpstreamTlsContext()", func() {
 					&caRequest{mesh: mesh},
 					given.upstreamService,
 					"",
+					nil,
 				)
 				// then
 				Expect(err).ToNot(HaveOccurred())

--- a/pkg/xds/envoy/types.go
+++ b/pkg/xds/envoy/types.go
@@ -145,6 +145,7 @@ type Service struct {
 	clusters           []Cluster
 	hasExternalService bool
 	tlsReady           bool
+	meshServiceName    string
 }
 
 func (c *Service) Add(cluster Cluster) {
@@ -172,6 +173,10 @@ func (c *Service) Clusters() []Cluster {
 
 func (c *Service) TLSReady() bool {
 	return c.tlsReady
+}
+
+func (c *Service) MeshServiceName() string {
+	return c.meshServiceName
 }
 
 type Services map[string]*Service
@@ -207,6 +212,19 @@ func (sa ServicesAccumulator) Add(clusters ...Cluster) {
 			sa.services[c.Service()] = &Service{
 				tlsReady: sa.tlsReadiness[c.Service()],
 				name:     c.Service(),
+			}
+		}
+		sa.services[c.Service()].Add(c)
+	}
+}
+
+func (sa ServicesAccumulator) AddMeshService(name string, clusters ...Cluster) {
+	for _, c := range clusters {
+		if sa.services[c.Service()] == nil {
+			sa.services[c.Service()] = &Service{
+				tlsReady:        sa.tlsReadiness[c.Service()],
+				name:            c.Service(),
+				meshServiceName: name,
 			}
 		}
 		sa.services[c.Service()].Add(c)

--- a/pkg/xds/topology/outbound.go
+++ b/pkg/xds/topology/outbound.go
@@ -92,6 +92,32 @@ func BuildEdsEndpointMap(
 	return outbound
 }
 
+type MeshServiceIdentity struct {
+	Resource   *meshservice_api.MeshServiceResource
+	Identities map[string]struct{}
+}
+
+func BuildMeshServiceIdentityMap(
+	meshServices []*meshservice_api.MeshServiceResource,
+	endpointMap core_xds.EndpointMap,
+) map[string]MeshServiceIdentity {
+	serviceIdentities := map[string]MeshServiceIdentity{}
+	for _, meshSvc := range meshServices {
+		identities := map[string]struct{}{}
+		for _, port := range meshSvc.Spec.Ports {
+			name := meshSvc.DestinationName(port.Port)
+			for _, endpoint := range endpointMap[name] {
+				identities[endpoint.Tags[mesh_proto.ServiceTag]] = struct{}{}
+			}
+		}
+		serviceIdentities[meshSvc.GetMeta().GetName()] = MeshServiceIdentity{
+			Resource:   meshSvc,
+			Identities: identities,
+		}
+	}
+	return serviceIdentities
+}
+
 // endpointWeight defines default weight for in-cluster endpoint.
 // Examples of having service "backend":
 //  1. Single-zone deployment, 2 instances in one cluster (zone1)

--- a/test/e2e_env/universal/meshservice/meshservice.go
+++ b/test/e2e_env/universal/meshservice/meshservice.go
@@ -16,7 +16,7 @@ func MeshService() {
 
 	BeforeAll(func() {
 		err := NewClusterSetup().
-			Install(MeshUniversal(meshName)).
+			Install(MTLSMeshUniversal(meshName)).
 			Install(TestServerUniversal(
 				"first-test-server",
 				meshName,
@@ -25,6 +25,7 @@ func MeshService() {
 				WithAdditionalTags(map[string]string{
 					"app": "test-server",
 				}))).
+			Install(MeshTrafficPermissionAllowAllUniversal(meshName)).
 			Install(DemoClientUniversal(AppModeDemoClient, meshName, WithTransparentProxy(true))).
 			Setup(universal.Cluster)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Add support for mTLS by verifying that the destination's cert comes from one of the identities (`kuma.io/service` values) matched by this `MeshService`'s selector.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
