### PR TITLE
fix(kuma-cp): panic on mesh delete

### DIFF
--- a/pkg/xds/context/aggregate_mesh_context.go
+++ b/pkg/xds/context/aggregate_mesh_context.go
@@ -25,6 +25,7 @@ func AggregateMeshContexts(
 
 	var meshContexts []MeshContext
 	meshContextsByName := map[string]MeshContext{}
+	var meshes []*core_mesh.MeshResource
 	for _, mesh := range meshList.Items {
 		meshCtx, err := fetcher(ctx, mesh.GetMeta().GetName())
 		if err != nil {
@@ -36,6 +37,7 @@ func AggregateMeshContexts(
 		}
 		meshContexts = append(meshContexts, meshCtx)
 		meshContextsByName[mesh.Meta.GetName()] = meshCtx
+		meshes = append(meshes, mesh)
 	}
 
 	hash := aggregatedHash(meshContexts)
@@ -60,7 +62,7 @@ func AggregateMeshContexts(
 
 	result := AggregatedMeshContexts{
 		Hash:               hash,
-		Meshes:             meshList.Items,
+		Meshes:             meshes,
 		MeshContextsByName: meshContextsByName,
 		ZoneEgressByName:   egressByName,
 	}

--- a/pkg/xds/context/aggregate_mesh_context_test.go
+++ b/pkg/xds/context/aggregate_mesh_context_test.go
@@ -1,0 +1,40 @@
+package context_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/resources/manager"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
+	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
+	"github.com/kumahq/kuma/pkg/plugins/resources/memory"
+	"github.com/kumahq/kuma/pkg/test/resources/samples"
+	xds_context "github.com/kumahq/kuma/pkg/xds/context"
+)
+
+var _ = Describe("AggregateMeshContexts", func() {
+	It("should ignore meshes that were deleted", func() {
+		// given
+		resManager := manager.NewResourceManager(memory.NewStore())
+		Expect(samples.MeshDefaultBuilder().Create(resManager)).To(Succeed())
+		Expect(samples.MeshDefaultBuilder().WithName("other").Create(resManager)).To(Succeed())
+
+		fetcher := func(ctx context.Context, meshName string) (xds_context.MeshContext, error) {
+			if meshName == "other" {
+				return xds_context.MeshContext{}, core_store.ErrorResourceNotFound(mesh.MeshType, "other", model.NoMesh)
+			}
+			return xds_context.MeshContext{}, nil
+		}
+
+		// when
+		ctxs, err := xds_context.AggregateMeshContexts(context.Background(), resManager, fetcher)
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ctxs.Meshes).To(HaveLen(1))
+		Expect(ctxs.Meshes[0].GetMeta().GetName()).To(Equal(model.DefaultMesh))
+	})
+})


### PR DESCRIPTION
### Checklist prior to review

Fixes
```
2024-06-20T21:03:00.1496054Z   2024-06-20T21:02:53.798Z	ERROR	xds-server.dataplane-sync-watchdog	OnTick() failed	{"dataplaneKey": {"Mesh":"","Name":"ingress"}, "error": "there should be a corresponding mesh context for every mesh in mesh contexts", "errorVerbose": "there should be a corresponding mesh context for every mesh in mesh contexts\ngithub.com/kumahq/kuma/pkg/util/watchdog.(*SimpleWatchdog).onTick.func1\n\tgithub.com/kumahq/kuma/pkg/util/watchdog/watchdog.go:64\nruntime.gopanic\n\truntime/panic.go:914\ngithub.com/kumahq/kuma/pkg/xds/context.AggregatedMeshContexts.MustGetMeshContext\n\tgithub.com/kumahq/kuma/pkg/xds/context/context.go:155\ngithub.com/kumahq/kuma/pkg/xds/sync.(*IngressProxyBuilder).buildZoneIngressProxy\n\tgithub.com/kumahq/kuma/pkg/xds/sync/ingress_proxy_builder.go:68\ngithub.com/kumahq/kuma/pkg/xds/sync.(*IngressProxyBuilder).Build\n\tgithub.com/kumahq/kuma/pkg/xds/sync/ingress_proxy_builder.go:48\ngithub.com/kumahq/kuma/pkg/xds/sync.(*DataplaneWatchdog).syncIngress\n\tgithub.com/kumahq/kuma/pkg/xds/sync/dataplane_watchdog.go:218\ngithub.com/kumahq/kuma/pkg/xds/sync.(*DataplaneWatchdog).Sync\n\tgithub.com/kumahq/kuma/pkg/xds/sync/dataplane_watchdog.go:82\ngithub.com/kumahq/kuma/pkg/xds/sync.(*dataplaneWatchdogFactory).New.func2\n\tgithub.com/kumahq/kuma/pkg/xds/sync/dataplane_watchdog_factory.go:43\ngithub.com/kumahq/kuma/pkg/util/watchdog.(*SimpleWatchdog).onTick\n\tgithub.com/kumahq/kuma/pkg/util/watchdog/watchdog.go:70\ngithub.com/kumahq/kuma/pkg/util/watchdog.(*SimpleWatchdog).Start\n\tgithub.com/kumahq/kuma/pkg/util/watchdog/watchdog.go:40\nruntime.goexit\n\truntime/asm_amd64.s:1650"}
```
That can occur under some condition when mesh is deleted. It won't crash the CP, it will error the XDS loop for zone proxies (which will recover in the next reconciliation loop)

When AggregatedMeshContext was introduced this method
```
// MustGetMeshContext panics if there is no mesh context for given mesh. Call it when iterating over .Meshes
// There is a guarantee that for every Mesh in .Meshes there is a MeshContext.
func (m AggregatedMeshContexts) MustGetMeshContext(meshName string) MeshContext {
```

However, this PR https://github.com/kumahq/kuma/pull/8503 broke this promise. This PR fixes this premise.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
