### PR TITLE
test(e2e): use GetServiceE instead of RunKubectl

### DIFF
--- a/test/e2e_env/kubernetes/gateway/delegated/meshpassthrough.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshpassthrough.go
@@ -24,7 +24,7 @@ func MeshPassthrough(config *Config) func() {
 
 		// we cannot test in a stable way first doing a successful request, because once connection is estabilished we don't break it after applying the policy (similar case to egress) the connection exists and works.
 		It("should control traffic to domains and IPs", func() {
-			esIP, err := framework.ServiceIP(kubernetes.Cluster, "external-service", config.NamespaceOutsideMesh)
+			esIP, err := kubernetes.Cluster.GetServiceIP("external-service", config.NamespaceOutsideMesh)
 			Expect(err).ToNot(HaveOccurred())
 
 			// given

--- a/test/e2e_env/kubernetes/gateway/gateway.go
+++ b/test/e2e_env/kubernetes/gateway/gateway.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -94,7 +93,7 @@ data:
 type: system.kuma.io/secret
 `, Config.KumaNamespace, secretData)
 	}
-	var clusterIP string
+	var gwIP string
 
 	BeforeAll(func() {
 		err := NewClusterSetup().
@@ -120,13 +119,9 @@ type: system.kuma.io/secret
 
 		Eventually(func(g Gomega) {
 			var err error
-			clusterIP, err = k8s.RunKubectlAndGetOutputE(
-				kubernetes.Cluster.GetTesting(),
-				kubernetes.Cluster.GetKubectlOptions(namespace),
-				"get", "service", "simple-gateway", "-ojsonpath={.spec.clusterIP}",
-			)
+			gwIP, err = kubernetes.Cluster.GetServiceIP("simple-gateway", namespace)
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(clusterIP).ToNot(BeEmpty())
+			g.Expect(gwIP).ToNot(BeEmpty())
 		}, "30s", "1s").Should(Succeed())
 	})
 
@@ -373,7 +368,7 @@ spec:
 					response, err := client.CollectEchoResponse(
 						kubernetes.Cluster, "demo-client",
 						"https://example.kuma.io:8081/",
-						client.Resolve("example.kuma.io:8081", clusterIP),
+						client.Resolve("example.kuma.io:8081", gwIP),
 						client.FromKubernetesPod(clientNamespace, "demo-client"),
 						client.Insecure(),
 					)
@@ -421,7 +416,7 @@ spec:
 					response, err := client.CollectEchoResponse(
 						kubernetes.Cluster, "demo-client",
 						"https://otherexample.kuma.io:8081/-specific-listener",
-						client.Resolve("otherexample.kuma.io:8081", clusterIP),
+						client.Resolve("otherexample.kuma.io:8081", gwIP),
 						client.FromKubernetesPod(clientNamespace, "demo-client"),
 						client.Insecure(),
 					)
@@ -438,7 +433,7 @@ spec:
 					response, err := client.CollectEchoResponse(
 						kubernetes.Cluster, "demo-client",
 						"https://example.kuma.io:8081/-specific-listener",
-						client.Resolve("example.kuma.io:8081", clusterIP),
+						client.Resolve("example.kuma.io:8081", gwIP),
 						client.FromKubernetesPod(clientNamespace, "demo-client"),
 						client.Insecure(),
 					)
@@ -455,7 +450,7 @@ spec:
 					status, err := client.CollectFailure(
 						kubernetes.Cluster, "demo-client",
 						"https://otherexample.kuma.io:8081/-specific-listener",
-						client.Resolve("otherexample.kuma.io:8081", clusterIP),
+						client.Resolve("otherexample.kuma.io:8081", gwIP),
 						// Note the header differs from the SNI
 						client.WithHeader("host", "example.kuma.io"),
 						client.FromKubernetesPod(clientNamespace, "demo-client"),

--- a/test/e2e_env/kubernetes/gateway/mtls.go
+++ b/test/e2e_env/kubernetes/gateway/mtls.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -446,11 +445,7 @@ spec:
 
 		It("should passthrough TLS connections", func() {
 			Eventually(func(g Gomega) {
-				clusterIP, err := k8s.RunKubectlAndGetOutputE(
-					kubernetes.Cluster.GetTesting(),
-					kubernetes.Cluster.GetKubectlOptions(namespace),
-					"get", "service", "mtls-edge-gateway", "-ojsonpath={.spec.clusterIP}",
-				)
+				clusterIP, err := kubernetes.Cluster.GetServiceIP("mtls-edge-gateway", namespace)
 				g.Expect(err).ToNot(HaveOccurred())
 
 				response, err := client.CollectEchoResponse(
@@ -468,11 +463,7 @@ spec:
 
 		It("should not passthrough TLS connections that don't match SNI", func() {
 			Consistently(func(g Gomega) {
-				clusterIP, err := k8s.RunKubectlAndGetOutputE(
-					kubernetes.Cluster.GetTesting(),
-					kubernetes.Cluster.GetKubectlOptions(namespace),
-					"get", "service", "mtls-edge-gateway", "-ojsonpath={.spec.clusterIP}",
-				)
+				clusterIP, err := kubernetes.Cluster.GetServiceIP("mtls-edge-gateway", namespace)
 				g.Expect(err).ToNot(HaveOccurred())
 
 				g.Expect(err).ToNot(HaveOccurred())

--- a/test/framework/k8s.go
+++ b/test/framework/k8s.go
@@ -65,21 +65,6 @@ func PodIPOfApp(cluster Cluster, name string, namespace string) (string, error) 
 	return pods[0].Status.PodIP, nil
 }
 
-func ServiceIP(cluster Cluster, name string, namespace string) (string, error) {
-	clusterIP, err := k8s.RunKubectlAndGetOutputE(
-		cluster.GetTesting(),
-		cluster.GetKubectlOptions(namespace),
-		"get", "service", name, "-ojsonpath={.spec.clusterIP}",
-	)
-	if err != nil {
-		return "", err
-	}
-	if clusterIP == "" {
-		return "", errors.Errorf("expected not empty ClusterIP for service: %s namespace: %s", name, namespace)
-	}
-	return clusterIP, nil
-}
-
 func GatewayAPICRDs(cluster Cluster) error {
 	return k8s.RunKubectlE(
 		cluster.GetTesting(),

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -1027,6 +1027,32 @@ func (c *K8sCluster) DeleteMesh(mesh string) error {
 	return err
 }
 
+func (c *K8sCluster) GetServiceIP(serviceName, namespace string) (string, error) {
+	service, err := k8s.GetServiceE(
+		c.t,
+		c.GetKubectlOptions(namespace),
+		serviceName,
+	)
+	if err != nil {
+		return "", nil
+	}
+	switch service.Spec.Type {
+	case v1.ServiceTypeClusterIP:
+		return service.Spec.ClusterIP, nil
+	case v1.ServiceTypeLoadBalancer:
+		ingress := service.Status.LoadBalancer.Ingress
+		if len(ingress) == 0 {
+			return "", errors.New("address not found")
+		}
+		if ingress[0].Hostname == "" {
+			return ingress[0].IP, nil
+		}
+		return ingress[0].Hostname, nil
+	default:
+		return "", errors.Errorf("type: %s not supported", service.Spec.Type)
+	}
+}
+
 func (c *K8sCluster) DeployApp(opt ...AppDeploymentOption) error {
 	var opts appDeploymentOptions
 


### PR DESCRIPTION
### Checklist prior to review

Instead of running `RunKubectlAndGetOutputE` to retrieve service ip, I've added a method that uses `GetServiceE` and later from the service object retrieves IP

Another option is to retrieve Service and later call `GetServiceEndpoint` but in this case, we need to know the port, which sometimes we don't need (for curl resolve). That would require splitting a returned address so I think just getting service is enough.

- [ ] [Link to relevant issue][1] as well as docs and UI issues -- fix: https://github.com/kumahq/kuma/issues/9070
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
