### PR TITLE
feat(kds): create first, then remove synced resources

### DIFF
--- a/pkg/kds/v2/store/sync.go
+++ b/pkg/kds/v2/store/sync.go
@@ -204,14 +204,6 @@ func (s *syncResourceStore) Sync(syncCtx context.Context, upstreamResponse clien
 	}
 
 	return store.InTx(ctx, s.transactions, func(ctx context.Context) error {
-		for _, r := range onDelete {
-			rk := core_model.MetaToResourceKey(r.GetMeta())
-			log.Info("deleting a resource since it's no longer available in the upstream", "name", r.GetMeta().GetName(), "mesh", r.GetMeta().GetMesh())
-			if err := s.resourceStore.Delete(ctx, r, store.DeleteBy(rk)); err != nil {
-				return err
-			}
-		}
-
 		for _, r := range onCreate {
 			rk := core_model.MetaToResourceKey(r.GetMeta())
 			log.Info("creating a new resource from upstream", "name", r.GetMeta().GetName(), "mesh", r.GetMeta().GetMesh())
@@ -229,6 +221,14 @@ func (s *syncResourceStore) Sync(syncCtx context.Context, upstreamResponse clien
 			r.SetMeta(nil)
 
 			if err := s.resourceStore.Create(ctx, r, createOpts...); err != nil {
+				return err
+			}
+		}
+
+		for _, r := range onDelete {
+			rk := core_model.MetaToResourceKey(r.GetMeta())
+			log.Info("deleting a resource since it's no longer available in the upstream", "name", r.GetMeta().GetName(), "mesh", r.GetMeta().GetMesh())
+			if err := s.resourceStore.Delete(ctx, r, store.DeleteBy(rk)); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Previously:
```
│ 2024-06-19T11:55:46.828Z    INFO    kds-delta-zone    deleting a resource since it's no longer available in the upstream    {"type": "MeshRetry", "name": "mesh-retry-all-default-4266fddczv5d2fvv.kuma-system", "mesh": "default"}                                                                                                                                                                                                                                                        │
│ 2024-06-19T11:55:46.853Z    INFO    kds-delta-zone    creating a new resource from upstream    {"type": "MeshRetry", "name": "mesh-retry-all-default-d4zvfwwxf4x44z76.kuma-system", "mesh": "default"}    
```

When we change how resource name hash is computed, we will need to recreate resources in other zones. Previously we were starting with removing resources and then creating new ones. This could lead to unexpected behaviour for a period without resources. With this change we are first creating new resources and then we remove old ones.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
