### PR TITLE
fix(kumactl): in apply support empty docs

### DIFF
--- a/app/kumactl/cmd/apply/testdata/apply-multiple-resource-different-type.yaml
+++ b/app/kumactl/cmd/apply/testdata/apply-multiple-resource-different-type.yaml
@@ -1,3 +1,4 @@
+# Just a starting comment
 ---
 name: sample1
 # --- Checking a random separation doesn't break everything

--- a/pkg/util/yaml/split.go
+++ b/pkg/util/yaml/split.go
@@ -5,8 +5,10 @@ import (
 	"strings"
 )
 
-var sep = regexp.MustCompile("(?:^|\\s*\n)---\\s*")
-var comment = regexp.MustCompile("^#.*$")
+var (
+	sep     = regexp.MustCompile("(?:^|\\s*\n)---\\s*")
+	comment = regexp.MustCompile("^#.*$")
+)
 
 // SplitYAML takes YAMLs separated by `---` line and splits it into multiple YAMLs. Empty entries are ignored
 func SplitYAML(yamls string) []string {

--- a/pkg/util/yaml/split.go
+++ b/pkg/util/yaml/split.go
@@ -6,6 +6,7 @@ import (
 )
 
 var sep = regexp.MustCompile("(?:^|\\s*\n)---\\s*")
+var comment = regexp.MustCompile("^#.*$")
 
 // SplitYAML takes YAMLs separated by `---` line and splits it into multiple YAMLs. Empty entries are ignored
 func SplitYAML(yamls string) []string {
@@ -14,6 +15,7 @@ func SplitYAML(yamls string) []string {
 	trimYAMLs := strings.TrimSpace(yamls)
 	docs := sep.Split(trimYAMLs, -1)
 	for _, doc := range docs {
+		doc = comment.ReplaceAllString(doc, "")
 		if doc == "" {
 			continue
 		}

--- a/test/e2e/federation/federation_suite_test.go
+++ b/test/e2e/federation/federation_suite_test.go
@@ -14,6 +14,6 @@ func TestE2E(t *testing.T) {
 }
 
 var (
-	_ = PDescribe("Federation with Kube Global", Label("job-3"), federation.FederateKubeZoneCPToKubeGlobal, Ordered)
-	_ = PDescribe("Federation with Universal Global", Label("job-3"), federation.FederateKubeZoneCPToUniversalGlobal, Ordered)
+	_ = Describe("Federation with Kube Global", Label("job-3"), federation.FederateKubeZoneCPToKubeGlobal, Ordered)
+	_ = Describe("Federation with Universal Global", Label("job-3"), federation.FederateKubeZoneCPToUniversalGlobal, Ordered)
 )


### PR DESCRIPTION
When a document had just 1 comment this would cause problems when doing `kumactl apply -f`.
We now strip comments before doing anything which would ignore this doc

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
