### PR TITLE
fix(meshpassthrough): do not require port

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -3974,8 +3974,6 @@ spec:
                         value:
                           description: Value for the specified Type.
                           type: string
-                      required:
-                      - port
                       type: object
                     type: array
                   passthroughMode:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -3974,8 +3974,6 @@ spec:
                         value:
                           description: Value for the specified Type.
                           type: string
-                      required:
-                      - port
                       type: object
                     type: array
                   passthroughMode:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -3994,8 +3994,6 @@ spec:
                         value:
                           description: Value for the specified Type.
                           type: string
-                      required:
-                      - port
                       type: object
                     type: array
                   passthroughMode:

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -5528,8 +5528,6 @@ spec:
                         value:
                           description: Value for the specified Type.
                           type: string
-                      required:
-                      - port
                       type: object
                     type: array
                   passthroughMode:

--- a/deployments/charts/kuma/crds/kuma.io_meshpassthroughs.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshpassthroughs.yaml
@@ -81,8 +81,6 @@ spec:
                         value:
                           description: Value for the specified Type.
                           type: string
-                      required:
-                      - port
                       type: object
                     type: array
                   passthroughMode:

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -7248,8 +7248,6 @@ components:
                       value:
                         description: Value for the specified Type.
                         type: string
-                    required:
-                      - port
                     type: object
                   type: array
                 passthroughMode:

--- a/docs/generated/raw/crds/kuma.io_meshpassthroughs.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshpassthroughs.yaml
@@ -81,8 +81,6 @@ spec:
                         value:
                           description: Value for the specified Type.
                           type: string
-                      required:
-                      - port
                       type: object
                     type: array
                   passthroughMode:

--- a/pkg/plugins/policies/meshpassthrough/api/v1alpha1/meshpassthrough.go
+++ b/pkg/plugins/policies/meshpassthrough/api/v1alpha1/meshpassthrough.go
@@ -47,7 +47,7 @@ type Match struct {
 	// Value for the specified Type.
 	Value string `json:"value,omitempty"`
 	// Port defines the port to which a user makes a request.
-	Port *int `json:"port"`
+	Port *int `json:"port,omitempty"`
 	// Protocol defines the communication protocol. Possible values: `tcp`, `tls`, `grpc`, `http`, `http2`.
 	// +kubebuilder:default=tcp
 	Protocol ProtocolType `json:"protocol,omitempty"`

--- a/pkg/plugins/policies/meshpassthrough/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshpassthrough/api/v1alpha1/schema.yaml
@@ -51,8 +51,6 @@ properties:
                 value:
                   description: Value for the specified Type.
                   type: string
-              required:
-                - port
               type: object
             type: array
           passthroughMode:

--- a/pkg/plugins/policies/meshpassthrough/k8s/crd/kuma.io_meshpassthroughs.yaml
+++ b/pkg/plugins/policies/meshpassthrough/k8s/crd/kuma.io_meshpassthroughs.yaml
@@ -81,8 +81,6 @@ spec:
                         value:
                           description: Value for the specified Type.
                           type: string
-                      required:
-                      - port
                       type: object
                     type: array
                   passthroughMode:


### PR DESCRIPTION
### Checklist prior to review

We had a pointer to int for a `port` but it requires `omitempty` to make it nor required.

- [X] [Link to relevant issue][1] as well as docs and UI issues -- fix: https://github.com/kumahq/kuma/issues/10880
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
