### PR TITLE
feat(hostnamegenerator): prevent template being empty

### DIFF
--- a/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/validate.go
+++ b/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/validate.go
@@ -17,6 +17,9 @@ func (r *HostnameGeneratorResource) validate() error {
 
 func validateTemplate(tmpl string) validators.ValidationError {
 	var verr validators.ValidationError
+	if tmpl == "" {
+		verr.AddViolationAt(validators.Root(), validators.MustNotBeEmpty)
+	}
 	_, err := template.New("").
 		Funcs(map[string]any{"label": func(key string) (string, error) { return "", nil }}).
 		Parse(tmpl)

--- a/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/validate_test.go
+++ b/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/validate_test.go
@@ -20,6 +20,15 @@ type: HostnameGenerator
 name: route-1
 template: "{{ .Name[4 }}.mesh"
 `),
+		ErrorCase("spec.template empty",
+			validators.Violation{
+				Field:   `spec.template`,
+				Message: `must not be empty`,
+			}, `
+type: HostnameGenerator
+name: route-1
+template: ""
+`),
 	)
 	DescribeValidCases(
 		api.NewHostnameGeneratorResource,


### PR DESCRIPTION
I don't think there is a valid case for an empty template.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
