### PR TITLE
fix(MeshGateway): prevent duplicate virtual hosts

### DIFF
--- a/pkg/plugins/policies/core/xds/meshroute/gateway.go
+++ b/pkg/plugins/policies/core/xds/meshroute/gateway.go
@@ -135,22 +135,16 @@ func AddToListenerByHostname(
 	listenerTls *mesh_proto.MeshGateway_TLS_Conf,
 	hostInfos ...plugin_gateway.GatewayHostInfo,
 ) {
-	// This is the key by which we partition route rules, which is only
-	// necessary/possible when using HTTPS + listener hostnames
-	listenerKey := "*"
-	switch listenerProtocol {
-	case mesh_proto.MeshGateway_Listener_HTTPS, mesh_proto.MeshGateway_Listener_TLS:
-		listenerKey = listenerHostname
-	}
-	listenerEntry, ok := acc[listenerKey]
+	listenerEntry, ok := acc[listenerHostname]
 	if !ok {
 		listenerEntry = plugin_gateway.GatewayListenerHostname{
-			Hostname: listenerKey,
+			Hostname: listenerHostname,
+			Protocol: listenerProtocol,
 			TLS:      listenerTls,
 		}
 	}
 	listenerEntry.HostInfos = append(listenerEntry.HostInfos, hostInfos...)
-	acc[listenerKey] = listenerEntry
+	acc[listenerHostname] = listenerEntry
 }
 
 func SortByHostname(listenersByHostname map[string]plugin_gateway.GatewayListenerHostname) []plugin_gateway.GatewayListenerHostname {

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/gateway_routes.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/gateway_routes.go
@@ -4,6 +4,7 @@ import (
 	"slices"
 	"strings"
 
+	"golang.org/x/exp/maps"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
@@ -36,7 +37,20 @@ func sortRulesToHosts(
 ) []plugin_gateway.GatewayListenerHostname {
 	hostInfosByHostname := map[string]plugin_gateway.GatewayListenerHostname{}
 
-	for _, hostnameTag := range sublisteners {
+	// Iterate over the listeners in order
+	sublistenersByHostname := map[string]meshroute.Sublistener{}
+	for _, sublistener := range sublisteners {
+		sublistenersByHostname[sublistener.Hostname] = sublistener
+	}
+
+	// Keep track of which hostnames we've seen at the listener level
+	// so we can track which matches can't be matched at a different listener
+	// Very important for the HTTP listeners where every virtual host ends up
+	// under the same route config
+	var observedHostnames []string
+
+	for _, hostname := range match.SortHostnamesByExactnessDec(maps.Keys(sublistenersByHostname)) {
+		hostnameTag := sublistenersByHostname[hostname]
 		inboundListener := rules.NewInboundListenerHostname(
 			address,
 			port,
@@ -104,6 +118,15 @@ func sortRulesToHosts(
 				}
 				rules = append(rules, hostnameRules...)
 			}
+			// As mentioned above we shouldn't add rules if this hostname match
+			// can't match because of a listener hostname
+			var hostnameMatchUnmatchable bool
+			for _, observedHostname := range observedHostnames {
+				hostnameMatchUnmatchable = hostnameMatchUnmatchable || match.Contains(observedHostname, hostnameMatch)
+			}
+			if hostnameMatchUnmatchable {
+				continue
+			}
 			// Create an info for every hostname match
 			// We may end up duplicating info more than once so we copy it here
 			host := plugin_gateway.GatewayHost{
@@ -131,6 +154,7 @@ func sortRulesToHosts(
 				hostInfo,
 			)
 		}
+		observedHostnames = append(observedHostnames, hostname)
 	}
 
 	return meshroute.SortByHostname(hostInfosByHostname)

--- a/pkg/plugins/runtime/gateway/filter_chain_generator.go
+++ b/pkg/plugins/runtime/gateway/filter_chain_generator.go
@@ -73,11 +73,7 @@ func (g *HTTPFilterChainGenerator) Generate(
 	// if there's already a filter chain, we have nothing to do.
 	chain := newHTTPFilterChain(ctx.Mesh, info)
 
-	if len(info.ListenerHostnames) != 1 {
-		return nil, nil, errors.New("expected exactly one ListenerHostname with HTTP listener")
-	}
-	routeName := info.ListenerHostnames[0].EnvoyRouteName(info.Listener.EnvoyListenerName)
-	chain.Configure(envoy_listeners.HttpDynamicRoute(routeName))
+	chain.Configure(envoy_listeners.HttpDynamicRoute(info.Listener.EnvoyListenerName + ":*"))
 	return nil, []*envoy_listeners.FilterChainBuilder{chain}, nil
 }
 

--- a/pkg/plugins/runtime/gateway/generator.go
+++ b/pkg/plugins/runtime/gateway/generator.go
@@ -78,12 +78,18 @@ type GatewayHost struct {
 
 type GatewayListenerHostname struct {
 	Hostname  string
+	Protocol  mesh_proto.MeshGateway_Listener_Protocol
 	TLS       *mesh_proto.MeshGateway_TLS_Conf
 	HostInfos []GatewayHostInfo
 }
 
 func (h GatewayListenerHostname) EnvoyRouteName(envoyListenerName string) string {
-	return envoyListenerName + ":" + h.Hostname
+	switch h.Protocol {
+	case mesh_proto.MeshGateway_Listener_TCP, mesh_proto.MeshGateway_Listener_HTTP:
+		return envoyListenerName + ":*"
+	default:
+		return envoyListenerName + ":" + h.Hostname
+	}
 }
 
 type GatewayListener struct {
@@ -340,7 +346,7 @@ func (g Generator) generateRDS(ctx xds_context.Context, info GatewayListenerInfo
 
 		// Make a pass over the generators for each virtual host.
 		for _, hostInfo := range hostInfos.HostInfos {
-			vh, err := GenerateVirtualHost(ctx, info, hostInfo.Host, hostInfo.Entries())
+			vh, err := GenerateVirtualHost(ctx, info, hostInfo.Host.Hostname, hostInfo.Entries())
 			if err != nil {
 				return nil, err
 			}
@@ -450,6 +456,7 @@ func MakeGatewayListener(
 
 		listenerHostnames = append(listenerHostnames, GatewayListenerHostname{
 			Hostname:  hostname,
+			Protocol:  listeners[0].GetProtocol(),
 			TLS:       hostAcc.tls,
 			HostInfos: hostInfos,
 		})

--- a/pkg/plugins/runtime/gateway/route_table_generator.go
+++ b/pkg/plugins/runtime/gateway/route_table_generator.go
@@ -22,12 +22,12 @@ const emptyGatewayMsg = "This is a Kuma MeshGateway. No routes match this MeshGa
 
 // GenerateVirtualHost generates xDS resources for the current route table.
 func GenerateVirtualHost(
-	ctx xds_context.Context, info GatewayListenerInfo, host GatewayHost, routes []route.Entry,
+	ctx xds_context.Context, info GatewayListenerInfo, hostname string, routes []route.Entry,
 ) (
 	*envoy_virtual_hosts.VirtualHostBuilder, error,
 ) {
-	vh := envoy_virtual_hosts.NewVirtualHostBuilder(info.Proxy.APIVersion, host.Hostname).Configure(
-		envoy_virtual_hosts.DomainNames(host.Hostname),
+	vh := envoy_virtual_hosts.NewVirtualHostBuilder(info.Proxy.APIVersion, hostname).Configure(
+		envoy_virtual_hosts.DomainNames(hostname),
 	)
 
 	// Ensure that we get TLS on HTTPS protocol listeners or crossMesh.

--- a/test/e2e_env/gatewayapi/conformance_test.go
+++ b/test/e2e_env/gatewayapi/conformance_test.go
@@ -89,6 +89,7 @@ func TestConformance(t *testing.T) {
 		ManifestFS: []fs.FS{&conformance.Manifests},
 		SupportedFeatures: sets.New(
 			features.SupportGateway,
+			features.SupportGatewayHTTPListenerIsolation,
 			features.SupportGatewayPort8080,
 			features.SupportReferenceGrant,
 			features.SupportHTTPRouteResponseHeaderModification,


### PR DESCRIPTION
And now it passes the isolation conformance tests

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
