### PR TITLE
test(e2e): fix test flakiness

### DIFF
--- a/test/e2e_env/universal/matching/matching.go
+++ b/test/e2e_env/universal/matching/matching.go
@@ -36,12 +36,11 @@ func Matching() {
 		Expect(universal.Cluster.DeleteMesh(mesh)).To(Succeed())
 	})
 
-	// Added Flake because: https://github.com/kumahq/kuma/issues/4700
-	It("should both fault injections with the same destination proxy", FlakeAttempts(3), func() {
+	It("should both fault injections with the same destination proxy", func() {
 		Expect(YamlUniversal(fmt.Sprintf(`
 type: FaultInjection
 mesh: %s
-name: fi1
+name: matching-fi1
 sources:
    - match:
        kuma.io/service: demo-client-1
@@ -57,7 +56,7 @@ conf:
 		Expect(YamlUniversal(fmt.Sprintf(`
 type: FaultInjection
 mesh: %s
-name: fi2
+name: matching-fi2
 sources:
    - match:
        kuma.io/service: demo-client-2


### PR DESCRIPTION
### Checklist prior to review

Fix #4864

There is another `fi1` in another test.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
