### PR TITLE
feat(meshpassthrough): allow only proxyType sidecar

### DIFF
--- a/pkg/plugins/policies/meshpassthrough/api/v1alpha1/testdata/full-invalid.output.yaml
+++ b/pkg/plugins/policies/meshpassthrough/api/v1alpha1/testdata/full-invalid.output.yaml
@@ -1,4 +1,6 @@
 violations:
+- field: spec.targetRef.proxyTypes
+  message: proxyTypes needs to be set, currently only Sidecar is supported
 - field: spec.default.appendMatch[0].port
   message: port must be a valid (1-65535)
 - field: spec.default.appendMatch[0].protocol

--- a/pkg/plugins/policies/meshpassthrough/api/v1alpha1/testdata/valid.input.yaml
+++ b/pkg/plugins/policies/meshpassthrough/api/v1alpha1/testdata/valid.input.yaml
@@ -1,5 +1,6 @@
 targetRef:
   kind: Mesh
+  proxyTypes: ["Sidecar"]
 default:
   appendMatch:
   - type: IP

--- a/pkg/plugins/policies/meshpassthrough/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshpassthrough/api/v1alpha1/validator.go
@@ -36,6 +36,9 @@ func validateTop(targetRef common_api.TargetRef) validators.ValidationError {
 			common_api.MeshSubset,
 		},
 	})
+	if len(targetRef.ProxyTypes) != 1 && !slices.Contains(targetRef.ProxyTypes, common_api.Sidecar) {
+		targetRefErr.AddViolationAt(validators.RootedAt("proxyTypes"), "proxyTypes needs to be set, currently only Sidecar is supported")
+	}
 	return targetRefErr
 }
 

--- a/test/e2e_env/kubernetes/meshpassthrough/meshpassthrough.go
+++ b/test/e2e_env/kubernetes/meshpassthrough/meshpassthrough.go
@@ -93,6 +93,7 @@ metadata:
 spec:
   targetRef:
     kind: MeshSubset
+    proxyTypes: ["Sidecar"]
     tags:
       kuma.io/service: demo-client_mesh-passthrough_svc
   default:
@@ -127,6 +128,7 @@ metadata:
 spec:
   targetRef:
     kind: MeshSubset
+    proxyTypes: ["Sidecar"]
     tags:
       kuma.io/service: demo-client_mesh-passthrough_svc
   default:
@@ -158,6 +160,7 @@ metadata:
 spec:
   targetRef:
     kind: MeshSubset
+    proxyTypes: ["Sidecar"]
     tags:
       kuma.io/service: demo-client_mesh-passthrough_svc
   default:


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues -- fix: https://github.com/kumahq/kuma/issues/10468
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
