### PR TITLE
feat(kuma-cp): make loggers naming from xds package consistent

### DIFF
--- a/pkg/xds/bootstrap/handler.go
+++ b/pkg/xds/bootstrap/handler.go
@@ -15,7 +15,7 @@ import (
 	"github.com/kumahq/kuma/pkg/xds/bootstrap/types"
 )
 
-var log = core.Log.WithName("bootstrap")
+var log = core.Log.WithName("xds").WithName("bootstrap")
 
 type BootstrapHandler struct {
 	Generator BootstrapGenerator

--- a/pkg/xds/context/context.go
+++ b/pkg/xds/context/context.go
@@ -15,6 +15,8 @@ import (
 	"github.com/kumahq/kuma/pkg/xds/secrets"
 )
 
+var logger = core.Log.WithName("xds").WithName("context")
+
 type Context struct {
 	ControlPlane *ControlPlaneContext
 	Mesh         MeshContext
@@ -91,7 +93,7 @@ func (mc *MeshContext) GetTracingBackend(tt *core_mesh.TrafficTraceResource) *me
 		return nil
 	}
 	if tb := mc.Resource.GetTracingBackend(tt.Spec.GetConf().GetBackend()); tb == nil {
-		core.Log.WithName("xds").Info("Tracing backend is not found. Ignoring.",
+		logger.Info("Tracing backend is not found. Ignoring.",
 			"backendName", tt.Spec.GetConf().GetBackend(),
 			"trafficTraceName", tt.GetMeta().GetName(),
 			"trafficTraceMesh", tt.GetMeta().GetMesh())
@@ -106,7 +108,7 @@ func (mc *MeshContext) GetLoggingBackend(tl *core_mesh.TrafficLogResource) *mesh
 		return nil
 	}
 	if lb := mc.Resource.GetLoggingBackend(tl.Spec.GetConf().GetBackend()); lb == nil {
-		core.Log.WithName("xds").Info("Logging backend is not found. Ignoring.",
+		logger.Info("Logging backend is not found. Ignoring.",
 			"backendName", tl.Spec.GetConf().GetBackend(),
 			"trafficLogName", tl.GetMeta().GetName(),
 			"trafficLogMesh", tl.GetMeta().GetMesh())

--- a/pkg/xds/context/mesh_context_builder.go
+++ b/pkg/xds/context/mesh_context_builder.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/datasource"
 	"github.com/kumahq/kuma/pkg/core/dns/lookup"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
@@ -30,8 +29,6 @@ import (
 	util_protocol "github.com/kumahq/kuma/pkg/util/protocol"
 	xds_topology "github.com/kumahq/kuma/pkg/xds/topology"
 )
-
-var logger = core.Log.WithName("xds").WithName("context")
 
 type meshContextBuilder struct {
 	rm                manager.ReadOnlyResourceManager

--- a/pkg/xds/envoy/clusters/v3/health_check_configurer.go
+++ b/pkg/xds/envoy/clusters/v3/health_check_configurer.go
@@ -15,6 +15,8 @@ import (
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 )
 
+var log = core.Log.WithName("xds").WithName("health-check-configurer")
+
 type HealthCheckConfigurer struct {
 	HealthCheck *core_mesh.HealthCheckResource
 	Protocol    core_mesh.Protocol
@@ -128,7 +130,7 @@ func failTrafficOnPanic(cluster *envoy_cluster.Cluster, value *wrapperspb.BoolVa
 	if cluster.CommonLbConfig.GetLocalityWeightedLbConfig() != nil {
 		// used load balancing type doesn't support 'fail_traffic_on_panic', right now we don't use
 		// 'locality_weighted_lb_config' in Kuma, locality aware load balancing is implemented based on priority levels
-		core.Log.WithName("health-check-configurer").Error(
+		log.Error(
 			errors.New("unable to set 'fail_traffic_on_panic' for 'locality_weighted_lb_config' load balancer"),
 			"unable to configure 'fail_traffic_on_panic', parameter is ignored")
 		return

--- a/pkg/xds/generator/egress/generator.go
+++ b/pkg/xds/generator/egress/generator.go
@@ -24,7 +24,7 @@ const (
 	OriginEgress = "egress"
 )
 
-var log = core.Log.WithName("xds").WithName("generator").WithName("egress")
+var log = core.Log.WithName("xds").WithName("egress-proxy-generator")
 
 // ZoneEgressGenerator is responsible for generating xDS resources for
 // a single ZoneEgress.

--- a/pkg/xds/generator/outbound_proxy_generator.go
+++ b/pkg/xds/generator/outbound_proxy_generator.go
@@ -23,7 +23,7 @@ import (
 	envoy_tags "github.com/kumahq/kuma/pkg/xds/envoy/tags"
 )
 
-var outboundLog = core.Log.WithName("outbound-proxy-generator")
+var outboundLog = core.Log.WithName("xds").WithName("outbound-proxy-generator")
 
 // OriginOutbound is a marker to indicate by which ProxyGenerator resources were generated.
 const OriginOutbound = "outbound"

--- a/pkg/xds/generator/prometheus_endpoint_generator.go
+++ b/pkg/xds/generator/prometheus_endpoint_generator.go
@@ -30,7 +30,7 @@ const OriginPrometheus = "prometheus"
 // rather than introduce undeterministic behavior.
 type PrometheusEndpointGenerator struct{}
 
-var prometheusLog = core.Log.WithName("prometheus-endpoint-generator")
+var prometheusLog = core.Log.WithName("xds").WithName("prometheus-endpoint-generator")
 
 func (g PrometheusEndpointGenerator) Generate(ctx context.Context, _ *core_xds.ResourceSet, xdsCtx xds_context.Context, proxy *core_xds.Proxy) (*core_xds.ResourceSet, error) {
 	prometheusEndpoint, err := proxy.Dataplane.GetPrometheusConfig(xdsCtx.Mesh.Resource)

--- a/pkg/xds/generator/secrets/generator.go
+++ b/pkg/xds/generator/secrets/generator.go
@@ -13,6 +13,8 @@ import (
 	generator_core "github.com/kumahq/kuma/pkg/xds/generator/core"
 )
 
+var generatorLogger = core.Log.WithName("secrets-generator")
+
 // OriginSecrets is a marker to indicate by which ProxyGenerator resources were generated.
 const OriginSecrets = "secrets"
 
@@ -50,7 +52,7 @@ func (g Generator) GenerateForZoneEgress(
 ) (*core_xds.ResourceSet, error) {
 	resources := core_xds.NewResourceSet()
 
-	log := core.Log.WithName("secrets-generator").WithValues("proxyID", proxyId.String())
+	log := generatorLogger.WithValues("proxyID", proxyId.String())
 
 	if !mesh.MTLSEnabled() {
 		return nil, nil
@@ -88,7 +90,7 @@ func (g Generator) Generate(
 ) (*core_xds.ResourceSet, error) {
 	resources := core_xds.NewResourceSet()
 
-	log := core.Log.WithName("secrets-generator").WithValues("proxyID", proxy.Id.String())
+	log := generatorLogger.WithValues("proxyID", proxy.Id.String())
 
 	if proxy.Dataplane != nil {
 		log = log.WithValues("mesh", xdsCtx.Mesh.Resource.GetMeta().GetName())

--- a/pkg/xds/server/callbacks/dataplane_sync_tracker.go
+++ b/pkg/xds/server/callbacks/dataplane_sync_tracker.go
@@ -10,7 +10,7 @@ import (
 	util_watchdog "github.com/kumahq/kuma/pkg/util/watchdog"
 )
 
-var dataplaneSyncTrackerLog = core.Log.WithName("xds-server").WithName("dataplane-sync-tracker")
+var dataplaneSyncTrackerLog = core.Log.WithName("xds").WithName("dataplane-sync-tracker")
 
 type NewDataplaneWatchdogFunc func(key core_model.ResourceKey) util_watchdog.Watchdog
 

--- a/pkg/xds/server/v3/components.go
+++ b/pkg/xds/server/v3/components.go
@@ -25,7 +25,7 @@ import (
 	xds_template "github.com/kumahq/kuma/pkg/xds/template"
 )
 
-var xdsServerLog = core.Log.WithName("xds-server")
+var xdsServerLog = core.Log.WithName("xds").WithName("server")
 
 func RegisterXDS(
 	statsCallbacks util_xds.StatsCallbacks,

--- a/pkg/xds/server/v3/context.go
+++ b/pkg/xds/server/v3/context.go
@@ -17,14 +17,10 @@ type XdsContext interface {
 }
 
 func NewXdsContext() XdsContext {
-	return newXdsContext("xds-server", true)
-}
-
-func newXdsContext(name string, ads bool) XdsContext {
-	log := core.Log.WithName(name)
+	log := core.Log.WithName("xds").WithName("server")
 	hasher := hasher{log}
 	logger := util_xds.NewLogger(log)
-	cache := envoy_cache.NewSnapshotCache(ads, hasher, logger)
+	cache := envoy_cache.NewSnapshotCache(true, hasher, logger)
 	return &xdsContext{
 		NodeHash:      hasher,
 		Logger:        logger,

--- a/pkg/xds/server/v3/reconcile.go
+++ b/pkg/xds/server/v3/reconcile.go
@@ -21,7 +21,7 @@ import (
 	xds_template "github.com/kumahq/kuma/pkg/xds/template"
 )
 
-var reconcileLog = core.Log.WithName("xds-server").WithName("reconcile")
+var reconcileLog = core.Log.WithName("xds").WithName("reconcile")
 
 var _ xds_sync.SnapshotReconciler = &reconciler{}
 

--- a/pkg/xds/sync/components.go
+++ b/pkg/xds/sync/components.go
@@ -9,7 +9,7 @@ import (
 	xds_metrics "github.com/kumahq/kuma/pkg/xds/metrics"
 )
 
-var xdsServerLog = core.Log.WithName("xds-server")
+var xdsServerLog = core.Log.WithName("xds").WithName("server")
 
 func DefaultDataplaneProxyBuilder(
 	config kuma_cp.Config,

--- a/pkg/xds/sync/dataplane_watchdog.go
+++ b/pkg/xds/sync/dataplane_watchdog.go
@@ -61,7 +61,7 @@ func NewDataplaneWatchdog(deps DataplaneWatchdogDependencies, dpKey core_model.R
 	return &DataplaneWatchdog{
 		DataplaneWatchdogDependencies: deps,
 		key:                           dpKey,
-		log:                           core.Log.WithValues("key", dpKey),
+		log:                           core.Log.WithName("xds").WithValues("key", dpKey),
 		proxyTypeSettled:              false,
 	}
 }

--- a/pkg/xds/template/proxy_template_resolver.go
+++ b/pkg/xds/template/proxy_template_resolver.go
@@ -14,7 +14,7 @@ import (
 	model "github.com/kumahq/kuma/pkg/core/xds"
 )
 
-var templateResolverLog = core.Log.WithName("proxy-template-resolver")
+var templateResolverLog = core.Log.WithName("xds").WithName("proxy-template-resolver")
 
 type ProxyTemplateResolver interface {
 	GetTemplate(proxy *model.Proxy) *mesh_proto.ProxyTemplate

--- a/pkg/xds/topology/outbound.go
+++ b/pkg/xds/topology/outbound.go
@@ -26,7 +26,7 @@ import (
 	envoy_tags "github.com/kumahq/kuma/pkg/xds/envoy/tags"
 )
 
-var log = core.Log.WithName("xds")
+var log = core.Log.WithName("xds").WithName("outbound")
 
 func BuildExternalServicesEndpointMap(
 	ctx context.Context,

--- a/pkg/xds/topology/outbound.go
+++ b/pkg/xds/topology/outbound.go
@@ -26,7 +26,7 @@ import (
 	envoy_tags "github.com/kumahq/kuma/pkg/xds/envoy/tags"
 )
 
-var log = core.Log.WithName("xds").WithName("outbound")
+var outboundLog = core.Log.WithName("xds").WithName("outbound")
 
 func BuildExternalServicesEndpointMap(
 	ctx context.Context,
@@ -607,7 +607,7 @@ func fillExternalServicesReachableFromZone(
 		if mes.IsReachableFromZone(zone) {
 			err := createMeshExternalServiceEndpoint(ctx, outbound, mes, mesh, loader, zone)
 			if err != nil {
-				log.Error(err, "unable to create MeshExternalService endpoint. Endpoint won't be included in the XDS.", "name", mes.Meta.GetName(), "mesh", mes.Meta.GetMesh())
+				outboundLog.Error(err, "unable to create MeshExternalService endpoint. Endpoint won't be included in the XDS.", "name", mes.Meta.GetName(), "mesh", mes.Meta.GetMesh())
 				return
 			}
 		}
@@ -630,7 +630,7 @@ func fillExternalServicesOutbounds(
 	for _, mes := range meshExternalServices {
 		err := createMeshExternalServiceEndpoint(ctx, outbound, mes, mesh, loader, zone)
 		if err != nil {
-			log.Error(err, "unable to create MeshExternalService endpoint. Endpoint won't be included in the XDS.", "name", mes.Meta.GetName(), "mesh", mes.Meta.GetMesh())
+			outboundLog.Error(err, "unable to create MeshExternalService endpoint. Endpoint won't be included in the XDS.", "name", mes.Meta.GetName(), "mesh", mes.Meta.GetMesh())
 		}
 	}
 }
@@ -778,7 +778,7 @@ func createExternalServiceEndpoint(
 	service := externalService.Spec.GetService()
 	externalServiceEndpoint, err := NewExternalServiceEndpoint(ctx, externalService, mesh, loader, zone)
 	if err != nil {
-		log.Error(err, "unable to create ExternalService endpoint. Endpoint won't be included in the XDS.", "name", externalService.Meta.GetName(), "mesh", externalService.Meta.GetMesh())
+		outboundLog.Error(err, "unable to create ExternalService endpoint. Endpoint won't be included in the XDS.", "name", externalService.Meta.GetName(), "mesh", externalService.Meta.GetMesh())
 		return
 	}
 	outbound[service] = append(outbound[service], *externalServiceEndpoint)

--- a/pkg/xds/topology/outbound.go
+++ b/pkg/xds/topology/outbound.go
@@ -26,6 +26,8 @@ import (
 	envoy_tags "github.com/kumahq/kuma/pkg/xds/envoy/tags"
 )
 
+var log = core.Log.WithName("xds")
+
 func BuildExternalServicesEndpointMap(
 	ctx context.Context,
 	mesh *core_mesh.MeshResource,
@@ -605,7 +607,7 @@ func fillExternalServicesReachableFromZone(
 		if mes.IsReachableFromZone(zone) {
 			err := createMeshExternalServiceEndpoint(ctx, outbound, mes, mesh, loader, zone)
 			if err != nil {
-				core.Log.Error(err, "unable to create MeshExternalService endpoint. Endpoint won't be included in the XDS.", "name", mes.Meta.GetName(), "mesh", mes.Meta.GetMesh())
+				log.Error(err, "unable to create MeshExternalService endpoint. Endpoint won't be included in the XDS.", "name", mes.Meta.GetName(), "mesh", mes.Meta.GetMesh())
 				return
 			}
 		}
@@ -628,7 +630,7 @@ func fillExternalServicesOutbounds(
 	for _, mes := range meshExternalServices {
 		err := createMeshExternalServiceEndpoint(ctx, outbound, mes, mesh, loader, zone)
 		if err != nil {
-			core.Log.Error(err, "unable to create MeshExternalService endpoint. Endpoint won't be included in the XDS.", "name", mes.Meta.GetName(), "mesh", mes.Meta.GetMesh())
+			log.Error(err, "unable to create MeshExternalService endpoint. Endpoint won't be included in the XDS.", "name", mes.Meta.GetName(), "mesh", mes.Meta.GetMesh())
 		}
 	}
 }
@@ -776,7 +778,7 @@ func createExternalServiceEndpoint(
 	service := externalService.Spec.GetService()
 	externalServiceEndpoint, err := NewExternalServiceEndpoint(ctx, externalService, mesh, loader, zone)
 	if err != nil {
-		core.Log.Error(err, "unable to create ExternalService endpoint. Endpoint won't be included in the XDS.", "name", externalService.Meta.GetName(), "mesh", externalService.Meta.GetMesh())
+		log.Error(err, "unable to create ExternalService endpoint. Endpoint won't be included in the XDS.", "name", externalService.Meta.GetName(), "mesh", externalService.Meta.GetMesh())
 		return
 	}
 	outbound[service] = append(outbound[service], *externalServiceEndpoint)


### PR DESCRIPTION
Fixes: #2313

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
