### PR TITLE
feat(meshservice): rename protocol to appprotocol

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -5482,15 +5482,15 @@ spec:
               ports:
                 items:
                   properties:
+                    appProtocol:
+                      default: tcp
+                      description: Protocol identifies a protocol supported by a service.
+                      type: string
                     name:
                       type: string
                     port:
                       format: int32
                       type: integer
-                    protocol:
-                      default: tcp
-                      description: Protocol identifies a protocol supported by a service.
-                      type: string
                     targetPort:
                       anyOf:
                       - type: integer
@@ -5502,7 +5502,7 @@ spec:
                 type: array
                 x-kubernetes-list-map-keys:
                 - port
-                - protocol
+                - appProtocol
                 x-kubernetes-list-type: map
               selector:
                 properties:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -5482,15 +5482,15 @@ spec:
               ports:
                 items:
                   properties:
+                    appProtocol:
+                      default: tcp
+                      description: Protocol identifies a protocol supported by a service.
+                      type: string
                     name:
                       type: string
                     port:
                       format: int32
                       type: integer
-                    protocol:
-                      default: tcp
-                      description: Protocol identifies a protocol supported by a service.
-                      type: string
                     targetPort:
                       anyOf:
                       - type: integer
@@ -5502,7 +5502,7 @@ spec:
                 type: array
                 x-kubernetes-list-map-keys:
                 - port
-                - protocol
+                - appProtocol
                 x-kubernetes-list-type: map
               selector:
                 properties:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -5502,15 +5502,15 @@ spec:
               ports:
                 items:
                   properties:
+                    appProtocol:
+                      default: tcp
+                      description: Protocol identifies a protocol supported by a service.
+                      type: string
                     name:
                       type: string
                     port:
                       format: int32
                       type: integer
-                    protocol:
-                      default: tcp
-                      description: Protocol identifies a protocol supported by a service.
-                      type: string
                     targetPort:
                       anyOf:
                       - type: integer
@@ -5522,7 +5522,7 @@ spec:
                 type: array
                 x-kubernetes-list-map-keys:
                 - port
-                - protocol
+                - appProtocol
                 x-kubernetes-list-type: map
               selector:
                 properties:

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -7029,15 +7029,15 @@ spec:
               ports:
                 items:
                   properties:
+                    appProtocol:
+                      default: tcp
+                      description: Protocol identifies a protocol supported by a service.
+                      type: string
                     name:
                       type: string
                     port:
                       format: int32
                       type: integer
-                    protocol:
-                      default: tcp
-                      description: Protocol identifies a protocol supported by a service.
-                      type: string
                     targetPort:
                       anyOf:
                       - type: integer
@@ -7049,7 +7049,7 @@ spec:
                 type: array
                 x-kubernetes-list-map-keys:
                 - port
-                - protocol
+                - appProtocol
                 x-kubernetes-list-type: map
               selector:
                 properties:

--- a/deployments/charts/kuma/crds/kuma.io_meshservices.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshservices.yaml
@@ -57,15 +57,15 @@ spec:
               ports:
                 items:
                   properties:
+                    appProtocol:
+                      default: tcp
+                      description: Protocol identifies a protocol supported by a service.
+                      type: string
                     name:
                       type: string
                     port:
                       format: int32
                       type: integer
-                    protocol:
-                      default: tcp
-                      description: Protocol identifies a protocol supported by a service.
-                      type: string
                     targetPort:
                       anyOf:
                       - type: integer

--- a/deployments/charts/kuma/crds/kuma.io_meshservices.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshservices.yaml
@@ -77,7 +77,7 @@ spec:
                 type: array
                 x-kubernetes-list-map-keys:
                 - port
-                - protocol
+                - appProtocol
                 x-kubernetes-list-type: map
               selector:
                 properties:

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -10993,7 +10993,7 @@ components:
               type: array
               x-kubernetes-list-map-keys:
                 - port
-                - protocol
+                - appProtocol
               x-kubernetes-list-type: map
             selector:
               properties:

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -10973,15 +10973,15 @@ components:
             ports:
               items:
                 properties:
+                  appProtocol:
+                    default: tcp
+                    description: Protocol identifies a protocol supported by a service.
+                    type: string
                   name:
                     type: string
                   port:
                     format: int32
                     type: integer
-                  protocol:
-                    default: tcp
-                    description: Protocol identifies a protocol supported by a service.
-                    type: string
                   targetPort:
                     anyOf:
                       - type: integer

