### PR TITLE
test(transparent-proxy): refactor InstallFlagsToTest to use a map

### DIFF
--- a/test/framework/utils/utils.go
+++ b/test/framework/utils/utils.go
@@ -95,57 +95,51 @@ func cleanName(name string) string {
 	).Replace(strings.ToLower(name))
 }
 
-// BuildIptablesGoldenFileName constructs the complete file path for a golden file used
-// for storing expected iptables rules based on a specific test configuration.
+// BuildIptablesGoldenFileName constructs the complete file path for a golden
+// file used for storing expected iptables rules based on a specific test
+// configuration.
 //
 // Args:
-//
-//	dir (string): The base directory containing transparent proxy tests.
-//	image (string): The Docker image name used for testing.
-//	cmd (string): The iptables save command used in the test.
-//	flags ([]string): The list of flags used during transparent proxy
-//	  installation.
+//   - dir (string): The base directory containing transparent proxy tests.
+//   - image (string): The Docker image name used for testing.
+//   - cmd (string): The iptables save command used in the test.
+//   - suffix (string): The optional suffix to be added to the file name.
 //
 // Returns:
-//
-//	[]string: A slice of strings representing the complete file path for the
-//	  golden file.
-//	  - The first element is the provided base directory.
-//	  - The second element is always "testdata", a subdirectory for storing
-//	    golden files.
-//	  - The third element is the actual golden file name based on the sanitized
-//	    image name and flags joined with hyphens with iptables cmd suffix.
+//   - []string: A slice of strings representing the complete file path for the
+//     golden file.
+//   - The first element is the provided base directory.
+//   - The second element is always "testdata", a subdirectory for storing
+//     golden files.
+//   - The third element is the actual golden file name based on the sanitized
+//     image name and flags joined with hyphens, ending with the command and
+//     ".golden" suffix.
 //
 // Example:
 //
 //	BuildIptablesGoldenFileName(
 //	  "install",
-//	  "Ubuntu 22.04",
+//	  "RHEL 8",
 //	  "iptables-save",
