### PR TITLE
fix(MeshService): don't skip endpoints for headless with ZoneIngress

### DIFF
--- a/pkg/xds/ingress/outbound.go
+++ b/pkg/xds/ingress/outbound.go
@@ -98,10 +98,6 @@ func BuildEndpointMap(
 
 		for _, meshSvc := range meshServices {
 			tagSelector := mesh_proto.TagSelector(meshSvc.Spec.Selector.DataplaneTags)
-			if meshSvc.Spec.Selector.DataplaneRef != nil {
-				continue
-			}
-
 			for _, inbound := range dpNetworking.GetHealthyInbounds() {
 				if !tagSelector.Matches(inbound.GetTags()) {
 					continue

--- a/pkg/xds/ingress/outbound_test.go
+++ b/pkg/xds/ingress/outbound_test.go
@@ -327,6 +327,14 @@ var _ = Describe("IngressTrafficRoute", func() {
 					},
 				},
 				expected: core_xds.EndpointMap{
+					"redis-0_svc_6379": []core_xds.Endpoint{
+						{
+							Target: "192.168.0.1",
+							Port:   6379,
+							Tags:   map[string]string{mesh_proto.ServiceTag: "redis_svc_6379"},
+							Weight: 1,
+						},
+					},
 				},
 			}),
 		)


### PR DESCRIPTION
Headless MeshService didn't work cross-zone.

See #10684

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
