### PR TITLE
feat(hostnamegenerator): add zone and namespace variables

### DIFF
--- a/pkg/core/resources/apis/meshexternalservice/hostname/generator.go
+++ b/pkg/core/resources/apis/meshexternalservice/hostname/generator.go
@@ -2,14 +2,10 @@ package hostname
 
 import (
 	"context"
-	"fmt"
 	"reflect"
-	"strings"
-	"text/template"
 
 	"github.com/pkg/errors"
 
-	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	hostnamegenerator_api "github.com/kumahq/kuma/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/hostnamegenerator/hostname"
 	meshexternalservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
@@ -68,44 +64,5 @@ func (g *MeshExternalServiceHostnameGenerator) GenerateHostname(generator *hostn
 	if !generator.Spec.Selector.MeshExternalService.Matches(es.Meta.GetLabels()) {
 		return "", nil
 	}
-	sb := strings.Builder{}
-	tmpl := template.New("").Funcs(
-		map[string]any{
-			"label": func(key string) (string, error) {
-				val, ok := es.GetMeta().GetLabels()[key]
-				if !ok {
-					return "", errors.Errorf("label %s not found", key)
-				}
-				return val, nil
-			},
-		},
-	)
-	tmpl, err := tmpl.Parse(generator.Spec.Template)
-	if err != nil {
-		return "", fmt.Errorf("failed compiling gotemplate error=%q", err.Error())
-	}
-	type meshedName struct {
-		Name        string
-		DisplayName string
-		Namespace   string
-		Mesh        string
-	}
-	name := es.GetMeta().GetNameExtensions()[model.K8sNameComponent]
-	if name == "" {
-		name = es.GetMeta().GetName()
-	}
-	displayName, ok := es.GetMeta().GetLabels()[mesh_proto.DisplayName]
-	if !ok {
-		displayName = name
-	}
-	err = tmpl.Execute(&sb, meshedName{
-		Name:        name,
-		DisplayName: displayName,
-		Namespace:   es.GetMeta().GetNameExtensions()[model.K8sNamespaceComponent],
-		Mesh:        es.GetMeta().GetMesh(),
-	})
-	if err != nil {
-		return "", fmt.Errorf("pre evaluation of template with parameters failed with error=%q", err.Error())
-	}
-	return sb.String(), nil
+	return hostname.EvaluateTemplate(generator.Spec.Template, es.GetMeta())
 }


### PR DESCRIPTION
### Checklist prior to review

Not sure what it was copy paste.

Added `.Namespace` and `.Zone` resolution.

xref https://github.com/kumahq/kuma/pull/10476
https://github.com/kumahq/kuma/pull/10478/files#r1642600471 

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
