### PR TITLE
feat(meshservice): cross-zone connectivity

### DIFF
--- a/pkg/plugins/policies/core/xds/meshroute/listeners.go
+++ b/pkg/plugins/policies/core/xds/meshroute/listeners.go
@@ -207,7 +207,7 @@ func makeSplit(
 		}
 
 		if len(meshServiceName) > 0 {
-			servicesAcc.AddMeshService(meshServiceName, clusterBuilder.Build())
+			servicesAcc.AddMeshService(meshServiceName, *ref.Port, clusterBuilder.Build())
 		} else {
 			servicesAcc.Add(clusterBuilder.Build())
 		}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.clusters.golden.yaml
@@ -33,7 +33,7 @@ resources:
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
-        sni: backend{mesh=default}
+        sni: a601e0c00295a9fbe.backend.80.default.ms
     type: EDS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners.go
@@ -32,7 +32,7 @@ func generateFromService(
 	serviceName := svc.ServiceName
 	protocol := meshCtx.GetServiceProtocol(serviceName)
 
-	backendRefs := getBackendRefs(toRulesTCP, toRulesHTTP, serviceName, protocol, svc.BackendRef.Tags)
+	backendRefs := getBackendRefs(toRulesTCP, toRulesHTTP, serviceName, protocol, svc.BackendRef)
 	if len(backendRefs) == 0 {
 		return nil, nil
 	}

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners_backendrefs.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners_backendrefs.go
@@ -6,16 +6,9 @@ import (
 	core_xds "github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
 	meshhttproute_api "github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
 	api "github.com/kumahq/kuma/pkg/plugins/policies/meshtcproute/api/v1alpha1"
-	"github.com/kumahq/kuma/pkg/util/pointer"
 )
 
-func getBackendRefs(
-	toRulesTCP core_xds.Rules,
-	toRulesHTTP core_xds.Rules,
-	serviceName string,
-	protocol core_mesh.Protocol,
-	tags map[string]string,
-) []common_api.BackendRef {
+func getBackendRefs(toRulesTCP core_xds.Rules, toRulesHTTP core_xds.Rules, serviceName string, protocol core_mesh.Protocol, backendRef common_api.BackendRef) []common_api.BackendRef {
 	service := core_xds.MeshService(serviceName)
 
 	tcpConf := core_xds.ComputeConf[api.Rule](toRulesTCP, service)
@@ -42,13 +35,6 @@ func getBackendRefs(
 		return tcpConf.Default.BackendRefs
 	}
 	return []common_api.BackendRef{
-		{
-			TargetRef: common_api.TargetRef{
-				Kind: common_api.MeshService,
-				Name: serviceName,
-				Tags: tags,
-			},
-			Weight: pointer.To(uint(100)),
-		},
+		backendRef,
 	}
 }

--- a/pkg/xds/envoy/clusters/configurers.go
+++ b/pkg/xds/envoy/clusters/configurers.go
@@ -36,14 +36,15 @@ func ClientSideMTLS(tracker core_xds.SecretsTracker, mesh *core_mesh.MeshResourc
 	})
 }
 
