### PR TITLE
fix(kuma-cp): check if zone is online before forwarding request

### DIFF
--- a/pkg/core/rest/errors/error_handler.go
+++ b/pkg/core/rest/errors/error_handler.go
@@ -147,7 +147,7 @@ func HandleError(ctx context.Context, response *restful.Response, err error, tit
 			Title:  title,
 			Detail: err.Error(),
 		}
-	case errors.Is(err, &kds_envoyadmin.KDSTransportError{}), errors.Is(err, &envoyadmin.ForwardKDSRequestError{}):
+	case errors.Is(err, &kds_envoyadmin.KDSTransportError{}), errors.Is(err, &envoyadmin.ForwardKDSRequestError{}), errors.Is(err, &envoyadmin.ZoneOfflineError{}):
 		kumaErr = &types.Error{
 			Status: 400,
 			Title:  title,

--- a/pkg/intercp/envoyadmin/forwarding_kds_client.go
+++ b/pkg/intercp/envoyadmin/forwarding_kds_client.go
@@ -165,6 +165,9 @@ func (f *forwardingKdsEnvoyAdminClient) globalInstanceID(ctx context.Context, zo
 	if err := f.resManager.Get(ctx, zoneInsightRes, core_store.GetByKey(zone, core_model.NoMesh)); err != nil {
 		return "", err
 	}
+	if !zoneInsightRes.Spec.IsOnline() {
+		return "", &ZoneOfflineError{rpcName: rpcName}
+	}
 	streams := zoneInsightRes.Spec.GetEnvoyAdminStreams()
 	var globalInstanceID string
 	switch rpcName {
@@ -212,5 +215,17 @@ func (e *ForwardKDSRequestError) Error() string {
 }
 
 func (e *ForwardKDSRequestError) Is(err error) bool {
+	return reflect.TypeOf(e) == reflect.TypeOf(err)
+}
+
+type ZoneOfflineError struct {
+	rpcName string
+}
+
+func (e *ZoneOfflineError) Error() string {
+	return fmt.Sprintf("couldn't execute %s operation, zone is oflline", e.rpcName)
+}
+
+func (e *ZoneOfflineError) Is(err error) bool {
 	return reflect.TypeOf(e) == reflect.TypeOf(err)
 }


### PR DESCRIPTION
### Checklist prior to review

When the user enters GUI and his zone is offline, it is still possible to execute an admin operation. We don't check if zone is online. This PR introduces a check to validate if zone is online before going forward. Also, added a mapping to 400 status code.

- [ ] [Link to relevant issue][1] as well as docs and UI issues -- fix: https://github.com/Kong/mink-charts/issues/1078
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
