### PR TITLE
fix(meshservice): do not wipe out identities of synced service

### DIFF
--- a/pkg/insights/components.go
+++ b/pkg/insights/components.go
@@ -20,6 +20,7 @@ func Setup(rt runtime.Runtime) error {
 			rt.ResourceManager(),
 			10*time.Second, // todo config
 			rt.Metrics(),
+			rt.Config().Multizone.Zone.Name,
 		)
 		if err != nil {
 			return err

--- a/pkg/test/resources/builders/meshservice_builder.go
+++ b/pkg/test/resources/builders/meshservice_builder.go
@@ -63,6 +63,14 @@ func (m *MeshServiceBuilder) AddIntPort(port, target uint32, protocol core_mesh.
 	return m
 }
 
+func (m *MeshServiceBuilder) AddServiceTagIdentity(identity string) *MeshServiceBuilder {
+	m.res.Spec.Identities = append(m.res.Spec.Identities, v1alpha1.MeshServiceIdentity{
+		Type:  v1alpha1.MeshServiceIdentityServiceTagType,
+		Value: identity,
+	})
+	return m
+}
+
 func (m *MeshServiceBuilder) WithKumaVIP(vip string) *MeshServiceBuilder {
 	m.res.Status.VIPs = []v1alpha1.VIP{
 		{


### PR DESCRIPTION
### Checklist prior to review

I noticed that MeshService status E2E test is flaky while working on other PR.
It turned out that we wipe out `spec.identities` from synced MeshServices, which also breaks multicluster communication.
We should only compute `spec.identities` for local MeshServices.

How did it pass through all the testing and how did multizone traffic work?
We always tested it with a local service and remote service with same selectors.
If you have local and sycned MeshService that selects `app: xyz` and you have local DPPs that have `app: xyz` tag then we would correctly compute identities to synced MeshService.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
