### PR TITLE
test(e2e): fix previous version installs

### DIFF
--- a/test/e2e/helm/kuma_helm_upgrade_multizone.go
+++ b/test/e2e/helm/kuma_helm_upgrade_multizone.go
@@ -12,10 +12,10 @@ import (
 
 	"github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
-	"github.com/kumahq/kuma/pkg/util/versions"
 	. "github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/framework/api"
 	"github.com/kumahq/kuma/test/framework/deployments/testserver"
+	"github.com/kumahq/kuma/test/framework/versions"
 )
 
 func UpgradingWithHelmChartMultizone() {
@@ -26,9 +26,7 @@ func UpgradingWithHelmChartMultizone() {
 	var oldestSupportedVersion string
 
 	BeforeAll(func() {
-		vers, err := versions.ParseFromFile(Config.VersionsYamlPath)
-		Expect(err).ToNot(HaveOccurred())
-		oldestSupportedVersion = versions.OldestUpgradableToLatest(vers)
+		oldestSupportedVersion = versions.OldestUpgradableToBuildVersion(Config.SupportedVersions())
 	})
 
 	BeforeAll(func() {

--- a/test/e2e/helm/kuma_helm_upgrade_standalone.go
+++ b/test/e2e/helm/kuma_helm_upgrade_standalone.go
@@ -11,8 +11,8 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/kumahq/kuma/pkg/config/core"
-	"github.com/kumahq/kuma/pkg/util/versions"
 	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/versions"
 )
 
 func UpgradingWithHelmChartStandalone() {
@@ -26,9 +26,7 @@ func UpgradingWithHelmChartStandalone() {
 	var oldestSupportedVersion string
 
 	BeforeAll(func() {
-		vers, err := versions.ParseFromFile(Config.VersionsYamlPath)
-		Expect(err).ToNot(HaveOccurred())
-		oldestSupportedVersion = versions.OldestUpgradableToLatest(vers)
+		oldestSupportedVersion = versions.OldestUpgradableToBuildVersion(Config.SupportedVersions())
 	})
 
 	It("should successfully upgrade Kuma via Helm", func() {

--- a/test/e2e_env/universal/compatibility/dp_compatibility.go
+++ b/test/e2e_env/universal/compatibility/dp_compatibility.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kumahq/kuma/pkg/config/core"
 	. "github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/framework/client"
+	"github.com/kumahq/kuma/test/framework/versions"
 )
 
 func UniversalCompatibility() {
@@ -15,13 +16,14 @@ func UniversalCompatibility() {
 	BeforeEach(func() {
 		cluster = NewUniversalCluster(NewTestingT(), "kuma-compat", Silent)
 
+		oldestUpgradble := versions.OldestUpgradableToBuildVersion(Config.SupportedVersions())
 		err := NewClusterSetup().
 			Install(Kuma(core.Zone)).
 			Install(TestServerUniversal("test-server", "default",
 				WithArgs([]string{"echo", "--instance", "universal1"}),
-				WithDPVersion("1.5.0"))).
+				WithDPVersion(oldestUpgradble))).
 			Install(DemoClientUniversal(AppModeDemoClient, "default",
-				WithDPVersion("1.5.0"),
+				WithDPVersion(oldestUpgradble),
 				WithTransparentProxy(true)),
 			).
 			SetupWithRetries(cluster, 3)

--- a/test/e2e_env/universal/universal_suite_test.go
+++ b/test/e2e_env/universal/universal_suite_test.go
@@ -99,7 +99,7 @@ var (
 	_ = Describe("MeshRateLimit", meshratelimit.Policy, Ordered)
 	_ = Describe("MeshTimeout", timeout.PluginTest, Ordered)
 	_ = Describe("Projected Service Account Token", projectedsatoken.ProjectedServiceAccountToken, Ordered)
-	_ = XDescribe("Compatibility", compatibility.UniversalCompatibility, Label("arm-not-supported"), Ordered)
+	_ = Describe("Compatibility", compatibility.UniversalCompatibility, Label("arm-not-supported"), Ordered)
 	_ = Describe("Resilience", resilience.ResilienceUniversal, Ordered)
 	_ = Describe("Leader Election", resilience.LeaderElectionPostgres, Ordered)
 	_ = Describe("MeshFaultInjection", meshfaultinjection.Policy, Ordered)

--- a/test/framework/config.go
+++ b/test/framework/config.go
@@ -7,10 +7,12 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/config"
 	kuma_version "github.com/kumahq/kuma/pkg/version"
+	"github.com/kumahq/kuma/test/framework/versions"
 )
 
 var _ config.Config = E2eConfig{}
@@ -63,6 +65,10 @@ type E2eConfig struct {
 	VersionsYamlPath              string            `json:"versionsYamlPath,omitempty" envconfig:"VERSIONS_YAML_PATH"`
 
 	SuiteConfig SuiteConfig `json:"suites,omitempty"`
+}
+
+func (c E2eConfig) SupportedVersions() []*semver.Version {
+	return versions.ParseFromFile(c.VersionsYamlPath)
 }
 
 type SuiteConfig struct {

--- a/test/framework/universal_app.go
+++ b/test/framework/universal_app.go
@@ -376,7 +376,7 @@ func (s *UniversalApp) OverrideDpVersion(version string) error {
 	// It is important to store installation package in /tmp/kuma/, not /tmp/ otherwise root was taking over /tmp/ and Kuma DP could not store /tmp files
 	err := ssh.NewApp(s.containerName, "", s.verbose, s.ports[sshPort], nil, []string{
 		"wget",
-		fmt.Sprintf("https://download.konghq.com/mesh-alpine/kuma-%s-ubuntu-amd64.tar.gz", version),
+		fmt.Sprintf("https://packages.konghq.com/public/kuma-binaries-release/raw/names/kuma-linux-amd64/versions/%[1]s/kuma-%[1]s-linux-amd64.tar.gz", version),
 		"-O",
 		fmt.Sprintf("/tmp/kuma-%s-ubuntu-amd64.tar.gz", version),
 	}).Run()

--- a/test/framework/versions/suite_test.go
+++ b/test/framework/versions/suite_test.go
@@ -1,0 +1,11 @@
+package versions_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/pkg/test"
+)
+
+func TestVersions(t *testing.T) {
+	test.RunSpecs(t, "Versions Suite")
+}

--- a/test/framework/versions/versions.go
+++ b/test/framework/versions/versions.go
@@ -1,0 +1,61 @@
+package versions
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Masterminds/semver/v3"
+	"sigs.k8s.io/yaml"
+
+	"github.com/kumahq/kuma/pkg/version"
+)
+
+const previewVersion = "preview"
+
+func ParseFromFile(path string) []*semver.Version {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		panic(err)
+	}
+
+	plainVersions := []struct {
+		Version string `json:"version"`
+	}{}
+	if err := yaml.Unmarshal(content, &plainVersions); err != nil {
+		panic(err)
+	}
+
+	var versions []*semver.Version
+	for _, v := range plainVersions {
+		if v.Version == previewVersion {
+			continue
+		}
+
+		ver, err := semver.NewVersion(v.Version)
+		if err != nil {
+			panic(err)
+		}
+		versions = append(versions, ver)
+	}
+
+	return versions
+}
+
+func OldestUpgradableToBuildVersion(versions []*semver.Version) string {
+	currentVersion := *semver.MustParse(version.Build.Version)
+	return OldestUpgradableToVersion(versions, currentVersion)
+}
+
+func OldestUpgradableToVersion(versions []*semver.Version, currentVersion semver.Version) string {
+	if currentVersion.Major() == 0 && currentVersion.Minor() == 0 && currentVersion.Patch() == 0 {
+		// Assume we are minor+1 of the last version in versions
+		currentVersion = versions[len(versions)-1].IncMinor()
+	}
+
+	for _, version := range versions {
+		if version.Major() == currentVersion.Major() && version.Minor() == currentVersion.Minor()-2 {
+			return version.String()
+		}
+	}
+	panic(fmt.Sprintf("couldn't find version 2 minors behind current: %s", currentVersion))
+}

--- a/test/framework/versions/versions_test.go
+++ b/test/framework/versions/versions_test.go
@@ -1,0 +1,30 @@
+package versions_test
+
+import (
+	"github.com/Masterminds/semver/v3"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/test/framework/versions"
+)
+
+var _ = Describe("versions", func() {
+	DescribeTable("should return the oldest version that can be upgraded to the latest", func(currentStr string, expectedVersion string) {
+		// given
+		vers := []*semver.Version{
+			semver.MustParse("1.2.3"),
+			semver.MustParse("1.3.1"),
+			semver.MustParse("1.4.2"),
+			semver.MustParse("1.5.8"),
+		}
+		// when
+		current := semver.MustParse(currentStr)
+		oldest := versions.OldestUpgradableToVersion(vers, *current)
+		// then
+		Expect(oldest).To(Equal(expectedVersion))
+	},
+		Entry("preview", "0.0.0-preview.v123456789", "1.4.2"),
+		Entry("new version before being added to list", "1.6.0", "1.4.2"),
+		Entry("version in list", "1.5.8", "1.3.1"),
+	)
+})


### PR DESCRIPTION
Partial backport of https://github.com/kumahq/kuma/pull/8410

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
