### PR TITLE
fix(meshpassthrough): return 503 when no route found

### DIFF
--- a/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/testdata/basic.listener.golden.yaml
+++ b/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/testdata/basic.listener.golden.yaml
@@ -153,7 +153,7 @@ resources:
                       This is a Kuma Sidecar. No routes match this Domain!
                   status: 503
                 match:
-                  path: /
+                  prefix: /
           statPrefix: meshpassthrough_http_8080
       name: meshpassthrough_http_8080
     - filterChainMatch:
@@ -194,7 +194,7 @@ resources:
                       This is a Kuma Sidecar. No routes match this Domain!
                   status: 503
                 match:
-                  path: /
+                  prefix: /
           statPrefix: meshpassthrough_http_19000
       name: meshpassthrough_http_19000
     listenerFilters:
@@ -360,7 +360,7 @@ resources:
                       This is a Kuma Sidecar. No routes match this Domain!
                   status: 503
                 match:
-                  path: /
+                  prefix: /
           statPrefix: meshpassthrough_http_8080
       name: meshpassthrough_http_8080
     - filterChainMatch:
@@ -401,7 +401,7 @@ resources:
                       This is a Kuma Sidecar. No routes match this Domain!
                   status: 503
                 match:
-                  path: /
+                  prefix: /
           statPrefix: meshpassthrough_http_19000
       name: meshpassthrough_http_19000
     listenerFilters:

--- a/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/testdata/basic.listener.golden.yaml
+++ b/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/testdata/basic.listener.golden.yaml
@@ -143,6 +143,17 @@ resources:
                   path: /
                 route:
                   cluster: meshpassthrough_other.com_8080
+            - domains:
+              - '*'
+              name: no_match
+              routes:
+              - directResponse:
+                  body:
+                    inlineString: |
+                      This is a Kuma Sidecar. No routes match this Domain!
+                  status: 503
+                match:
+                  path: /
           statPrefix: meshpassthrough_http_8080
       name: meshpassthrough_http_8080
     - filterChainMatch:
@@ -173,6 +184,17 @@ resources:
                   path: /
                 route:
                   cluster: meshpassthrough_grpcdomain.com_19000
+            - domains:
+              - '*'
+              name: no_match
+              routes:
+              - directResponse:
+                  body:
+                    inlineString: |
+                      This is a Kuma Sidecar. No routes match this Domain!
+                  status: 503
+                match:
+                  path: /
           statPrefix: meshpassthrough_http_19000
       name: meshpassthrough_http_19000
     listenerFilters:
@@ -328,6 +350,17 @@ resources:
                   path: /
                 route:
                   cluster: meshpassthrough_other.com_8080
+            - domains:
+              - '*'
+              name: no_match
+              routes:
+              - directResponse:
+                  body:
+                    inlineString: |
+                      This is a Kuma Sidecar. No routes match this Domain!
+                  status: 503
+                match:
+                  path: /
           statPrefix: meshpassthrough_http_8080
       name: meshpassthrough_http_8080
     - filterChainMatch:
@@ -358,6 +391,17 @@ resources:
                   path: /
                 route:
                   cluster: meshpassthrough_grpcdomain.com_19000
+            - domains:
+              - '*'
+              name: no_match
+              routes:
+              - directResponse:
+                  body:
+                    inlineString: |
+                      This is a Kuma Sidecar. No routes match this Domain!
+                  status: 503
+                match:
+                  path: /
           statPrefix: meshpassthrough_http_19000
       name: meshpassthrough_http_19000
     listenerFilters:

--- a/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/testdata/basic.listener.golden.yaml
+++ b/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/testdata/basic.listener.golden.yaml
@@ -150,7 +150,7 @@ resources:
               - directResponse:
                   body:
                     inlineString: |
-                      This is a Kuma Sidecar. No routes match this Domain!
+                      This response comes from Kuma Sidecar. No routes matched this domain - check configuration of your MeshPassthrough policy.
                   status: 503
                 match:
                   prefix: /
@@ -191,7 +191,7 @@ resources:
               - directResponse:
                   body:
                     inlineString: |
-                      This is a Kuma Sidecar. No routes match this Domain!
+                      This response comes from Kuma Sidecar. No routes matched this domain - check configuration of your MeshPassthrough policy.
                   status: 503
                 match:
                   prefix: /
@@ -357,7 +357,7 @@ resources:
               - directResponse:
                   body:
                     inlineString: |
-                      This is a Kuma Sidecar. No routes match this Domain!
+                      This response comes from Kuma Sidecar. No routes matched this domain - check configuration of your MeshPassthrough policy.
                   status: 503
                 match:
                   prefix: /
@@ -398,7 +398,7 @@ resources:
               - directResponse:
                   body:
                     inlineString: |
-                      This is a Kuma Sidecar. No routes match this Domain!
+                      This response comes from Kuma Sidecar. No routes matched this domain - check configuration of your MeshPassthrough policy.
                   status: 503
                 match:
                   prefix: /