-func ClientSideMultiIdentitiesMTLS(tracker core_xds.SecretsTracker, mesh *core_mesh.MeshResource, upstreamTLSReady bool, tags []envoy_tags.Tags, identities []string) ClusterBuilderOpt {
+func ClientSideMultiIdentitiesMTLS(tracker core_xds.SecretsTracker, mesh *core_mesh.MeshResource, upstreamTLSReady bool, sni string, identities []string) ClusterBuilderOpt {
 	return ClusterBuilderOptFunc(func(builder *ClusterBuilder) {
 		builder.AddConfigurer(&v3.ClientSideMTLSConfigurer{
 			SecretsTracker:   tracker,
 			UpstreamMesh:     mesh,
 			UpstreamService:  "*",
 			LocalMesh:        mesh,
-			Tags:             tags,
+			SNI:              sni,
+			Tags:             nil,
 			UpstreamTLSReady: upstreamTLSReady,
 			VerifyIdentities: identities,
 		})

--- a/pkg/xds/envoy/clusters/v3/client_side_mtls_configurer.go
+++ b/pkg/xds/envoy/clusters/v3/client_side_mtls_configurer.go
@@ -21,6 +21,7 @@ type ClientSideMTLSConfigurer struct {
 	UpstreamService  string
 	LocalMesh        *core_mesh.MeshResource
 	Tags             []tags.Tags
+	SNI              string
 	UpstreamTLSReady bool
 	VerifyIdentities []string
 }
@@ -41,7 +42,7 @@ func (c *ClientSideMTLSConfigurer) Configure(cluster *envoy_cluster.Cluster) err
 	distinctTags := tags.DistinctTags(c.Tags)
 	switch {
 	case len(distinctTags) == 0:
-		transportSocket, err := c.createTransportSocket("")
+		transportSocket, err := c.createTransportSocket(c.SNI)
 		if err != nil {
 			return err
 		}

--- a/pkg/xds/envoy/tls/sni.go
+++ b/pkg/xds/envoy/tls/sni.go
@@ -2,11 +2,16 @@ package tls
 
 import (
 	"fmt"
+	"hash/fnv"
 	"strings"
 
 	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	meshexternalservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
+	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/util/maps"
 	envoy_tags "github.com/kumahq/kuma/pkg/xds/envoy/tags"
 )
 
@@ -34,4 +39,39 @@ func TagsFromSNI(sni string) (envoy_tags.Tags, error) {
 	}
 	tags[mesh_proto.ServiceTag] = parts[0]
 	return tags, nil
+}
+
+const (
+	sniFormatVersion = "a"
+	dnsLabelLimit    = 63
+)
+
+func SNIForResource(resName string, meshName string, resType model.ResourceType, port uint32, additionalData map[string]string) string {
+	var mapStrings []string
+	for _, key := range maps.SortedKeys(additionalData) {
+		mapStrings = append(mapStrings, fmt.Sprintf("%s=%s", key, additionalData[key]))
+	}
+
+	hash := fnv.New64a()
+	_, _ = hash.Write([]byte(fmt.Sprintf("%s;%s;%v", resName, meshName, strings.Join(mapStrings, ",")))) // fnv64a does not return error
+	hashBytes := hash.Sum(nil)
+
+	if len(resName) > dnsLabelLimit-1 {
+		resName = resName[:dnsLabelLimit-1] + "x"
+	}
+	if len(meshName) > dnsLabelLimit-1 {
+		meshName = meshName[:dnsLabelLimit-1] + "x"
+	}
+
+	resTypeAbbrv := ""
+	switch resType {
+	case meshservice_api.MeshServiceType:
+		resTypeAbbrv = "ms"
+	case meshexternalservice_api.MeshExternalServiceType:
+		resTypeAbbrv = "mes"
+	default:
+		panic("resource type not supported for SNI")
+	}
+
+	return fmt.Sprintf("%s%x.%s.%d.%s.%s", sniFormatVersion, hashBytes, resName, port, meshName, resTypeAbbrv)
 }

--- a/pkg/xds/envoy/types.go
+++ b/pkg/xds/envoy/types.go
@@ -146,6 +146,7 @@ type Service struct {
 	hasExternalService bool
 	tlsReady           bool
 	meshServiceName    string
+	meshServicePort    uint32
 }
 
 func (c *Service) Add(cluster Cluster) {
@@ -177,6 +178,10 @@ func (c *Service) TLSReady() bool {
 
 func (c *Service) MeshServiceName() string {
 	return c.meshServiceName
+}
+
+func (c *Service) MeshServicePort() uint32 {
+	return c.meshServicePort
 }
 
 type Services map[string]*Service
@@ -218,13 +223,14 @@ func (sa ServicesAccumulator) Add(clusters ...Cluster) {
 	}
 }
 
-func (sa ServicesAccumulator) AddMeshService(name string, clusters ...Cluster) {
+func (sa ServicesAccumulator) AddMeshService(name string, port uint32, clusters ...Cluster) {
 	for _, c := range clusters {
 		if sa.services[c.Service()] == nil {
 			sa.services[c.Service()] = &Service{
 				tlsReady:        sa.tlsReadiness[c.Service()],
 				name:            c.Service(),
 				meshServiceName: name,
+				meshServicePort: port,
 			}
 		}
 		sa.services[c.Service()].Add(c)

--- a/pkg/xds/generator/egress/external_services_generator.go
+++ b/pkg/xds/generator/egress/external_services_generator.go
@@ -34,12 +34,13 @@ func (g *ExternalServicesGenerator) Generate(
 	destinations := zoneproxy.BuildMeshDestinations(
 		nil,
 		xds_context.Resources{MeshLocalResources: meshResources.Resources},
+		nil,
 	)
 	services := g.buildServices(endpointMap, zone, meshResources)
 
 	g.addFilterChains(
 		apiVersion,
-		destinations,
+		destinations.KumaIoServices,
 		endpointMap,
 		meshResources,
 		listenerBuilder,

--- a/pkg/xds/generator/egress/internal_services_generator.go
+++ b/pkg/xds/generator/egress/internal_services_generator.go
@@ -32,6 +32,7 @@ func (g *InternalServicesGenerator) Generate(
 	destinations := zoneproxy.BuildMeshDestinations(
 		availableServices,
 		xds_context.Resources{MeshLocalResources: meshResources.Resources},
+		nil, // todo(jakubdyszkiewicz) add support for MeshService + egress
 	)
 
 	services := zoneproxy.AddFilterChains(availableServices, proxy.APIVersion, listenerBuilder, destinations, meshResources.EndpointMap)

--- a/pkg/xds/generator/testdata/ingress/mesh-service.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/mesh-service.envoy.golden.yaml
@@ -1,0 +1,66 @@
+resources:
+- name: mesh1:backend2_svc_80
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    altStatName: mesh1_backend2_svc_80
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+        resourceApiVersion: V3
+    name: mesh1:backend2_svc_80
+    type: EDS
+- name: mesh1:backend_svc_80
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    altStatName: mesh1_backend_svc_80
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+        resourceApiVersion: V3
+    name: mesh1:backend_svc_80
+    type: EDS
+- name: mesh1:backend2_svc_80
+  resource:
+    '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
+    clusterName: mesh1:backend2_svc_80
+- name: mesh1:backend_svc_80
+  resource:
+    '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
+    clusterName: mesh1:backend_svc_80
+- name: inbound:10.0.0.1:10001
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 10.0.0.1
+        portValue: 10001
+    enableReusePort: false
+    filterChains:
+    - filterChainMatch:
+        serverNames:
+        - a601e0c00295a9fbe.backend.80.default.ms
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: default:backend_svc_80
+          statPrefix: default_backend_svc_80
+    - filterChainMatch:
+        serverNames:
+        - aec60634adf0f45d6.backend2.80.default.ms
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: default:backend2_svc_80
+          statPrefix: default_backend2_svc_80
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: inbound:10.0.0.1:10001
+    trafficDirection: INBOUND

--- a/pkg/xds/ingress/outbound.go
+++ b/pkg/xds/ingress/outbound.go
@@ -1,8 +1,13 @@
 package ingress
 
 import (
+	"maps"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/xds/envoy/tags"
 	"github.com/kumahq/kuma/pkg/xds/topology"
@@ -14,11 +19,8 @@ func BuildEndpointMap(
 	externalServices []*core_mesh.ExternalServiceResource,
 	zoneEgresses []*core_mesh.ZoneEgressResource,
 	gateways []*core_mesh.MeshGatewayResource,
+	meshServices []*meshservice_api.MeshServiceResource,
 ) core_xds.EndpointMap {
-	if len(destinations) == 0 {
-		return nil
-	}
-
 	outbound := core_xds.EndpointMap{}
 	for _, dataplane := range dataplanes {
 		for _, inbound := range dataplane.Spec.GetNetworking().GetHealthyInbounds() {
@@ -86,6 +88,51 @@ func BuildEndpointMap(
 				Weight:          1,
 				ExternalService: &core_xds.ExternalService{},
 			})
+		}
+	}
+
+	// O(dataplane*meshsvc) can be optimized by sharding both by namespace
+	// this is copy of topology/outbound.go
+	for _, dataplane := range dataplanes {
+		dpNetworking := dataplane.Spec.GetNetworking()
+
+		for _, meshSvc := range meshServices {
+			tagSelector := mesh_proto.TagSelector(meshSvc.Spec.Selector.DataplaneTags)
+			if meshSvc.Spec.Selector.DataplaneRef != nil {
+				continue
+			}
+
+			for _, inbound := range dpNetworking.GetHealthyInbounds() {
+				if !tagSelector.Matches(inbound.GetTags()) {
+					continue
+				}
+				for _, port := range meshSvc.Spec.Ports {
+					switch port.TargetPort.Type {
+					case intstr.Int:
+						if uint32(port.TargetPort.IntVal) != inbound.Port {
+							continue
+						}
+					case intstr.String:
+						if port.TargetPort.StrVal != inbound.Name {
+							continue
+						}
+					}
+
+					inboundTags := maps.Clone(inbound.GetTags())
+					serviceName := meshSvc.DestinationName(port.Port)
+					if serviceName == inboundTags[mesh_proto.ServiceTag] {
+						continue // it was already added by fillDataplaneOutbounds
+					}
+					inboundInterface := dpNetworking.ToInboundInterface(inbound)
+
+					outbound[serviceName] = append(outbound[serviceName], core_xds.Endpoint{
+						Target: inboundInterface.DataplaneAdvertisedIP,
+						Port:   inboundInterface.DataplanePort,
+						Tags:   inboundTags,
+						Weight: 1,
+					})
+				}
+			}
 		}
 	}
 

--- a/pkg/xds/ingress/outbound_test.go
+++ b/pkg/xds/ingress/outbound_test.go
@@ -23,7 +23,7 @@ var _ = Describe("IngressTrafficRoute", func() {
 		DescribeTable("should generate ingress outbounds matching given selectors",
 			func(given testCase) {
 				// when
-				endpoints := BuildEndpointMap(given.destinations, given.dataplanes, given.externalServices, given.zoneEgress, nil)
+				endpoints := BuildEndpointMap(given.destinations, given.dataplanes, given.externalServices, given.zoneEgress, nil, nil)
 				// then
 				Expect(endpoints).To(Equal(given.expected))
 			},

--- a/pkg/xds/sync/ingress_proxy_builder.go
+++ b/pkg/xds/sync/ingress_proxy_builder.go
@@ -70,12 +70,13 @@ func (p *IngressProxyBuilder) buildZoneIngressProxy(
 
 		meshResources := &core_xds.MeshIngressResources{
 			Mesh: mesh,
-			EndpointMap: ingress.BuildEndpointMap(
+			EndpointMap: ingress.BuildEndpointMap( // todo reuse this for all ingress (follow egress pattern)
 				ingress.BuildDestinationMap(meshName, zoneIngress),
 				meshCtx.Resources.Dataplanes().Items,
 				meshCtx.Resources.ExternalServices().Items,
 				zoneEgressesList,
 				meshCtx.Resources.Gateways().Items,
+				meshCtx.Resources.MeshServices().Items,
 			),
 			Resources: meshCtx.Resources.MeshLocalResources,
 		}


### PR DESCRIPTION
### Checklist prior to review

Cross zone connectivity using synced MeshServices.

Required things to have E2E tests:
* Syncing identities

Things to improve:
* Splits
* Routing through egress

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
