### PR TITLE
test(e2e): set concurrency level for gateway

### DIFF
--- a/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid_gateway.go
+++ b/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid_gateway.go
@@ -93,7 +93,7 @@ conf:
 
 		// Universal Zone 4
 		Expect(NewClusterSetup().
-			Install(GatewayProxyUniversal(mesh, "edge-gateway")).
+			Install(GatewayProxyUniversal(mesh, "edge-gateway", WithConcurrency(1))).
 			Install(TestServerUniversal("gateway-client", mesh, WithoutDataplane())).
 			Install(TestServerUniversal("test-server-zone-4", mesh,
 				WithServiceName("test-server_locality-aware-lb-gateway_svc_80"),

--- a/test/framework/gateway.go
+++ b/test/framework/gateway.go
@@ -2,7 +2,7 @@ package framework
 
 import "fmt"
 
-func GatewayProxyUniversal(mesh, name string) InstallFunc {
+func GatewayProxyUniversal(mesh, name string, appDeploymentOptions ...AppDeploymentOption) InstallFunc {
 	return func(cluster Cluster) error {
 		token, err := cluster.GetKuma().GenerateDpToken(mesh, name)
 		if err != nil {
@@ -20,12 +20,9 @@ networking:
     tags:
       kuma.io/service: %s
 `, mesh, name)
-		return cluster.DeployApp(
-			WithName(name),
-			WithMesh(mesh),
-			WithToken(token),
-			WithVerbose(),
-			WithYaml(dataplaneYaml),
-		)
+
+		deploymentOpts := []AppDeploymentOption{WithName(name), WithMesh(mesh), WithToken(token), WithVerbose(), WithYaml(dataplaneYaml)}
+		deploymentOpts = append(deploymentOpts, appDeploymentOptions...)
+		return cluster.DeployApp(deploymentOpts...)
 	}
 }


### PR DESCRIPTION
### Checklist prior to review

We can sometimes observe inconsistencies in the number of requests reaching a specific server. Since each Envoy worker might take and serve a request, the distribution might not closely adhere to the assigned weights. By specifying the concurrency level as 1, the behavior might become more predictable.


- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
