### PR TITLE
feat(GatewayAPI): support port in parentRef

### DIFF
--- a/api/mesh/v1alpha1/dataplane_helpers.go
+++ b/api/mesh/v1alpha1/dataplane_helpers.go
@@ -40,6 +40,9 @@ const (
 	// Listener tag is used to select Gateway listeners
 	ListenerTag = "gateways.kuma.io/listener-name"
 
+	// Port tag is used to select Gateway listeners
+	PortTag = "gateways.kuma.io/listener-port"
+
 	// Used for Service-less dataplanes
 	TCPPortReserved = 49151 // IANA Reserved
 

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/attachment/attachment.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/attachment/attachment.go
@@ -42,14 +42,14 @@ const (
 // the Gateway or specific Listener.
 // refSectionName is nil if the ref refers to the whole Gateway.
 func findRouteListenerAttachment(
-	gateway *gatewayapi.Gateway,
+	gatewayNs string,
 	routeNs kube_client.Object,
-	refSectionName *gatewayapi.SectionName,
+	attemptedAttachments []gatewayapi.Listener,
 ) (Attachment, error) {
 	// Build a map of whether attaching to each listener is possible
-	listeners := map[gatewayapi.SectionName]Attachment{}
+	listenerAttachments := map[gatewayapi.SectionName]Attachment{}
 
-	for _, l := range gateway.Spec.Listeners {
+	for _, l := range attemptedAttachments {
 		ns := l.AllowedRoutes.Namespaces
 
 		// The gateway controller ensures Kinds is either empty or contains

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_conversion.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_conversion.go
@@ -3,6 +3,7 @@ package gatewayapi
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	kube_core "k8s.io/api/core/v1"
@@ -182,6 +183,7 @@ func (r *GatewayReconciler) gapiToKumaGateway(
 				// gateway-api routes are configured using direct references to
 				// Gateways, so just create a tag specifically for this listener
 				mesh_proto.ListenerTag: string(l.Name),
+				mesh_proto.PortTag:     strconv.Itoa(int(l.Port)),
 			},
 			CrossMesh: config.CrossMesh,
 		}

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -201,9 +201,10 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 			case attachment.Gateway:
 				tags := map[string]string{}
 				if ref.SectionName != nil {
-					tags = map[string]string{
-						mesh_proto.ListenerTag: string(*ref.SectionName),
-					}
+					tags[mesh_proto.ListenerTag] = string(*ref.SectionName)
+				}
+				if ref.Port != nil {
+					tags[mesh_proto.PortTag] = strconv.Itoa(int(*ref.Port))
 				}
 
 				var headers []string

--- a/test/e2e_env/gatewayapi/conformance_test.go
+++ b/test/e2e_env/gatewayapi/conformance_test.go
@@ -95,6 +95,7 @@ func TestConformance(t *testing.T) {
 			features.SupportHTTPRoute,
 			features.SupportHTTPRouteHostRewrite,
 			features.SupportHTTPRouteMethodMatching,
+			features.SupportHTTPRouteParentRefPort,
 			features.SupportHTTPRoutePathRedirect,
 			features.SupportHTTPRoutePathRewrite,
 			features.SupportHTTPRoutePortRedirect,


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