--- a/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/testdata/simple.listener.golden.yaml
+++ b/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/testdata/simple.listener.golden.yaml
@@ -51,7 +51,7 @@ resources:
               - directResponse:
                   body:
                     inlineString: |
-                      This is a Kuma Sidecar. No routes match this Domain!
+                      This response comes from Kuma Sidecar. No routes matched this domain - check configuration of your MeshPassthrough policy.
                   status: 503
                 match:
                   prefix: /
@@ -105,7 +105,7 @@ resources:
               - directResponse:
                   body:
                     inlineString: |
-                      This is a Kuma Sidecar. No routes match this Domain!
+                      This response comes from Kuma Sidecar. No routes matched this domain - check configuration of your MeshPassthrough policy.
                   status: 503
                 match:
                   prefix: /

--- a/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/testdata/simple.listener.golden.yaml
+++ b/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/testdata/simple.listener.golden.yaml
@@ -44,6 +44,17 @@ resources:
                   path: /
                 route:
                   cluster: meshpassthrough_api.example.com_80
+            - domains:
+              - '*'
+              name: no_match
+              routes:
+              - directResponse:
+                  body:
+                    inlineString: |
+                      This is a Kuma Sidecar. No routes match this Domain!
+                  status: 503
+                match:
+                  path: /
           statPrefix: meshpassthrough_http_80
       name: meshpassthrough_http_80
     listenerFilters:
@@ -87,6 +98,17 @@ resources:
                   path: /
                 route:
                   cluster: meshpassthrough_api.example.com_80
+            - domains:
+              - '*'
+              name: no_match
+              routes:
+              - directResponse:
+                  body:
+                    inlineString: |
+                      This is a Kuma Sidecar. No routes match this Domain!
+                  status: 503
+                match:
+                  path: /
           statPrefix: meshpassthrough_http_80
       name: meshpassthrough_http_80
     listenerFilters:

--- a/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/testdata/simple.listener.golden.yaml
+++ b/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/testdata/simple.listener.golden.yaml
@@ -54,7 +54,7 @@ resources:
                       This is a Kuma Sidecar. No routes match this Domain!
                   status: 503
                 match:
-                  path: /
+                  prefix: /
           statPrefix: meshpassthrough_http_80
       name: meshpassthrough_http_80
     listenerFilters:
@@ -108,7 +108,7 @@ resources:
                       This is a Kuma Sidecar. No routes match this Domain!
                   status: 503
                 match:
-                  path: /
+                  prefix: /
           statPrefix: meshpassthrough_http_80
       name: meshpassthrough_http_80
     listenerFilters:

--- a/pkg/plugins/policies/meshpassthrough/plugin/xds/configurer.go
+++ b/pkg/plugins/policies/meshpassthrough/plugin/xds/configurer.go
@@ -6,7 +6,7 @@ import (
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	api "github.com/kumahq/kuma/pkg/plugins/policies/meshpassthrough/api/v1alpha1"
-	xds_listeners "github.com/kumahq/kuma/pkg/xds/envoy/listeners/v3"
+	xds_listeners_v3 "github.com/kumahq/kuma/pkg/xds/envoy/listeners/v3"
 )
 
 const (
@@ -68,30 +68,33 @@ func (c Configurer) configureListener(
 			return err
 		}
 	}
