### PR TITLE
feat(meshpassthrough): add support for delegated gateway

### DIFF
--- a/pkg/plugins/policies/meshpassthrough/api/v1alpha1/testdata/full-invalid.output.yaml
+++ b/pkg/plugins/policies/meshpassthrough/api/v1alpha1/testdata/full-invalid.output.yaml
@@ -1,6 +1,4 @@
 violations:
-- field: spec.targetRef.proxyTypes
-  message: proxyTypes needs to be set, currently only Sidecar is supported
 - field: spec.default.appendMatch[0].port
   message: port must be a valid (1-65535)
 - field: spec.default.appendMatch[0].protocol

--- a/pkg/plugins/policies/meshpassthrough/api/v1alpha1/testdata/valid.input.yaml
+++ b/pkg/plugins/policies/meshpassthrough/api/v1alpha1/testdata/valid.input.yaml
@@ -1,6 +1,5 @@
 targetRef:
   kind: Mesh
-  proxyTypes: ["Sidecar"]
 default:
   appendMatch:
   - type: IP

--- a/pkg/plugins/policies/meshpassthrough/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshpassthrough/api/v1alpha1/validator.go
@@ -36,9 +36,6 @@ func validateTop(targetRef common_api.TargetRef) validators.ValidationError {
 			common_api.MeshSubset,
 		},
 	})
-	if len(targetRef.ProxyTypes) != 1 && !slices.Contains(targetRef.ProxyTypes, common_api.Sidecar) {
-		targetRefErr.AddViolationAt(validators.RootedAt("proxyTypes"), "proxyTypes needs to be set, currently only Sidecar is supported")
-	}
 	return targetRefErr
 }
 

