### PR TITLE
refactor(transparent-proxy): improvements in table builders

### DIFF
--- a/pkg/transparentproxy/config/config.go
+++ b/pkg/transparentproxy/config/config.go
@@ -28,6 +28,39 @@ type Owner struct {
 // ranges and multiple values can be mixed e.g. 1000,1005:1006 meaning 1000,1005,1006
 type ValueOrRangeList string
 
+// NewValueOrRangeList creates a ValueOrRangeList from a given value or range of
+// values. It accepts a parameter of type []uint16, uint16, or string and
+// converts it to a ValueOrRangeList, which is a comma-separated string
+// representation of the values.
+//
+// Args:
+//   - v (T): The input value which can be a slice of uint16, a single uint16,
+//     or a string.
+//
+// Returns:
+//   - ValueOrRangeList: A comma-separated string representation of the input
+//     values.
+//
+// The function panics if an unsupported type is provided, although the type
+// constraints should prevent this from occurring.
+func NewValueOrRangeList[T ~[]uint16 | ~uint16 | ~string](v T) ValueOrRangeList {
+	switch value := any(v).(type) {
+	case []uint16:
+		var ports []string
+		for _, port := range value {
+			ports = append(ports, strconv.Itoa(int(port)))
+		}
+		return ValueOrRangeList(strings.Join(ports, ","))
+	case uint16:
+		return ValueOrRangeList(strconv.Itoa(int(value)))
+	case string:
+		return ValueOrRangeList(value)
+	default:
+		// Shouldn't be possible to catch this
+		panic(errors.Errorf("invalid value type: %T", value))
+	}
+}
+
 type Exclusion struct {
 	Protocol string
 	Address  string

--- a/pkg/transparentproxy/config/config_executables_functionality.go
+++ b/pkg/transparentproxy/config/config_executables_functionality.go
@@ -32,6 +32,7 @@ type FunctionalityModules struct {
 	// more connection tracking information than the "state" match.
 	// ref. iptables-extensions(8) > conntrack
 	Conntrack bool
+	Multiport bool
 }
 
 type FunctionalityChains struct {
@@ -120,6 +121,7 @@ func verifyFunctionality(
 			Udp:       verifyModule(ctx, iptables, ModuleUdp),
 			Comment:   verifyModule(ctx, iptables, ModuleComment),
 			Conntrack: verifyModule(ctx, iptables, ModuleConntrack),
+			Multiport: verifyModule(ctx, iptables, ModuleMultiport),
 		},
 	}
 

--- a/pkg/transparentproxy/config/config_suite_test.go
+++ b/pkg/transparentproxy/config/config_suite_test.go
@@ -1,0 +1,13 @@
+package config_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func Test(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Transparent Proxy Config Suite")
+}

--- a/pkg/transparentproxy/config/config_test.go
+++ b/pkg/transparentproxy/config/config_test.go
@@ -1,0 +1,30 @@
+package config
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("NewValueOrRangeList", func() {
+	DescribeTable("should create ValueOrRangeList",
+		func(input interface{}, expected string) {
+			// when
+			var result ValueOrRangeList
+
+			switch v := input.(type) {
+			case []uint16:
+				result = NewValueOrRangeList(v)
+			case uint16:
+				result = NewValueOrRangeList(v)
+			case string:
+				result = NewValueOrRangeList(v)
+			}
+
+			// then
+			Expect(string(result)).To(Equal(expected))
+		},
+		Entry("from uint16 slice", []uint16{80, 443}, "80,443"),
+		Entry("from single uint16", uint16(8080), "8080"),
+		Entry("from string", "1000-2000", "1000-2000"),
+	)
+})

--- a/pkg/transparentproxy/iptables/builder/builder_table_mangle.go
+++ b/pkg/transparentproxy/iptables/builder/builder_table_mangle.go
@@ -17,7 +17,7 @@ func buildMangleTable(cfg config.InitializedConfigIPvX) *tables.MangleTable {
 	if cfg.DropInvalidPackets {
 		mangle.Prerouting().AddRules(
 			rules.
-				NewRule(
+				NewAppendRule(
 					Match(Conntrack(Ctstate(INVALID))),
 					Jump(Drop()),
 				).

--- a/pkg/transparentproxy/iptables/builder/builder_table_nat.go
+++ b/pkg/transparentproxy/iptables/builder/builder_table_nat.go
@@ -236,11 +236,11 @@ func addOutputRules(cfg config.InitializedConfigIPvX, nat *tables.NatTable) {
 					MatchIf(exclusion.Ports != "", Multiport()),
 					Protocol(
 						TcpIf(
-							exclusion.Protocol == TCP,
+							exclusion.Protocol == ProtocolTCP,
 							DestinationPortRangeOrValue(exclusion),
 						),
 						UdpIf(
-							exclusion.Protocol == UDP,
+							exclusion.Protocol == ProtocolUDP,
 							DestinationPortRangeOrValue(exclusion),
 						),
 					),

--- a/pkg/transparentproxy/iptables/builder/builder_table_raw.go
+++ b/pkg/transparentproxy/iptables/builder/builder_table_raw.go
@@ -18,14 +18,14 @@ func buildRawTable(cfg config.InitializedConfigIPvX) *tables.RawTable {
 	if cfg.Redirect.DNS.ConntrackZoneSplit {
 		raw.Output().AddRules(
 			rules.
-				NewRule(
+				NewAppendRule(
 					Protocol(Udp(DestinationPort(DNSPort))),
 					Match(Owner(Uid(cfg.Owner.UID))),
 					Jump(Ct(Zone("1"))),
 				).
 				WithCommentf("assign connection tracking zone 1 to DNS traffic from the kuma-dp user (UID %s)", cfg.Owner.UID),
 			rules.
-				NewRule(
+				NewAppendRule(
 					Protocol(Udp(SourcePort(cfg.Redirect.DNS.Port))),
 					Match(Owner(Uid(cfg.Owner.UID))),
 					Jump(Ct(Zone("2"))),
@@ -36,7 +36,7 @@ func buildRawTable(cfg config.InitializedConfigIPvX) *tables.RawTable {
 		if cfg.Redirect.DNS.CaptureAll {
 			raw.Output().AddRules(
 				rules.
-					NewRule(
+					NewAppendRule(
 						Protocol(Udp(DestinationPort(DNSPort))),
 						Jump(Ct(Zone("2"))),
 					).
@@ -45,7 +45,7 @@ func buildRawTable(cfg config.InitializedConfigIPvX) *tables.RawTable {
 
 			raw.Prerouting().AddRules(
 				rules.
-					NewRule(
+					NewAppendRule(
 						Protocol(Udp(SourcePort(DNSPort))),
 						Jump(Ct(Zone("1"))),
 					).
@@ -55,7 +55,7 @@ func buildRawTable(cfg config.InitializedConfigIPvX) *tables.RawTable {
 			for _, ip := range cfg.Redirect.DNS.Servers {
 				raw.Output().AddRules(
 					rules.
-						NewRule(
+						NewAppendRule(
 							Destination(ip),
 							Protocol(Udp(DestinationPort(DNSPort))),
 							Jump(Ct(Zone("2"))),
@@ -64,7 +64,7 @@ func buildRawTable(cfg config.InitializedConfigIPvX) *tables.RawTable {
 				)
 				raw.Prerouting().AddRules(
 					rules.
-						NewRule(
+						NewAppendRule(
 							Destination(ip),
 							Protocol(Udp(SourcePort(DNSPort))),
 							Jump(Ct(Zone("1"))),

--- a/pkg/transparentproxy/iptables/consts/consts.go
+++ b/pkg/transparentproxy/iptables/consts/consts.go
@@ -111,6 +111,7 @@ const (
 	ModuleUdp       = "udp"
 	ModuleComment   = "comment"
 	ModuleConntrack = "conntrack"
+	ModuleMultiport = "multiport"
 )
 
 type IptablesMode string

--- a/pkg/transparentproxy/iptables/consts/consts.go
+++ b/pkg/transparentproxy/iptables/consts/consts.go
@@ -2,6 +2,7 @@ package consts
 
 import (
 	"regexp"
+	"strings"
 )
 
 const (
@@ -45,9 +46,36 @@ const (
 	InboundPassthroughSourceAddressCIDRIPv6 = "::6/128"
 	OutputLogPrefix                         = "OUTPUT:"
 	PreroutingLogPrefix                     = "PREROUTING:"
-	UDP                                     = "udp"
-	TCP                                     = "tcp"
 )
+
+type ProtocolL4 string
+
+const (
+	ProtocolUDP ProtocolL4 = "udp"
+	ProtocolTCP ProtocolL4 = "tcp"
+	// ProtocolUndefined represents an undefined or unsupported protocol.
+	ProtocolUndefined ProtocolL4 = ""
+)
+
+// ParseProtocolL4 parses a string and returns the corresponding ProtocolL4
+// constant. If the input string is not "udp" or "tcp", it returns
+// ProtocolUndefined.
+//
+// Args:
+//   - s (string): The input string representing the protocol type.
+//
+// Returns:
+//   - ProtocolL4: The parsed ProtocolL4 constant. It will be ProtocolUDP for
+//     "udp", ProtocolTCP for "tcp", and ProtocolUndefined for any other input
+//     string.
+func ParseProtocolL4(s string) ProtocolL4 {
+	switch s := strings.ToLower(strings.TrimSpace(s)); s {
+	case "udp", "tcp":
+		return ProtocolL4(s)
+	default:
+		return ProtocolUndefined
+	}
+}
 
 type TableName string
 

--- a/pkg/transparentproxy/iptables/parameters/protocol.go
+++ b/pkg/transparentproxy/iptables/parameters/protocol.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 
 	"github.com/kumahq/kuma/pkg/transparentproxy/config"
+	"github.com/kumahq/kuma/pkg/transparentproxy/iptables/consts"
 )
 
 var _ ParameterBuilder = &ProtocolParameter{}
@@ -127,7 +128,7 @@ func SourcePort(port uint16) *TcpUdpParameter {
 	return sourcePort(port, false)
 }
 
-func tcpUdp(proto string, params []*TcpUdpParameter) *ProtocolParameter {
+func tcpUdp(proto consts.ProtocolL4, params []*TcpUdpParameter) *ProtocolParameter {
 	var parameters []ParameterBuilder
 
 	for _, parameter := range params {
@@ -137,13 +138,13 @@ func tcpUdp(proto string, params []*TcpUdpParameter) *ProtocolParameter {
 	}
 
 	return &ProtocolParameter{
-		name:       proto,
+		name:       string(proto),
 		parameters: parameters,
 	}
 }
 
 func Udp(udpParameters ...*TcpUdpParameter) *ProtocolParameter {
-	return tcpUdp("udp", udpParameters)
+	return tcpUdp(consts.ProtocolUDP, udpParameters)
 }
 
 func UdpIf(predicate bool, udpParameters ...*TcpUdpParameter) *ProtocolParameter {
@@ -151,11 +152,11 @@ func UdpIf(predicate bool, udpParameters ...*TcpUdpParameter) *ProtocolParameter
 		return nil
 	}
 
-	return tcpUdp("udp", udpParameters)
+	return tcpUdp(consts.ProtocolUDP, udpParameters)
 }
 
 func Tcp(tcpParameters ...*TcpUdpParameter) *ProtocolParameter {
-	return tcpUdp("tcp", tcpParameters)
+	return tcpUdp(consts.ProtocolTCP, tcpParameters)
 }
 
 func TcpIf(predicate bool, tcpParameters ...*TcpUdpParameter) *ProtocolParameter {
@@ -163,7 +164,7 @@ func TcpIf(predicate bool, tcpParameters ...*TcpUdpParameter) *ProtocolParameter
 		return nil
 	}
 
-	return tcpUdp("tcp", tcpParameters)
+	return tcpUdp(consts.ProtocolTCP, tcpParameters)
 }
 
 func Protocol(p ...*ProtocolParameter) *Parameter {

--- a/pkg/transparentproxy/iptables/parameters/source.go
+++ b/pkg/transparentproxy/iptables/parameters/source.go
@@ -15,6 +15,10 @@ func (p *SourceParameter) Negate() ParameterBuilder {
 }
 
 func Address(address string) *SourceParameter {
+	if address == "" {
+		return nil
+	}
+
 	return &SourceParameter{address: address}
 }
 
@@ -28,6 +32,10 @@ func Address(address string) *SourceParameter {
 //
 // ref. iptables(8) > PARAMETERS
 func Source(parameter *SourceParameter) *Parameter {
+	if parameter == nil {
+		return nil
+	}
+
 	return &Parameter{
 		long:       "--source",
 		short:      "-s",

--- a/pkg/transparentproxy/iptables/rules/rules.go
+++ b/pkg/transparentproxy/iptables/rules/rules.go
@@ -20,7 +20,7 @@ type Rule struct {
 type RuleBuilder struct {
 	parameters parameters.Parameters
 	comment    string
-	position   uint
+	insert     bool
 }
 
 func (b *RuleBuilder) WithComment(comment string) *RuleBuilder {
@@ -47,23 +47,32 @@ func (b *RuleBuilder) WithConditionalComment(
 	return b
 }
 
-func (b *RuleBuilder) WithPosition(position uint) *RuleBuilder {
-	b.position = position
-	return b
-}
-
-func (b *RuleBuilder) Build(table consts.TableName, chain string) *Rule {
-	return &Rule{
+func (b *RuleBuilder) Build(
+	table consts.TableName,
+	chain string,
+	position uint,
+) (*Rule, uint) {
+	rule := &Rule{
 		table:      table,
 		chain:      chain,
-		position:   b.position,
 		parameters: b.parameters,
 		comment:    b.comment,
 	}
+
+	if b.insert {
+		position++
+		rule.position = position
+	}
+
+	return rule, position
 }
 
 func NewRule(parameters ...*parameters.Parameter) *RuleBuilder {
 	return &RuleBuilder{parameters: parameters}
+}
+
+func NewInsertRule(parameters ...*parameters.Parameter) *RuleBuilder {
+	return &RuleBuilder{parameters: parameters, insert: true}
 }
 
 // BuildForRestore generates an iptables rule formatted for use with

--- a/pkg/transparentproxy/iptables/rules/rules.go
+++ b/pkg/transparentproxy/iptables/rules/rules.go
@@ -67,10 +67,35 @@ func (b *RuleBuilder) Build(
 	return rule, position
 }
 
-func NewRule(parameters ...*parameters.Parameter) *RuleBuilder {
+// NewAppendRule creates a new RuleBuilder for an iptables rule that will be
+// appended to the end of an existing chain. This function takes a variable
+// number of parameters, each represented as a pointer to a Parameter object,
+// which specify the various conditions and actions for the rule.
+//
+// Args:
+//   - parameters (...*parameters.Parameter): A variadic list of pointers to
+//     Parameter objects that define the rule's conditions and actions.
+//
+// Returns:
+//   - *RuleBuilder: A pointer to a RuleBuilder configured to append a new rule
+//     with the specified parameters.
+func NewAppendRule(parameters ...*parameters.Parameter) *RuleBuilder {
 	return &RuleBuilder{parameters: parameters}
 }
 
+// NewInsertRule creates a new RuleBuilder for an iptables rule that will be
+// inserted at a specific position within an existing chain. This function takes
+// a variable number of parameters, each represented as a pointer to a Parameter
+// object, which specify the various conditions and actions for the rule.
+// The rule will be marked for insertion rather than appending.
+//
+// Args:
+//   - parameters (...*parameters.Parameter): A variadic list of pointers to
+//     Parameter objects that define the rule's conditions and actions.
+//
+// Returns:
+//   - *RuleBuilder: A pointer to a RuleBuilder configured to insert a new rule
+//     with the specified parameters.
 func NewInsertRule(parameters ...*parameters.Parameter) *RuleBuilder {
 	return &RuleBuilder{parameters: parameters, insert: true}
 }


### PR DESCRIPTION
> [!TIP]
> I recommend reviewing each commit individually, as I've organized the work into self-contained, descriptive commits for easier understanding.

This PR introduces several key improvements and refactorings to enhance the maintainability, flexibility, and clarity of the iptables rule generation process in the transparent proxy.

#### Key Changes:

- **Add Multiport module validation to `Functionality` struct**
  
  This commit enhances the `Functionality` struct by incorporating validation for the Multiport module. This update allows the system to determine whether the Multiport module is supported, enabling more efficient handling of port exclusions.

- **Add `NewValueOrRangeList` function**

  This commit introduces the `NewValueOrRangeList` function, which provides a flexible and type-safe way to create a `ValueOrRangeList` from different input types. This function supports input as a slice of `uint16`, a single `uint16` value, or a string, allowing for more versatile and efficient handling of port and value ranges.

- **Refactor logic for inserting rules at specific positions**

  This refactoring removes the need to manage rule positions externally. Now, the `rules.NewInsertRule` function is used to directly create rules that need to be inserted at specific positions within the chain. This change simplifies the code and reduces the complexity of managing rule positions manually.

- **Rename `rules.NewRule` to `rules.NewAppendRule`**

  This commit refactors the function name `rules.NewRule` to `rules.NewAppendRule` to better reflect its purpose of creating rules that are appended to the end of an existing chain. This change improves code readability and clarity, making it more evident when a rule is being appended versus inserted.

- **Enhance `Address` and `Source` functions to handle empty parameters**

  This commit improves the `Address` and `Source` functions to handle cases where empty parameters are passed. This change helps prevent the creation of invalid or empty parameters that could lead to runtime errors or unexpected behavior in the iptables rule generation process.

- **Refactor: Use `ProtocolL4` abstraction instead of hardcoded strings**

  This commit replaces the hardcoded "tcp" and "udp" strings with the `ProtocolL4` abstraction. By using the `ProtocolL4` type, the code becomes more maintainable and reduces the risk of errors related to protocol string mismatches.

  - Introduced the `ProtocolL4` type to represent Layer 4 protocols (TCP and UDP).
  - Updated all instances of hardcoded "tcp" and "udp" strings to use the `ProtocolL4` constants (`ProtocolTCP` and `ProtocolUDP`).
  - Implemented the `ParseProtocolL4` function to convert strings to `ProtocolL4` types, ensuring consistent protocol handling throughout the codebase.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - https://github.com/kumahq/kuma/issues/8324
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - There is no need

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