-	return c.configureListenerFilter(listener)
+	if err := c.configureListenerFilter(listener); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (c Configurer) configureListenerFilter(listener *envoy_listener.Listener) error {
 	hasTlsInspector := false
 	hasHttpInspector := false
 	for _, filter := range listener.ListenerFilters {
-		if filter.Name == xds_listeners.TlsInspectorName {
+		if filter.Name == xds_listeners_v3.TlsInspectorName {
 			hasTlsInspector = true
 		}
-		if filter.Name == xds_listeners.HttpInspectorName {
+		if filter.Name == xds_listeners_v3.HttpInspectorName {
 			hasHttpInspector = true
 		}
 	}
 	var err error
 	if !hasTlsInspector {
-		configurer := xds_listeners.TLSInspectorConfigurer{}
+		configurer := xds_listeners_v3.TLSInspectorConfigurer{}
 		err = configurer.Configure(listener)
 	}
 	if err != nil {
 		return err
 	}
 	if !hasHttpInspector {
-		configurer := xds_listeners.HTTPInspectorConfigurer{}
+		configurer := xds_listeners_v3.HTTPInspectorConfigurer{}
 		err = configurer.Configure(listener)
 	}
 	return err

--- a/pkg/plugins/policies/meshpassthrough/plugin/xds/listeners_filter_chain.go
+++ b/pkg/plugins/policies/meshpassthrough/plugin/xds/listeners_filter_chain.go
@@ -14,7 +14,7 @@ import (
 	xds_virtual_hosts "github.com/kumahq/kuma/pkg/xds/envoy/virtualhosts"
 )
 
-const NoMatchMsg = "This is a Kuma Sidecar. No routes match this Domain!\n"
+const NoMatchMsg = "This response comes from Kuma Sidecar. No routes matched this domain - check configuration of your MeshPassthrough policy.\n"
 
 type FilterChainConfigurer struct {
 	APIVersion core_xds.APIVersion

--- a/pkg/xds/envoy/virtualhosts/configurer.go
+++ b/pkg/xds/envoy/virtualhosts/configurer.go
@@ -79,6 +79,14 @@ func BasicRoute(cluster string) VirtualHostBuilderOpt {
 		})
 }
 
+func DirectResponseRoute(status uint32, responseMsg string) VirtualHostBuilderOpt {
+	return AddVirtualHostConfigurer(
+		&VirtualHostDirectResponseRouteConfigurer{
+			status:      status,
+			responseMsg: responseMsg,
+		})
+}
+
 func Route(matchPath string, newPath string, cluster string, allowGetOnly bool) VirtualHostBuilderOpt {
 	return AddVirtualHostConfigurer(
 		&VirtualHostRouteConfigurer{

--- a/pkg/xds/envoy/virtualhosts/route_configurer.go
+++ b/pkg/xds/envoy/virtualhosts/route_configurer.go
@@ -1,6 +1,7 @@
 package virtualhosts
 
 import (
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_type_matcher_v3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 
@@ -71,6 +72,32 @@ func (c VirtualHostBasicRouteConfigurer) Configure(virtualHost *envoy_config_rou
 			Route: &envoy_config_route_v3.RouteAction{
 				ClusterSpecifier: &envoy_config_route_v3.RouteAction_Cluster{
 					Cluster: c.Cluster,
+				},
+			},
+		},
+	})
+	return nil
+}
+
+type VirtualHostDirectResponseRouteConfigurer struct {
+	status      uint32
+	responseMsg string
+}
+
+func (c VirtualHostDirectResponseRouteConfigurer) Configure(virtualHost *envoy_config_route_v3.VirtualHost) error {
+	virtualHost.Routes = append(virtualHost.Routes, &envoy_config_route_v3.Route{
+		Match: &envoy_config_route_v3.RouteMatch{
+			PathSpecifier: &envoy_config_route_v3.RouteMatch_Path{
+				Path: "/",
+			},
+		},
+		Action: &envoy_config_route_v3.Route_DirectResponse{
+			DirectResponse: &envoy_config_route_v3.DirectResponseAction{
+				Status: c.status,
+				Body: &corev3.DataSource{
+					Specifier: &corev3.DataSource_InlineString{
+						InlineString: c.responseMsg,
+					},
 				},
 			},
 		},

--- a/pkg/xds/envoy/virtualhosts/route_configurer.go
+++ b/pkg/xds/envoy/virtualhosts/route_configurer.go
@@ -87,8 +87,8 @@ type VirtualHostDirectResponseRouteConfigurer struct {
 func (c VirtualHostDirectResponseRouteConfigurer) Configure(virtualHost *envoy_config_route_v3.VirtualHost) error {
 	virtualHost.Routes = append(virtualHost.Routes, &envoy_config_route_v3.Route{
 		Match: &envoy_config_route_v3.RouteMatch{
-			PathSpecifier: &envoy_config_route_v3.RouteMatch_Path{
-				Path: "/",
+			PathSpecifier: &envoy_config_route_v3.RouteMatch_Prefix{
+				Prefix: "/",
 			},
 		},
 		Action: &envoy_config_route_v3.Route_DirectResponse{

--- a/test/e2e_env/kubernetes/meshpassthrough/meshpassthrough.go
+++ b/test/e2e_env/kubernetes/meshpassthrough/meshpassthrough.go
@@ -205,7 +205,7 @@ spec:
 				client.FromKubernetesPod(namespace, "demo-client"),
 			)
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(resp.ResponseCode).To(Equal(404))
+			g.Expect(resp.ResponseCode).To(Equal(503))
 		}, "30s", "1s").Should(Succeed())
 
 		Eventually(func(g Gomega) {
@@ -214,7 +214,7 @@ spec:
 				client.FromKubernetesPod(namespace, "demo-client"),
 			)
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(resp.ResponseCode).To(Equal(404))
+			g.Expect(resp.ResponseCode).To(Equal(503))
 		}, "30s", "1s").Should(Succeed())
 	})
 }


### PR DESCRIPTION
### Checklist prior to review

When MeshPassthrough doesn't expose traffic, but the traffic is HTTP and there is other HTTP traffic exposed, we used to return a 404 error indicating that there is no route. I have changed this to return a 503 error when there is no route because the traffic is forbidden.

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

> Changelog: feat(meshpassthrough): implement new policy

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
