### PR TITLE
refactor(transparent-proxy): put default ports in consts package

### DIFF
--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
@@ -25,7 +25,7 @@ import (
 	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/containers"
 	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/metadata"
 	k8s_util "github.com/kumahq/kuma/pkg/plugins/runtime/k8s/util"
-	tp_cfg "github.com/kumahq/kuma/pkg/transparentproxy/config"
+	tp_iptables_consts "github.com/kumahq/kuma/pkg/transparentproxy/iptables/consts"
 	tp_k8s "github.com/kumahq/kuma/pkg/transparentproxy/kubernetes"
 	"github.com/kumahq/kuma/pkg/util/pointer"
 )
@@ -584,12 +584,11 @@ func (i *KumaInjector) NewAnnotations(pod *kube_core.Pod, mesh string, logger lo
 		annotations[metadata.KumaTrafficExcludeOutboundPorts] = val
 	}
 
-	defaultTPCfg := tp_cfg.DefaultConfig()
 	if i.cfg.SidecarContainer.RedirectPortInboundV6 == 0 {
 		i.cfg.SidecarContainer.IpFamilyMode = metadata.IpFamilyModeIPv4
 	} else if i.cfg.SidecarContainer.RedirectPortInboundV6 > 0 &&
-		i.cfg.SidecarContainer.RedirectPortInboundV6 != uint32(defaultTPCfg.Redirect.Inbound.PortIPv6) &&
-		i.cfg.SidecarContainer.RedirectPortInboundV6 != uint32(defaultTPCfg.Redirect.Inbound.Port) {
+		i.cfg.SidecarContainer.RedirectPortInboundV6 != uint32(tp_iptables_consts.DefaultRedirectInbountPortIPv6) &&
+		i.cfg.SidecarContainer.RedirectPortInboundV6 != uint32(tp_iptables_consts.DefaultRedirectInbountPort) {
 		annotations[metadata.KumaTransparentProxyingInboundPortAnnotationV6] = fmt.Sprintf("%d", i.cfg.SidecarContainer.RedirectPortInboundV6)
 	}
 	annotations[metadata.KumaTransparentProxyingIPFamilyMode] = i.cfg.SidecarContainer.IpFamilyMode

--- a/pkg/transparentproxy/config/config.go
+++ b/pkg/transparentproxy/config/config.go
@@ -376,8 +376,8 @@ func DefaultConfig() Config {
 			NamePrefix: "KUMA_",
 			Inbound: TrafficFlow{
 				Enabled:       true,
-				Port:          15006,
-				PortIPv6:      15010,
+				Port:          DefaultRedirectInbountPort,
+				PortIPv6:      DefaultRedirectInbountPortIPv6,
 				Chain:         Chain{Name: "MESH_INBOUND"},
 				RedirectChain: Chain{Name: "MESH_INBOUND_REDIRECT"},
 				ExcludePorts:  []uint16{},
@@ -385,14 +385,14 @@ func DefaultConfig() Config {
 			},
 			Outbound: TrafficFlow{
 				Enabled:       true,
-				Port:          15001,
+				Port:          DefaultRedirectOutboundPort,
 				Chain:         Chain{Name: "MESH_OUTBOUND"},
 				RedirectChain: Chain{Name: "MESH_OUTBOUND_REDIRECT"},
 				ExcludePorts:  []uint16{},
 				IncludePorts:  []uint16{},
 			},
 			DNS: DNS{
-				Port:               15053,
+				Port:               DefaultRedirectDNSPort,
 				Enabled:            false,
 				CaptureAll:         false,
 				ConntrackZoneSplit: true,

--- a/pkg/transparentproxy/iptables/consts/consts.go
+++ b/pkg/transparentproxy/iptables/consts/consts.go
@@ -17,6 +17,14 @@ var IptablesCommandByFamily = map[bool]string{
 	true:  Ip6tables,
 }
 
+// Default ports used for iptables redirection.
+const (
+	DefaultRedirectInbountPort     uint16 = 15006
+	DefaultRedirectInbountPortIPv6 uint16 = 15010
+	DefaultRedirectOutboundPort    uint16 = 15001
+	DefaultRedirectDNSPort         uint16 = 15053
+)
+
 const (
 	DNSPort           uint16 = 53
 	LocalhostIPv4            = "127.0.0.1"


### PR DESCRIPTION
Instead of relying on `config.DefaultConfig()` in k8s injector, we are now importing only consts package, which makes it possible, to build `kuma-cp` on non-unix-based systems.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - No relevant issues
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Manually tested
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
