### PR TITLE
test(framework): init TProxyConfig only in tproxy tests

### DIFF
--- a/test/framework/config_transparentproxy.go
+++ b/test/framework/config_transparentproxy.go
@@ -80,7 +80,7 @@ var defaultTProxyConf = TransparentProxyConfig{
 	IPV6: false,
 }
 
-func init() {
+func InitTproxyConfig() {
 	TProxyConfig = defaultTProxyConf
 
 	if err := config.Load(os.Getenv("TPROXY_TESTS_CONFIG_FILE"), &TProxyConfig); err != nil {

--- a/test/transparentproxy/transparentproxy_suite_test.go
+++ b/test/transparentproxy/transparentproxy_suite_test.go
@@ -6,10 +6,13 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 
 	"github.com/kumahq/kuma/pkg/test"
+	"github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/transparentproxy/install"
 )
 
 func TestTransparentProxy(t *testing.T) {
+	framework.InitTproxyConfig()
+
 	test.RunSpecs(t, "Transparent Proxy Suite")
 }
 


### PR DESCRIPTION
TProxyConfig is used only in tproxy tests, and when it was initialized in `init()` function, it was run even for e2e tests, which in case of legacy e2e tests was failing because of missing kumactl binary.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - No relevant issues
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - There is no need

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
