### PR TITLE
feat(api-server): update policies api response structure

### DIFF
--- a/api/openapi/specs/common/resource.yaml
+++ b/api/openapi/specs/common/resource.yaml
@@ -41,7 +41,7 @@ components:
           type: boolean
     Meta:
       type: object
-      required: [type, mesh, name]
+      required: [type, mesh, name, labels]
       properties:
         type:
           type: string
@@ -55,14 +55,16 @@ components:
           type: string
           example: my-resource
           description: the name of the resource
-        displayName:
-          type: string
-          example: mtp
-          description: the original name of the resource
-        namespace:
-          type: string
-          example: kuma-system
-          description: the namespace of this resource
+        labels:
+          type: object
+          additionalProperties:
+            type: string
+          example:
+            "k8s.kuma.io/namespace": "kuma-system"
+            "kuma.io/display-name": "mtp"
+            "kuma.io/mesh": "default"
+            "kuma.io/origin": "zone"
+          description: the label of the resource
     InspectRule:
       type: object
       required: [type]

--- a/api/openapi/specs/common/resource.yaml
+++ b/api/openapi/specs/common/resource.yaml
@@ -55,6 +55,14 @@ components:
           type: string
           example: my-resource
           description: the name of the resource
+        displayName:
+          type: string
+          example: mtp
+          description: the original name of the resource
+        namespace:
+          type: string
+          example: kuma-system
+          description: the namespace of this resource
     InspectRule:
       type: object
       required: [type]

