### PR TITLE
fix(GatewayAPI): check manual endpoints ref properly

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/pod_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller.go
@@ -491,16 +491,16 @@ func EndpointSliceToPodsMapper(l logr.Logger, client kube_client.Client) kube_ha
 			kube_types.NamespacedName{Namespace: slice.Namespace, Name: slice.Name},
 		)
 
+		svcName, ok := slice.Labels[kube_discovery.LabelServiceName]
+		if !ok {
+			return nil
+		}
 		var req []kube_reconcile.Request
 		for _, endpoint := range slice.Endpoints {
 			l := l.WithValues(
 				"Endpoint",
 				endpoint,
 			)
-			svcName, ok := slice.Labels[kube_discovery.LabelServiceName]
-			if !ok {
-				continue
-			}
 
 			l = l.WithValues(
 				"Service",

--- a/pkg/plugins/runtime/k8s/controllers/pod_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller.go
@@ -456,7 +456,8 @@ func ServiceToPodsMapper(l logr.Logger, client kube_client.Client) kube_handler.
 			var req []kube_reconcile.Request
 			for _, slice := range endpointSlices.Items {
 				for _, endpoint := range slice.Endpoints {
-					if endpoint.TargetRef != nil && endpoint.TargetRef.Kind == "Pod" && endpoint.TargetRef.APIVersion == kube_core.SchemeGroupVersion.String() {
+					if endpoint.TargetRef != nil && endpoint.TargetRef.Kind == "Pod" && (endpoint.TargetRef.APIVersion == kube_core.SchemeGroupVersion.String() ||
+						endpoint.TargetRef.APIVersion == "") {
 						req = append(req, kube_reconcile.Request{
 							NamespacedName: kube_types.NamespacedName{Name: endpoint.TargetRef.Name, Namespace: endpoint.TargetRef.Namespace},
 						})
@@ -519,7 +520,8 @@ func EndpointSliceToPodsMapper(l logr.Logger, client kube_client.Client) kube_ha
 				continue
 			}
 
-			if endpoint.TargetRef != nil && endpoint.TargetRef.Kind == "Pod" && endpoint.TargetRef.APIVersion == kube_core.SchemeGroupVersion.String() {
+			if endpoint.TargetRef != nil && endpoint.TargetRef.Kind == "Pod" && (endpoint.TargetRef.APIVersion == kube_core.SchemeGroupVersion.String() ||
+				endpoint.TargetRef.APIVersion == "") {
 				req = append(req, kube_reconcile.Request{
 					NamespacedName: kube_types.NamespacedName{Namespace: endpoint.TargetRef.Namespace, Name: endpoint.TargetRef.Name},
 				})

--- a/test/e2e_env/gatewayapi/conformance_test.go
+++ b/test/e2e_env/gatewayapi/conformance_test.go
@@ -105,9 +105,6 @@ func TestConformance(t *testing.T) {
 		),
 		Implementation:      implementation,
 		ConformanceProfiles: sets.New(suite.GatewayHTTPConformanceProfileName, suite.MeshHTTPConformanceProfileName),
-		SkipTests: []string{
-			tests.HTTPRouteServiceTypes.ShortName,
-		},
 	}
 
 	conformanceSuite, err := suite.NewConformanceTestSuite(options)


### PR DESCRIPTION
`apiVersion` isn't set by k8s for `Pods` for some reason.

Closes https://github.com/kumahq/kuma/issues/10768

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
