### PR TITLE
feat(hostnamegenerator): add display name to HostnameGenerator

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -7831,8 +7831,6 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
-                      matchName:
-                        type: string
                     type: object
                   meshService:
                     properties:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -7831,8 +7831,6 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
-                      matchName:
-                        type: string
                     type: object
                   meshService:
                     properties:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -7851,8 +7851,6 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
-                      matchName:
-                        type: string
                     type: object
                   meshService:
                     properties:

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -483,8 +483,6 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
-                      matchName:
-                        type: string
                     type: object
                   meshService:
                     properties:

--- a/deployments/charts/kuma/crds/kuma.io_hostnamegenerators.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_hostnamegenerators.yaml
@@ -48,8 +48,6 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
-                      matchName:
-                        type: string
                     type: object
                   meshService:
                     properties:

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -10543,8 +10543,6 @@ components:
                       additionalProperties:
                         type: string
                       type: object
-                    matchName:
-                      type: string
                   type: object
                 meshService:
                   properties:

--- a/docs/generated/raw/crds/kuma.io_hostnamegenerators.yaml
+++ b/docs/generated/raw/crds/kuma.io_hostnamegenerators.yaml
@@ -48,8 +48,6 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
-                      matchName:
-                        type: string
                     type: object
                   meshService:
                     properties:

--- a/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/hostnamegenerator.go
+++ b/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/hostnamegenerator.go
@@ -10,7 +10,6 @@ type LabelSelector struct {
 }
 
 type NameLabelsSelector struct {
-	MatchName   string            `json:"matchName,omitempty"`
 	MatchLabels map[string]string `json:"matchLabels,omitempty"`
 }
 
@@ -19,10 +18,7 @@ type Selector struct {
 	MeshExternalService NameLabelsSelector `json:"meshExternalService,omitempty"`
 }
 
