### PR TITLE
test(e2e): check that universal CP did not crash

### DIFF
--- a/test/e2e_env/kubernetes/kubernetes_suite_test.go
+++ b/test/e2e_env/kubernetes/kubernetes_suite_test.go
@@ -45,20 +45,10 @@ func TestE2E(t *testing.T) {
 	test.RunE2ESpecs(t, "E2E Kubernetes Suite")
 }
 
-var _ = E2ESynchronizedBeforeSuite(kubernetes.SetupAndGetState, kubernetes.RestoreState)
-
-// SynchronizedAfterSuite keeps the main process alive until all other processes finish.
-// Otherwise, we would close port-forward to the CP and remaining tests executed in different processes may fail.
 var (
-	_ = SynchronizedAfterSuite(func() {}, func() {
-		kubernetes.ExpectCpToNotCrash()
-		kubernetes.ExpectCpToNotPanic()
-	})
-)
-
-var (
-	_ = ReportAfterSuite("cp logs", kubernetes.PrintCPLogsOnFailure)
-	_ = ReportAfterSuite("kube state", kubernetes.PrintKubeState)
+	_ = E2ESynchronizedBeforeSuite(kubernetes.SetupAndGetState, kubernetes.RestoreState)
+	_ = SynchronizedAfterSuite(func() {}, kubernetes.SynchronizedAfterSuite)
+	_ = ReportAfterSuite("kubernetes after suite", kubernetes.AfterSuite)
 )
 
 var (

--- a/test/e2e_env/multizone/multizone_suite_test.go
+++ b/test/e2e_env/multizone/multizone_suite_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/kumahq/kuma/test/e2e_env/multizone/zoneegress"
 	. "github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/framework/envs/multizone"
-	"github.com/kumahq/kuma/test/framework/universal_logs"
 )
 
 func TestE2E(t *testing.T) {
@@ -38,17 +37,8 @@ func TestE2E(t *testing.T) {
 
 var (
 	_ = E2ESynchronizedBeforeSuite(multizone.SetupAndGetState, multizone.RestoreState)
-	_ = SynchronizedAfterSuite(func() {}, func() {
-		multizone.ExpectCpsToNotCrash()
-		multizone.ExpectCpsToNotPanic()
-	})
-	_ = ReportAfterSuite("cleanup", func(report Report) {
-		if Config.CleanupLogsOnSuccess {
-			universal_logs.CleanupIfSuccess(Config.UniversalE2ELogsPath, report)
-		}
-	})
-	_ = ReportAfterSuite("cp logs", multizone.PrintCPLogsOnFailure)
-	_ = ReportAfterSuite("kube state", multizone.PrintKubeState)
+	_ = SynchronizedAfterSuite(func() {}, multizone.SynchronizedAfterSuite)
+	_ = ReportAfterSuite("multizone after suite", multizone.AfterSuite)
 )
 
 var (

--- a/test/e2e_env/universal/universal_suite_test.go
+++ b/test/e2e_env/universal/universal_suite_test.go
@@ -44,7 +44,6 @@ import (
 	"github.com/kumahq/kuma/test/e2e_env/universal/zoneegress"
 	. "github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/framework/envs/universal"
-	"github.com/kumahq/kuma/test/framework/universal_logs"
 )
 
 func TestE2E(t *testing.T) {
@@ -53,13 +52,8 @@ func TestE2E(t *testing.T) {
 
 var (
 	_ = E2ESynchronizedBeforeSuite(universal.SetupAndGetState, universal.RestoreState)
-	_ = SynchronizedAfterSuite(func() {}, universal.ExpectCpToNotPanic)
-	_ = ReportAfterSuite("cleanup", func(report Report) {
-		if Config.CleanupLogsOnSuccess {
-			universal_logs.CleanupIfSuccess(Config.UniversalE2ELogsPath, report)
-		}
-	})
-	_ = ReportAfterSuite("cp logs", universal.PrintCPLogsOnFailure)
+	_ = SynchronizedAfterSuite(func() {}, universal.SynchronizedAfterSuite)
+	_ = ReportAfterSuite("universal after suite", universal.AfterSuite)
 )
 
 var (

--- a/test/framework/debug.go
+++ b/test/framework/debug.go
@@ -101,11 +101,12 @@ func ensureDebugDir() {
 func CpRestarted(cluster Cluster) bool {
 	switch cluster.(type) {
 	case *UniversalCluster:
+		// CP does not recover restart on universal. If it crashed, we can just check if the process is still running.
 		out, _, _ := cluster.Exec("", "", AppModeCP, "ps", "aux")
-		return strings.Contains(out, "kuma-cp run")
+		return !strings.Contains(out, "kuma-cp run")
 	case *K8sCluster:
 		restartCount := RestartCount(cluster.GetKuma().(*K8sControlPlane).GetKumaCPPods())
-		return restartCount == 0
+		return restartCount > 0
 	default:
 		return false
 	}

--- a/test/framework/debug.go
+++ b/test/framework/debug.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/gruntwork-io/terratest/modules/k8s"
@@ -95,4 +96,17 @@ func ensureDebugDir() {
 		return
 	}
 	Expect(err).ToNot(HaveOccurred())
+}
+
+func CpRestarted(cluster Cluster) bool {
+	switch cluster.(type) {
+	case *UniversalCluster:
+		out, _, _ := cluster.Exec("", "", AppModeCP, "ps", "aux")
+		return strings.Contains(out, "kuma-cp run")
+	case *K8sCluster:
+		restartCount := RestartCount(cluster.GetKuma().(*K8sControlPlane).GetKumaCPPods())
+		return restartCount == 0
+	default:
+		return false
+	}
 }

--- a/test/framework/envs/kubernetes/env.go
+++ b/test/framework/envs/kubernetes/env.go
@@ -102,11 +102,6 @@ func PrintKubeState(report ginkgo.Report) {
 	}
 }
 
-func ExpectCpToNotCrash() {
-	restartCount := framework.RestartCount(Cluster.GetKuma().(*framework.K8sControlPlane).GetKumaCPPods())
-	Expect(restartCount).To(Equal(0), "CP restarted in this suite, this should not happen.")
-}
-
 func ExpectCpToNotPanic() {
 	logs, err := Cluster.GetKumaCPLogs()
 	if err != nil {
@@ -114,4 +109,14 @@ func ExpectCpToNotPanic() {
 	} else {
 		Expect(utils.HasPanicInCpLogs(logs)).To(BeFalse())
 	}
+}
+
+func SynchronizedAfterSuite() {
+	Expect(framework.CpRestarted(Cluster)).To(BeFalse(), "CP restarted in this suite, this should not happen.")
+	ExpectCpToNotPanic()
+}
+
+func AfterSuite(report ginkgo.Report) {
+	PrintCPLogsOnFailure(report)
+	PrintKubeState(report)
 }

--- a/test/framework/envs/multizone/env.go
+++ b/test/framework/envs/multizone/env.go
@@ -5,12 +5,13 @@ import (
 	"sync"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
-	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/test/framework"
 	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/universal_logs"
 	"github.com/kumahq/kuma/test/framework/utils"
 )
 
@@ -65,7 +66,7 @@ func setupKubeZone(wg *sync.WaitGroup, clusterName string, extraOptions ...frame
 	options = append(options, extraOptions...)
 	zone := NewK8sCluster(NewTestingT(), clusterName, Verbose)
 	go func() {
-		defer GinkgoRecover()
+		defer ginkgo.GinkgoRecover()
 		defer wg.Done()
 		Expect(zone.Install(Kuma(core.Zone, options...))).To(Succeed())
 	}()
@@ -85,9 +86,8 @@ func setupUniZone(wg *sync.WaitGroup, clusterName string, extraOptions ...framew
 		extraOptions...,
 	)
 	zone := NewUniversalCluster(NewTestingT(), clusterName, Silent)
-	E2EDeferCleanup(zone.DismissCluster) // clean up any containers if needed
 	go func() {
-		defer GinkgoRecover()
+		defer ginkgo.GinkgoRecover()
 		defer wg.Done()
 		err := NewClusterSetup().
 			Install(Kuma(core.Zone, options...)).
@@ -102,7 +102,6 @@ func setupUniZone(wg *sync.WaitGroup, clusterName string, extraOptions ...framew
 // SetupAndGetState to be used with Ginkgo SynchronizedBeforeSuite
 func SetupAndGetState() []byte {
 	Global = NewUniversalCluster(NewTestingT(), Kuma3, Silent)
-	E2EDeferCleanup(Global.DismissCluster) // clean up any containers if needed
 	globalOptions := append(
 		[]framework.KumaDeploymentOption{
 			WithEnv("KUMA_MULTIZONE_GLOBAL_KDS_NACK_BACKOFF", "1s"),
@@ -244,7 +243,23 @@ func RestoreState(bytes []byte) {
 	UniZone2 = restoreUniZone(Kuma5, &state.UniZone2)
 }
 
-func PrintCPLogsOnFailure(report Report) {
+func SynchronizedAfterSuite() {
+	ExpectCpsToNotCrash()
+	ExpectCpsToNotPanic()
+	Expect(Global.DismissCluster()).To(Succeed())
+	Expect(UniZone1.DismissCluster()).To(Succeed())
+	Expect(UniZone2.DismissCluster()).To(Succeed())
+}
+
+func AfterSuite(report ginkgo.Report) {
+	if Config.CleanupLogsOnSuccess {
+		universal_logs.CleanupIfSuccess(Config.UniversalE2ELogsPath, report)
+	}
+	PrintCPLogsOnFailure(report)
+	PrintKubeState(report)
+}
+
+func PrintCPLogsOnFailure(report ginkgo.Report) {
 	if !report.SuiteSucceeded {
 		for _, cluster := range append(Zones(), Global) {
 			Logf("\n\n\n\n\nCP logs of: " + cluster.Name())
@@ -258,7 +273,7 @@ func PrintCPLogsOnFailure(report Report) {
 	}
 }
 
-func PrintKubeState(report Report) {
+func PrintKubeState(report ginkgo.Report) {
 	if !report.SuiteSucceeded {
 		for _, cluster := range []Cluster{KubeZone1, KubeZone2} {
 			Logf("Kube state of cluster: " + cluster.Name())
@@ -271,10 +286,9 @@ func PrintKubeState(report Report) {
 }
 
 func ExpectCpsToNotCrash() {
-	restartCount := framework.RestartCount(KubeZone1.GetKuma().(*framework.K8sControlPlane).GetKumaCPPods())
-	Expect(restartCount).To(Equal(0), "Zone 1 CP restarted in this suite, this should not happen.")
-	restartCount = framework.RestartCount(KubeZone2.GetKuma().(*framework.K8sControlPlane).GetKumaCPPods())
-	Expect(restartCount).To(Equal(0), "Zone 2 CP restarted in this suite, this should not happen.")
+	for _, cluster := range append(Zones(), Global) {
+		Expect(CpRestarted(cluster)).To(BeFalse(), cluster.Name()+" restarted in this suite, this should not happen.")
+	}
 }
 
 func ExpectCpsToNotPanic() {

--- a/test/framework/envs/universal/env.go
+++ b/test/framework/envs/universal/env.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/universal_logs"
 	"github.com/kumahq/kuma/test/framework/utils"
 )
 
@@ -16,7 +17,6 @@ var Cluster *framework.UniversalCluster
 // SetupAndGetState to be used with Ginkgo SynchronizedBeforeSuite
 func SetupAndGetState() []byte {
 	Cluster = framework.NewUniversalCluster(framework.NewTestingT(), framework.Kuma3, framework.Silent)
-	framework.E2EDeferCleanup(Cluster.DismissCluster)
 	kumaOptions := append(
 		[]framework.KumaDeploymentOption{
 			framework.WithEnv("KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL", "1s"), // speed up some tests by flushing stats quicker than default 10s
@@ -76,4 +76,17 @@ func ExpectCpToNotPanic() {
 	} else {
 		Expect(utils.HasPanicInCpLogs(logs)).To(BeFalse())
 	}
+}
+
+func SynchronizedAfterSuite() {
+	ExpectCpToNotPanic()
+	Expect(framework.CpRestarted(Cluster)).To(BeFalse(), "CP restarted in this suite, this should not happen.")
+	Expect(Cluster.DismissCluster()).To(Succeed())
+}
+
+func AfterSuite(report ginkgo.Report) {
+	if framework.Config.CleanupLogsOnSuccess {
+		universal_logs.CleanupIfSuccess(framework.Config.UniversalE2ELogsPath, report)
+	}
+	PrintCPLogsOnFailure(report)
 }


### PR DESCRIPTION
### Checklist prior to review

Check that universal CP did not crash.

Additionally, I extracted all responsibilities to one common `*AfterSuite` in each env, so whenever we add a new responsibility here, it also goes automatically to all projects that are based on Kuma (ex. Kong Mesh).

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
