### PR TITLE
test(upgrades): skip versions if does not have release date

### DIFF
--- a/test/framework/versions/versions.go
+++ b/test/framework/versions/versions.go
@@ -17,6 +17,7 @@ type Version struct {
 	Version       string `json:"version"`
 	Lts           bool   `json:"lts,omitempty"`
 	EndOfLifeDate string `json:"endOfLifeDate"`
+	ReleaseDate   string `json:"releaseDate"`
 	SemVer        *semver.Version
 }
 
@@ -55,6 +56,9 @@ func UpgradableVersions(versions []Version, currentVersion semver.Version) []str
 	}
 	var res []string
 	for _, version := range versions {
+		if version.ReleaseDate == "" {
+			continue
+		}
 		if version.EndOfLifeDate != "" {
 			eol, err := time.Parse(time.DateOnly, version.EndOfLifeDate)
 			if err != nil {

--- a/test/framework/versions/versions_test.go
+++ b/test/framework/versions/versions_test.go
@@ -12,11 +12,12 @@ var _ = Describe("versions", func() {
 	DescribeTable("should return the list of versions that can be upgraded to the latest", func(currentStr string, expectedVersions []string) {
 		// given
 		vers := []versions.Version{
-			{SemVer: semver.MustParse("1.1.1")},
-			{SemVer: semver.MustParse("1.2.3"), Lts: true, EndOfLifeDate: "2100-01-01"},
-			{SemVer: semver.MustParse("1.3.1")},
-			{SemVer: semver.MustParse("1.4.2")},
-			{SemVer: semver.MustParse("1.5.8")},
+			{SemVer: semver.MustParse("1.1.1"), ReleaseDate: "2024-02-01"},
+			{SemVer: semver.MustParse("1.2.3"), Lts: true, EndOfLifeDate: "2100-01-01", ReleaseDate: "2024-03-01"},
+			{SemVer: semver.MustParse("1.3.1"), ReleaseDate: "2024-04-01"},
+			{SemVer: semver.MustParse("1.4.2"), ReleaseDate: "2024-05-01"},
+			{SemVer: semver.MustParse("1.5.8"), ReleaseDate: "2024-06-01"},
+			{SemVer: semver.MustParse("1.5.9")},
 		}
 		// when
 		current := semver.MustParse(currentStr)


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