-func (s NameLabelsSelector) Matches(name string, labels map[string]string) bool {
-	if s.MatchName != "" && s.MatchName != name {
-		return false
-	}
+func (s NameLabelsSelector) Matches(labels map[string]string) bool {
 	for tag, matchValue := range s.MatchLabels {
 		labelValue, exist := labels[tag]
 		if !exist {

--- a/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/schema.yaml
+++ b/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/schema.yaml
@@ -25,8 +25,6 @@ properties:
                 additionalProperties:
                   type: string
                 type: object
-              matchName:
-                type: string
             type: object
           meshService:
             properties:

--- a/pkg/core/resources/apis/hostnamegenerator/k8s/crd/kuma.io_hostnamegenerators.yaml
+++ b/pkg/core/resources/apis/hostnamegenerator/k8s/crd/kuma.io_hostnamegenerators.yaml
@@ -48,8 +48,6 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
-                      matchName:
-                        type: string
                     type: object
                   meshService:
                     properties:

--- a/pkg/core/resources/apis/meshexternalservice/hostname/generator.go
+++ b/pkg/core/resources/apis/meshexternalservice/hostname/generator.go
@@ -3,13 +3,13 @@ package hostname
 import (
 	"context"
 	"fmt"
-	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"reflect"
 	"strings"
 	"text/template"
 
 	"github.com/pkg/errors"
 
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	hostnamegenerator_api "github.com/kumahq/kuma/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/hostnamegenerator/hostname"
 	meshexternalservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
@@ -99,10 +99,10 @@ func (g *MeshExternalServiceHostnameGenerator) GenerateHostname(generator *hostn
 		displayName = name
 	}
 	err = tmpl.Execute(&sb, meshedName{
-		Name:      name,
+		Name:        name,
 		DisplayName: displayName,
-		Namespace: es.GetMeta().GetNameExtensions()[model.K8sNamespaceComponent],
-		Mesh:      es.GetMeta().GetMesh(),
+		Namespace:   es.GetMeta().GetNameExtensions()[model.K8sNamespaceComponent],
+		Mesh:        es.GetMeta().GetMesh(),
 	})
 	if err != nil {
 		return "", fmt.Errorf("pre evaluation of template with parameters failed with error=%q", err.Error())

--- a/pkg/xds/bootstrap/testdata/bootstrap.gateway.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.gateway.golden.yaml
@@ -62,7 +62,7 @@ node:
         gitCommit: 91ce236824a9d875601679aa80c63783fb0e8725
         gitTag: v0.0.1
         version: 0.0.1
-    workdir: "/tmp"
+    workdir: /tmp
 overloadManager:
   actions:
   - name: envoy.overload_actions.shrink_heap

--- a/pkg/xds/bootstrap/testdata/bootstrap.k8s.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.k8s.golden.yaml
@@ -53,7 +53,7 @@ node:
         gitCommit: 91ce236824a9d875601679aa80c63783fb0e8725
         gitTag: v0.0.1
         version: 0.0.1
-    workdir: "/tmp"
+    workdir: /tmp
 staticResources:
   clusters:
   - connectTimeout: 1s

--- a/pkg/xds/bootstrap/testdata/bootstrap.overridden.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.overridden.golden.yaml
@@ -65,7 +65,7 @@ node:
         gitCommit: 91ce236824a9d875601679aa80c63783fb0e8725
         gitTag: v0.0.1
         version: 0.0.1
-    workdir: "/tmp"
+    workdir: /tmp
 staticResources:
   clusters:
   - connectTimeout: 1s

--- a/pkg/xds/bootstrap/testdata/bootstrap.universal.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.universal.golden.yaml
@@ -53,7 +53,7 @@ node:
         gitCommit: 91ce236824a9d875601679aa80c63783fb0e8725
         gitTag: v0.0.1
         version: 0.0.1
-    workdir: "/tmp"
+    workdir: /tmp
 staticResources:
   clusters:
   - connectTimeout: 1s

--- a/pkg/xds/bootstrap/testdata/generator.custom-config-minimal-request.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.custom-config-minimal-request.golden.yaml
@@ -59,7 +59,7 @@ node:
         gitCommit: 91ce236824a9d875601679aa80c63783fb0e8725
         gitTag: v0.0.1
         version: 0.0.1
-    workdir: "/tmp"
+    workdir: /tmp
 staticResources:
   clusters:
   - connectTimeout: 2s

--- a/pkg/xds/bootstrap/testdata/generator.custom-config.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.custom-config.golden.yaml
@@ -92,7 +92,7 @@ node:
         gitCommit: 91ce236824a9d875601679aa80c63783fb0e8725
         gitTag: v0.0.1
         version: 0.0.1
-    workdir: "/tmp"
+    workdir: /tmp
 staticResources:
   clusters:
   - connectTimeout: 2s

--- a/pkg/xds/bootstrap/testdata/generator.default-config-minimal-request.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config-minimal-request.golden.yaml
@@ -47,7 +47,7 @@ node:
         gitCommit: 91ce236824a9d875601679aa80c63783fb0e8725
         gitTag: v0.0.1
         version: 0.0.1
-    workdir: "/tmp"
+    workdir: /tmp
 staticResources:
   clusters:
   - connectTimeout: 1s

--- a/pkg/xds/bootstrap/testdata/generator.default-config-token-path.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config-token-path.golden.yaml
@@ -86,7 +86,7 @@ node:
         gitCommit: 91ce236824a9d875601679aa80c63783fb0e8725
         gitTag: v0.0.1
         version: 0.0.1
-    workdir: "/tmp"
+    workdir: /tmp
 staticResources:
   clusters:
   - connectTimeout: 1s

--- a/pkg/xds/bootstrap/testdata/generator.default-config.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config.golden.yaml
@@ -66,7 +66,7 @@ node:
         gitCommit: 91ce236824a9d875601679aa80c63783fb0e8725
         gitTag: v0.0.1
         version: 0.0.1
-    workdir: "/tmp"
+    workdir: /tmp
 staticResources:
   clusters:
   - connectTimeout: 1s

--- a/pkg/xds/bootstrap/testdata/generator.default-config.kubernetes.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config.kubernetes.golden.yaml
@@ -55,7 +55,7 @@ node:
         gitCommit: 91ce236824a9d875601679aa80c63783fb0e8725
         gitTag: v0.0.1
         version: 0.0.1
-    workdir: "/tmp"
+    workdir: /tmp
 staticResources:
   clusters:
   - connectTimeout: 1s

--- a/pkg/xds/bootstrap/testdata/generator.default-config.kubernetes.ipv6.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config.kubernetes.ipv6.golden.yaml
@@ -55,7 +55,7 @@ node:
         gitCommit: 91ce236824a9d875601679aa80c63783fb0e8725
         gitTag: v0.0.1
         version: 0.0.1
-    workdir: "/tmp"
+    workdir: /tmp
 staticResources:
   clusters:
   - connectTimeout: 1s

--- a/pkg/xds/bootstrap/testdata/generator.gateway.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.gateway.golden.yaml
@@ -83,7 +83,7 @@ node:
         gitCommit: 91ce236824a9d875601679aa80c63783fb0e8725
         gitTag: v0.0.1
         version: 0.0.1
-    workdir: "/tmp"
+    workdir: /tmp
 staticResources:
   clusters:
   - connectTimeout: 1s

--- a/pkg/xds/bootstrap/testdata/generator.metrics-config.kubernetes.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.metrics-config.kubernetes.golden.yaml
@@ -55,7 +55,7 @@ node:
         gitCommit: 91ce236824a9d875601679aa80c63783fb0e8725
         gitTag: v0.0.1
         version: 0.0.1
-    workdir: "/tmp"
+    workdir: /tmp
 staticResources:
   clusters:
   - connectTimeout: 1s

--- a/pkg/xds/bootstrap/testdata/generator.system-cert-config.kubernetes.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.system-cert-config.kubernetes.golden.yaml
@@ -55,7 +55,7 @@ node:
         gitCommit: 91ce236824a9d875601679aa80c63783fb0e8725
         gitTag: v0.0.1
         version: 0.0.1
-    workdir: "/tmp"
+    workdir: /tmp
 staticResources:
   clusters:
   - connectTimeout: 1s


### PR DESCRIPTION
And I removed support for nameMatch since we decided it no longer makes sense. First part is in the first commit so you can just look at that.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
