### PR TITLE
test(transparent-proxy): add exclude ports flags to tproxy tests

### DIFF
--- a/test/transparentproxy/config.go
+++ b/test/transparentproxy/config.go
@@ -99,6 +99,8 @@ var defaultConfig = TransparentProxyConfig{
 			"--exclude-outbound-ports-for-uids", "53,3000-5000:106-108",
 			"--exclude-outbound-ips", "10.0.0.1,192.168.0.0/24,fe80::1",
 			"--exclude-outbound-ips", "fd00::/8",
+			"--exclude-outbound-ports", "1,22,333",
+			"--exclude-inbound-ports", "4444,55555",
 		},
 	},
 	IPV6: false,

--- a/test/transparentproxy/install/testdata/alpine-3-with-multiple-flags.ip6tables-nft.golden
+++ b/test/transparentproxy/install/testdata/alpine-3-with-multiple-flags.ip6tables-nft.golden
@@ -25,8 +25,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s ::6/128 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using ::6/128) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d ::1/128 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address ::1/128, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/alpine-3-with-multiple-flags.ip6tables.golden
+++ b/test/transparentproxy/install/testdata/alpine-3-with-multiple-flags.ip6tables.golden
@@ -25,8 +25,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s ::6/128 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using ::6/128) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d ::1/128 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address ::1/128, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/alpine-3-with-multiple-flags.iptables-nft.golden
+++ b/test/transparentproxy/install/testdata/alpine-3-with-multiple-flags.iptables-nft.golden
@@ -27,8 +27,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s 127.0.0.6/32 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using 127.0.0.6/32) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d 127.0.0.1/32 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address 127.0.0.1/32, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/alpine-3-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/alpine-3-with-multiple-flags.iptables.golden
@@ -27,8 +27,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s 127.0.0.6/32 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using 127.0.0.6/32) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d 127.0.0.1/32 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address 127.0.0.1/32, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/amazon-linux-2-with-multiple-flags.ip6tables-legacy.golden
+++ b/test/transparentproxy/install/testdata/amazon-linux-2-with-multiple-flags.ip6tables-legacy.golden
@@ -32,8 +32,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s ::6/128 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using ::6/128) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d ::1/128 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address ::1/128, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/amazon-linux-2-with-multiple-flags.ip6tables.golden
+++ b/test/transparentproxy/install/testdata/amazon-linux-2-with-multiple-flags.ip6tables.golden
@@ -32,8 +32,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s ::6/128 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using ::6/128) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d ::1/128 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address ::1/128, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/amazon-linux-2-with-multiple-flags.iptables-legacy.golden
+++ b/test/transparentproxy/install/testdata/amazon-linux-2-with-multiple-flags.iptables-legacy.golden
@@ -34,8 +34,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s 127.0.0.6/32 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using 127.0.0.6/32) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d 127.0.0.1/32 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address 127.0.0.1/32, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/amazon-linux-2-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/amazon-linux-2-with-multiple-flags.iptables.golden
@@ -34,8 +34,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s 127.0.0.6/32 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using 127.0.0.6/32) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d 127.0.0.1/32 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address 127.0.0.1/32, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/amazon-linux-2023-with-multiple-flags.ip6tables-nft.golden
+++ b/test/transparentproxy/install/testdata/amazon-linux-2023-with-multiple-flags.ip6tables-nft.golden
@@ -25,8 +25,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s ::6/128 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using ::6/128) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d ::1/128 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address ::1/128, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/amazon-linux-2023-with-multiple-flags.ip6tables.golden
+++ b/test/transparentproxy/install/testdata/amazon-linux-2023-with-multiple-flags.ip6tables.golden
@@ -25,8 +25,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s ::6/128 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using ::6/128) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d ::1/128 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address ::1/128, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/amazon-linux-2023-with-multiple-flags.iptables-nft.golden
+++ b/test/transparentproxy/install/testdata/amazon-linux-2023-with-multiple-flags.iptables-nft.golden
@@ -27,8 +27,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s 127.0.0.6/32 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using 127.0.0.6/32) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d 127.0.0.1/32 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address 127.0.0.1/32, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/amazon-linux-2023-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/amazon-linux-2023-with-multiple-flags.iptables.golden
@@ -27,8 +27,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s 127.0.0.6/32 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using 127.0.0.6/32) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d 127.0.0.1/32 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address 127.0.0.1/32, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/debian-10-with-multiple-flags.ip6tables-nft.golden
+++ b/test/transparentproxy/install/testdata/debian-10-with-multiple-flags.ip6tables-nft.golden
@@ -17,7 +17,12 @@
 -A OUTPUT -p 17 -m udp --dport 53 -m owner --uid-owner 5678 -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -j RETURN
 -A OUTPUT -p 17 -m udp --dport 53 -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -j REDIRECT --to-ports 15053
 -A OUTPUT -p 6 -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p 6 -m tcp --dport 4444 -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -j RETURN
