### PR TITLE
fix(kuma-cp): paginate Secrets correctly in universal

### DIFF
--- a/pkg/core/bootstrap/bootstrap.go
+++ b/pkg/core/bootstrap/bootstrap.go
@@ -320,7 +320,7 @@ func initializeSecretStore(cfg kuma_cp.Config, builder *core_runtime.Builder) er
 	if ss, err := plugin.NewSecretStore(builder, pluginConfig); err != nil {
 		return err
 	} else {
-		builder.WithSecretStore(core_store.NewPaginationStore(ss))
+		builder.WithSecretStore(ss)
 		return nil
 	}
 }

--- a/pkg/plugins/secrets/k8s/plugin.go
+++ b/pkg/plugins/secrets/k8s/plugin.go
@@ -4,6 +4,7 @@ import (
 	"github.com/pkg/errors"
 
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
+	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 	secret_store "github.com/kumahq/kuma/pkg/core/secrets/store"
 	k8s_extensions "github.com/kumahq/kuma/pkg/plugins/extensions/k8s"
 )
@@ -25,5 +26,9 @@ func (p *plugin) NewSecretStore(pc core_plugins.PluginContext, _ core_plugins.Pl
 	if !ok {
 		return nil, errors.Errorf("secret client hasn't been configured")
 	}
-	return NewStore(client, client, mgr.GetScheme(), pc.Config().Store.Kubernetes.SystemNamespace)
+	coreStore, err := NewStore(client, client, mgr.GetScheme(), pc.Config().Store.Kubernetes.SystemNamespace)
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't create k8s secret store")
+	}
+	return core_store.NewPaginationStore(coreStore), nil
 }


### PR DESCRIPTION
We were wrapping a store that already had a pagination store with another pagination store.
This led to inconsistent results like:

```
% kumactl get secrets --mesh nonprod --size 1000 | grep -v MESH | wc -l
450
% kumactl get secrets --mesh nonprod --offset 100 | grep -v MESH | wc -l
0
```

Only k8s stores needs to be wrapped with a pagination store, the default store for universal is already paginated:

https://github.com/kumahq/kuma/blob/7075f0e17466c73ec82aa95649124edad6cafe8d/pkg/core/bootstrap/bootstrap.go#L295-L301

https://github.com/kumahq/kuma/blob/7075f0e17466c73ec82aa95649124edad6cafe8d/pkg/plugins/secrets/universal/plugin.go#L17


### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
