### PR TITLE
fix(cni): set proper namespace for the taint controller

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -673,6 +673,8 @@ spec:
               value: "docker.io/kumahq/kuma-dp:0.0.1"
             - name: KUMA_RUNTIME_KUBERNETES_NODE_TAINT_CONTROLLER_CNI_APP
               value: "kuma-cni"
+            - name: KUMA_RUNTIME_KUBERNETES_NODE_TAINT_CONTROLLER_CNI_NAMESPACE
+              value: "kube-system"
             - name: KUMA_RUNTIME_KUBERNETES_NODE_TAINT_CONTROLLER_ENABLED
               value: "true"
             - name: KUMA_STORE_KUBERNETES_SYSTEM_NAMESPACE

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
@@ -749,6 +749,8 @@ spec:
               value: "docker.io/kumahq/kuma-dp:0.0.1"
             - name: KUMA_RUNTIME_KUBERNETES_NODE_TAINT_CONTROLLER_CNI_APP
               value: "kuma-cni"
+            - name: KUMA_RUNTIME_KUBERNETES_NODE_TAINT_CONTROLLER_CNI_NAMESPACE
+              value: "kube-system"
             - name: KUMA_RUNTIME_KUBERNETES_NODE_TAINT_CONTROLLER_ENABLED
               value: "true"
             - name: KUMA_STORE_KUBERNETES_SYSTEM_NAMESPACE

--- a/deployments/charts/kuma/templates/_helpers.tpl
+++ b/deployments/charts/kuma/templates/_helpers.tpl
@@ -274,6 +274,8 @@ env:
   value: "true"
 - name: KUMA_RUNTIME_KUBERNETES_NODE_TAINT_CONTROLLER_CNI_APP
   value: "{{ include "kuma.name" . }}-cni"
+- name: KUMA_RUNTIME_KUBERNETES_NODE_TAINT_CONTROLLER_CNI_NAMESPACE
+  value: {{ .Values.cni.namespace }}
 {{- end }}
 {{- if .Values.experimental.ebpf.enabled }}
 - name: KUMA_RUNTIME_KUBERNETES_INJECTOR_EBPF_ENABLED

--- a/test/e2e/cni/taint_controller_race.go
+++ b/test/e2e/cni/taint_controller_race.go
@@ -48,6 +48,7 @@ metadata:
 				WithHelmReleaseName(releaseName),
 				WithSkipDefaultMesh(true), // it's common case for HELM deployments that Mesh is also managed by HELM therefore it's not created by default
 				WithHelmOpt("cni.delayStartupSeconds", "40"),
+				WithHelmOpt("cni.namespace", Config.KumaNamespace),
 				WithCNI(),
 			)).
 			Install(YamlK8s(defaultMesh)).

--- a/test/e2e/cni/taint_controller_race.go
+++ b/test/e2e/cni/taint_controller_race.go
@@ -23,6 +23,7 @@ kind: Mesh
 metadata:
   name: default
 `
+	customNamespace := "cni-namespace"
 
 	var cluster Cluster
 	var k8sCluster *K8sCluster
@@ -41,6 +42,7 @@ metadata:
 			"kuma-%s",
 			strings.ToLower(random.UniqueId()),
 		)
+		Expect(NewClusterSetup().Install(Namespace(customNamespace)).Setup(cluster)).To(Succeed())
 
 		err := NewClusterSetup().
 			Install(Kuma(core.Zone,
@@ -48,8 +50,9 @@ metadata:
 				WithHelmReleaseName(releaseName),
 				WithSkipDefaultMesh(true), // it's common case for HELM deployments that Mesh is also managed by HELM therefore it's not created by default
 				WithHelmOpt("cni.delayStartupSeconds", "40"),
-				WithHelmOpt("cni.namespace", Config.KumaNamespace),
+				WithHelmOpt("cni.namespace", customNamespace),
 				WithCNI(),
+				WithCNINamespace(customNamespace),
 			)).
 			Install(YamlK8s(defaultMesh)).
 			Setup(cluster)

--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -42,6 +42,7 @@ type kumaDeploymentOptions struct {
 	zoneEgress                  bool
 	zoneEgressEnvoyAdminTunnel  bool
 	cni                         bool
+	cniNamespace                string
 	cpReplicas                  int
 	hdsDisabled                 bool
 	runPostgresMigration        bool
@@ -317,6 +318,12 @@ func WithEgress() KumaDeploymentOption {
 func WithCNI() KumaDeploymentOption {
 	return KumaOptionFunc(func(o *kumaDeploymentOptions) {
 		o.cni = true
+	})
+}
+
+func WithCNINamespace(namespace string) KumaDeploymentOption {
+	return KumaOptionFunc(func(o *kumaDeploymentOptions) {
+		o.cniNamespace = namespace
 	})
 }
 

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -520,7 +520,13 @@ func (c *K8sCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOption) e
 	var wg sync.WaitGroup
 	var appsToInstall []appInstallation
 	if c.opts.cni {
-		appsToInstall = append(appsToInstall, appInstallation{Config.CNIApp, Config.CNINamespace, 1, nil})
+		namespace := ""
+		if c.opts.cniNamespace != "" {
+			namespace = c.opts.cniNamespace
+		} else {
+			namespace = Config.CNINamespace
+		}
+		appsToInstall = append(appsToInstall, appInstallation{Config.CNIApp, namespace, 1, nil})
 	}
 	if c.opts.zoneIngress {
 		appsToInstall = append(appsToInstall, appInstallation{Config.ZoneIngressApp, Config.KumaNamespace, 1, nil})


### PR DESCRIPTION
The controller did not get the system namespace set so it was always checking for CNI pods in the default `kube-system` namespace. 

xrel: https://github.com/kumahq/kuma/pull/6721/files

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
