### PR TITLE
test(e2e): mesh service connectivity

### DIFF
--- a/test/e2e_env/multizone/meshservice/connectivity.go
+++ b/test/e2e_env/multizone/meshservice/connectivity.go
@@ -23,7 +23,7 @@ func Connectivity() {
 type: HostnameGenerator
 name: kube-msconnectivity
 spec:
-  template: '{{ .DisplayName }}.{{ .Namespace }}.{{ .Zone }}.msconnectivity'
+  template: '{{ .DisplayName }}.{{ .Namespace }}.{{ .Zone }}.k8s.msconnectivity'
   selector:
     meshService:
       matchLabels:
@@ -34,7 +34,7 @@ spec:
 type: HostnameGenerator
 name: uni-msconnectivity
 spec:
-  template: '{{ .DisplayName }}.{{ .Zone }}.msconnectivity'
+  template: '{{ .DisplayName }}.{{ .Zone }}.universal.msconnectivity'
   selector:
     meshService:
       matchLabels:
@@ -148,16 +148,16 @@ spec:
 				g.Expect(response.Instance).To(Equal(given.expectedInstance))
 			}, "30s", "1s").Should(Succeed())
 		},
-		Entry("should access service in another Kubernetes cluster", testCase{
+		Entry("should access service in the same Kubernetes cluster", testCase{
 			address:          "http://test-server.msconnectivity.svc.cluster.local:80",
 			expectedInstance: "kube-test-server-1",
 		}),
 		Entry("should access service in another Kubernetes cluster", testCase{
-			address:          "http://test-server.msconnectivity.kuma-2.msconnectivity:80",
+			address:          "http://test-server.msconnectivity.kuma-2.k8s.msconnectivity:80",
 			expectedInstance: "kube-test-server-2",
 		}),
-		Entry("should access service in another Kubernetes cluster", testCase{
-			address:          "http://test-server.kuma-5.msconnectivity:80",
+		Entry("should access service in another Universal cluster", testCase{
+			address:          "http://test-server.kuma-5.universal.msconnectivity:80",
 			expectedInstance: "uni-test-server",
 		}),
 	)
@@ -171,15 +171,15 @@ spec:
 			}, "30s", "1s").Should(Succeed())
 		},
 		Entry("should access service in another Kubernetes cluster 1", testCase{
-			address:          "http://test-server.msconnectivity.kuma-1.msconnectivity:80",
+			address:          "http://test-server.msconnectivity.kuma-1.k8s.msconnectivity:80",
 			expectedInstance: "kube-test-server-1",
 		}),
 		Entry("should access service in another Kubernetes cluster 2", testCase{
-			address:          "http://test-server.msconnectivity.kuma-2.msconnectivity:80",
+			address:          "http://test-server.msconnectivity.kuma-2.k8s.msconnectivity:80",
 			expectedInstance: "kube-test-server-2",
 		}),
