### PR TITLE
fix(transparent-proxy): fix IPv6 iptables rules when no IPv6 DNS servers

### DIFF
--- a/pkg/transparentproxy/iptables/builder/builder_table_raw.go
+++ b/pkg/transparentproxy/iptables/builder/builder_table_raw.go
@@ -11,12 +11,9 @@ func buildRawTable(cfg config.InitializedConfig, ipv6 bool) *tables.RawTable {
 	raw := tables.Raw()
 
 	dnsServers := cfg.Redirect.DNS.ServersIPv4
-	if ipv6 {
-		dnsServers = cfg.Redirect.DNS.ServersIPv6
-	}
-
 	conntractZoneSplit := cfg.Redirect.DNS.ConntrackZoneSplitIPv4
 	if ipv6 {
+		dnsServers = cfg.Redirect.DNS.ServersIPv6
 		conntractZoneSplit = cfg.Redirect.DNS.ConntrackZoneSplitIPv6
 	}
 

--- a/pkg/transparentproxy/iptables/parameters/protocol.go
+++ b/pkg/transparentproxy/iptables/parameters/protocol.go
@@ -95,7 +95,11 @@ func NotDestinationPort(port uint16) *TcpUdpParameter {
 }
 
 func NotDestinationPortIf(predicate func() bool, port uint16) *TcpUdpParameter {
-	if predicate() {
+	return NotDestinationPortIfBool(predicate(), port)
+}
+
+func NotDestinationPortIfBool(condition bool, port uint16) *TcpUdpParameter {
+	if condition {
 		return destinationPort(port, true)
 	}
 


### PR DESCRIPTION
When the `--redirect-dns` flag is present during the execution of `kumactl install transparent-proxy`, the `/etc/resolv.conf` file is parsed to obtain DNS servers. However, when the transparent proxy is configured to include IPv6 and no valid IPv6 servers are found, incorrect iptables rules were generated.

This commit fixes this when in such situation logs warning and skip IPv6 DNS traffic redirection.

Generated earlier IPv6 rules:

```sh
* raw
-A OUTPUT -p udp --dport 53 -m owner --uid-owner 5678 -j CT --zone 1
-A OUTPUT -p udp --sport 15053 -m owner --uid-owner 5678 -j CT --zone 2
COMMIT
* nat
-N KUMA_MESH_INBOUND
-N KUMA_MESH_OUTBOUND
-N KUMA_MESH_INBOUND_REDIRECT
-N KUMA_MESH_OUTBOUND_REDIRECT
-A PREROUTING -p tcp -j KUMA_MESH_INBOUND
-I OUTPUT 1 -p udp --dport 53 -m owner --uid-owner 5678 -j RETURN
-A OUTPUT -p tcp -j KUMA_MESH_OUTBOUND
-A KUMA_MESH_INBOUND -p tcp -j KUMA_MESH_INBOUND_REDIRECT
-A KUMA_MESH_OUTBOUND -s ::6/128 -o lo -j RETURN
-A KUMA_MESH_OUTBOUND -p tcp ! --dport 53 -o lo ! -d ::1/128 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
-A KUMA_MESH_OUTBOUND -p tcp ! --dport 53 -o lo -m owner ! --uid-owner 5678 -j RETURN
-A KUMA_MESH_OUTBOUND -m owner --uid-owner 5678 -j RETURN
-A KUMA_MESH_OUTBOUND -d ::1/128 -j RETURN
-A KUMA_MESH_OUTBOUND -j KUMA_MESH_OUTBOUND_REDIRECT
-A KUMA_MESH_INBOUND_REDIRECT -p tcp -j REDIRECT --to-ports 15006
-A KUMA_MESH_OUTBOUND_REDIRECT -p tcp -j REDIRECT --to-ports 15001
COMMIT
```

Generated rules after this fix:

```sh
# [WARNING]: couldn't find any IPv6 servers in /etc/resolv.conf file. Capturing IPv6 DNS traffic will be disabled
* nat
-N KUMA_MESH_INBOUND
-N KUMA_MESH_OUTBOUND
-N KUMA_MESH_INBOUND_REDIRECT
-N KUMA_MESH_OUTBOUND_REDIRECT
-A PREROUTING -p tcp -j KUMA_MESH_INBOUND
-A OUTPUT -p tcp -j KUMA_MESH_OUTBOUND
-A KUMA_MESH_INBOUND -p tcp -j KUMA_MESH_INBOUND_REDIRECT
-A KUMA_MESH_OUTBOUND -s ::6/128 -o lo -j RETURN
-A KUMA_MESH_OUTBOUND -p tcp -o lo ! -d ::1/128 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
-A KUMA_MESH_OUTBOUND -p tcp -o lo -m owner ! --uid-owner 5678 -j RETURN
-A KUMA_MESH_OUTBOUND -m owner --uid-owner 5678 -j RETURN
-A KUMA_MESH_OUTBOUND -d ::1/128 -j RETURN
-A KUMA_MESH_OUTBOUND -j KUMA_MESH_OUTBOUND_REDIRECT
-A KUMA_MESH_INBOUND_REDIRECT -p tcp -j REDIRECT --to-ports 15006
-A KUMA_MESH_OUTBOUND_REDIRECT -p tcp -j REDIRECT --to-ports 15001
COMMIT

```

Fixes: https://github.com/kumahq/kuma/issues/10799

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - https://github.com/kumahq/kuma/issues/10799
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Manually tested
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - There is no need

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
