### PR TITLE
fix(meshexternalservice): correctly set tls context and protocol

### DIFF
--- a/pkg/core/xds/types.go
+++ b/pkg/core/xds/types.go
@@ -111,6 +111,14 @@ func (e Endpoint) Address() string {
 	return fmt.Sprintf("%s:%d", e.Target, e.Port)
 }
 
+func (e Endpoint) Protocol() string {
+	protocol := e.Tags[mesh_proto.ProtocolTag]
+	if e.ExternalService != nil && e.ExternalService.Protocol != "" {
+		protocol = string(e.ExternalService.Protocol)
+	}
+	return protocol
+}
+
 // EndpointList is a list of Endpoints with convenience methods.
 type EndpointList []Endpoint
 

--- a/pkg/plugins/policies/core/xds/meshroute/clusters.go
+++ b/pkg/plugins/policies/core/xds/meshroute/clusters.go
@@ -53,7 +53,7 @@ func GenerateClusters(
 						Configure(envoy_clusters.ProvidedCustomEndpointCluster(isIPv6, isMeshExternalService(endpoints), endpoints...))
 					if isMeshExternalService(endpoints) {
 						edsClusterBuilder.Configure(
-							envoy_clusters.MeshExternalServiceClientSideTLS(endpoints, proxy.Metadata.SystemCaPath, false),
+							envoy_clusters.MeshExternalServiceClientSideTLS(endpoints, proxy.Metadata.SystemCaPath, true),
 						)
 					} else {
 						edsClusterBuilder.

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
@@ -300,6 +300,10 @@ var _ = Describe("MeshHTTPRoute", func() {
 							Address: "example.com",
 							Port:    pointer.To(meshexternalservice_api.Port(10000)),
 						},
+						{
+							Address: "example2.com",
+							Port:    pointer.To(meshexternalservice_api.Port(11111)),
+						},
 					},
 					Tls: &meshexternalservice_api.Tls{
 						Enabled: true,

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.clusters.golden.yaml
@@ -14,13 +14,6 @@ resources:
                 portValue: 10000
           loadBalancingWeight: 1
     name: example
-    transportSocketMatches:
-    - name: example.com
-      transportSocket:
-        name: envoy.transport_sockets.tls
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-          sni: example.com
     type: STRICT_DNS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.clusters.golden.yaml
@@ -14,6 +14,13 @@ resources:
                 portValue: 10000
           loadBalancingWeight: 1
     name: example
+    transportSocketMatches:
+    - name: example.com
+      transportSocket:
+        name: envoy.transport_sockets.tls
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+          sni: example.com
     type: STRICT_DNS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.clusters.golden.yaml
@@ -13,10 +13,15 @@ resources:
                 address: example.com
                 portValue: 10000
           loadBalancingWeight: 1
+        - endpoint:
+            address:
+              socketAddress:
+                address: example2.com
+                portValue: 11111
+          loadBalancingWeight: 1
     name: example
     transportSocketMatches:
-    - match: {}
-      name: example.com
+    - name: example.com
       transportSocket:
         name: envoy.transport_sockets.tls
         typedConfig:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.clusters.golden.yaml
@@ -15,8 +15,7 @@ resources:
           loadBalancingWeight: 1
     name: example
     transportSocketMatches:
-    - match: {}
-      name: example.com
+    - name: example.com
       transportSocket:
         name: envoy.transport_sockets.tls
         typedConfig:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.clusters.golden.yaml
@@ -15,8 +15,7 @@ resources:
           loadBalancingWeight: 1
     name: example
     transportSocketMatches:
-    - match: {}
-      name: example.com
+    - name: example.com
       transportSocket:
         name: envoy.transport_sockets.tls
         typedConfig:

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.clusters.golden.yaml
@@ -35,26 +35,7 @@ resources:
           loadBalancingWeight: 1
     name: example
     transportSocketMatches:
-    - match: {}
-      name: example.com
-      transportSocket:
-        name: envoy.transport_sockets.tls
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-          commonTlsContext:
-            validationContext:
-              matchTypedSubjectAltNames:
-              - matcher:
-                  exact: example.com
-                sanType: DNS
-              - matcher:
-                  exact: example.com
-                sanType: IP_ADDRESS
-              trustedCa:
-                filename: /tmp/ca-certs.crt
-          sni: example.com
-    - match: {}
-      name: 192.168.1.1
+    - name: example.com
       transportSocket:
         name: envoy.transport_sockets.tls
         typedConfig:

--- a/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin_test.go
@@ -226,6 +226,22 @@ var _ = Describe("RBAC", func() {
 										},
 									},
 								},
+								"example-mes": {
+									policies_api.MeshTrafficPermissionType: core_xds.TypedMatchingPolicies{
+										FromRules: core_rules.FromRules{
+											Rules: map[core_rules.InboundListener]core_rules.Rules{
+												{
+													Address: "192.168.0.1", Port: 10002,
+												}: {
+													{
+														Subset: core_rules.MeshSubset(),
+														Conf:   policies_api.Conf{Action: policies_api.Allow},
+													},
+												},
+											},
+										},
+									},
+								},
 							},
 						},
 						{

--- a/pkg/xds/context/mesh_context_builder.go
+++ b/pkg/xds/context/mesh_context_builder.go
@@ -553,6 +553,9 @@ func inferServiceProtocol(endpoints []xds.Endpoint) core_mesh.Protocol {
 	}
 	for _, endpoint := range endpoints[1:] {
 		endpointProtocol := core_mesh.ParseProtocol(endpoint.Tags[mesh_proto.ProtocolTag])
+		if endpoints[0].ExternalService != nil && endpoints[0].ExternalService.Protocol != "" {
+			endpointProtocol = endpoints[0].ExternalService.Protocol
+		}
 		serviceProtocol = util_protocol.GetCommonProtocol(serviceProtocol, endpointProtocol)
 	}
 	return serviceProtocol

--- a/pkg/xds/context/mesh_context_builder.go
+++ b/pkg/xds/context/mesh_context_builder.go
@@ -553,8 +553,8 @@ func inferServiceProtocol(endpoints []xds.Endpoint) core_mesh.Protocol {
 	}
 	for _, endpoint := range endpoints[1:] {
 		endpointProtocol := core_mesh.ParseProtocol(endpoint.Tags[mesh_proto.ProtocolTag])
-		if endpoints[0].ExternalService != nil && endpoints[0].ExternalService.Protocol != "" {
-			endpointProtocol = endpoints[0].ExternalService.Protocol
+		if endpoint.ExternalService != nil && endpoint.ExternalService.Protocol != "" {
+			endpointProtocol = endpoint.ExternalService.Protocol
 		}
 		serviceProtocol = util_protocol.GetCommonProtocol(serviceProtocol, endpointProtocol)
 	}

--- a/pkg/xds/envoy/clusters/v3/client_side_tls_configurer.go
+++ b/pkg/xds/envoy/clusters/v3/client_side_tls_configurer.go
@@ -25,11 +25,13 @@ var _ ClusterConfigurer = &ClientSideTLSConfigurer{}
 func (c *ClientSideTLSConfigurer) Configure(cluster *envoy_cluster.Cluster) error {
 	if c.UseCommonTlsContext && len(c.Endpoints) > 0 {
 		ep := c.Endpoints[0]
-		tsm, err := c.createTransportSocketMatch(&ep, false)
-		if err != nil {
-			return err
+		if ep.ExternalService != nil && ep.ExternalService.TLSEnabled {
+			tsm, err := c.createTransportSocketMatch(&ep, false)
+			if err != nil {
+				return err
+			}
+			cluster.TransportSocketMatches = append(cluster.TransportSocketMatches, tsm)
 		}
-		cluster.TransportSocketMatches = append(cluster.TransportSocketMatches, tsm)
 	} else {
 		for i, ep := range c.Endpoints {
 			if ep.ExternalService != nil && ep.ExternalService.TLSEnabled {

--- a/pkg/xds/generator/egress/generator_test.go
+++ b/pkg/xds/generator/egress/generator_test.go
@@ -86,8 +86,9 @@ var _ = Describe("EgressGenerator", func() {
 					if _, ok := meshResourcesMap[meshName]; !ok {
 						meshResourcesMap[meshName] = &core_xds.MeshResources{
 							Resources: map[core_model.ResourceType]core_model.ResourceList{
-								core_mesh.TrafficRouteType:          &core_mesh.TrafficRouteResourceList{},
-								meshhttproute_api.MeshHTTPRouteType: &meshhttproute_api.MeshHTTPRouteResourceList{},
+								core_mesh.TrafficRouteType:                      &core_mesh.TrafficRouteResourceList{},
+								meshhttproute_api.MeshHTTPRouteType:             &meshhttproute_api.MeshHTTPRouteResourceList{},
+								meshexternalservice_api.MeshExternalServiceType: &meshexternalservice_api.MeshExternalServiceResourceList{},
 							},
 						}
 					}

--- a/pkg/xds/generator/egress/testdata/01.externalservice-only.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/01.externalservice-only.golden.yaml
@@ -30,6 +30,47 @@ resources:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         explicitHttpConfig:
           httpProtocolOptions: {}
+- name: meshexternalservice-1
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    altStatName: mesh-1_meshexternalservice-1
+    connectTimeout: 5s
+    dnsLookupFamily: V4_ONLY
+    loadAssignment:
+      clusterName: mesh-1:meshexternalservice-1
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 127.0.0.1
+                portValue: 8080
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                mesh: mesh-1
+              envoy.transport_socket_match:
+                mesh: mesh-1
+        - endpoint:
+            address:
+              socketAddress:
+                address: example.com
+                portValue: 1234
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                mesh: mesh-1
+              envoy.transport_socket_match:
+                mesh: mesh-1
+    name: mesh-1:meshexternalservice-1
+    type: STRICT_DNS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          httpProtocolOptions: {}
 - name: inbound:192.168.0.1:10002
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener
@@ -78,6 +119,60 @@ resources:
                   timeout: 0s
           statPrefix: externalservice-1
       name: externalservice-1_mesh-1
+      transportSocket:
+        name: envoy.transport_sockets.tls
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          commonTlsContext:
+            combinedValidationContext:
+              defaultValidationContext:
+                matchTypedSubjectAltNames:
+                - matcher:
+                    prefix: spiffe://mesh-1/
+                  sanType: URI
+              validationContextSdsSecretConfig:
+                name: mesh_ca:secret:mesh-1
+                sdsConfig:
+                  ads: {}
+                  resourceApiVersion: V3
+            tlsCertificateSdsSecretConfigs:
+            - name: identity_cert:secret:mesh-1
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+          requireClientCertificate: true
+    - filterChainMatch:
+        serverNames:
+        - meshexternalservice-1{mesh=mesh-1}
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          httpFilters:
+          - name: envoy.filters.http.rbac
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC
+              rules: {}
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          routeConfig:
+            name: outbound:meshexternalservice-1
+            validateClusters: false
+            virtualHosts:
+            - domains:
+              - '*'
+              name: meshexternalservice-1
+              routes:
+              - match:
+                  prefix: /
+                route:
+                  autoHostRewrite: true
+                  cluster: mesh-1:meshexternalservice-1
+                  timeout: 0s
+          statPrefix: meshexternalservice-1
+      name: meshexternalservice-1_mesh-1
       transportSocket:
         name: envoy.transport_sockets.tls
         typedConfig:

--- a/pkg/xds/generator/egress/testdata/input/01.externalservice-only.yaml
+++ b/pkg/xds/generator/egress/testdata/input/01.externalservice-only.yaml
@@ -46,3 +46,17 @@ tags:
   kuma.io/protocol: http
 networking:
   address: kuma.io:80
+---
+type: MeshExternalService
+name: meshexternalservice-1
+mesh: mesh-1
+spec:
+  match:
+    type: HostnameGenerator
+    port: 9090
+    protocol: http
+  endpoints:
+  - address: 127.0.0.1
+    port: 8080
+  - address: example.com
+    port: 1234

--- a/test/e2e_env/kubernetes/meshexternalservice/meshexternalservice.go
+++ b/test/e2e_env/kubernetes/meshexternalservice/meshexternalservice.go
@@ -173,7 +173,7 @@ spec:
 					client.FromKubernetesPod(clientNamespace, "demo-client-egress"),
 				)
 				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(response.ResponseCode).To(Equal(503))
+				g.Expect(response.ResponseCode).To(Equal(403))
 			}, "30s", "1s").Should(Succeed())
 
 			// when MTP targeting MeshExternalService added


### PR DESCRIPTION
### Checklist prior to review

* fix setting tls context for MeshExternalService
* take the correct protocol for MeshExternalService
* do not set tls context when tls disabled
* use correct way of checking protocol for egress

- [ ] [Link to relevant issue][1] as well as docs and UI issues -- fix: https://github.com/kumahq/kuma/issues/10560 fix: https://github.com/kumahq/kuma/issues/10559
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
