### PR TITLE
fix(ZoneIngress): fix no pointer panic for advertised address resolving

### DIFF
--- a/pkg/xds/context/mesh_context_builder.go
+++ b/pkg/xds/context/mesh_context_builder.go
@@ -342,13 +342,12 @@ func (m *meshContextBuilder) fetchResourceList(ctx context.Context, resType core
 				return nil, errors.New("entry is not a zoneIngress this shouldn't happen")
 			}
 
-			zoneIngressName := zi.GetMeta().GetName()
-			zi, err := xds_topology.ResolveZoneIngressPublicAddress(m.ipFunc, zi)
+			resolvedZoneIngress, err := xds_topology.ResolveZoneIngressPublicAddress(m.ipFunc, zi)
 			if err != nil {
-				l.Error(err, "failed to resolve zoneIngress's domain name, ignoring zoneIngress", "name", zoneIngressName)
+				l.Error(err, "failed to resolve zoneIngress's domain name, ignoring zoneIngress", "name", zi.GetMeta().GetName())
 				return nil, nil
 			}
-			return zi, nil
+			return resolvedZoneIngress, nil
 		case core_mesh.DataplaneType:
 			list, err = modifyAllEntries(list, func(resource core_model.Resource) (core_model.Resource, error) {
 				dp, ok := resource.(*core_mesh.DataplaneResource)

--- a/pkg/xds/context/mesh_context_builder.go
+++ b/pkg/xds/context/mesh_context_builder.go
@@ -341,9 +341,11 @@ func (m *meshContextBuilder) fetchResourceList(ctx context.Context, resType core
 			if !ok {
 				return nil, errors.New("entry is not a zoneIngress this shouldn't happen")
 			}
+
+			zoneIngressName := zi.GetMeta().GetName()
 			zi, err := xds_topology.ResolveZoneIngressPublicAddress(m.ipFunc, zi)
 			if err != nil {
-				l.Error(err, "failed to resolve zoneIngress's domain name, ignoring zoneIngress", "name", zi.GetMeta().GetName())
+				l.Error(err, "failed to resolve zoneIngress's domain name, ignoring zoneIngress", "name", zoneIngressName)
 				return nil, nil
 			}
 			return zi, nil


### PR DESCRIPTION
Refer to #10421, we made a mistake in the past to use a no pointer variable which leads to a panic

close #10421

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