+-A KUMA_MESH_INBOUND -p 6 -m tcp --dport 55555 -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -j RETURN
 -A KUMA_MESH_INBOUND -p 6 -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
+-A KUMA_MESH_OUTBOUND -p 6 -m tcp --dport 1 -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -j RETURN
+-A KUMA_MESH_OUTBOUND -p 6 -m tcp --dport 22 -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -j RETURN
+-A KUMA_MESH_OUTBOUND -p 6 -m tcp --dport 333 -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -j RETURN
 -A KUMA_MESH_OUTBOUND -s ::6/128 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using ::6/128) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d ::1/128 -o ifPlaceholder -p 6 -m tcp ! --dport 53 -m owner --uid-owner 5678 -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address ::1/128, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p 6 -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -j RETURN

--- a/test/transparentproxy/install/testdata/debian-10-with-multiple-flags.ip6tables.golden
+++ b/test/transparentproxy/install/testdata/debian-10-with-multiple-flags.ip6tables.golden
@@ -17,7 +17,12 @@
 -A OUTPUT -p 17 -m udp --dport 53 -m owner --uid-owner 5678 -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -j RETURN
 -A OUTPUT -p 17 -m udp --dport 53 -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -j REDIRECT --to-ports 15053
 -A OUTPUT -p 6 -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p 6 -m tcp --dport 4444 -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -j RETURN
+-A KUMA_MESH_INBOUND -p 6 -m tcp --dport 55555 -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -j RETURN
 -A KUMA_MESH_INBOUND -p 6 -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
+-A KUMA_MESH_OUTBOUND -p 6 -m tcp --dport 1 -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -j RETURN
+-A KUMA_MESH_OUTBOUND -p 6 -m tcp --dport 22 -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -j RETURN
+-A KUMA_MESH_OUTBOUND -p 6 -m tcp --dport 333 -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -j RETURN
 -A KUMA_MESH_OUTBOUND -s ::6/128 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using ::6/128) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d ::1/128 -o ifPlaceholder -p 6 -m tcp ! --dport 53 -m owner --uid-owner 5678 -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address ::1/128, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p 6 -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -j RETURN

--- a/test/transparentproxy/install/testdata/debian-10-with-multiple-flags.iptables-nft.golden
+++ b/test/transparentproxy/install/testdata/debian-10-with-multiple-flags.iptables-nft.golden
@@ -27,7 +27,12 @@ COMMIT
 -A OUTPUT -p 17 -m udp --dport 53 -m owner --uid-owner 5678 -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -j RETURN
 -A OUTPUT -p 17 -m udp --dport 53 -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -j REDIRECT --to-ports 15053
 -A OUTPUT -p 6 -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p 6 -m tcp --dport 4444 -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -j RETURN
+-A KUMA_MESH_INBOUND -p 6 -m tcp --dport 55555 -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -j RETURN
 -A KUMA_MESH_INBOUND -p 6 -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
