### PR TITLE
fix(MeshService): limit display name to 63 characters

### DIFF
--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/meshservice.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/meshservice.go
@@ -27,6 +27,8 @@ type Port struct {
 	AppProtocol core_mesh.Protocol `json:"appProtocol,omitempty"`
 }
 
+const maxNameLength = 63
+
 // MeshService
 // +kuma:policy:is_policy=false
 // +kuma:policy:has_status=true

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/validator.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/validator.go
@@ -1,13 +1,15 @@
 package v1alpha1
 
 import (
+	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/validators"
 )
 
 func (r *MeshServiceResource) validate() error {
 	var verr validators.ValidationError
 
-	verr.Add(validators.ValidateLength(validators.RootedAt("name"), 63, r.GetMeta().GetName()))
+	name := model.GetDisplayName(r.GetMeta())
+	verr.Add(validators.ValidateLength(validators.RootedAt("name"), maxNameLength, name))
 
 	return verr.OrNil()
 }


### PR DESCRIPTION
The name was being validated to have the given length leading to errors with syncing and the `name.namespace` format on Kubernetes. We actually only need to limit the display name.

See https://github.com/kumahq/kuma/issues/10474

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
