### PR TITLE
feat(meshroute): pass ref with correct name

### DIFF
--- a/pkg/plugins/policies/core/xds/meshroute/listeners.go
+++ b/pkg/plugins/policies/core/xds/meshroute/listeners.go
@@ -148,7 +148,10 @@ func CollectServices(
 				if port.AppProtocol != "" {
 					protocol = port.AppProtocol
 				}
-
+				ns := ""
+				if ms.GetMeta().GetNameExtensions() != nil {
+					ns = ms.GetMeta().GetNameExtensions()[model.K8sNamespaceComponent]
+				}
 				dests = append(dests, DestinationService{
 					Outbound:    oface,
 					Protocol:    protocol,
@@ -157,7 +160,7 @@ func CollectServices(
 						TargetRef: common_api.TargetRef{
 							Kind:      common_api.MeshService,
 							Name:      ms.GetMeta().GetName(),
-							Namespace: ms.GetMeta().GetNameExtensions()[model.K8sNamespaceComponent],
+							Namespace: ns,
 						},
 						Port: &port.Port,
 					},
@@ -166,6 +169,10 @@ func CollectServices(
 			if mesOk {
 				port := mes.Spec.Match.Port
 				protocol := mes.Spec.Match.Protocol
+				ns := ""
+				if mes.GetMeta().GetNameExtensions() != nil {
+					ns = mes.GetMeta().GetNameExtensions()[model.K8sNamespaceComponent]
+				}
 				dests = append(dests, DestinationService{
 					Outbound:    oface,
 					Protocol:    core_mesh.Protocol(protocol),
@@ -174,7 +181,7 @@ func CollectServices(
 						TargetRef: common_api.TargetRef{
 							Kind:      common_api.MeshExternalService,
 							Name:      mes.GetMeta().GetName(),
-							Namespace: ms.GetMeta().GetNameExtensions()[model.K8sNamespaceComponent],
+							Namespace: ns,
 						},
 						Port: pointer.To(uint32(port)),
 					},

--- a/pkg/plugins/policies/core/xds/meshroute/listeners.go
+++ b/pkg/plugins/policies/core/xds/meshroute/listeners.go
@@ -2,12 +2,18 @@ package meshroute
 
 import (
 	"fmt"
+	"sort"
+	"strings"
+
+
+	"golang.org/x/exp/maps"
 
 	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	plugins_xds "github.com/kumahq/kuma/pkg/plugins/policies/core/xds"
+	util_k8s "github.com/kumahq/kuma/pkg/util/k8s"
 	"github.com/kumahq/kuma/pkg/util/pointer"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
@@ -15,8 +21,59 @@ import (
 	envoy_tags "github.com/kumahq/kuma/pkg/xds/envoy/tags"
 )
 
+type BackendRef struct {
+	CoreName string
+	Port     *uint32
+	Kind     common_api.TargetRefKind
+	Tags     map[string]string
+	Weight   *uint
+	Mesh     string
+}
+
+type BackendRefHash string
+
+// Hash returns a hash of the BackendRef
+func (in BackendRef) Hash() BackendRefHash {
+	keys := maps.Keys(in.Tags)
+	sort.Strings(keys)
+	orderedTags := make([]string, 0, len(keys))
+	for _, k := range keys {
+		orderedTags = append(orderedTags, fmt.Sprintf("%s=%s", k, in.Tags[k]))
+	}
+	name := in.CoreName
+	if in.Port != nil {
+		name = fmt.Sprintf("%s_svc_%d", in.CoreName, *in.Port)
+	}
+	return BackendRefHash(fmt.Sprintf("%s/%s/%s/%s", in.Kind, name, strings.Join(orderedTags, "/"), in.Mesh))
+}
+
+func mapToSplitBackendRefs(refs []common_api.BackendRef) []BackendRef {
+	var newRefs []BackendRef
+
+	for _, ref := range refs {
+		var coreName string
+
+		if ref.Namespace != "" {
+			coreName = util_k8s.K8sNamespacedNameToCoreName(ref.Name, ref.Namespace)
+		} else {
+			coreName = ref.Name
+		}
+
+		newRef := BackendRef{
+			CoreName: coreName,
+			Port:     ref.Port,
+			Kind:     ref.Kind,
+			Tags:     ref.Tags,
+			Weight:   ref.Weight,
+			Mesh:     ref.Mesh,
+		}
+		newRefs = append(newRefs, newRef)
+	}
+
+	return newRefs
+}
 func MakeTCPSplit(
-	clusterCache map[common_api.BackendRefHash]string,
+	clusterCache map[BackendRefHash]string,
 	servicesAcc envoy_common.ServicesAccumulator,
 	refs []common_api.BackendRef,
 	meshCtx xds_context.MeshContext,
@@ -32,7 +89,7 @@ func MakeTCPSplit(
 		},
 		clusterCache,
 		servicesAcc,
-		refs,
+		mapToSplitBackendRefs(refs),
 		meshCtx,
 	)
 }
@@ -51,7 +108,7 @@ func MakeHTTPSplit(
 		},
 		clusterCache,
 		servicesAcc,
-		refs,
+		mapToSplitBackendRefs(refs),
 		meshCtx,
 	)
 }
@@ -138,11 +195,11 @@ func CollectServices(
 	return dests
 }
 
-func makeSplit(
+func makeSplit[T ~string](
 	protocols map[core_mesh.Protocol]struct{},
-	clusterCache map[common_api.BackendRefHash]string,
+	clusterCache map[T]string,
 	servicesAcc envoy_common.ServicesAccumulator,
-	refs []common_api.BackendRef,
+	refs []BackendRef,
 	meshCtx xds_context.MeshContext,
 ) []envoy_common.Split {
 	var split []envoy_common.Split
@@ -162,7 +219,7 @@ func makeSplit(
 		var meshServiceName string
 		switch {
 		case ref.Kind == common_api.MeshExternalService:
-			mes, ok := meshCtx.MeshExternalServiceByName[ref.Name]
+			mes, ok := meshCtx.MeshExternalServiceByName[ref.CoreName]
 			if !ok {
 				continue
 			}
@@ -170,7 +227,7 @@ func makeSplit(
 			service = mes.DestinationName(port)
 			protocol = meshCtx.GetServiceProtocol(service)
 		case ref.Port != nil: // in this case, reference real MeshService instead of kuma.io/service tag
-			ms, ok := meshCtx.MeshServiceByName[ref.Name]
+			ms, ok := meshCtx.MeshServiceByName[ref.CoreName]
 			if !ok {
 				continue
 			}
@@ -182,7 +239,7 @@ func makeSplit(
 			service = ms.DestinationName(*ref.Port)
 			protocol = port.AppProtocol // todo(jakubdyszkiewicz): do we need to default to TCP or will this be done by MeshService defaulter?
 		default:
-			service = ref.Name
+			service = ref.CoreName
 			protocol = meshCtx.GetServiceProtocol(service)
 		}
 		if _, ok := protocols[protocol]; !ok {
@@ -191,7 +248,7 @@ func makeSplit(
 
 		var clusterName string
 		if ref.Kind == common_api.MeshExternalService {
-			clusterName = envoy_names.GetMeshExternalServiceName(ref.Name)
+			clusterName = envoy_names.GetMeshExternalServiceName(ref.CoreName)
 		} else {
 			clusterName, _ = envoy_tags.Tags(ref.Tags).
 				WithTags(mesh_proto.ServiceTag, service).
@@ -207,7 +264,7 @@ func makeSplit(
 		}
 
 		isExternalService := meshCtx.IsExternalService(service)
-		refHash := ref.Hash()
+		refHash := T(ref.Hash())
 
 		if existingClusterName, ok := clusterCache[refHash]; ok {
 			// cluster already exists, so adding only split
@@ -231,7 +288,7 @@ func makeSplit(
 			WithService(service).
 			WithName(clusterName).
 			WithTags(envoy_tags.Tags(ref.Tags).
-				WithTags(mesh_proto.ServiceTag, ref.Name).
+				WithTags(mesh_proto.ServiceTag, ref.CoreName).
 				WithoutTags(mesh_proto.MeshTag)).
 			WithExternalService(isExternalService)
 

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners.go
@@ -3,7 +3,6 @@ package v1alpha1
 import (
 	"github.com/pkg/errors"
 
-	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
@@ -19,7 +18,7 @@ import (
 func generateFromService(
 	meshCtx xds_context.MeshContext,
 	proxy *core_xds.Proxy,
-	clusterCache map[common_api.BackendRefHash]string,
+	clusterCache map[meshroute_xds.BackendRefHash]string,
 	servicesAccumulator envoy_common.ServicesAccumulator,
 	toRulesTCP rules.Rules,
 	svc meshroute_xds.DestinationService,
@@ -36,7 +35,6 @@ func generateFromService(
 	if len(backendRefs) == 0 {
 		return nil, nil
 	}
-
 	splits := meshroute_xds.MakeTCPSplit(clusterCache, servicesAccumulator, backendRefs, meshCtx)
 	filterChain := buildFilterChain(proxy, serviceName, splits, protocol)
 
@@ -63,7 +61,7 @@ func generateListeners(
 	// Cluster cache protects us from creating excessive amount of clusters.
 	// For one outbound we pick one traffic route, so LB and Timeout are
 	// the same.
-	clusterCache := map[common_api.BackendRefHash]string{}
+	clusterCache := map[meshroute_xds.BackendRefHash]string{}
 	for _, svc := range meshroute_xds.CollectServices(proxy, meshCtx) {
 		rs, err := generateFromService(
 			meshCtx,

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
@@ -2,7 +2,6 @@ package v1alpha1_test
 
 import (
 	"context"
-	"github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	"net"
 	"path/filepath"
 	"strings"
@@ -21,6 +20,7 @@ import (
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	meshexternalservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
+	"github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
@@ -223,7 +223,7 @@ var _ = Describe("MeshTCPRoute", func() {
 				To(matchers.MatchGoldenYAML(endpointsGolden))
 		},
 
-		FEntry("split-traffic", func() outboundsTestCase {
+		Entry("split-traffic", func() outboundsTestCase {
 			outboundTargets := xds_builders.EndpointMap().
 				AddEndpoints("backend",
 					xds_builders.Endpoint().
@@ -276,7 +276,7 @@ var _ = Describe("MeshTCPRoute", func() {
 									},
 									{
 										TargetRef: builders.TargetRefService(
-										    "other-backend",
+											"other-backend",
 										),
 										Weight: pointer.To(uint(10)),
 									},
@@ -287,7 +287,7 @@ var _ = Describe("MeshTCPRoute", func() {
 											WithNamespace("kuma-system").
 											Build(),
 										Weight: pointer.To(uint(5)),
-										Port: pointer.To(uint32(8007)),
+										Port:   pointer.To(uint32(8007)),
 									},
 									{
 										TargetRef: builders.TargetRefService(
@@ -303,7 +303,7 @@ var _ = Describe("MeshTCPRoute", func() {
 			}
 			resources := xds_context.NewResources()
 			resources.MeshLocalResources[v1alpha1.MeshServiceType] = &v1alpha1.MeshServiceResourceList{
-				Items:      []*v1alpha1.MeshServiceResource{
+				Items: []*v1alpha1.MeshServiceResource{
 					builders.MeshService().AddIntPort(8007, 8007, core_mesh.ProtocolHTTP).WithName("ms-1.kuma-system").WithMesh("default").Build(),
 				},
 			}

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/split-traffic.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/split-traffic.clusters.golden.yaml
@@ -53,6 +53,20 @@ resources:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         explicitHttpConfig:
           http2ProtocolOptions: {}
+- name: ms-1_kuma-system_svc_8007
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+        resourceApiVersion: V3
+    name: ms-1_kuma-system_svc_8007
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
 - name: other-backend
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/split-traffic.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/split-traffic.endpoints.golden.yaml
@@ -39,6 +39,10 @@ resources:
             envoy.transport_socket_match:
               kuma.io/protocol: http
               region: us
+- name: ms-1_kuma-system_svc_8007
+  resource:
+    '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
+    clusterName: ms-1_kuma-system_svc_8007
 - name: other-backend
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/split-traffic.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/split-traffic.listeners.golden.yaml
@@ -19,7 +19,9 @@ resources:
             - name: backend-c72efb5be46fae6b
               weight: 15
             - name: other-backend
-              weight: 15
+              weight: 10
+            - name: ms-1_kuma-system_svc_8007
+              weight: 5
             - name: externalservice
               weight: 15
     metadata:

--- a/pkg/test/resources/builders/targetref_builder.go
+++ b/pkg/test/resources/builders/targetref_builder.go
@@ -31,3 +31,58 @@ func TargetRefServiceSubset(name string, kv ...string) common_api.TargetRef {
 		Tags: TagsKVToMap(kv),
 	}
 }
+
+type TargetRefBuilder struct {
+	targetRef *common_api.TargetRef
+}
+
+func NewTargetRefBuilder() *TargetRefBuilder {
+	targetRef := common_api.TargetRef{}
+	b := &TargetRefBuilder{targetRef: &targetRef}
+	return b
+}
+
+func (b *TargetRefBuilder) WithKind(kind common_api.TargetRefKind) *TargetRefBuilder {
+	b.targetRef.Kind = kind
+	return b
+}
+
+func (b *TargetRefBuilder) WithName(name string) *TargetRefBuilder {
+	b.targetRef.Name = name
+	return b
+}
+
+func (b *TargetRefBuilder) WithTags(tags map[string]string) *TargetRefBuilder {
+	b.targetRef.Tags = tags
+	return b
+}
+
+func (b *TargetRefBuilder) WithMesh(mesh string) *TargetRefBuilder {
+	b.targetRef.Mesh = mesh
+	return b
+}
+
+func (b *TargetRefBuilder) WithProxyTypes(proxyTypes []common_api.TargetRefProxyType) *TargetRefBuilder {
+	b.targetRef.ProxyTypes = proxyTypes
+	return b
+}
+
+func (b *TargetRefBuilder) WithNamespace(namespace string) *TargetRefBuilder {
+	b.targetRef.Namespace = namespace
+	return b
+}
+
+func (b *TargetRefBuilder) WithLabels(labels map[string]string) *TargetRefBuilder {
+	b.targetRef.Labels = labels
+	return b
+}
+
+func (b *TargetRefBuilder) WithSectionName(sectionName string) *TargetRefBuilder {
+	b.targetRef.SectionName = sectionName
+	return b
+}
+
+func (b *TargetRefBuilder) Build() *common_api.TargetRef {
+	return b.targetRef
+}
+


### PR DESCRIPTION
WIP: this should also be changed for MeshService - just wanted to get Mike's opinion on this.

This change is needed because there is a mismatch in `name` when they come back from `getBackendRefs` https://github.com/kumahq/kuma/blob/22b289699f6f4adc92d495e66396d1b74d526082/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners.go#L34 

because `tcpConf.Default.BackendRefs` returns a name without a namespace suffix and `meshCtx.MeshExternalServiceByName` used in `makeSplit` relies on names with suffixes.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