+-A KUMA_MESH_OUTBOUND -p 6 -m tcp --dport 1 -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -j RETURN
+-A KUMA_MESH_OUTBOUND -p 6 -m tcp --dport 22 -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -j RETURN
+-A KUMA_MESH_OUTBOUND -p 6 -m tcp --dport 333 -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -j RETURN
 -A KUMA_MESH_OUTBOUND -s 127.0.0.6/32 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using 127.0.0.6/32) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d 127.0.0.1/32 -o ifPlaceholder -p 6 -m tcp ! --dport 53 -m owner --uid-owner 5678 -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address 127.0.0.1/32, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p 6 -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -j RETURN

--- a/test/transparentproxy/install/testdata/debian-10-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/debian-10-with-multiple-flags.iptables.golden
@@ -27,7 +27,12 @@ COMMIT
 -A OUTPUT -p 17 -m udp --dport 53 -m owner --uid-owner 5678 -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -j RETURN
 -A OUTPUT -p 17 -m udp --dport 53 -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -j REDIRECT --to-ports 15053
 -A OUTPUT -p 6 -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p 6 -m tcp --dport 4444 -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -j RETURN
+-A KUMA_MESH_INBOUND -p 6 -m tcp --dport 55555 -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -j RETURN
 -A KUMA_MESH_INBOUND -p 6 -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
+-A KUMA_MESH_OUTBOUND -p 6 -m tcp --dport 1 -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -j RETURN
+-A KUMA_MESH_OUTBOUND -p 6 -m tcp --dport 22 -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -j RETURN
+-A KUMA_MESH_OUTBOUND -p 6 -m tcp --dport 333 -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -j RETURN
 -A KUMA_MESH_OUTBOUND -s 127.0.0.6/32 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using 127.0.0.6/32) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d 127.0.0.1/32 -o ifPlaceholder -p 6 -m tcp ! --dport 53 -m owner --uid-owner 5678 -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address 127.0.0.1/32, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p 6 -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -j RETURN

