### PR TITLE
chore(deps): ignore go-control-plane updates by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,11 @@ updates:
       go.opentelemetry.io:
           patterns:
             - "go.opentelemetry.io/*"
+    ignore:
+      # go-control-plane v0.12.0 introduced a potential deadlock issue. This issue is
+      # being tracked in https://github.com/envoyproxy/go-control-plane/issues/875.
+      # Remove this once the issue is resolved.
+      - dependency-name: github.com/envoyproxy/go-control-plane
 
   - package-ecosystem: "docker"
     directory: "/tools/releases/dockerfiles"
@@ -37,5 +42,5 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 15
     labels:
-      - "dependencies"      
+      - "dependencies"
       - "ci/skip-test" # No need to run tests on github actions updates


### PR DESCRIPTION
v0.12.0 introduced deadlock so just to be sure it won't be upgraded by mistake when new patch will be released

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - no relevant issues
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - it won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - no tests
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - there is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
