### PR TITLE
fix(kuma-cp): pass future meta to Validate when creating a resource

### DIFF
--- a/pkg/core/resources/manager/manager.go
+++ b/pkg/core/resources/manager/manager.go
@@ -59,9 +59,7 @@ func (r *resourcesManager) Create(ctx context.Context, resource model.Resource, 
 	if err := model.Validate(resource); err != nil {
 		return err
 	}
-	if existingMeta == nil {
-		resource.SetMeta(existingMeta)
-	}
+	resource.SetMeta(existingMeta)
 
 	var owner model.Resource
 	if resource.Descriptor().Scope == model.ScopeMesh {

--- a/pkg/core/resources/manager/manager.go
+++ b/pkg/core/resources/manager/manager.go
@@ -49,10 +49,19 @@ func (r *resourcesManager) List(ctx context.Context, list model.ResourceList, fs
 }
 
 func (r *resourcesManager) Create(ctx context.Context, resource model.Resource, fs ...store.CreateOptionsFunc) error {
+	opts := store.NewCreateOptions(fs...)
+
+	// Create temporary meta so validation can see the meta that the store will set
+	existingMeta := resource.GetMeta()
+	if existingMeta == nil {
+		resource.SetMeta(metaFromCreateOpts(resource.Descriptor(), *opts))
+	}
 	if err := model.Validate(resource); err != nil {
 		return err
 	}
-	opts := store.NewCreateOptions(fs...)
+	if existingMeta == nil {
+		resource.SetMeta(existingMeta)
+	}
 
 	var owner model.Resource
 	if resource.Descriptor().Scope == model.ScopeMesh {

--- a/pkg/core/resources/manager/meta.go
+++ b/pkg/core/resources/manager/meta.go
@@ -1,0 +1,63 @@
+package manager
+
+import (
+	"time"
+
+	"github.com/kumahq/kuma/pkg/core/resources/model"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/core/resources/store"
+)
+
+type resourceMetaObject struct {
+	Name             string
+	Version          string
+	Mesh             string
+	CreationTime     time.Time
+	ModificationTime time.Time
+	Labels           map[string]string
+}
+
+var _ core_model.ResourceMeta = &resourceMetaObject{}
+
+func (r *resourceMetaObject) GetName() string {
+	return r.Name
+}
+
+func (r *resourceMetaObject) GetNameExtensions() core_model.ResourceNameExtensions {
+	return core_model.ResourceNameExtensionsUnsupported
+}
+
+func (r *resourceMetaObject) GetVersion() string {
+	return r.Version
+}
+
+func (r *resourceMetaObject) GetMesh() string {
+	return r.Mesh
+}
+
+func (r *resourceMetaObject) GetCreationTime() time.Time {
+	return r.CreationTime
+}
+
+func (r *resourceMetaObject) GetModificationTime() time.Time {
+	return r.ModificationTime
+}
+
+func (r *resourceMetaObject) GetLabels() map[string]string {
+	return r.Labels
+}
+
+func metaFromCreateOpts(descriptor model.ResourceTypeDescriptor, fs store.CreateOptions) core_model.ResourceMeta {
+	if fs.Name == "" {
+		return nil
+	}
+	if fs.Mesh == "" && descriptor.Scope == model.ScopeMesh {
+		return nil
+	}
+	return &resourceMetaObject{
+		Name:         fs.Name,
+		Mesh:         fs.Mesh,
+		CreationTime: fs.CreationTime,
+		Labels:       fs.Labels,
+	}
+}


### PR DESCRIPTION
At the moment the [MeshService validator](https://github.com/kumahq/kuma/blob/master/pkg/core/resources/apis/meshservice/api/v1alpha1/validator.go) fails when Create is called because the meta is `nil` and the future name of the resource is missing.

needed to get rid of [this commit in #10917](https://github.com/michaelbeaumont/kuma/commit/7bcee67d58d0deb7e2db192d2a3c3133a5aacbc4)

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