--- a/test/transparentproxy/install/testdata/debian-11-with-multiple-flags.ip6tables-nft.golden
+++ b/test/transparentproxy/install/testdata/debian-11-with-multiple-flags.ip6tables-nft.golden
@@ -25,8 +25,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s ::6/128 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using ::6/128) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d ::1/128 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address ::1/128, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/debian-11-with-multiple-flags.ip6tables.golden
+++ b/test/transparentproxy/install/testdata/debian-11-with-multiple-flags.ip6tables.golden
@@ -25,8 +25,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s ::6/128 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using ::6/128) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d ::1/128 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address ::1/128, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/debian-11-with-multiple-flags.iptables-nft.golden
+++ b/test/transparentproxy/install/testdata/debian-11-with-multiple-flags.iptables-nft.golden
@@ -27,8 +27,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s 127.0.0.6/32 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using 127.0.0.6/32) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d 127.0.0.1/32 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address 127.0.0.1/32, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/debian-11-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/debian-11-with-multiple-flags.iptables.golden
@@ -27,8 +27,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s 127.0.0.6/32 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using 127.0.0.6/32) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d 127.0.0.1/32 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address 127.0.0.1/32, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/debian-12-with-multiple-flags.ip6tables-nft.golden
+++ b/test/transparentproxy/install/testdata/debian-12-with-multiple-flags.ip6tables-nft.golden
@@ -25,8 +25,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s ::6/128 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using ::6/128) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d ::1/128 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address ::1/128, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/debian-12-with-multiple-flags.ip6tables.golden
+++ b/test/transparentproxy/install/testdata/debian-12-with-multiple-flags.ip6tables.golden
@@ -25,8 +25,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s ::6/128 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using ::6/128) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d ::1/128 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address ::1/128, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/debian-12-with-multiple-flags.iptables-nft.golden
+++ b/test/transparentproxy/install/testdata/debian-12-with-multiple-flags.iptables-nft.golden
@@ -27,8 +27,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s 127.0.0.6/32 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using 127.0.0.6/32) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d 127.0.0.1/32 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address 127.0.0.1/32, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/debian-12-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/debian-12-with-multiple-flags.iptables.golden
@@ -27,8 +27,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s 127.0.0.6/32 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using 127.0.0.6/32) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d 127.0.0.1/32 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address 127.0.0.1/32, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/fedora-38-with-multiple-flags.ip6tables-legacy.golden
+++ b/test/transparentproxy/install/testdata/fedora-38-with-multiple-flags.ip6tables-legacy.golden
@@ -32,8 +32,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s ::6/128 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using ::6/128) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d ::1/128 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address ::1/128, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/fedora-38-with-multiple-flags.ip6tables.golden
+++ b/test/transparentproxy/install/testdata/fedora-38-with-multiple-flags.ip6tables.golden
@@ -32,8 +32,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s ::6/128 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using ::6/128) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d ::1/128 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address ::1/128, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/fedora-38-with-multiple-flags.iptables-legacy.golden
+++ b/test/transparentproxy/install/testdata/fedora-38-with-multiple-flags.iptables-legacy.golden
@@ -34,8 +34,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s 127.0.0.6/32 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using 127.0.0.6/32) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d 127.0.0.1/32 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address 127.0.0.1/32, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/fedora-38-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/fedora-38-with-multiple-flags.iptables.golden
@@ -34,8 +34,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s 127.0.0.6/32 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using 127.0.0.6/32) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d 127.0.0.1/32 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address 127.0.0.1/32, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/fedora-39-with-multiple-flags.ip6tables-legacy.golden
+++ b/test/transparentproxy/install/testdata/fedora-39-with-multiple-flags.ip6tables-legacy.golden
@@ -32,8 +32,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s ::6/128 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using ::6/128) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d ::1/128 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address ::1/128, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/fedora-39-with-multiple-flags.ip6tables.golden
+++ b/test/transparentproxy/install/testdata/fedora-39-with-multiple-flags.ip6tables.golden
@@ -32,8 +32,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s ::6/128 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using ::6/128) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d ::1/128 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address ::1/128, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/fedora-39-with-multiple-flags.iptables-legacy.golden
+++ b/test/transparentproxy/install/testdata/fedora-39-with-multiple-flags.iptables-legacy.golden
@@ -34,8 +34,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s 127.0.0.6/32 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using 127.0.0.6/32) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d 127.0.0.1/32 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address 127.0.0.1/32, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/fedora-39-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/fedora-39-with-multiple-flags.iptables.golden
@@ -34,8 +34,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s 127.0.0.6/32 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using 127.0.0.6/32) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d 127.0.0.1/32 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address 127.0.0.1/32, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/fedora-40-with-multiple-flags.ip6tables-legacy.golden
+++ b/test/transparentproxy/install/testdata/fedora-40-with-multiple-flags.ip6tables-legacy.golden
@@ -32,8 +32,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s ::6/128 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using ::6/128) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d ::1/128 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address ::1/128, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/fedora-40-with-multiple-flags.ip6tables.golden
+++ b/test/transparentproxy/install/testdata/fedora-40-with-multiple-flags.ip6tables.golden
@@ -32,8 +32,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s ::6/128 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using ::6/128) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d ::1/128 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address ::1/128, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/fedora-40-with-multiple-flags.iptables-legacy.golden
+++ b/test/transparentproxy/install/testdata/fedora-40-with-multiple-flags.iptables-legacy.golden
@@ -34,8 +34,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s 127.0.0.6/32 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using 127.0.0.6/32) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d 127.0.0.1/32 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address 127.0.0.1/32, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/fedora-40-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/fedora-40-with-multiple-flags.iptables.golden
@@ -34,8 +34,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s 127.0.0.6/32 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using 127.0.0.6/32) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d 127.0.0.1/32 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address 127.0.0.1/32, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/fedora-41-with-multiple-flags.ip6tables-legacy.golden
+++ b/test/transparentproxy/install/testdata/fedora-41-with-multiple-flags.ip6tables-legacy.golden
@@ -32,8 +32,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s ::6/128 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using ::6/128) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d ::1/128 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address ::1/128, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/fedora-41-with-multiple-flags.ip6tables.golden
+++ b/test/transparentproxy/install/testdata/fedora-41-with-multiple-flags.ip6tables.golden
@@ -32,8 +32,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s ::6/128 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using ::6/128) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d ::1/128 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address ::1/128, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/fedora-41-with-multiple-flags.iptables-legacy.golden
+++ b/test/transparentproxy/install/testdata/fedora-41-with-multiple-flags.iptables-legacy.golden
@@ -34,8 +34,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s 127.0.0.6/32 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using 127.0.0.6/32) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d 127.0.0.1/32 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address 127.0.0.1/32, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/fedora-41-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/fedora-41-with-multiple-flags.iptables.golden
@@ -34,8 +34,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s 127.0.0.6/32 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using 127.0.0.6/32) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d 127.0.0.1/32 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address 127.0.0.1/32, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/rhel-8-with-multiple-flags.ip6tables.golden
+++ b/test/transparentproxy/install/testdata/rhel-8-with-multiple-flags.ip6tables.golden
@@ -17,7 +17,12 @@
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s ::6/128 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using ::6/128) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d ::1/128 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address ::1/128, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/rhel-8-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/rhel-8-with-multiple-flags.iptables.golden
@@ -27,7 +27,12 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s 127.0.0.6/32 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using 127.0.0.6/32) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d 127.0.0.1/32 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address 127.0.0.1/32, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/rhel-9-with-multiple-flags.ip6tables-nft.golden
+++ b/test/transparentproxy/install/testdata/rhel-9-with-multiple-flags.ip6tables-nft.golden
@@ -25,8 +25,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s ::6/128 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using ::6/128) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d ::1/128 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address ::1/128, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/rhel-9-with-multiple-flags.ip6tables.golden
+++ b/test/transparentproxy/install/testdata/rhel-9-with-multiple-flags.ip6tables.golden
@@ -25,8 +25,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s ::6/128 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using ::6/128) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d ::1/128 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address ::1/128, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/rhel-9-with-multiple-flags.iptables-nft.golden
+++ b/test/transparentproxy/install/testdata/rhel-9-with-multiple-flags.iptables-nft.golden
@@ -27,8 +27,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s 127.0.0.6/32 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using 127.0.0.6/32) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d 127.0.0.1/32 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address 127.0.0.1/32, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/rhel-9-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/rhel-9-with-multiple-flags.iptables.golden
@@ -27,8 +27,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s 127.0.0.6/32 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using 127.0.0.6/32) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d 127.0.0.1/32 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address 127.0.0.1/32, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/ubuntu-18-04-with-multiple-flags.ip6tables.golden
+++ b/test/transparentproxy/install/testdata/ubuntu-18-04-with-multiple-flags.ip6tables.golden
@@ -32,8 +32,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s ::6/128 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using ::6/128) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d ::1/128 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address ::1/128, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/ubuntu-18-04-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/ubuntu-18-04-with-multiple-flags.iptables.golden
@@ -34,8 +34,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s 127.0.0.6/32 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using 127.0.0.6/32) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d 127.0.0.1/32 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address 127.0.0.1/32, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/ubuntu-20-04-with-multiple-flags.ip6tables-nft.golden
+++ b/test/transparentproxy/install/testdata/ubuntu-20-04-with-multiple-flags.ip6tables-nft.golden
@@ -25,7 +25,12 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s ::6/128 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using ::6/128) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d ::1/128 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address ::1/128, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/ubuntu-20-04-with-multiple-flags.iptables-nft.golden
+++ b/test/transparentproxy/install/testdata/ubuntu-20-04-with-multiple-flags.iptables-nft.golden
@@ -27,7 +27,12 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s 127.0.0.6/32 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using 127.0.0.6/32) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d 127.0.0.1/32 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address 127.0.0.1/32, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/ubuntu-22-04-with-multiple-flags.ip6tables-nft.golden
+++ b/test/transparentproxy/install/testdata/ubuntu-22-04-with-multiple-flags.ip6tables-nft.golden
@@ -25,8 +25,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s ::6/128 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using ::6/128) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d ::1/128 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address ::1/128, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/ubuntu-22-04-with-multiple-flags.ip6tables.golden
+++ b/test/transparentproxy/install/testdata/ubuntu-22-04-with-multiple-flags.ip6tables.golden
@@ -25,8 +25,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s ::6/128 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using ::6/128) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d ::1/128 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address ::1/128, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/ubuntu-22-04-with-multiple-flags.iptables-nft.golden
+++ b/test/transparentproxy/install/testdata/ubuntu-22-04-with-multiple-flags.iptables-nft.golden
@@ -27,8 +27,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s 127.0.0.6/32 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using 127.0.0.6/32) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d 127.0.0.1/32 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address 127.0.0.1/32, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/ubuntu-22-04-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/ubuntu-22-04-with-multiple-flags.iptables.golden
@@ -27,8 +27,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s 127.0.0.6/32 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using 127.0.0.6/32) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d 127.0.0.1/32 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address 127.0.0.1/32, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/ubuntu-24-04-with-multiple-flags.ip6tables-nft.golden
+++ b/test/transparentproxy/install/testdata/ubuntu-24-04-with-multiple-flags.ip6tables-nft.golden
@@ -25,8 +25,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s ::6/128 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using ::6/128) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d ::1/128 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address ::1/128, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/ubuntu-24-04-with-multiple-flags.ip6tables.golden
+++ b/test/transparentproxy/install/testdata/ubuntu-24-04-with-multiple-flags.ip6tables.golden
@@ -25,8 +25,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s ::6/128 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using ::6/128) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d ::1/128 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address ::1/128, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/ubuntu-24-04-with-multiple-flags.iptables-nft.golden
+++ b/test/transparentproxy/install/testdata/ubuntu-24-04-with-multiple-flags.iptables-nft.golden
@@ -27,8 +27,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s 127.0.0.6/32 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using 127.0.0.6/32) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d 127.0.0.1/32 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address 127.0.0.1/32, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN

