### PR TITLE
fix(meshservice): tags and selector

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/01.meshservice.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/01.meshservice.yaml
@@ -24,7 +24,9 @@ items:
       port: 443
       protocol: tcp
       targetPort: 8443
-    selector: {}
+    selector:
+      dataplaneTags:
+        k8s.kuma.io/namespace: demo
   status:
     tls: {}
     vips:

--- a/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/02.meshservice.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/02.meshservice.yaml
@@ -22,7 +22,9 @@ items:
     - port: 443
       protocol: tcp
       targetPort: 8443
-    selector: {}
+    selector:
+      dataplaneTags:
+        k8s.kuma.io/namespace: demo
   status:
     tls: {}
     vips:

--- a/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/headless.meshservice.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/headless.meshservice.yaml
@@ -26,7 +26,7 @@ items:
       targetPort: 8443
     selector:
       dataplaneRef:
-        name: example-1
+        name: example-1.demo
   status:
     tls: {}
     vips:
@@ -58,7 +58,7 @@ items:
       targetPort: 8443
     selector:
       dataplaneRef:
-        name: example-2
+        name: example-2.demo
   status:
     tls: {}
     vips:
@@ -88,7 +88,7 @@ items:
       targetPort: 8443
     selector:
       dataplaneRef:
-        name: very-long-very-long-very-long-very-long-very-long-v
+        name: very-long-very-long-very-long-very-long-very-long-v.demo
   status:
     tls: {}
     vips:


### PR DESCRIPTION
### Checklist prior to review

`k8s.kuma.io/namespace` was missing from the selector. We have the following option
1) Add this using controller
2) Add this using webhook.
3) Infer when retrieving from the store
4) Handle this every time when using selecotr

Since it's not really something users would apply manually on kube, I think adding this in controller is fine. 4) option is error prone.

Additionally, DataplaneRef does not contain a namespace. I don't think it's even handleded anywhere. Added an issue for e2e test https://github.com/kumahq/kuma/issues/10534

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
