### PR TITLE
feat(meshservice): permissive mtls

### DIFF
--- a/pkg/core/resources/apis/meshservice/status/updater.go
+++ b/pkg/core/resources/apis/meshservice/status/updater.go
@@ -160,11 +160,12 @@ func buildTLS(
 
 	issuedBackends := 0
 	for _, dpp := range dpps {
-		insight := insightsByName[core_model.MetaToResourceKey(dpp.Meta)]
-		// Cert issued by any backend means that mTLS cert was issued to the DP
-		// We don't want to check specific backend value, because we might be in a middle of CA rotation.
-		if insight.Spec.GetMTLS().GetIssuedBackend() != "" {
-			issuedBackends++
+		if insight := insightsByName[core_model.MetaToResourceKey(dpp.Meta)]; insight != nil {
+			// Cert issued by any backend means that mTLS cert was issued to the DP
+			// We don't want to check specific backend value, because we might be in a middle of CA rotation.
+			if insight.Spec.GetMTLS().GetIssuedBackend() != "" {
+				issuedBackends++
+			}
 		}
 	}
 	if issuedBackends == len(dpps) {

--- a/pkg/core/resources/apis/meshservice/status/updater_test.go
+++ b/pkg/core/resources/apis/meshservice/status/updater_test.go
@@ -93,6 +93,7 @@ var _ = Describe("Updater", func() {
 	type testCase struct {
 		meshBuilder            *builders.MeshBuilder
 		dpInsightIssuedBackend string
+		dpInsightMissing       bool
 		existingTLSStatus      meshservice_api.TLSStatus
 		expectedTLSStatus      meshservice_api.TLSStatus
 	}
@@ -102,10 +103,12 @@ var _ = Describe("Updater", func() {
 			// given
 			Expect(given.meshBuilder.WithName("test").Create(resManager)).To(Succeed())
 			Expect(samples.DataplaneBackendBuilder().WithMesh("test").Create(resManager)).To(Succeed())
-			Expect(samples.DataplaneInsightBackendBuilder().
-				WithMesh("test").
-				WithMTLSIssuedBackend(given.dpInsightIssuedBackend).
-				Create(resManager)).To(Succeed())
+			if !given.dpInsightMissing {
+				Expect(samples.DataplaneInsightBackendBuilder().
+					WithMesh("test").
+					WithMTLSIssuedBackend(given.dpInsightIssuedBackend).
+					Create(resManager)).To(Succeed())
+			}
 			Expect(samples.MeshServiceBackendBuilder().
 				WithMesh("test").
 				WithTLSStatus(given.existingTLSStatus).
@@ -145,6 +148,13 @@ var _ = Describe("Updater", func() {
 			dpInsightIssuedBackend: "",
 			existingTLSStatus:      meshservice_api.TLSReady,
 			expectedTLSStatus:      meshservice_api.TLSReady,
+		}),
+		Entry("should set TLS to NotReady when DP has no insight", testCase{
+			meshBuilder:            samples.MeshMTLSBuilder(),
+			dpInsightMissing:       true,
+			dpInsightIssuedBackend: "",
+			existingTLSStatus:      "",
+			expectedTLSStatus:      meshservice_api.TLSNotReady,
 		}),
 	)
 

--- a/pkg/core/resources/apis/meshservice/status/updater_test.go
+++ b/pkg/core/resources/apis/meshservice/status/updater_test.go
@@ -16,6 +16,7 @@ import (
 	core_metrics "github.com/kumahq/kuma/pkg/metrics"
 	"github.com/kumahq/kuma/pkg/plugins/resources/memory"
 	test_metrics "github.com/kumahq/kuma/pkg/test/metrics"
+	"github.com/kumahq/kuma/pkg/test/resources/builders"
 	"github.com/kumahq/kuma/pkg/test/resources/samples"
 )
 
@@ -88,6 +89,64 @@ var _ = Describe("Updater", func() {
 			}))
 		}, "1s", "100ms").Should(Succeed())
 	})
+
+	type testCase struct {
+		meshBuilder            *builders.MeshBuilder
+		dpInsightIssuedBackend string
+		existingTLSStatus      meshservice_api.TLSStatus
+		expectedTLSStatus      meshservice_api.TLSStatus
+	}
+
+	DescribeTable("mTLS updater",
+		func(given testCase) {
+			// given
+			Expect(given.meshBuilder.WithName("test").Create(resManager)).To(Succeed())
+			Expect(samples.DataplaneBackendBuilder().WithMesh("test").Create(resManager)).To(Succeed())
+			Expect(samples.DataplaneInsightBackendBuilder().
+				WithMesh("test").
+				WithMTLSIssuedBackend(given.dpInsightIssuedBackend).
+				Create(resManager)).To(Succeed())
+			Expect(samples.MeshServiceBackendBuilder().
+				WithMesh("test").
+				WithTLSStatus(given.existingTLSStatus).
+				Create(resManager)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				// when
+				ms := meshservice_api.NewMeshServiceResource()
+				err := resManager.Get(context.Background(), ms, store.GetByKey("backend", "test"))
+
+				// then
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(ms.Status.TLS.Status).To(Equal(given.expectedTLSStatus))
+			}, "10s", "50ms").MustPassRepeatedly(3).Should(Succeed())
+			// MustPassRepeatedly is to make sure that when existingTLSStatus == expectedTLSStatus we actually preserve it.
+		},
+		Entry("should set TLS to NotReady when mTLS is disabled", testCase{
+			meshBuilder:            samples.MeshDefaultBuilder(),
+			dpInsightIssuedBackend: "builtin-1",
+			existingTLSStatus:      meshservice_api.TLSReady,
+			expectedTLSStatus:      meshservice_api.TLSNotReady,
+		}),
+		Entry("should set TLS to Ready when we issued certs to all DPPs", testCase{
+			meshBuilder:            samples.MeshMTLSBuilder(),
+			dpInsightIssuedBackend: "builtin-1",
+			existingTLSStatus:      meshservice_api.TLSNotReady,
+			expectedTLSStatus:      meshservice_api.TLSReady,
+		}),
+		Entry("should set TLS to NotReady when we did not issued certs to all DPPs", testCase{
+			meshBuilder:            samples.MeshMTLSBuilder(),
+			dpInsightIssuedBackend: "",
+			existingTLSStatus:      "",
+			expectedTLSStatus:      meshservice_api.TLSNotReady,
+		}),
+		Entry("should preserve TLS Ready even through we did not issue certs to all DPPs", testCase{
+			meshBuilder:            samples.MeshMTLSBuilder(),
+			dpInsightIssuedBackend: "",
+			existingTLSStatus:      meshservice_api.TLSReady,
+			expectedTLSStatus:      meshservice_api.TLSReady,
+		}),
+	)
 
 	It("should emit metric", func() {
 		Eventually(func(g Gomega) {

--- a/pkg/core/resources/model/resource.go
+++ b/pkg/core/resources/model/resource.go
@@ -627,3 +627,12 @@ type PolicyWithSingleItem interface {
 	Policy
 	GetPolicyItem() PolicyItem
 }
+
+func IndexByKey[T Resource](resources []T) map[ResourceKey]T {
+	indexedResources := make(map[ResourceKey]T)
+	for _, resource := range resources {
+		key := MetaToResourceKey(resource.GetMeta())
+		indexedResources[key] = resource
+	}
+	return indexedResources
+}

--- a/pkg/plugins/policies/core/xds/meshroute/clusters.go
+++ b/pkg/plugins/policies/core/xds/meshroute/clusters.go
@@ -91,6 +91,11 @@ func GenerateClusters(
 					}
 				} else {
 					if service.BackendRef().ReferencesRealObject() {
+						if service.BackendRef().Kind == common_api.MeshService {
+							if ms := meshCtx.MeshServiceByName[service.BackendRef().Name]; ms != nil {
+								tlsReady = ms.Status.TLS.Status == v1alpha1.TLSReady
+							}
+						}
 						edsClusterBuilder.Configure(envoy_clusters.ClientSideMultiIdentitiesMTLS(
 							proxy.SecretsTracker,
 							meshCtx.Resource,

--- a/pkg/test/resources/builders/dataplane_insight_builder.go
+++ b/pkg/test/resources/builders/dataplane_insight_builder.go
@@ -1,0 +1,67 @@
+package builders
+
+import (
+	"context"
+
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/core/resources/store"
+	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
+)
+
+type DataplaneInsightBuilder struct {
+	res *core_mesh.DataplaneInsightResource
+}
+
+func DataplaneInsight() *DataplaneInsightBuilder {
+	return &DataplaneInsightBuilder{
+		res: &core_mesh.DataplaneInsightResource{
+			Meta: &test_model.ResourceMeta{
+				Mesh: core_model.DefaultMesh,
+				Name: "dp-1",
+			},
+			Spec: &mesh_proto.DataplaneInsight{},
+		},
+	}
+}
+
+func (d *DataplaneInsightBuilder) Build() *core_mesh.DataplaneInsightResource {
+	return d.res
+}
+
+func (d *DataplaneInsightBuilder) Create(s store.ResourceStore) error {
+	return s.Create(context.Background(), d.Build(), store.CreateBy(d.Key()))
+}
+
+func (d *DataplaneInsightBuilder) Key() core_model.ResourceKey {
+	return core_model.MetaToResourceKey(d.res.GetMeta())
+}
+
+func (d *DataplaneInsightBuilder) With(fn func(resource *core_mesh.DataplaneInsightResource)) *DataplaneInsightBuilder {
+	fn(d.res)
+	return d
+}
+
+func (d *DataplaneInsightBuilder) WithName(name string) *DataplaneInsightBuilder {
+	d.res.Meta.(*test_model.ResourceMeta).Name = name
+	return d
+}
+
+func (d *DataplaneInsightBuilder) WithMesh(mesh string) *DataplaneInsightBuilder {
+	d.res.Meta.(*test_model.ResourceMeta).Mesh = mesh
+	return d
+}
+
+func (d *DataplaneInsightBuilder) WithMTLS(mtls *mesh_proto.DataplaneInsight_MTLS) *DataplaneInsightBuilder {
+	d.res.Spec.MTLS = mtls
+	return d
+}
+
+func (d *DataplaneInsightBuilder) WithMTLSIssuedBackend(issuedBackend string) *DataplaneInsightBuilder {
+	if d.res.Spec.MTLS == nil {
+		d.res.Spec.MTLS = &mesh_proto.DataplaneInsight_MTLS{}
+	}
+	d.res.Spec.MTLS.IssuedBackend = issuedBackend
+	return d
+}

--- a/pkg/test/resources/builders/meshservice_builder.go
+++ b/pkg/test/resources/builders/meshservice_builder.go
@@ -98,6 +98,11 @@ func (m *MeshServiceBuilder) WithoutVIP() *MeshServiceBuilder {
 	return m
 }
 
+func (m *MeshServiceBuilder) WithTLSStatus(status v1alpha1.TLSStatus) *MeshServiceBuilder {
+	m.res.Status.TLS.Status = status
+	return m
+}
+
 func (m *MeshServiceBuilder) Build() *v1alpha1.MeshServiceResource {
 	if err := m.res.Validate(); err != nil {
 		panic(err)

--- a/pkg/test/resources/samples/dataplane_insight_samples.go
+++ b/pkg/test/resources/samples/dataplane_insight_samples.go
@@ -1,0 +1,14 @@
+package samples
+
+import (
+	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/test/resources/builders"
+)
+
+func DataplaneInsightBackendBuilder() *builders.DataplaneInsightBuilder {
+	return builders.DataplaneInsight()
+}
+
+func DataplaneInsight() *mesh.DataplaneInsightResource {
+	return DataplaneInsightBackendBuilder().Build()
+}

--- a/test/e2e_env/universal/meshservice/meshservice.go
+++ b/test/e2e_env/universal/meshservice/meshservice.go
@@ -2,10 +2,13 @@ package meshservice
 
 import (
 	"fmt"
+	"sync/atomic"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/kumahq/kuma/pkg/util/channels"
 	. "github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/framework/client"
 	"github.com/kumahq/kuma/test/framework/envs/universal"
@@ -16,7 +19,7 @@ func MeshService() {
 
 	BeforeAll(func() {
 		err := NewClusterSetup().
-			Install(MTLSMeshUniversal(meshName)).
+			Install(MeshUniversal(meshName)).
 			Install(TestServerUniversal(
 				"first-test-server",
 				meshName,
@@ -95,5 +98,59 @@ spec:
 			)
 			g.Expect(err).ToNot(HaveOccurred())
 		}, "30s", "500ms", MustPassRepeatedly(10)).Should(Succeed())
+	})
+
+	It("should switch to permissive mTLS without drop of the traffic", func() {
+		// given constant requests to the service
+		reqError := atomic.Value{}
+		stopCh := make(chan struct{})
+		defer close(stopCh)
+		go func() {
+			for {
+				if channels.IsClosed(stopCh) {
+					return
+				}
+				_, err := client.CollectEchoResponse(
+					universal.Cluster, "demo-client", "backend.meshservice.othertld",
+				)
+				if err != nil {
+					reqError.Store(err)
+				}
+				time.Sleep(50 * time.Millisecond)
+			}
+		}()
+
+		// when
+		yaml := `
+type: Mesh
+name: mesh-service
+mtls:
+  enabledBackend: ca-1
+  backends:
+  - name: ca-1
+    type: builtin
+    mode: PERMISSIVE
+`
+		err := universal.Cluster.Install(YamlUniversal(yaml))
+
+		// then traffic went over mTLS with no errors
+		Expect(err).ToNot(HaveOccurred())
+		Eventually(func(g Gomega) {
+			stdout, _, err := client.CollectResponse(
+				universal.Cluster, "demo-client", "http://localhost:9901/stats",
+			)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(stdout).To(ContainSubstring("cluster.backend_svc_80.ssl.handshake"))
+			g.Expect(stdout).ToNot(ContainSubstring("cluster.backend_svc_80.ssl.handshake: 0"))
+		}, "30s", "1s").Should(Succeed())
+		Expect(reqError.Load()).To(BeNil())
+
+		// when switch to strict mTLS
+		err = universal.Cluster.Install(MTLSMeshUniversal(meshName))
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		time.Sleep(5 * time.Second) // let the goroutine execute more requests
+		Expect(reqError.Load()).To(BeNil())
 	})
 }


### PR DESCRIPTION
### Checklist prior to review

Implementation of https://github.com/kumahq/kuma/pull/10924

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
