### PR TITLE
fix(kumactl): remove service in prometheus config

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -112,6 +112,13 @@ If the `--kuma-dp-user` flag is not provided, the system will attempt to use the
 
 Please update your scripts and configurations accordingly to accommodate this change.
 
+### kumactl
+
+#### Default prometheus scrape config removes `service`
+
+If you rely on a scrape config from previous version it's advised to remove the relabel config that was adding `service`.
+Indeed `service` is a very common label and metrics were sometimes coliding with Kuma metrics. If you want the label `kuma_io_service` is always the same as `service`.
+
 ## Upgrade to `2.8.x`
 
 ### MeshFaultInjection responseBandwidth.limit

--- a/app/kumactl/cmd/install/testdata/install-observability.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.defaults.golden.yaml
@@ -430,10 +430,6 @@ data:
         - __meta_kuma_dataplane
         regex: "(.*)"
         target_label: dataplane
-      - source_labels:
-        - __meta_kuma_service
-        regex: "(.*)"
-        target_label: service
       - action: labelmap
         regex: __meta_kuma_label_(.+)
       - source_labels:

--- a/app/kumactl/cmd/install/testdata/install-observability.no-grafana.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-grafana.golden.yaml
@@ -287,10 +287,6 @@ data:
         - __meta_kuma_dataplane
         regex: "(.*)"
         target_label: dataplane
-      - source_labels:
-        - __meta_kuma_service
-        regex: "(.*)"
-        target_label: service
       - action: labelmap
         regex: __meta_kuma_label_(.+)
       - source_labels:

--- a/app/kumactl/cmd/install/testdata/install-observability.no-jaeger.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-jaeger.golden.yaml
@@ -430,10 +430,6 @@ data:
         - __meta_kuma_dataplane
         regex: "(.*)"
         target_label: dataplane
-      - source_labels:
-        - __meta_kuma_service
-        regex: "(.*)"
-        target_label: service
       - action: labelmap
         regex: __meta_kuma_label_(.+)
       - source_labels:

--- a/app/kumactl/cmd/install/testdata/install-observability.no-loki.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-loki.golden.yaml
@@ -430,10 +430,6 @@ data:
         - __meta_kuma_dataplane
         regex: "(.*)"
         target_label: dataplane
-      - source_labels:
-        - __meta_kuma_service
-        regex: "(.*)"
-        target_label: service
       - action: labelmap
         regex: __meta_kuma_label_(.+)
       - source_labels:

--- a/app/kumactl/cmd/install/testdata/install-observability.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.overrides.golden.yaml
@@ -430,10 +430,6 @@ data:
         - __meta_kuma_dataplane
         regex: "(.*)"
         target_label: dataplane
-      - source_labels:
-        - __meta_kuma_service
-        regex: "(.*)"
-        target_label: service
       - action: labelmap
         regex: __meta_kuma_label_(.+)
       - source_labels:

--- a/app/kumactl/data/install/k8s/metrics/prometheus/server.yaml
+++ b/app/kumactl/data/install/k8s/metrics/prometheus/server.yaml
@@ -259,10 +259,6 @@ data:
         - __meta_kuma_dataplane
         regex: "(.*)"
         target_label: dataplane
-      - source_labels:
-        - __meta_kuma_service
-        regex: "(.*)"
-        target_label: service
       - action: labelmap
         regex: __meta_kuma_label_(.+)
       - source_labels:


### PR DESCRIPTION
Service can be used by a lot of things and cause label collision kuma_service is a better alternative.

Dashboards currently don't use this label so the change is transparent for demos

part of kong/kong-mesh#4576

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
