### PR TITLE
test(e2e): enable upgrade test

### DIFF
--- a/test/e2e/helm/e2e_suite_test.go
+++ b/test/e2e/helm/e2e_suite_test.go
@@ -22,5 +22,5 @@ var (
 	_ = Describe("App deployment with Helm", Label("job-2"), helm.AppDeploymentWithHelmChart)
 	_ = Describe("Upgrade Standalone with Helm", Label("job-2"), helm.UpgradingWithHelmChartStandalone, Ordered)
 	// Fails because of the bug in 2.6.7 (and potentially 2.7.3) https://github.com/kumahq/kuma/issues/10463
-	_ = PDescribe("Upgrade Multizone with Helm", Label("job-2"), helm.UpgradingWithHelmChartMultizone, Ordered)
+	_ = Describe("Upgrade Multizone with Helm", Label("job-2"), helm.UpgradingWithHelmChartMultizone, Ordered)
 )


### PR DESCRIPTION
### Checklist prior to review

We have released patch releases with a fix (2.6.8, 2.7.4), so we should enable it again.

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
