### PR TITLE
perf(kuma-cp): faster service to dpp matching

### DIFF
--- a/pkg/core/resources/apis/meshservice/match.go
+++ b/pkg/core/resources/apis/meshservice/match.go
@@ -40,6 +40,9 @@ func indexDpsForMatching(
 	map[string]*core_mesh.DataplaneResource,
 ) {
 	// Map of tag pair in a context of a mesh (ex. app:redis from default mesh) to dpp name to dpp.
+	// While this could be a map[string][]*core_mesh.DataplaneResource, we also want to get rid of duplicates.
+	// For example, if a DPP has 2 inbounds with app:xyz and MeshService matches app:xyz, we only want to
+	// have one occurrence of a dpp as a result.
 	dppsByNameByTag := map[string]map[string]*core_mesh.DataplaneResource{}
 	dppsByName := map[string]*core_mesh.DataplaneResource{}
 

--- a/pkg/core/resources/apis/meshservice/match.go
+++ b/pkg/core/resources/apis/meshservice/match.go
@@ -57,7 +57,7 @@ func indexDpsForMatching(
 					dataplanes = map[string]*core_mesh.DataplaneResource{}
 					dppsByNameByTag[tag] = dataplanes
 				}
-				dppsByNameByTag[tag][dpp.Meta.GetName()] = dpp
+				dataplanes[dpp.Meta.GetName()] = dpp
 			}
 		}
 		if len(inbounds) > 0 {

--- a/pkg/core/resources/apis/meshservice/match.go
+++ b/pkg/core/resources/apis/meshservice/match.go
@@ -1,0 +1,114 @@
+package meshservice
+
+import (
+	"fmt"
+
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
+	"github.com/kumahq/kuma/pkg/util/maps"
+)
+
+func MatchDataplanesWithMeshServices(
+	dpps []*core_mesh.DataplaneResource,
+	meshServices []*meshservice_api.MeshServiceResource,
+	matchOnlyHealthy bool,
+) map[*meshservice_api.MeshServiceResource][]*core_mesh.DataplaneResource {
+	result := map[*meshservice_api.MeshServiceResource][]*core_mesh.DataplaneResource{}
+
+	dppsByNameByTag, dppsByName := indexDpsForMatching(dpps, matchOnlyHealthy)
+
+	for _, ms := range meshServices {
+		switch {
+		case ms.Spec.Selector.DataplaneRef != nil:
+			result[ms] = matchByRef(ms, dppsByName)
+		case ms.Spec.Selector.DataplaneTags != nil:
+			result[ms] = matchByTags(ms, dppsByNameByTag)
+		default:
+			result[ms] = nil
+		}
+	}
+
+	return result
+}
+
+func indexDpsForMatching(
+	dpps []*core_mesh.DataplaneResource,
+	matchOnlyHealthy bool,
+) (
+	map[string]map[string]*core_mesh.DataplaneResource,
+	map[string]*core_mesh.DataplaneResource,
+) {
+	// Map of tag pair in a context of a mesh (ex. app:redis from default mesh) to dpp name to dpp.
+	dppsByNameByTag := map[string]map[string]*core_mesh.DataplaneResource{}
+	dppsByName := map[string]*core_mesh.DataplaneResource{}
+
+	for _, dpp := range dpps {
+		inbounds := dpp.Spec.GetNetworking().GetInbound()
+		if matchOnlyHealthy {
+			inbounds = dpp.Spec.GetNetworking().GetHealthyInbounds()
+		}
+
+		for _, inbound := range inbounds {
+			for tagName, tagValue := range inbound.GetTags() {
+				tag := fmt.Sprintf("%s;%s;%s", dpp.Meta.GetMesh(), tagName, tagValue)
+				dataplanes, ok := dppsByNameByTag[tag]
+				if !ok {
+					dataplanes = map[string]*core_mesh.DataplaneResource{}
+					dppsByNameByTag[tag] = dataplanes
+				}
+				dppsByNameByTag[tag][dpp.Meta.GetName()] = dpp
+			}
+		}
+		if len(inbounds) > 0 {
+			dppsByName[fmt.Sprintf("%s;%s", dpp.Meta.GetMesh(), dpp.Meta.GetName())] = dpp
+		}
+	}
+	return dppsByNameByTag, dppsByName
+}
+
+func matchByRef(
+	ms *meshservice_api.MeshServiceResource,
+	dppsByName map[string]*core_mesh.DataplaneResource,
+) []*core_mesh.DataplaneResource {
+	key := fmt.Sprintf("%s;%s", ms.Meta.GetMesh(), ms.Spec.Selector.DataplaneRef.Name)
+	if dpp, ok := dppsByName[key]; ok {
+		return []*core_mesh.DataplaneResource{dpp}
+	}
+	return nil
+}
+
+func matchByTags(
+	ms *meshservice_api.MeshServiceResource,
+	dppsByNameByTag map[string]map[string]*core_mesh.DataplaneResource,
+) []*core_mesh.DataplaneResource {
+	// Find the shortest map of dpps by name that matches the tags
+	// For example, if we have MeshService with selector of `app: redis` and `k8s.kuma.io/namespace: kuma-demo`
+	// and DPPs:
+	// * `app: redis`, `k8s.kuma.io/namespace: kuma-demo`
+	// * `app: demo-app`, `k8s.kuma.io/namespace: kuma-demo`
+	// It's better to grab the shortest list of DPPs (app:redis) to reduce number of operations (.Matches) for the next step.
+	var shortestDppMap map[string]*core_mesh.DataplaneResource
+	for tagName, tagValue := range ms.Spec.Selector.DataplaneTags {
+		tagsKey := fmt.Sprintf("%s;%s;%s", ms.GetMeta().GetMesh(), tagName, tagValue)
+		if dppsByName, ok := dppsByNameByTag[tagsKey]; ok {
+			if shortestDppMap == nil || len(dppsByName) < len(shortestDppMap) {
+				shortestDppMap = dppsByName
+			}
+		} else {
+			// No proxies will match this pair of tags, no point in going further.
+			shortestDppMap = nil
+			break
+		}
+	}
+
+	// Go over the shortest list of data plane proxies and pick only proxies that matches all tags.
+	var dpps []*core_mesh.DataplaneResource
+	for _, dppName := range maps.SortedKeys(shortestDppMap) {
+		dpp := shortestDppMap[dppName]
+		if dpp.Spec.Matches(mesh_proto.TagSelector(ms.Spec.Selector.DataplaneTags)) {
+			dpps = append(dpps, dpp)
+		}
+	}
+	return dpps
+}

--- a/pkg/core/resources/apis/meshservice/match_benchmark_test.go
+++ b/pkg/core/resources/apis/meshservice/match_benchmark_test.go
@@ -1,0 +1,90 @@
+package meshservice_test
+
+import (
+	"fmt"
+	"testing"
+
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/resources/apis/meshservice"
+	"github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
+	"github.com/kumahq/kuma/pkg/test/resources/builders"
+)
+
+// To run, remove X from the prefix
+// $ cd /Users/jakub/kong/kuma/pkg/core/resources/apis/meshservice
+// $ go test -bench=BenchmarkMatchDataplanesWithMeshServices -run=^# -count 10 | tee bench.txt
+// $ go install golang.org/x/perf/cmd/benchstat@latest
+// $ benchstat bench.txt
+// goos: darwin
+// goarch: arm64
+// pkg: github.com/kumahq/kuma/pkg/core/resources/apis/meshservice
+//
+//	│     bench.txt     │
+//	│     sec/op        │
+//
+// MatchDataplanesWithMeshServices/faster-matching-ns_200-svc_20-dpp_5-10     0.02471n ± 1%
+// MatchDataplanesWithMeshServices/naive-matching-ns_200-svc_20-dpp_5-10        5.633 ± 1%
+// MatchDataplanesWithMeshServices/faster-matching-ns_50-svc_5-dpp_5-10      0.001591n ± 3%
+// MatchDataplanesWithMeshServices/naive-matching-ns_50-svc_5-dpp_5-10       0.02013n ± 1%
+// MatchDataplanesWithMeshServices/faster-matching-ns_10-svc_5-dpp_1-10     0.0001143n ± 9%
+// MatchDataplanesWithMeshServices/naive-matching-ns_10-svc_5-dpp_1-10     0.0001701n ± 4%
+func XBenchmarkMatchDataplanesWithMeshServices(b *testing.B) {
+	var table = []struct {
+		dppsPerService       int
+		servicesPerNamespace int
+		namespaces           int
+	}{
+		{dppsPerService: 5, servicesPerNamespace: 20, namespaces: 200},
+		{dppsPerService: 5, servicesPerNamespace: 5, namespaces: 50},
+		{dppsPerService: 1, servicesPerNamespace: 5, namespaces: 10},
+	}
+
+	for _, testCase := range table {
+		var meshServices []*v1alpha1.MeshServiceResource
+		var dpps []*mesh.DataplaneResource
+		for nsIdx := 0; nsIdx < testCase.namespaces; nsIdx++ {
+			nsName := fmt.Sprintf("ns-%d", nsIdx)
+			for svcIdx := 0; svcIdx < testCase.servicesPerNamespace; svcIdx++ {
+				svcName := fmt.Sprintf("ms-%d-%d", nsIdx, svcIdx)
+				ms := builders.MeshService().
+					WithName(svcName).
+					WithDataplaneTagsSelectorKV("app", svcName, "k8s.kuma.io/namespace", nsName).
+					Build()
+				meshServices = append(meshServices, ms)
+				for dppIdx := 0; dppIdx < testCase.dppsPerService; dppIdx++ {
+					dppName := fmt.Sprintf("dpp-%d-%d-%d", nsIdx, svcIdx, dppIdx)
+					dpp := builders.Dataplane().
+						WithName(dppName).
+						WithInboundOfTags("kuma.io/service", svcName, "app", svcName, "k8s.kuma.io/namespace", nsName).
+						Build()
+					dpps = append(dpps, dpp)
+				}
+			}
+		}
+
+		suffix := fmt.Sprintf("-ns_%d-svc_%d-dpp_%d", testCase.namespaces, testCase.servicesPerNamespace, testCase.dppsPerService)
+		b.Run("faster-matching"+suffix, func(b *testing.B) {
+			_ = meshservice.MatchDataplanesWithMeshServices(dpps, meshServices, false)
+		})
+
+		b.Run("naive-matching"+suffix, func(b *testing.B) {
+			_ = naiveMatching(dpps, meshServices)
+		})
+
+	}
+
+}
+
+func naiveMatching(dpps []*mesh.DataplaneResource, meshServices []*v1alpha1.MeshServiceResource) map[*v1alpha1.MeshServiceResource][]*mesh.DataplaneResource {
+	// naive O(n^2) matching, works for healthy inbounds matched by tags
+	result := map[*v1alpha1.MeshServiceResource][]*mesh.DataplaneResource{}
+	for _, ms := range meshServices {
+		for _, dpp := range dpps {
+			if dpp.Spec.Matches(mesh_proto.TagSelector(ms.Spec.Selector.DataplaneTags)) {
+				result[ms] = append(result[ms], dpp)
+			}
+		}
+	}
+	return result
+}

--- a/pkg/core/resources/apis/meshservice/match_benchmark_test.go
+++ b/pkg/core/resources/apis/meshservice/match_benchmark_test.go
@@ -19,8 +19,10 @@ import (
 // goos: darwin
 // goarch: arm64
 // pkg: github.com/kumahq/kuma/pkg/core/resources/apis/meshservice
-//                                                                        │  bench.txt  │
-//                                                                        │   sec/op    │
+//
+//	│  bench.txt  │
+//	│   sec/op    │
+//
 // MatchDataplanesWithMeshServices/faster-matching-ns_200-svc_20-dpp_5-10   14.59m ± 1%
 // MatchDataplanesWithMeshServices/naive-matching-ns_200-svc_20-dpp_5-10     5.891 ± 0%
 // MatchDataplanesWithMeshServices/faster-matching-ns_50-svc_5-dpp_5-10     878.2µ ± 0%
@@ -29,8 +31,9 @@ import (
 // MatchDataplanesWithMeshServices/naive-matching-ns_10-svc_5-dpp_1-10      162.6µ ± 0%
 // geomean                                                                  5.019m
 //
-//                                                                        │  bench.txt   │
-//                                                                        │     B/op     │
+//	│  bench.txt   │
+//	│     B/op     │
+//
 // MatchDataplanesWithMeshServices/faster-matching-ns_200-svc_20-dpp_5-10   9.931Mi ± 0%
 // MatchDataplanesWithMeshServices/naive-matching-ns_200-svc_20-dpp_5-10    1.070Mi ± 0%
 // MatchDataplanesWithMeshServices/faster-matching-ns_50-svc_5-dpp_5-10     631.7Ki ± 0%
@@ -39,8 +42,9 @@ import (
 // MatchDataplanesWithMeshServices/naive-matching-ns_10-svc_5-dpp_1-10      5.301Ki ± 0%
 // geomean                                                                  239.6Ki
 //
-//                                                                        │  bench.txt  │
-//                                                                        │  allocs/op  │
+//	│  bench.txt  │
+//	│  allocs/op  │
+//
 // MatchDataplanesWithMeshServices/faster-matching-ns_200-svc_20-dpp_5-10   38.88k ± 0%
 // MatchDataplanesWithMeshServices/naive-matching-ns_200-svc_20-dpp_5-10    16.09k ± 0%
 // MatchDataplanesWithMeshServices/faster-matching-ns_50-svc_5-dpp_5-10     2.567k ± 0%

--- a/pkg/core/resources/apis/meshservice/match_benchmark_test.go
+++ b/pkg/core/resources/apis/meshservice/match_benchmark_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // To run, remove X from the prefix
-// $ cd /Users/jakub/kong/kuma/pkg/core/resources/apis/meshservice
+// $ cd pkg/core/resources/apis/meshservice
 // $ go test -bench=BenchmarkMatchDataplanesWithMeshServices -run=^# -count 10 | tee bench.txt
 // $ go install golang.org/x/perf/cmd/benchstat@latest
 // $ benchstat bench.txt

--- a/pkg/core/resources/apis/meshservice/match_benchmark_test.go
+++ b/pkg/core/resources/apis/meshservice/match_benchmark_test.go
@@ -13,22 +13,44 @@ import (
 
 // To run, remove X from the prefix
 // $ cd pkg/core/resources/apis/meshservice
-// $ go test -bench=BenchmarkMatchDataplanesWithMeshServices -run=^# -count 10 | tee bench.txt
+// $ go test -bench=BenchmarkMatchDataplanesWithMeshServices -benchmem -run=^# -count 10 | tee bench.txt
 // $ go install golang.org/x/perf/cmd/benchstat@latest
 // $ benchstat bench.txt
 // goos: darwin
 // goarch: arm64
 // pkg: github.com/kumahq/kuma/pkg/core/resources/apis/meshservice
 //
-//	│     bench.txt     │
-//	│     sec/op        │
+//	│  bench.txt  │
+//	│   sec/op    │
 //
-// MatchDataplanesWithMeshServices/faster-matching-ns_200-svc_20-dpp_5-10     0.02471n ± 1%
-// MatchDataplanesWithMeshServices/naive-matching-ns_200-svc_20-dpp_5-10        5.633 ± 1%
-// MatchDataplanesWithMeshServices/faster-matching-ns_50-svc_5-dpp_5-10      0.001591n ± 3%
-// MatchDataplanesWithMeshServices/naive-matching-ns_50-svc_5-dpp_5-10       0.02013n ± 1%
-// MatchDataplanesWithMeshServices/faster-matching-ns_10-svc_5-dpp_1-10     0.0001143n ± 9%
-// MatchDataplanesWithMeshServices/naive-matching-ns_10-svc_5-dpp_1-10     0.0001701n ± 4%
+// MatchDataplanesWithMeshServices/faster-matching-ns_200-svc_20-dpp_5-10   23.96m ± 4%
+// MatchDataplanesWithMeshServices/naive-matching-ns_200-svc_20-dpp_5-10     5.243 ± 4%
+// MatchDataplanesWithMeshServices/faster-matching-ns_50-svc_5-dpp_5-10     1.447m ± 4%
+// MatchDataplanesWithMeshServices/naive-matching-ns_50-svc_5-dpp_5-10      18.51m ± 0%
+// MatchDataplanesWithMeshServices/faster-matching-ns_10-svc_5-dpp_1-10     89.15µ ± 1%
+// MatchDataplanesWithMeshServices/naive-matching-ns_10-svc_5-dpp_1-10      149.5µ ± 2%
+// geomean                                                                  5.961m
+//
+//	│  bench.txt   │
+//	│     B/op     │
+//
+// MatchDataplanesWithMeshServices/faster-matching-ns_200-svc_20-dpp_5-10   15.61Mi ± 0%
+// MatchDataplanesWithMeshServices/naive-matching-ns_200-svc_20-dpp_5-10    1.055Mi ± 0%
+// MatchDataplanesWithMeshServices/faster-matching-ns_50-svc_5-dpp_5-10     971.0Ki ± 0%
+// MatchDataplanesWithMeshServices/naive-matching-ns_50-svc_5-dpp_5-10      67.88Ki ± 0%
+// MatchDataplanesWithMeshServices/faster-matching-ns_10-svc_5-dpp_1-10     84.60Ki ± 0%
+// MatchDataplanesWithMeshServices/naive-matching-ns_10-svc_5-dpp_1-10      9.911Ki ± 0%
+// geomean                                                                  313.8Ki
+//
+//	│  bench.txt  │
+//	│  allocs/op  │
+//
+// MatchDataplanesWithMeshServices/faster-matching-ns_200-svc_20-dpp_5-10   370.5k ± 0%
+// MatchDataplanesWithMeshServices/naive-matching-ns_200-svc_20-dpp_5-10    16.04k ± 0%
+// MatchDataplanesWithMeshServices/faster-matching-ns_50-svc_5-dpp_5-10     23.34k ± 0%
+// MatchDataplanesWithMeshServices/naive-matching-ns_50-svc_5-dpp_5-10      1.014k ± 0%
+// MatchDataplanesWithMeshServices/faster-matching-ns_10-svc_5-dpp_1-10     1.497k ± 0%
+// MatchDataplanesWithMeshServices/naive-matching-ns_10-svc_5-dpp_1-10       58.00 ± 0%
 func XBenchmarkMatchDataplanesWithMeshServices(b *testing.B) {
 	table := []struct {
 		dppsPerService       int
@@ -65,11 +87,15 @@ func XBenchmarkMatchDataplanesWithMeshServices(b *testing.B) {
 
 		suffix := fmt.Sprintf("-ns_%d-svc_%d-dpp_%d", testCase.namespaces, testCase.servicesPerNamespace, testCase.dppsPerService)
 		b.Run("faster-matching"+suffix, func(b *testing.B) {
-			_ = meshservice.MatchDataplanesWithMeshServices(dpps, meshServices, false)
+			for i := 0; i < b.N; i++ {
+				_ = meshservice.MatchDataplanesWithMeshServices(dpps, meshServices, false)
+			}
 		})
 
 		b.Run("naive-matching"+suffix, func(b *testing.B) {
-			_ = naiveMatching(dpps, meshServices)
+			for i := 0; i < b.N; i++ {
+				_ = naiveMatching(dpps, meshServices)
+			}
 		})
 	}
 }

--- a/pkg/core/resources/apis/meshservice/match_benchmark_test.go
+++ b/pkg/core/resources/apis/meshservice/match_benchmark_test.go
@@ -30,7 +30,7 @@ import (
 // MatchDataplanesWithMeshServices/faster-matching-ns_10-svc_5-dpp_1-10     0.0001143n ± 9%
 // MatchDataplanesWithMeshServices/naive-matching-ns_10-svc_5-dpp_1-10     0.0001701n ± 4%
 func XBenchmarkMatchDataplanesWithMeshServices(b *testing.B) {
-	var table = []struct {
+	table := []struct {
 		dppsPerService       int
 		servicesPerNamespace int
 		namespaces           int
@@ -71,9 +71,7 @@ func XBenchmarkMatchDataplanesWithMeshServices(b *testing.B) {
 		b.Run("naive-matching"+suffix, func(b *testing.B) {
 			_ = naiveMatching(dpps, meshServices)
 		})
-
 	}
-
 }
 
 func naiveMatching(dpps []*mesh.DataplaneResource, meshServices []*v1alpha1.MeshServiceResource) map[*v1alpha1.MeshServiceResource][]*mesh.DataplaneResource {

--- a/pkg/core/resources/apis/meshservice/match_benchmark_test.go
+++ b/pkg/core/resources/apis/meshservice/match_benchmark_test.go
@@ -19,38 +19,35 @@ import (
 // goos: darwin
 // goarch: arm64
 // pkg: github.com/kumahq/kuma/pkg/core/resources/apis/meshservice
+//                                                                        │  bench.txt  │
+//                                                                        │   sec/op    │
+// MatchDataplanesWithMeshServices/faster-matching-ns_200-svc_20-dpp_5-10   14.59m ± 1%
+// MatchDataplanesWithMeshServices/naive-matching-ns_200-svc_20-dpp_5-10     5.891 ± 0%
+// MatchDataplanesWithMeshServices/faster-matching-ns_50-svc_5-dpp_5-10     878.2µ ± 0%
+// MatchDataplanesWithMeshServices/naive-matching-ns_50-svc_5-dpp_5-10      20.52m ± 1%
+// MatchDataplanesWithMeshServices/faster-matching-ns_10-svc_5-dpp_1-10     63.44µ ± 0%
+// MatchDataplanesWithMeshServices/naive-matching-ns_10-svc_5-dpp_1-10      162.6µ ± 0%
+// geomean                                                                  5.019m
 //
-//	│  bench.txt  │
-//	│   sec/op    │
+//                                                                        │  bench.txt   │
+//                                                                        │     B/op     │
+// MatchDataplanesWithMeshServices/faster-matching-ns_200-svc_20-dpp_5-10   9.931Mi ± 0%
+// MatchDataplanesWithMeshServices/naive-matching-ns_200-svc_20-dpp_5-10    1.070Mi ± 0%
+// MatchDataplanesWithMeshServices/faster-matching-ns_50-svc_5-dpp_5-10     631.7Ki ± 0%
+// MatchDataplanesWithMeshServices/naive-matching-ns_50-svc_5-dpp_5-10      68.91Ki ± 0%
+// MatchDataplanesWithMeshServices/faster-matching-ns_10-svc_5-dpp_1-10     73.62Ki ± 0%
+// MatchDataplanesWithMeshServices/naive-matching-ns_10-svc_5-dpp_1-10      5.301Ki ± 0%
+// geomean                                                                  239.6Ki
 //
-// MatchDataplanesWithMeshServices/faster-matching-ns_200-svc_20-dpp_5-10   23.96m ± 4%
-// MatchDataplanesWithMeshServices/naive-matching-ns_200-svc_20-dpp_5-10     5.243 ± 4%
-// MatchDataplanesWithMeshServices/faster-matching-ns_50-svc_5-dpp_5-10     1.447m ± 4%
-// MatchDataplanesWithMeshServices/naive-matching-ns_50-svc_5-dpp_5-10      18.51m ± 0%
-// MatchDataplanesWithMeshServices/faster-matching-ns_10-svc_5-dpp_1-10     89.15µ ± 1%
-// MatchDataplanesWithMeshServices/naive-matching-ns_10-svc_5-dpp_1-10      149.5µ ± 2%
-// geomean                                                                  5.961m
-//
-//	│  bench.txt   │
-//	│     B/op     │
-//
-// MatchDataplanesWithMeshServices/faster-matching-ns_200-svc_20-dpp_5-10   15.61Mi ± 0%
-// MatchDataplanesWithMeshServices/naive-matching-ns_200-svc_20-dpp_5-10    1.055Mi ± 0%
-// MatchDataplanesWithMeshServices/faster-matching-ns_50-svc_5-dpp_5-10     971.0Ki ± 0%
-// MatchDataplanesWithMeshServices/naive-matching-ns_50-svc_5-dpp_5-10      67.88Ki ± 0%
-// MatchDataplanesWithMeshServices/faster-matching-ns_10-svc_5-dpp_1-10     84.60Ki ± 0%
-// MatchDataplanesWithMeshServices/naive-matching-ns_10-svc_5-dpp_1-10      9.911Ki ± 0%
-// geomean                                                                  313.8Ki
-//
-//	│  bench.txt  │
-//	│  allocs/op  │
-//
-// MatchDataplanesWithMeshServices/faster-matching-ns_200-svc_20-dpp_5-10   370.5k ± 0%
-// MatchDataplanesWithMeshServices/naive-matching-ns_200-svc_20-dpp_5-10    16.04k ± 0%
-// MatchDataplanesWithMeshServices/faster-matching-ns_50-svc_5-dpp_5-10     23.34k ± 0%
-// MatchDataplanesWithMeshServices/naive-matching-ns_50-svc_5-dpp_5-10      1.014k ± 0%
-// MatchDataplanesWithMeshServices/faster-matching-ns_10-svc_5-dpp_1-10     1.497k ± 0%
-// MatchDataplanesWithMeshServices/naive-matching-ns_10-svc_5-dpp_1-10       58.00 ± 0%
+//                                                                        │  bench.txt  │
+//                                                                        │  allocs/op  │
+// MatchDataplanesWithMeshServices/faster-matching-ns_200-svc_20-dpp_5-10   38.88k ± 0%
+// MatchDataplanesWithMeshServices/naive-matching-ns_200-svc_20-dpp_5-10    16.09k ± 0%
+// MatchDataplanesWithMeshServices/faster-matching-ns_50-svc_5-dpp_5-10     2.567k ± 0%
+// MatchDataplanesWithMeshServices/naive-matching-ns_50-svc_5-dpp_5-10      1.018k ± 0%
+// MatchDataplanesWithMeshServices/faster-matching-ns_10-svc_5-dpp_1-10      347.0 ± 0%
+// MatchDataplanesWithMeshServices/naive-matching-ns_10-svc_5-dpp_1-10       57.00 ± 0%
+// geomean                                                                  1.785k
 func XBenchmarkMatchDataplanesWithMeshServices(b *testing.B) {
 	table := []struct {
 		dppsPerService       int

--- a/pkg/core/resources/apis/meshservice/match_test.go
+++ b/pkg/core/resources/apis/meshservice/match_test.go
@@ -1,0 +1,231 @@
+package meshservice_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/resources/apis/meshservice"
+	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/test/resources/builders"
+)
+
+var _ = Describe("MatchDataplanesWithMeshServices", func() {
+	type testCase struct {
+		dpps             []*core_mesh.DataplaneResource
+		meshServices     []*meshservice_api.MeshServiceResource
+		expectedSummary  map[model.ResourceKey][]model.ResourceKey
+		matchOnlyHealthy bool
+	}
+
+	DescribeTable("matching dpps for mesh service",
+		func(given testCase) {
+			result := meshservice.MatchDataplanesWithMeshServices(given.dpps, given.meshServices, given.matchOnlyHealthy)
+			summary := map[model.ResourceKey][]model.ResourceKey{}
+			for ms, dpps := range result {
+				msKey := model.MetaToResourceKey(ms.GetMeta())
+				summary[msKey] = []model.ResourceKey{}
+				for _, dpp := range dpps {
+					summary[msKey] = append(summary[msKey], model.MetaToResourceKey(dpp.GetMeta()))
+				}
+			}
+			Expect(summary).To(Equal(given.expectedSummary))
+		},
+		Entry("should match by tags", testCase{
+			dpps: []*core_mesh.DataplaneResource{
+				builders.Dataplane().
+					WithName("redis-01").
+					WithInboundOfTags("kuma.io/service", "redis", "app", "redis", "k8s.kuma.io/namespace", "kuma-demo").
+					Build(),
+				builders.Dataplane().
+					WithName("redis-02").
+					WithInboundOfTags("kuma.io/service", "redis", "app", "redis", "k8s.kuma.io/namespace", "kuma-demo").
+					Build(),
+				builders.Dataplane().
+					WithName("demo-app-01").
+					WithInboundOfTags("kuma.io/service", "demo-app", "app", "demo-app", "k8s.kuma.io/namespace", "kuma-demo").
+					Build(),
+			},
+			meshServices: []*meshservice_api.MeshServiceResource{
+				builders.MeshService().
+					WithName("redis").
+					WithDataplaneTagsSelectorKV("app", "redis", "k8s.kuma.io/namespace", "kuma-demo").
+					Build(),
+				builders.MeshService().
+					WithName("demo-app").
+					WithDataplaneTagsSelectorKV("app", "demo-app", "k8s.kuma.io/namespace", "kuma-demo").
+					Build(),
+			},
+			expectedSummary: map[model.ResourceKey][]model.ResourceKey{
+				{Mesh: "default", Name: "redis"}: {
+					{Mesh: "default", Name: "redis-01"},
+					{Mesh: "default", Name: "redis-02"},
+				},
+				{Mesh: "default", Name: "demo-app"}: {
+					{Mesh: "default", Name: "demo-app-01"},
+				},
+			},
+		}),
+		Entry("should not duplicate multiple inbounds in the result", testCase{
+			dpps: []*core_mesh.DataplaneResource{
+				builders.Dataplane().
+					WithName("demo-app-01").
+					WithoutInbounds().
+					AddInboundOfTags("kuma.io/service", "demo-app", "app", "demo-app", "k8s.kuma.io/namespace", "kuma-demo").
+					AddInboundOfTags("kuma.io/service", "demo-app-admin", "app", "demo-app", "k8s.kuma.io/namespace", "kuma-demo").
+					Build(),
+			},
+			meshServices: []*meshservice_api.MeshServiceResource{
+				builders.MeshService().
+					WithName("demo-app").
+					WithDataplaneTagsSelectorKV("app", "demo-app", "k8s.kuma.io/namespace", "kuma-demo").
+					Build(),
+			},
+			expectedSummary: map[model.ResourceKey][]model.ResourceKey{
+				{Mesh: "default", Name: "demo-app"}: {
+					{Mesh: "default", Name: "demo-app-01"},
+				},
+			},
+		}),
+		Entry("should not mix meshes", testCase{
+			dpps: []*core_mesh.DataplaneResource{
+				builders.Dataplane().
+					WithName("redis-01").
+					WithInboundOfTags("kuma.io/service", "redis", "app", "redis", "k8s.kuma.io/namespace", "kuma-demo").
+					Build(),
+				builders.Dataplane().
+					WithName("redis-02").
+					WithMesh("mesh-other").
+					WithInboundOfTags("kuma.io/service", "redis", "app", "redis", "k8s.kuma.io/namespace", "kuma-demo").
+					Build(),
+			},
+			meshServices: []*meshservice_api.MeshServiceResource{
+				builders.MeshService().
+					WithName("redis").
+					WithDataplaneTagsSelectorKV("app", "redis", "k8s.kuma.io/namespace", "kuma-demo").
+					Build(),
+				builders.MeshService().
+					WithName("redis").
+					WithMesh("mesh-other").
+					WithDataplaneTagsSelectorKV("app", "redis", "k8s.kuma.io/namespace", "kuma-demo").
+					Build(),
+			},
+			expectedSummary: map[model.ResourceKey][]model.ResourceKey{
+				{Mesh: "default", Name: "redis"}: {
+					{Mesh: "default", Name: "redis-01"},
+				},
+				{Mesh: "mesh-other", Name: "redis"}: {
+					{Mesh: "mesh-other", Name: "redis-02"},
+				},
+			},
+		}),
+		Entry("should not match mesh service that selects nothing", testCase{
+			dpps: []*core_mesh.DataplaneResource{
+				builders.Dataplane().
+					WithName("redis-01").
+					WithInboundOfTags("kuma.io/service", "redis", "app", "redis", "k8s.kuma.io/namespace", "kuma-demo").
+					Build(),
+			},
+			meshServices: []*meshservice_api.MeshServiceResource{
+				builders.MeshService().
+					WithName("demo-app").
+					WithDataplaneTagsSelectorKV("app", "demo-app", "k8s.kuma.io/namespace", "kuma-demo").
+					Build(),
+			},
+			expectedSummary: map[model.ResourceKey][]model.ResourceKey{
+				{Mesh: "default", Name: "demo-app"}: {},
+			},
+		}),
+		Entry("should not match unhealthy inbound matched by tags", testCase{
+			matchOnlyHealthy: true,
+			dpps: []*core_mesh.DataplaneResource{
+				builders.Dataplane().
+					WithName("redis-01").
+					WithInboundOfTags("kuma.io/service", "redis", "app", "redis", "k8s.kuma.io/namespace", "kuma-demo").
+					With(func(resource *core_mesh.DataplaneResource) {
+						resource.Spec.Networking.Inbound[0].State = mesh_proto.Dataplane_Networking_Inbound_NotReady
+					}).
+					Build(),
+			},
+			meshServices: []*meshservice_api.MeshServiceResource{
+				builders.MeshService().
+					WithName("redis").
+					WithDataplaneTagsSelectorKV("app", "redis", "k8s.kuma.io/namespace", "kuma-demo").
+					Build(),
+			},
+			expectedSummary: map[model.ResourceKey][]model.ResourceKey{
+				{Mesh: "default", Name: "redis"}: {},
+			},
+		}),
+		Entry("should match by ref name", testCase{
+			dpps: []*core_mesh.DataplaneResource{
+				builders.Dataplane().
+					WithName("redis-01").
+					WithInboundOfTags("kuma.io/service", "redis", "app", "redis", "k8s.kuma.io/namespace", "kuma-demo").
+					Build(),
+				builders.Dataplane().
+					WithName("demo-app-01").
+					WithInboundOfTags("kuma.io/service", "demo-app", "app", "demo-app", "k8s.kuma.io/namespace", "kuma-demo").
+					Build(),
+			},
+			meshServices: []*meshservice_api.MeshServiceResource{
+				builders.MeshService().
+					WithName("redis").
+					WithDataplaneRefNameSelector("redis-01").
+					Build(),
+				builders.MeshService().
+					WithName("demo-app").
+					WithDataplaneRefNameSelector("demo-app-01").
+					Build(),
+			},
+			expectedSummary: map[model.ResourceKey][]model.ResourceKey{
+				{Mesh: "default", Name: "redis"}: {
+					{Mesh: "default", Name: "redis-01"},
+				},
+				{Mesh: "default", Name: "demo-app"}: {
+					{Mesh: "default", Name: "demo-app-01"},
+				},
+			},
+		}),
+		Entry("should not match names that did not match", testCase{
+			dpps: []*core_mesh.DataplaneResource{
+				builders.Dataplane().
+					WithName("redis-01").
+					WithInboundOfTags("kuma.io/service", "redis", "app", "redis", "k8s.kuma.io/namespace", "kuma-demo").
+					Build(),
+			},
+			meshServices: []*meshservice_api.MeshServiceResource{
+				builders.MeshService().
+					WithName("redis").
+					WithDataplaneRefNameSelector("redis-not-found").
+					Build(),
+			},
+			expectedSummary: map[model.ResourceKey][]model.ResourceKey{
+				{Mesh: "default", Name: "redis"}: {},
+			},
+		}),
+		Entry("should not match unhealthy inbound matched by name", testCase{
+			matchOnlyHealthy: true,
+			dpps: []*core_mesh.DataplaneResource{
+				builders.Dataplane().
+					WithName("redis-01").
+					WithInboundOfTags("kuma.io/service", "redis", "app", "redis", "k8s.kuma.io/namespace", "kuma-demo").
+					With(func(resource *core_mesh.DataplaneResource) {
+						resource.Spec.Networking.Inbound[0].State = mesh_proto.Dataplane_Networking_Inbound_NotReady
+					}).
+					Build(),
+			},
+			meshServices: []*meshservice_api.MeshServiceResource{
+				builders.MeshService().
+					WithName("redis").
+					WithDataplaneRefNameSelector("redis-01").
+					Build(),
+			},
+			expectedSummary: map[model.ResourceKey][]model.ResourceKey{
+				{Mesh: "default", Name: "redis"}: {},
+			},
+		}),
+	)
+})

--- a/pkg/core/resources/apis/meshservice/status/updater.go
+++ b/pkg/core/resources/apis/meshservice/status/updater.go
@@ -11,6 +11,7 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/resources/apis/meshservice"
 	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/runtime/component"
@@ -86,16 +87,13 @@ func (s *StatusUpdater) updateStatus(ctx context.Context) error {
 	if err := s.roResManager.List(ctx, &dpList); err != nil {
 		return errors.Wrap(err, "could not list of Dataplanes")
 	}
-	dpInsights := mesh.DataplaneInsightResourceList{}
-	if err := s.roResManager.List(ctx, &dpInsights); err != nil {
-		return errors.Wrap(err, "could not list of Dataplanes")
-	}
-	dpOverviews := mesh.NewDataplaneOverviews(dpList, dpInsights)
 
-	for ms, dpOverviews := range dataplaneOverviewsForMeshService(dpOverviews.Items, msList.Items) {
+	dppsForMs := meshservice.MatchDataplanesWithMeshServices(dpList.Items, msList.Items, false)
+
+	for ms, dpps := range dppsForMs {
 		serviceTagIdentities := map[string]struct{}{}
-		for _, dpOverview := range dpOverviews {
-			for service := range dpOverview.Spec.Dataplane.TagSet()[mesh_proto.ServiceTag] {
+		for _, dpp := range dpps {
+			for service := range dpp.Spec.TagSet()[mesh_proto.ServiceTag] {
 				serviceTagIdentities[service] = struct{}{}
 			}
 		}
@@ -116,21 +114,6 @@ func (s *StatusUpdater) updateStatus(ctx context.Context) error {
 		}
 	}
 	return nil
-}
-
-func dataplaneOverviewsForMeshService(
-	dpOverviews []*mesh.DataplaneOverviewResource,
-	meshServices []*meshservice_api.MeshServiceResource,
-) map[*meshservice_api.MeshServiceResource][]*mesh.DataplaneOverviewResource {
-	result := map[*meshservice_api.MeshServiceResource][]*mesh.DataplaneOverviewResource{}
-	for _, ms := range meshServices {
-		for _, dpOverview := range dpOverviews {
-			if dpOverview.Spec.Dataplane.Matches(mesh_proto.TagSelector(ms.Spec.Selector.DataplaneTags)) {
-				result[ms] = append(result[ms], dpOverview)
-			}
-		}
-	}
-	return result
 }
 
 func (s *StatusUpdater) NeedLeaderElection() bool {

--- a/pkg/core/resources/apis/meshservice/suite_test.go
+++ b/pkg/core/resources/apis/meshservice/suite_test.go
@@ -1,0 +1,11 @@
+package meshservice_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/pkg/test"
+)
+
+func TestMeshService(t *testing.T) {
+	test.RunSpecs(t, "MeshService Suite")
+}

--- a/pkg/test/resources/builders/meshservice_builder.go
+++ b/pkg/test/resources/builders/meshservice_builder.go
@@ -44,11 +44,24 @@ func (m *MeshServiceBuilder) WithMesh(mesh string) *MeshServiceBuilder {
 	return m
 }
 
+func (m *MeshServiceBuilder) WithDataplaneRefNameSelector(name string) *MeshServiceBuilder {
+	m.res.Spec.Selector = v1alpha1.Selector{
+		DataplaneRef: &v1alpha1.DataplaneRef{
+			Name: name,
+		},
+	}
+	return m
+}
+
 func (m *MeshServiceBuilder) WithDataplaneTagsSelector(selector map[string]string) *MeshServiceBuilder {
 	m.res.Spec.Selector = v1alpha1.Selector{
 		DataplaneTags: selector,
 	}
 	return m
+}
+
+func (m *MeshServiceBuilder) WithDataplaneTagsSelectorKV(selectorKV ...string) *MeshServiceBuilder {
+	return m.WithDataplaneTagsSelector(TagsKVToMap(selectorKV))
 }
 
 func (m *MeshServiceBuilder) AddIntPort(port, target uint32, protocol core_mesh.Protocol) *MeshServiceBuilder {

--- a/pkg/xds/topology/outbound.go
+++ b/pkg/xds/topology/outbound.go
@@ -300,7 +300,6 @@ func fillLocalMeshServices(
 				}
 			}
 		}
-
 	}
 }
 


### PR DESCRIPTION
### Checklist prior to review

Fix #10477

This PR optimizes MeshService to Dataplane matching.
Instead of naive `O(n_mehservices * n_datpalanes)` we now do `O(n_mehservices * n_shortest_list_of_matched_tag_dpps + n_datpalanes)`, so in practice, it's almost a linear complexity.

The idea is to index all the DPPs by tag pairs, for each MeshService select the shortest list of DPPs of all tag pairs and then only iterate over this shortest list. In practice this is usually `app: xyz` or `kuma.io/service: xyz` so all of them will match.

I also did benchmarks. On small data (10 namespaces, 5 services per namespace, 1 dpp per service) naive version takes 50% more time. On large data (200 namespaces , 20 services per namespace, 5 dpps per service) it takes 230x more time.


<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
