### PR TITLE
test(framework): move tproxy tests config from test framework

### DIFF
--- a/test/transparentproxy/config.go
+++ b/test/transparentproxy/config.go
@@ -1,4 +1,4 @@
-package framework
+package transparentproxy
 
 import (
 	"fmt"
@@ -23,13 +23,13 @@ type TransparentProxyConfig struct {
 }
 
 func (c TransparentProxyConfig) Validate() error {
-	if TProxyConfig.KumactlLinuxBin != "" {
-		_, err := os.Stat(TProxyConfig.KumactlLinuxBin)
+	if Config.KumactlLinuxBin != "" {
+		_, err := os.Stat(Config.KumactlLinuxBin)
 		if os.IsNotExist(err) {
 			return errors.Wrapf(
 				err,
 				"unable to find kumactl for linux at: %s",
-				TProxyConfig.KumactlLinuxBin,
+				Config.KumactlLinuxBin,
 			)
 		}
 
@@ -40,19 +40,19 @@ func (c TransparentProxyConfig) Validate() error {
 }
 
 func (c TransparentProxyConfig) AutoConfigure() error {
-	absoluteKumactlPath, err := filepath.Abs(TProxyConfig.KumactlLinuxBin)
+	absoluteKumactlPath, err := filepath.Abs(Config.KumactlLinuxBin)
 	if err != nil {
 		return err
 	}
 
-	TProxyConfig.KumactlLinuxBin = absoluteKumactlPath
+	Config.KumactlLinuxBin = absoluteKumactlPath
 
 	return nil
 }
 
-var TProxyConfig TransparentProxyConfig
+var Config TransparentProxyConfig
 
-var defaultTProxyConf = TransparentProxyConfig{
+var defaultConfig = TransparentProxyConfig{
 	KumactlLinuxBin: fmt.Sprintf(
 		"../../../build/artifacts-linux-%s/kumactl/kumactl",
 		runtime.GOARCH,
@@ -80,14 +80,14 @@ var defaultTProxyConf = TransparentProxyConfig{
 	IPV6: false,
 }
 
-func InitTproxyConfig() {
-	TProxyConfig = defaultTProxyConf
+func init() {
+	Config = defaultConfig
 
-	if err := config.Load(os.Getenv("TPROXY_TESTS_CONFIG_FILE"), &TProxyConfig); err != nil {
+	if err := config.Load(os.Getenv("TPROXY_TESTS_CONFIG_FILE"), &Config); err != nil {
 		panic(err)
 	}
 
-	if err := TProxyConfig.AutoConfigure(); err != nil {
+	if err := Config.AutoConfigure(); err != nil {
 		panic(err)
 	}
 }

--- a/test/transparentproxy/install/install.go
+++ b/test/transparentproxy/install/install.go
@@ -12,9 +12,9 @@ import (
 	"github.com/testcontainers/testcontainers-go/exec"
 
 	"github.com/kumahq/kuma/pkg/test/matchers"
-	. "github.com/kumahq/kuma/test/framework"
 	test_container "github.com/kumahq/kuma/test/framework/container"
 	"github.com/kumahq/kuma/test/framework/utils"
+	. "github.com/kumahq/kuma/test/transparentproxy"
 )
 
 var (
@@ -46,11 +46,11 @@ func Install() {
 	DescribeTable(
 		"kumactl install transparent-proxy inside Docker container",
 		func(tc testCase) {
-			Expect(TProxyConfig.KumactlLinuxBin).NotTo(BeEmpty())
+			Expect(Config.KumactlLinuxBin).NotTo(BeEmpty())
 
 			container, err := test_container.NewContainerSetup().
 				WithImage(tc.image).
-				WithKumactlBinary(TProxyConfig.KumactlLinuxBin).
+				WithKumactlBinary(Config.KumactlLinuxBin).
 				WithPostStart(tc.postStart).
 				WithPrivileged(true).
 				Start(context.Background())
@@ -64,7 +64,7 @@ func Install() {
 			EnsureInstallSuccessful(container, tc.additionalFlags)
 			EnsureGoldenFiles(container, tc)
 		},
-		EntriesForImages(TProxyConfig.DockerImagesToTest),
+		EntriesForImages(Config.DockerImagesToTest),
 	)
 }
 
@@ -104,7 +104,7 @@ func EnsureGoldenFiles(container testcontainers.Container, tc testCase) {
 		"iptables-nft-save",
 	}
 
-	if TProxyConfig.IPV6 {
+	if Config.IPV6 {
 		saveCmds = append(
 			saveCmds,
 			"ip6tables-save",
@@ -185,7 +185,7 @@ func genEntriesForImages(
 	var entries []TableEntry
 	var flags [][]string
 
-	for _, flag := range TProxyConfig.InstallFlagsToTest {
+	for _, flag := range Config.InstallFlagsToTest {
 		flags = append(flags, strings.Split(flag, " "))
 	}
 

--- a/test/transparentproxy/transparentproxy_suite_test.go
+++ b/test/transparentproxy/transparentproxy_suite_test.go
@@ -6,13 +6,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 
 	"github.com/kumahq/kuma/pkg/test"
-	"github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/transparentproxy/install"
 )
 
 func TestTransparentProxy(t *testing.T) {
-	framework.InitTproxyConfig()
-
 	test.RunSpecs(t, "Transparent Proxy Suite")
 }
 


### PR DESCRIPTION
This Config is and will be used only in transparent proxy tests, so we can safely move it there. As now there is no conflict in names, I renamed it from `TProxyConfig` to just `Config`.

re. https://github.com/kumahq/kuma/pull/10706#discussion_r1661984816

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - No relevant issues
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - There is no need

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
