### PR TITLE
test(e2e): rename resource for delegated to avoid conflicts

### DIFF
--- a/test/e2e_env/kubernetes/gateway/delegated.go
+++ b/test/e2e_env/kubernetes/gateway/delegated.go
@@ -145,6 +145,9 @@ spec:
 			To(Succeed())
 	})
 
+	// If you copy the test case from a non-gateway test or create a new test,
+	// remember the the name of policies needs to be unique.
+	// If they have the same name, one might override the other, causing a flake.
 	Context("MeshCircuitBreaker", delegated.CircuitBreaker(&config))
 	Context("MeshProxyPatch", delegated.MeshProxyPatch(&config))
 	Context("MeshHealthCheck", delegated.MeshHealthCheck(&config))

--- a/test/e2e_env/kubernetes/gateway/delegated/meshpassthrough.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshpassthrough.go
@@ -63,7 +63,7 @@ spec:
 apiVersion: kuma.io/v1alpha1 
 kind: MeshPassthrough
 metadata:
-  name: disable-passthrough
+  name: disable-passthrough-delegated
   namespace: %s
   labels:
     kuma.io/mesh: %s
@@ -96,7 +96,7 @@ spec:
 apiVersion: kuma.io/v1alpha1 
 kind: MeshPassthrough
 metadata:
-  name: allow-specified
+  name: allow-specified-delegated
   namespace: %s
   labels:
     kuma.io/mesh: %s


### PR DESCRIPTION
### Checklist prior to review

MeshPassthrough test is using the same resource name and it might cause an overriding. Renaming to avoid this situation and flakes

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
