### PR TITLE
fix(kds): fix resource name hashing on global

### DIFF
--- a/pkg/kds/context/context.go
+++ b/pkg/kds/context/context.go
@@ -88,7 +88,7 @@ func DefaultContext(
 				// particular format to be able to reference them
 				reconcile.Not(reconcile.TypeIs(system.SecretType)),
 			),
-			HashSuffixMapper(true)),
+			HashSuffixMapper(true, mesh_proto.ZoneTag, mesh_proto.KubeNamespaceTag)),
 	}
 
 	zoneMappers := []reconcile.ResourceMapper{

--- a/pkg/kds/context/context_test.go
+++ b/pkg/kds/context/context_test.go
@@ -480,7 +480,9 @@ var _ = Describe("Context", func() {
 			meta := &test_model.ResourceMeta{
 				Name: given.name,
 				Labels: map[string]string{
-					mesh_proto.DisplayName: given.displayName,
+					mesh_proto.DisplayName:      given.displayName,
+					mesh_proto.ZoneTag:          "zone-1",
+					mesh_proto.KubeNamespaceTag: "custom-ns",
 				},
 			}
 			r.SetMeta(meta)
@@ -511,7 +513,7 @@ var _ = Describe("Context", func() {
 				},
 				name:         "foo.custom-namespace",
 				displayName:  "foo",
-				expectedName: "foo-zxw6c95d42zfz9cc",
+				expectedName: "foo-696vzv497z4cv4f4",
 				scope:        model.ScopeMesh,
 				features: map[string]bool{
 					kds.FeatureHashSuffix: true,


### PR DESCRIPTION
Fixes: #10433

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
