### PR TITLE
docs(MADR): update referencing synced resources by `name/namespace`

### DIFF
--- a/docs/madr/decisions/046-meshservice-policy-matching.md
+++ b/docs/madr/decisions/046-meshservice-policy-matching.md
@@ -206,8 +206,13 @@ On a k8s zone:
 
 On a universal zone, `namespace` is not valid.
 
-Note that this means it's possible to refer to synced `MeshServices` via their
-transformed `<service>-<hash-suffix>` name.
+Note that referring to synced `MeshServices` using transformed `<service>-<hash-suffix>` name
+shouldn't be possible. 
+Using hashed name in the ref would make it extremely difficult to implement Inspect API on Global.
+For example, MeshTimeout is synced from Zone to Global, and it refers to the `targetRef.name: <value>`. 
+There is no easy way to process `<value>` to figure out what resource on Global it refers to.
+When `name/namespace` are referring to the `<service>-<hash-suffix>`, the policy is accepted but has no effect
+as the search for `name/namespace` resource is happening only across locally-originated resources.
 
 ##### Backwards compatibility
 


### PR DESCRIPTION
While trying to support Inspect API I realised it might be not possible to resolve targetRef with `name/namespace` in case it's referring to already synced resource (with hash suffix).

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
