### PR TITLE
fix(transparent-proxy): enable `kuma.io/transparent-proxying-ip-family-mode` annotation per pod

### DIFF
--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
@@ -520,6 +520,33 @@ func (i *KumaInjector) NewAnnotations(pod *kube_core.Pod, mesh string, logger lo
 
 	podAnnotations := metadata.Annotations(pod.Annotations)
 
+	if val, ok, _ := metadata.Annotations(pod.Annotations).GetEnabled(
+		metadata.KumaTransparentProxyingAnnotation,
+	); ok && !val {
+		logger.Info(fmt.Sprintf(
+			"WARNING: cannot change the value of annotation %s as the transparent proxy must be enabled in Kubernetes",
+			metadata.KumaTransparentProxyingAnnotation,
+		))
+	}
+
+	if val, ok, _ := metadata.Annotations(pod.Annotations).GetUint32(
+		metadata.KumaTransparentProxyingInboundPortAnnotation,
+	); ok && val != i.cfg.SidecarContainer.RedirectPortInbound {
+		logger.Info(fmt.Sprintf(
+			"WARNING: cannot change the value of annotation %s on a per pod basis. The global setting will be used",
+			metadata.KumaTransparentProxyingInboundPortAnnotation,
+		))
+	}
+
+	if val, ok, _ := metadata.Annotations(pod.Annotations).GetUint32(
+		metadata.KumaTransparentProxyingOutboundPortAnnotation,
+	); ok && val != i.cfg.SidecarContainer.RedirectPortOutbound {
+		logger.Info(fmt.Sprintf(
+			"WARNING: cannot change the value of annotation %s on a per pod basis. The global setting will be used",
+			metadata.KumaTransparentProxyingOutboundPortAnnotation,
+		))
+	}
+
 	ebpfEnabled, _, err := podAnnotations.GetEnabledWithDefault(i.cfg.EBPF.Enabled, metadata.KumaTransparentProxyingEbpf)
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting %s annotation failed", metadata.KumaTransparentProxyingEbpf)
@@ -591,7 +618,8 @@ func (i *KumaInjector) NewAnnotations(pod *kube_core.Pod, mesh string, logger lo
 		i.cfg.SidecarContainer.RedirectPortInboundV6 != uint32(tp_iptables_consts.DefaultRedirectInbountPort) {
 		annotations[metadata.KumaTransparentProxyingInboundPortAnnotationV6] = fmt.Sprintf("%d", i.cfg.SidecarContainer.RedirectPortInboundV6)
 	}
-	annotations[metadata.KumaTransparentProxyingIPFamilyMode] = i.cfg.SidecarContainer.IpFamilyMode
+	ipFamilyMode, _ := metadata.Annotations(pod.Annotations).GetStringWithDefault(i.cfg.SidecarContainer.IpFamilyMode, metadata.KumaTransparentProxyingIPFamilyMode)
+	annotations[metadata.KumaTransparentProxyingIPFamilyMode] = ipFamilyMode
 	dropInvalidPackets, _, err := podAnnotations.GetBoolean(metadata.KumaTrafficDropInvalidPackets)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Allow setting `kuma.io/transparent-proxying-ip-family-mode` annotation on a per-pod basis.

Log warnings when `kuma.io/transparent-proxying`,
`kuma.io/transparent-proxying-inbound-port`, or
`kuma.io/transparent-proxying-outbound-port` are specified on a per-pod basis, as these values are ignored.

Closes https://github.com/kumahq/kuma/issues/10903

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - https://github.com/kumahq/kuma/issues/10903
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Tested on local k3d cluster:
    - with init containers
    - with init containers and ` --set controlPlane.envVars.KUMA_RUNTIME_KUBERNETES_INJECTOR_SIDECAR_CONTAINER_IP_FAMILY_MODE=ipv4`
    - with CNI
    - with CNI and ` --set controlPlane.envVars.KUMA_RUNTIME_KUBERNETES_INJECTOR_SIDECAR_CONTAINER_IP_FAMILY_MODE=ipv4`
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - There is no need

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
