### PR TITLE
perf(MeshProxyPatch): remove filters without allocation

### DIFF
--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/http_filter_mod.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/http_filter_mod.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"slices"
+
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
@@ -98,13 +100,9 @@ func (h *httpFilterModificator) patch(hcm *envoy_hcm.HttpConnectionManager, filt
 }
 
 func (h *httpFilterModificator) remove(hcm *envoy_hcm.HttpConnectionManager) {
-	var filters []*envoy_hcm.HttpFilter
-	for _, filter := range hcm.HttpFilters {
-		if !h.filterMatches(filter) {
-			filters = append(filters, filter)
-		}
-	}
-	hcm.HttpFilters = filters
+	hcm.HttpFilters = slices.DeleteFunc(hcm.HttpFilters, func(filter *envoy_hcm.HttpFilter) bool {
+		return h.filterMatches(filter)
+	})
 }
 
 func (h *httpFilterModificator) addBefore(hcm *envoy_hcm.HttpConnectionManager, filterMod *envoy_hcm.HttpFilter) {

--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/network_filter_mod.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/network_filter_mod.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"slices"
+
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/pkg/errors"
@@ -78,13 +80,9 @@ func (n *networkFilterModificator) addBefore(chain *envoy_listener.FilterChain, 
 }
 
 func (n *networkFilterModificator) remove(chain *envoy_listener.FilterChain) {
-	var filters []*envoy_listener.Filter
-	for _, filter := range chain.Filters {
-		if !n.filterMatches(filter) {
-			filters = append(filters, filter)
-		}
-	}
-	chain.Filters = filters
+	chain.Filters = slices.DeleteFunc(chain.Filters, func(filter *envoy_listener.Filter) bool {
+		return n.filterMatches(filter)
+	})
 }
 
 func (n *networkFilterModificator) patch(chain *envoy_listener.FilterChain, filterPatch *envoy_listener.Filter) error {

--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/virtual_host_mod.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/virtual_host_mod.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"slices"
+
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
@@ -93,13 +95,9 @@ func (c *virtualHostModificator) patch(routeCfg *envoy_route.RouteConfiguration,
 }
 
 func (c *virtualHostModificator) remove(routeCfg *envoy_route.RouteConfiguration) {
-	var vHosts []*envoy_route.VirtualHost
-	for _, vHost := range routeCfg.VirtualHosts {
-		if !c.virtualHostMatches(vHost) {
-			vHosts = append(vHosts, vHost)
-		}
-	}
-	routeCfg.VirtualHosts = vHosts
+	routeCfg.VirtualHosts = slices.DeleteFunc(routeCfg.VirtualHosts, func(vHost *envoy_route.VirtualHost) bool {
+		return c.virtualHostMatches(vHost)
+	})
 }
 
 func (c *virtualHostModificator) add(routeCfg *envoy_route.RouteConfiguration, vHost *envoy_route.VirtualHost) {

--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/virtual_host_test.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/virtual_host_test.go
@@ -180,6 +180,111 @@ var _ = Describe("Virtual Host modifications", func() {
                     name: outbound:192.168.0.1:8080
                     trafficDirection: INBOUND`,
 		}),
+		Entry("should remove virtual hosts of given name from all listeners", testCase{
+			routeCfgs: []string{
+				`
+                address:
+                  socketAddress:
+                    address: 192.168.0.1
+                    portValue: 8080
+                filterChains:
+                - filters:
+                  - name: envoy.filters.network.http_connection_manager
+                    typedConfig:
+                      '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                      httpFilters:
+                      - name: envoy.filters.http.router
+                      routeConfig:
+                        name: outbound:backend
+                        virtualHosts:
+                        - domains:
+                          - backend.com
+                          name: backend
+                          routes:
+                          - match:
+                              prefix: /
+                            route:
+                              cluster: backend
+                      statPrefix: localhost_8080
+                name: outbound:192.168.0.1:8080
+                trafficDirection: INBOUND
+`,
+				`
+                address:
+                  socketAddress:
+                    address: 192.168.0.1
+                    portValue: 80
+                filterChains:
+                - filters:
+                  - name: envoy.filters.network.http_connection_manager
+                    typedConfig:
+                      '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                      httpFilters:
+                      - name: envoy.filters.http.router
+                      routeConfig:
+                        name: outbound:backend
+                        virtualHosts:
+                        - domains:
+                          - backend.com
+                          name: backend
+                          routes:
+                          - match:
+                              prefix: /
+                            route:
+                              cluster: backend
+                      statPrefix: localhost_80
+                name: outbound:192.168.0.1:80
+                trafficDirection: INBOUND
+`,
+			},
+			modifications: []string{
+				`
+                virtualHost:
+                   operation: Remove
+                   match:
+                     name: backend`,
+			},
+			expected: `
+                resources:
+                - name: outbound:192.168.0.1:80
+                  resource:
+                    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+                    address:
+                      socketAddress:
+                        address: 192.168.0.1
+                        portValue: 80
+                    filterChains:
+                    - filters:
+                      - name: envoy.filters.network.http_connection_manager
+                        typedConfig:
+                          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                          httpFilters:
+                          - name: envoy.filters.http.router
+                          routeConfig:
+                            name: outbound:backend
+                          statPrefix: localhost_80
+                    name: outbound:192.168.0.1:80
+                    trafficDirection: INBOUND
+                - name: outbound:192.168.0.1:8080
+                  resource:
+                    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+                    address:
+                      socketAddress:
+                        address: 192.168.0.1
+                        portValue: 8080
+                    filterChains:
+                    - filters:
+                      - name: envoy.filters.network.http_connection_manager
+                        typedConfig:
+                          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                          httpFilters:
+                          - name: envoy.filters.http.router
+                          routeConfig:
+                            name: outbound:backend
+                          statPrefix: localhost_8080
+                    name: outbound:192.168.0.1:8080
+                    trafficDirection: INBOUND`,
+		}),
 		Entry("should patch a virtual host", testCase{
 			routeCfgs: []string{
 				`


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
