### PR TITLE
test(e2e): use MeshService managed-by label, same as when autogenerated

### DIFF
--- a/test/e2e_env/multizone/meshservice/connectivity.go
+++ b/test/e2e_env/multizone/meshservice/connectivity.go
@@ -28,7 +28,7 @@ spec:
     meshService:
       matchLabels:
         kuma.io/origin: global
-        kuma.io/env: kubernetes
+        kuma.io/managed-by: k8s-controller
 `)).
 			Install(YamlUniversal(`
 type: HostnameGenerator
@@ -53,7 +53,7 @@ metadata:
   labels:
     kuma.io/origin: zone
     kuma.io/mesh: msconnectivity
-    kuma.io/env: kubernetes
+    kuma.io/managed-by: k8s-controller
 spec:
   selector:
     dataplaneTags:


### PR DESCRIPTION
This works now because we create the MeshService manually.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
