### PR TITLE
fix(transparent-proxy): don't add comments if no comment iptables module

### DIFF
--- a/pkg/transparentproxy/iptables/builder/builder.go
+++ b/pkg/transparentproxy/iptables/builder/builder.go
@@ -48,9 +48,9 @@ func BuildIPTablesForRestore(
 	// Build the rules for raw, NAT, and mangle tables, filtering out any empty
 	// sets.
 	result := slices.DeleteFunc([]string{
-		tables.BuildRulesForRestore(cfg, buildRawTable(cfg, ipv6)),
-		tables.BuildRulesForRestore(cfg, natTable),
-		tables.BuildRulesForRestore(cfg, buildMangleTable(cfg, ipv6)),
+		tables.BuildRulesForRestore(cfg, ipv6, buildRawTable(cfg, ipv6)),
+		tables.BuildRulesForRestore(cfg, ipv6, natTable),
+		tables.BuildRulesForRestore(cfg, ipv6, buildMangleTable(cfg, ipv6)),
 	}, func(s string) bool { return s == "" })
 
 	// Determine the separator based on verbosity setting.

--- a/pkg/transparentproxy/iptables/builder/builder_table_nat_test.go
+++ b/pkg/transparentproxy/iptables/builder/builder_table_nat_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Builder nat", func() {
 
 			// when
 			Expect(addPreroutingRules(cfg, nat, ipv6)).ToNot(HaveOccurred())
-			table := tables.BuildRulesForRestore(cfg, nat)
+			table := tables.BuildRulesForRestore(cfg, ipv6, nat)
 
 			// then
 			for _, rule := range expect {
@@ -147,7 +147,7 @@ var _ = Describe("Builder nat", func() {
 
 			// when
 			Expect(addPreroutingRules(cfg, nat, ipv6)).ToNot(HaveOccurred())
-			table := tables.BuildRulesForRestore(cfg, nat)
+			table := tables.BuildRulesForRestore(cfg, ipv6, nat)
 
 			// then
 			for _, rule := range expect {

--- a/pkg/transparentproxy/iptables/chains/chains.go
+++ b/pkg/transparentproxy/iptables/chains/chains.go
@@ -33,11 +33,14 @@ func (c *Chain) AddRules(rules ...*rules.RuleBuilder) *Chain {
 // `BuildForRestore(verbose)` method to generate the individual command string
 // for each rule. The `verbose` flag is passed along to maintain consistent
 // output formatting throughout the chain.
-func (c *Chain) BuildForRestore(cfg config.InitializedConfig) []string {
+func (c *Chain) BuildForRestore(
+	cfg config.InitializedConfig,
+	ipv6 bool,
+) []string {
 	var lines []string
 
 	for _, rule := range c.rules {
-		lines = append(lines, rule.BuildForRestore(cfg))
+		lines = append(lines, rule.BuildForRestore(cfg, ipv6))
 	}
 
 	return lines

--- a/pkg/transparentproxy/iptables/rules/rules.go
+++ b/pkg/transparentproxy/iptables/rules/rules.go
@@ -82,7 +82,8 @@ func NewRule(parameters ...*parameters.Parameter) *RuleBuilder {
 //
 // The command string is built as a space-separated list of components:
 // the flag, the chain name, the optional position (if not zero), and the rule
-// parameters. If a comment is provided (`r.comment`), it is included in the
+// parameters. If a comment is provided (`r.comment`) and the comment
+// functionality is enabled in the configuration, it is included in the
 // parameters with the prefix specified by `consts.IptablesRuleCommentPrefix`.
 //
 // The `parameters.Build(cfg.Verbose)` method is used to generate the final
@@ -91,10 +92,11 @@ func NewRule(parameters ...*parameters.Parameter) *RuleBuilder {
 // Args:
 //   - cfg (config.InitializedConfig): Configuration settings that control the
 //     verbose output and other behaviors.
+//   - ipv6 (bool): Boolean flag indicating whether the rule is for IPv6.
 //
 // Returns:
 // - string: The constructed iptables rule formatted for `iptables-restore`.
-func (r *Rule) BuildForRestore(cfg config.InitializedConfig) string {
+func (r *Rule) BuildForRestore(cfg config.InitializedConfig, ipv6 bool) string {
 	flag := consts.FlagVariationsMap[consts.FlagAppend][cfg.Verbose]
 	if r.position != 0 {
 		flag = consts.FlagVariationsMap[consts.FlagInsert][cfg.Verbose]
@@ -108,7 +110,12 @@ func (r *Rule) BuildForRestore(cfg config.InitializedConfig) string {
 
 	var params parameters.Parameters
 
-	if r.comment != "" {
+	commentFunctionality := cfg.Executables.IPv4.Functionality.Modules.Comment
+	if ipv6 {
+		commentFunctionality = cfg.Executables.IPv6.Functionality.Modules.Comment
+	}
+
+	if commentFunctionality && r.comment != "" {
 		params = append(
 			params,
 			parameters.Match(

--- a/pkg/transparentproxy/iptables/tables/tables.go
+++ b/pkg/transparentproxy/iptables/tables/tables.go
@@ -39,13 +39,17 @@ type Table interface {
 //
 // TODO (bartsmykla): refactor
 // TODO (bartsmykla): add tests
-func BuildRulesForRestore(cfg config.InitializedConfig, table Table) string {
+func BuildRulesForRestore(
+	cfg config.InitializedConfig,
+	ipv6 bool,
+	table Table,
+) string {
 	tableLine := fmt.Sprintf("* %s", table.Name())
 	var customChainLines []string
 	var ruleLines []string
 
 	for _, c := range table.Chains() {
-		ruleLines = append(ruleLines, c.BuildForRestore(cfg)...)
+		ruleLines = append(ruleLines, c.BuildForRestore(cfg, ipv6)...)
 	}
 
 	for _, c := range table.CustomChains() {
@@ -57,7 +61,7 @@ func BuildRulesForRestore(cfg config.InitializedConfig, table Table) string {
 				c.Name(),
 			),
 		)
-		ruleLines = append(ruleLines, c.BuildForRestore(cfg)...)
+		ruleLines = append(ruleLines, c.BuildForRestore(cfg, ipv6)...)
 	}
 
 	if cfg.Verbose {


### PR DESCRIPTION
In the PR introducing comments in iptables rules, I neglected to verify the availability of the comment iptables extension/module. This change addresses that oversight.

I acknowledge that passing the ipv6 value everywhere is cumbersome. I plan to refactor the builders to handle IP types in a more agnostic manner. This improvement will be addressed in subsequent PRs, as it requires a more complex update.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - https://github.com/kumahq/kuma/pull/10809
  - https://github.com/kumahq/kuma/issues/8411
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - There is no need

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
