### PR TITLE
feat(meshmultizoneservice): generate xds

### DIFF
--- a/api/common/v1alpha1/ref.go
+++ b/api/common/v1alpha1/ref.go
@@ -13,23 +13,25 @@ import (
 type TargetRefKind string
 
 var (
-	Mesh                TargetRefKind = "Mesh"
-	MeshSubset          TargetRefKind = "MeshSubset"
-	MeshGateway         TargetRefKind = "MeshGateway"
-	MeshService         TargetRefKind = "MeshService"
-	MeshExternalService TargetRefKind = "MeshExternalService"
-	MeshServiceSubset   TargetRefKind = "MeshServiceSubset"
-	MeshHTTPRoute       TargetRefKind = "MeshHTTPRoute"
+	Mesh                 TargetRefKind = "Mesh"
+	MeshSubset           TargetRefKind = "MeshSubset"
+	MeshGateway          TargetRefKind = "MeshGateway"
+	MeshService          TargetRefKind = "MeshService"
+	MeshExternalService  TargetRefKind = "MeshExternalService"
+	MeshMultiZoneService TargetRefKind = "MeshMultiZoneService"
+	MeshServiceSubset    TargetRefKind = "MeshServiceSubset"
+	MeshHTTPRoute        TargetRefKind = "MeshHTTPRoute"
 )
 
 var order = map[TargetRefKind]int{
-	Mesh:                1,
-	MeshSubset:          2,
-	MeshGateway:         3,
-	MeshService:         4,
-	MeshExternalService: 5,
-	MeshServiceSubset:   6,
-	MeshHTTPRoute:       7,
+	Mesh:                 1,
+	MeshSubset:           2,
+	MeshGateway:          3,
+	MeshService:          4,
+	MeshExternalService:  5,
+	MeshMultiZoneService: 6,
+	MeshServiceSubset:    7,
+	MeshHTTPRoute:        8,
 }
 
 // +kubebuilder:validation:Enum=Sidecar;Gateway
@@ -102,6 +104,17 @@ type BackendRef struct {
 	Weight *uint `json:"weight,omitempty"`
 	// Port is only supported when this ref refers to a real MeshService object
 	Port *uint32 `json:"port,omitempty"`
+}
+
+func (b BackendRef) ReferencesRealObject() bool {
+	switch b.Kind {
+	case MeshService:
+		return b.Port != nil
+	case MeshServiceSubset:
+		return false
+	default:
+		return true
+	}
 }
 
 type BackendRefHash string

--- a/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/helpers.go
+++ b/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/helpers.go
@@ -1,6 +1,9 @@
 package v1alpha1
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/kumahq/kuma/pkg/core/resources/apis/core/vip"
 	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
 )
@@ -19,4 +22,17 @@ func (t *MeshMultiZoneServiceResource) AllocateVIP(vip string) {
 	t.Status.VIPs = append(t.Status.VIPs, meshservice_api.VIP{
 		IP: vip,
 	})
+}
+
+func (m *MeshMultiZoneServiceResource) FindPort(port uint32) (meshservice_api.Port, bool) {
+	for _, p := range m.Status.Ports {
+		if p.Port == port {
+			return p, true
+		}
+	}
+	return meshservice_api.Port{}, false
+}
+
+func (m *MeshMultiZoneServiceResource) DestinationName(port uint32) string {
+	return fmt.Sprintf("%s_mzsvc_%d", strings.ReplaceAll(m.GetMeta().GetName(), ".", "_"), port)
 }

