### PR TITLE
test(refactor): change the name from WithMesh to WithMeshBuilder

### DIFF
--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
@@ -953,7 +953,7 @@ var _ = Describe("MeshAccessLog", func() {
 			}
 
 			xdsCtx := *xds_builders.Context().
-				WithMesh(samples.MeshDefaultBuilder()).
+				WithMeshBuilder(samples.MeshDefaultBuilder()).
 				WithResources(resources).
 				AddServiceProtocol("backend", core_mesh.ProtocolHTTP).
 				AddServiceProtocol("other-service", core_mesh.ProtocolHTTP).

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin_test.go
@@ -405,7 +405,7 @@ var _ = Describe("MeshCircuitBreaker", func() {
 			}
 
 			xdsCtx := *xds_builders.Context().
-				WithMesh(samples.MeshDefaultBuilder()).
+				WithMeshBuilder(samples.MeshDefaultBuilder()).
 				WithResources(resources).
 				AddServiceProtocol("backend", core_mesh.ProtocolHTTP).
 				Build()

--- a/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin_test.go
@@ -243,7 +243,7 @@ var _ = Describe("MeshFaultInjection", func() {
 
 		// mesh with enabled mTLS and egress
 		ctxMesh1 := xds_builders.Context().
-			WithMesh(builders.Mesh().
+			WithMeshBuilder(builders.Mesh().
 				WithName("mesh-1").
 				WithBuiltinMTLSBackend("builtin-1").
 				WithEnabledMTLSBackend("builtin-1").

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
@@ -89,7 +89,7 @@ var _ = Describe("MeshHealthCheck", func() {
 			}
 
 			context := *xds_builders.Context().
-				WithMesh(samples.MeshDefaultBuilder()).
+				WithMeshBuilder(samples.MeshDefaultBuilder()).
 				WithResources(xds_context.NewResources()).
 				AddServiceProtocol(httpServiceTag, core_mesh.ProtocolHTTP).
 				AddServiceProtocol(tcpServiceTag, core_mesh.ProtocolTCP).
@@ -297,7 +297,7 @@ var _ = Describe("MeshHealthCheck", func() {
 			}
 
 			xdsCtx := *xds_builders.Context().
-				WithMesh(samples.MeshDefaultBuilder()).
+				WithMeshBuilder(samples.MeshDefaultBuilder()).
 				WithResources(resources).
 				AddServiceProtocol("backend", core_mesh.ProtocolHTTP).
 				Build()

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
@@ -153,7 +153,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 			}
 			return outboundsTestCase{
 				xdsContext: *xds_builders.Context().
-					WithMesh(builders.Mesh().WithBuiltinMTLSBackend("builtin").WithEnabledMTLSBackend("builtin")).
+					WithMeshBuilder(builders.Mesh().WithBuiltinMTLSBackend("builtin").WithEnabledMTLSBackend("builtin")).
 					WithEndpointMap(outboundTargets).
 					WithResources(resources).
 					AddServiceProtocol("backend_svc_80", core_mesh.ProtocolHTTP).
@@ -784,7 +784,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 					WithTags(mesh_proto.ServiceTag, "backend", mesh_proto.ProtocolTag, core_mesh.ProtocolHTTP, "region", "us"),
 				)
 			xdsContext := xds_builders.Context().
-				WithMesh(samples.MeshDefaultBuilder()).
+				WithMeshBuilder(samples.MeshDefaultBuilder()).
 				WithResources(resources).
 				WithEndpointMap(outboundTargets).Build()
 
@@ -928,7 +928,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 					WithTags(mesh_proto.ServiceTag, "backend", mesh_proto.ProtocolTag, core_mesh.ProtocolHTTP, "region", "us"),
 				)
 			xdsContext := xds_builders.Context().
-				WithMesh(samples.MeshDefaultBuilder()).
+				WithMeshBuilder(samples.MeshDefaultBuilder()).
 				WithResources(resources).
 				WithEndpointMap(outboundTargets).Build()
 			return outboundsTestCase{
@@ -1079,7 +1079,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 					WithTags(mesh_proto.ServiceTag, "backend", mesh_proto.ProtocolTag, core_mesh.ProtocolHTTP, "region", "us"),
 				)
 			xdsContext := xds_builders.Context().
-				WithMesh(samples.MeshDefaultBuilder()).
+				WithMeshBuilder(samples.MeshDefaultBuilder()).
 				WithResources(resources).
 				WithEndpointMap(outboundTargets).Build()
 			return outboundsTestCase{

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
@@ -1502,6 +1502,6 @@ func backendListener() envoy_common.NamedResource {
 
 func contextWithEgressEnabled() xds_context.Context {
 	return *xds_builders.Context().
-		WithMesh(samples.MeshMTLSBuilder().WithEgressRoutingEnabled()).
+		WithMeshBuilder(samples.MeshMTLSBuilder().WithEgressRoutingEnabled()).
 		Build()
 }

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin_test.go
@@ -194,7 +194,7 @@ var _ = Describe("MeshMetric", func() {
 				Build(),
 		}),
 		Entry("provided_tls", testCase{
-			context: *xds_builders.Context().WithMesh(samples.MeshMTLSBuilder()).Build(),
+			context: *xds_builders.Context().WithMeshBuilder(samples.MeshMTLSBuilder()).Build(),
 			proxy: xds_builders.Proxy().
 				WithDataplane(samples.DataplaneBackendBuilder()).
 				WithMetadata(&xds.DataplaneMetadata{

--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin_test.go
@@ -468,7 +468,7 @@ var _ = Describe("MeshRateLimit", func() {
 
 		// mesh with enabled mTLS and egress
 		ctx := xds_builders.Context().
-			WithMesh(builders.Mesh().
+			WithMeshBuilder(builders.Mesh().
 				WithName("mesh-1").
 				WithBuiltinMTLSBackend("builtin-1").
 				WithEnabledMTLSBackend("builtin-1").
@@ -683,7 +683,7 @@ var _ = Describe("MeshRateLimit", func() {
 			}
 
 			xdsCtx := *xds_builders.Context().
-				WithMesh(samples.MeshDefaultBuilder()).
+				WithMeshBuilder(samples.MeshDefaultBuilder()).
 				WithResources(resources).
 				AddServiceProtocol("backend", core_mesh.ProtocolHTTP).
 				Build()

--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin_test.go
@@ -52,7 +52,7 @@ var _ = Describe("MeshRetry", func() {
 		}
 
 		context := *xds_builders.Context().
-			WithMesh(samples.MeshDefaultBuilder()).
+			WithMeshBuilder(samples.MeshDefaultBuilder()).
 			WithResources(xds_context.NewResources()).
 			AddServiceProtocol("http-service", core_mesh.ProtocolHTTP).
 			AddServiceProtocol("tcp-service", core_mesh.ProtocolTCP).

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
@@ -699,7 +699,7 @@ var _ = Describe("MeshTCPRoute", func() {
 					WithTags(mesh_proto.ServiceTag, "backend", mesh_proto.ProtocolTag, core_mesh.ProtocolTCP, "region", "us"),
 				)
 			xdsContext := xds_builders.Context().
-				WithMesh(samples.MeshDefaultBuilder()).
+				WithMeshBuilder(samples.MeshDefaultBuilder()).
 				WithResources(resources).
 				WithEndpointMap(outboundTargets).Build()
 

--- a/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin_test.go
@@ -53,7 +53,7 @@ var _ = Describe("MeshTimeout", func() {
 		}
 
 		context := *xds_builders.Context().
-			WithMesh(samples.MeshDefaultBuilder()).
+			WithMeshBuilder(samples.MeshDefaultBuilder()).
 			WithResources(xds_context.NewResources()).
 			AddServiceProtocol("other-service", core_mesh.ProtocolHTTP).
 			AddServiceProtocol("second-service", core_mesh.ProtocolTCP).
@@ -425,7 +425,7 @@ var _ = Describe("MeshTimeout", func() {
 		}
 
 		xdsCtx := *xds_builders.Context().
-			WithMesh(samples.MeshDefaultBuilder()).
+			WithMeshBuilder(samples.MeshDefaultBuilder()).
 			WithResources(resources).
 			AddServiceProtocol("other-service", core_mesh.ProtocolHTTP).
 			AddServiceProtocol("backend", core_mesh.ProtocolHTTP).

--- a/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin_test.go
@@ -31,7 +31,7 @@ var _ = Describe("RBAC", func() {
 			// given
 			rs := core_xds.NewResourceSet()
 			ctx := xds_builders.Context().
-				WithMesh(samples.MeshMTLSBuilder().WithName("mesh-1")).
+				WithMeshBuilder(samples.MeshMTLSBuilder().WithName("mesh-1")).
 				Build()
 
 			// listener that matches
@@ -170,7 +170,7 @@ var _ = Describe("RBAC", func() {
 
 			// mesh with enabled mTLS and egress
 			ctx := xds_builders.Context().
-				WithMesh(builders.Mesh().
+				WithMeshBuilder(builders.Mesh().
 					WithName("mesh-1").
 					WithBuiltinMTLSBackend("builtin-1").
 					WithEnabledMTLSBackend("builtin-1").

--- a/pkg/test/xds/builders/context_builder.go
+++ b/pkg/test/xds/builders/context_builder.go
@@ -66,8 +66,13 @@ func (mc *ContextBuilder) WithResources(resources xds_context.Resources) *Contex
 	return mc
 }
 
-func (mc *ContextBuilder) WithMesh(mesh *builders.MeshBuilder) *ContextBuilder {
+func (mc *ContextBuilder) WithMeshBuilder(mesh *builders.MeshBuilder) *ContextBuilder {
 	mc.res.Mesh.Resource = mesh.Build()
+	return mc
+}
+
+func (mc *ContextBuilder) WithMesh(mesh *xds_context.MeshContext) *ContextBuilder {
+	mc.res.Mesh = *mesh
 	return mc
 }
 

--- a/pkg/test/xds/builders/context_builder.go
+++ b/pkg/test/xds/builders/context_builder.go
@@ -71,7 +71,7 @@ func (mc *ContextBuilder) WithMeshBuilder(mesh *builders.MeshBuilder) *ContextBu
 	return mc
 }
 
-func (mc *ContextBuilder) WithMesh(mesh *xds_context.MeshContext) *ContextBuilder {
+func (mc *ContextBuilder) WithMeshContext(mesh *xds_context.MeshContext) *ContextBuilder {
 	mc.res.Mesh = *mesh
 	return mc
 }

--- a/pkg/test/xds/samples/meshcontext_samples.go
+++ b/pkg/test/xds/samples/meshcontext_samples.go
@@ -13,7 +13,7 @@ func SampleContext() xds_context.Context {
 
 func SampleContextWith(resources xds_context.Resources) xds_context.Context {
 	return *builders.Context().
-		WithMesh(samples.MeshDefaultBuilder()).
+		WithMeshBuilder(samples.MeshDefaultBuilder()).
 		WithResources(resources).
 		WithEndpointMap(
 			builders.EndpointMap().


### PR DESCRIPTION
### Checklist prior to review

* renamed `WithMesh` to `WithMeshBuilder` because we ar providing Builder

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
