### PR TITLE
feat(MeshService): tag with headlessness, add pod-name/pod-index labels

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/meshservice_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/meshservice_controller.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
+	kube_apps "k8s.io/api/apps/v1"
 	kube_core "k8s.io/api/core/v1"
 	kube_discovery "k8s.io/api/discovery/v1"
 	kube_apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -85,7 +86,7 @@ func (r *MeshServiceReconciler) Reconcile(ctx context.Context, req kube_ctrl.Req
 		}
 	}
 
-	if svc.Spec.ClusterIP == "" { // todo(jakubdyszkiewicz) headless service support will come later
+	if svc.Spec.ClusterIP == "" {
 		log.V(1).Info("service has no cluster IP. Ignoring.")
 		return kube_ctrl.Result{}, nil
 	}
@@ -236,7 +237,7 @@ func (r *MeshServiceReconciler) Reconcile(ctx context.Context, req kube_ctrl.Req
 	return kube_ctrl.Result{}, nil
 }
 
-func (r *MeshServiceReconciler) setFromClusterIPSvc(ms *meshservice_k8s.MeshService, svc *kube_core.Service) error {
+func (r *MeshServiceReconciler) setFromClusterIPSvc(_ context.Context, ms *meshservice_k8s.MeshService, svc *kube_core.Service) error {
 	if ms.ObjectMeta.GetGeneration() != 0 {
 		if owners := ms.GetOwnerReferences(); len(owners) == 0 || owners[0].UID != svc.GetUID() {
 			r.EventRecorder.Eventf(
@@ -245,6 +246,7 @@ func (r *MeshServiceReconciler) setFromClusterIPSvc(ms *meshservice_k8s.MeshServ
 			return errors.Errorf("MeshService already exists and isn't owned by Service")
 		}
 	}
+	ms.ObjectMeta.Labels[metadata.HeadlessService] = "false"
 	ms.Spec.Selector = meshservice_api.Selector{
 		DataplaneTags: svc.Spec.Selector,
 	}
@@ -261,14 +263,31 @@ func (r *MeshServiceReconciler) setFromClusterIPSvc(ms *meshservice_k8s.MeshServ
 	return nil
 }
 
-func (r *MeshServiceReconciler) setFromPodAndHeadlessSvc(endpoint kube_discovery.Endpoint) func(*meshservice_k8s.MeshService, *kube_core.Service) error {
-	return func(ms *meshservice_k8s.MeshService, svc *kube_core.Service) error {
+func (r *MeshServiceReconciler) setFromPodAndHeadlessSvc(endpoint kube_discovery.Endpoint) func(context.Context, *meshservice_k8s.MeshService, *kube_core.Service) error {
+	return func(ctx context.Context, ms *meshservice_k8s.MeshService, svc *kube_core.Service) error {
 		if ms.ObjectMeta.GetGeneration() != 0 {
 			if owners := ms.GetOwnerReferences(); len(owners) == 0 || owners[0].UID != endpoint.TargetRef.UID {
 				r.EventRecorder.Eventf(
 					svc, kube_core.EventTypeWarning, FailedToGenerateMeshServiceReason, "MeshService already exists and isn't owned by Pod",
 				)
 				return errors.Errorf("MeshService already exists and isn't owned by Pod")
+			}
+		}
+		if ms.ObjectMeta.Labels == nil {
+			ms.ObjectMeta.Labels = map[string]string{}
+		}
+		ms.ObjectMeta.Labels[metadata.HeadlessService] = "true"
+		pod := kube_core.Pod{}
+		if err := r.Client.Get(ctx, kube_types.NamespacedName{Name: endpoint.TargetRef.Name, Namespace: endpoint.TargetRef.Namespace}, &pod); err != nil {
+			if !kube_apierrs.IsNotFound(err) {
+				return errors.Wrap(err, "couldn't lookup Pod for endpoint")
+			}
+		} else {
+			if v, ok := pod.Labels[kube_apps.StatefulSetPodNameLabel]; ok {
+				ms.ObjectMeta.Labels[kube_apps.StatefulSetPodNameLabel] = v
+			}
+			if v, ok := pod.Labels[kube_apps.PodIndexLabel]; ok {
+				ms.ObjectMeta.Labels[kube_apps.PodIndexLabel] = v
 			}
 		}
 		ms.Spec.Selector = meshservice_api.Selector{
@@ -300,7 +319,7 @@ func (r *MeshServiceReconciler) manageMeshService(
 	ctx context.Context,
 	svc *kube_core.Service,
 	mesh string,
-	setSpec func(*meshservice_k8s.MeshService, *kube_core.Service) error,
+	setSpec func(context.Context, *meshservice_k8s.MeshService, *kube_core.Service) error,
 	meshServiceName kube_types.NamespacedName,
 ) (kube_controllerutil.OperationResult, error) {
 	ms := &meshservice_k8s.MeshService{
@@ -337,7 +356,7 @@ func (r *MeshServiceReconciler) manageMeshService(
 		if ms.Status == nil {
 			ms.Status = &meshservice_api.MeshServiceStatus{}
 		}
-		return setSpec(ms, svc)
+		return setSpec(ctx, ms, svc)
 	})
 }
 

--- a/pkg/plugins/runtime/k8s/controllers/meshservice_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/meshservice_controller_test.go
@@ -52,6 +52,8 @@ var _ = Describe("MeshServiceController", func() {
 					obj = &kube_discovery.EndpointSlice{}
 				case strings.Contains(yamlObj, "kind: Namespace"):
 					obj = &kube_core.Namespace{}
+				case strings.Contains(yamlObj, "kind: Pod"):
+					obj = &kube_core.Pod{}
 				case strings.Contains(yamlObj, "kind: Mesh"):
 					obj = &v1alpha1.Mesh{}
 				}

--- a/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/01.meshservice.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/01.meshservice.yaml
@@ -2,6 +2,7 @@ items:
 - metadata:
     creationTimestamp: null
     labels:
+      k8s.kuma.io/headless-service: "false"
       k8s.kuma.io/service-name: example
       kuma.io/mesh: default
     name: example

--- a/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/01.meshservice.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/01.meshservice.yaml
@@ -2,7 +2,7 @@ items:
 - metadata:
     creationTimestamp: null
     labels:
-      k8s.kuma.io/headless-service: "false"
+      k8s.kuma.io/is-headless-service: "false"
       k8s.kuma.io/service-name: example
       kuma.io/mesh: default
     name: example

--- a/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/02.meshservice.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/02.meshservice.yaml
@@ -2,6 +2,7 @@ items:
 - metadata:
     creationTimestamp: null
     labels:
+      k8s.kuma.io/headless-service: "false"
       k8s.kuma.io/service-name: example
       kuma.io/mesh: default
     name: example

--- a/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/02.meshservice.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/02.meshservice.yaml
@@ -2,7 +2,7 @@ items:
 - metadata:
     creationTimestamp: null
     labels:
-      k8s.kuma.io/headless-service: "false"
+      k8s.kuma.io/is-headless-service: "false"
       k8s.kuma.io/service-name: example
       kuma.io/mesh: default
     name: example

--- a/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/headless.meshservice.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/headless.meshservice.yaml
@@ -3,7 +3,7 @@ items:
     creationTimestamp: null
     labels:
       apps.kubernetes.io/pod-index: "1"
-      k8s.kuma.io/headless-service: "true"
+      k8s.kuma.io/is-headless-service: "true"
       k8s.kuma.io/service-name: example
       kuma.io/mesh: default
       statefulset.kubernetes.io/pod-name: example-1
@@ -34,7 +34,7 @@ items:
     creationTimestamp: null
     labels:
       apps.kubernetes.io/pod-index: "2"
-      k8s.kuma.io/headless-service: "true"
+      k8s.kuma.io/is-headless-service: "true"
       k8s.kuma.io/service-name: example
       kuma.io/mesh: default
       statefulset.kubernetes.io/pod-name: example-2
@@ -64,7 +64,7 @@ items:
 - metadata:
     creationTimestamp: null
     labels:
-      k8s.kuma.io/headless-service: "true"
+      k8s.kuma.io/is-headless-service: "true"
       k8s.kuma.io/service-name: example
       kuma.io/mesh: default
     name: very-long-very-long-very-long-very-long-very-long-v-87ff74c98

--- a/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/headless.meshservice.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/headless.meshservice.yaml
@@ -2,8 +2,11 @@ items:
 - metadata:
     creationTimestamp: null
     labels:
+      apps.kubernetes.io/pod-index: "1"
+      k8s.kuma.io/headless-service: "true"
       k8s.kuma.io/service-name: example
       kuma.io/mesh: default
+      statefulset.kubernetes.io/pod-name: example-1
     name: example-1-87ff74c98
     namespace: demo
     ownerReferences:
@@ -30,8 +33,11 @@ items:
 - metadata:
     creationTimestamp: null
     labels:
+      apps.kubernetes.io/pod-index: "2"
+      k8s.kuma.io/headless-service: "true"
       k8s.kuma.io/service-name: example
       kuma.io/mesh: default
+      statefulset.kubernetes.io/pod-name: example-2
     name: example-2-87ff74c98
     namespace: demo
     ownerReferences:
@@ -58,6 +64,7 @@ items:
 - metadata:
     creationTimestamp: null
     labels:
+      k8s.kuma.io/headless-service: "true"
       k8s.kuma.io/service-name: example
       kuma.io/mesh: default
     name: very-long-very-long-very-long-very-long-very-long-v-87ff74c98

--- a/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/headless.resources.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/headless.resources.yaml
@@ -47,6 +47,34 @@ spec:
       protocol: TCP
 ---
 apiVersion: v1
+kind: Pod
+metadata:
+  namespace: demo
+  name: example-1
+  uid: example-1-1
+  labels:
+    statefulset.kubernetes.io/pod-name: example-1
+    apps.kubernetes.io/pod-index: "1"
+spec:
+  containers: []
+status:
+  podIP: 192.168.0.5
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: demo
+  name: example-2
+  uid: example-2-1
+  labels:
+    statefulset.kubernetes.io/pod-name: example-2
+    apps.kubernetes.io/pod-index: "2"
+spec:
+  containers: []
+status:
+  podIP: 192.168.0.6
+---
+apiVersion: v1
 kind: Namespace
 metadata:
   name: demo

--- a/pkg/plugins/runtime/k8s/metadata/annotations.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations.go
@@ -118,6 +118,9 @@ const (
 
 	// KumaServiceName points to the Service that a MeshService is derived from
 	KumaServiceName = "k8s.kuma.io/service-name"
+
+	// HeadlessService is "true" when the Service had ClusterIP: None, otherwise "false"
+	HeadlessService = "k8s.kuma.io/headless-service"
 )
 
 var PodAnnotationDeprecations = []Deprecation{

--- a/pkg/plugins/runtime/k8s/metadata/annotations.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations.go
@@ -120,7 +120,7 @@ const (
 	KumaServiceName = "k8s.kuma.io/service-name"
 
 	// HeadlessService is "true" when the Service had ClusterIP: None, otherwise "false"
-	HeadlessService = "k8s.kuma.io/headless-service"
+	HeadlessService = "k8s.kuma.io/is-headless-service"
 )
 
 var PodAnnotationDeprecations = []Deprecation{


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