--- a/api/openapi/types/common/zz_generated.resource.go
+++ b/api/openapi/types/common/zz_generated.resource.go
@@ -45,11 +45,17 @@ type InspectRule struct {
 
 // Meta defines model for Meta.
 type Meta struct {
+	// DisplayName the original name of the resource
+	DisplayName *string `json:"displayName,omitempty"`
+
 	// Mesh the mesh this resource is part of
 	Mesh string `json:"mesh"`
 
 	// Name the name of the resource
 	Name string `json:"name"`
+
+	// Namespace the namespace of this resource
+	Namespace *string `json:"namespace,omitempty"`
 
 	// Type the type of this resource
 	Type string `json:"type"`

--- a/api/openapi/types/common/zz_generated.resource.go
+++ b/api/openapi/types/common/zz_generated.resource.go
@@ -45,17 +45,14 @@ type InspectRule struct {
 
 // Meta defines model for Meta.
 type Meta struct {
-	// DisplayName the original name of the resource
-	DisplayName *string `json:"displayName,omitempty"`
+	// Labels the label of the resource
+	Labels map[string]string `json:"labels"`
 
 	// Mesh the mesh this resource is part of
 	Mesh string `json:"mesh"`
 
 	// Name the name of the resource
 	Name string `json:"name"`
-
-	// Namespace the namespace of this resource
-	Namespace *string `json:"namespace,omitempty"`
 
 	// Type the type of this resource
 	Type string `json:"type"`

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -2222,6 +2222,7 @@ components:
         - type
         - mesh
         - name
+        - labels
       properties:
         type:
           type: string
@@ -2235,6 +2236,16 @@ components:
           type: string
           example: my-resource
           description: the name of the resource
+        labels:
+          type: object
+          additionalProperties:
+            type: string
+          example:
+            k8s.kuma.io/namespace: kuma-system
+            kuma.io/display-name: mtp
+            kuma.io/mesh: default
+            kuma.io/origin: zone
+          description: the label of the resource
     ProxyRule:
       type: object
       required:

--- a/pkg/api-server/oapi-helpers/helpers.go
+++ b/pkg/api-server/oapi-helpers/helpers.go
@@ -12,9 +12,10 @@ func ResourceToMeta(m core_model.Resource) api_common.Meta {
 
 func ResourceMetaToMeta(resType core_model.ResourceType, m core_model.ResourceMeta) api_common.Meta {
 	return api_common.Meta{
-		Type: string(resType),
-		Mesh: m.GetMesh(),
-		Name: m.GetName(),
+		Type:   string(resType),
+		Mesh:   m.GetMesh(),
+		Name:   m.GetName(),
+		Labels: m.GetLabels(),
 	}
 }
 

--- a/pkg/api-server/oapi-helpers/helpers.go
+++ b/pkg/api-server/oapi-helpers/helpers.go
@@ -11,11 +11,17 @@ func ResourceToMeta(m core_model.Resource) api_common.Meta {
 }
 
 func ResourceMetaToMeta(resType core_model.ResourceType, m core_model.ResourceMeta) api_common.Meta {
+	// We use an empty object rather than a nil
+	labels := m.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
 	return api_common.Meta{
 		Type:   string(resType),
 		Mesh:   m.GetMesh(),
 		Name:   m.GetName(),
-		Labels: m.GetLabels(),
+		Labels: labels,
 	}
 }
 

--- a/pkg/api-server/resource_endpoints_test.go
+++ b/pkg/api-server/resource_endpoints_test.go
@@ -14,7 +14,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	api_types "github.com/kumahq/kuma/api/openapi/types"
 	api_server "github.com/kumahq/kuma/pkg/api-server"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
@@ -223,72 +222,5 @@ var _ = Describe("Resource Endpoints on Zone, label origin", func() {
 		Expect(actualDpp.Meta.GetLabels()).To(Equal(map[string]string{
 			mesh_proto.ResourceOriginLabel: string(mesh_proto.ZoneResourceOrigin),
 		}))
-	})
-
-	It("should return the labels from the policy dataplane API response", func() {
-		apiServer, store, stop := createServer(true, true)
-		defer stop()
-
-		meshName := "mesh-2"
-		createMesh(store, meshName)
-
-		// create a dataplane
-		dpName := "demo-app-fcc8bc4cb-m2rbm-7ff4vxf287bbfv9d.kuma-system"
-		dpLabels := map[string]string{
-			mesh_proto.DisplayName:         "demo-app-fcc8bc4cb-m2rbm",
-			mesh_proto.KubeNamespaceTag:    "kuma-demo",
-			mesh_proto.ResourceOriginLabel: "zone",
-		}
-		dpResource := &unversioned.Resource{
-			Meta: rest_v1alpha1.ResourceMeta{
-				Name:   dpName,
-				Mesh:   meshName,
-				Type:   string(core_mesh.DataplaneType),
-				Labels: dpLabels,
-			},
-			Spec: builders.Dataplane().
-				WithName("backend-1").
-				WithHttpServices("backend").
-				AddOutboundsToServices("redis", "elastic", "postgres").
-				Build().Spec,
-		}
-		resp, err := put(apiServer.Address(), meshName, core_mesh.DataplaneResourceTypeDescriptor, dpName, dpResource)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(http.StatusCreated))
-
-		// create a MeshTrafficPermission policy
-		mtpName := "mtp-1"
-		mtpResource := &rest_v1alpha1.Resource{
-			ResourceMeta: rest_v1alpha1.ResourceMeta{
-				Name: mtpName,
-				Mesh: meshName,
-				Type: string(v1alpha1.MeshTrafficPermissionType),
-				Labels: map[string]string{
-					mesh_proto.ResourceOriginLabel: "zone",
-				},
-			},
-			Spec: builders.MeshTrafficPermission().
-				WithTargetRef(builders.TargetRefMesh()).
-				AddFrom(builders.TargetRefMesh(), v1alpha1.Allow).
-				Build().Spec,
-		}
-		resp, err = put(apiServer.Address(), meshName, v1alpha1.MeshTrafficPermissionResourceTypeDescriptor, mtpName, mtpResource)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(http.StatusCreated))
-
-		// send a request to the kuma api-server to fetch the MeshTrafficPermission dataplanes details
-		req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/meshes/%s/meshtrafficpermissions/%s/_resources/dataplanes", apiServer.Address(), meshName, mtpName), nil)
-		Expect(err).NotTo(HaveOccurred())
-		resp, err = http.DefaultClient.Do(req)
-		Expect(err).NotTo(HaveOccurred())
-		respBytes, err := io.ReadAll(resp.Body)
-		Expect(err).ToNot(HaveOccurred())
-
-		// validate the response labels
-		var data api_types.InspectDataplanesForPolicyResponse
-		err = json.Unmarshal(respBytes, &data)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(data.Items).To(HaveLen(1))
-		Expect(data.Items[0].Labels).To(Equal(dpLabels), fmt.Sprintf("unmatched api-server policy dataplanes response label data: %+v", data.Items[0].Labels))
 	})
 })

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/empty.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/empty.golden.json
@@ -1,6 +1,7 @@
 {
  "httpMatches": [],
  "resource": {
+  "labels": null,
   "mesh": "default",
   "name": "dp-1",
   "type": "Dataplane"

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/empty.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/empty.golden.json
@@ -1,7 +1,7 @@
 {
  "httpMatches": [],
  "resource": {
-  "labels": null,
+  "labels": {},
   "mesh": "default",
   "name": "dp-1",
   "type": "Dataplane"

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/meshgateway.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/meshgateway.golden.json
@@ -1,7 +1,10 @@
 {
  "httpMatches": [],
  "resource": {
-  "labels": null,
+  "labels": {
+   "k8s.kuma.io/namespace": "kuma-demo",
+   "kuma.io/display-name": "dp-1"
+  },
   "mesh": "default",
   "name": "dp-1",
   "type": "Dataplane"
@@ -21,7 +24,10 @@
      "matchers": [],
      "origin": [
       {
-       "labels": null,
+       "labels": {
+        "k8s.kuma.io/namespace": "kuma-demo",
+        "kuma.io/display-name": "mt-on-gateway"
+       },
        "mesh": "default",
        "name": "mt-on-gateway",
        "type": "MeshTimeout"
@@ -47,7 +53,10 @@
     },
     "origin": [
      {
-      "labels": null,
+      "labels": {
+       "k8s.kuma.io/namespace": "kuma-demo",
+       "kuma.io/display-name": "mpp-on-gateway"
+      },
       "mesh": "default",
       "name": "mpp-on-gateway",
       "type": "MeshProxyPatch"

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/meshgateway.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/meshgateway.golden.json
@@ -1,6 +1,7 @@
 {
  "httpMatches": [],
  "resource": {
+  "labels": null,
   "mesh": "default",
   "name": "dp-1",
   "type": "Dataplane"
@@ -20,6 +21,7 @@
      "matchers": [],
      "origin": [
       {
+       "labels": null,
        "mesh": "default",
        "name": "mt-on-gateway",
        "type": "MeshTimeout"
@@ -45,6 +47,7 @@
     },
     "origin": [
      {
+      "labels": null,
       "mesh": "default",
       "name": "mpp-on-gateway",
       "type": "MeshProxyPatch"

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/meshgateway.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/meshgateway.input.yaml
@@ -16,6 +16,9 @@ conf:
 type: Dataplane
 name: dp-1
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: dp-1
 networking:
   address: 127.0.0.1
   gateway:
@@ -27,6 +30,9 @@ networking:
 type: MeshTimeout
 name: mt-on-gateway
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: mt-on-gateway
 spec:
   targetRef:
     kind: MeshGateway
@@ -43,6 +49,9 @@ spec:
 type: MeshProxyPatch
 mesh: default
 name: mpp-on-gateway
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: mpp-on-gateway
 spec:
   targetRef:
     kind: MeshGateway

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/meshhttproute.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/meshhttproute.golden.json
@@ -13,7 +13,7 @@
   }
  ],
  "resource": {
-  "labels": null,
+  "labels": {},
   "mesh": "default",
   "name": "dp-1",
   "type": "Dataplane"
@@ -57,7 +57,7 @@
      ],
      "origin": [
       {
-       "labels": null,
+       "labels": {},
        "mesh": "default",
        "name": "the-http-route",
        "type": "MeshHTTPRoute"
@@ -106,7 +106,7 @@
      ],
      "origin": [
       {
-       "labels": null,
+       "labels": {},
        "mesh": "default",
        "name": "the-other-http-route",
        "type": "MeshHTTPRoute"
@@ -140,13 +140,13 @@
      ],
      "origin": [
       {
-       "labels": null,
+       "labels": {},
        "mesh": "default",
        "name": "on-route",
        "type": "MeshTimeout"
       },
       {
-       "labels": null,
+       "labels": {},
        "mesh": "default",
        "name": "on-service",
        "type": "MeshTimeout"
@@ -173,7 +173,7 @@
      ],
      "origin": [
       {
-       "labels": null,
+       "labels": {},
        "mesh": "default",
        "name": "on-service",
        "type": "MeshTimeout"

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/meshhttproute.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/meshhttproute.golden.json
@@ -13,6 +13,7 @@
   }
  ],
  "resource": {
+  "labels": null,
   "mesh": "default",
   "name": "dp-1",
   "type": "Dataplane"
@@ -56,6 +57,7 @@
      ],
      "origin": [
       {
+       "labels": null,
        "mesh": "default",
        "name": "the-http-route",
        "type": "MeshHTTPRoute"
@@ -104,6 +106,7 @@
      ],
      "origin": [
       {
+       "labels": null,
        "mesh": "default",
        "name": "the-other-http-route",
        "type": "MeshHTTPRoute"
@@ -137,11 +140,13 @@
      ],
      "origin": [
       {
+       "labels": null,
        "mesh": "default",
        "name": "on-route",
        "type": "MeshTimeout"
       },
       {
+       "labels": null,
        "mesh": "default",
        "name": "on-service",
        "type": "MeshTimeout"
@@ -168,6 +173,7 @@
      ],
      "origin": [
       {
+       "labels": null,
        "mesh": "default",
        "name": "on-service",
        "type": "MeshTimeout"

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/meshhttprouteabsent.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/meshhttprouteabsent.golden.json
@@ -1,6 +1,7 @@
 {
  "httpMatches": [],
  "resource": {
+  "labels": null,
   "mesh": "default",
   "name": "dp-1",
   "type": "Dataplane"

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/meshhttprouteabsent.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/meshhttprouteabsent.golden.json
@@ -1,7 +1,7 @@
 {
  "httpMatches": [],
  "resource": {
-  "labels": null,
+  "labels": {},
   "mesh": "default",
   "name": "dp-1",
   "type": "Dataplane"

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/overriding_meshtimeout.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/overriding_meshtimeout.golden.json
@@ -1,7 +1,7 @@
 {
  "httpMatches": [],
  "resource": {
-  "labels": null,
+  "labels": {},
   "mesh": "default",
   "name": "dp-1",
   "type": "Dataplane"
@@ -28,13 +28,13 @@
        "matchers": [],
        "origin": [
         {
-         "labels": null,
+         "labels": {},
          "mesh": "default",
          "name": "default",
          "type": "MeshTimeout"
         },
         {
-         "labels": null,
+         "labels": {},
          "mesh": "default",
          "name": "override",
          "type": "MeshTimeout"
@@ -62,13 +62,13 @@
      ],
      "origin": [
       {
-       "labels": null,
+       "labels": {},
        "mesh": "default",
        "name": "default",
        "type": "MeshTimeout"
       },
       {
-       "labels": null,
+       "labels": {},
        "mesh": "default",
        "name": "override",
        "type": "MeshTimeout"
@@ -92,13 +92,13 @@
      ],
      "origin": [
       {
-       "labels": null,
+       "labels": {},
        "mesh": "default",
        "name": "default",
        "type": "MeshTimeout"
       },
       {
-       "labels": null,
+       "labels": {},
        "mesh": "default",
        "name": "override",
        "type": "MeshTimeout"
@@ -127,7 +127,7 @@
      ],
      "origin": [
       {
-       "labels": null,
+       "labels": {},
        "mesh": "default",
        "name": "default",
        "type": "MeshTimeout"

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/overriding_meshtimeout.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/overriding_meshtimeout.golden.json
@@ -1,6 +1,7 @@
 {
  "httpMatches": [],
  "resource": {
+  "labels": null,
   "mesh": "default",
   "name": "dp-1",
   "type": "Dataplane"
@@ -27,11 +28,13 @@
        "matchers": [],
        "origin": [
         {
+         "labels": null,
          "mesh": "default",
          "name": "default",
          "type": "MeshTimeout"
         },
         {
+         "labels": null,
          "mesh": "default",
          "name": "override",
          "type": "MeshTimeout"
@@ -59,11 +62,13 @@
      ],
      "origin": [
       {
+       "labels": null,
        "mesh": "default",
        "name": "default",
        "type": "MeshTimeout"
       },
       {
+       "labels": null,
        "mesh": "default",
        "name": "override",
        "type": "MeshTimeout"
@@ -87,11 +92,13 @@
      ],
      "origin": [
       {
+       "labels": null,
        "mesh": "default",
        "name": "default",
        "type": "MeshTimeout"
       },
       {
+       "labels": null,
        "mesh": "default",
        "name": "override",
        "type": "MeshTimeout"
@@ -120,6 +127,7 @@
      ],
      "origin": [
       {
+       "labels": null,
        "mesh": "default",
        "name": "default",
        "type": "MeshTimeout"

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/overriding_meshtrace.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/overriding_meshtrace.golden.json
@@ -1,6 +1,7 @@
 {
  "httpMatches": [],
  "resource": {
+  "labels": null,
   "mesh": "default",
   "name": "dp-1",
   "type": "Dataplane"
@@ -40,11 +41,13 @@
     },
     "origin": [
      {
+      "labels": null,
       "mesh": "default",
       "name": "default",
       "type": "MeshTrace"
      },
      {
+      "labels": null,
       "mesh": "default",
       "name": "override",
       "type": "MeshTrace"

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/overriding_meshtrace.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/overriding_meshtrace.golden.json
@@ -1,7 +1,7 @@
 {
  "httpMatches": [],
  "resource": {
-  "labels": null,
+  "labels": {},
   "mesh": "default",
   "name": "dp-1",
   "type": "Dataplane"
@@ -41,13 +41,13 @@
     },
     "origin": [
      {
-      "labels": null,
+      "labels": {},
       "mesh": "default",
       "name": "default",
       "type": "MeshTrace"
      },
      {
-      "labels": null,
+      "labels": {},
       "mesh": "default",
       "name": "override",
       "type": "MeshTrace"

--- a/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/empty.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/empty.golden.json
@@ -1,7 +1,7 @@
 {
  "httpMatches": [],
  "resource": {
-  "labels": null,
+  "labels": {},
   "mesh": "default",
   "name": "gw-1",
   "type": "MeshGateway"

--- a/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/empty.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/empty.golden.json
@@ -1,6 +1,7 @@
 {
  "httpMatches": [],
  "resource": {
+  "labels": null,
   "mesh": "default",
   "name": "gw-1",
   "type": "MeshGateway"

--- a/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshgateway.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshgateway.golden.json
@@ -1,7 +1,10 @@
 {
  "httpMatches": [],
  "resource": {
-  "labels": null,
+  "labels": {
+   "k8s.kuma.io/namespace": "kuma-demo",
+   "kuma.io/display-name": "the-gateway"
+  },
   "mesh": "default",
   "name": "the-gateway",
   "type": "MeshGateway"
@@ -21,7 +24,10 @@
      "matchers": [],
      "origin": [
       {
-       "labels": null,
+       "labels": {
+        "k8s.kuma.io/namespace": "kuma-demo",
+        "kuma.io/display-name": "mt-on-gateway"
+       },
        "mesh": "default",
        "name": "mt-on-gateway",
        "type": "MeshTimeout"
@@ -47,7 +53,10 @@
     },
     "origin": [
      {
-      "labels": null,
+      "labels": {
+       "k8s.kuma.io/namespace": "kuma-demo",
+       "kuma.io/display-name": "mpp-on-gateway"
+      },
       "mesh": "default",
       "name": "mpp-on-gateway",
       "type": "MeshProxyPatch"

--- a/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshgateway.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshgateway.golden.json
@@ -1,6 +1,7 @@
 {
  "httpMatches": [],
  "resource": {
+  "labels": null,
   "mesh": "default",
   "name": "the-gateway",
   "type": "MeshGateway"
@@ -20,6 +21,7 @@
      "matchers": [],
      "origin": [
       {
+       "labels": null,
        "mesh": "default",
        "name": "mt-on-gateway",
        "type": "MeshTimeout"
@@ -45,6 +47,7 @@
     },
     "origin": [
      {
+      "labels": null,
       "mesh": "default",
       "name": "mpp-on-gateway",
       "type": "MeshProxyPatch"

--- a/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshgateway.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshgateway.input.yaml
@@ -5,6 +5,9 @@ name: default
 type: MeshGateway
 name: the-gateway
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: the-gateway
 selectors:
   - match:
       kuma.io/service: gw-1
@@ -16,6 +19,9 @@ conf:
 type: MeshTimeout
 name: mt-on-gateway
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: mt-on-gateway
 spec:
   targetRef:
     kind: MeshGateway
@@ -32,6 +38,9 @@ spec:
 type: MeshProxyPatch
 mesh: default
 name: mpp-on-gateway
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: mpp-on-gateway
 spec:
   targetRef:
     kind: MeshGateway

--- a/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshgateway2.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshgateway2.golden.json
@@ -44,7 +44,10 @@
   }
  ],
  "resource": {
-  "labels": null,
+  "labels": {
+   "k8s.kuma.io/namespace": "kuma-demo",
+   "kuma.io/display-name": "gw-1"
+  },
   "mesh": "default",
   "name": "gw-1",
   "type": "MeshGateway"
@@ -109,19 +112,28 @@
      "matchers": [],
      "origin": [
       {
-       "labels": null,
+       "labels": {
+        "k8s.kuma.io/namespace": "kuma-demo",
+        "kuma.io/display-name": "http-route-1"
+       },
        "mesh": "default",
        "name": "http-route-1",
        "type": "MeshHTTPRoute"
       },
       {
-       "labels": null,
+       "labels": {
+        "k8s.kuma.io/namespace": "kuma-demo",
+        "kuma.io/display-name": "http-route-2"
+       },
        "mesh": "default",
        "name": "http-route-2",
        "type": "MeshHTTPRoute"
       },
       {
-       "labels": null,
+       "labels": {
+        "k8s.kuma.io/namespace": "kuma-demo",
+        "kuma.io/display-name": "http-route-3"
+       },
        "mesh": "default",
        "name": "http-route-3",
        "type": "MeshHTTPRoute"
@@ -163,19 +175,28 @@
      "matchers": [],
      "origin": [
       {
-       "labels": null,
+       "labels": {
+        "k8s.kuma.io/namespace": "kuma-demo",
+        "kuma.io/display-name": "http-route-1"
+       },
        "mesh": "default",
        "name": "http-route-1",
        "type": "MeshHTTPRoute"
       },
       {
-       "labels": null,
+       "labels": {
+        "k8s.kuma.io/namespace": "kuma-demo",
+        "kuma.io/display-name": "http-route-2"
+       },
        "mesh": "default",
        "name": "http-route-2",
        "type": "MeshHTTPRoute"
       },
       {
-       "labels": null,
+       "labels": {
+        "k8s.kuma.io/namespace": "kuma-demo",
+        "kuma.io/display-name": "http-route-3"
+       },
        "mesh": "default",
        "name": "http-route-3",
        "type": "MeshHTTPRoute"

--- a/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshgateway2.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshgateway2.golden.json
@@ -44,6 +44,7 @@
   }
  ],
  "resource": {
+  "labels": null,
   "mesh": "default",
   "name": "gw-1",
   "type": "MeshGateway"
@@ -108,16 +109,19 @@
      "matchers": [],
      "origin": [
       {
+       "labels": null,
        "mesh": "default",
        "name": "http-route-1",
        "type": "MeshHTTPRoute"
       },
       {
+       "labels": null,
        "mesh": "default",
        "name": "http-route-2",
        "type": "MeshHTTPRoute"
       },
       {
+       "labels": null,
        "mesh": "default",
        "name": "http-route-3",
        "type": "MeshHTTPRoute"
@@ -159,16 +163,19 @@
      "matchers": [],
      "origin": [
       {
+       "labels": null,
        "mesh": "default",
        "name": "http-route-1",
        "type": "MeshHTTPRoute"
       },
       {
+       "labels": null,
        "mesh": "default",
        "name": "http-route-2",
        "type": "MeshHTTPRoute"
       },
       {
+       "labels": null,
        "mesh": "default",
        "name": "http-route-3",
        "type": "MeshHTTPRoute"

--- a/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshgateway2.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshgateway2.input.yaml
@@ -8,6 +8,9 @@ name: default
 type: MeshGateway
 name: gw-1
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: gw-1
 selectors:
   - match:
       kuma.io/service: gw-1
@@ -26,6 +29,9 @@ conf:
 type: MeshHTTPRoute
 name: http-route-1
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: http-route-1
 spec:
   targetRef:
     kind: MeshGateway
@@ -49,6 +55,9 @@ spec:
 type: MeshHTTPRoute
 name: http-route-2
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: http-route-2
 spec:
   targetRef:
     kind: MeshGateway
@@ -75,6 +84,9 @@ spec:
 type: MeshHTTPRoute
 name: http-route-3
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: http-route-3
 spec:
   targetRef:
     kind: MeshGateway

--- a/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshhttproute.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshhttproute.golden.json
@@ -24,6 +24,7 @@
   }
  ],
  "resource": {
+  "labels": null,
   "mesh": "default",
   "name": "the-gateway",
   "type": "MeshGateway"
@@ -89,11 +90,13 @@
      "matchers": [],
      "origin": [
       {
+       "labels": null,
        "mesh": "default",
        "name": "the-http-route",
        "type": "MeshHTTPRoute"
       },
       {
+       "labels": null,
        "mesh": "default",
        "name": "the-other-http-route",
        "type": "MeshHTTPRoute"
@@ -127,11 +130,13 @@
      ],
      "origin": [
       {
+       "labels": null,
        "mesh": "default",
        "name": "on-route",
        "type": "MeshTimeout"
       },
       {
+       "labels": null,
        "mesh": "default",
        "name": "on-service",
        "type": "MeshTimeout"
@@ -158,6 +163,7 @@
      ],
      "origin": [
       {
+       "labels": null,
        "mesh": "default",
        "name": "on-service",
        "type": "MeshTimeout"
@@ -184,6 +190,7 @@
      ],
      "origin": [
       {
+       "labels": null,
        "mesh": "default",
        "name": "on-route",
        "type": "MeshTimeout"

--- a/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshhttproute.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshhttproute.golden.json
@@ -24,7 +24,10 @@
   }
  ],
  "resource": {
-  "labels": null,
+  "labels": {
+   "k8s.kuma.io/namespace": "kuma-demo",
+   "kuma.io/display-name": "the-gateway"
+  },
   "mesh": "default",
   "name": "the-gateway",
   "type": "MeshGateway"
@@ -90,13 +93,19 @@
      "matchers": [],
      "origin": [
       {
-       "labels": null,
+       "labels": {
+        "k8s.kuma.io/namespace": "kuma-demo",
+        "kuma.io/display-name": "the-http-route"
+       },
        "mesh": "default",
        "name": "the-http-route",
        "type": "MeshHTTPRoute"
       },
       {
-       "labels": null,
+       "labels": {
+        "k8s.kuma.io/namespace": "kuma-demo",
+        "kuma.io/display-name": "the-other-http-route"
+       },
        "mesh": "default",
        "name": "the-other-http-route",
        "type": "MeshHTTPRoute"
@@ -130,13 +139,19 @@
      ],
      "origin": [
       {
-       "labels": null,
+       "labels": {
+        "k8s.kuma.io/namespace": "kuma-demo",
+        "kuma.io/display-name": "on-route"
+       },
        "mesh": "default",
        "name": "on-route",
        "type": "MeshTimeout"
       },
       {
-       "labels": null,
+       "labels": {
+        "k8s.kuma.io/namespace": "kuma-demo",
+        "kuma.io/display-name": "on-service"
+       },
        "mesh": "default",
        "name": "on-service",
        "type": "MeshTimeout"
@@ -163,7 +178,10 @@
      ],
      "origin": [
       {
-       "labels": null,
+       "labels": {
+        "k8s.kuma.io/namespace": "kuma-demo",
+        "kuma.io/display-name": "on-service"
+       },
        "mesh": "default",
        "name": "on-service",
        "type": "MeshTimeout"
@@ -190,7 +208,10 @@
      ],
      "origin": [
       {
-       "labels": null,
+       "labels": {
+        "k8s.kuma.io/namespace": "kuma-demo",
+        "kuma.io/display-name": "on-route"
+       },
        "mesh": "default",
        "name": "on-route",
        "type": "MeshTimeout"

--- a/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshhttproute.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshhttproute.input.yaml
@@ -6,6 +6,9 @@ name: default
 type: MeshTimeout
 name: on-route
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: on-route
 spec:
   targetRef:
     kind: MeshHTTPRoute
@@ -20,6 +23,9 @@ spec:
 type: MeshTimeout
 name: on-service
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: on-service
 spec:
   targetRef:
     kind: Mesh
@@ -34,6 +40,9 @@ spec:
 type: MeshHTTPRoute
 name: the-http-route
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: the-http-route
 spec:
   targetRef:
     kind: MeshGateway
@@ -56,6 +65,9 @@ spec:
 type: MeshHTTPRoute
 name: the-other-http-route
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: the-other-http-route
 spec:
   targetRef:
     kind: MeshGateway
@@ -82,6 +94,9 @@ spec:
 type: MeshGateway
 name: the-gateway
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: the-gateway
 selectors:
   - match:
       kuma.io/service: gw-1

--- a/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshtrace_on_mesh.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshtrace_on_mesh.golden.json
@@ -1,7 +1,10 @@
 {
  "httpMatches": [],
  "resource": {
-  "labels": null,
+  "labels": {
+   "k8s.kuma.io/namespace": "kuma-demo",
+   "kuma.io/display-name": "the-gateway"
+  },
   "mesh": "default",
   "name": "the-gateway",
   "type": "MeshGateway"
@@ -22,7 +25,10 @@
     },
     "origin": [
      {
-      "labels": null,
+      "labels": {
+       "k8s.kuma.io/namespace": "kuma-demo",
+       "kuma.io/display-name": "default"
+      },
       "mesh": "default",
       "name": "default",
       "type": "MeshTrace"

--- a/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshtrace_on_mesh.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshtrace_on_mesh.golden.json
@@ -1,6 +1,7 @@
 {
  "httpMatches": [],
  "resource": {
+  "labels": null,
   "mesh": "default",
   "name": "the-gateway",
   "type": "MeshGateway"
@@ -21,6 +22,7 @@
     },
     "origin": [
      {
+      "labels": null,
       "mesh": "default",
       "name": "default",
       "type": "MeshTrace"

--- a/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshtrace_on_mesh.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshtrace_on_mesh.input.yaml
@@ -5,6 +5,9 @@ name: default
 type: MeshGateway
 name: the-gateway
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: the-gateway
 selectors:
   - match:
       kuma.io/service: gw-1
@@ -16,6 +19,9 @@ conf:
 type: MeshTrace
 name: default
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: default
 spec:
   targetRef:
     kind: Mesh

--- a/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/match_mesh_dataplanes.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/match_mesh_dataplanes.golden.json
@@ -1,7 +1,10 @@
 {
  "items": [
   {
-   "labels": null,
+   "labels": {
+    "k8s.kuma.io/namespace": "kuma-demo",
+    "kuma.io/display-name": "dp-1"
+   },
    "mesh": "default",
    "name": "dp-1",
    "type": "Dataplane"

--- a/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/match_mesh_dataplanes.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/match_mesh_dataplanes.golden.json
@@ -1,6 +1,7 @@
 {
  "items": [
   {
+   "labels": null,
    "mesh": "default",
    "name": "dp-1",
    "type": "Dataplane"

--- a/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/match_mesh_dataplanes.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/match_mesh_dataplanes.input.yaml
@@ -17,6 +17,9 @@ spec:
 type: Dataplane
 name: dp-1
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: dp-1
 networking:
   address: 127.0.0.1
   inbound:

--- a/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/match_meshservice_dataplanes.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/match_meshservice_dataplanes.golden.json
@@ -1,7 +1,10 @@
 {
  "items": [
   {
-   "labels": null,
+   "labels": {
+    "k8s.kuma.io/namespace": "kuma-demo",
+    "kuma.io/display-name": "dp-1"
+   },
    "mesh": "default",
    "name": "dp-1",
    "type": "Dataplane"

--- a/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/match_meshservice_dataplanes.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/match_meshservice_dataplanes.golden.json
@@ -1,6 +1,7 @@
 {
  "items": [
   {
+   "labels": null,
    "mesh": "default",
    "name": "dp-1",
    "type": "Dataplane"

--- a/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/match_meshservice_dataplanes.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/match_meshservice_dataplanes.input.yaml
@@ -18,6 +18,9 @@ spec:
 type: Dataplane
 name: dp-1
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: dp-1
 networking:
   address: 127.0.0.1
   inbound:
@@ -28,6 +31,9 @@ networking:
 type: Dataplane
 name: dp-2
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: dp-2
 networking:
   address: 127.0.0.1
   inbound:

--- a/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/meshgatewayroute_dataplanes.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/meshgatewayroute_dataplanes.golden.json
@@ -1,7 +1,10 @@
 {
  "items": [
   {
-   "labels": null,
+   "labels": {
+    "k8s.kuma.io/namespace": "kuma-demo",
+    "kuma.io/display-name": "dp-3"
+   },
    "mesh": "default",
    "name": "dp-3",
    "type": "Dataplane"

--- a/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/meshgatewayroute_dataplanes.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/meshgatewayroute_dataplanes.golden.json
@@ -1,6 +1,7 @@
 {
  "items": [
   {
+   "labels": null,
    "mesh": "default",
    "name": "dp-3",
    "type": "Dataplane"

--- a/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/meshgatewayroute_dataplanes.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/meshgatewayroute_dataplanes.input.yaml
@@ -33,6 +33,9 @@ conf:
 type: Dataplane
 name: dp-1
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: dp-1
 networking:
   address: 127.0.0.1
   gateway:
@@ -43,6 +46,9 @@ networking:
 type: Dataplane
 name: dp-2
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: dp-2
 networking:
   address: 127.0.0.1
   gateway:
@@ -53,6 +59,9 @@ networking:
 type: Dataplane
 name: dp-3
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: dp-3
 networking:
   address: 127.0.0.1
   gateway:

--- a/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/meshhttproute_dataplanes.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/meshhttproute_dataplanes.golden.json
@@ -1,7 +1,10 @@
 {
  "items": [
   {
-   "labels": null,
+   "labels": {
+    "k8s.kuma.io/namespace": "kuma-demo",
+    "kuma.io/display-name": "dp-1"
+   },
    "mesh": "default",
    "name": "dp-1",
    "type": "Dataplane"

--- a/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/meshhttproute_dataplanes.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/meshhttproute_dataplanes.golden.json
@@ -1,6 +1,7 @@
 {
  "items": [
   {
+   "labels": null,
    "mesh": "default",
    "name": "dp-1",
    "type": "Dataplane"

--- a/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/meshhttproute_dataplanes.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/meshhttproute_dataplanes.input.yaml
@@ -42,6 +42,9 @@ spec:
 type: Dataplane
 name: dp-1
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: dp-1
 networking:
   address: 127.0.0.1
   inbound:
@@ -52,6 +55,9 @@ networking:
 type: Dataplane
 name: dp-3
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: dp-3
 networking:
   address: 127.0.0.1
   inbound:

--- a/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/meshtimeouthttproute.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/meshtimeouthttproute.golden.json
@@ -1,7 +1,10 @@
 {
  "items": [
   {
-   "labels": null,
+   "labels": {
+    "k8s.kuma.io/namespace": "kuma-demo",
+    "kuma.io/display-name": "the-dp"
+   },
    "mesh": "default",
    "name": "the-dp",
    "type": "Dataplane"

--- a/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/meshtimeouthttproute.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/meshtimeouthttproute.golden.json
@@ -1,6 +1,7 @@
 {
  "items": [
   {
+   "labels": null,
    "mesh": "default",
    "name": "the-dp",
    "type": "Dataplane"

--- a/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/meshtimeouthttproute.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/meshtimeouthttproute.input.yaml
@@ -41,6 +41,9 @@ spec:
 type: Dataplane
 name: not-the-dp
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: not-the-dp
 networking:
   address: 127.0.0.1
   inbound:
@@ -51,6 +54,9 @@ networking:
 type: Dataplane
 name: the-dp
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: the-dp
 networking:
   address: 127.0.0.1
   inbound:

--- a/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/namefilter_dataplanes.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/namefilter_dataplanes.golden.json
@@ -1,7 +1,10 @@
 {
  "items": [
   {
-   "labels": null,
+   "labels": {
+    "k8s.kuma.io/namespace": "kuma-demo",
+    "kuma.io/display-name": "the-dp"
+   },
    "mesh": "default",
    "name": "the-dp",
    "type": "Dataplane"

--- a/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/namefilter_dataplanes.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/namefilter_dataplanes.golden.json
@@ -1,6 +1,7 @@
 {
  "items": [
   {
+   "labels": null,
    "mesh": "default",
    "name": "the-dp",
    "type": "Dataplane"

--- a/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/namefilter_dataplanes.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/namefilter_dataplanes.input.yaml
@@ -17,6 +17,9 @@ spec:
 type: Dataplane
 name: dp-1
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: dp-1
 networking:
   address: 127.0.0.1
   inbound:
@@ -27,6 +30,9 @@ networking:
 type: Dataplane
 name: dp-2
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: dp-2
 networking:
   address: 127.0.0.1
   inbound:
@@ -37,6 +43,9 @@ networking:
 type: Dataplane
 name: the-dp
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: the-dp
 networking:
   address: 127.0.0.1
   inbound:

--- a/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/pagination_dataplanes.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/pagination_dataplanes.golden.json
@@ -1,7 +1,10 @@
 {
  "items": [
   {
-   "labels": null,
+   "labels": {
+    "k8s.kuma.io/namespace": "kuma-demo",
+    "kuma.io/display-name": "dp-2"
+   },
    "mesh": "default",
    "name": "dp-2",
    "type": "Dataplane"

--- a/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/pagination_dataplanes.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/pagination_dataplanes.golden.json
@@ -1,6 +1,7 @@
 {
  "items": [
   {
+   "labels": null,
    "mesh": "default",
    "name": "dp-2",
    "type": "Dataplane"

--- a/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/pagination_dataplanes.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/pagination_dataplanes.input.yaml
@@ -17,6 +17,9 @@ spec:
 type: Dataplane
 name: dp-1
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: dp-1
 networking:
   address: 127.0.0.1
   inbound:
@@ -27,6 +30,9 @@ networking:
 type: Dataplane
 name: dp-2
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: dp-2
 networking:
   address: 127.0.0.1
   inbound:
@@ -37,6 +43,9 @@ networking:
 type: Dataplane
 name: the-dp
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: the-dp
 networking:
   address: 127.0.0.1
   inbound:

--- a/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/proxytemplate_dataplanes.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/proxytemplate_dataplanes.golden.json
@@ -1,13 +1,19 @@
 {
  "items": [
   {
-   "labels": null,
+   "labels": {
+    "k8s.kuma.io/namespace": "kuma-demo",
+    "kuma.io/display-name": "dp-1"
+   },
    "mesh": "default",
    "name": "dp-1",
    "type": "Dataplane"
   },
   {
-   "labels": null,
+   "labels": {
+    "k8s.kuma.io/namespace": "kuma-demo",
+    "kuma.io/display-name": "dp-2"
+   },
    "mesh": "default",
    "name": "dp-2",
    "type": "Dataplane"

--- a/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/proxytemplate_dataplanes.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/proxytemplate_dataplanes.golden.json
@@ -1,11 +1,13 @@
 {
  "items": [
   {
+   "labels": null,
    "mesh": "default",
    "name": "dp-1",
    "type": "Dataplane"
   },
   {
+   "labels": null,
    "mesh": "default",
    "name": "dp-2",
    "type": "Dataplane"

--- a/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/proxytemplate_dataplanes.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/proxytemplate_dataplanes.input.yaml
@@ -15,6 +15,9 @@ conf:
 type: Dataplane
 name: dp-1
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: dp-1
 networking:
   address: 127.0.0.1
   inbound:
@@ -25,6 +28,9 @@ networking:
 type: Dataplane
 name: dp-2
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: dp-2
 networking:
   address: 127.0.0.1
   inbound:
@@ -35,6 +41,9 @@ networking:
 type: Dataplane
 name: dp-3
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: dp-3
 networking:
   address: 127.0.0.1
   inbound:

--- a/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/retry_dataplanes.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/retry_dataplanes.golden.json
@@ -1,16 +1,19 @@
 {
  "items": [
   {
+   "labels": null,
    "mesh": "default",
    "name": "dp-1",
    "type": "Dataplane"
   },
   {
+   "labels": null,
    "mesh": "default",
    "name": "dp-2",
    "type": "Dataplane"
   },
   {
+   "labels": null,
    "mesh": "default",
    "name": "dp-3",
    "type": "Dataplane"

--- a/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/retry_dataplanes.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/retry_dataplanes.golden.json
@@ -1,19 +1,28 @@
 {
  "items": [
   {
-   "labels": null,
+   "labels": {
+    "k8s.kuma.io/namespace": "kuma-demo",
+    "kuma.io/display-name": "dp-1"
+   },
    "mesh": "default",
    "name": "dp-1",
    "type": "Dataplane"
   },
   {
-   "labels": null,
+   "labels": {
+    "k8s.kuma.io/namespace": "kuma-demo",
+    "kuma.io/display-name": "dp-2"
+   },
    "mesh": "default",
    "name": "dp-2",
    "type": "Dataplane"
   },
   {
-   "labels": null,
+   "labels": {
+    "k8s.kuma.io/namespace": "kuma-demo",
+    "kuma.io/display-name": "dp-3"
+   },
    "mesh": "default",
    "name": "dp-3",
    "type": "Dataplane"

--- a/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/retry_dataplanes.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/retry_dataplanes.input.yaml
@@ -18,6 +18,9 @@ conf:
 type: Dataplane
 name: dp-1
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: dp-1
 networking:
   address: 127.0.0.1
   inbound:
@@ -28,6 +31,9 @@ networking:
 type: Dataplane
 name: dp-2
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: dp-2
 networking:
   address: 127.0.0.1
   inbound:
@@ -38,6 +44,9 @@ networking:
 type: Dataplane
 name: dp-3
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: dp-3
 networking:
   address: 127.0.0.1
   inbound:
@@ -48,6 +57,9 @@ networking:
 type: Dataplane
 name: dp-4
 mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: dp-4
 networking:
   address: 127.0.0.1
   inbound:


### PR DESCRIPTION
Add `lables` map property for the kuma api-server `Meta` property which will improve 2 apis to get more details about the dataplanes and rules.

The following 2 http routes will be afftected:
* `/meshes/{mesh}/{policyType}/{policyName}/_resources/dataplanes`
* `/meshes/{mesh}/{resourceType}/{resourceName}/_rules`

Close #9851 

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
