### PR TITLE
fix(MeshService): don't skip endpoints for headless

### DIFF
--- a/pkg/xds/topology/outbound.go
+++ b/pkg/xds/topology/outbound.go
@@ -267,10 +267,6 @@ func fillLocalMeshServices(
 			continue
 		}
 
-		if meshSvc.Spec.Selector.DataplaneRef != nil {
-			continue
-		}
-
 		for _, dpp := range dpps {
 			dpNetworking := dpp.Spec.GetNetworking()
 			for _, inbound := range dpNetworking.GetHealthyInbounds() {

--- a/pkg/xds/topology/outbound_test.go
+++ b/pkg/xds/topology/outbound_test.go
@@ -1168,7 +1168,7 @@ var _ = Describe("TrafficRoute", func() {
 				},
 				dataplanes: []*core_mesh.DataplaneResource{
 					{
-						Meta: &test_model.ResourceMeta{Mesh: defaultMeshName},
+						Meta: &test_model.ResourceMeta{Mesh: defaultMeshName, Name: "redis-0"},
 						Spec: &mesh_proto.Dataplane{
 							Networking: &mesh_proto.Dataplane_Networking{
 								Address: "192.168.0.1",
@@ -1248,10 +1248,38 @@ var _ = Describe("TrafficRoute", func() {
 							},
 						},
 					},
+					{
+						Meta: &test_model.ResourceMeta{
+							Mesh: "default",
+							Name: "redis-0",
+						},
+						Spec: &v1alpha1.MeshService{
+							Selector: v1alpha1.Selector{
+								DataplaneRef: &v1alpha1.DataplaneRef{
+									Name: "redis-0",
+								},
+							},
+							Ports: []v1alpha1.Port{
+								{
+									Port:       6379,
+									TargetPort: intstr.FromInt(6379),
+								},
+							},
+						},
+					},
 				},
 				mesh: defaultMeshWithMTLS,
 				expected: core_xds.EndpointMap{
 					"redis_svc_6379": []core_xds.Endpoint{
+						{
+							Target:   "192.168.0.1",
+							Port:     6379,
+							Tags:     map[string]string{mesh_proto.ServiceTag: "redis_svc_6379", "version": "v1"},
+							Locality: nil,
+							Weight:   1,
+						},
+					},
+					"redis-0_svc_6379": []core_xds.Endpoint{
 						{
 							Target:   "192.168.0.1",
 							Port:     6379,


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
