### PR TITLE
Fix(kuma-cp): don't add zone on global originated

### DIFF
--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -533,9 +533,11 @@ func (r *resourceEndpoints) validateLabels(resource rest.Resource) validators.Va
 	}
 
 	if r.mode != config_core.Global {
-		zoneTag, ok := resource.GetMeta().GetLabels()[mesh_proto.ZoneTag]
-		if ok && zoneTag != r.zoneName {
-			err.AddViolationAt(validators.Root().Key(mesh_proto.ZoneTag), fmt.Sprintf("%s label should have %s value", mesh_proto.ZoneTag, r.zoneName))
+		if origin != mesh_proto.GlobalResourceOrigin {
+			zoneTag, ok := resource.GetMeta().GetLabels()[mesh_proto.ZoneTag]
+			if ok && zoneTag != r.zoneName {
+				err.AddViolationAt(validators.Root().Key(mesh_proto.ZoneTag), fmt.Sprintf("%s label should have %s value", mesh_proto.ZoneTag, r.zoneName))
+			}
 		}
 	}
 

--- a/pkg/core/resources/model/resource.go
+++ b/pkg/core/resources/model/resource.go
@@ -456,7 +456,9 @@ func ComputeLabels(r Resource, mode config_core.CpMode, isK8s bool, systemNamesp
 
 	if mode == config_core.Zone {
 		setIfNotExist(mesh_proto.ResourceOriginLabel, string(mesh_proto.ZoneResourceOrigin))
-		setIfNotExist(mesh_proto.ZoneTag, localZone)
+		if labels[mesh_proto.ResourceOriginLabel] != string(mesh_proto.GlobalResourceOrigin) {
+			setIfNotExist(mesh_proto.ZoneTag, localZone)
+		}
 	}
 
 	if ns, ok := labels[mesh_proto.KubeNamespaceTag]; ok && r.Descriptor().IsPolicy && r.Descriptor().IsPluginOriginated {

--- a/pkg/plugins/runtime/k8s/webhooks/defaulter_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/defaulter_test.go
@@ -328,6 +328,50 @@ var _ = Describe("Defaulter", func() {
             }
 `,
 		}),
+		Entry("should not set zone label when origin is set to global, federated zone", testCase{
+			checker: zoneChecker(true, false),
+			kind:    string(v1alpha1.MeshTrafficPermissionType),
+			inputObject: `
+            {
+              "apiVersion": "kuma.io/v1alpha1",
+              "kind": "MeshTrafficPermission",
+              "metadata": {
+                "namespace": "example",
+                "name": "empty",
+                "creationTimestamp": null,
+                "labels": {
+                  "kuma.io/origin": "global"
+                }
+              },
+              "spec": {
+                "targetRef": {}
+              }
+            }
+`,
+			expected: `
+            {
+              "apiVersion": "kuma.io/v1alpha1",
+              "kind": "MeshTrafficPermission",
+              "metadata": {
+                "namespace": "example",
+                "name": "empty",
+                "creationTimestamp": null,
+                "labels": {
+                  "k8s.kuma.io/namespace": "example",
+                  "kuma.io/mesh": "default",
+                  "kuma.io/origin": "global",
+                  "kuma.io/policy-role": "workload-owner"
+                },
+                "annotations": {
+                  "kuma.io/display-name": "empty"
+                }
+              },
+              "spec": {
+                "targetRef": {}
+              }
+            }
+`,
+		}),
 		Entry("should set mesh and origin label when origin validation is disabled, non-federated zone", testCase{
 			checker: zoneChecker(false, false),
 			kind:    string(v1alpha1.MeshTrafficPermissionType),

--- a/pkg/plugins/runtime/k8s/webhooks/resourceadmissionchecker.go
+++ b/pkg/plugins/runtime/k8s/webhooks/resourceadmissionchecker.go
@@ -99,9 +99,12 @@ func (c *ResourceAdmissionChecker) isPrivilegedUser(allowedUsers []string, userI
 
 func (c *ResourceAdmissionChecker) validateLabels(r core_model.Resource, ns string) *admission.Response {
 	if c.Mode != core.Global {
-		zoneTag, ok := r.GetMeta().GetLabels()[mesh_proto.ZoneTag]
-		if ok && zoneTag != c.ZoneName {
-			return resourceLabelsNotAllowedResponse(mesh_proto.ZoneTag, c.ZoneName, zoneTag)
+		resourceOrigin, originPresent := core_model.ResourceOrigin(r.GetMeta())
+		if originPresent && resourceOrigin != mesh_proto.GlobalResourceOrigin {
+			zoneTag, ok := r.GetMeta().GetLabels()[mesh_proto.ZoneTag]
+			if ok && zoneTag != c.ZoneName {
+				return resourceLabelsNotAllowedResponse(mesh_proto.ZoneTag, c.ZoneName, zoneTag)
+			}
 		}
 	}
 

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-origin-global.federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-origin-global.federated.golden.yaml
@@ -1,0 +1,15 @@
+Patches: null
+allowed: false
+status:
+  code: 403
+  details:
+    causes:
+    - field: metadata.labels[kuma.io/origin]
+      message: cannot be empty
+      reason: FieldValueInvalid
+  message: Operation not allowed. Applying policies on Zone CP requires 'kuma.io/origin'
+    label to be set to 'zone'.
+  metadata: {}
+  reason: Forbidden
+  status: Failure
+uid: "12345"

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-origin-global.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-origin-global.global.golden.yaml
@@ -1,0 +1,6 @@
+Patches: null
+allowed: true
+status:
+  code: 200
+  metadata: {}
+uid: "12345"

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-origin-global.input.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-origin-global.input.yaml
@@ -1,0 +1,18 @@
+# user=cli-user,operation=CREATE,namespace=kuma-system
+apiVersion: kuma.io/v1alpha1
+kind: MeshTimeout
+metadata:
+  name: backend-v3
+  labels:
+    kuma.io/origin: global
+    kuma.io/mesh: default
+spec:
+  targetRef:
+    kind: Mesh
+  to:
+    - targetRef:
+        kind: Mesh
+      default:
+        http:
+          requestTimeout: 19s
+          streamIdleTimeout: 1h

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-origin-global.non-federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-origin-global.non-federated.golden.yaml
@@ -1,0 +1,6 @@
+Patches: null
+allowed: true
+status:
+  code: 200
+  metadata: {}
+uid: "12345"


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --


> Changelog: skip
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
