### PR TITLE
ci(golangci-lint): update deprecated config fields

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,14 +27,7 @@ linters:
     - makezero
 
 run:
-  skip-files:
-    - app/kumactl/pkg/k8s/kubectl_proxy.go # excluded to keep as close to original file from K8S repository
-    - pkg/xds/server/server.go # excluded to keep as close to original file from Envoy repository
-    - pkg/xds/server/server_test.go # excluded to keep as close to original file from Envoy repository
   modules-download-mode: readonly
-  skip-dirs-use-default: false # The default skip omits "builtin" directories, which we have.
-  skip-dirs:
-    - (^|/)vendored($|/)
   timeout: 30m
 
 linters-settings:
@@ -113,6 +106,13 @@ linters-settings:
 
 issues:
   fix: true
+  exclude-files:
+    - app/kumactl/pkg/k8s/kubectl_proxy.go # excluded to keep as close to original file from K8S repository
+    - pkg/xds/server/server.go # excluded to keep as close to original file from Envoy repository
+    - pkg/xds/server/server_test.go # excluded to keep as close to original file from Envoy repository
+  exclude-dirs-use-default: false # The default skip omits "builtin" directories, which we have.
+  exclude-dirs:
+    - (^|/)vendored($|/)
   exclude-rules:
     - linters:
         - staticcheck


### PR DESCRIPTION
```
WARN [config_reader] The configuration option `run.skip-files` is deprecated, please use `issues.exclude-files`.
WARN [config_reader] The configuration option `run.skip-dirs` is deprecated, please use `issues.exclude-dirs`.
WARN [config_reader] The configuration option `run.skip-dirs-use-default` is deprecated, please use `issues.exclude-dirs-use-default`.
```

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
