### PR TITLE
test(e2e): add assertions to not panic in e2e tests

### DIFF
--- a/test/e2e_env/kubernetes/kubernetes_suite_test.go
+++ b/test/e2e_env/kubernetes/kubernetes_suite_test.go
@@ -50,8 +50,10 @@ var _ = E2ESynchronizedBeforeSuite(kubernetes.SetupAndGetState, kubernetes.Resto
 // SynchronizedAfterSuite keeps the main process alive until all other processes finish.
 // Otherwise, we would close port-forward to the CP and remaining tests executed in different processes may fail.
 var (
-	_ = SynchronizedAfterSuite(func() {}, kubernetes.ExpectCpToNotCrash)
-	_ = SynchronizedAfterSuite(func() {}, kubernetes.ExpectCpToNotPanic)
+	_ = SynchronizedAfterSuite(func() {}, func() {
+		kubernetes.ExpectCpToNotCrash()
+		kubernetes.ExpectCpToNotPanic()
+	})
 )
 
 var (

--- a/test/e2e_env/kubernetes/kubernetes_suite_test.go
+++ b/test/e2e_env/kubernetes/kubernetes_suite_test.go
@@ -49,8 +49,10 @@ var _ = E2ESynchronizedBeforeSuite(kubernetes.SetupAndGetState, kubernetes.Resto
 
 // SynchronizedAfterSuite keeps the main process alive until all other processes finish.
 // Otherwise, we would close port-forward to the CP and remaining tests executed in different processes may fail.
-var _ = SynchronizedAfterSuite(func() {}, kubernetes.ExpectCpToNotCrash)
-var _ = SynchronizedAfterSuite(func() {}, kubernetes.ExceptCpToNotPanic)
+var (
+	_ = SynchronizedAfterSuite(func() {}, kubernetes.ExpectCpToNotCrash)
+	_ = SynchronizedAfterSuite(func() {}, kubernetes.ExpectCpToNotPanic)
+)
 
 var (
 	_ = ReportAfterSuite("cp logs", kubernetes.PrintCPLogsOnFailure)

--- a/test/e2e_env/kubernetes/kubernetes_suite_test.go
+++ b/test/e2e_env/kubernetes/kubernetes_suite_test.go
@@ -50,6 +50,7 @@ var _ = E2ESynchronizedBeforeSuite(kubernetes.SetupAndGetState, kubernetes.Resto
 // SynchronizedAfterSuite keeps the main process alive until all other processes finish.
 // Otherwise, we would close port-forward to the CP and remaining tests executed in different processes may fail.
 var _ = SynchronizedAfterSuite(func() {}, kubernetes.ExpectCpToNotCrash)
+var _ = SynchronizedAfterSuite(func() {}, kubernetes.ExceptCpToNotPanic)
 
 var (
 	_ = ReportAfterSuite("cp logs", kubernetes.PrintCPLogsOnFailure)

--- a/test/e2e_env/multizone/multizone_suite_test.go
+++ b/test/e2e_env/multizone/multizone_suite_test.go
@@ -39,6 +39,7 @@ func TestE2E(t *testing.T) {
 var (
 	_ = E2ESynchronizedBeforeSuite(multizone.SetupAndGetState, multizone.RestoreState)
 	_ = SynchronizedAfterSuite(func() {}, multizone.ExpectCpsToNotCrash)
+	_ = SynchronizedAfterSuite(func() {}, multizone.ExpectCpsToNotPanic)
 	_ = ReportAfterSuite("cleanup", func(report Report) {
 		if Config.CleanupLogsOnSuccess {
 			universal_logs.CleanupIfSuccess(Config.UniversalE2ELogsPath, report)

--- a/test/e2e_env/multizone/multizone_suite_test.go
+++ b/test/e2e_env/multizone/multizone_suite_test.go
@@ -38,8 +38,10 @@ func TestE2E(t *testing.T) {
 
 var (
 	_ = E2ESynchronizedBeforeSuite(multizone.SetupAndGetState, multizone.RestoreState)
-	_ = SynchronizedAfterSuite(func() {}, multizone.ExpectCpsToNotCrash)
-	_ = SynchronizedAfterSuite(func() {}, multizone.ExpectCpsToNotPanic)
+	_ = SynchronizedAfterSuite(func() {}, func() {
+		multizone.ExpectCpsToNotCrash()
+		multizone.ExpectCpsToNotPanic()
+	})
 	_ = ReportAfterSuite("cleanup", func(report Report) {
 		if Config.CleanupLogsOnSuccess {
 			universal_logs.CleanupIfSuccess(Config.UniversalE2ELogsPath, report)

--- a/test/e2e_env/universal/universal_suite_test.go
+++ b/test/e2e_env/universal/universal_suite_test.go
@@ -53,6 +53,7 @@ func TestE2E(t *testing.T) {
 
 var (
 	_ = E2ESynchronizedBeforeSuite(universal.SetupAndGetState, universal.RestoreState)
+	_ = SynchronizedAfterSuite(func() {}, universal.ExceptCpToNotPanic)
 	_ = ReportAfterSuite("cleanup", func(report Report) {
 		if Config.CleanupLogsOnSuccess {
 			universal_logs.CleanupIfSuccess(Config.UniversalE2ELogsPath, report)

--- a/test/e2e_env/universal/universal_suite_test.go
+++ b/test/e2e_env/universal/universal_suite_test.go
@@ -53,7 +53,7 @@ func TestE2E(t *testing.T) {
 
 var (
 	_ = E2ESynchronizedBeforeSuite(universal.SetupAndGetState, universal.RestoreState)
-	_ = SynchronizedAfterSuite(func() {}, universal.ExceptCpToNotPanic)
+	_ = SynchronizedAfterSuite(func() {}, universal.ExpectCpToNotPanic)
 	_ = ReportAfterSuite("cleanup", func(report Report) {
 		if Config.CleanupLogsOnSuccess {
 			universal_logs.CleanupIfSuccess(Config.UniversalE2ELogsPath, report)

--- a/test/framework/envs/kubernetes/env.go
+++ b/test/framework/envs/kubernetes/env.go
@@ -2,9 +2,8 @@ package kubernetes
 
 import (
 	"encoding/json"
-	"strings"
-
 	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/kumahq/kuma/test/framework/utils"
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -112,6 +111,6 @@ func ExceptCpToNotPanic() {
 	if err != nil {
 		framework.Logf("could not retrieve cp logs")
 	} else {
-		Expect(strings.Contains(logs, "runtime.gopanic")).To(BeFalse())
+		Expect(utils.HasPanicInCpLogs(logs)).To(BeFalse())
 	}
 }

--- a/test/framework/envs/kubernetes/env.go
+++ b/test/framework/envs/kubernetes/env.go
@@ -2,13 +2,14 @@ package kubernetes
 
 import (
 	"encoding/json"
+
 	"github.com/gruntwork-io/terratest/modules/k8s"
-	"github.com/kumahq/kuma/test/framework/utils"
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/utils"
 )
 
 var Cluster *framework.K8sCluster
@@ -106,7 +107,7 @@ func ExpectCpToNotCrash() {
 	Expect(restartCount).To(Equal(0), "CP restarted in this suite, this should not happen.")
 }
 
-func ExceptCpToNotPanic() {
+func ExpectCpToNotPanic() {
 	logs, err := Cluster.GetKumaCPLogs()
 	if err != nil {
 		framework.Logf("could not retrieve cp logs")

--- a/test/framework/envs/kubernetes/env.go
+++ b/test/framework/envs/kubernetes/env.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/onsi/ginkgo/v2"
@@ -104,4 +105,13 @@ func PrintKubeState(report ginkgo.Report) {
 func ExpectCpToNotCrash() {
 	restartCount := framework.RestartCount(Cluster.GetKuma().(*framework.K8sControlPlane).GetKumaCPPods())
 	Expect(restartCount).To(Equal(0), "CP restarted in this suite, this should not happen.")
+}
+
+func ExceptCpToNotPanic() {
+	logs, err := Cluster.GetKumaCPLogs()
+	if err != nil {
+		framework.Logf("could not retrieve cp logs")
+	} else {
+		Expect(strings.Contains(logs, "runtime.gopanic")).To(BeFalse())
+	}
 }

--- a/test/framework/envs/multizone/env.go
+++ b/test/framework/envs/multizone/env.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"sync"
 
-
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/test/framework/envs/multizone/env.go
+++ b/test/framework/envs/multizone/env.go
@@ -2,6 +2,7 @@ package multizone
 
 import (
 	"encoding/json"
+	"strings"
 	"sync"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
@@ -315,4 +316,15 @@ func ExpectCpsToNotCrash() {
 	Expect(restartCount).To(Equal(0), "Zone 1 CP restarted in this suite, this should not happen.")
 	restartCount = framework.RestartCount(KubeZone2.GetKuma().(*framework.K8sControlPlane).GetKumaCPPods())
 	Expect(restartCount).To(Equal(0), "Zone 2 CP restarted in this suite, this should not happen.")
+}
+
+func ExpectCpsToNotPanic() {
+	for _, cluster := range append(Zones(), Global) {
+		logs, err := cluster.GetKumaCPLogs()
+		if err != nil {
+			Logf("could not retrieve cp logs")
+		} else {
+			Expect(strings.Contains(logs, "runtime.gopanic")).To(BeFalse())
+		}
+	}
 }

--- a/test/framework/envs/multizone/env.go
+++ b/test/framework/envs/multizone/env.go
@@ -2,8 +2,8 @@ package multizone
 
 import (
 	"encoding/json"
-	"github.com/kumahq/kuma/test/framework/utils"
 	"sync"
+
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	. "github.com/onsi/ginkgo/v2"
@@ -12,6 +12,7 @@ import (
 	"github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/test/framework"
 	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/utils"
 )
 
 var (

--- a/test/framework/envs/multizone/env.go
+++ b/test/framework/envs/multizone/env.go
@@ -2,7 +2,7 @@ package multizone
 
 import (
 	"encoding/json"
-	"strings"
+	"github.com/kumahq/kuma/test/framework/utils"
 	"sync"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
@@ -324,7 +324,7 @@ func ExpectCpsToNotPanic() {
 		if err != nil {
 			Logf("could not retrieve cp logs")
 		} else {
-			Expect(strings.Contains(logs, "runtime.gopanic")).To(BeFalse())
+			Expect(utils.HasPanicInCpLogs(logs)).To(BeFalse())
 		}
 	}
 }

--- a/test/framework/envs/universal/env.go
+++ b/test/framework/envs/universal/env.go
@@ -2,6 +2,7 @@ package universal
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -65,5 +66,14 @@ func PrintCPLogsOnFailure(report ginkgo.Report) {
 		} else {
 			framework.Logf(logs)
 		}
+	}
+}
+
+func ExceptCpToNotPanic() {
+	logs, err := Cluster.GetKumaCPLogs()
+	if err != nil {
+		framework.Logf("could not retrieve cp logs")
+	} else {
+		Expect(strings.Contains(logs, "runtime.gopanic")).To(BeFalse())
 	}
 }

--- a/test/framework/envs/universal/env.go
+++ b/test/framework/envs/universal/env.go
@@ -2,8 +2,7 @@ package universal
 
 import (
 	"encoding/json"
-	"strings"
-
+	"github.com/kumahq/kuma/test/framework/utils"
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -74,6 +73,6 @@ func ExceptCpToNotPanic() {
 	if err != nil {
 		framework.Logf("could not retrieve cp logs")
 	} else {
-		Expect(strings.Contains(logs, "runtime.gopanic")).To(BeFalse())
+		Expect(utils.HasPanicInCpLogs(logs)).To(BeFalse())
 	}
 }

--- a/test/framework/envs/universal/env.go
+++ b/test/framework/envs/universal/env.go
@@ -3,7 +3,6 @@ package universal
 import (
 	"encoding/json"
 
-
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 

--- a/test/framework/envs/universal/env.go
+++ b/test/framework/envs/universal/env.go
@@ -2,12 +2,14 @@ package universal
 
 import (
 	"encoding/json"
-	"github.com/kumahq/kuma/test/framework/utils"
+
+
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/utils"
 )
 
 var Cluster *framework.UniversalCluster
@@ -68,7 +70,7 @@ func PrintCPLogsOnFailure(report ginkgo.Report) {
 	}
 }
 
-func ExceptCpToNotPanic() {
+func ExpectCpToNotPanic() {
 	logs, err := Cluster.GetKumaCPLogs()
 	if err != nil {
 		framework.Logf("could not retrieve cp logs")

--- a/test/framework/utils/utils.go
+++ b/test/framework/utils/utils.go
@@ -42,3 +42,7 @@ func TestCaseName(ginkgo ginko.FullGinkgoTInterface) string {
 	nameSplit := strings.Split(ginkgo.Name(), " ")
 	return nameSplit[len(nameSplit)-1]
 }
+
+func HasPanicInCpLogs(logs string) bool {
+	return strings.Contains(logs, "runtime.gopanic") || strings.Contains(logs, "panic:")
+}


### PR DESCRIPTION
so we know earlier about: https://github.com/kumahq/kuma/actions/runs/9603592697/job/26488848273#step:13:25165 

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
