### PR TITLE
test(e2e): tweak and reenable available services test

### DIFF
--- a/test/e2e_env/multizone/connectivity/available_services.go
+++ b/test/e2e_env/multizone/connectivity/available_services.go
@@ -97,12 +97,10 @@ func AvailableServices() {
 		// Bring back CP
 		Expect(statefulCluster.GetApp(AppModeCP).StartMainApp()).To(Succeed())
 		// Kill app
+		Expect(statefulCluster.DeleteApp("test-server")).To(Succeed())
 		Eventually(func(g Gomega) {
 			g.Expect(kumactl.KumactlDelete("dataplane", "test-server", meshName)).To(Succeed())
 		}).Should(Succeed())
-		Expect(statefulCluster.DeleteApp("test-server")).To(Succeed())
-
-		Expect(kumactl.KumactlList("dataplanes", meshName)).To(BeEmpty())
 
 		Eventually(func(g Gomega) {
 			ingress := getIngress(g, kumactl, UniversalZoneIngressPort+1)

--- a/test/e2e_env/multizone/multizone_suite_test.go
+++ b/test/e2e_env/multizone/multizone_suite_test.go
@@ -80,6 +80,5 @@ var (
 	_ = Describe("Defaults", defaults.Defaults, Ordered)
 	_ = Describe("MeshService Sync", meshservice.Sync, Ordered)
 	_ = Describe("MeshService Connectivity", meshservice.Connectivity, Ordered)
-	// TODO this is flaky atm
-	_ = XDescribe("Available services", connectivity.AvailableServices, Ordered)
+	_ = Describe("Available services", connectivity.AvailableServices, Ordered)
 )


### PR DESCRIPTION
I saw a failure on the dataplane list being empty. I think the app deletion should happen first here, otherwise there's a race with it recreating the Dataplane on reconnection. Also reenable to keep testing it on master.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
