### PR TITLE
refactor(transparent-proxy): move exclude ports for uids parsing to config initialization

### DIFF
--- a/app/cni/pkg/cni/injector_linux.go
+++ b/app/cni/pkg/cni/injector_linux.go
@@ -85,14 +85,9 @@ func mapToConfig(intermediateConfig *IntermediateConfig, logWriter *bufio.Writer
 		return nil, err
 	}
 
-	excludePortsForUIDs := []string{}
+	var excludePortsForUIDs []string
 	if intermediateConfig.excludeOutboundPortsForUIDs != "" {
 		excludePortsForUIDs = strings.Split(intermediateConfig.excludeOutboundPortsForUIDs, ";")
-	}
-
-	excludePortsForUIDsParsed, err := transparentproxy.ParseExcludePortsForUIDs(excludePortsForUIDs)
-	if err != nil {
-		return nil, err
 	}
 
 	cfg.Verbose = true
@@ -101,7 +96,7 @@ func mapToConfig(intermediateConfig *IntermediateConfig, logWriter *bufio.Writer
 	cfg.Redirect.Outbound.Enabled = true
 	cfg.Redirect.Outbound.Port = port
 	cfg.Redirect.Outbound.ExcludePorts = excludePorts
-	cfg.Redirect.Outbound.ExcludePortsForUIDs = excludePortsForUIDsParsed
+	cfg.Redirect.Outbound.ExcludePortsForUIDs = excludePortsForUIDs
 
 	cfg.DropInvalidPackets, err = GetEnabled(intermediateConfig.dropInvalidPackets)
 	if err != nil {

--- a/pkg/transparentproxy/iptables/builder/builder_table_nat.go
+++ b/pkg/transparentproxy/iptables/builder/builder_table_nat.go
@@ -13,7 +13,7 @@ import (
 )
 
 func buildMeshInbound(
-	cfg config.TrafficFlow,
+	cfg config.InitializedTrafficFlow,
 	prefix string,
 	meshInboundRedirect string,
 ) (*Chain, error) {
@@ -244,7 +244,11 @@ func buildMeshOutbound(
 // buildMeshRedirect creates a chain in the NAT table to handle traffic redirection
 // to a specified port. The chain will be configured to redirect TCP traffic to the
 // provided port, which can be different for IPv4 and IPv6.
-func buildMeshRedirect(cfg config.TrafficFlow, prefix string, ipv6 bool) (*Chain, error) {
+func buildMeshRedirect(
+	cfg config.InitializedTrafficFlow,
+	prefix string,
+	ipv6 bool,
+) (*Chain, error) {
 	chainName := cfg.RedirectChain.GetFullName(prefix)
 
 	// Determine the redirect port based on the IP version.

--- a/pkg/transparentproxy/test/config.go
+++ b/pkg/transparentproxy/test/config.go
@@ -5,6 +5,16 @@ import (
 )
 
 func InitializeConfig(cfg config.Config) config.InitializedConfig {
+	inbound, err := cfg.Redirect.Inbound.Initialize()
+	if err != nil {
+		panic(err)
+	}
+
+	outbound, err := cfg.Redirect.Outbound.Initialize()
+	if err != nil {
+		panic(err)
+	}
+
 	vnet, err := cfg.Redirect.VNet.Initialize()
 	if err != nil {
 		panic(err)
@@ -19,7 +29,9 @@ func InitializeConfig(cfg config.Config) config.InitializedConfig {
 				ServersIPv4: nil,
 				ServersIPv6: nil,
 			},
-			VNet: vnet,
+			Inbound:  inbound,
+			Outbound: outbound,
+			VNet:     vnet,
 		},
 		LoopbackInterfaceName: "",
 	}

--- a/pkg/transparentproxy/transparentproxy.go
+++ b/pkg/transparentproxy/transparentproxy.go
@@ -8,8 +8,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/kumahq/kuma/pkg/transparentproxy/config"
 	"github.com/kumahq/kuma/pkg/transparentproxy/ebpf"
 	"github.com/kumahq/kuma/pkg/transparentproxy/iptables"
@@ -81,89 +79,6 @@ func SplitPorts(ports string) ([]uint16, error) {
 	}
 
 	return result, nil
-}
-
-func ParseExcludePortsForUIDs(excludeOutboundPortsForUIDs []string) ([]config.UIDsToPorts, error) {
-	var uidsToPorts []config.UIDsToPorts
-	for _, excludePort := range excludeOutboundPortsForUIDs {
-		parts := strings.Split(excludePort, ":")
-		if len(parts) == 0 || len(parts) > 3 {
-			return nil, fmt.Errorf("value: '%s' is invalid - format for excluding ports by uids <protocol:>?<ports:>?uids", excludePort)
-		}
-		var portValuesOrRange string
-		var protocolOpts string
-		var uidValuesOrRange string
-		switch len(parts) {
-		case 1:
-			protocolOpts = "*"
-			portValuesOrRange = "*"
-			uidValuesOrRange = parts[0]
-		case 2:
-			protocolOpts = "*"
-			portValuesOrRange = parts[0]
-			uidValuesOrRange = parts[1]
-		case 3:
-			protocolOpts = parts[0]
-			portValuesOrRange = parts[1]
-			uidValuesOrRange = parts[2]
-		}
-		if uidValuesOrRange == "*" {
-			return nil, errors.New("can't use wildcard '*' for uids")
-		}
-		if portValuesOrRange == "*" || portValuesOrRange == "" {
-			portValuesOrRange = "1-65535"
-		}
-
-		if err := validateUintValueOrRange(portValuesOrRange); err != nil {
-			return nil, err
-		}
-
-		if strings.Contains(uidValuesOrRange, ",") {
-			return nil, fmt.Errorf("uid entry invalid:'%s', it should either be a single item or a range", uidValuesOrRange)
-		}
-		if err := validateUintValueOrRange(uidValuesOrRange); err != nil {
-			return nil, err
-		}
-
-		var protocols []string
-		if protocolOpts == "" || protocolOpts == "*" {
-			protocols = []string{"tcp", "udp"}
-		} else {
-			for _, p := range strings.Split(protocolOpts, ",") {
-				pCleaned := strings.ToLower(strings.TrimSpace(p))
-				if pCleaned != "tcp" && pCleaned != "udp" {
-					return nil, fmt.Errorf("protocol '%s' is invalid or unsupported", pCleaned)
-				}
-				protocols = append(protocols, pCleaned)
-			}
-		}
-		for _, p := range protocols {
-			uidsToPorts = append(uidsToPorts, config.UIDsToPorts{
-				Ports:    config.ValueOrRangeList(strings.ReplaceAll(portValuesOrRange, "-", ":")),
-				UIDs:     config.ValueOrRangeList(strings.ReplaceAll(uidValuesOrRange, "-", ":")),
-				Protocol: p,
-			})
-		}
-	}
-
-	return uidsToPorts, nil
-}
-
-func validateUintValueOrRange(valueOrRange string) error {
-	elements := strings.Split(valueOrRange, ",")
-
-	for _, element := range elements {
-		portRanges := strings.Split(element, "-")
-
-		for _, port := range portRanges {
-			_, err := ParseUint16(port)
-			if err != nil {
-				return errors.Wrapf(err, "values or range '%s' failed validation", valueOrRange)
-			}
-		}
-	}
-
-	return nil
 }
 
 func Setup(ctx context.Context, cfg config.InitializedConfig) (string, error) {

--- a/test/blackbox_network_tests/dns_test.go
+++ b/test/blackbox_network_tests/dns_test.go
@@ -129,11 +129,9 @@ var _ = Describe("Outbound IPv4 DNS/UDP traffic to port 53", func() {
 					},
 					Outbound: config.TrafficFlow{
 						Enabled: true,
-						ExcludePortsForUIDs: []config.UIDsToPorts{{
-							UIDs:     config.ValueOrRangeList(strconv.Itoa(int(dnsUserUid))),
-							Ports:    config.ValueOrRangeList(strconv.Itoa(int(consts.DNSPort))),
-							Protocol: "udp",
-						}},
+						ExcludePortsForUIDs: []string{
+							fmt.Sprintf("udp:%d:%d", consts.DNSPort, dnsUserUid),
+						},
 					},
 				},
 				RuntimeStdout: io.Discard,
@@ -221,11 +219,9 @@ var _ = Describe("Outbound IPv6 DNS/UDP traffic to port 53", func() {
 					},
 					Outbound: config.TrafficFlow{
 						Enabled: true,
-						ExcludePortsForUIDs: []config.UIDsToPorts{{
-							UIDs:     config.ValueOrRangeList(strconv.Itoa(int(dnsUserUid))),
-							Ports:    config.ValueOrRangeList(strconv.Itoa(int(consts.DNSPort))),
-							Protocol: "udp",
-						}},
+						ExcludePortsForUIDs: []string{
+							fmt.Sprintf("udp:%d:%d", consts.DNSPort, dnsUserUid),
+						},
 					},
 				},
 				IPv6:          true,

--- a/test/blackbox_network_tests/outbound_redirect_test.go
+++ b/test/blackbox_network_tests/outbound_redirect_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"strconv"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -328,11 +327,9 @@ var _ = Describe("Outbound IPv4 TCP traffic to any address:port except ports exc
 					Outbound: config.TrafficFlow{
 						Enabled: true,
 						Port:    serverPort,
-						ExcludePortsForUIDs: []config.UIDsToPorts{{
-							UIDs:     config.ValueOrRangeList(strconv.Itoa(int(dnsUserUid))),
-							Ports:    config.ValueOrRangeList(strconv.Itoa(int(excludedPort))),
-							Protocol: "tcp",
-						}},
+						ExcludePortsForUIDs: []string{
+							fmt.Sprintf("tcp:%d:%d", excludedPort, dnsUserUid),
+						},
 					},
 					Inbound: config.TrafficFlow{
 						Enabled: true,
@@ -904,11 +901,9 @@ var _ = Describe("Outbound IPv6 TCP traffic to any address:port except ports exc
 					Outbound: config.TrafficFlow{
 						Enabled: true,
 						Port:    serverPort,
-						ExcludePortsForUIDs: []config.UIDsToPorts{{
-							UIDs:     config.ValueOrRangeList(strconv.Itoa(int(dnsUserUid))),
-							Ports:    config.ValueOrRangeList(strconv.Itoa(int(excludedPort))),
-							Protocol: "tcp",
-						}},
+						ExcludePortsForUIDs: []string{
+							fmt.Sprintf("tcp:%d:%d", excludedPort, dnsUserUid),
+						},
 					},
 					Inbound: config.TrafficFlow{
 						Enabled: true,

--- a/test/transparentproxy/config.go
+++ b/test/transparentproxy/config.go
@@ -96,6 +96,7 @@ var defaultConfig = TransparentProxyConfig{
 			"--vnet", "docker0:172.17.0.0/16",
 			"--vnet", "br+:172.18.0.0/16",
 			"--vnet", "iface:::1/64",
+			"--exclude-outbound-ports-for-uids", "53,3000-5000:106-108",
 		},
 	},
 	IPV6: false,

--- a/test/transparentproxy/install/testdata/alpine-3-with-multiple-flags.ip6tables-nft.golden
+++ b/test/transparentproxy/install/testdata/alpine-3-with-multiple-flags.ip6tables-nft.golden
@@ -18,6 +18,8 @@ COMMIT
 -A PREROUTING -i iface -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface iface to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d ::/64 -i iface -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface iface, excluding destination ::1/64, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/alpine-3-with-multiple-flags.ip6tables.golden
+++ b/test/transparentproxy/install/testdata/alpine-3-with-multiple-flags.ip6tables.golden
@@ -18,6 +18,8 @@ COMMIT
 -A PREROUTING -i iface -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface iface to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d ::/64 -i iface -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface iface, excluding destination ::1/64, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/alpine-3-with-multiple-flags.iptables-nft.golden
+++ b/test/transparentproxy/install/testdata/alpine-3-with-multiple-flags.iptables-nft.golden
@@ -15,10 +15,10 @@ COMMIT
 :KUMA_MESH_INBOUND_REDIRECT -
 :KUMA_MESH_OUTBOUND -
 :KUMA_MESH_OUTBOUND_REDIRECT -
--A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
--A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -i br+ -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface br+ to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.18.0.0/16 -i br+ -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface br+, excluding destination 172.18.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
+-A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
+-A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053

--- a/test/transparentproxy/install/testdata/alpine-3-with-multiple-flags.iptables-nft.golden
+++ b/test/transparentproxy/install/testdata/alpine-3-with-multiple-flags.iptables-nft.golden
@@ -20,6 +20,8 @@ COMMIT
 -A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/alpine-3-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/alpine-3-with-multiple-flags.iptables.golden
@@ -15,10 +15,10 @@ COMMIT
 :KUMA_MESH_INBOUND_REDIRECT -
 :KUMA_MESH_OUTBOUND -
 :KUMA_MESH_OUTBOUND_REDIRECT -
--A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
--A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -i br+ -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface br+ to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.18.0.0/16 -i br+ -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface br+, excluding destination 172.18.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
+-A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
+-A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053

--- a/test/transparentproxy/install/testdata/alpine-3-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/alpine-3-with-multiple-flags.iptables.golden
@@ -20,6 +20,8 @@ COMMIT
 -A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/amazon-linux-2-with-multiple-flags.ip6tables-legacy.golden
+++ b/test/transparentproxy/install/testdata/amazon-linux-2-with-multiple-flags.ip6tables-legacy.golden
@@ -25,6 +25,8 @@ COMMIT
 -A PREROUTING -i iface -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface iface to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d ::/64 -i iface -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface iface, excluding destination ::1/64, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/amazon-linux-2-with-multiple-flags.ip6tables.golden
+++ b/test/transparentproxy/install/testdata/amazon-linux-2-with-multiple-flags.ip6tables.golden
@@ -25,6 +25,8 @@ COMMIT
 -A PREROUTING -i iface -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface iface to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d ::/64 -i iface -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface iface, excluding destination ::1/64, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/amazon-linux-2-with-multiple-flags.iptables-legacy.golden
+++ b/test/transparentproxy/install/testdata/amazon-linux-2-with-multiple-flags.iptables-legacy.golden
@@ -22,10 +22,10 @@ COMMIT
 :KUMA_MESH_INBOUND_REDIRECT -
 :KUMA_MESH_OUTBOUND -
 :KUMA_MESH_OUTBOUND_REDIRECT -
--A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
--A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -i br+ -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface br+ to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.18.0.0/16 -i br+ -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface br+, excluding destination 172.18.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
+-A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
+-A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053

--- a/test/transparentproxy/install/testdata/amazon-linux-2-with-multiple-flags.iptables-legacy.golden
+++ b/test/transparentproxy/install/testdata/amazon-linux-2-with-multiple-flags.iptables-legacy.golden
@@ -27,6 +27,8 @@ COMMIT
 -A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/amazon-linux-2-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/amazon-linux-2-with-multiple-flags.iptables.golden
@@ -22,10 +22,10 @@ COMMIT
 :KUMA_MESH_INBOUND_REDIRECT -
 :KUMA_MESH_OUTBOUND -
 :KUMA_MESH_OUTBOUND_REDIRECT -
--A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
--A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -i br+ -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface br+ to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.18.0.0/16 -i br+ -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface br+, excluding destination 172.18.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
+-A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
+-A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053

--- a/test/transparentproxy/install/testdata/amazon-linux-2-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/amazon-linux-2-with-multiple-flags.iptables.golden
@@ -27,6 +27,8 @@ COMMIT
 -A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/amazon-linux-2023-with-multiple-flags.ip6tables-nft.golden
+++ b/test/transparentproxy/install/testdata/amazon-linux-2023-with-multiple-flags.ip6tables-nft.golden
@@ -18,6 +18,8 @@ COMMIT
 -A PREROUTING -i iface -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface iface to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d ::/64 -i iface -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface iface, excluding destination ::1/64, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/amazon-linux-2023-with-multiple-flags.ip6tables.golden
+++ b/test/transparentproxy/install/testdata/amazon-linux-2023-with-multiple-flags.ip6tables.golden
@@ -18,6 +18,8 @@ COMMIT
 -A PREROUTING -i iface -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface iface to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d ::/64 -i iface -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface iface, excluding destination ::1/64, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/amazon-linux-2023-with-multiple-flags.iptables-nft.golden
+++ b/test/transparentproxy/install/testdata/amazon-linux-2023-with-multiple-flags.iptables-nft.golden
@@ -15,10 +15,10 @@ COMMIT
 :KUMA_MESH_INBOUND_REDIRECT -
 :KUMA_MESH_OUTBOUND -
 :KUMA_MESH_OUTBOUND_REDIRECT -
--A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
--A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -i br+ -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface br+ to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.18.0.0/16 -i br+ -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface br+, excluding destination 172.18.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
+-A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
+-A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053

--- a/test/transparentproxy/install/testdata/amazon-linux-2023-with-multiple-flags.iptables-nft.golden
+++ b/test/transparentproxy/install/testdata/amazon-linux-2023-with-multiple-flags.iptables-nft.golden
@@ -20,6 +20,8 @@ COMMIT
 -A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/amazon-linux-2023-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/amazon-linux-2023-with-multiple-flags.iptables.golden
@@ -15,10 +15,10 @@ COMMIT
 :KUMA_MESH_INBOUND_REDIRECT -
 :KUMA_MESH_OUTBOUND -
 :KUMA_MESH_OUTBOUND_REDIRECT -
--A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
--A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -i br+ -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface br+ to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.18.0.0/16 -i br+ -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface br+, excluding destination 172.18.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
+-A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
+-A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053

--- a/test/transparentproxy/install/testdata/amazon-linux-2023-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/amazon-linux-2023-with-multiple-flags.iptables.golden
@@ -20,6 +20,8 @@ COMMIT
 -A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/debian-10-with-multiple-flags.ip6tables-nft.golden
+++ b/test/transparentproxy/install/testdata/debian-10-with-multiple-flags.ip6tables-nft.golden
@@ -10,6 +10,8 @@
 -A PREROUTING -i iface -p 17 -m udp --dport 53 -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface iface to the kuma-dp DNS proxy (listening on port 15053)" -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d ::/64 -i iface -p 6 -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface iface, excluding destination ::1/64, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p 6 -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p 6 -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -j RETURN
+-A OUTPUT -p 17 -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -j RETURN
 -A OUTPUT -p 17 -m udp --dport 53 -m owner --uid-owner 5678 -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -j RETURN
 -A OUTPUT -p 17 -m udp --dport 53 -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -j REDIRECT --to-ports 15053
 -A OUTPUT -p 6 -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/debian-10-with-multiple-flags.ip6tables.golden
+++ b/test/transparentproxy/install/testdata/debian-10-with-multiple-flags.ip6tables.golden
@@ -10,6 +10,8 @@
 -A PREROUTING -i iface -p 17 -m udp --dport 53 -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface iface to the kuma-dp DNS proxy (listening on port 15053)" -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d ::/64 -i iface -p 6 -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface iface, excluding destination ::1/64, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p 6 -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p 6 -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -j RETURN
+-A OUTPUT -p 17 -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -j RETURN
 -A OUTPUT -p 17 -m udp --dport 53 -m owner --uid-owner 5678 -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -j RETURN
 -A OUTPUT -p 17 -m udp --dport 53 -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -j REDIRECT --to-ports 15053
 -A OUTPUT -p 6 -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/debian-10-with-multiple-flags.iptables-nft.golden
+++ b/test/transparentproxy/install/testdata/debian-10-with-multiple-flags.iptables-nft.golden
@@ -15,10 +15,10 @@ COMMIT
 :KUMA_MESH_OUTBOUND -
 :KUMA_MESH_INBOUND_REDIRECT -
 :KUMA_MESH_OUTBOUND_REDIRECT -
--A PREROUTING -i docker0 -p 17 -m udp --dport 53 -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -j REDIRECT --to-ports 15053
--A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p 6 -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -i br+ -p 17 -m udp --dport 53 -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface br+ to the kuma-dp DNS proxy (listening on port 15053)" -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.18.0.0/16 -i br+ -p 6 -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface br+, excluding destination 172.18.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
+-A PREROUTING -i docker0 -p 17 -m udp --dport 53 -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -j REDIRECT --to-ports 15053
+-A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p 6 -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p 6 -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
 -A OUTPUT -p 17 -m udp --dport 53 -m owner --uid-owner 5678 -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -j RETURN
 -A OUTPUT -p 17 -m udp --dport 53 -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -j REDIRECT --to-ports 15053

--- a/test/transparentproxy/install/testdata/debian-10-with-multiple-flags.iptables-nft.golden
+++ b/test/transparentproxy/install/testdata/debian-10-with-multiple-flags.iptables-nft.golden
@@ -20,6 +20,8 @@ COMMIT
 -A PREROUTING -i docker0 -p 17 -m udp --dport 53 -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p 6 -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p 6 -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p 6 -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -j RETURN
+-A OUTPUT -p 17 -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -j RETURN
 -A OUTPUT -p 17 -m udp --dport 53 -m owner --uid-owner 5678 -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -j RETURN
 -A OUTPUT -p 17 -m udp --dport 53 -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -j REDIRECT --to-ports 15053
 -A OUTPUT -p 6 -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/debian-10-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/debian-10-with-multiple-flags.iptables.golden
@@ -15,10 +15,10 @@ COMMIT
 :KUMA_MESH_OUTBOUND -
 :KUMA_MESH_INBOUND_REDIRECT -
 :KUMA_MESH_OUTBOUND_REDIRECT -
--A PREROUTING -i docker0 -p 17 -m udp --dport 53 -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -j REDIRECT --to-ports 15053
--A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p 6 -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -i br+ -p 17 -m udp --dport 53 -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface br+ to the kuma-dp DNS proxy (listening on port 15053)" -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.18.0.0/16 -i br+ -p 6 -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface br+, excluding destination 172.18.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
+-A PREROUTING -i docker0 -p 17 -m udp --dport 53 -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -j REDIRECT --to-ports 15053
+-A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p 6 -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p 6 -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
 -A OUTPUT -p 17 -m udp --dport 53 -m owner --uid-owner 5678 -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -j RETURN
 -A OUTPUT -p 17 -m udp --dport 53 -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -j REDIRECT --to-ports 15053

--- a/test/transparentproxy/install/testdata/debian-10-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/debian-10-with-multiple-flags.iptables.golden
@@ -20,6 +20,8 @@ COMMIT
 -A PREROUTING -i docker0 -p 17 -m udp --dport 53 -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p 6 -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p 6 -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p 6 -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -j RETURN
+-A OUTPUT -p 17 -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -j RETURN
 -A OUTPUT -p 17 -m udp --dport 53 -m owner --uid-owner 5678 -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -j RETURN
 -A OUTPUT -p 17 -m udp --dport 53 -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -j REDIRECT --to-ports 15053
 -A OUTPUT -p 6 -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/debian-11-with-multiple-flags.ip6tables-nft.golden
+++ b/test/transparentproxy/install/testdata/debian-11-with-multiple-flags.ip6tables-nft.golden
@@ -18,6 +18,8 @@ COMMIT
 -A PREROUTING -i iface -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface iface to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d ::/64 -i iface -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface iface, excluding destination ::1/64, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/debian-11-with-multiple-flags.ip6tables.golden
+++ b/test/transparentproxy/install/testdata/debian-11-with-multiple-flags.ip6tables.golden
@@ -18,6 +18,8 @@ COMMIT
 -A PREROUTING -i iface -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface iface to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d ::/64 -i iface -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface iface, excluding destination ::1/64, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/debian-11-with-multiple-flags.iptables-nft.golden
+++ b/test/transparentproxy/install/testdata/debian-11-with-multiple-flags.iptables-nft.golden
@@ -15,10 +15,10 @@ COMMIT
 :KUMA_MESH_INBOUND_REDIRECT -
 :KUMA_MESH_OUTBOUND -
 :KUMA_MESH_OUTBOUND_REDIRECT -
--A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
--A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -i br+ -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface br+ to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.18.0.0/16 -i br+ -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface br+, excluding destination 172.18.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
+-A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
+-A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053

--- a/test/transparentproxy/install/testdata/debian-11-with-multiple-flags.iptables-nft.golden
+++ b/test/transparentproxy/install/testdata/debian-11-with-multiple-flags.iptables-nft.golden
@@ -20,6 +20,8 @@ COMMIT
 -A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/debian-11-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/debian-11-with-multiple-flags.iptables.golden
@@ -15,10 +15,10 @@ COMMIT
 :KUMA_MESH_INBOUND_REDIRECT -
 :KUMA_MESH_OUTBOUND -
 :KUMA_MESH_OUTBOUND_REDIRECT -
--A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
--A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -i br+ -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface br+ to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.18.0.0/16 -i br+ -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface br+, excluding destination 172.18.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
+-A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
+-A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053

--- a/test/transparentproxy/install/testdata/debian-11-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/debian-11-with-multiple-flags.iptables.golden
@@ -20,6 +20,8 @@ COMMIT
 -A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/debian-12-with-multiple-flags.ip6tables-nft.golden
+++ b/test/transparentproxy/install/testdata/debian-12-with-multiple-flags.ip6tables-nft.golden
@@ -18,6 +18,8 @@ COMMIT
 -A PREROUTING -i iface -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface iface to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d ::/64 -i iface -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface iface, excluding destination ::1/64, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/debian-12-with-multiple-flags.ip6tables.golden
+++ b/test/transparentproxy/install/testdata/debian-12-with-multiple-flags.ip6tables.golden
@@ -18,6 +18,8 @@ COMMIT
 -A PREROUTING -i iface -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface iface to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d ::/64 -i iface -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface iface, excluding destination ::1/64, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/debian-12-with-multiple-flags.iptables-nft.golden
+++ b/test/transparentproxy/install/testdata/debian-12-with-multiple-flags.iptables-nft.golden
@@ -15,10 +15,10 @@ COMMIT
 :KUMA_MESH_INBOUND_REDIRECT -
 :KUMA_MESH_OUTBOUND -
 :KUMA_MESH_OUTBOUND_REDIRECT -
--A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
--A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -i br+ -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface br+ to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.18.0.0/16 -i br+ -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface br+, excluding destination 172.18.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
+-A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
+-A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053

--- a/test/transparentproxy/install/testdata/debian-12-with-multiple-flags.iptables-nft.golden
+++ b/test/transparentproxy/install/testdata/debian-12-with-multiple-flags.iptables-nft.golden
@@ -20,6 +20,8 @@ COMMIT
 -A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/debian-12-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/debian-12-with-multiple-flags.iptables.golden
@@ -15,10 +15,10 @@ COMMIT
 :KUMA_MESH_INBOUND_REDIRECT -
 :KUMA_MESH_OUTBOUND -
 :KUMA_MESH_OUTBOUND_REDIRECT -
--A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
--A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -i br+ -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface br+ to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.18.0.0/16 -i br+ -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface br+, excluding destination 172.18.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
+-A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
+-A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053

--- a/test/transparentproxy/install/testdata/debian-12-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/debian-12-with-multiple-flags.iptables.golden
@@ -20,6 +20,8 @@ COMMIT
 -A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/fedora-38-with-multiple-flags.ip6tables-legacy.golden
+++ b/test/transparentproxy/install/testdata/fedora-38-with-multiple-flags.ip6tables-legacy.golden
@@ -25,6 +25,8 @@ COMMIT
 -A PREROUTING -i iface -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface iface to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d ::/64 -i iface -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface iface, excluding destination ::1/64, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/fedora-38-with-multiple-flags.ip6tables.golden
+++ b/test/transparentproxy/install/testdata/fedora-38-with-multiple-flags.ip6tables.golden
@@ -25,6 +25,8 @@ COMMIT
 -A PREROUTING -i iface -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface iface to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d ::/64 -i iface -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface iface, excluding destination ::1/64, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/fedora-38-with-multiple-flags.iptables-legacy.golden
+++ b/test/transparentproxy/install/testdata/fedora-38-with-multiple-flags.iptables-legacy.golden
@@ -22,10 +22,10 @@ COMMIT
 :KUMA_MESH_INBOUND_REDIRECT -
 :KUMA_MESH_OUTBOUND -
 :KUMA_MESH_OUTBOUND_REDIRECT -
--A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
--A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -i br+ -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface br+ to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.18.0.0/16 -i br+ -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface br+, excluding destination 172.18.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
+-A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
+-A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053

--- a/test/transparentproxy/install/testdata/fedora-38-with-multiple-flags.iptables-legacy.golden
+++ b/test/transparentproxy/install/testdata/fedora-38-with-multiple-flags.iptables-legacy.golden
@@ -27,6 +27,8 @@ COMMIT
 -A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/fedora-38-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/fedora-38-with-multiple-flags.iptables.golden
@@ -22,10 +22,10 @@ COMMIT
 :KUMA_MESH_INBOUND_REDIRECT -
 :KUMA_MESH_OUTBOUND -
 :KUMA_MESH_OUTBOUND_REDIRECT -
--A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
--A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -i br+ -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface br+ to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.18.0.0/16 -i br+ -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface br+, excluding destination 172.18.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
+-A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
+-A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053

--- a/test/transparentproxy/install/testdata/fedora-38-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/fedora-38-with-multiple-flags.iptables.golden
@@ -27,6 +27,8 @@ COMMIT
 -A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/fedora-39-with-multiple-flags.ip6tables-legacy.golden
+++ b/test/transparentproxy/install/testdata/fedora-39-with-multiple-flags.ip6tables-legacy.golden
@@ -25,6 +25,8 @@ COMMIT
 -A PREROUTING -i iface -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface iface to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d ::/64 -i iface -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface iface, excluding destination ::1/64, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/fedora-39-with-multiple-flags.ip6tables.golden
+++ b/test/transparentproxy/install/testdata/fedora-39-with-multiple-flags.ip6tables.golden
@@ -25,6 +25,8 @@ COMMIT
 -A PREROUTING -i iface -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface iface to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d ::/64 -i iface -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface iface, excluding destination ::1/64, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/fedora-39-with-multiple-flags.iptables-legacy.golden
+++ b/test/transparentproxy/install/testdata/fedora-39-with-multiple-flags.iptables-legacy.golden
@@ -22,10 +22,10 @@ COMMIT
 :KUMA_MESH_INBOUND_REDIRECT -
 :KUMA_MESH_OUTBOUND -
 :KUMA_MESH_OUTBOUND_REDIRECT -
--A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
--A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -i br+ -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface br+ to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.18.0.0/16 -i br+ -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface br+, excluding destination 172.18.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
+-A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
+-A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053

--- a/test/transparentproxy/install/testdata/fedora-39-with-multiple-flags.iptables-legacy.golden
+++ b/test/transparentproxy/install/testdata/fedora-39-with-multiple-flags.iptables-legacy.golden
@@ -27,6 +27,8 @@ COMMIT
 -A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/fedora-39-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/fedora-39-with-multiple-flags.iptables.golden
@@ -22,10 +22,10 @@ COMMIT
 :KUMA_MESH_INBOUND_REDIRECT -
 :KUMA_MESH_OUTBOUND -
 :KUMA_MESH_OUTBOUND_REDIRECT -
--A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
--A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -i br+ -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface br+ to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.18.0.0/16 -i br+ -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface br+, excluding destination 172.18.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
+-A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
+-A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053

--- a/test/transparentproxy/install/testdata/fedora-39-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/fedora-39-with-multiple-flags.iptables.golden
@@ -27,6 +27,8 @@ COMMIT
 -A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/fedora-40-with-multiple-flags.ip6tables-legacy.golden
+++ b/test/transparentproxy/install/testdata/fedora-40-with-multiple-flags.ip6tables-legacy.golden
@@ -25,6 +25,8 @@ COMMIT
 -A PREROUTING -i iface -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface iface to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d ::/64 -i iface -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface iface, excluding destination ::1/64, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/fedora-40-with-multiple-flags.ip6tables.golden
+++ b/test/transparentproxy/install/testdata/fedora-40-with-multiple-flags.ip6tables.golden
@@ -25,6 +25,8 @@ COMMIT
 -A PREROUTING -i iface -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface iface to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d ::/64 -i iface -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface iface, excluding destination ::1/64, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/fedora-40-with-multiple-flags.iptables-legacy.golden
+++ b/test/transparentproxy/install/testdata/fedora-40-with-multiple-flags.iptables-legacy.golden
@@ -22,10 +22,10 @@ COMMIT
 :KUMA_MESH_INBOUND_REDIRECT -
 :KUMA_MESH_OUTBOUND -
 :KUMA_MESH_OUTBOUND_REDIRECT -
--A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
--A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -i br+ -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface br+ to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.18.0.0/16 -i br+ -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface br+, excluding destination 172.18.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
+-A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
+-A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053

--- a/test/transparentproxy/install/testdata/fedora-40-with-multiple-flags.iptables-legacy.golden
+++ b/test/transparentproxy/install/testdata/fedora-40-with-multiple-flags.iptables-legacy.golden
@@ -27,6 +27,8 @@ COMMIT
 -A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/fedora-40-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/fedora-40-with-multiple-flags.iptables.golden
@@ -22,10 +22,10 @@ COMMIT
 :KUMA_MESH_INBOUND_REDIRECT -
 :KUMA_MESH_OUTBOUND -
 :KUMA_MESH_OUTBOUND_REDIRECT -
--A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
--A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -i br+ -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface br+ to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.18.0.0/16 -i br+ -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface br+, excluding destination 172.18.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
+-A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
+-A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053

--- a/test/transparentproxy/install/testdata/fedora-40-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/fedora-40-with-multiple-flags.iptables.golden
@@ -27,6 +27,8 @@ COMMIT
 -A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/fedora-41-with-multiple-flags.ip6tables-legacy.golden
+++ b/test/transparentproxy/install/testdata/fedora-41-with-multiple-flags.ip6tables-legacy.golden
@@ -25,6 +25,8 @@ COMMIT
 -A PREROUTING -i iface -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface iface to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d ::/64 -i iface -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface iface, excluding destination ::1/64, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/fedora-41-with-multiple-flags.ip6tables.golden
+++ b/test/transparentproxy/install/testdata/fedora-41-with-multiple-flags.ip6tables.golden
@@ -25,6 +25,8 @@ COMMIT
 -A PREROUTING -i iface -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface iface to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d ::/64 -i iface -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface iface, excluding destination ::1/64, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/fedora-41-with-multiple-flags.iptables-legacy.golden
+++ b/test/transparentproxy/install/testdata/fedora-41-with-multiple-flags.iptables-legacy.golden
@@ -22,10 +22,10 @@ COMMIT
 :KUMA_MESH_INBOUND_REDIRECT -
 :KUMA_MESH_OUTBOUND -
 :KUMA_MESH_OUTBOUND_REDIRECT -
--A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
--A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -i br+ -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface br+ to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.18.0.0/16 -i br+ -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface br+, excluding destination 172.18.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
+-A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
+-A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053

--- a/test/transparentproxy/install/testdata/fedora-41-with-multiple-flags.iptables-legacy.golden
+++ b/test/transparentproxy/install/testdata/fedora-41-with-multiple-flags.iptables-legacy.golden
@@ -27,6 +27,8 @@ COMMIT
 -A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/fedora-41-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/fedora-41-with-multiple-flags.iptables.golden
@@ -22,10 +22,10 @@ COMMIT
 :KUMA_MESH_INBOUND_REDIRECT -
 :KUMA_MESH_OUTBOUND -
 :KUMA_MESH_OUTBOUND_REDIRECT -
--A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
--A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -i br+ -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface br+ to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.18.0.0/16 -i br+ -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface br+, excluding destination 172.18.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
+-A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
+-A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053

--- a/test/transparentproxy/install/testdata/fedora-41-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/fedora-41-with-multiple-flags.iptables.golden
@@ -27,6 +27,8 @@ COMMIT
 -A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/rhel-8-with-multiple-flags.ip6tables.golden
+++ b/test/transparentproxy/install/testdata/rhel-8-with-multiple-flags.ip6tables.golden
@@ -10,6 +10,8 @@
 -A PREROUTING -i iface -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface iface to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d ::/64 -i iface -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface iface, excluding destination ::1/64, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/rhel-8-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/rhel-8-with-multiple-flags.iptables.golden
@@ -15,10 +15,10 @@ COMMIT
 :KUMA_MESH_OUTBOUND -
 :KUMA_MESH_INBOUND_REDIRECT -
 :KUMA_MESH_OUTBOUND_REDIRECT -
--A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
--A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -i br+ -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface br+ to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.18.0.0/16 -i br+ -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface br+, excluding destination 172.18.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
+-A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
+-A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053

--- a/test/transparentproxy/install/testdata/rhel-8-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/rhel-8-with-multiple-flags.iptables.golden
@@ -20,6 +20,8 @@ COMMIT
 -A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/rhel-9-with-multiple-flags.ip6tables-nft.golden
+++ b/test/transparentproxy/install/testdata/rhel-9-with-multiple-flags.ip6tables-nft.golden
@@ -18,6 +18,8 @@ COMMIT
 -A PREROUTING -i iface -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface iface to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d ::/64 -i iface -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface iface, excluding destination ::1/64, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/rhel-9-with-multiple-flags.ip6tables.golden
+++ b/test/transparentproxy/install/testdata/rhel-9-with-multiple-flags.ip6tables.golden
@@ -18,6 +18,8 @@ COMMIT
 -A PREROUTING -i iface -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface iface to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d ::/64 -i iface -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface iface, excluding destination ::1/64, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/rhel-9-with-multiple-flags.iptables-nft.golden
+++ b/test/transparentproxy/install/testdata/rhel-9-with-multiple-flags.iptables-nft.golden
@@ -20,6 +20,8 @@ COMMIT
 -A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/rhel-9-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/rhel-9-with-multiple-flags.iptables.golden
@@ -20,6 +20,8 @@ COMMIT
 -A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/ubuntu-18-04-with-multiple-flags.ip6tables.golden
+++ b/test/transparentproxy/install/testdata/ubuntu-18-04-with-multiple-flags.ip6tables.golden
@@ -25,6 +25,8 @@ COMMIT
 -A PREROUTING -i iface -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface iface to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d ::/64 -i iface -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface iface, excluding destination ::1/64, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/ubuntu-18-04-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/ubuntu-18-04-with-multiple-flags.iptables.golden
@@ -22,10 +22,10 @@ COMMIT
 :KUMA_MESH_INBOUND_REDIRECT -
 :KUMA_MESH_OUTBOUND -
 :KUMA_MESH_OUTBOUND_REDIRECT -
--A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
--A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -i br+ -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface br+ to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.18.0.0/16 -i br+ -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface br+, excluding destination 172.18.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
+-A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
+-A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053

--- a/test/transparentproxy/install/testdata/ubuntu-18-04-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/ubuntu-18-04-with-multiple-flags.iptables.golden
@@ -27,6 +27,8 @@ COMMIT
 -A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/ubuntu-20-04-with-multiple-flags.ip6tables-nft.golden
+++ b/test/transparentproxy/install/testdata/ubuntu-20-04-with-multiple-flags.ip6tables-nft.golden
@@ -18,6 +18,8 @@ COMMIT
 -A PREROUTING -i iface -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface iface to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d ::/64 -i iface -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface iface, excluding destination ::1/64, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/ubuntu-20-04-with-multiple-flags.iptables-nft.golden
+++ b/test/transparentproxy/install/testdata/ubuntu-20-04-with-multiple-flags.iptables-nft.golden
@@ -15,10 +15,10 @@ COMMIT
 :KUMA_MESH_OUTBOUND -
 :KUMA_MESH_INBOUND_REDIRECT -
 :KUMA_MESH_OUTBOUND_REDIRECT -
--A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
--A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -i br+ -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface br+ to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.18.0.0/16 -i br+ -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface br+, excluding destination 172.18.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
+-A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
+-A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053

--- a/test/transparentproxy/install/testdata/ubuntu-20-04-with-multiple-flags.iptables-nft.golden
+++ b/test/transparentproxy/install/testdata/ubuntu-20-04-with-multiple-flags.iptables-nft.golden
@@ -20,6 +20,8 @@ COMMIT
 -A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/ubuntu-22-04-with-multiple-flags.ip6tables-nft.golden
+++ b/test/transparentproxy/install/testdata/ubuntu-22-04-with-multiple-flags.ip6tables-nft.golden
@@ -18,6 +18,8 @@ COMMIT
 -A PREROUTING -i iface -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface iface to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d ::/64 -i iface -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface iface, excluding destination ::1/64, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/ubuntu-22-04-with-multiple-flags.ip6tables.golden
+++ b/test/transparentproxy/install/testdata/ubuntu-22-04-with-multiple-flags.ip6tables.golden
@@ -18,6 +18,8 @@ COMMIT
 -A PREROUTING -i iface -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface iface to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d ::/64 -i iface -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface iface, excluding destination ::1/64, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/ubuntu-22-04-with-multiple-flags.iptables-nft.golden
+++ b/test/transparentproxy/install/testdata/ubuntu-22-04-with-multiple-flags.iptables-nft.golden
@@ -15,10 +15,10 @@ COMMIT
 :KUMA_MESH_INBOUND_REDIRECT -
 :KUMA_MESH_OUTBOUND -
 :KUMA_MESH_OUTBOUND_REDIRECT -
--A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
--A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -i br+ -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface br+ to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.18.0.0/16 -i br+ -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface br+, excluding destination 172.18.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
+-A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
+-A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053

--- a/test/transparentproxy/install/testdata/ubuntu-22-04-with-multiple-flags.iptables-nft.golden
+++ b/test/transparentproxy/install/testdata/ubuntu-22-04-with-multiple-flags.iptables-nft.golden
@@ -20,6 +20,8 @@ COMMIT
 -A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/ubuntu-22-04-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/ubuntu-22-04-with-multiple-flags.iptables.golden
@@ -15,10 +15,10 @@ COMMIT
 :KUMA_MESH_INBOUND_REDIRECT -
 :KUMA_MESH_OUTBOUND -
 :KUMA_MESH_OUTBOUND_REDIRECT -
--A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
--A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -i br+ -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface br+ to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.18.0.0/16 -i br+ -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface br+, excluding destination 172.18.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
+-A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
+-A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053

--- a/test/transparentproxy/install/testdata/ubuntu-22-04-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/ubuntu-22-04-with-multiple-flags.iptables.golden
@@ -20,6 +20,8 @@ COMMIT
 -A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/ubuntu-24-04-with-multiple-flags.ip6tables-nft.golden
+++ b/test/transparentproxy/install/testdata/ubuntu-24-04-with-multiple-flags.ip6tables-nft.golden
@@ -18,6 +18,8 @@ COMMIT
 -A PREROUTING -i iface -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface iface to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d ::/64 -i iface -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface iface, excluding destination ::1/64, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/ubuntu-24-04-with-multiple-flags.ip6tables.golden
+++ b/test/transparentproxy/install/testdata/ubuntu-24-04-with-multiple-flags.ip6tables.golden
@@ -18,6 +18,8 @@ COMMIT
 -A PREROUTING -i iface -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface iface to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d ::/64 -i iface -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface iface, excluding destination ::1/64, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/ubuntu-24-04-with-multiple-flags.iptables-nft.golden
+++ b/test/transparentproxy/install/testdata/ubuntu-24-04-with-multiple-flags.iptables-nft.golden
@@ -15,10 +15,10 @@ COMMIT
 :KUMA_MESH_INBOUND_REDIRECT -
 :KUMA_MESH_OUTBOUND -
 :KUMA_MESH_OUTBOUND_REDIRECT -
--A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
--A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -i br+ -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface br+ to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.18.0.0/16 -i br+ -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface br+, excluding destination 172.18.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
+-A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
+-A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053

--- a/test/transparentproxy/install/testdata/ubuntu-24-04-with-multiple-flags.iptables-nft.golden
+++ b/test/transparentproxy/install/testdata/ubuntu-24-04-with-multiple-flags.iptables-nft.golden
@@ -20,6 +20,8 @@ COMMIT
 -A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND

--- a/test/transparentproxy/install/testdata/ubuntu-24-04-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/ubuntu-24-04-with-multiple-flags.iptables.golden
@@ -15,10 +15,10 @@ COMMIT
 :KUMA_MESH_INBOUND_REDIRECT -
 :KUMA_MESH_OUTBOUND -
 :KUMA_MESH_OUTBOUND_REDIRECT -
--A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
--A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -i br+ -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface br+ to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.18.0.0/16 -i br+ -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface br+, excluding destination 172.18.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
+-A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
+-A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053

--- a/test/transparentproxy/install/testdata/ubuntu-24-04-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/ubuntu-24-04-with-multiple-flags.iptables.golden
@@ -20,6 +20,8 @@ COMMIT
 -A PREROUTING -i docker0 -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect DNS requests on interface docker0 to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A PREROUTING ! -d 172.17.0.0/16 -i docker0 -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic on interface docker0, excluding destination 172.17.0.0/16, to the envoy\'s outbound passthrough port 15001" -j REDIRECT --to-ports 15001
 -A PREROUTING -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect remaining TCP traffic to our custom chain for processing" -j KUMA_MESH_INBOUND
+-A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
+-A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/skip further processing for configured ports and UIDs" -m multiport --dports 53,3000:5000 -m owner --uid-owner 106-108 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND


### PR DESCRIPTION
Parsing ExcludePortsForUIDs definitions during config initialization is more logical and simplifies the nat rules building phase.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - https://github.com/kumahq/kuma/issues/8324
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - There is no need

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