-//	  []string{"--redirect-dns"},
-//	) # Returns [
-//	  "install",
-//	  "testdata",
-//	  "ubuntu-22-04-iptables-redirect-dns.iptables.golden",
-//	]
+//	  "redirect-dns",
+//	) # Returns ["install", "testdata", "rhel-8-redirect-dns.iptables.golden"]
 func BuildIptablesGoldenFileName(
 	dir string,
 	image string,
 	cmd string,
-	flags []string,
+	suffix string,
 ) []string {
 	// Construct the golden file name by combining the sanitized image name,
-	// cleaned flag names joined with hyphens, and the optional suffix.
-	// The final file name has the format"<sanitized-image>-<flags>-<suffix>.golden".
+	// cleaned suffix joined with hyphens, and the trimmed command.
+	// The final file name has the format
+	// "<sanitized-image>-<suffix>.<cmd>.golden".
 	fileName := fmt.Sprintf(
 		"%s.%s.golden",
 		joinNonEmptyWithHyphen(
 			// Sanitize the Docker image name (e.g., "ubuntu:22.04" becomes
 			// "ubuntu-22-04").
 			cleanName(image),
-			// Sanitize and join the flag names with hyphens (e.g.,
-			// ["--redirect-dns"] becomes "redirect-dns").
-			cleanName(strings.Join(flags, "-")),
+			suffix,
 		),
 		// Remove the "-save" suffix from the command.
 		strings.TrimSuffix(cmd, "-save"),

--- a/test/transparentproxy/config.go
+++ b/test/transparentproxy/config.go
@@ -1,6 +1,7 @@
 package transparentproxy
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,12 +14,26 @@ import (
 
 var _ config.Config = TransparentProxyConfig{}
 
+type FlagsMap map[string][]string
+
+func (f *FlagsMap) Decode(value string) error {
+	result := map[string][]string{}
+
+	if err := json.Unmarshal([]byte(value), &result); err != nil {
+		return err
+	}
+
+	*f = result
+
+	return nil
+}
+
 type TransparentProxyConfig struct {
 	config.BaseConfig
 
 	KumactlLinuxBin    string            `json:"kumactlLinuxBin,omitempty" envconfig:"KUMACTL_LINUX_BIN"`
 	DockerImagesToTest map[string]string `json:"dockerImagesToTest,omitempty" envconfig:"DOCKER_IMAGES_TO_TEST"`
-	InstallFlagsToTest []string          `json:"additionalFlagsToTest,omitempty" envconfig:"ADDITIONAL_FLAGS_TO_TEST"`
+	InstallFlagsToTest *FlagsMap         `json:"additionalFlagsToTest,omitempty" envconfig:"ADDITIONAL_FLAGS_TO_TEST"`
 	IPV6               bool              `json:"ipv6,omitempty" envconfig:"IPV6"`
 }
 
@@ -75,8 +90,10 @@ var defaultConfig = TransparentProxyConfig{
 		"Fedora 39":         "fedora:39",
 		"Fedora 38":         "fedora:38",
 	},
-	InstallFlagsToTest: []string{
-		"--redirect-all-dns-traffic",
+	InstallFlagsToTest: &FlagsMap{
+		"redirect-all-dns-traffic": {
+			"--redirect-all-dns-traffic",
+		},
 	},
 	IPV6: false,
 }

--- a/test/transparentproxy/install/install.go
+++ b/test/transparentproxy/install/install.go
@@ -12,6 +12,7 @@ import (
 	"github.com/testcontainers/testcontainers-go/exec"
 
 	"github.com/kumahq/kuma/pkg/test/matchers"
+	"github.com/kumahq/kuma/pkg/util/pointer"
 	test_container "github.com/kumahq/kuma/test/framework/container"
 	"github.com/kumahq/kuma/test/framework/utils"
 	. "github.com/kumahq/kuma/test/transparentproxy"
@@ -36,10 +37,11 @@ var (
 )
 
 type testCase struct {
-	name            string
-	image           string
-	postStart       [][]string
-	additionalFlags []string
+	name             string
+	image            string
+	postStart        [][]string
+	goldenFileSuffix string
+	additionalFlags  []string
 }
 
 func Install() {
@@ -118,7 +120,7 @@ func EnsureGoldenFiles(container testcontainers.Container, tc testCase) {
 			"install",
 			tc.name,
 			cmd,
-			tc.additionalFlags,
+			tc.goldenFileSuffix,
 		)
 
 		exitCode, reader, err := container.Exec(
@@ -183,16 +185,17 @@ func genEntriesForImages(
 	decorators ...interface{},
 ) []TableEntry {
 	var entries []TableEntry
-	var flags [][]string
-
-	for _, flag := range Config.InstallFlagsToTest {
-		flags = append(flags, strings.Split(flag, " "))
-	}
 
 	for name, image := range images {
 		entries = append(
 			entries,
-			genEntriesForImage(name, image, flags, entry, decorators...)...,
+			genEntriesForImage(
+				name,
+				image,
+				Config.InstallFlagsToTest,
+				entry,
+				decorators...,
+			)...,
 		)
 	}
 
@@ -203,32 +206,31 @@ func genEntriesForImages(
 // involving Transparent Proxy (tproxy) installation within a Docker image.
 //
 // Args:
-//
-//	name (string): The shortened name of the Docker image for easier reference.
-//	image (string): The base Docker image name to use for testing.
-//	additionalFlagsToTest ([][]string): A 2D slice of strings representing
-//	  optional flags to include during tproxy installation. Each inner slice
-//	  represents a set of flags for a single test case (e.g.,
-//	  ["--redirect-all-dns-traffic"]).
-//	entry (func(description interface{}, args ...interface{}) TableEntry):
-//	  A function used to create Ginkgo TableEntry objects. Use PEntry or XEntry
-//	  for creating paused or excluded entries.
-//	decorators (...interface{}): Optional decorators to apply to each TableEntry
-//	  for additional customization or configuration.
+//   - name (string): The shortened name of the Docker image for easier
+//     reference.
+//   - image (string): The base Docker image name to use for testing.
+//   - additionalFlagsToTest (*FlagsMap): A map of optional flags to include
+//     during tproxy installation. Each key is a string suffix for the golden
+//     file, and each value is a slice of flags for a single test case (e.g.,
+//     {"--redirect-all-dns-traffic"}).
+//   - entry (func(description interface{}, args ...interface{}) TableEntry):
+//     A function used to create Ginkgo TableEntry objects. Use PEntry or XEntry
+//     for creating paused or excluded entries.
+//   - decorators (...interface{}): Optional decorators to apply to each
+//     TableEntry for additional customization or configuration.
 //
 // Returns:
-//
-//	[]TableEntry: A slice of Ginkgo TableEntry objects, each representing a
-//	  unique test case with the following configuration:
-//	  - Image name: The Docker image name used for the test (may include
-//	    additional flags).
-//	  - testCase: A struct containing detailed test case parameters:
-//	    - name: The shortened name of the Docker image.
-//	    - image: The base Docker image name.
-//	    - postStart: Commands to execute after starting the container (e.g.,
-//	      adding a user, updating package lists, installing iptables).
-//	    - additionalFlags (optional): Additional flags to pass during tproxy
-//	      installation.
+//   - []TableEntry: A slice of Ginkgo TableEntry objects, each representing a
+//     unique test case with the following configuration:
+//   - Image name: The Docker image name used for the test (may include
+//     additional flags).
+//   - testCase: A struct containing detailed test case parameters:
+//   - name: The shortened name of the Docker image.
+//   - image: The base Docker image name.
+//   - postStart: Commands to execute after starting the container (e.g.,
+//     adding a user, updating package lists, installing iptables).
+//   - additionalFlags (optional): Additional flags to pass during tproxy
+//     installation.
 //
 // This function generates entries for the following test variations:
 //   - Base installation on different Docker images (Ubuntu, Debian, Alpine,
@@ -242,7 +244,7 @@ func genEntriesForImages(
 func genEntriesForImage(
 	name string,
 	image string,
-	additionalFlagsToTest [][]string,
+	additionalFlagsToTest *FlagsMap,
 	entry func(description interface{}, args ...interface{}) TableEntry,
 	decorators ...interface{},
 ) []TableEntry {
@@ -270,14 +272,19 @@ func genEntriesForImage(
 
 	// buildArgs is a helper function that combines test case parameters with
 	// any additional decorators.
-	buildArgs := func(flags []string, decorators []interface{}) []interface{} {
+	buildArgs := func(
+		goldenFileSuffix string,
+		flags []string,
+		decorators []interface{},
+	) []interface{} {
 		var args []interface{}
 
 		args = append(args, testCase{
-			name:            name,
-			image:           image,
-			postStart:       postStart,
-			additionalFlags: flags,
+			name:             name,
+			image:            image,
+			postStart:        postStart,
+			goldenFileSuffix: goldenFileSuffix,
+			additionalFlags:  flags,
 		})
 		args = append(args, decorators...)
 
@@ -287,12 +294,12 @@ func genEntriesForImage(
 	entries := []TableEntry{
 		entry(
 			fmt.Sprintf("%s (%s)", name, image),
-			buildArgs(nil, decorators)...,
+			buildArgs("", nil, decorators)...,
 		),
 	}
 
-	for _, flags := range additionalFlagsToTest {
-		func(flags []string) {
+	for goldenFileSuffix, flags := range pointer.Deref(additionalFlagsToTest) {
+		func(goldenFileSuffix string, flags []string) {
 			entries = append(entries, entry(
 				fmt.Sprintf(
 					"%s (%s) with flags: %s",
@@ -300,9 +307,9 @@ func genEntriesForImage(
 					image,
 					strings.Join(flags, " "),
 				),
-				buildArgs(flags, decorators)...,
+				buildArgs(goldenFileSuffix, flags, decorators)...,
 			))
-		}(flags)
+		}(goldenFileSuffix, flags)
 	}
 
 	return entries


### PR DESCRIPTION
This update allows specifying a map where keys are prefixes used for generating golden file names, and values are lists of arguments for the `kumactl install transparent-proxy` command.

You can specify this using an env var, e.g.:
```sh
ADDITIONAL_FLAGS_TO_TEST='{"foo":["--verbose","--iptables-logs"]}'
```

It improves situation when you want to test multiple flags in one test case. In such situation golden files would include all flags in the name before. Now the name would contain a key from the map.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - No relevant issues
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Manually tested
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
