### PR TITLE
feat(meshexternalservice): relax validation of port on universal

### DIFF
--- a/pkg/core/resources/apis/mesh/dataplane_validator.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator.go
@@ -16,7 +16,7 @@ import (
 const meshExternalServiceKind = "MeshExternalService"
 
 var allowedKinds = map[string]struct{}{
-	"MeshService":         {},
+	"MeshService":           {},
 	meshExternalServiceKind: {},
 }
 

--- a/pkg/core/resources/apis/mesh/dataplane_validator.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator.go
@@ -13,9 +13,11 @@ import (
 	"github.com/kumahq/kuma/pkg/util/maps"
 )
 
+const meshExternalServiceKind = "MeshExternalService"
+
 var allowedKinds = map[string]struct{}{
 	"MeshService":         {},
-	"MeshExternalService": {},
+	meshExternalServiceKind: {},
 }
 
 func (d *DataplaneResource) Validate() error {
@@ -233,7 +235,10 @@ func validateOutbound(outbound *mesh_proto.Dataplane_Networking_Outbound) valida
 		if outbound.BackendRef.Name == "" {
 			result.AddViolation("backendRef.name", "cannot be empty")
 		}
-		result.Add(ValidatePort(validators.RootedAt("backendRef").Field("port"), outbound.BackendRef.Port))
+		// for MeshExternalService the port does not matter because it's taken from endpoints
+		if outbound.BackendRef.Kind != meshExternalServiceKind {
+			result.Add(ValidatePort(validators.RootedAt("backendRef").Field("port"), outbound.BackendRef.Port))
+		}
 	case len(outbound.Tags) == 0:
 		// nolint:staticcheck
 		if outbound.GetService() == "" {

--- a/pkg/core/resources/apis/mesh/dataplane_validator_test.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator_test.go
@@ -279,7 +279,7 @@ var _ = Describe("Dataplane", func() {
                         kuma.io/service: redis
                 metrics:
                   type: prometheus`),
-		Entry("dataplane with backend ref", `
+		Entry("dataplane with backend ref for MeshService", `
             type: Dataplane
             name: dp-1
             mesh: default
@@ -296,6 +296,23 @@ var _ = Describe("Dataplane", func() {
                     kind: MeshService
                     name: xyz
                     port: 80`,
+		),
+		Entry("dataplane with backend ref for MeshExternalService", `
+            type: Dataplane
+            name: dp-1
+            mesh: default
+            networking:
+              address: 192.168.0.1
+              inbound:
+                - port: 8080
+                  tags:
+                    kuma.io/service: backend
+                    version: "1"
+              outbound:
+                - port: 3333
+                  backendRef:
+                    kind: MeshExternalService
+                    name: xyz`,
 		),
 	)
 
@@ -1202,7 +1219,7 @@ var _ = Describe("Dataplane", func() {
                 - field: networking.outbound[0].backendRef.port
                   message: port must be in the range [1, 65535]`,
 		}),
-		Entry("backend ref clashes with tags or service", testCase{
+		Entry("backend ref clashes with tags or service and missing port", testCase{
 			dataplane: `
             type: Dataplane
             name: dp-1
@@ -1229,12 +1246,13 @@ var _ = Describe("Dataplane", func() {
                     service: xyz
                   backendRef:
                     kind: MeshService
-                    name: xyz
-                    port: 8080`,
+                    name: xyz`,
 			expected: `
                 violations:
                 - field: networking.outbound[0].backendRef
                   message: both backendRef and tags/service cannot be defined
+                - field: networking.outbound[1].backendRef.port
+                  message: port must be in the range [1, 65535]
                 - field: networking.outbound[1].backendRef
                   message: both backendRef and tags/service cannot be defined`,
 		}),


### PR DESCRIPTION
relax validation of port on universal for mesh external service

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
