### PR TITLE
feat(api): add meshexternalservice TargetRefKind and changed int to Port

### DIFF
--- a/api/common/v1alpha1/ref.go
+++ b/api/common/v1alpha1/ref.go
@@ -13,21 +13,23 @@ import (
 type TargetRefKind string
 
 var (
-	Mesh              TargetRefKind = "Mesh"
-	MeshSubset        TargetRefKind = "MeshSubset"
-	MeshGateway       TargetRefKind = "MeshGateway"
-	MeshService       TargetRefKind = "MeshService"
-	MeshServiceSubset TargetRefKind = "MeshServiceSubset"
-	MeshHTTPRoute     TargetRefKind = "MeshHTTPRoute"
+	Mesh                TargetRefKind = "Mesh"
+	MeshSubset          TargetRefKind = "MeshSubset"
+	MeshGateway         TargetRefKind = "MeshGateway"
+	MeshService         TargetRefKind = "MeshService"
+	MeshExternalService TargetRefKind = "MeshExternalService"
+	MeshServiceSubset   TargetRefKind = "MeshServiceSubset"
+	MeshHTTPRoute       TargetRefKind = "MeshHTTPRoute"
 )
 
 var order = map[TargetRefKind]int{
-	Mesh:              1,
-	MeshSubset:        2,
-	MeshGateway:       3,
-	MeshService:       4,
-	MeshServiceSubset: 5,
-	MeshHTTPRoute:     6,
+	Mesh:                1,
+	MeshSubset:          2,
+	MeshGateway:         3,
+	MeshService:         4,
+	MeshExternalService: 5,
+	MeshServiceSubset:   6,
+	MeshHTTPRoute:       7,
 }
 
 // +kubebuilder:validation:Enum=Sidecar;Gateway
@@ -57,7 +59,7 @@ func (x TargetRefKindSlice) Swap(i, j int)      { x[i], x[j] = x[j], x[i] }
 // TargetRef defines structure that allows attaching policy to various objects
 type TargetRef struct {
 	// Kind of the referenced resource
-	// +kubebuilder:validation:Enum=Mesh;MeshSubset;MeshGateway;MeshService;MeshServiceSubset;MeshHTTPRoute
+	// +kubebuilder:validation:Enum=Mesh;MeshSubset;MeshGateway;MeshService;MeshExternalService;MeshServiceSubset;MeshHTTPRoute
 	Kind TargetRefKind `json:"kind,omitempty"`
 	// Name of the referenced resource. Can only be used with kinds: `MeshService`,
 	// `MeshServiceSubset` and `MeshGatewayRoute`

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -330,6 +330,8 @@ spec:
                 properties:
                   port:
                     description: Port defines a port to which a user does request.
+                    maximum: 65535
+                    minimum: 1
                     type: integer
                   protocol:
                     default: tcp
@@ -719,6 +721,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -784,6 +787,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -929,6 +933,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -1737,6 +1742,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -1996,6 +2002,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -2117,6 +2124,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -2202,6 +2210,7 @@ spec:
                                       - MeshSubset
                                       - MeshGateway
                                       - MeshService
+                                      - MeshExternalService
                                       - MeshServiceSubset
                                       - MeshHTTPRoute
                                       type: string
@@ -2326,6 +2335,7 @@ spec:
                                               - MeshSubset
                                               - MeshGateway
                                               - MeshService
+                                              - MeshExternalService
                                               - MeshServiceSubset
                                               - MeshHTTPRoute
                                               type: string
@@ -2660,6 +2670,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -2878,6 +2889,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -3326,6 +3338,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -3622,6 +3635,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -3784,6 +3798,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -4342,6 +4357,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -4584,6 +4600,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -4649,6 +4666,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -4834,6 +4852,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -4955,6 +4974,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -5339,6 +5359,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -5641,6 +5662,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -5718,6 +5740,7 @@ spec:
                                       - MeshSubset
                                       - MeshGateway
                                       - MeshService
+                                      - MeshExternalService
                                       - MeshServiceSubset
                                       - MeshHTTPRoute
                                       type: string
@@ -5797,6 +5820,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -5975,6 +5999,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -6040,6 +6065,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -6157,6 +6183,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -6444,6 +6471,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -6650,6 +6678,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -6715,6 +6744,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -8015,6 +8045,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -8080,6 +8111,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -8294,6 +8326,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -8659,6 +8692,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -8724,6 +8758,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -9029,6 +9064,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -330,6 +330,8 @@ spec:
                 properties:
                   port:
                     description: Port defines a port to which a user does request.
+                    maximum: 65535
+                    minimum: 1
                     type: integer
                   protocol:
                     default: tcp
@@ -719,6 +721,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -784,6 +787,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -929,6 +933,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -1737,6 +1742,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -1996,6 +2002,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -2117,6 +2124,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -2202,6 +2210,7 @@ spec:
                                       - MeshSubset
                                       - MeshGateway
                                       - MeshService
+                                      - MeshExternalService
                                       - MeshServiceSubset
                                       - MeshHTTPRoute
                                       type: string
@@ -2326,6 +2335,7 @@ spec:
                                               - MeshSubset
                                               - MeshGateway
                                               - MeshService
+                                              - MeshExternalService
                                               - MeshServiceSubset
                                               - MeshHTTPRoute
                                               type: string
@@ -2660,6 +2670,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -2878,6 +2889,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -3326,6 +3338,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -3622,6 +3635,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -3784,6 +3798,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -4342,6 +4357,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -4584,6 +4600,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -4649,6 +4666,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -4834,6 +4852,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -4955,6 +4974,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -5339,6 +5359,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -5641,6 +5662,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -5718,6 +5740,7 @@ spec:
                                       - MeshSubset
                                       - MeshGateway
                                       - MeshService
+                                      - MeshExternalService
                                       - MeshServiceSubset
                                       - MeshHTTPRoute
                                       type: string
@@ -5797,6 +5820,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -5975,6 +5999,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -6040,6 +6065,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -6157,6 +6183,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -6444,6 +6471,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -6650,6 +6678,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -6715,6 +6744,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -8015,6 +8045,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -8080,6 +8111,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -8294,6 +8326,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -8659,6 +8692,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -8724,6 +8758,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -9029,6 +9064,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -350,6 +350,8 @@ spec:
                 properties:
                   port:
                     description: Port defines a port to which a user does request.
+                    maximum: 65535
+                    minimum: 1
                     type: integer
                   protocol:
                     default: tcp
@@ -739,6 +741,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -804,6 +807,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -949,6 +953,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -1757,6 +1762,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -2016,6 +2022,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -2137,6 +2144,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -2222,6 +2230,7 @@ spec:
                                       - MeshSubset
                                       - MeshGateway
                                       - MeshService
+                                      - MeshExternalService
                                       - MeshServiceSubset
                                       - MeshHTTPRoute
                                       type: string
@@ -2346,6 +2355,7 @@ spec:
                                               - MeshSubset
                                               - MeshGateway
                                               - MeshService
+                                              - MeshExternalService
                                               - MeshServiceSubset
                                               - MeshHTTPRoute
                                               type: string
@@ -2680,6 +2690,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -2898,6 +2909,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -3346,6 +3358,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -3642,6 +3655,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -3804,6 +3818,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -4362,6 +4377,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -4604,6 +4620,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -4669,6 +4686,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -4854,6 +4872,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -4975,6 +4994,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -5359,6 +5379,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -5661,6 +5682,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -5738,6 +5760,7 @@ spec:
                                       - MeshSubset
                                       - MeshGateway
                                       - MeshService
+                                      - MeshExternalService
                                       - MeshServiceSubset
                                       - MeshHTTPRoute
                                       type: string
@@ -5817,6 +5840,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -5995,6 +6019,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -6060,6 +6085,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -6177,6 +6203,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -6464,6 +6491,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -6670,6 +6698,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -6735,6 +6764,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -8035,6 +8065,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -8100,6 +8131,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -8314,6 +8346,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -8679,6 +8712,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -8744,6 +8778,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -9049,6 +9084,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -715,6 +715,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -780,6 +781,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -994,6 +996,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -1359,6 +1362,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -1424,6 +1428,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -1729,6 +1734,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -1923,6 +1929,8 @@ spec:
                 properties:
                   port:
                     description: Port defines a port to which a user does request.
+                    maximum: 65535
+                    minimum: 1
                     type: integer
                   protocol:
                     default: tcp
@@ -2312,6 +2320,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -2377,6 +2386,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -2522,6 +2532,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -3330,6 +3341,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -3589,6 +3601,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -3710,6 +3723,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -3795,6 +3809,7 @@ spec:
                                       - MeshSubset
                                       - MeshGateway
                                       - MeshService
+                                      - MeshExternalService
                                       - MeshServiceSubset
                                       - MeshHTTPRoute
                                       type: string
@@ -3919,6 +3934,7 @@ spec:
                                               - MeshSubset
                                               - MeshGateway
                                               - MeshService
+                                              - MeshExternalService
                                               - MeshServiceSubset
                                               - MeshHTTPRoute
                                               type: string
@@ -4253,6 +4269,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -4421,6 +4438,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -4869,6 +4887,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -5165,6 +5184,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -5327,6 +5347,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -5885,6 +5906,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -6127,6 +6149,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -6192,6 +6215,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -6377,6 +6401,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -6498,6 +6523,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -6882,6 +6908,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -7184,6 +7211,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -7261,6 +7289,7 @@ spec:
                                       - MeshSubset
                                       - MeshGateway
                                       - MeshService
+                                      - MeshExternalService
                                       - MeshServiceSubset
                                       - MeshHTTPRoute
                                       type: string
@@ -7340,6 +7369,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -7518,6 +7548,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -7583,6 +7614,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -7700,6 +7732,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -7987,6 +8020,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -8123,6 +8157,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -8188,6 +8223,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string

--- a/deployments/charts/kuma/crds/kuma.io_meshaccesslogs.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshaccesslogs.yaml
@@ -213,6 +213,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -278,6 +279,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -492,6 +494,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/deployments/charts/kuma/crds/kuma.io_meshcircuitbreakers.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshcircuitbreakers.yaml
@@ -304,6 +304,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -369,6 +370,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -674,6 +676,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/deployments/charts/kuma/crds/kuma.io_meshexternalservices.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshexternalservices.yaml
@@ -83,6 +83,8 @@ spec:
                 properties:
                   port:
                     description: Port defines a port to which a user does request.
+                    maximum: 65535
+                    minimum: 1
                     type: integer
                   protocol:
                     default: tcp

--- a/deployments/charts/kuma/crds/kuma.io_meshfaultinjections.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshfaultinjections.yaml
@@ -145,6 +145,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -210,6 +211,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -355,6 +357,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/deployments/charts/kuma/crds/kuma.io_meshhealthchecks.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshhealthchecks.yaml
@@ -60,6 +60,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -319,6 +320,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/deployments/charts/kuma/crds/kuma.io_meshhttproutes.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshhttproutes.yaml
@@ -60,6 +60,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -145,6 +146,7 @@ spec:
                                       - MeshSubset
                                       - MeshGateway
                                       - MeshService
+                                      - MeshExternalService
                                       - MeshServiceSubset
                                       - MeshHTTPRoute
                                       type: string
@@ -269,6 +271,7 @@ spec:
                                               - MeshSubset
                                               - MeshGateway
                                               - MeshService
+                                              - MeshExternalService
                                               - MeshServiceSubset
                                               - MeshHTTPRoute
                                               type: string
@@ -603,6 +606,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/deployments/charts/kuma/crds/kuma.io_meshloadbalancingstrategies.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshloadbalancingstrategies.yaml
@@ -61,6 +61,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -509,6 +510,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/deployments/charts/kuma/crds/kuma.io_meshmetrics.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshmetrics.yaml
@@ -235,6 +235,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string

--- a/deployments/charts/kuma/crds/kuma.io_meshpassthroughs.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshpassthroughs.yaml
@@ -105,6 +105,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string

--- a/deployments/charts/kuma/crds/kuma.io_meshproxypatches.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshproxypatches.yaml
@@ -501,6 +501,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string

--- a/deployments/charts/kuma/crds/kuma.io_meshratelimits.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshratelimits.yaml
@@ -184,6 +184,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -249,6 +250,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -434,6 +436,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/deployments/charts/kuma/crds/kuma.io_meshretries.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshretries.yaml
@@ -60,6 +60,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -444,6 +445,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/deployments/charts/kuma/crds/kuma.io_meshtcproutes.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtcproutes.yaml
@@ -60,6 +60,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -137,6 +138,7 @@ spec:
                                       - MeshSubset
                                       - MeshGateway
                                       - MeshService
+                                      - MeshExternalService
                                       - MeshServiceSubset
                                       - MeshHTTPRoute
                                       type: string
@@ -216,6 +218,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/deployments/charts/kuma/crds/kuma.io_meshtimeouts.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtimeouts.yaml
@@ -116,6 +116,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -181,6 +182,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -298,6 +300,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/deployments/charts/kuma/crds/kuma.io_meshtraces.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtraces.yaml
@@ -226,6 +226,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string

--- a/deployments/charts/kuma/crds/kuma.io_meshtrafficpermissions.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtrafficpermissions.yaml
@@ -79,6 +79,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -144,6 +145,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -2295,6 +2295,7 @@ components:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                         type: string
@@ -2379,6 +2380,7 @@ components:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                   type: string
@@ -2626,6 +2628,7 @@ components:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                         type: string
@@ -3202,6 +3205,7 @@ components:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                         type: string
@@ -3286,6 +3290,7 @@ components:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                   type: string
@@ -3822,6 +3827,7 @@ components:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                         type: string
@@ -4046,6 +4052,7 @@ components:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                         type: string
@@ -4130,6 +4137,7 @@ components:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                   type: string
@@ -4312,6 +4320,7 @@ components:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                         type: string
@@ -4432,6 +4441,7 @@ components:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                   type: string
@@ -4778,6 +4788,7 @@ components:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                         type: string
@@ -4898,6 +4909,7 @@ components:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                   type: string
@@ -5005,6 +5017,7 @@ components:
                                       - MeshSubset
                                       - MeshGateway
                                       - MeshService
+                                      - MeshExternalService
                                       - MeshServiceSubset
                                       - MeshHTTPRoute
                                     type: string
@@ -5153,6 +5166,7 @@ components:
                                               - MeshSubset
                                               - MeshGateway
                                               - MeshService
+                                              - MeshExternalService
                                               - MeshServiceSubset
                                               - MeshHTTPRoute
                                             type: string
@@ -5558,6 +5572,7 @@ components:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                         type: string
@@ -5676,6 +5691,7 @@ components:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                   type: string
@@ -6294,6 +6310,7 @@ components:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                         type: string
@@ -6613,6 +6630,7 @@ components:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                   type: string
@@ -6777,6 +6795,7 @@ components:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                   type: string
@@ -7483,6 +7502,7 @@ components:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                   type: string
@@ -7739,6 +7759,7 @@ components:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                         type: string
@@ -7823,6 +7844,7 @@ components:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                   type: string
@@ -8042,6 +8064,7 @@ components:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                         type: string
@@ -8162,6 +8185,7 @@ components:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                   type: string
@@ -8667,6 +8691,7 @@ components:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                         type: string
@@ -8787,6 +8812,7 @@ components:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                   type: string
@@ -8882,6 +8908,7 @@ components:
                                       - MeshSubset
                                       - MeshGateway
                                       - MeshService
+                                      - MeshExternalService
                                       - MeshServiceSubset
                                       - MeshHTTPRoute
                                     type: string
@@ -8983,6 +9010,7 @@ components:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                         type: string
@@ -9191,6 +9219,7 @@ components:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                         type: string
@@ -9275,6 +9304,7 @@ components:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                   type: string
@@ -9440,6 +9470,7 @@ components:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                         type: string
@@ -9777,6 +9808,7 @@ components:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                   type: string
@@ -9913,6 +9945,7 @@ components:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                         type: string
@@ -9997,6 +10030,7 @@ components:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                   type: string

--- a/docs/generated/raw/crds/kuma.io_meshaccesslogs.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshaccesslogs.yaml
@@ -213,6 +213,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -278,6 +279,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -492,6 +494,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/docs/generated/raw/crds/kuma.io_meshcircuitbreakers.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshcircuitbreakers.yaml
@@ -304,6 +304,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -369,6 +370,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -674,6 +676,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/docs/generated/raw/crds/kuma.io_meshexternalservices.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshexternalservices.yaml
@@ -83,6 +83,8 @@ spec:
                 properties:
                   port:
                     description: Port defines a port to which a user does request.
+                    maximum: 65535
+                    minimum: 1
                     type: integer
                   protocol:
                     default: tcp

--- a/docs/generated/raw/crds/kuma.io_meshfaultinjections.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshfaultinjections.yaml
@@ -145,6 +145,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -210,6 +211,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -355,6 +357,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/docs/generated/raw/crds/kuma.io_meshhealthchecks.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshhealthchecks.yaml
@@ -60,6 +60,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -319,6 +320,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/docs/generated/raw/crds/kuma.io_meshhttproutes.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshhttproutes.yaml
@@ -60,6 +60,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -145,6 +146,7 @@ spec:
                                       - MeshSubset
                                       - MeshGateway
                                       - MeshService
+                                      - MeshExternalService
                                       - MeshServiceSubset
                                       - MeshHTTPRoute
                                       type: string
@@ -269,6 +271,7 @@ spec:
                                               - MeshSubset
                                               - MeshGateway
                                               - MeshService
+                                              - MeshExternalService
                                               - MeshServiceSubset
                                               - MeshHTTPRoute
                                               type: string
@@ -603,6 +606,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/docs/generated/raw/crds/kuma.io_meshloadbalancingstrategies.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshloadbalancingstrategies.yaml
@@ -61,6 +61,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -509,6 +510,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/docs/generated/raw/crds/kuma.io_meshmetrics.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshmetrics.yaml
@@ -235,6 +235,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string

--- a/docs/generated/raw/crds/kuma.io_meshpassthroughs.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshpassthroughs.yaml
@@ -105,6 +105,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string

--- a/docs/generated/raw/crds/kuma.io_meshproxypatches.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshproxypatches.yaml
@@ -501,6 +501,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string

--- a/docs/generated/raw/crds/kuma.io_meshratelimits.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshratelimits.yaml
@@ -184,6 +184,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -249,6 +250,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -434,6 +436,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/docs/generated/raw/crds/kuma.io_meshretries.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshretries.yaml
@@ -60,6 +60,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -444,6 +445,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/docs/generated/raw/crds/kuma.io_meshtcproutes.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshtcproutes.yaml
@@ -60,6 +60,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -137,6 +138,7 @@ spec:
                                       - MeshSubset
                                       - MeshGateway
                                       - MeshService
+                                      - MeshExternalService
                                       - MeshServiceSubset
                                       - MeshHTTPRoute
                                       type: string
@@ -216,6 +218,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/docs/generated/raw/crds/kuma.io_meshtimeouts.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshtimeouts.yaml
@@ -116,6 +116,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -181,6 +182,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -298,6 +300,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/docs/generated/raw/crds/kuma.io_meshtraces.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshtraces.yaml
@@ -226,6 +226,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string

--- a/docs/generated/raw/crds/kuma.io_meshtrafficpermissions.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshtrafficpermissions.yaml
@@ -79,6 +79,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -144,6 +145,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string

--- a/pkg/api-server/testdata/base_endpoints/_resources.golden.json
+++ b/pkg/api-server/testdata/base_endpoints/_resources.golden.json
@@ -292,7 +292,7 @@
    "singularDisplayName": "Mesh Retry"
   },
   {
-   "includeInFederation": false,
+   "includeInFederation": true,
    "name": "MeshService",
    "path": "meshservices",
    "pluralDisplayName": "Mesh Services",

--- a/pkg/api-server/testdata/base_endpoints/_resources.golden.json
+++ b/pkg/api-server/testdata/base_endpoints/_resources.golden.json
@@ -292,7 +292,7 @@
    "singularDisplayName": "Mesh Retry"
   },
   {
-   "includeInFederation": true,
+   "includeInFederation": false,
    "name": "MeshService",
    "path": "meshservices",
    "pluralDisplayName": "Mesh Services",

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/meshexternalservice.go
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/meshexternalservice.go
@@ -44,7 +44,7 @@ type Match struct {
 	// +kubebuilder:default=HostnameGenerator
 	Type MatchType `json:"type,omitempty"`
 	// Port defines a port to which a user does request.
-	Port int `json:"port"`
+	Port Port `json:"port"`
 	// Protocol defines a protocol of the communication. Possible values: `tcp`, `grpc`, `http`, `http2`.
 	// +kubebuilder:default=tcp
 	Protocol ProtocolType `json:"protocol,omitempty"`

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/schema.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/schema.yaml
@@ -51,6 +51,8 @@ properties:
         properties:
           port:
             description: Port defines a port to which a user does request.
+            maximum: 65535
+            minimum: 1
             type: integer
           protocol:
             default: tcp

--- a/pkg/core/resources/apis/meshexternalservice/k8s/crd/kuma.io_meshexternalservices.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/k8s/crd/kuma.io_meshexternalservices.yaml
@@ -83,6 +83,8 @@ spec:
                 properties:
                   port:
                     description: Port defines a port to which a user does request.
+                    maximum: 65535
+                    minimum: 1
                     type: integer
                   protocol:
                     default: tcp

--- a/pkg/plugins/policies/donothingpolicy/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/donothingpolicy/api/v1alpha1/schema.yaml
@@ -42,6 +42,7 @@ properties:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                   type: string
@@ -106,6 +107,7 @@ properties:
               - MeshSubset
               - MeshGateway
               - MeshService
+              - MeshExternalService
               - MeshServiceSubset
               - MeshHTTPRoute
             type: string
@@ -180,6 +182,7 @@ properties:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                   type: string

--- a/pkg/plugins/policies/donothingpolicy/k8s/crd/kuma.io_donothingpolicies.yaml
+++ b/pkg/plugins/policies/donothingpolicy/k8s/crd/kuma.io_donothingpolicies.yaml
@@ -75,6 +75,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -140,6 +141,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -216,6 +218,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/schema.yaml
@@ -177,6 +177,7 @@ properties:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                   type: string
@@ -241,6 +242,7 @@ properties:
               - MeshSubset
               - MeshGateway
               - MeshService
+              - MeshExternalService
               - MeshServiceSubset
               - MeshHTTPRoute
             type: string
@@ -450,6 +452,7 @@ properties:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                   type: string

--- a/pkg/plugins/policies/meshaccesslog/k8s/crd/kuma.io_meshaccesslogs.yaml
+++ b/pkg/plugins/policies/meshaccesslog/k8s/crd/kuma.io_meshaccesslogs.yaml
@@ -213,6 +213,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -278,6 +279,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -492,6 +494,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/schema.yaml
@@ -268,6 +268,7 @@ properties:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                   type: string
@@ -332,6 +333,7 @@ properties:
               - MeshSubset
               - MeshGateway
               - MeshService
+              - MeshExternalService
               - MeshServiceSubset
               - MeshHTTPRoute
             type: string
@@ -634,6 +636,7 @@ properties:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                   type: string

--- a/pkg/plugins/policies/meshcircuitbreaker/k8s/crd/kuma.io_meshcircuitbreakers.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/k8s/crd/kuma.io_meshcircuitbreakers.yaml
@@ -304,6 +304,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -369,6 +370,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -674,6 +676,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/schema.yaml
@@ -106,6 +106,7 @@ properties:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                   type: string
@@ -170,6 +171,7 @@ properties:
               - MeshSubset
               - MeshGateway
               - MeshService
+              - MeshExternalService
               - MeshServiceSubset
               - MeshHTTPRoute
             type: string
@@ -308,6 +310,7 @@ properties:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                   type: string

--- a/pkg/plugins/policies/meshfaultinjection/k8s/crd/kuma.io_meshfaultinjections.yaml
+++ b/pkg/plugins/policies/meshfaultinjection/k8s/crd/kuma.io_meshfaultinjections.yaml
@@ -145,6 +145,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -210,6 +211,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -355,6 +357,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/schema.yaml
@@ -28,6 +28,7 @@ properties:
               - MeshSubset
               - MeshGateway
               - MeshService
+              - MeshExternalService
               - MeshServiceSubset
               - MeshHTTPRoute
             type: string
@@ -280,6 +281,7 @@ properties:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                   type: string

--- a/pkg/plugins/policies/meshhealthcheck/k8s/crd/kuma.io_meshhealthchecks.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/k8s/crd/kuma.io_meshhealthchecks.yaml
@@ -60,6 +60,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -319,6 +320,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/schema.yaml
@@ -28,6 +28,7 @@ properties:
               - MeshSubset
               - MeshGateway
               - MeshService
+              - MeshExternalService
               - MeshServiceSubset
               - MeshHTTPRoute
             type: string
@@ -110,6 +111,7 @@ properties:
                                 - MeshSubset
                                 - MeshGateway
                                 - MeshService
+                                - MeshExternalService
                                 - MeshServiceSubset
                                 - MeshHTTPRoute
                               type: string
@@ -231,6 +233,7 @@ properties:
                                         - MeshSubset
                                         - MeshGateway
                                         - MeshService
+                                        - MeshExternalService
                                         - MeshServiceSubset
                                         - MeshHTTPRoute
                                       type: string
@@ -557,6 +560,7 @@ properties:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                   type: string

--- a/pkg/plugins/policies/meshhttproute/k8s/crd/kuma.io_meshhttproutes.yaml
+++ b/pkg/plugins/policies/meshhttproute/k8s/crd/kuma.io_meshhttproutes.yaml
@@ -60,6 +60,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -145,6 +146,7 @@ spec:
                                       - MeshSubset
                                       - MeshGateway
                                       - MeshService
+                                      - MeshExternalService
                                       - MeshServiceSubset
                                       - MeshHTTPRoute
                                       type: string
@@ -269,6 +271,7 @@ spec:
                                               - MeshSubset
                                               - MeshGateway
                                               - MeshService
+                                              - MeshExternalService
                                               - MeshServiceSubset
                                               - MeshHTTPRoute
                                               type: string
@@ -603,6 +606,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/schema.yaml
@@ -28,6 +28,7 @@ properties:
               - MeshSubset
               - MeshGateway
               - MeshService
+              - MeshExternalService
               - MeshServiceSubset
               - MeshHTTPRoute
             type: string
@@ -453,6 +454,7 @@ properties:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                   type: string

--- a/pkg/plugins/policies/meshloadbalancingstrategy/k8s/crd/kuma.io_meshloadbalancingstrategies.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/k8s/crd/kuma.io_meshloadbalancingstrategies.yaml
@@ -61,6 +61,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -509,6 +510,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/schema.yaml
@@ -187,6 +187,7 @@ properties:
               - MeshSubset
               - MeshGateway
               - MeshService
+              - MeshExternalService
               - MeshServiceSubset
               - MeshHTTPRoute
             type: string

--- a/pkg/plugins/policies/meshmetric/k8s/crd/kuma.io_meshmetrics.yaml
+++ b/pkg/plugins/policies/meshmetric/k8s/crd/kuma.io_meshmetrics.yaml
@@ -235,6 +235,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string

--- a/pkg/plugins/policies/meshpassthrough/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshpassthrough/api/v1alpha1/schema.yaml
@@ -69,6 +69,7 @@ properties:
               - MeshSubset
               - MeshGateway
               - MeshService
+              - MeshExternalService
               - MeshServiceSubset
               - MeshHTTPRoute
             type: string

--- a/pkg/plugins/policies/meshpassthrough/k8s/crd/kuma.io_meshpassthroughs.yaml
+++ b/pkg/plugins/policies/meshpassthrough/k8s/crd/kuma.io_meshpassthroughs.yaml
@@ -105,6 +105,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string

--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/schema.yaml
@@ -437,6 +437,7 @@ properties:
               - MeshSubset
               - MeshGateway
               - MeshService
+              - MeshExternalService
               - MeshServiceSubset
               - MeshHTTPRoute
             type: string

--- a/pkg/plugins/policies/meshproxypatch/k8s/crd/kuma.io_meshproxypatches.yaml
+++ b/pkg/plugins/policies/meshproxypatch/k8s/crd/kuma.io_meshproxypatches.yaml
@@ -501,6 +501,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/schema.yaml
@@ -143,6 +143,7 @@ properties:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                   type: string
@@ -207,6 +208,7 @@ properties:
               - MeshSubset
               - MeshGateway
               - MeshService
+              - MeshExternalService
               - MeshServiceSubset
               - MeshHTTPRoute
             type: string
@@ -382,6 +384,7 @@ properties:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                   type: string

--- a/pkg/plugins/policies/meshratelimit/k8s/crd/kuma.io_meshratelimits.yaml
+++ b/pkg/plugins/policies/meshratelimit/k8s/crd/kuma.io_meshratelimits.yaml
@@ -184,6 +184,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -249,6 +250,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -434,6 +436,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/schema.yaml
@@ -28,6 +28,7 @@ properties:
               - MeshSubset
               - MeshGateway
               - MeshService
+              - MeshExternalService
               - MeshServiceSubset
               - MeshHTTPRoute
             type: string
@@ -400,6 +401,7 @@ properties:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                   type: string

--- a/pkg/plugins/policies/meshretry/k8s/crd/kuma.io_meshretries.yaml
+++ b/pkg/plugins/policies/meshretry/k8s/crd/kuma.io_meshretries.yaml
@@ -60,6 +60,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -444,6 +445,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/schema.yaml
@@ -28,6 +28,7 @@ properties:
               - MeshSubset
               - MeshGateway
               - MeshService
+              - MeshExternalService
               - MeshServiceSubset
               - MeshHTTPRoute
             type: string
@@ -103,6 +104,7 @@ properties:
                                 - MeshSubset
                                 - MeshGateway
                                 - MeshService
+                                - MeshExternalService
                                 - MeshServiceSubset
                                 - MeshHTTPRoute
                               type: string
@@ -180,6 +182,7 @@ properties:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                   type: string

--- a/pkg/plugins/policies/meshtcproute/k8s/crd/kuma.io_meshtcproutes.yaml
+++ b/pkg/plugins/policies/meshtcproute/k8s/crd/kuma.io_meshtcproutes.yaml
@@ -60,6 +60,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -137,6 +138,7 @@ spec:
                                       - MeshSubset
                                       - MeshGateway
                                       - MeshService
+                                      - MeshExternalService
                                       - MeshServiceSubset
                                       - MeshHTTPRoute
                                       type: string
@@ -216,6 +218,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/schema.yaml
@@ -82,6 +82,7 @@ properties:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                   type: string
@@ -146,6 +147,7 @@ properties:
               - MeshSubset
               - MeshGateway
               - MeshService
+              - MeshExternalService
               - MeshServiceSubset
               - MeshHTTPRoute
             type: string
@@ -260,6 +262,7 @@ properties:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                   type: string

--- a/pkg/plugins/policies/meshtimeout/k8s/crd/kuma.io_meshtimeouts.yaml
+++ b/pkg/plugins/policies/meshtimeout/k8s/crd/kuma.io_meshtimeouts.yaml
@@ -116,6 +116,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -181,6 +182,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string
@@ -298,6 +300,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/schema.yaml
@@ -193,6 +193,7 @@ properties:
               - MeshSubset
               - MeshGateway
               - MeshService
+              - MeshExternalService
               - MeshServiceSubset
               - MeshHTTPRoute
             type: string

--- a/pkg/plugins/policies/meshtrace/k8s/crd/kuma.io_meshtraces.yaml
+++ b/pkg/plugins/policies/meshtrace/k8s/crd/kuma.io_meshtraces.yaml
@@ -226,6 +226,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string

--- a/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/schema.yaml
@@ -44,6 +44,7 @@ properties:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                   type: string
@@ -108,6 +109,7 @@ properties:
               - MeshSubset
               - MeshGateway
               - MeshService
+              - MeshExternalService
               - MeshServiceSubset
               - MeshHTTPRoute
             type: string

--- a/pkg/plugins/policies/meshtrafficpermission/k8s/crd/kuma.io_meshtrafficpermissions.yaml
+++ b/pkg/plugins/policies/meshtrafficpermission/k8s/crd/kuma.io_meshtrafficpermissions.yaml
@@ -79,6 +79,7 @@ spec:
                           - MeshSubset
                           - MeshGateway
                           - MeshService
+                          - MeshExternalService
                           - MeshServiceSubset
                           - MeshHTTPRoute
                           type: string
@@ -144,6 +145,7 @@ spec:
                     - MeshSubset
                     - MeshGateway
                     - MeshService
+                    - MeshExternalService
                     - MeshServiceSubset
                     - MeshHTTPRoute
                     type: string


### PR DESCRIPTION
### Checklist prior to review

* changed port type from int to Port
* added new TargetRefKind: `MeshExternalService`
 
- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
