### PR TITLE
feat(Mesh*Service): validate name length

### DIFF
--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/testdata/name-too-long.input.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/testdata/name-too-long.input.yaml
@@ -1,0 +1,7 @@
+match:
+  type: HostnameGenerator
+  port: 80
+  protocol: http
+endpoints:
+  - address: 1.1.1.1
+    port: 12345

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/testdata/name-too-long.output.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/testdata/name-too-long.output.yaml
@@ -1,0 +1,3 @@
+violations:
+- field: name
+  message: must not be longer than 63 characters

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/validator.go
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/validator.go
@@ -21,6 +21,9 @@ var (
 
 func (r *MeshExternalServiceResource) validate() error {
 	var verr validators.ValidationError
+
+	verr.Add(validators.ValidateLength(validators.RootedAt("name"), 63, r.Meta.GetName()))
+
 	path := validators.RootedAt("spec")
 
 	verr.AddErrorAt(path.Field("match"), validateMatch(r.Spec.Match))

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/validator_test.go
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/validator_test.go
@@ -11,26 +11,33 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/test/matchers"
+	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
 )
 
 var _ = Describe("MeshExternalService", func() {
 	Describe("Validate()", func() {
 		type testCase struct {
+			name string
 			file string
 		}
 
 		DescribeTable("should validate all fields and return as much individual errors as possible",
 			func(given testCase) {
 				// setup
-				MeshExternalService := v1alpha1.NewMeshExternalServiceResource()
+				meshExternalService := v1alpha1.NewMeshExternalServiceResource()
 
 				// when
 				contents, err := os.ReadFile(path.Join("testdata", given.file+".input.yaml"))
 				Expect(err).ToNot(HaveOccurred())
-				err = core_model.FromYAML(contents, &MeshExternalService.Spec)
+				err = core_model.FromYAML(contents, &meshExternalService.Spec)
 				Expect(err).ToNot(HaveOccurred())
+
+				meshExternalService.SetMeta(&test_model.ResourceMeta{
+					Name: given.name,
+					Mesh: core_model.DefaultMesh,
+				})
 				// and
-				verr := MeshExternalService.Validate()
+				verr := meshExternalService.Validate()
 				actual, err := yaml.Marshal(verr)
 				// have to do this otherwise valid cases will have null in the contents
 				if string(actual) == "null\n" {
@@ -42,24 +49,31 @@ var _ = Describe("MeshExternalService", func() {
 				Expect(actual).To(matchers.MatchGoldenYAML(path.Join("testdata", given.file+".output.yaml")))
 			},
 			Entry("minimal passing example", testCase{
+				name: "external-service",
 				file: "minimal-valid",
 			}),
 			Entry("full example without extension", testCase{
+				name: "external-service",
 				file: "full-without-extension-valid",
 			}),
 			Entry("minimal failing example with unknown port", testCase{
+				name: "external-service",
 				file: "minimal-invalid",
 			}),
 			Entry("failing example with missing extension type", testCase{
+				name: "external-service",
 				file: "minimal-invalid-extension",
 			}),
 			Entry("missing client-cert", testCase{
+				name: "external-service",
 				file: "missing-client-cert-invalid",
 			}),
 			Entry("full failing example", testCase{
+				name: "external-service",
 				file: "full-invalid",
 			}),
 			Entry("min tls version higher than max", testCase{
+				name: "external-service",
 				file: "min-higher-than-max-invalid",
 			}),
 		)

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/validator_test.go
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/validator_test.go
@@ -76,6 +76,10 @@ var _ = Describe("MeshExternalService", func() {
 				name: "external-service",
 				file: "min-higher-than-max-invalid",
 			}),
+			Entry("name too long", testCase{
+				name: "external-service-very-long-very-long-very-long-very-long-very-long-very-long-very-long",
+				file: "name-too-long",
+			}),
 		)
 	})
 })

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/suite_test.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/suite_test.go
@@ -1,0 +1,11 @@
+package v1alpha1_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/pkg/test"
+)
+
+func TestMeshService(t *testing.T) {
+	test.RunSpecs(t, "MeshService Suite")
+}

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/validator.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/validator.go
@@ -1,0 +1,13 @@
+package v1alpha1
+
+import (
+	"github.com/kumahq/kuma/pkg/core/validators"
+)
+
+func (r *MeshServiceResource) validate() error {
+	var verr validators.ValidationError
+
+	verr.Add(validators.ValidateLength(validators.RootedAt("name"), 63, r.GetMeta().GetName()))
+
+	return verr.OrNil()
+}

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/validator_test.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/validator_test.go
@@ -12,7 +12,7 @@ var _ = Describe("MeshService", func() {
 	DescribeErrorCases(
 		api.NewMeshServiceResource,
 		Entry(
-			"accepts valid resource",
+			"name too long",
 			ResourceValidationCase{
 				Violations: []validators.Violation{{
 					Field:   `name`,

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/validator_test.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/validator_test.go
@@ -1,0 +1,36 @@
+package v1alpha1_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+
+	api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
+	"github.com/kumahq/kuma/pkg/core/validators"
+	. "github.com/kumahq/kuma/pkg/test/resources/validators"
+)
+
+var _ = Describe("MeshService", func() {
+	DescribeErrorCases(
+		api.NewMeshServiceResource,
+		Entry(
+			"accepts valid resource",
+			ResourceValidationCase{
+				Violations: []validators.Violation{{
+					Field:   `name`,
+					Message: `must not be longer than 63 characters`,
+				}},
+				Name:     "meshservice-too-long-too-long-too-long-too-long-too-long-too-long-too-long-too-long-too-long",
+				Resource: "",
+			},
+		),
+	)
+	DescribeValidCases(
+		api.NewMeshServiceResource,
+		Entry(
+			"accepts valid resource",
+			ResourceValidationCase{
+				Name:     "meshservice",
+				Resource: "",
+			},
+		),
+	)
+})

--- a/pkg/core/resources/model/rest/unmarshaller.go
+++ b/pkg/core/resources/model/rest/unmarshaller.go
@@ -83,9 +83,13 @@ func (u *unmarshaler) Unmarshal(bytes []byte, desc core_model.ResourceTypeDescri
 		return nil, &InvalidResourceError{Reason: fmt.Sprintf("invalid %s object: %q", desc.Name, err.Error())}
 	}
 
+	if resource.GetMeta() == nil {
+		resource.SetMeta(From.Meta(resource))
+	}
 	if err := core_model.Validate(resource); err != nil {
 		return nil, err
 	}
+
 	return restResource, nil
 }
 

--- a/pkg/core/validators/common_validators.go
+++ b/pkg/core/validators/common_validators.go
@@ -252,3 +252,13 @@ func ValidatePort(path PathBuilder, value uint32) ValidationError {
 	}
 	return err
 }
+
+// ValidateLength should only be used when kubebuilder annotations can't be used
+func ValidateLength(path PathBuilder, maxLength int, v string) ValidationError {
+	var err ValidationError
+	if len(v) > maxLength {
+		err.AddViolationAt(path, fmt.Sprintf("must not be longer than %d characters", maxLength))
+	}
+
+	return err
+}

--- a/pkg/util/k8s/name_converter.go
+++ b/pkg/util/k8s/name_converter.go
@@ -38,3 +38,11 @@ func HashToString(h hash.Hash32) string {
 
 // MaxHashStringLength is the max length of a string returned by HashToString
 const MaxHashStringLength = 10
+
+// EnsureMaxLength truncates the string if it's too long
+func EnsureMaxLength(s string, length int) string {
+	if len(s) <= length {
+		return s
+	}
+	return s[0:length]
+}


### PR DESCRIPTION
Closes #10474 

- [x] trying to validate meta here works on k8s but leads to NPEs on universal...

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