--- a/docs/generated/raw/crds/kuma.io_meshservices.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshservices.yaml
@@ -57,15 +57,15 @@ spec:
               ports:
                 items:
                   properties:
+                    appProtocol:
+                      default: tcp
+                      description: Protocol identifies a protocol supported by a service.
+                      type: string
                     name:
                       type: string
                     port:
                       format: int32
                       type: integer
-                    protocol:
-                      default: tcp
-                      description: Protocol identifies a protocol supported by a service.
-                      type: string
                     targetPort:
                       anyOf:
                       - type: integer

--- a/docs/generated/raw/crds/kuma.io_meshservices.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshservices.yaml
@@ -77,7 +77,7 @@ spec:
                 type: array
                 x-kubernetes-list-map-keys:
                 - port
-                - protocol
+                - appProtocol
                 x-kubernetes-list-type: map
               selector:
                 properties:

--- a/pkg/api-server/testdata/resources/crud/list_meshservices.golden.json
+++ b/pkg/api-server/testdata/resources/crud/list_meshservices.golden.json
@@ -17,7 +17,7 @@
      {
       "port": 6379,
       "targetPort": 6379,
-      "protocol": "tcp"
+      "appProtocol": "tcp"
      }
     ]
    },
@@ -46,7 +46,7 @@
      {
       "port": 6379,
       "targetPort": 6379,
-      "protocol": "tcp"
+      "appProtocol": "tcp"
      }
     ]
    },

--- a/pkg/api-server/testdata/resources/crud/list_meshservices.input.yaml
+++ b/pkg/api-server/testdata/resources/crud/list_meshservices.input.yaml
@@ -12,7 +12,7 @@ spec:
   ports:
     - port: 6379
       targetPort: 6379
-      protocol: tcp
+      appProtocol: tcp
 status:
   vips:
     - ip: 10.0.0.1
@@ -27,7 +27,7 @@ spec:
   ports:
     - port: 6379
       targetPort: 6379
-      protocol: tcp
+      appProtocol: tcp
 status:
   vips:
     - ip: 10.0.0.2

--- a/pkg/api-server/testdata/resources/crud/put_meshservice_01.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_meshservice_01.golden.json
@@ -16,8 +16,7 @@
   "ports": [
    {
     "port": 6379,
-    "targetPort": 6379,
-    "protocol": "tcp"
+    "targetPort": 6379
    }
   ]
  },

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/meshservice.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/meshservice.go
@@ -37,7 +37,7 @@ type MeshService struct {
 	// +patchStrategy=merge
 	// +listType=map
 	// +listMapKey=port
-	// +listMapKey=protocol
+	// +listMapKey=appProtocol
 	Ports      []Port                `json:"ports,omitempty"`
 	Identities []MeshServiceIdentity `json:"identities,omitempty"`
 }

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/meshservice.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/meshservice.go
@@ -24,7 +24,7 @@ type Port struct {
 	Port       uint32             `json:"port"`
 	TargetPort intstr.IntOrString `json:"targetPort,omitempty"`
 	// +kubebuilder:default=tcp
-	Protocol core_mesh.Protocol `json:"protocol,omitempty"`
+	AppProtocol core_mesh.Protocol `json:"appProtocol,omitempty"`
 }
 
 // MeshService

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/schema.yaml
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/schema.yaml
@@ -38,15 +38,15 @@ properties:
       ports:
         items:
           properties:
+            appProtocol:
+              default: tcp
+              description: Protocol identifies a protocol supported by a service.
+              type: string
             name:
               type: string
             port:
               format: int32
               type: integer
-            protocol:
-              default: tcp
-              description: Protocol identifies a protocol supported by a service.
-              type: string
             targetPort:
               anyOf:
                 - type: integer

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/schema.yaml
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/schema.yaml
@@ -58,7 +58,7 @@ properties:
         type: array
         x-kubernetes-list-map-keys:
           - port
-          - protocol
+          - appProtocol
         x-kubernetes-list-type: map
       selector:
         properties:

--- a/pkg/core/resources/apis/meshservice/k8s/crd/kuma.io_meshservices.yaml
+++ b/pkg/core/resources/apis/meshservice/k8s/crd/kuma.io_meshservices.yaml
@@ -57,15 +57,15 @@ spec:
               ports:
                 items:
                   properties:
