### PR TITLE
feat(meshservice): disable available services on disabled vips

### DIFF
--- a/pkg/zone/available_services_test.go
+++ b/pkg/zone/available_services_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kumahq/kuma/pkg/dns/vips"
 	core_metrics "github.com/kumahq/kuma/pkg/metrics"
 	"github.com/kumahq/kuma/pkg/plugins/resources/memory"
+	"github.com/kumahq/kuma/pkg/test/resources/builders"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
 	"github.com/kumahq/kuma/pkg/test/resources/samples"
 	cache_mesh "github.com/kumahq/kuma/pkg/xds/cache/mesh"
@@ -28,124 +29,165 @@ import (
 	"github.com/kumahq/kuma/pkg/zone"
 )
 
-var _ = Describe("AvailableServices", func() {
-	var resManager manager.ResourceManager
-	var meshContextBuilder xds_context.MeshContextBuilder
-	var metrics core_metrics.Metrics
-	var meshCache *cache_mesh.Cache
+var _ = Describe("AvailableServices Tracker", func() {
+	Context("Enabled Available Services", func() {
+		var resManager manager.ResourceManager
+		var meshContextBuilder xds_context.MeshContextBuilder
+		var metrics core_metrics.Metrics
+		var meshCache *cache_mesh.Cache
 
-	var stop chan struct{}
-	var done chan struct{}
-	BeforeEach(func() {
-		resourceStore := memory.NewStore()
-		resManager = manager.NewResourceManager(resourceStore)
-		meshContextBuilder = xds_context.NewMeshContextBuilder(
-			resManager,
-			server.MeshResourceTypes(),
-			net.LookupIP,
-			"zone",
-			vips.NewPersistence(resManager, config_manager.NewConfigManager(resourceStore), false),
-			".mesh",
-			80,
-			xds_context.AnyToAnyReachableServicesGraphBuilder,
-			false,
-		)
-		var err error
-		metrics, err = core_metrics.NewMetrics("Zone")
-		Expect(err).ToNot(HaveOccurred())
+		var stop chan struct{}
+		var done chan struct{}
+		BeforeEach(func() {
+			resourceStore := memory.NewStore()
+			resManager = manager.NewResourceManager(resourceStore)
+			meshContextBuilder = xds_context.NewMeshContextBuilder(
+				resManager,
+				server.MeshResourceTypes(),
+				net.LookupIP,
+				"zone",
+				vips.NewPersistence(resManager, config_manager.NewConfigManager(resourceStore), false),
+				".mesh",
+				80,
+				xds_context.AnyToAnyReachableServicesGraphBuilder,
+				false,
+			)
+			var err error
+			metrics, err = core_metrics.NewMetrics("Zone")
+			Expect(err).ToNot(HaveOccurred())
 
-		meshCache, err = cache_mesh.NewCache(
-			1*time.Second,
-			meshContextBuilder,
-			metrics,
-		)
-		Expect(err).ToNot(HaveOccurred())
+			meshCache, err = cache_mesh.NewCache(
+				1*time.Second,
+				meshContextBuilder,
+				metrics,
+			)
+			Expect(err).ToNot(HaveOccurred())
 
-		tracker, err := zone.NewZoneAvailableServicesTracker(
-			core.Log.WithName("test"),
-			metrics,
-			resManager,
-			meshCache,
-			20*time.Millisecond,
-			nil,
-			"zone",
-		)
-		Expect(err).ToNot(HaveOccurred())
+			tracker, err := zone.NewZoneAvailableServicesTracker(
+				core.Log.WithName("test"),
+				metrics,
+				resManager,
+				meshCache,
+				20*time.Millisecond,
+				nil,
+				"zone",
+				false,
+			)
+			Expect(err).ToNot(HaveOccurred())
 
-		stop = make(chan struct{})
-		done = make(chan struct{})
-		go func() {
-			defer GinkgoRecover()
-			Expect(tracker.Start(stop)).To(Succeed())
-			close(done)
-		}()
+			stop = make(chan struct{})
+			done = make(chan struct{})
+			go func() {
+				defer GinkgoRecover()
+				Expect(tracker.Start(stop)).To(Succeed())
+				close(done)
+			}()
+		})
+		AfterEach(func() {
+			close(stop)
+			Eventually(done).Should(BeClosed())
+		})
+		It("should update all ZoneIngresses", func() {
+			Expect(builders.ZoneIngress().Create(resManager)).To(Succeed())
+			Expect(samples.MeshMTLSBuilder().WithEgressRoutingEnabled().Create(resManager)).To(Succeed())
+			externalService := &core_mesh.ExternalServiceResource{
+				Meta: &test_model.ResourceMeta{
+					Mesh: "default",
+					Name: "es-1",
+				},
+				Spec: &mesh_proto.ExternalService{
+					Networking: &mesh_proto.ExternalService_Networking{
+						Address: "127.0.0.1:80",
+					},
+					Tags: map[string]string{
+						"kuma.io/service":  "httpbin",
+						"version":          "v1",
+						mesh_proto.ZoneTag: "zone",
+					},
+				},
+			}
+			Expect(resManager.Create(context.Background(), externalService, store.CreateByKey("es-1", core_model.DefaultMesh))).To(Succeed())
+			Expect(samples.DataplaneBackendBuilder().Create(resManager)).To(Succeed())
+			Expect(samples.DataplaneWebBuilder().Create(resManager)).To(Succeed())
+
+			expected := []*mesh_proto.ZoneIngress_AvailableService{
+				{
+					Instances: 1,
+					Tags: map[string]string{
+						"kuma.io/service":  "web",
+						"kuma.io/protocol": "http",
+					},
+					Mesh: core_model.DefaultMesh,
+				},
+				{
+					Instances: 1,
+					Tags: map[string]string{
+						"kuma.io/service": "backend",
+					},
+					Mesh: core_model.DefaultMesh,
+				},
+				{
+					Instances: 1,
+					Tags: map[string]string{
+						"kuma.io/service":  "httpbin",
+						"version":          "v1",
+						mesh_proto.ZoneTag: "zone",
+					},
+					Mesh:            core_model.DefaultMesh,
+					ExternalService: true,
+				},
+			}
+			Eventually(func(g Gomega) {
+				zi := core_mesh.NewZoneIngressResource()
+				g.Expect(resManager.Get(context.Background(), zi, store.GetByKey("zoneingress-1", ""))).To(Succeed())
+				g.Expect(zi.Spec.AvailableServices).To(BeComparableTo(expected, cmp.Comparer(proto.Equal)))
+			}).Should(Succeed())
+		})
 	})
-	AfterEach(func() {
-		close(stop)
-		Eventually(done).Should(BeClosed())
-	})
-	It("should update all ZoneIngresses", func() {
-		ingress := &core_mesh.ZoneIngressResource{
-			Spec: &mesh_proto.ZoneIngress{
-				Networking: &mesh_proto.ZoneIngress_Networking{
-					Port:    10000,
-					Address: "127.0.0.1",
-				},
-			},
-		}
-		Expect(resManager.Create(context.Background(), ingress, store.CreateByKey("ingress-1", ""))).To(Succeed())
-		Expect(samples.MeshMTLSBuilder().WithEgressRoutingEnabled().Create(resManager)).To(Succeed())
-		externalService := &core_mesh.ExternalServiceResource{
-			Meta: &test_model.ResourceMeta{
-				Mesh: "default",
-				Name: "es-1",
-			},
-			Spec: &mesh_proto.ExternalService{
-				Networking: &mesh_proto.ExternalService_Networking{
-					Address: "127.0.0.1:80",
-				},
-				Tags: map[string]string{
-					"kuma.io/service":  "httpbin",
-					"version":          "v1",
-					mesh_proto.ZoneTag: "zone",
-				},
-			},
-		}
-		Expect(resManager.Create(context.Background(), externalService, store.CreateByKey("es-1", core_model.DefaultMesh))).To(Succeed())
-		Expect(samples.DataplaneBackendBuilder().Create(resManager)).To(Succeed())
-		Expect(samples.DataplaneWebBuilder().Create(resManager)).To(Succeed())
 
-		expected := []*mesh_proto.ZoneIngress_AvailableService{
-			{
-				Instances: 1,
-				Tags: map[string]string{
-					"kuma.io/service":  "web",
-					"kuma.io/protocol": "http",
-				},
-				Mesh: core_model.DefaultMesh,
-			},
-			{
-				Instances: 1,
-				Tags: map[string]string{
-					"kuma.io/service": "backend",
-				},
-				Mesh: core_model.DefaultMesh,
-			},
-			{
-				Instances: 1,
-				Tags: map[string]string{
-					"kuma.io/service":  "httpbin",
-					"version":          "v1",
-					mesh_proto.ZoneTag: "zone",
-				},
-				Mesh:            core_model.DefaultMesh,
-				ExternalService: true,
-			},
-		}
-		Eventually(func(g Gomega) {
-			zi := core_mesh.NewZoneIngressResource()
-			g.Expect(resManager.Get(context.Background(), zi, store.GetByKey("ingress-1", ""))).To(Succeed())
-			g.Expect(zi.Spec.AvailableServices).To(BeComparableTo(expected, cmp.Comparer(proto.Equal)))
-		}).Should(Succeed())
+	Context("Disabled Available Services", func() {
+		var resManager manager.ResourceManager
+		var stop chan struct{}
+
+		BeforeEach(func() {
+			resManager = manager.NewResourceManager(memory.NewStore())
+			var err error
+			metrics, err := core_metrics.NewMetrics("Zone")
+			Expect(err).ToNot(HaveOccurred())
+
+			tracker, err := zone.NewZoneAvailableServicesTracker(
+				core.Log.WithName("test"),
+				metrics,
+				resManager,
+				nil, // not used when available services are disabled
+				20*time.Millisecond,
+				nil,
+				"zone",
+				true,
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			stop = make(chan struct{})
+			go func() {
+				defer GinkgoRecover()
+				Expect(tracker.Start(stop)).To(Succeed())
+			}()
+		})
+
+		AfterEach(func() {
+			close(stop)
+		})
+
+		It("should clear available services list when available services are disabled", func() {
+			Expect(builders.ZoneIngress().
+				AddSimpleAvailableService("backend").
+				Create(resManager)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				zi := core_mesh.NewZoneIngressResource()
+				g.Expect(resManager.Get(context.Background(), zi, store.GetByKey("zoneingress-1", ""))).To(Succeed())
+				g.Expect(zi.Spec.AvailableServices).To(BeEmpty())
+			}).Should(Succeed())
+		})
 	})
 })

--- a/pkg/zone/components.go
+++ b/pkg/zone/components.go
@@ -20,6 +20,7 @@ func Setup(rt runtime.Runtime) error {
 		rt.Config().Multizone.Zone.IngressUpdateInterval.Duration,
 		rt.Config().Experimental.IngressTagFilters,
 		rt.Config().Multizone.Zone.Name,
+		rt.Config().Experimental.SkipPersistedVIPs,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fix #10611

Disable available services when service tag vips are disabled.

I put the existing test into `Context("Enabled Available Services` and switched to using a zone ingress builder. 

It's intentional to put it to master. I don't want to add this to release branch last minute

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
