### PR TITLE
test(e2e): ipv6 for mesh service and mesh external service

### DIFF
--- a/test/e2e_env/kubernetes/kubernetes_suite_test.go
+++ b/test/e2e_env/kubernetes/kubernetes_suite_test.go
@@ -80,7 +80,7 @@ var (
 	_ = Describe("Defaults", defaults.Defaults, Ordered)
 	_ = Describe("External Services", externalservices.ExternalServices, Ordered)
 	_ = Describe("External Services Permissive MTLS", externalservices.PermissiveMTLS, Ordered)
-	_ = Describe("Mesh External Services", Label("ipv6-not-supported"), meshexternalservices.MeshExternalServices, Ordered)
+	_ = Describe("Mesh External Services", meshexternalservices.MeshExternalServices, Ordered)
 	_ = Describe("ExternalName Services", externalname_services.ExternalNameServices, Ordered)
 	_ = Describe("Virtual Outbound", virtualoutbound.VirtualOutbound, Ordered)
 	_ = Describe("Kong Ingress Controller", kic.KICKubernetes, Ordered)

--- a/test/e2e_env/multizone/meshservice/status.go
+++ b/test/e2e_env/multizone/meshservice/status.go
@@ -102,12 +102,19 @@ spec:
 	}
 
 	It("should sync MeshService to global with VIP status", func() {
+		vipPrefix := "241.0.0."
+		vipOverridePrefix := "251.0.0."
+		if Config.IPV6 {
+			vipPrefix = "fd00:fd01:"
+			vipOverridePrefix = "fd00:fd11:"
+		}
+
 		// VIP and identities are assigned
 		Eventually(func(g Gomega) {
 			spec, status, err := msStatus(multizone.UniZone1, "backend")
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(status.VIPs).To(HaveLen(1))
-			g.Expect(status.VIPs[0].IP).To(ContainSubstring("241.0.0."))
+			g.Expect(status.VIPs[0].IP).To(ContainSubstring(vipPrefix))
 			g.Expect(spec.Identities).To(Equal([]v1alpha1.MeshServiceIdentity{
 				{
 					Type:  v1alpha1.MeshServiceIdentityServiceTagType,
@@ -121,7 +128,7 @@ spec:
 			spec, status, err := msStatus(multizone.Global, hash.HashedName(meshName, "backend", "kuma-4"))
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(status.VIPs).To(HaveLen(1))
-			g.Expect(status.VIPs[0].IP).To(ContainSubstring("241.0.0."))
+			g.Expect(status.VIPs[0].IP).To(ContainSubstring(vipPrefix))
 			g.Expect(spec.Identities).To(Equal([]v1alpha1.MeshServiceIdentity{
 				{
 					Type:  v1alpha1.MeshServiceIdentityServiceTagType,
@@ -135,7 +142,7 @@ spec:
 			spec, status, err := msStatus(multizone.UniZone2, hash.HashedName(meshName, "backend", "kuma-4"))
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(status.VIPs).To(HaveLen(1))
-			g.Expect(status.VIPs[0].IP).To(ContainSubstring("251.0.0."))
+			g.Expect(status.VIPs[0].IP).To(ContainSubstring(vipOverridePrefix))
 			g.Expect(spec.Identities).To(Equal([]v1alpha1.MeshServiceIdentity{
 				{
 					Type:  v1alpha1.MeshServiceIdentityServiceTagType,

--- a/test/e2e_env/multizone/multizone_suite_test.go
+++ b/test/e2e_env/multizone/multizone_suite_test.go
@@ -78,6 +78,6 @@ var (
 	_ = Describe("Advanced LocalityAwareness with MeshLoadBalancingStrategy with Gateway", localityawarelb.LocalityAwareLBGateway, Ordered)
 	_ = Describe("Advanced LocalityAwareness with MeshLoadBalancingStrategy and Enabled Egress", localityawarelb.LocalityAwareLBEgress, Ordered)
 	_ = Describe("Defaults", defaults.Defaults, Ordered)
-	_ = Describe("MeshService", Label("ipv6-not-supported"), meshservice.MeshService, Ordered)
+	_ = Describe("MeshService", meshservice.MeshService, Ordered)
 	_ = Describe("Available services", connectivity.AvailableServices, Ordered)
 )

--- a/test/e2e_env/universal/universal_suite_test.go
+++ b/test/e2e_env/universal/universal_suite_test.go
@@ -75,7 +75,7 @@ var (
 	_ = Describe("External Services", externalservices.Policy, Ordered)
 	_ = Describe("External Services through Zone Egress", externalservices.ThroughZoneEgress, Ordered)
 	_ = Describe("Inspect", inspect.Inspect, Ordered)
-	_ = Describe("Mesh External Services", Label("ipv6-not-supported"), meshexternalservice.MeshExternalService, Ordered)
+	_ = Describe("Mesh External Services", meshexternalservice.MeshExternalService, Ordered)
 	_ = Describe("MeshService", meshservice.MeshService, Ordered)
 	_ = Describe("Applications Metrics", observability.ApplicationsMetrics, Ordered)
 	_ = Describe("Tracing", observability.Tracing, Ordered)

--- a/test/framework/config.go
+++ b/test/framework/config.go
@@ -49,7 +49,6 @@ type E2eConfig struct {
 	IPV6                              bool              `json:"ipv6,omitempty" envconfig:"IPV6"`
 	UseHostnameInsteadOfIP            bool              `json:"useHostnameInsteadOfIP,omitempty" envconfig:"KUMA_USE_HOSTNAME_INSTEAD_OF_ID"`
 	UseLoadBalancer                   bool              `json:"useLoadBalancer,omitempty" envconfig:"KUMA_USE_LOAD_BALANCER"`
-	CIDR                              string            `json:"kumaCidr,omitempty"`
 	DefaultClusterStartupRetries      int               `json:"defaultClusterStartupRetries,omitempty" envconfig:"KUMA_DEFAULT_RETRIES"`
 	DefaultClusterStartupTimeout      time.Duration     `json:"defaultClusterStartupTimeout,omitempty" envconfig:"KUMA_DEFAULT_TIMEOUT"`
 	KumactlBin                        string            `json:"kumactlBin,omitempty" envconfig:"KUMACTLBIN"`
@@ -148,10 +147,6 @@ func (c E2eConfig) AutoConfigure() error {
 		default:
 			return fmt.Errorf("you must set a supported KUMA_K8S_TYPE got:%s", Config.K8sType)
 		}
-	}
-
-	if Config.IPV6 && Config.CIDR == "" {
-		Config.CIDR = "fd00:fd00::/64"
 	}
 
 	Config.Arch = runtime.GOARCH

--- a/test/framework/envs/multizone/env.go
+++ b/test/framework/envs/multizone/env.go
@@ -134,6 +134,10 @@ func SetupAndGetState() []byte {
 		Expect(err).ToNot(HaveOccurred())
 	}()
 
+	vipCIDROverride := "251.0.0.0/8"
+	if Config.IPV6 {
+		vipCIDROverride = "fd00:fd11::/64"
+	}
 	UniZone2 = NewUniversalCluster(NewTestingT(), Kuma5, Silent)
 	uniZone2Options := append(
 		[]framework.KumaDeploymentOption{
@@ -142,7 +146,7 @@ func SetupAndGetState() []byte {
 			WithIngressEnvoyAdminTunnel(),
 			WithEnv("KUMA_XDS_DATAPLANE_DEREGISTRATION_DELAY", "0s"), // we have only 1 Kuma CP instance so there is no risk setting this to 0
 			WithEnv("KUMA_MULTIZONE_ZONE_KDS_NACK_BACKOFF", "1s"),
-			WithEnv("KUMA_IPAM_MESH_SERVICE_CIDR", "251.0.0.0/8"), // just to see that the status is not synced around
+			WithEnv("KUMA_IPAM_MESH_SERVICE_CIDR", vipCIDROverride), // just to see that the status is not synced around
 		},
 		framework.KumaDeploymentOptionsFromConfig(framework.Config.KumaCpConfig.Multizone.UniZone2)...,
 	)

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -327,10 +327,6 @@ func (c *K8sCluster) yamlForKumaViaKubectl(mode string) (string, error) {
 		argsMap["--env-var"] = "KUMA_BOOTSTRAP_SERVER_API_VERSION=" + Config.XDSApiVersion
 	}
 
-	if Config.CIDR != "" {
-		argsMap["--env-var"] = fmt.Sprintf("KUMA_DNS_SERVER_CIDR=%s", Config.CIDR)
-	}
-
 	for opt, value := range c.opts.ctlOpts {
 		argsMap[opt] = value
 	}
@@ -338,6 +334,12 @@ func (c *K8sCluster) yamlForKumaViaKubectl(mode string) (string, error) {
 	var args []string
 	for k, v := range argsMap {
 		args = append(args, k, v)
+	}
+
+	if Config.IPV6 {
+		args = append(args, "--env-var", "KUMA_DNS_SERVER_CIDR=fd00:fd00::/64")
+		args = append(args, "--env-var", "KUMA_IPAM_MESH_SERVICE_CIDR=fd00:fd01::/64")
+		args = append(args, "--env-var", "KUMA_IPAM_MESH_EXTERNAL_SERVICE_CIDR=fd00:fd02::/64")
 	}
 
 	for k, v := range c.opts.env {
@@ -387,8 +389,10 @@ func (c *K8sCluster) genValues(mode string) map[string]string {
 		values["cni.confName"] = Config.CNIConf.ConfName
 	}
 
-	if Config.CIDR != "" {
-		values["controlPlane.envVars.KUMA_DNS_SERVER_CIDR"] = Config.CIDR
+	if Config.IPV6 {
+		values["controlPlane.envVars.KUMA_DNS_SERVER_CIDR"] = "fd00:fd00::/64"
+		values["controlPlane.envVars.KUMA_IPAM_MESH_SERVICE_CIDR"] = "fd00:fd01::/64"
+		values["controlPlane.envVars.KUMA_IPAM_MESH_EXTERNAL_SERVICE_CIDR"] = "fd00:fd02::/64"
 	}
 
 	switch mode {

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -119,6 +119,12 @@ func (c *UniversalCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOpt
 
 	env := map[string]string{"KUMA_MODE": mode, "KUMA_DNS_SERVER_PORT": "53"}
 
+	if Config.IPV6 {
+		env["KUMA_DNS_SERVER_CIDR"] = "fd00:fd00::/64"
+		env["KUMA_IPAM_MESH_SERVICE_CIDR"] = "fd00:fd01::/64"
+		env["KUMA_IPAM_MESH_EXTERNAL_SERVICE_CIDR"] = "fd00:fd02::/64"
+	}
+
 	for k, v := range c.opts.env {
 		env[k] = v
 	}
@@ -131,10 +137,6 @@ func (c *UniversalCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOpt
 
 	if Config.XDSApiVersion != "" {
 		env["KUMA_BOOTSTRAP_SERVER_API_VERSION"] = Config.XDSApiVersion
-	}
-
-	if Config.CIDR != "" {
-		env["KUMA_DNS_SERVER_CIDR"] = Config.CIDR
 	}
 
 	var dockerVolumes []string


### PR DESCRIPTION
### Checklist prior to review

IPV6 works by setting CIDR for our VIPs to IPV6. It turned out to be just a matter of test configuration. I deleted CIDR in E2E config, because it sounds like an overkill.

Fix #10471

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
