### PR TITLE
fix(Mesh*Service): rename HostnameGenerator ref `name` to `coreName`

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -494,10 +494,10 @@ spec:
                       type: string
                     hostnameGeneratorRef:
                       properties:
-                        name:
+                        coreName:
                           type: string
                       required:
-                      - name
+                      - coreName
                       type: object
                     origin:
                       type: string
@@ -557,10 +557,10 @@ spec:
                       x-kubernetes-list-type: map
                     hostnameGeneratorRef:
                       properties:
-                        name:
+                        coreName:
                           type: string
                       required:
-                      - name
+                      - coreName
                       type: object
                   required:
                   - hostnameGeneratorRef
@@ -5531,10 +5531,10 @@ spec:
                       type: string
                     hostnameGeneratorRef:
                       properties:
-                        name:
+                        coreName:
                           type: string
                       required:
-                      - name
+                      - coreName
                       type: object
                     origin:
                       type: string
@@ -5594,10 +5594,10 @@ spec:
                       x-kubernetes-list-type: map
                     hostnameGeneratorRef:
                       properties:
-                        name:
+                        coreName:
                           type: string
                       required:
-                      - name
+                      - coreName
                       type: object
                   required:
                   - hostnameGeneratorRef

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -494,10 +494,10 @@ spec:
                       type: string
                     hostnameGeneratorRef:
                       properties:
-                        name:
+                        coreName:
                           type: string
                       required:
-                      - name
+                      - coreName
                       type: object
                     origin:
                       type: string
@@ -557,10 +557,10 @@ spec:
                       x-kubernetes-list-type: map
                     hostnameGeneratorRef:
                       properties:
-                        name:
+                        coreName:
                           type: string
                       required:
-                      - name
+                      - coreName
                       type: object
                   required:
                   - hostnameGeneratorRef
@@ -5531,10 +5531,10 @@ spec:
                       type: string
                     hostnameGeneratorRef:
                       properties:
-                        name:
+                        coreName:
                           type: string
                       required:
-                      - name
+                      - coreName
                       type: object
                     origin:
                       type: string
@@ -5594,10 +5594,10 @@ spec:
                       x-kubernetes-list-type: map
                     hostnameGeneratorRef:
                       properties:
-                        name:
+                        coreName:
                           type: string
                       required:
-                      - name
+                      - coreName
                       type: object
                   required:
                   - hostnameGeneratorRef

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -514,10 +514,10 @@ spec:
                       type: string
                     hostnameGeneratorRef:
                       properties:
-                        name:
+                        coreName:
                           type: string
                       required:
-                      - name
+                      - coreName
                       type: object
                     origin:
                       type: string
@@ -577,10 +577,10 @@ spec:
                       x-kubernetes-list-type: map
                     hostnameGeneratorRef:
                       properties:
-                        name:
+                        coreName:
                           type: string
                       required:
-                      - name
+                      - coreName
                       type: object
                   required:
                   - hostnameGeneratorRef
@@ -5551,10 +5551,10 @@ spec:
                       type: string
                     hostnameGeneratorRef:
                       properties:
-                        name:
+                        coreName:
                           type: string
                       required:
-                      - name
+                      - coreName
                       type: object
                     origin:
                       type: string
@@ -5614,10 +5614,10 @@ spec:
                       x-kubernetes-list-type: map
                     hostnameGeneratorRef:
                       properties:
-                        name:
+                        coreName:
                           type: string
                       required:
-                      - name
+                      - coreName
                       type: object
                   required:
                   - hostnameGeneratorRef

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -2091,10 +2091,10 @@ spec:
                       type: string
                     hostnameGeneratorRef:
                       properties:
-                        name:
+                        coreName:
                           type: string
                       required:
-                      - name
+                      - coreName
                       type: object
                     origin:
                       type: string
@@ -2154,10 +2154,10 @@ spec:
                       x-kubernetes-list-type: map
                     hostnameGeneratorRef:
                       properties:
-                        name:
+                        coreName:
                           type: string
                       required:
-                      - name
+                      - coreName
                       type: object
                   required:
                   - hostnameGeneratorRef
@@ -7078,10 +7078,10 @@ spec:
                       type: string
                     hostnameGeneratorRef:
                       properties:
-                        name:
+                        coreName:
                           type: string
                       required:
-                      - name
+                      - coreName
                       type: object
                     origin:
                       type: string
@@ -7141,10 +7141,10 @@ spec:
                       x-kubernetes-list-type: map
                     hostnameGeneratorRef:
                       properties:
-                        name:
+                        coreName:
                           type: string
                       required:
-                      - name
+                      - coreName
                       type: object
                   required:
                   - hostnameGeneratorRef

--- a/deployments/charts/kuma/crds/kuma.io_meshexternalservices.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshexternalservices.yaml
@@ -247,10 +247,10 @@ spec:
                       type: string
                     hostnameGeneratorRef:
                       properties:
-                        name:
+                        coreName:
                           type: string
                       required:
-                      - name
+                      - coreName
                       type: object
                     origin:
                       type: string
@@ -310,10 +310,10 @@ spec:
                       x-kubernetes-list-type: map
                     hostnameGeneratorRef:
                       properties:
-                        name:
+                        coreName:
                           type: string
                       required:
-                      - name
+                      - coreName
                       type: object
                   required:
                   - hostnameGeneratorRef

--- a/deployments/charts/kuma/crds/kuma.io_meshservices.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshservices.yaml
@@ -102,10 +102,10 @@ spec:
                       type: string
                     hostnameGeneratorRef:
                       properties:
-                        name:
+                        coreName:
                           type: string
                       required:
-                      - name
+                      - coreName
                       type: object
                     origin:
                       type: string
@@ -165,10 +165,10 @@ spec:
                       x-kubernetes-list-type: map
                     hostnameGeneratorRef:
                       properties:
