### PR TITLE
fix(kds): do not throw an error when context cancelled

### DIFF
--- a/pkg/kds/global/components.go
+++ b/pkg/kds/global/components.go
@@ -140,7 +140,7 @@ func Setup(rt runtime.Runtime) error {
 			return
 		}
 
-		if err := kdsServerV2.GlobalToZoneSync(stream); err != nil && status.Code(err) != codes.Canceled {
+		if err := kdsServerV2.GlobalToZoneSync(stream); err != nil && (status.Code(err) != codes.Canceled || !errors.Is(err, context.Canceled)) {
 			select {
 			case errChan <- err:
 			default:
@@ -174,7 +174,7 @@ func Setup(rt runtime.Runtime) error {
 		)
 		go func() {
 			err := sink.Receive()
-			if err != nil && status.Code(err) != codes.Canceled {
+			if err != nil && (status.Code(err) != codes.Canceled || !errors.Is(err, context.Canceled)) {
 				err = errors.Wrap(err, "KDSSyncClient finished with an error")
 				select {
 				case errChan <- err:


### PR DESCRIPTION
### Checklist prior to review

The function `status.Code(err)` retrieves a gRPC error code from the error. The `context.Canceled` error is not entirely under our control in this scenario, as it results from the user's intention to stop the stream. I have made a change to check if the error is `context.Canceled`, ensuring that this action is logged as an info message rather than an error.

```
KDSSyncClient finished with an error: failed to store Dataplane resources: context canceled
```

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
