### PR TITLE
fix(kuma-cp): mistakenly setting 'kuma.io/display-name' as label

### DIFF
--- a/pkg/plugins/resources/k8s/store.go
+++ b/pkg/plugins/resources/k8s/store.go
@@ -58,7 +58,7 @@ func (s *KubernetesStore) Create(ctx context.Context, r core_model.Resource, fs 
 		return err
 	}
 
-	labels, annotations := splitLabelsAndAnnotations(opts.Labels, obj.GetAnnotations())
+	labels, annotations := SplitLabelsAndAnnotations(opts.Labels, obj.GetAnnotations())
 	obj.GetObjectMeta().SetLabels(labels)
 	obj.GetObjectMeta().SetAnnotations(annotations)
 	obj.SetMesh(opts.Mesh)
@@ -103,7 +103,7 @@ func (s *KubernetesStore) Update(ctx context.Context, r core_model.Resource, fs 
 	if opts.ModifyLabels {
 		updateLabels = opts.Labels
 	}
-	labels, annotations := splitLabelsAndAnnotations(updateLabels, obj.GetAnnotations())
+	labels, annotations := SplitLabelsAndAnnotations(updateLabels, obj.GetAnnotations())
 	obj.GetObjectMeta().SetLabels(labels)
 	obj.GetObjectMeta().SetAnnotations(annotations)
 	obj.SetMesh(r.GetMeta().GetMesh())
@@ -241,7 +241,7 @@ func k8sNameNamespace(coreName string, scope k8s_model.Scope) (string, string, e
 
 // Kuma resource labels are generally stored on Kubernetes as labels, except "kuma.io/display-name".
 // We store it as an annotation because the resource name on k8s is limited by 253 and the label value is limited by 63.
-func splitLabelsAndAnnotations(coreLabels map[string]string, currentAnnotations map[string]string) (map[string]string, map[string]string) {
+func SplitLabelsAndAnnotations(coreLabels map[string]string, currentAnnotations map[string]string) (map[string]string, map[string]string) {
 	labels := maps.Clone(coreLabels)
 	annotations := maps.Clone(currentAnnotations)
 	if annotations == nil {

--- a/pkg/plugins/runtime/k8s/webhooks/defaulter_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/defaulter_test.go
@@ -122,7 +122,7 @@ var _ = Describe("Defaulter", func() {
               "metadata": {
 				"name": "empty",
 				"creationTimestamp": null,
-				"labels": {
+				"annotations": {
 				  "kuma.io/display-name": "empty"
 				}
               },
@@ -178,7 +178,7 @@ var _ = Describe("Defaulter", func() {
               "metadata": {
 				"name": "empty",
 				"creationTimestamp": null,
-				"labels": {
+				"annotations": {
 				  "kuma.io/display-name": "empty"
 				}
               },
@@ -230,7 +230,9 @@ var _ = Describe("Defaulter", func() {
                 "creationTimestamp": null,
                 "labels": {
                   "kuma.io/mesh": "my-mesh-1",
-                  "k8s.kuma.io/namespace": "example",
+                  "k8s.kuma.io/namespace": "example"
+                },
+                "annotations": {
                   "kuma.io/display-name": "empty"
                 }
               },
@@ -270,7 +272,9 @@ var _ = Describe("Defaulter", func() {
                   "kuma.io/origin": "zone",
                   "kuma.io/mesh": "default",
                   "kuma.io/policy-role": "workload-owner",
-                  "k8s.kuma.io/namespace": "example",
+                  "k8s.kuma.io/namespace": "example"
+                },
+                "annotations": {
                   "kuma.io/display-name": "empty"
                 }
               },
@@ -307,10 +311,12 @@ var _ = Describe("Defaulter", func() {
                 "creationTimestamp": null,
                 "labels": {
                   "k8s.kuma.io/namespace": "example",
-                  "kuma.io/display-name": "empty",
                   "kuma.io/mesh": "default",
                   "kuma.io/origin": "zone",
                   "kuma.io/policy-role": "workload-owner"
+                },
+                "annotations": {
+                  "kuma.io/display-name": "empty"
                 }
               },
               "spec": {
@@ -346,10 +352,12 @@ var _ = Describe("Defaulter", func() {
                 "creationTimestamp": null,
                 "labels": {
                   "k8s.kuma.io/namespace": "example",
-                  "kuma.io/display-name": "empty",
                   "kuma.io/mesh": "default",
                   "kuma.io/origin": "zone",
                   "kuma.io/policy-role": "workload-owner"
+                },
+                "annotations": {
+                  "kuma.io/display-name": "empty"
                 }
               },
               "spec": {
@@ -396,9 +404,11 @@ var _ = Describe("Defaulter", func() {
                 "creationTimestamp":null,
                 "labels": {
                   "k8s.kuma.io/namespace": "example",
-                  "kuma.io/display-name": "empty",
                   "kuma.io/mesh": "default",
                   "kuma.io/origin": "zone"
+                },
+                "annotations": {
+                  "kuma.io/display-name": "empty"
                 }
               },
               "spec":{
@@ -443,9 +453,11 @@ var _ = Describe("Defaulter", func() {
                 "creationTimestamp": null,
                 "labels": {
                   "k8s.kuma.io/namespace": "example",
-                  "kuma.io/display-name": "empty",
                   "kuma.io/mesh": "default",
                   "kuma.io/policy-role": "workload-owner"
+                },
+                "annotations": {
+                  "kuma.io/display-name": "empty"
                 }
               },
               "spec": {


### PR DESCRIPTION
https://github.com/kumahq/kuma/pull/10361 introduced a bug that resulted in setting `kuma.io/display-name` as a label instead of an annotation. We can't set `kuma.io/display-name` as label, because it can be longer than 63 char.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