--- a/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/plugin.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 
+	"github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
@@ -29,7 +30,7 @@ func (p plugin) MatchedPolicies(dataplane *core_mesh.DataplaneResource, resource
 }
 
 func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *core_xds.Proxy) error {
-	if proxy.Dataplane == nil {
+	if proxy.Dataplane == nil || (proxy.Dataplane.Spec.Networking.Gateway != nil && proxy.Dataplane.Spec.Networking.Gateway.Type == v1alpha1.Dataplane_Networking_Gateway_BUILTIN) {
 		return nil
 	}
 	policies, ok := proxy.Policies.Dynamic[api.MeshPassthroughType]

--- a/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/plugin_test.go
@@ -180,6 +180,12 @@ var _ = Describe("MeshPassthrough", func() {
 								},
 								{
 									Type:     api.MatchType("IP"),
+									Value:    "192.168.19.1",
+									Port:     pointer.To[int](10000),
+									Protocol: api.ProtocolType("http"),
+								},
+								{
+									Type:     api.MatchType("IP"),
 									Value:    "192.168.0.1",
 									Port:     pointer.To[int](9091),
 									Protocol: api.ProtocolType("tcp"),

--- a/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/testdata/basic.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/testdata/basic.clusters.golden.yaml
@@ -47,6 +47,14 @@ resources:
     lbPolicy: CLUSTER_PROVIDED
     name: meshpassthrough_192.168.19.1_*
     type: ORIGINAL_DST
+- name: meshpassthrough_192.168.19.1_10000
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    altStatName: meshpassthrough_192_168_19_1_10000
+    connectTimeout: 5s
+    lbPolicy: CLUSTER_PROVIDED
+    name: meshpassthrough_192.168.19.1_10000
+    type: ORIGINAL_DST
 - name: meshpassthrough_9942:9abf:d0e0:f2da:2290:333b:e590:f497_9091
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster

--- a/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/testdata/basic.listener.golden.yaml
+++ b/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/testdata/basic.listener.golden.yaml
@@ -117,6 +117,44 @@ resources:
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           routeConfig:
+            name: meshpassthrough_http_10000
+            virtualHosts:
+            - domains:
+              - 192.168.19.1
+              - 192.168.19.1:10000
+              name: 192.168.19.1
+              routes:
+              - match:
+                  path: /
+                route:
+                  cluster: meshpassthrough_192.168.19.1_10000
+            - domains:
+              - '*'
+              name: no_match
+              routes:
+              - directResponse:
+                  body:
+                    inlineString: |
+                      This response comes from Kuma Sidecar. No routes matched this domain - check configuration of your MeshPassthrough policy.
+                  status: 503
+                match:
+                  prefix: /
+          statPrefix: meshpassthrough_http_10000
+      name: meshpassthrough_http_10000
+    - filterChainMatch:
+        applicationProtocols:
+        - http/1.1
+        - h2c
+        transportProtocol: raw_buffer
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          httpFilters:
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          routeConfig:
             name: meshpassthrough_http_8080
             virtualHosts:
             - domains:
@@ -310,6 +348,35 @@ resources:
           cluster: meshpassthrough_b0ce:f616:4e74:28f7:427c:b969:8016:6344/64_*
           statPrefix: meshpassthrough_b0ce_f616_4e74_28f7_427c_b969_8016_6344_64__
       name: meshpassthrough_b0ce:f616:4e74:28f7:427c:b969:8016:6344/64_*
+    - filterChainMatch:
+        applicationProtocols:
+        - http/1.1
+        - h2c
+        transportProtocol: raw_buffer
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          httpFilters:
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          routeConfig:
+            name: meshpassthrough_http_10000
+            virtualHosts:
+            - domains:
+              - '*'
+              name: no_match
+              routes:
+              - directResponse:
+                  body:
+                    inlineString: |
+                      This response comes from Kuma Sidecar. No routes matched this domain - check configuration of your MeshPassthrough policy.
+                  status: 503
+                match:
+                  prefix: /
+          statPrefix: meshpassthrough_http_10000
+      name: meshpassthrough_http_10000
     - filterChainMatch:
         applicationProtocols:
         - http/1.1

--- a/pkg/plugins/policies/meshpassthrough/plugin/xds/listeners_filter_chain.go
+++ b/pkg/plugins/policies/meshpassthrough/plugin/xds/listeners_filter_chain.go
@@ -65,11 +65,12 @@ func (c FilterChainConfigurer) addFilterChainConfiguration(listener *envoy_liste
 			switch route.MatchType {
 			case Domain, WildcardDomain, IP, IPV6:
 				domains := []string{route.Value}
+				// based on the RFC, the host header might include a port, so we add another entry with the port defined
 				if route.MatchType == IP {
 					domains = append(domains, fmt.Sprintf("%s:%d", route.Value, c.Port))
 				}
 				if route.MatchType == IPV6 {
-					domains = append(domains, fmt.Sprintf("[%s]", route.Value))
+					domains = append(domains, fmt.Sprintf("[%s]", route.Value), fmt.Sprintf("[%s]:%d", route.Value, c.Port))
 				}
 				clusterName := ClusterName(route, c.Protocol, c.Port)
 				routeBuilder.Configure(xds_routes.VirtualHost(xds_virtual_hosts.NewVirtualHostBuilder(c.APIVersion, route.Value).

--- a/pkg/plugins/policies/meshpassthrough/plugin/xds/listeners_filter_chain.go
+++ b/pkg/plugins/policies/meshpassthrough/plugin/xds/listeners_filter_chain.go
@@ -65,6 +65,9 @@ func (c FilterChainConfigurer) addFilterChainConfiguration(listener *envoy_liste
 			switch route.MatchType {
 			case Domain, WildcardDomain, IP, IPV6:
 				domains := []string{route.Value}
+				if route.MatchType == IP {
+					domains = append(domains, fmt.Sprintf("%s:%d", route.Value, c.Port))
+				}
 				if route.MatchType == IPV6 {
 					domains = append(domains, fmt.Sprintf("[%s]", route.Value))
 				}

--- a/test/e2e_env/kubernetes/gateway/delegated/common.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/common.go
@@ -7,4 +7,5 @@ type Config struct {
 	KicIP                       string
 	CpNamespace                 string
 	ObservabilityDeploymentName string
+	IPV6                        bool
 }

--- a/test/e2e_env/kubernetes/gateway/delegated/meshpassthrough.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshpassthrough.go
@@ -28,6 +28,7 @@ func MeshPassthrough(config *Config) func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// given
+			// we want the connection to close quickly, so after configuration change requests will start to fail.
 			meshProxyPatch := fmt.Sprintf(`
 apiVersion: kuma.io/v1alpha1
 kind: MeshProxyPatch

--- a/test/e2e_env/kubernetes/gateway/delegated/meshpassthrough.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshpassthrough.go
@@ -47,7 +47,7 @@ spec:
 			// when
 			err = kubernetes.Cluster.Install(framework.YamlK8s(meshPassthrough))
 
-			// we need to wait for a config to arrive because once request is done, connection is estabilished and it won't return 502 
+			// we need to wait for a config to arrive because once request is done, connection is estabilished and it won't return 502
 			time.Sleep(5 * time.Second)
 
 			// then

--- a/test/e2e_env/kubernetes/gateway/delegated/meshpassthrough.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshpassthrough.go
@@ -1,0 +1,109 @@
+package delegated
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/pkg/plugins/policies/meshpassthrough/api/v1alpha1"
+	"github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/client"
+	"github.com/kumahq/kuma/test/framework/envs/kubernetes"
+)
+
+func MeshPassthrough(config *Config) func() {
+	GinkgoHelper()
+
+	return func() {
+		AfterEach(func() {
+			Expect(framework.DeleteMeshResources(kubernetes.Cluster, config.Mesh, v1alpha1.MeshPassthroughResourceTypeDescriptor)).To(Succeed())
+		})
+
+		// we cannot test in a stable way first doing a successful request, because once connection is estabilished we don't break it after applying the policy (similar case to egress) the connection exists and works.
+		It("should control traffic to domains and IPs", func() {
+			esIP, err := framework.ServiceIP(kubernetes.Cluster, "external-service", config.NamespaceOutsideMesh)
+			Expect(err).ToNot(HaveOccurred())
+			// given
+			meshPassthrough := fmt.Sprintf(`
+apiVersion: kuma.io/v1alpha1 
+kind: MeshPassthrough
+metadata:
+  name: disable-passthrough
+  namespace: %s
+  labels:
+    kuma.io/mesh: %s
+spec:
+  targetRef:
+    kind: MeshSubset
+    proxyTypes: ["Gateway"]
+    tags:
+      kuma.io/service: delegated-gateway-admin_delegated-gateway_svc_8444
+  default:
+    passthroughMode: None
+`, config.CpNamespace, config.Mesh)
+
+			// when
+			err = kubernetes.Cluster.Install(framework.YamlK8s(meshPassthrough))
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func(g Gomega) {
+				resp, err := client.CollectFailure(
+					kubernetes.Cluster, "demo-client",
+					fmt.Sprintf("http://%s/external-service", config.KicIP),
+					client.FromKubernetesPod(config.NamespaceOutsideMesh, "demo-client"),
+				)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(resp.ResponseCode).To(Equal(502))
+			}, "30s", "1s").Should(Succeed())
+
+			meshPassthrough = fmt.Sprintf(`
+apiVersion: kuma.io/v1alpha1 
+kind: MeshPassthrough
+metadata:
+  name: allow-specified
+  namespace: %s
+  labels:
+    kuma.io/mesh: %s
+spec:
+  targetRef:
+    kind: MeshSubset
+    proxyTypes: ["Gateway"]
+    tags:
+      kuma.io/service: delegated-gateway-admin_delegated-gateway_svc_8444
+  default:
+    passthroughMode: Matched
+    appendMatch:
+    - type: IP
+      value: %s
+      port: 80
+      protocol: tcp
+`, config.CpNamespace, config.Mesh, esIP)
+
+			// when
+			err = kubernetes.Cluster.Install(framework.YamlK8s(meshPassthrough))
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func(g Gomega) {
+				_, err := client.CollectEchoResponse(
+					kubernetes.Cluster, "demo-client",
+					fmt.Sprintf("http://%s/external-service", config.KicIP),
+					client.FromKubernetesPod(config.NamespaceOutsideMesh, "demo-client"),
+				)
+				g.Expect(err).ToNot(HaveOccurred())
+			}, "30s", "1s").Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				resp, err := client.CollectFailure(
+					kubernetes.Cluster, "demo-client",
+					fmt.Sprintf("http://%s/another-external-service", config.KicIP),
+					client.FromKubernetesPod(config.NamespaceOutsideMesh, "demo-client"),
+				)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(resp.ResponseCode).To(Equal(502))
+			}, "30s", "1s").Should(Succeed())
+		})
+	}
+}

--- a/test/e2e_env/kubernetes/gateway/delegated/meshpassthrough.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshpassthrough.go
@@ -46,12 +46,12 @@ spec:
 
 			// when
 			err = kubernetes.Cluster.Install(framework.YamlK8s(meshPassthrough))
+			Expect(err).ToNot(HaveOccurred())
 
 			// we need to wait for a config to arrive because once request is done, connection is estabilished and it won't return 502
 			time.Sleep(5 * time.Second)
 
 			// then
-			Expect(err).ToNot(HaveOccurred())
 			Eventually(func(g Gomega) {
 				resp, err := client.CollectFailure(
 					kubernetes.Cluster, "demo-client",

--- a/test/e2e_env/kubernetes/gateway/delegated/meshpassthrough.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshpassthrough.go
@@ -2,6 +2,7 @@ package delegated
 
 import (
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -45,6 +46,9 @@ spec:
 
 			// when
 			err = kubernetes.Cluster.Install(framework.YamlK8s(meshPassthrough))
+
+			// we need to wait for a config to arrive because once request is done, connection is estabilished and it won't return 502 
+			time.Sleep(5 * time.Second)
 
 			// then
 			Expect(err).ToNot(HaveOccurred())

--- a/test/framework/k8s.go
+++ b/test/framework/k8s.go
@@ -64,6 +64,21 @@ func PodIPOfApp(cluster Cluster, name string, namespace string) (string, error) 
 	return pods[0].Status.PodIP, nil
 }
 
+func ServiceIP(cluster Cluster, name string, namespace string) (string, error) {
+	clusterIP, err := k8s.RunKubectlAndGetOutputE(
+		cluster.GetTesting(),
+		cluster.GetKubectlOptions(namespace),
+		"get", "service", name, "-ojsonpath={.spec.clusterIP}",
+	)
+	if err != nil {
+		return "", err
+	}
+	if clusterIP == "" {
+		return "", errors.Errorf("expected not empty ClusterIP for service: %s namespace: %s", name, namespace)
+	}
+	return clusterIP, nil
+}
+
 func GatewayAPICRDs(cluster Cluster) error {
 	return k8s.RunKubectlE(
 		cluster.GetTesting(),


### PR DESCRIPTION
### Checklist prior to review

* Added support for MeshGateway in a delegated mode
* Added E2E test for delegated gateway
* Added appending domains with a port and adding them to the domains. Based on the [RFC](https://www.rfc-editor.org/rfc/rfc9110.html#section-7.2) host header might have a port at the end if it's not 80/443. 

- [ ] [Link to relevant issue][1] as well as docs and UI issues -- fix: https://github.com/kumahq/kuma/issues/10513
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
