### PR TITLE
refactor(ZoneIngress): put endpoints in mesh context

### DIFF
--- a/pkg/core/policy/types.go
+++ b/pkg/core/policy/types.go
@@ -1,6 +1,9 @@
 package policy
 
 import (
+	"fmt"
+	"strings"
+
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
@@ -27,3 +30,40 @@ type DataplanePolicy interface {
 }
 
 type InboundDataplanePolicyMap map[mesh_proto.InboundInterface]DataplanePolicy
+
+func MatchingRegex(tags mesh_proto.SingleValueTagSet) string {
+	var re string
+	for _, key := range tags.Keys() {
+		keyIsEqual := fmt.Sprintf(`&%s=`, key)
+		var value string
+		switch tags[key] {
+		case "*":
+			value = ``
+		default:
+			value = fmt.Sprintf(`[^&]*%s[,&]`, tags[key])
+		}
+		value = strings.ReplaceAll(value, ".", `\.`)
+		expr := keyIsEqual + value + `.*`
+		re += expr
+	}
+	re = `.*` + re
+	return re
+}
+
+func RegexOR(r ...string) string {
+	if len(r) == 0 {
+		return ""
+	}
+	if len(r) == 1 {
+		return r[0]
+	}
+	return fmt.Sprintf("(%s)", strings.Join(r, "|"))
+}
+
+func MatchSourceRegex(policy ConnectionPolicy) string {
+	var selectorRegexs []string
+	for _, selector := range policy.Sources() {
+		selectorRegexs = append(selectorRegexs, MatchingRegex(selector.Match))
+	}
+	return RegexOR(selectorRegexs...)
+}

--- a/pkg/core/xds/types.go
+++ b/pkg/core/xds/types.go
@@ -10,6 +10,7 @@ import (
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	util_tls "github.com/kumahq/kuma/pkg/tls"
+	envoy_tags "github.com/kumahq/kuma/pkg/xds/envoy/tags"
 )
 
 type APIVersion string
@@ -210,10 +211,14 @@ type ZoneEgressProxy struct {
 	MeshResourcesList  []*MeshResources
 }
 
+type ProxyDestinations map[string][]envoy_tags.Tags
+
 type MeshIngressResources struct {
-	Mesh        *core_mesh.MeshResource
-	EndpointMap EndpointMap
-	Resources   map[core_model.ResourceType]core_model.ResourceList
+	Mesh              *core_mesh.MeshResource
+	EndpointMap       EndpointMap
+	AvailableServices []*mesh_proto.ZoneIngress_AvailableService
+	Destinations      ProxyDestinations
+	Resources         map[core_model.ResourceType]core_model.ResourceList
 }
 
 type ZoneIngressProxy struct {

--- a/pkg/plugins/policies/meshfaultinjection/plugin/xds/configurer.go
+++ b/pkg/plugins/policies/meshfaultinjection/plugin/xds/configurer.go
@@ -12,6 +12,7 @@ import (
 
 	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/pkg/core/policy"
 	core_xds "github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
 	policies_xds "github.com/kumahq/kuma/pkg/plugins/policies/core/xds"
 	api "github.com/kumahq/kuma/pkg/plugins/policies/meshfaultinjection/api/v1alpha1"
@@ -87,7 +88,7 @@ func regexHeaderMatcher(tagSet mesh_proto.SingleValueTagSet, invert bool) *envoy
 				MatchPattern: &envoy_type_matcher.StringMatcher_SafeRegex{
 					SafeRegex: &envoy_type_matcher.RegexMatcher{
 						EngineType: &envoy_type_matcher.RegexMatcher_GoogleRe2{},
-						Regex:      tags.MatchingRegex(tagSet),
+						Regex:      policy.MatchingRegex(tagSet),
 					},
 				},
 			},

--- a/pkg/xds/context/context.go
+++ b/pkg/xds/context/context.go
@@ -58,18 +58,20 @@ func (g BaseMeshContext) Hash() string {
 // If there is an information that can be precomputed and shared between all data plane proxies
 // it should be put here. This way we can save CPU cycles of computing the same information.
 type MeshContext struct {
-	Hash                        string
-	Resource                    *core_mesh.MeshResource
-	Resources                   Resources
-	DataplanesByName            map[string]*core_mesh.DataplaneResource
-	EndpointMap                 xds.EndpointMap
-	ExternalServicesEndpointMap xds.EndpointMap
-	CrossMeshEndpoints          map[xds.MeshName]xds.EndpointMap
-	VIPDomains                  []xds.VIPDomains
-	VIPOutbounds                []*mesh_proto.Dataplane_Networking_Outbound
-	ServicesInformation         map[string]*ServiceInformation
-	DataSourceLoader            datasource.Loader
-	ReachableServicesGraph      ReachableServicesGraph
+	Hash                         string
+	Resource                     *core_mesh.MeshResource
+	Resources                    Resources
+	DataplanesByName             map[string]*core_mesh.DataplaneResource
+	EndpointMap                  xds.EndpointMap
+	ExternalServicesEndpointMap  xds.EndpointMap
+	CrossMeshEndpoints           map[xds.MeshName]xds.EndpointMap
+	VIPDomains                   []xds.VIPDomains
+	VIPOutbounds                 []*mesh_proto.Dataplane_Networking_Outbound
+	ServicesInformation          map[string]*ServiceInformation
+	DataSourceLoader             datasource.Loader
+	ReachableServicesGraph       ReachableServicesGraph
+	ZoneIngressAvailableServices []*mesh_proto.ZoneIngress_AvailableService
+	ZoneIngressDestinations      xds.ProxyDestinations
 }
 
 type ServiceInformation struct {

--- a/pkg/xds/envoy/listeners/v3/fault_injection_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/fault_injection_configurer.go
@@ -9,6 +9,7 @@ import (
 	envoy_type_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/pkg/core/policy"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/util/proto"
 	"github.com/kumahq/kuma/pkg/xds/envoy/tags"
@@ -64,9 +65,9 @@ func (f *FaultInjectionConfigurer) Configure(filterChain *envoy_listener.FilterC
 func createHeaders(selectors []mesh_proto.SingleValueTagSet) *envoy_route.HeaderMatcher {
 	var selectorRegexs []string
 	for _, selector := range selectors {
-		selectorRegexs = append(selectorRegexs, tags.MatchingRegex(selector))
+		selectorRegexs = append(selectorRegexs, policy.MatchingRegex(selector))
 	}
-	regexOR := tags.RegexOR(selectorRegexs...)
+	regexOR := policy.RegexOR(selectorRegexs...)
 
 	return &envoy_route.HeaderMatcher{
 		Name: tags.TagsHeaderName,

--- a/pkg/xds/envoy/listeners/v3/http_inbound_routes_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_inbound_routes_configurer_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/pkg/core/policy"
 	"github.com/kumahq/kuma/pkg/core/xds"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
@@ -29,9 +30,9 @@ var _ = Describe("HttpInboundRouteConfigurer", func() {
 
 			var selectorRegexs []string
 			for _, selector := range rateLimit.SourceTags() {
-				selectorRegexs = append(selectorRegexs, tags.MatchingRegex(selector))
+				selectorRegexs = append(selectorRegexs, policy.MatchingRegex(selector))
 			}
-			regexOR := tags.RegexOR(selectorRegexs...)
+			regexOR := policy.RegexOR(selectorRegexs...)
 
 			route.Match.Headers[tags.TagsHeaderName] = &v1alpha1.TrafficRoute_Http_Match_StringMatcher{
 				MatcherType: &v1alpha1.TrafficRoute_Http_Match_StringMatcher_Regex{

--- a/pkg/xds/envoy/tags/match.go
+++ b/pkg/xds/envoy/tags/match.go
@@ -10,7 +10,6 @@ import (
 
 	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	core_policy "github.com/kumahq/kuma/pkg/core/policy"
 	"github.com/kumahq/kuma/pkg/util/maps"
 )
 
@@ -255,41 +254,4 @@ func TagKeySlice(tags []Tags) TagKeysSlice {
 		r[i] = tags[i].Keys()
 	}
 	return r
-}
-
-func MatchingRegex(tags mesh_proto.SingleValueTagSet) string {
-	var re string
-	for _, key := range tags.Keys() {
-		keyIsEqual := fmt.Sprintf(`&%s=`, key)
-		var value string
-		switch tags[key] {
-		case "*":
-			value = ``
-		default:
-			value = fmt.Sprintf(`[^&]*%s[,&]`, tags[key])
-		}
-		value = strings.ReplaceAll(value, ".", `\.`)
-		expr := keyIsEqual + value + `.*`
-		re += expr
-	}
-	re = `.*` + re
-	return re
-}
-
-func RegexOR(r ...string) string {
-	if len(r) == 0 {
-		return ""
-	}
-	if len(r) == 1 {
-		return r[0]
-	}
-	return fmt.Sprintf("(%s)", strings.Join(r, "|"))
-}
-
-func MatchSourceRegex(policy core_policy.ConnectionPolicy) string {
-	var selectorRegexs []string
-	for _, selector := range policy.Sources() {
-		selectorRegexs = append(selectorRegexs, MatchingRegex(selector.Match))
-	}
-	return RegexOR(selectorRegexs...)
 }

--- a/pkg/xds/envoy/tags/match_test.go
+++ b/pkg/xds/envoy/tags/match_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/pkg/core/policy"
 	"github.com/kumahq/kuma/pkg/xds/envoy/tags"
 )
 
@@ -28,7 +29,7 @@ var _ = Describe("MatchingRegex", func() {
 	DescribeTable("should generate regex for matching service's tags",
 		func(given testCase) {
 			// when
-			regexStr := tags.MatchingRegex(given.selector)
+			regexStr := policy.MatchingRegex(given.selector)
 			re, err := regexp.Compile(regexStr)
 			// then
 			Expect(err).ToNot(HaveOccurred())
@@ -152,9 +153,9 @@ var _ = Describe("RegexOR", func() {
 		func(given testCase) {
 			var rss []string
 			for _, s := range given.selectors {
-				rss = append(rss, tags.MatchingRegex(s))
+				rss = append(rss, policy.MatchingRegex(s))
 			}
-			regexOR := tags.RegexOR(rss...)
+			regexOR := policy.RegexOR(rss...)
 			re, err := regexp.Compile(regexOR)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/xds/generator/egress/external_services_generator.go
+++ b/pkg/xds/generator/egress/external_services_generator.go
@@ -205,7 +205,7 @@ func (g *ExternalServicesGenerator) addFilterChains(
 
 					routes = append(routes, envoy_common.NewRoute(
 						envoy_common.WithCluster(cluster),
-						envoy_common.WithMatchHeaderRegex(tags.TagsHeaderName, tags.MatchSourceRegex(rl)),
+						envoy_common.WithMatchHeaderRegex(tags.TagsHeaderName, policy.MatchSourceRegex(rl)),
 						envoy_common.WithRateLimit(rl.Spec),
 					))
 				}

--- a/pkg/xds/generator/inbound_proxy_generator.go
+++ b/pkg/xds/generator/inbound_proxy_generator.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/pkg/core/policy"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/validators"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
@@ -81,7 +82,7 @@ func (g InboundProxyGenerator) Generate(ctx context.Context, _ *core_xds.Resourc
 
 			routes = append(routes, envoy_common.NewRoute(
 				envoy_common.WithCluster(cluster),
-				envoy_common.WithMatchHeaderRegex(tags.TagsHeaderName, tags.MatchSourceRegex(rl)),
+				envoy_common.WithMatchHeaderRegex(tags.TagsHeaderName, policy.MatchSourceRegex(rl)),
 				envoy_common.WithRateLimit(rl.Spec),
 			))
 		}

--- a/pkg/xds/generator/ingress_generator.go
+++ b/pkg/xds/generator/ingress_generator.go
@@ -2,10 +2,8 @@ package generator
 
 import (
 	"context"
-	"sort"
 
 	envoy_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
-	"golang.org/x/exp/maps"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
@@ -44,8 +42,6 @@ func (i IngressGenerator) Generate(
 
 	for _, mr := range proxy.ZoneIngressProxy.MeshResourceList {
 		meshName := mr.Mesh.GetMeta().GetName()
-		serviceList := maps.Keys(mr.EndpointMap)
-		sort.Strings(serviceList)
 		dest := zoneproxy.BuildMeshDestinations(
 			availableSvcsByMesh[meshName],
 			xds_context.Resources{MeshLocalResources: mr.Resources},

--- a/pkg/xds/sync/ingress_proxy_builder.go
+++ b/pkg/xds/sync/ingress_proxy_builder.go
@@ -76,7 +76,9 @@ func (p *IngressProxyBuilder) buildZoneIngressProxy(
 				zoneEgressesList,
 				meshCtx.Resources.Gateways().Items,
 			),
-			Resources: meshCtx.Resources.MeshLocalResources,
+			AvailableServices: meshCtx.ZoneIngressAvailableServices,
+			Destinations:      meshCtx.ZoneIngressDestinations,
+			Resources:         meshCtx.Resources.MeshLocalResources,
 		}
 
 		meshResourceList = append(meshResourceList, meshResources)


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --


> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