-		Entry("should access service in another Kubernetes cluster", testCase{
-			address:          "http://test-server.kuma-5.msconnectivity:80",
+		Entry("should access service in another Universal cluster", testCase{
+			address:          "http://test-server.kuma-5.universal.msconnectivity:80",
 			expectedInstance: "uni-test-server",
 		}),
 	)

--- a/test/e2e_env/multizone/meshservice/connectivity.go
+++ b/test/e2e_env/multizone/meshservice/connectivity.go
@@ -1,0 +1,186 @@
+package meshservice
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/client"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
+	"github.com/kumahq/kuma/test/framework/deployments/testserver"
+	"github.com/kumahq/kuma/test/framework/envs/multizone"
+)
+
+func Connectivity() {
+	namespace := "msconnectivity"
+	meshName := "msconnectivity"
+
+	BeforeAll(func() {
+		Expect(NewClusterSetup().
+			Install(MTLSMeshUniversal(meshName)).
+			Install(MeshTrafficPermissionAllowAllUniversal(meshName)).
+			Install(YamlUniversal(`
+type: HostnameGenerator
+name: kube-msconnectivity
+spec:
+  template: '{{ .DisplayName }}.{{ .Namespace }}.{{ .Zone }}.msconnectivity'
+  selector:
+    meshService:
+      matchLabels:
+        kuma.io/origin: global
+        kuma.io/env: kubernetes
+`)).
+			Install(YamlUniversal(`
+type: HostnameGenerator
+name: uni-msconnectivity
+spec:
+  template: '{{ .DisplayName }}.{{ .Zone }}.msconnectivity'
+  selector:
+    meshService:
+      matchLabels:
+        kuma.io/origin: global
+        kuma.io/env: universal
+`)).
+			Setup(multizone.Global)).To(Succeed())
+		Expect(WaitForMesh(meshName, multizone.Zones())).To(Succeed())
+
+		kubeServiceYAML := `
+apiVersion: kuma.io/v1alpha1
+kind: MeshService
+metadata:
+  name: test-server
+  namespace: msconnectivity
+  labels:
+    kuma.io/origin: zone
+    kuma.io/mesh: msconnectivity
+    kuma.io/env: kubernetes
+spec:
+  selector:
+    dataplaneTags:
+      app: test-server
+      k8s.kuma.io/namespace: msconnectivity
+  ports:
+  - port: 80
+    targetPort: 80
+    appProtocol: http
+`
+
+		err := NewClusterSetup().
+			Install(NamespaceWithSidecarInjection(namespace)).
+			Install(testserver.Install(
+				testserver.WithNamespace(namespace),
+				testserver.WithMesh(meshName),
+				testserver.WithEchoArgs("echo", "--instance", "kube-test-server-1"),
+			)).
+			Install(YamlK8s(kubeServiceYAML)).
+			Install(democlient.Install(democlient.WithNamespace(namespace), democlient.WithMesh(meshName))).
+			Setup(multizone.KubeZone1)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = NewClusterSetup().
+			Install(NamespaceWithSidecarInjection(namespace)).
+			Install(testserver.Install(
+				testserver.WithNamespace(namespace),
+				testserver.WithMesh(meshName),
+				testserver.WithEchoArgs("echo", "--instance", "kube-test-server-2"),
+			)).
+			Install(YamlK8s(kubeServiceYAML)).
+			Setup(multizone.KubeZone2)
+		Expect(err).ToNot(HaveOccurred())
+
+		uniServiceYAML := `
+type: MeshService
+name: test-server
+mesh: msconnectivity
+labels:
+  kuma.io/origin: zone
+  kuma.io/env: universal
+spec:
+  selector:
+    dataplaneTags:
+      kuma.io/service: test-server
+  ports:
+  - port: 80
+    targetPort: 80
+    appProtocol: http
+`
+
+		err = NewClusterSetup().
+			Install(DemoClientUniversal("uni-demo-client", meshName, WithTransparentProxy(true))).
+			Setup(multizone.UniZone1)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = NewClusterSetup().
+			Install(TestServerUniversal("test-server", meshName, WithArgs([]string{"echo", "--instance", "uni-test-server"}))).
+			Install(YamlUniversal(uniServiceYAML)).
+			Setup(multizone.UniZone2)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEachFailure(func() {
+		DebugUniversal(multizone.Global, meshName)
+		DebugUniversal(multizone.UniZone1, meshName)
+		DebugUniversal(multizone.UniZone2, meshName)
+		DebugKube(multizone.KubeZone1, meshName, namespace)
+		DebugKube(multizone.KubeZone2, meshName, namespace)
+	})
+
+	E2EAfterAll(func() {
+		Expect(multizone.KubeZone1.TriggerDeleteNamespace(namespace)).To(Succeed())
+		Expect(multizone.KubeZone2.TriggerDeleteNamespace(namespace)).To(Succeed())
+		Expect(multizone.UniZone1.DeleteMeshApps(meshName)).To(Succeed())
+		Expect(multizone.UniZone2.DeleteMeshApps(meshName)).To(Succeed())
+		Expect(multizone.Global.DeleteMesh(meshName)).To(Succeed())
+	})
+
+	type testCase struct {
+		address          string
+		expectedInstance string
+	}
+
+	DescribeTable("client from Kubernetes",
+		func(given testCase) {
+			Eventually(func(g Gomega) {
+				response, err := client.CollectEchoResponse(multizone.KubeZone1, "demo-client", given.address,
+					client.FromKubernetesPod(meshName, "demo-client"),
+				)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(response.Instance).To(Equal(given.expectedInstance))
+			}, "30s", "1s").Should(Succeed())
+		},
+		Entry("should access service in another Kubernetes cluster", testCase{
+			address:          "http://test-server.msconnectivity.svc.cluster.local:80",
+			expectedInstance: "kube-test-server-1",
+		}),
+		Entry("should access service in another Kubernetes cluster", testCase{
+			address:          "http://test-server.msconnectivity.kuma-2.msconnectivity:80",
+			expectedInstance: "kube-test-server-2",
+		}),
+		Entry("should access service in another Kubernetes cluster", testCase{
+			address:          "http://test-server.kuma-5.msconnectivity:80",
+			expectedInstance: "uni-test-server",
+		}),
+	)
+
+	DescribeTable("client from Universal",
+		func(given testCase) {
+			Eventually(func(g Gomega) {
+				response, err := client.CollectEchoResponse(multizone.UniZone1, "uni-demo-client", given.address)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(response.Instance).To(Equal(given.expectedInstance))
+			}, "30s", "1s").Should(Succeed())
+		},
+		Entry("should access service in another Kubernetes cluster 1", testCase{
+			address:          "http://test-server.msconnectivity.kuma-1.msconnectivity:80",
+			expectedInstance: "kube-test-server-1",
+		}),
+		Entry("should access service in another Kubernetes cluster 2", testCase{
+			address:          "http://test-server.msconnectivity.kuma-2.msconnectivity:80",
+			expectedInstance: "kube-test-server-2",
+		}),
+		Entry("should access service in another Kubernetes cluster", testCase{
+			address:          "http://test-server.kuma-5.msconnectivity:80",
+			expectedInstance: "uni-test-server",
+		}),
+	)
+}

--- a/test/e2e_env/multizone/meshservice/sync.go
+++ b/test/e2e_env/multizone/meshservice/sync.go
@@ -10,12 +10,11 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/model/rest"
 	"github.com/kumahq/kuma/pkg/kds/hash"
 	. "github.com/kumahq/kuma/test/framework"
-	"github.com/kumahq/kuma/test/framework/client"
 	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	"github.com/kumahq/kuma/test/framework/envs/multizone"
 )
 
-func MeshService() {
+func Sync() {
 	meshName := "meshservice"
 	namespace := "meshservice"
 
@@ -149,58 +148,6 @@ spec:
 					Value: "test-server",
 				},
 			}))