--- a/pkg/plugins/policies/core/xds/meshroute/listeners.go
+++ b/pkg/plugins/policies/core/xds/meshroute/listeners.go
@@ -69,9 +69,6 @@ func CollectServices(
 ) []DestinationService {
 	var dests []DestinationService
 	for _, outbound := range proxy.Dataplane.Spec.GetNetworking().GetOutbounds() {
-		if outbound.GetAddress() == proxy.Dataplane.Spec.GetNetworking().GetAddress() {
-			continue
-		}
 		var destinationService *DestinationService
 		switch outbound.GetBackendRef().GetKind() {
 		case string(common_api.MeshService):

--- a/pkg/plugins/policies/core/xds/meshroute/listeners.go
+++ b/pkg/plugins/policies/core/xds/meshroute/listeners.go
@@ -69,6 +69,9 @@ func CollectServices(
 ) []DestinationService {
 	var dests []DestinationService
 	for _, outbound := range proxy.Dataplane.Spec.GetNetworking().GetOutbounds() {
+		if outbound.GetAddress() == proxy.Dataplane.Spec.GetNetworking().GetAddress() {
+			continue
+		}
 		var destinationService *DestinationService
 		switch outbound.GetBackendRef().GetKind() {
 		case string(common_api.MeshService):

--- a/pkg/test/resources/builders/meshmultizoneservice_builder.go
+++ b/pkg/test/resources/builders/meshmultizoneservice_builder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	meshmzservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1"
+	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
@@ -43,6 +44,18 @@ func (m *MeshMultiZoneServiceBuilder) WithMesh(mesh string) *MeshMultiZoneServic
 
 func (m *MeshMultiZoneServiceBuilder) WithServiceLabelSelector(labels map[string]string) *MeshMultiZoneServiceBuilder {
 	m.res.Spec.Selector.MeshService.MatchLabels = labels
+	return m
+}
+
+func (m *MeshMultiZoneServiceBuilder) AddMatchedMeshServiceName(name string) *MeshMultiZoneServiceBuilder {
+	m.res.Status.MeshServices = append(m.res.Status.MeshServices, meshmzservice_api.MatchedMeshService{
+		Name: name,
+	})
+	return m
+}
+
+func (m *MeshMultiZoneServiceBuilder) AddPort(port meshservice_api.Port) *MeshMultiZoneServiceBuilder {
+	m.res.Status.Ports = append(m.res.Status.Ports, port)
 	return m
 }
 

--- a/pkg/test/resources/samples/meshservice_samples.go
+++ b/pkg/test/resources/samples/meshservice_samples.go
@@ -3,11 +3,15 @@ package samples
 import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
+	"github.com/kumahq/kuma/pkg/kds/hash"
 	"github.com/kumahq/kuma/pkg/test/resources/builders"
 )
 
 func MeshServiceBackendBuilder() *builders.MeshServiceBuilder {
 	return builders.MeshService().
+		WithLabels(map[string]string{
+			mesh_proto.DisplayName: "backend",
+		}).
 		WithDataplaneTagsSelector(map[string]string{
 			mesh_proto.ServiceTag: "backend",
 		}).
@@ -31,4 +35,19 @@ func MeshServiceWebBuilder() *builders.MeshServiceBuilder {
 
 func MeshServiceWeb() *v1alpha1.MeshServiceResource {
 	return MeshServiceBackendBuilder().Build()
+}
+
+func MeshServiceSyncedBackendBuilder() *builders.MeshServiceBuilder {
+	return MeshServiceBackendBuilder().
+		WithName(hash.HashedName("default", "backend", mesh_proto.ZoneTag, "east")).
+		WithLabels(map[string]string{
+			mesh_proto.DisplayName:         "backend",
+			mesh_proto.ZoneTag:             "east",
+			mesh_proto.ResourceOriginLabel: "global",
+		}).
+		WithKumaVIP("240.0.0.3")
+}
+
+func MeshServiceSyncedBackend() *v1alpha1.MeshServiceResource {
+	return MeshServiceSyncedBackendBuilder().Build()
 }

--- a/pkg/xds/context/context.go
+++ b/pkg/xds/context/context.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/datasource"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	meshexternalservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
+	meshmzservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1"
 	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/xds/envoy"
@@ -67,6 +68,7 @@ type MeshContext struct {
 	DataplanesByName            map[string]*core_mesh.DataplaneResource
 	MeshServiceByName           map[string]*meshservice_api.MeshServiceResource
 	MeshExternalServiceByName   map[string]*meshexternalservice_api.MeshExternalServiceResource
+	MeshMultiZoneServiceByName  map[string]*meshmzservice_api.MeshMultiZoneServiceResource
 	EndpointMap                 xds.EndpointMap
 	IngressEndpointMap          xds.EndpointMap
 	ExternalServicesEndpointMap xds.EndpointMap

--- a/pkg/xds/context/mesh_context_builder.go
+++ b/pkg/xds/context/mesh_context_builder.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/dns/lookup"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	meshextenralservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
+	meshmzservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
@@ -162,7 +163,7 @@ func (m *meshContextBuilder) BuildIfChanged(ctx context.Context, meshName string
 		dataplanesByName[dp.Meta.GetName()] = dp
 	}
 	meshServices := resources.MeshServices().Items
-	meshServicesByName := make(map[string]*v1alpha1.MeshServiceResource, len(dataplanes))
+	meshServicesByName := make(map[string]*v1alpha1.MeshServiceResource, len(meshServices))
 	for _, ms := range meshServices {
 		meshServicesByName[ms.Meta.GetName()] = ms
 	}
@@ -170,6 +171,11 @@ func (m *meshContextBuilder) BuildIfChanged(ctx context.Context, meshName string
 	meshExternalServicesByName := make(map[string]*meshextenralservice_api.MeshExternalServiceResource, len(meshExternalServices))
 	for _, mes := range meshExternalServices {
 		meshExternalServicesByName[mes.Meta.GetName()] = mes
+	}
+	meshMultiZoneServices := resources.MeshMultiZoneServices().Items
+	meshMultiZoneServicesByName := make(map[string]*meshmzservice_api.MeshMultiZoneServiceResource, len(meshMultiZoneServices))
+	for _, svc := range meshMultiZoneServices {
+		meshMultiZoneServicesByName[svc.Meta.GetName()] = svc
 	}
 
 	var domains []xds.VIPDomains
@@ -190,15 +196,19 @@ func (m *meshContextBuilder) BuildIfChanged(ctx context.Context, meshName string
 	mesDomains, mesOutbounds := xds_topology.MeshExternalServiceOutbounds(meshExternalServices)
 	outbounds = append(outbounds, mesOutbounds...)
 	domains = append(domains, mesDomains...)
+	mzmsDomains, mzmsOutbounds := xds_topology.MeshMultiZoneServiceOutbounds(meshMultiZoneServices)
+	outbounds = append(outbounds, mzmsOutbounds...)
+	domains = append(domains, mzmsDomains...)
+
 	loader := datasource.NewStaticLoader(resources.Secrets().Items)
 
 	mesh := baseMeshContext.Mesh
 	zoneIngresses := resources.ZoneIngresses().Items
 	zoneEgresses := resources.ZoneEgresses().Items
 	externalServices := resources.ExternalServices().Items
-	endpointMap := xds_topology.BuildEdsEndpointMap(mesh, m.zone, meshServices, meshExternalServices, dataplanes, zoneIngresses, zoneEgresses, externalServices)
+	endpointMap := xds_topology.BuildEdsEndpointMap(mesh, m.zone, meshServicesByName, meshMultiZoneServices, meshExternalServices, dataplanes, zoneIngresses, zoneEgresses, externalServices)
 	esEndpointMap := xds_topology.BuildExternalServicesEndpointMap(ctx, mesh, externalServices, meshExternalServices, loader, m.zone)
-	ingressEndpointMap := xds_topology.BuildIngressEndpointMap(mesh, m.zone, meshServices, meshExternalServices, dataplanes, externalServices, resources.Gateways().Items, zoneEgresses)
+	ingressEndpointMap := xds_topology.BuildIngressEndpointMap(mesh, m.zone, meshServicesByName, meshMultiZoneServices, meshExternalServices, dataplanes, externalServices, resources.Gateways().Items, zoneEgresses)
 
 	crossMeshEndpointMap := map[string]xds.EndpointMap{}
 	for otherMeshName, gateways := range resources.gatewaysAndDataplanesForMesh(mesh) {
@@ -220,6 +230,7 @@ func (m *meshContextBuilder) BuildIfChanged(ctx context.Context, meshName string
 		DataplanesByName:            dataplanesByName,
 		MeshServiceByName:           meshServicesByName,
 		MeshExternalServiceByName:   meshExternalServicesByName,
+		MeshMultiZoneServiceByName:  meshMultiZoneServicesByName,
 		EndpointMap:                 endpointMap,
 		ExternalServicesEndpointMap: esEndpointMap,
 		IngressEndpointMap:          ingressEndpointMap,

--- a/pkg/xds/context/resources.go
+++ b/pkg/xds/context/resources.go
@@ -5,6 +5,7 @@ import (
 
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	meshextsvc "github.com/kumahq/kuma/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
+	meshmzservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1"
 	meshsvc "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
@@ -161,6 +162,18 @@ func (r Resources) MeshExternalServices() *meshextsvc.MeshExternalServiceResourc
 		}
 	}
 	return list.(*meshextsvc.MeshExternalServiceResourceList)
+}
+
+func (r Resources) MeshMultiZoneServices() *meshmzservice_api.MeshMultiZoneServiceResourceList {
+	list, ok := r.MeshLocalResources[meshmzservice_api.MeshMultiZoneServiceType]
+	if !ok {
+		var err error
+		list, err = registry.Global().NewList(meshmzservice_api.MeshMultiZoneServiceType)
+		if err != nil {
+			return &meshmzservice_api.MeshMultiZoneServiceResourceList{}
+		}
+	}
+	return list.(*meshmzservice_api.MeshMultiZoneServiceResourceList)
 }
 
 type MeshGatewayDataplanes struct {

--- a/pkg/xds/envoy/tls/sni.go
+++ b/pkg/xds/envoy/tls/sni.go
@@ -9,6 +9,7 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	meshexternalservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
+	meshmzservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1"
 	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/util/maps"
@@ -69,6 +70,8 @@ func SNIForResource(resName string, meshName string, resType model.ResourceType,
 		resTypeAbbrv = "ms"
 	case meshexternalservice_api.MeshExternalServiceType:
 		resTypeAbbrv = "mes"
+	case meshmzservice_api.MeshMultiZoneServiceType:
+		resTypeAbbrv = "mzms"
 	default:
 		panic("resource type not supported for SNI")
 	}

--- a/pkg/xds/envoy/tls/sni_test.go
+++ b/pkg/xds/envoy/tls/sni_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	meshmzservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1"
 	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	envoy_tags "github.com/kumahq/kuma/pkg/xds/envoy/tags"
@@ -141,6 +142,14 @@ var _ = Describe("SNI", func() {
 				"x": "a",
 			},
 			expected: "a5b91d8a08567bf09.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaax.8080.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbx.ms",
+		}),
+		Entry("mesh multizone service", testCase{
+			resName:        "backend",
+			meshName:       "demo",
+			resType:        meshmzservice_api.MeshMultiZoneServiceType,
+			port:           8080,
+			additionalData: nil,
+			expected:       "ae10a8071b8a8eeb8.backend.8080.demo.mzms",
 		}),
 	)
 

--- a/pkg/xds/generator/egress/external_services_generator.go
+++ b/pkg/xds/generator/egress/external_services_generator.go
@@ -37,6 +37,8 @@ func (g *ExternalServicesGenerator) Generate(
 		nil,
 		xds_context.Resources{MeshLocalResources: meshResources.Resources},
 		nil,
+		nil,
+		"",
 	)
 	services := g.buildServices(endpointMap, zone, meshResources)
 

--- a/pkg/xds/generator/egress/internal_services_generator.go
+++ b/pkg/xds/generator/egress/internal_services_generator.go
@@ -33,6 +33,8 @@ func (g *InternalServicesGenerator) Generate(
 		availableServices,
 		xds_context.Resources{MeshLocalResources: meshResources.Resources},
 		nil, // todo(jakubdyszkiewicz) add support for MeshService + egress
+		nil, // todo(jakubdyszkiewicz) add support for MeshService + egress
+		"",
 	)
 
 	services := zoneproxy.AddFilterChains(availableServices, proxy.APIVersion, listenerBuilder, destinations, meshResources.EndpointMap)

--- a/pkg/xds/generator/ingress_generator.go
+++ b/pkg/xds/generator/ingress_generator.go
@@ -51,7 +51,13 @@ func (i IngressGenerator) Generate(
 		meshResources := xds_context.Resources{MeshLocalResources: mr.Resources}
 		// we only want to expose local mesh services
 		localMs := localMeshServices(xdsCtx.ControlPlane.Zone, meshResources.MeshServices().Items)
-		dest := zoneproxy.BuildMeshDestinations(availableSvcsByMesh[meshName], meshResources, localMs)
+		dest := zoneproxy.BuildMeshDestinations(
+			availableSvcsByMesh[meshName],
+			meshResources,
+			localMs,
+			meshResources.MeshMultiZoneServices().Items,
+			xdsCtx.ControlPlane.SystemNamespace,
+		)
 
 		services := zoneproxy.AddFilterChains(availableSvcsByMesh[meshName], proxy.APIVersion, listenerBuilder, dest, mr.EndpointMap)
 

--- a/pkg/xds/server/components.go
+++ b/pkg/xds/server/components.go
@@ -3,6 +3,7 @@ package server
 import (
 	"github.com/pkg/errors"
 
+	config_store "github.com/kumahq/kuma/pkg/config/core/resources/store"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_system "github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
@@ -69,11 +70,15 @@ func RegisterXDS(rt core_runtime.Runtime) error {
 		return err
 	}
 
+	systemNamespace := ""
+	if rt.Config().Store.Type == config_store.KubernetesStore {
+		systemNamespace = rt.Config().Store.Kubernetes.SystemNamespace
+	}
 	envoyCpCtx := &xds_context.ControlPlaneContext{
 		CLACache:        claCache,
 		Secrets:         secrets,
 		Zone:            rt.Config().Multizone.Zone.Name,
-		SystemNamespace: rt.Config().Store.Kubernetes.SystemNamespace,
+		SystemNamespace: systemNamespace,
 	}
 
 	if err := v3.RegisterXDS(statsCallbacks, rt.XDS().Metrics, envoyCpCtx, rt); err != nil {

--- a/pkg/xds/sync/dataplane_proxy_builder.go
+++ b/pkg/xds/sync/dataplane_proxy_builder.go
@@ -136,11 +136,11 @@ func (p *DataplaneProxyBuilder) resolveVIPOutbounds(meshContext xds_context.Mesh
 					continue
 				}
 			}
-			if dataplane.UsesInboundInterface(net.ParseIP(outbound.Address), outbound.Port) {
-				// Skip overlapping outbound interface with inbound.
-				// This may happen for example with Headless service on Kubernetes (outbound is a PodIP not ClusterIP, so it's the same as inbound).
-				continue
-			}
+		}
+		if dataplane.UsesInboundInterface(net.ParseIP(outbound.Address), outbound.Port) {
+			// Skip overlapping outbound interface with inbound.
+			// This may happen for example with Headless service on Kubernetes (outbound is a PodIP not ClusterIP, so it's the same as inbound).
+			continue
 		}
 		outbounds = append(outbounds, outbound)
 	}

--- a/pkg/xds/topology/ingress_outbound_test.go
+++ b/pkg/xds/topology/ingress_outbound_test.go
@@ -28,10 +28,15 @@ var _ = Describe("IngressTrafficRoute", func() {
 		DescribeTable("should generate ingress outbounds matching given selectors",
 			func(given testCase) {
 				// when
+				meshServicesByName := make(map[string]*v1alpha1.MeshServiceResource, len(given.meshServices))
+				for _, ms := range given.meshServices {
+					meshServicesByName[ms.Meta.GetName()] = ms
+				}
 				endpoints := topology.BuildIngressEndpointMap(
 					given.mesh,
 					"east",
-					given.meshServices,
+					meshServicesByName,
+					nil,
 					nil,
 					given.dataplanes,
 					given.externalServices,

--- a/pkg/xds/topology/outbound.go
+++ b/pkg/xds/topology/outbound.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/asaskevich/govalidator"
 	"github.com/pkg/errors"
+	exp_maps "golang.org/x/exp/maps"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
@@ -17,6 +18,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/datasource"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	meshexternalservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
+	meshmzservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/meshservice"
 	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
@@ -74,7 +76,8 @@ func BuildEgressEndpointMap(
 func BuildIngressEndpointMap(
 	mesh *core_mesh.MeshResource,
 	localZone string,
-	meshServices []*meshservice_api.MeshServiceResource,
+	meshServicesByName map[string]*meshservice_api.MeshServiceResource,
+	meshMultiZoneServices []*meshmzservice_api.MeshMultiZoneServiceResource,
 	meshExternalServices []*meshexternalservice_api.MeshExternalServiceResource,
 	dataplanes []*core_mesh.DataplaneResource,
 	externalServices []*core_mesh.ExternalServiceResource,
@@ -83,7 +86,7 @@ func BuildIngressEndpointMap(
 ) core_xds.EndpointMap {
 	// Build EDS endpoint map just like for regular DPP, but without list of Ingress.
 	// This way we only keep local endpoints.
-	outbound := BuildEdsEndpointMap(mesh, localZone, meshServices, meshExternalServices, dataplanes, nil, zoneEgresses, externalServices)
+	outbound := BuildEdsEndpointMap(mesh, localZone, meshServicesByName, meshMultiZoneServices, meshExternalServices, dataplanes, nil, zoneEgresses, externalServices)
 	fillLocalCrossMeshOutbounds(outbound, mesh, dataplanes, gateways, 1, localZone)
 	return outbound
 }
@@ -91,7 +94,8 @@ func BuildIngressEndpointMap(
 func BuildEdsEndpointMap(
 	mesh *core_mesh.MeshResource,
 	localZone string,
-	meshServices []*meshservice_api.MeshServiceResource,
+	meshServicesByName map[string]*meshservice_api.MeshServiceResource,
+	meshMultiZoneServices []*meshmzservice_api.MeshMultiZoneServiceResource,
 	meshExternalServices []*meshexternalservice_api.MeshExternalServiceResource,
 	dataplanes []*core_mesh.DataplaneResource,
 	zoneIngresses []*core_mesh.ZoneIngressResource,
@@ -99,6 +103,8 @@ func BuildEdsEndpointMap(
 	externalServices []*core_mesh.ExternalServiceResource,
 ) core_xds.EndpointMap {
 	outbound := core_xds.EndpointMap{}
+
+	meshServices := exp_maps.Values(meshServicesByName)
 
 	fillLocalMeshServices(outbound, meshServices, dataplanes, mesh, localZone)
 	// we want to prefer endpoints build by MeshService
@@ -122,7 +128,31 @@ func BuildEdsEndpointMap(
 		fillExternalServicesOutboundsThroughEgress(outbound, externalServices, meshExternalServices, zoneEgresses, mesh, localZone)
 	}
 
+	// it has to be last because it reuses endpoints for other cases
+	fillMeshMultiZoneServices(outbound, meshServicesByName, meshMultiZoneServices)
+
 	return outbound
+}
+
+func fillMeshMultiZoneServices(
+	outbound core_xds.EndpointMap,
+	meshServicesByName map[string]*meshservice_api.MeshServiceResource,
+	meshMultiZoneServices []*meshmzservice_api.MeshMultiZoneServiceResource,
+) {
+	for _, mzSvc := range meshMultiZoneServices {
+		for _, matchedMs := range mzSvc.Status.MeshServices {
+			ms, ok := meshServicesByName[matchedMs.Name]
+			if !ok {
+				continue
+			}
+			for _, port := range mzSvc.Status.Ports {
+				serviceName := mzSvc.DestinationName(port.Port)
+
+				existingEndpoints := outbound[ms.DestinationName(port.Port)]
+				outbound[serviceName] = append(outbound[serviceName], existingEndpoints...)
+			}
+		}
+	}
 }
 
 func fillRemoteMeshServices(
@@ -179,6 +209,10 @@ func fillRemoteMeshServices(
 			serviceName := ms.DestinationName(port.Port)
 			for _, endpoint := range zoneToEndpoints[msZone] {
 				ep := endpoint
+				ep.Locality = &core_xds.Locality{
+					Zone:     msZone,
+					Priority: priorityRemote,
+				}
 				ep.Tags = map[string]string{
 					mesh_proto.ServiceTag: serviceName,
 					mesh_proto.ZoneTag:    msZone,

--- a/pkg/xds/topology/outbound_test.go
+++ b/pkg/xds/topology/outbound_test.go
@@ -12,13 +12,16 @@ import (
 	"github.com/kumahq/kuma/pkg/core/datasource"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	meshexternalservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
-	"github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
+	meshmzservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1"
+	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/secrets/cipher"
 	secret_manager "github.com/kumahq/kuma/pkg/core/secrets/manager"
 	secret_store "github.com/kumahq/kuma/pkg/core/secrets/store"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/plugins/resources/memory"
+	"github.com/kumahq/kuma/pkg/test/resources/builders"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
+	"github.com/kumahq/kuma/pkg/test/resources/samples"
 	"github.com/kumahq/kuma/pkg/util/pointer"
 	. "github.com/kumahq/kuma/pkg/xds/topology"
 )
@@ -209,7 +212,7 @@ var _ = Describe("TrafficRoute", func() {
 
 			// when
 			targets := BuildEdsEndpointMap(
-				defaultMeshWithMTLS, "zone-1", nil, nil, dataplanes.Items, nil, nil, externalServices.Items,
+				defaultMeshWithMTLS, "zone-1", nil, nil, nil, dataplanes.Items, nil, nil, externalServices.Items,
 			)
 
 			Expect(targets).To(HaveLen(4))
@@ -288,8 +291,9 @@ var _ = Describe("TrafficRoute", func() {
 	Describe("BuildEndpointMap()", func() {
 		type testCase struct {
 			dataplanes           []*core_mesh.DataplaneResource
-			meshServices         []*v1alpha1.MeshServiceResource
+			meshServices         []*meshservice_api.MeshServiceResource
 			meshExternalServices []*meshexternalservice_api.MeshExternalServiceResource
+			meshMultiZoneService []*meshmzservice_api.MeshMultiZoneServiceResource
 			zoneIngresses        []*core_mesh.ZoneIngressResource
 			zoneEgresses         []*core_mesh.ZoneEgressResource
 			externalServices     []*core_mesh.ExternalServiceResource
@@ -299,8 +303,20 @@ var _ = Describe("TrafficRoute", func() {
 		DescribeTable("should include only those dataplanes that match given selectors",
 			func(given testCase) {
 				// when
+				meshServiceByName := map[string]*meshservice_api.MeshServiceResource{}
+				for _, ms := range given.meshServices {
+					meshServiceByName[ms.GetMeta().GetName()] = ms
+				}
 				endpoints := BuildEdsEndpointMap(
-					given.mesh, "zone-1", given.meshServices, given.meshExternalServices, given.dataplanes, given.zoneIngresses, given.zoneEgresses, given.externalServices,
+					given.mesh,
+					"zone-1",
+					meshServiceByName,
+					given.meshMultiZoneService,
+					given.meshExternalServices,
+					given.dataplanes,
+					given.zoneIngresses,
+					given.zoneEgresses,
+					given.externalServices,
 				)
 				esEndpoints := BuildExternalServicesEndpointMap(
 					context.Background(), given.mesh, given.externalServices, given.meshExternalServices, dataSourceLoader, "zone-1",
@@ -1203,19 +1219,19 @@ var _ = Describe("TrafficRoute", func() {
 						},
 					},
 				},
-				meshServices: []*v1alpha1.MeshServiceResource{
+				meshServices: []*meshservice_api.MeshServiceResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Mesh: "default",
 							Name: "kong.kong-system",
 						},
-						Spec: &v1alpha1.MeshService{
-							Selector: v1alpha1.Selector{
+						Spec: &meshservice_api.MeshService{
+							Selector: meshservice_api.Selector{
 								DataplaneTags: map[string]string{
 									"app": "kong",
 								},
 							},
-							Ports: []v1alpha1.Port{
+							Ports: []meshservice_api.Port{
 								{
 									Port:        80,
 									TargetPort:  intstr.FromInt(8080),
@@ -1234,13 +1250,13 @@ var _ = Describe("TrafficRoute", func() {
 							Mesh: "default",
 							Name: "redis",
 						},
-						Spec: &v1alpha1.MeshService{
-							Selector: v1alpha1.Selector{
+						Spec: &meshservice_api.MeshService{
+							Selector: meshservice_api.Selector{
 								DataplaneTags: map[string]string{
 									mesh_proto.ServiceTag: "redis_svc_6379",
 								},
 							},
-							Ports: []v1alpha1.Port{
+							Ports: []meshservice_api.Port{
 								{
 									Port:       6379,
 									TargetPort: intstr.FromInt(6379),
@@ -1253,13 +1269,13 @@ var _ = Describe("TrafficRoute", func() {
 							Mesh: "default",
 							Name: "redis-0",
 						},
-						Spec: &v1alpha1.MeshService{
-							Selector: v1alpha1.Selector{
-								DataplaneRef: &v1alpha1.DataplaneRef{
+						Spec: &meshservice_api.MeshService{
+							Selector: meshservice_api.Selector{
+								DataplaneRef: &meshservice_api.DataplaneRef{
 									Name: "redis-0",
 								},
 							},
-							Ports: []v1alpha1.Port{
+							Ports: []meshservice_api.Port{
 								{
 									Port:       6379,
 									TargetPort: intstr.FromInt(6379),
@@ -1483,6 +1499,84 @@ var _ = Describe("TrafficRoute", func() {
 									},
 								},
 							},
+						},
+					},
+				},
+			}),
+			Entry("uses MeshMultiZoneService", testCase{
+				zoneIngresses: []*core_mesh.ZoneIngressResource{
+					builders.ZoneIngress().
+						WithZone("east").
+						WithAdvertisedAddress("192.168.0.100").
+						WithAdvertisedPort(12345).
+						Build(),
+				},
+				dataplanes: []*core_mesh.DataplaneResource{
+					samples.DataplaneBackend(),
+				},
+				meshServices: []*meshservice_api.MeshServiceResource{
+					samples.MeshServiceBackend(),
+					samples.MeshServiceSyncedBackend(),
+				},
+				meshMultiZoneService: []*meshmzservice_api.MeshMultiZoneServiceResource{
+					samples.MeshMultiZoneServiceBackendBuilder().
+						AddMatchedMeshServiceName(samples.MeshServiceBackend().GetMeta().GetName()).
+						AddMatchedMeshServiceName(samples.MeshServiceSyncedBackend().GetMeta().GetName()).
+						AddPort(samples.MeshServiceBackend().Spec.Ports[0]).
+						Build(),
+				},
+				mesh: defaultMeshWithMTLS,
+				expected: core_xds.EndpointMap{
+					"backend": []core_xds.Endpoint{
+						{
+							Target: "192.168.0.1",
+							Port:   80,
+							Tags: map[string]string{
+								"kuma.io/service": "backend",
+							},
+							Weight: 1,
+						},
+					},
+					"backend_svc_80": []core_xds.Endpoint{
+						{
+							Target: "192.168.0.1",
+							Port:   80,
+							Tags: map[string]string{
+								"kuma.io/service": "backend",
+							},
+							Weight: 1,
+						},
+					},
+					"backend-4v44xv7dwv4v8z2d_svc_80": []core_xds.Endpoint{
+						{
+							Target: "192.168.0.100",
+							Port:   12345,
+							Tags: map[string]string{
+								"kuma.io/service": "backend-4v44xv7dwv4v8z2d_svc_80",
+								"kuma.io/zone":    "east",
+							},
+							Weight:   1,
+							Locality: &core_xds.Locality{Zone: "east", SubZone: "", Priority: 1, Weight: 0},
+						},
+					},
+					"backend_mzsvc_80": []core_xds.Endpoint{
+						{
+							Target: "192.168.0.1",
+							Port:   80,
+							Tags: map[string]string{
+								"kuma.io/service": "backend",
+							},
+							Weight: 1,
+						},
+						{
+							Target: "192.168.0.100",
+							Port:   12345,
+							Tags: map[string]string{
+								"kuma.io/service": "backend-4v44xv7dwv4v8z2d_svc_80",
+								"kuma.io/zone":    "east",
+							},
+							Weight:   1,
+							Locality: &core_xds.Locality{Zone: "east", SubZone: "", Priority: 1, Weight: 0},
 						},
 					},
 				},

--- a/test/e2e_env/multizone/meshmultizoneservice/connectivity.go
+++ b/test/e2e_env/multizone/meshmultizoneservice/connectivity.go
@@ -1,0 +1,177 @@
+package meshmultizoneservice
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/client"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
+	"github.com/kumahq/kuma/test/framework/deployments/testserver"
+	"github.com/kumahq/kuma/test/framework/envs/multizone"
+)
+
+func Connectivity() {
+	namespace := "mzmsconnectivity"
+	meshName := "mzmsconnectivity"
+
+	BeforeAll(func() {
+		Expect(NewClusterSetup().
+			Install(MTLSMeshUniversal(meshName)).
+			Install(MeshTrafficPermissionAllowAllUniversal(meshName)).
+			Install(YamlUniversal(`
+type: HostnameGenerator
+name: mzmsconnectivity
+spec:
+  template: '{{ .DisplayName }}.global.mzmsconnectivity'
+  selector:
+    meshMultiZoneService:
+      matchLabels:
+        test-name: mzmsconnectivity
+`)).
+			Install(YamlUniversal(`
+type: MeshMultiZoneService
+name: test-server
+mesh: mzmsconnectivity
+labels:
+  test-name: mzmsconnectivity
+spec:
+  selector:
+    meshService:
+      matchLabels:
+        kuma.io/display-name: test-server
+        k8s.kuma.io/namespace: mzmsconnectivity
+`)).
+			Setup(multizone.Global)).To(Succeed())
+		Expect(WaitForMesh(meshName, multizone.Zones())).To(Succeed())
+
+		err := NewClusterSetup().
+			Install(NamespaceWithSidecarInjection(namespace)).
+			Install(testserver.Install(
+				testserver.WithNamespace(namespace),
+				testserver.WithMesh(meshName),
+				testserver.WithEchoArgs("echo", "--instance", "kube-test-server-1"),
+			)).
+			Install(democlient.Install(democlient.WithNamespace(namespace), democlient.WithMesh(meshName))).
+			Setup(multizone.KubeZone1)
+		Expect(err).ToNot(HaveOccurred())
+
+		kubeServiceYAML := `
+apiVersion: kuma.io/v1alpha1
+kind: MeshService
+metadata:
+  name: test-server
+  namespace: mzmsconnectivity
+  labels:
+    kuma.io/origin: zone
+    kuma.io/mesh: mzmsconnectivity
+    kuma.io/managed-by: k8s-controller
+    k8s.kuma.io/is-headless-service: "false"
+spec:
+  selector:
+    dataplaneTags:
+      app: test-server
+      k8s.kuma.io/namespace: mzmsconnectivity
+  ports:
+  - port: 80
+    name: main
+    targetPort: main
+    appProtocol: http
+`
+		err = NewClusterSetup().
+			Install(NamespaceWithSidecarInjection(namespace)).
+			Install(testserver.Install(
+				testserver.WithNamespace(namespace),
+				testserver.WithMesh(meshName),
+				testserver.WithEchoArgs("echo", "--instance", "kube-test-server-2"),
+			)).
+			Install(YamlK8s(kubeServiceYAML)).
+			Setup(multizone.KubeZone2)
+		Expect(err).ToNot(HaveOccurred())
+
+		uniServiceYAML := `
+type: MeshService
+name: test-server
+mesh: mzmsconnectivity
+labels:
+  kuma.io/origin: zone
+  kuma.io/env: universal
+  k8s.kuma.io/namespace: mzmsconnectivity # add a label to aggregate kube and uni service
+  kuma.io/display-name: test-server # add a label to aggregate kube and uni service
+spec:
+  selector:
+    dataplaneTags:
+      kuma.io/service: test-server
+  ports:
+  - port: 80
+    targetPort: 80
+    appProtocol: http
+`
+
+		err = NewClusterSetup().
+			Install(DemoClientUniversal("demo-client", meshName, WithTransparentProxy(true))).
+			Install(TestServerUniversal("test-server", meshName, WithArgs([]string{"echo", "--instance", "uni-test-server"}))).
+			Install(YamlUniversal(uniServiceYAML)).
+			Setup(multizone.UniZone1)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEachFailure(func() {
+		DebugUniversal(multizone.Global, meshName)
+		DebugUniversal(multizone.UniZone1, meshName)
+		DebugUniversal(multizone.UniZone2, meshName)
+		DebugKube(multizone.KubeZone1, meshName, namespace)
+		DebugKube(multizone.KubeZone2, meshName, namespace)
+	})
+
+	E2EAfterAll(func() {
+		Expect(multizone.KubeZone1.TriggerDeleteNamespace(namespace)).To(Succeed())
+		Expect(multizone.KubeZone2.TriggerDeleteNamespace(namespace)).To(Succeed())
+		Expect(multizone.UniZone1.DeleteMeshApps(meshName)).To(Succeed())
+		Expect(multizone.UniZone2.DeleteMeshApps(meshName)).To(Succeed())
+		Expect(multizone.Global.DeleteMesh(meshName)).To(Succeed())
+	})
+
+	responseFromInstance := func(cluster Cluster) func() (string, error) {
+		return func() (string, error) {
+			var opts []client.CollectResponsesOptsFn
+			if _, ok := cluster.(*K8sCluster); ok {
+				opts = append(opts, client.FromKubernetesPod(meshName, "demo-client"))
+			}
+			response, err := client.CollectEchoResponse(cluster, "demo-client", "http://test-server.global.mzmsconnectivity:80", opts...)
+			if err != nil {
+				return "", err
+			}
+			return response.Instance, nil
+		}
+	}
+
+	It("should access app from kube cluster and fallback to other zones", func() {
+		// given traffic to local zone only
+		Eventually(responseFromInstance(multizone.KubeZone1), "30s", "1s").
+			MustPassRepeatedly(5).Should(Equal("kube-test-server-1"))
+
+		// when
+		err := ScaleApp(multizone.KubeZone1, "test-server", namespace, 0)
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		Eventually(responseFromInstance(multizone.KubeZone1), "30s", "1s").
+			MustPassRepeatedly(5).Should(Or(Equal("kube-test-server-2"), Equal("uni-test-server")))
+	})
+
+	It("should access app from uni cluster and fallback to other zones", func() {
+		// given traffic to local zone only
+		Eventually(responseFromInstance(multizone.UniZone1), "30s", "1s").
+			MustPassRepeatedly(5).Should(Equal("uni-test-server"))
+
+		// when
+		err := multizone.UniZone1.DeleteApp("test-server")
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		Eventually(responseFromInstance(multizone.UniZone1), "30s", "1s").
+			Should(Equal("kube-test-server-2"))
+		// todo(jakubdyszkiewicz) add MustPassRepeatedly(5) after we solve excluding zones without any endpoints
+	})
+}

--- a/test/e2e_env/multizone/multizone_suite_test.go
+++ b/test/e2e_env/multizone/multizone_suite_test.go
@@ -74,6 +74,6 @@ var (
 	_ = Describe("Defaults", defaults.Defaults, Ordered)
 	_ = Describe("MeshService Sync", meshservice.Sync, Ordered)
 	_ = Describe("MeshService Connectivity", meshservice.Connectivity, Ordered)
-	_ = PDescribe("MeshMultiZoneService Connectivity", meshmultizoneservice.Connectivity, Ordered) // todo just to check if there is a test clash
+	_ = Describe("MeshMultiZoneService Connectivity", meshmultizoneservice.Connectivity, Ordered)
 	_ = Describe("Available services", connectivity.AvailableServices, Ordered)
 )

--- a/test/e2e_env/multizone/multizone_suite_test.go
+++ b/test/e2e_env/multizone/multizone_suite_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kumahq/kuma/test/e2e_env/multizone/inspect"
 	"github.com/kumahq/kuma/test/e2e_env/multizone/localityawarelb"
 	"github.com/kumahq/kuma/test/e2e_env/multizone/meshhttproute"
+	"github.com/kumahq/kuma/test/e2e_env/multizone/meshmultizoneservice"
 	"github.com/kumahq/kuma/test/e2e_env/multizone/meshservice"
 	"github.com/kumahq/kuma/test/e2e_env/multizone/meshtcproute"
 	"github.com/kumahq/kuma/test/e2e_env/multizone/meshtimeout"
@@ -73,5 +74,6 @@ var (
 	_ = Describe("Defaults", defaults.Defaults, Ordered)
 	_ = Describe("MeshService Sync", meshservice.Sync, Ordered)
 	_ = Describe("MeshService Connectivity", meshservice.Connectivity, Ordered)
+	_ = Describe("MeshMultiZoneService Connectivity", meshmultizoneservice.Connectivity, Ordered)
 	_ = Describe("Available services", connectivity.AvailableServices, Ordered)
 )

--- a/test/e2e_env/multizone/multizone_suite_test.go
+++ b/test/e2e_env/multizone/multizone_suite_test.go
@@ -74,6 +74,6 @@ var (
 	_ = Describe("Defaults", defaults.Defaults, Ordered)
 	_ = Describe("MeshService Sync", meshservice.Sync, Ordered)
 	_ = Describe("MeshService Connectivity", meshservice.Connectivity, Ordered)
-	_ = Describe("MeshMultiZoneService Connectivity", meshmultizoneservice.Connectivity, Ordered)
+	_ = PDescribe("MeshMultiZoneService Connectivity", meshmultizoneservice.Connectivity, Ordered) // todo just to check if there is a test clash
 	_ = Describe("Available services", connectivity.AvailableServices, Ordered)
 )


### PR DESCRIPTION
Part of https://github.com/kumahq/kuma/issues/10507

* Generate clusters of `<name>_mzsvc_<port>`.
* To generate endpoints for those clusters, leverage existing endpoints
* It prefers local endpoints but fallbacks to other zone.
* Right now we don't exclude the zone with 0 endpoints of MeshService. See E2E test. Out of scope of this PR
* Building SNI is annoying. It most likely will go on the resource itself. Out of scope of this PR.

### Checklist prior to review



<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