-                        name:
+                        coreName:
                           type: string
                       required:
-                      - name
+                      - coreName
                       type: object
                   required:
                   - hostnameGeneratorRef

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -10815,10 +10815,10 @@ components:
                     type: string
                   hostnameGeneratorRef:
                     properties:
-                      name:
+                      coreName:
                         type: string
                     required:
-                      - name
+                      - coreName
                     type: object
                   origin:
                     type: string
@@ -10898,10 +10898,10 @@ components:
                     x-kubernetes-list-type: map
                   hostnameGeneratorRef:
                     properties:
-                      name:
+                      coreName:
                         type: string
                     required:
-                      - name
+                      - coreName
                     type: object
                 required:
                   - hostnameGeneratorRef
@@ -11021,10 +11021,10 @@ components:
                     type: string
                   hostnameGeneratorRef:
                     properties:
-                      name:
+                      coreName:
                         type: string
                     required:
-                      - name
+                      - coreName
                     type: object
                   origin:
                     type: string
@@ -11104,10 +11104,10 @@ components:
                     x-kubernetes-list-type: map
                   hostnameGeneratorRef:
                     properties:
-                      name:
+                      coreName:
                         type: string
                     required:
-                      - name
+                      - coreName
                     type: object
                 required:
                   - hostnameGeneratorRef

--- a/docs/generated/raw/crds/kuma.io_meshexternalservices.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshexternalservices.yaml
@@ -247,10 +247,10 @@ spec:
                       type: string
                     hostnameGeneratorRef:
                       properties:
-                        name:
+                        coreName:
                           type: string
                       required:
-                      - name
+                      - coreName
                       type: object
                     origin:
                       type: string
@@ -310,10 +310,10 @@ spec:
                       x-kubernetes-list-type: map
                     hostnameGeneratorRef:
                       properties:
-                        name:
+                        coreName:
                           type: string
                       required:
-                      - name
+                      - coreName
                       type: object
                   required:
                   - hostnameGeneratorRef

--- a/docs/generated/raw/crds/kuma.io_meshservices.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshservices.yaml
@@ -102,10 +102,10 @@ spec:
                       type: string
                     hostnameGeneratorRef:
                       properties:
-                        name:
+                        coreName:
                           type: string
                       required:
-                      - name
+                      - coreName
                       type: object
                     origin:
                       type: string
@@ -165,10 +165,10 @@ spec:
                       x-kubernetes-list-type: map
                     hostnameGeneratorRef:
                       properties:
-                        name:
+                        coreName:
                           type: string
                       required:
-                      - name
+                      - coreName
                       type: object
                   required:
                   - hostnameGeneratorRef

--- a/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/hostnamegenerator.go
+++ b/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/hostnamegenerator.go
@@ -77,7 +77,7 @@ const (
 )
 
 type HostnameGeneratorRef struct {
-	CoreName string `json:"name"`
+	CoreName string `json:"coreName"`
 }
 
 type HostnameGeneratorStatus struct {

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/schema.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/schema.yaml
@@ -206,10 +206,10 @@ properties:
               type: string
             hostnameGeneratorRef:
               properties:
-                name:
+                coreName:
                   type: string
               required:
-                - name
+                - coreName
               type: object
             origin:
               type: string
@@ -268,10 +268,10 @@ properties:
               x-kubernetes-list-type: map
             hostnameGeneratorRef:
               properties:
-                name:
+                coreName:
                   type: string
               required:
-                - name
+                - coreName
               type: object
           required:
             - hostnameGeneratorRef

--- a/pkg/core/resources/apis/meshexternalservice/k8s/crd/kuma.io_meshexternalservices.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/k8s/crd/kuma.io_meshexternalservices.yaml
@@ -247,10 +247,10 @@ spec:
                       type: string
                     hostnameGeneratorRef:
                       properties:
-                        name:
+                        coreName:
                           type: string
                       required:
-                      - name
+                      - coreName
                       type: object
                     origin:
                       type: string
@@ -310,10 +310,10 @@ spec:
                       x-kubernetes-list-type: map
                     hostnameGeneratorRef:
                       properties:
-                        name:
+                        coreName:
                           type: string
                       required:
-                      - name
+                      - coreName
                       type: object
                   required:
                   - hostnameGeneratorRef

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/schema.yaml
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/schema.yaml
@@ -83,10 +83,10 @@ properties:
               type: string
             hostnameGeneratorRef:
               properties:
-                name:
+                coreName:
                   type: string
               required:
-                - name
+                - coreName
               type: object
             origin:
               type: string
@@ -145,10 +145,10 @@ properties:
               x-kubernetes-list-type: map
             hostnameGeneratorRef:
               properties:
-                name:
+                coreName:
                   type: string
               required:
-                - name
+                - coreName
               type: object
           required:
             - hostnameGeneratorRef

--- a/pkg/core/resources/apis/meshservice/k8s/crd/kuma.io_meshservices.yaml
+++ b/pkg/core/resources/apis/meshservice/k8s/crd/kuma.io_meshservices.yaml
@@ -102,10 +102,10 @@ spec:
                       type: string
                     hostnameGeneratorRef:
                       properties:
-                        name:
+                        coreName:
                           type: string
                       required:
-                      - name
+                      - coreName
                       type: object
                     origin:
                       type: string
@@ -165,10 +165,10 @@ spec:
                       x-kubernetes-list-type: map
                     hostnameGeneratorRef:
                       properties:
-                        name:
+                        coreName:
                           type: string
                       required:
-                      - name
+                      - coreName
                       type: object
                   required:
                   - hostnameGeneratorRef


### PR DESCRIPTION
In the future if we want to introduce smarter refs involving `name`/`namespace` we can.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