--- a/test/transparentproxy/install/testdata/ubuntu-24-04-with-multiple-flags.iptables.golden
+++ b/test/transparentproxy/install/testdata/ubuntu-24-04-with-multiple-flags.iptables.golden
@@ -27,8 +27,13 @@ COMMIT
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/return early for DNS traffic from kuma-dp" -m udp --dport 53 -m owner --uid-owner 5678 -j RETURN
 -A OUTPUT -p udp -m comment --comment "kuma/mesh/transparent/proxy/redirect all DNS requests to the kuma-dp DNS proxy (listening on port 15053)" -m udp --dport 53 -j REDIRECT --to-ports 15053
 -A OUTPUT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic to our custom chain for processing" -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 4444 from redirection" -m tcp --dport 4444 -j RETURN
+-A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude inbound traffic from port 55555 from redirection" -m tcp --dport 55555 -j RETURN
 -A KUMA_MESH_INBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect all inbound traffic to the custom chain for processing" -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect TCP traffic to envoy (port 15006)" -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 1 from redirection" -m tcp --dport 1 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 22 from redirection" -m tcp --dport 22 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp -m comment --comment "kuma/mesh/transparent/proxy/exclude outbound traffic from port 333 from redirection" -m tcp --dport 333 -j RETURN
 -A KUMA_MESH_OUTBOUND -s 127.0.0.6/32 -o ifPlaceholder -m comment --comment "kuma/mesh/transparent/proxy/prevent traffic loops by ensuring traffic from the sidecar proxy (using 127.0.0.6/32) to loopback interface is not redirected again" -j RETURN
 -A KUMA_MESH_OUTBOUND ! -d 127.0.0.1/32 -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/redirect outbound TCP traffic (except to DNS port 53) destined for loopback interface, but not targeting address 127.0.0.1/32, and owned by UID 5678 (kuma-dp user) to KUMA_MESH_INBOUND_REDIRECT chain for proper handling" -m tcp ! --dport 53 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -o ifPlaceholder -p tcp -m comment --comment "kuma/mesh/transparent/proxy/return outbound TCP traffic (except to DNS port 53) destined for loopback interface, owned by any UID other than 5678 (kuma-dp user)" -m tcp ! --dport 53 -m owner ! --uid-owner 5678 -j RETURN


### PR DESCRIPTION
This PR adds `--exclude-outbound-ports` and `--exclude-inbound-ports` flags to transparent proxy tests

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - No relevant issues
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
