### PR TITLE
test(e2e): add HeadlessService option to test-server deployment

### DIFF
--- a/test/e2e/virtualoutbound/virtualoutbound_k8s.go
+++ b/test/e2e/virtualoutbound/virtualoutbound_k8s.go
@@ -24,7 +24,7 @@ func VirtualOutboundOnK8s() {
 			)).
 			Install(NamespaceWithSidecarInjection(namespace)).
 			Install(democlient.Install(democlient.WithNamespace(namespace), democlient.WithMesh("default"))).
-			Install(testserver.Install(testserver.WithStatefulSet(true), testserver.WithReplicas(2), testserver.WithNamespace(namespace))).
+			Install(testserver.Install(testserver.WithStatefulSet(), testserver.WithReplicas(2), testserver.WithNamespace(namespace))).
 			Setup(k8sCluster)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/test/e2e_env/kubernetes/gateway/delegated.go
+++ b/test/e2e_env/kubernetes/gateway/delegated.go
@@ -40,7 +40,7 @@ func Delegated() {
 				testserver.WithMesh(config.Mesh),
 				testserver.WithNamespace(config.Namespace),
 				testserver.WithName("test-server"),
-				testserver.WithStatefulSet(true),
+				testserver.WithStatefulSet(),
 				testserver.WithReplicas(3),
 			)).
 			Install(testserver.Install(

--- a/test/e2e_env/kubernetes/gateway/gateway.go
+++ b/test/e2e_env/kubernetes/gateway/gateway.go
@@ -563,7 +563,7 @@ spec:
 					testserver.WithMesh(meshName),
 					testserver.WithNamespace(namespace),
 					testserver.WithName("test-server-mlbs"),
-					testserver.WithStatefulSet(true),
+					testserver.WithStatefulSet(),
 					testserver.WithReplicas(3),
 				)).
 				Install(YamlK8s(routes...)).

--- a/test/e2e_env/kubernetes/virtualoutbound/virtualoutbound.go
+++ b/test/e2e_env/kubernetes/virtualoutbound/virtualoutbound.go
@@ -24,7 +24,7 @@ func VirtualOutbound() {
 			Install(testserver.Install(
 				testserver.WithMesh(meshName),
 				testserver.WithNamespace(namespace),
-				testserver.WithStatefulSet(true),
+				testserver.WithStatefulSet(),
 				testserver.WithReplicas(2),
 			)).
 			Setup(kubernetes.Cluster)

--- a/test/e2e_env/multizone/virtualoutbound/virtualoutbound.go
+++ b/test/e2e_env/multizone/virtualoutbound/virtualoutbound.go
@@ -47,7 +47,7 @@ func virtualOutbound(meshName string, meshBuilder *builders.MeshBuilder) {
 			Install(testserver.Install(
 				testserver.WithNamespace(namespace),
 				testserver.WithMesh(meshName),
-				testserver.WithStatefulSet(true),
+				testserver.WithStatefulSet(),
 				testserver.WithReplicas(2),
 			)).
 			Setup(multizone.KubeZone2)

--- a/test/framework/deployments/testserver/deployment.go
+++ b/test/framework/deployments/testserver/deployment.go
@@ -20,6 +20,7 @@ type DeploymentOpts struct {
 	WaitingToBeReady    bool
 	EnableProbes        bool
 	EnableService       bool
+	HeadlessService     bool
 	PodAnnotations      map[string]string
 	PodLabels           map[string]string
 	NodeSelector        map[string]string
@@ -133,6 +134,12 @@ func WithoutProbes() DeploymentOptsFn {
 func WithoutService() DeploymentOptsFn {
 	return func(opts *DeploymentOpts) {
 		opts.EnableService = false
+	}
+}
+
+func WithHeadlessService() DeploymentOptsFn {
+	return func(opts *DeploymentOpts) {
+		opts.HeadlessService = true
 	}
 }
 

--- a/test/framework/deployments/testserver/deployment.go
+++ b/test/framework/deployments/testserver/deployment.go
@@ -83,9 +83,9 @@ func WithReplicas(n int32) DeploymentOptsFn {
 	}
 }
 
-func WithStatefulSet(apply bool) DeploymentOptsFn {
+func WithStatefulSet() DeploymentOptsFn {
 	return func(opts *DeploymentOpts) {
-		opts.WithStatefulSet = apply
+		opts.WithStatefulSet = true
 	}
 }
 

--- a/test/framework/deployments/testserver/kubernetes.go
+++ b/test/framework/deployments/testserver/kubernetes.go
@@ -55,6 +55,12 @@ func (k *k8SDeployment) service() *corev1.Service {
 	}
 }
 
+func (k *k8SDeployment) headlessService() *corev1.Service {
+	svc := k.service()
+	svc.Spec.ClusterIP = corev1.ClusterIPNone
+	return svc
+}
+
 func (k *k8SDeployment) serviceAccount() *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		TypeMeta: metav1.TypeMeta{
@@ -305,7 +311,11 @@ func (k *k8SDeployment) Deploy(cluster framework.Cluster) error {
 		funcs = append(funcs, framework.YamlK8sObject(k.deployment()))
 	}
 	if k.opts.EnableService {
-		funcs = append(funcs, framework.YamlK8sObject(k.service()))
+		if k.opts.HeadlessService {
+			funcs = append(funcs, framework.YamlK8sObject(k.headlessService()))
+		} else {
+			funcs = append(funcs, framework.YamlK8sObject(k.service()))
+		}
 	}
 	if k.opts.WaitingToBeReady {
 		funcs = append(funcs,


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