+                    appProtocol:
+                      default: tcp
+                      description: Protocol identifies a protocol supported by a service.
+                      type: string
                     name:
                       type: string
                     port:
                       format: int32
                       type: integer
-                    protocol:
-                      default: tcp
-                      description: Protocol identifies a protocol supported by a service.
-                      type: string
                     targetPort:
                       anyOf:
                       - type: integer

--- a/pkg/core/resources/apis/meshservice/k8s/crd/kuma.io_meshservices.yaml
+++ b/pkg/core/resources/apis/meshservice/k8s/crd/kuma.io_meshservices.yaml
@@ -77,7 +77,7 @@ spec:
                 type: array
                 x-kubernetes-list-map-keys:
                 - port
-                - protocol
+                - appProtocol
                 x-kubernetes-list-type: map
               selector:
                 properties:

--- a/pkg/plugins/policies/core/xds/meshroute/listeners.go
+++ b/pkg/plugins/policies/core/xds/meshroute/listeners.go
@@ -87,8 +87,8 @@ func CollectServices(
 					continue
 				}
 				protocol := core_mesh.Protocol(core_mesh.ProtocolTCP)
-				if port.Protocol != "" {
-					protocol = port.Protocol
+				if port.AppProtocol != "" {
+					protocol = port.AppProtocol
 				}
 				dests = append(dests, DestinationService{
 					Outbound:    oface,
@@ -180,7 +180,7 @@ func makeSplit(
 				continue
 			}
 			service = ms.DestinationName(*ref.Port)
-			protocol = port.Protocol // todo(jakubdyszkiewicz): do we need to default to TCP or will this be done by MeshService defaulter?
+			protocol = port.AppProtocol // todo(jakubdyszkiewicz): do we need to default to TCP or will this be done by MeshService defaulter?
 		default:
 			service = ref.Name
 			protocol = meshCtx.GetServiceProtocol(service)

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
@@ -143,9 +143,9 @@ var _ = Describe("MeshHTTPRoute", func() {
 				Spec: &meshservice_api.MeshService{
 					Selector: meshservice_api.Selector{},
 					Ports: []meshservice_api.Port{{
-						Port:       80,
-						TargetPort: intstr.FromInt(8084),
-						Protocol:   core_mesh.ProtocolHTTP,
+						Port:        80,
+						TargetPort:  intstr.FromInt(8084),
+						AppProtocol: core_mesh.ProtocolHTTP,
 					}},
 					Identities: []meshservice_api.MeshServiceIdentity{
 						{

--- a/pkg/plugins/runtime/k8s/controllers/meshservice_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/meshservice_controller.go
@@ -353,10 +353,10 @@ func (r *MeshServiceReconciler) manageMeshService(
 				continue
 			}
 			ms.Spec.Ports = append(ms.Spec.Ports, meshservice_api.Port{
-				Name:       port.Name,
-				Port:       uint32(port.Port),
-				TargetPort: port.TargetPort,
-				Protocol:   core_mesh.Protocol(pointer.DerefOr(port.AppProtocol, "tcp")),
+				Name:        port.Name,
+				Port:        uint32(port.Port),
+				TargetPort:  port.TargetPort,
+				AppProtocol: core_mesh.Protocol(pointer.DerefOr(port.AppProtocol, "tcp")),
 			})
 		}
 

--- a/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/01.meshservice.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/01.meshservice.yaml
@@ -16,13 +16,13 @@ items:
     resourceVersion: "1"
   spec:
     ports:
-    - name: http-port
+    - appProtocol: http
+      name: http-port
       port: 80
-      protocol: http
       targetPort: 8080
-    - name: tcp-port
+    - appProtocol: tcp
+      name: tcp-port
       port: 443
-      protocol: tcp
       targetPort: 8443
     selector:
       dataplaneTags:

--- a/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/02.meshservice.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/02.meshservice.yaml
@@ -16,11 +16,11 @@ items:
     resourceVersion: "1"
   spec:
     ports:
-    - port: 80
-      protocol: http
+    - appProtocol: http
+      port: 80
       targetPort: 8080
-    - port: 443
-      protocol: tcp
+    - appProtocol: tcp
+      port: 443
       targetPort: 8443
     selector:
       dataplaneTags:

--- a/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/headless.meshservice.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/headless.meshservice.yaml
@@ -18,11 +18,11 @@ items:
     resourceVersion: "1"
   spec:
     ports:
-    - port: 80
-      protocol: http
+    - appProtocol: http
+      port: 80
       targetPort: 8080
-    - port: 443
-      protocol: tcp
+    - appProtocol: tcp
+      port: 443
       targetPort: 8443
     selector:
       dataplaneRef:
@@ -50,11 +50,11 @@ items:
     resourceVersion: "1"
   spec:
     ports:
-    - port: 80
-      protocol: http
+    - appProtocol: http
+      port: 80
       targetPort: 8080
-    - port: 443
-      protocol: tcp
+    - appProtocol: tcp
+      port: 443
       targetPort: 8443
     selector:
       dataplaneRef:
@@ -80,11 +80,11 @@ items:
     resourceVersion: "1"
   spec:
     ports:
-    - port: 80
-      protocol: http
+    - appProtocol: http
+      port: 80
       targetPort: 8080
-    - port: 443
-      protocol: tcp
+    - appProtocol: tcp
+      port: 443
       targetPort: 8443
     selector:
       dataplaneRef:

--- a/pkg/test/resources/builders/meshservice_builder.go
+++ b/pkg/test/resources/builders/meshservice_builder.go
@@ -58,7 +58,7 @@ func (m *MeshServiceBuilder) AddIntPort(port, target uint32, protocol core_mesh.
 			Type:   intstr.Int,
 			IntVal: int32(target),
 		},
-		Protocol: protocol,
+		AppProtocol: protocol,
 	})
 	return m
 }

--- a/pkg/test/store/store_test_template.go
+++ b/pkg/test/store/store_test_template.go
@@ -125,9 +125,9 @@ func ExecuteStoreTests(
 						},
 						Ports: []meshservice_api.Port{
 							{
-								Port:       80,
-								TargetPort: intstr.FromInt(80),
-								Protocol:   "http",
+								Port:        80,
+								TargetPort:  intstr.FromInt(80),
+								AppProtocol: "http",
 							},
 						},
 					},
@@ -271,9 +271,9 @@ func ExecuteStoreTests(
 						},
 						Ports: []meshservice_api.Port{
 							{
-								Port:       80,
-								TargetPort: intstr.FromInt(80),
-								Protocol:   "http",
+								Port:        80,
+								TargetPort:  intstr.FromInt(80),
+								AppProtocol: "http",
 							},
 						},
 					},

--- a/pkg/xds/topology/outbound_test.go
+++ b/pkg/xds/topology/outbound_test.go
@@ -1196,14 +1196,14 @@ var _ = Describe("TrafficRoute", func() {
 							},
 							Ports: []v1alpha1.Port{
 								{
-									Port:       80,
-									TargetPort: intstr.FromInt(8080),
-									Protocol:   "http",
+									Port:        80,
+									TargetPort:  intstr.FromInt(8080),
+									AppProtocol: "http",
 								},
 								{
-									Port:       8081,
-									TargetPort: intstr.FromInt(8081),
-									Protocol:   "http",
+									Port:        8081,
+									TargetPort:  intstr.FromInt(8081),
+									AppProtocol: "http",
 								},
 							},
 						},

--- a/test/e2e_env/multizone/meshservice/status.go
+++ b/test/e2e_env/multizone/meshservice/status.go
@@ -40,7 +40,7 @@ spec:
   ports:
   - port: 80
     targetPort: 80
-    protocol: http
+    appProtocol: http
 `)).
 			Install(TestServerUniversal("dp-echo-1", meshName,
 				WithArgs([]string{"echo", "--instance", "echo-v1"}),
@@ -62,7 +62,7 @@ spec:
   ports:
   - port: 80
     targetPort: 80
-    protocol: http
+    appProtocol: http
 `)).
 			Install(DemoClientUniversal("uni-demo-client", meshName, WithTransparentProxy(true))).
 			Setup(multizone.UniZone2)).To(Succeed())

--- a/test/e2e_env/universal/meshservice/meshservice.go
+++ b/test/e2e_env/universal/meshservice/meshservice.go
@@ -64,7 +64,7 @@ spec:
   ports:
   - port: 80 
     targetPort: 80
-    protocol: http
+    appProtocol: http
   selector:
     dataplaneTags:
       app: test-server


### PR DESCRIPTION
### Checklist prior to review

Rename protocol to appprotocol. We decided on appprotocol in this madr https://github.com/kumahq/kuma/blob/master/docs/madr/decisions/039-meshservice-api.md
but we didn't get to rename it. 

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
