### PR TITLE
docs(MADR): proxies stats of MeshService

### DIFF
--- a/docs/madr/decisions/056-meshservice-proxies-stats.md
+++ b/docs/madr/decisions/056-meshservice-proxies-stats.md
@@ -46,7 +46,7 @@ This information is computed by the source zone and synced to global for visibil
 
 Fields:
 * `dataplaneProxies.connected` - number of DPPs connected to the Zone CP
-* `dataplaneProxies.healthy` - number of DPPs connected with all healthy inbounds
+* `dataplaneProxies.healthy` - number of DPPs connected with all healthy inbounds selected by the MeshService
 
 Fields that are in `ServiceInsights`, but won't be included in status of `MeshService`
 * `status` - If we want to present in the GUI if `MeshService` is available to consume, we can use `spec.state` described in the next section

--- a/docs/madr/decisions/056-meshservice-proxies-stats.md
+++ b/docs/madr/decisions/056-meshservice-proxies-stats.md
@@ -1,0 +1,80 @@
+# MeshService proxies stats
+
+* Status: accepted
+
+Technical Story: https://github.com/kumahq/kuma/issues/10915
+
+## Context and Problem Statement
+
+[ServiceInsight](https://github.com/kumahq/kuma/blob/master/api/mesh/v1alpha1/service_insight.proto) has detailed information about the Service.
+We need an equivalent of it in MeshService.
+
+ServiceInsight includes the Status field
+* Online - all dataplane proxies are connected to CP and have healthy inbounds
+* Offline - all dataplane proxies are not connected or have no healthy inbounds
+* Partially degraded - not all are "online" and not all are "offline"
+
+This mixing of whether the DPP is connected to CP and whether is healthy is confusing.
+
+When aggregating multiple `MeshService` into `MeshMultiZoneService` we need to know to which zones we can send the traffic to.
+A zone can have `MeshService` but have no healthy endpoints, in this case we should try other zone instead.
+
+## Considered Options
+
+* Count in status
+* State in spec
+
+## Decision Outcome
+
+Chosen option: "Count in status" and "state in spec".
+
+## Pros and Cons of the Options
+
+### Count in status and state in spec
+
+```
+kind: MeshService
+status:
+  dataplaneProxies:
+    connected: 10
+    healthy: 8
+    total: 10
+```
+
+We now separate connected proxies to the zone control plane from proxies that have healthy inbounds.
+This information is computed by the source zone and synced to global for visibility.
+
+Fields:
+* `dataplaneProxies.connected` - number of DPPs connected to the Zone CP
+* `dataplaneProxies.healthy` - number of DPPs connected with all healthy inbounds
+
+Fields that are in `ServiceInsights`, but won't be included in status of `MeshService`
+* `status` - If we want to present in the GUI if `MeshService` is available to consume, we can use `spec.state` described in the next section
+* `zones` - `MeshService` is bound to specific zone, so it makes no sense to include this
+* `serviceType` - `MeshService` is always `internal`
+* `addressPort` - `MeshService` already defines ports in `spec`
+* `issuedBackends` - Permissive mTLS will be covered by a separate MADR
+
+### State in spec
+
+```
+kind: MeshService
+spec:
+  state: Available | Unavailable
+```
+
+We need to pass an information for client's zone if there is any healthy endpoint available.
+Because `status` of MeshService is synced from Zone CP to Global CP only (it's not synced cross zone),
+we need to put this in `spec` just like we did with `spec.identities`.
+Client's zone do not care how many endpoints are in the zone, it only cares if there is at least one endpoint available.
+Not sending the exact number of endpoints cross zone helps with excessive KDS updates of remote MeshServices.
+`state` gets two states:
+* `Available` - at least one DPP selected by `MeshService` is healthy.
+  While technically health status can be different for each port, assuming each port is exposed from different container,
+  we want to avoid this complexity, and we want to use just one status. 
+* `Unavailable` - no DPPs selected by `MeshService` are healthy
+If `state` field is missing, we assume that it is `Unavailable`.
+
+This is a lightweight equivalent of `ZoneIngress#availableServices`
+
+`spec.state` and `status.dataplaneProxies` are computed using `StatusUpdater` component that already updates the resource with `spec.identities`.


### PR DESCRIPTION
### Checklist prior to review

xref #10915

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
