### PR TITLE
fix(k8s): take mesh from label of the namespace

### DIFF
--- a/pkg/plugins/runtime/k8s/util/util.go
+++ b/pkg/plugins/runtime/k8s/util/util.go
@@ -158,12 +158,17 @@ func MeshOfByLabelOrAnnotation(log logr.Logger, obj kube_client.Object, namespac
 		return mesh
 	}
 	if mesh, exists := metadata.Annotations(obj.GetAnnotations()).GetString(metadata.KumaMeshAnnotation); exists && mesh != "" {
-		log.Info("WARNING: The kuma.io/mesh annotation is deprecated for this object kind", "name", obj.GetName(), "namespace", obj.GetNamespace(), "kind", obj.GetObjectKind().GroupVersionKind().Kind)
+		log.Info("WARNING: The kuma.io/mesh annotation is deprecated for this object kind. Use label instead", "name", obj.GetName(), "namespace", obj.GetNamespace(), "kind", obj.GetObjectKind().GroupVersionKind().Kind)
 		return mesh
 	}
 
 	// Label wasn't found on the object, let's look on the namespace instead
+	if mesh, exists := metadata.Annotations(namespace.GetLabels()).GetString(metadata.KumaMeshAnnotation); exists && mesh != "" {
+		return mesh
+	}
+
 	if mesh, exists := metadata.Annotations(namespace.GetAnnotations()).GetString(metadata.KumaMeshAnnotation); exists && mesh != "" {
+		log.Info("WARNING: The kuma.io/mesh annotation is deprecated for this object kind. Use label instead", "name", obj.GetName(), "namespace", obj.GetNamespace(), "kind", obj.GetObjectKind().GroupVersionKind().Kind)
 		return mesh
 	}
 

--- a/pkg/plugins/runtime/k8s/util/util_test.go
+++ b/pkg/plugins/runtime/k8s/util/util_test.go
@@ -265,6 +265,7 @@ var _ = Describe("Util", func() {
 		type testCase struct {
 			podLabels      map[string]string
 			podAnnotations map[string]string
+			nsLabels       map[string]string
 			nsAnnotations  map[string]string
 			expected       string
 		}
@@ -281,6 +282,7 @@ var _ = Describe("Util", func() {
 				ns := &kube_core.Namespace{
 					ObjectMeta: kube_meta.ObjectMeta{
 						Annotations: given.nsAnnotations,
+						Labels:      given.nsLabels,
 					},
 				}
 
@@ -305,6 +307,15 @@ var _ = Describe("Util", func() {
 			}),
 			Entry("Pod with non-empty `kuma.io/mesh` annotation", testCase{
 				podAnnotations: map[string]string{
+					"kuma.io/mesh": "demo",
+				},
+				expected: "demo",
+			}),
+			Entry("Pod with empty `kuma.io/mesh` annotation, Namespace with label", testCase{
+				podAnnotations: map[string]string{
+					"kuma.io/mesh": "",
+				},
+				nsLabels: map[string]string{
 					"kuma.io/mesh": "demo",
 				},
 				expected: "demo",


### PR DESCRIPTION
### Checklist prior to review

`kuma.io/mesh` annotation was deprecated. It is but not for namespace for some reason. It should be consistent for all objects.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