-		}, "30s", "1s").Should(Succeed())
-	})
-
-	It("should connect cross-zone using MeshService from universal cluster", func() {
-		err := multizone.UniZone2.Install(YamlUniversal(`
-type: HostnameGenerator
-mesh: meshservice
-name: basic-uni
-labels:
-  kuma.io/origin: zone
-spec:
-  template: '{{ label "kuma.io/display-name" }}.{{ label "kuma.io/zone" }}.ms.mesh'
-  selector:
-    meshService:
-      matchLabels:
-        kuma.io/display-name: backend
-        kuma.io/origin: global
-`))
-		Expect(err).ToNot(HaveOccurred())
-
-		Eventually(func(g Gomega) {
-			response, err := client.CollectEchoResponse(multizone.UniZone2, "uni-demo-client", "backend.kuma-4.ms.mesh:80")
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(response.Instance).To(Equal("echo-v1"))
-		}, "30s", "1s").Should(Succeed())
-	})
-
-	It("should connect cross-zone using MeshService from kubernetes cluster", func() {
-		err := multizone.KubeZone2.Install(YamlK8s(`
-apiVersion: kuma.io/v1alpha1
-kind: HostnameGenerator
-metadata:
-  name: basic-kube
-  labels:
-    kuma.io/mesh: meshservice
-    kuma.io/origin: zone
-spec:
-  template: '{{ label "kuma.io/display-name" }}.{{ label "kuma.io/zone" }}.ms.mesh'
-  selector:
-    meshService:
-      matchLabels:
-        kuma.io/display-name: backend
-        kuma.io/origin: global
-`))
-		Expect(err).ToNot(HaveOccurred())
-
-		Eventually(func(g Gomega) {
-			response, err := client.CollectEchoResponse(multizone.KubeZone2, "demo-client", "backend.kuma-4.ms.mesh:80",
-				client.FromKubernetesPod(meshName, "demo-client"),
-			)
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(response.Instance).To(Equal("echo-v1"))
 		}, "30s", "1s").Should(Succeed())
 	})
 

--- a/test/e2e_env/multizone/multizone_suite_test.go
+++ b/test/e2e_env/multizone/multizone_suite_test.go
@@ -78,6 +78,7 @@ var (
 	_ = Describe("Advanced LocalityAwareness with MeshLoadBalancingStrategy with Gateway", localityawarelb.LocalityAwareLBGateway, Ordered)
 	_ = Describe("Advanced LocalityAwareness with MeshLoadBalancingStrategy and Enabled Egress", localityawarelb.LocalityAwareLBEgress, Ordered)
 	_ = Describe("Defaults", defaults.Defaults, Ordered)
-	_ = Describe("MeshService", meshservice.MeshService, Ordered)
+	_ = Describe("MeshService Sync", meshservice.Sync, Ordered)
+	_ = Describe("MeshService Connectivity", meshservice.Connectivity, Ordered)
 	_ = Describe("Available services", connectivity.AvailableServices, Ordered)
 )


### PR DESCRIPTION
### Checklist prior to review

E2E tests improvements for MeshService.
I extracted connectivity part from the sync part.
The connectivity part now checks not only uni -> kube, uni -> uni, but all combinations. It's a "mirror" of `e2e/connectivity/connectivity`

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
