### PR TITLE
feat(MeshService): set kuma.io/managed-by for converted MeshServices

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/meshservice_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/meshservice_controller.go
@@ -317,6 +317,8 @@ func (r *MeshServiceReconciler) manageMeshService(
 		}
 		ms.ObjectMeta.Labels[mesh_proto.MeshTag] = mesh
 		ms.ObjectMeta.Labels[metadata.KumaServiceName] = svc.GetName()
+		ms.ObjectMeta.Labels[metadata.ManagedBy] = "k8s-controller"
+
 		if ms.Spec == nil {
 			ms.Spec = &meshservice_api.MeshService{}
 		}

--- a/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/01.meshservice.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/01.meshservice.yaml
@@ -3,6 +3,7 @@ items:
     creationTimestamp: null
     labels:
       k8s.kuma.io/service-name: example
+      kuma.io/managed-by: k8s-controller
       kuma.io/mesh: default
     name: example
     namespace: demo

--- a/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/02.meshservice.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/02.meshservice.yaml
@@ -3,6 +3,7 @@ items:
     creationTimestamp: null
     labels:
       k8s.kuma.io/service-name: example
+      kuma.io/managed-by: k8s-controller
       kuma.io/mesh: default
     name: example
     namespace: demo

--- a/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/headless.meshservice.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/headless.meshservice.yaml
@@ -3,6 +3,7 @@ items:
     creationTimestamp: null
     labels:
       k8s.kuma.io/service-name: example
+      kuma.io/managed-by: k8s-controller
       kuma.io/mesh: default
     name: example-1-87ff74c98
     namespace: demo
@@ -31,6 +32,7 @@ items:
     creationTimestamp: null
     labels:
       k8s.kuma.io/service-name: example
+      kuma.io/managed-by: k8s-controller
       kuma.io/mesh: default
     name: example-2-87ff74c98
     namespace: demo
@@ -59,6 +61,7 @@ items:
     creationTimestamp: null
     labels:
       k8s.kuma.io/service-name: example
+      kuma.io/managed-by: k8s-controller
       kuma.io/mesh: default
     name: very-long-very-long-very-long-very-long-very-long-v-87ff74c98
     namespace: demo

--- a/pkg/plugins/runtime/k8s/metadata/annotations.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations.go
@@ -116,6 +116,10 @@ const (
 	// KumaWaitForDataplaneReady allows to specify if the application sidecar should be hold until Envoy is ready
 	KumaWaitForDataplaneReady = "kuma.io/wait-for-dataplane-ready"
 
+	// ManagedBy points to the Service that a MeshService is derived from. If
+	// it's converted from a Kubernetes Service, it has the value
+	// "k8s-controller"
+	ManagedBy = "kuma.io/managed-by"
 	// KumaServiceName points to the Service that a MeshService is derived from
 	KumaServiceName = "k8s.kuma.io/service-name"
 )


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
