### PR TITLE
feat(meshexternalservice): add servername

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -427,6 +427,10 @@ spec:
                         - Secured
                         - SkipAll
                         type: string
+                      serverName:
+                        description: ServerName overrides the default Server Name
+                          Indicator set by Kuma.
+                        type: string
                       subjectAltNames:
                         description: SubjectAltNames list of names to verify in the
                           certificate.

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -427,6 +427,10 @@ spec:
                         - Secured
                         - SkipAll
                         type: string
+                      serverName:
+                        description: ServerName overrides the default Server Name
+                          Indicator set by Kuma.
+                        type: string
                       subjectAltNames:
                         description: SubjectAltNames list of names to verify in the
                           certificate.

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -447,6 +447,10 @@ spec:
                         - Secured
                         - SkipAll
                         type: string
+                      serverName:
+                        description: ServerName overrides the default Server Name
+                          Indicator set by Kuma.
+                        type: string
                       subjectAltNames:
                         description: SubjectAltNames list of names to verify in the
                           certificate.

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -2026,6 +2026,10 @@ spec:
                         - Secured
                         - SkipAll
                         type: string
+                      serverName:
+                        description: ServerName overrides the default Server Name
+                          Indicator set by Kuma.
+                        type: string
                       subjectAltNames:
                         description: SubjectAltNames list of names to verify in the
                           certificate.

--- a/deployments/charts/kuma/crds/kuma.io_meshexternalservices.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshexternalservices.yaml
@@ -180,6 +180,10 @@ spec:
                         - Secured
                         - SkipAll
                         type: string
+                      serverName:
+                        description: ServerName overrides the default Server Name
+                          Indicator set by Kuma.
+                        type: string
                       subjectAltNames:
                         description: SubjectAltNames list of names to verify in the
                           certificate.

--- a/docs/generated/raw/crds/kuma.io_meshexternalservices.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshexternalservices.yaml
@@ -180,6 +180,10 @@ spec:
                         - Secured
                         - SkipAll
                         type: string
+                      serverName:
+                        description: ServerName overrides the default Server Name
+                          Indicator set by Kuma.
+                        type: string
                       subjectAltNames:
                         description: SubjectAltNames list of names to verify in the
                           certificate.

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/meshexternalservice.go
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/meshexternalservice.go
@@ -127,6 +127,8 @@ type Verification struct {
 	// Mode defines if proxy should skip verification, one of `SkipSAN`, `SkipCA`, `Secured`, `SkipAll`. Default `Secured`.
 	// +kubebuilder:default=Secured
 	Mode *VerificationMode `json:"mode,omitempty"`
+	// ServerName overrides the default Server Name Indicator set by Kuma.
+	ServerName *string `json:"serverName,omitempty"`
 	// SubjectAltNames list of names to verify in the certificate.
 	SubjectAltNames *[]SANMatch `json:"subjectAltNames,omitempty"`
 	// CaCert defines a certificate of CA.

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/schema.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/schema.yaml
@@ -139,6 +139,9 @@ properties:
                   - Secured
                   - SkipAll
                 type: string
+              serverName:
+                description: ServerName overrides the default Server Name Indicator set by Kuma.
+                type: string
               subjectAltNames:
                 description: SubjectAltNames list of names to verify in the certificate.
                 items:

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/testdata/full-invalid.input.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/testdata/full-invalid.input.yaml
@@ -15,6 +15,7 @@ tls:
     min: TLS15
     max: TLS16
   verification:
+    serverName: not[]valid
     mode: Unknown
     subjectAltNames:
       - type: Regex

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/testdata/full-invalid.output.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/testdata/full-invalid.output.yaml
@@ -19,6 +19,8 @@ violations:
   message: '"min" must be one of ["TLSAuto", "TLS10", "TLS11", "TLS12", "TLS13"]'
 - field: spec.tls.version.max
   message: '"max" must be one of ["TLSAuto", "TLS10", "TLS11", "TLS12", "TLS13"]'
+- field: spec.tls.verification.serverName
+  message: must be a valid DNS name
 - field: spec.tls.verification.mode
   message: '"mode" must be one of ["SkipSAN", "SkipCA", "SkipAll", "Secured"]'
 - field: spec.tls.verification.subjectAltNames[0].type

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/testdata/full-without-extension-valid.input.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/testdata/full-without-extension-valid.input.yaml
@@ -14,6 +14,7 @@ tls:
     max: TLS13
   allowRenegotiation: false
   verification:
+    serverName: "example.com"
     subjectAltNames:
       - type: Exact
         value: example.com

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/validator.go
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/validator.go
@@ -50,6 +50,9 @@ func validateTls(tls *Tls) validators.ValidationError {
 
 	if tls.Verification != nil {
 		path := validators.RootedAt("verification")
+		if tls.Verification.ServerName != nil && !govalidator.IsDNSName(*tls.Verification.ServerName) {
+			verr.AddViolationAt(path.Field("serverName"), "must be a valid DNS name")
+		}
 		if tls.Verification.Mode != nil {
 			if !slices.Contains(allVerificationModes, string(*tls.Verification.Mode)) {
 				verr.AddErrorAt(path.Field("mode"), validators.MakeFieldMustBeOneOfErr("mode", allVerificationModes...))

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/zz_generated.deepcopy.go
@@ -189,6 +189,11 @@ func (in *Verification) DeepCopyInto(out *Verification) {
 		*out = new(VerificationMode)
 		**out = **in
 	}
+	if in.ServerName != nil {
+		in, out := &in.ServerName, &out.ServerName
+		*out = new(string)
+		**out = **in
+	}
 	if in.SubjectAltNames != nil {
 		in, out := &in.SubjectAltNames, &out.SubjectAltNames
 		*out = new([]SANMatch)

--- a/pkg/core/resources/apis/meshexternalservice/k8s/crd/kuma.io_meshexternalservices.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/k8s/crd/kuma.io_meshexternalservices.yaml
@@ -180,6 +180,10 @@ spec:
                         - Secured
                         - SkipAll
                         type: string
+                      serverName:
+                        description: ServerName overrides the default Server Name
+                          Indicator set by Kuma.
+                        type: string
                       subjectAltNames:
                         description: SubjectAltNames list of names to verify in the
                           certificate.


### PR DESCRIPTION
### Checklist prior to review

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
