### PR TITLE
chore(refactor): ensuring default resources

### DIFF
--- a/pkg/core/tokens/default_signing_key.go
+++ b/pkg/core/tokens/default_signing_key.go
@@ -2,71 +2,16 @@ package tokens
 
 import (
 	"context"
-	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
-	"github.com/sethvargo/go-retry"
 
-	"github.com/kumahq/kuma/pkg/core/runtime/component"
-	"github.com/kumahq/kuma/pkg/core/user"
-	kuma_log "github.com/kumahq/kuma/pkg/log"
+	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
 )
 
-type defaultSigningKeyComponent struct {
-	signingKeyManager SigningKeyManager
-	log               logr.Logger
-	ctx               context.Context
-	extensions        context.Context
-}
-
-var _ component.Component = &defaultSigningKeyComponent{}
-
-func NewDefaultSigningKeyComponent(
-	ctx context.Context,
-	signingKeyManager SigningKeyManager,
-	log logr.Logger,
-	extensions context.Context,
-) component.Component {
-	return &defaultSigningKeyComponent{
-		signingKeyManager: signingKeyManager,
-		log:               log,
-		ctx:               ctx,
-		extensions:        extensions,
-	}
-}
-
-func (d *defaultSigningKeyComponent) Start(stop <-chan struct{}) error {
-	ctx, cancelFn := context.WithCancel(user.Ctx(d.ctx, user.ControlPlane))
-	defer cancelFn()
-	errChan := make(chan error)
-	go func() {
-		defer close(errChan)
-		backoff := retry.WithMaxDuration(10*time.Minute, retry.NewConstant(5*time.Second)) // if after this time we cannot create a resource - something is wrong and we should return an error which will restart CP.
-		err := retry.Do(ctx, backoff, func(ctx context.Context) error {
-			return retry.RetryableError(CreateDefaultSigningKeyIfNotExist(ctx, d.log, d.signingKeyManager, d.extensions)) // retry all errors
-		})
-		if err != nil {
-			// Retry this operation since on Kubernetes, secrets are validated.
-			// This code can execute before the control plane is ready therefore hooks can fail.
-			errChan <- errors.Wrap(err, "could not create the default signing key")
-		}
-	}()
-	select {
-	case <-stop:
-		return nil
-	case err := <-errChan:
-		return err
-	}
-}
-
-func CreateDefaultSigningKeyIfNotExist(
-	ctx context.Context,
-	log logr.Logger,
-	signingKeyManager SigningKeyManager,
-	extensions context.Context,
-) error {
-	logger := kuma_log.AddFieldsFromCtx(log, ctx, extensions)
+func EnsureDefaultSigningKeyExist(signingKeyPrefix string, ctx context.Context, resManager core_manager.ResourceManager, logger logr.Logger) error {
+	logger = logger.WithValues("prefix", signingKeyPrefix)
+	signingKeyManager := NewSigningKeyManager(resManager, signingKeyPrefix)
 	_, _, err := signingKeyManager.GetLatestSigningKey(ctx)
 	if err == nil {
 		logger.V(1).Info("signing key already exists. Skip creating.")
@@ -76,13 +21,8 @@ func CreateDefaultSigningKeyIfNotExist(
 		return err
 	}
 	if err := signingKeyManager.CreateDefaultSigningKey(ctx); err != nil {
-		logger.V(1).Info("could not create signing key", "err", err)
-		return err
+		return errors.Wrapf(err, "could not create signing key with prefix %s", signingKeyPrefix)
 	}
 	logger.Info("default signing key created")
 	return nil
-}
-
-func (d *defaultSigningKeyComponent) NeedLeaderElection() bool {
-	return true
 }

--- a/pkg/defaults/components.go
+++ b/pkg/defaults/components.go
@@ -2,143 +2,87 @@ package defaults
 
 import (
 	"context"
-	"sync"
 	"time"
 
-	"github.com/pkg/errors"
+	"github.com/go-logr/logr"
 	"github.com/sethvargo/go-retry"
-	"go.uber.org/multierr"
 
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
-	config_core "github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/pkg/core"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
-	"github.com/kumahq/kuma/pkg/core/resources/store"
 	"github.com/kumahq/kuma/pkg/core/runtime"
 	"github.com/kumahq/kuma/pkg/core/runtime/component"
 	"github.com/kumahq/kuma/pkg/core/tokens"
 	"github.com/kumahq/kuma/pkg/core/user"
+	kuma_log "github.com/kumahq/kuma/pkg/log"
 	"github.com/kumahq/kuma/pkg/tokens/builtin/zone"
 )
 
 var log = core.Log.WithName("defaults")
+
+type EnsureDefaultFunc = func(ctx context.Context, resManager core_manager.ResourceManager, logger logr.Logger, cfg kuma_cp.Config) error
+
+var EnsureDefaultFuncs = []EnsureDefaultFunc{
+	EnsureEnvoyAdminCaExists,
+	EnsureOnlyOneZoneExists,
+	EnsureDefaultMeshExists,
+	EnsureZoneTokenSigningKeyExists,
+}
 
 func Setup(runtime runtime.Runtime) error {
 	if runtime.Config().Defaults.SkipTenantResources {
 		log.V(1).Info("skipping default tenant resources because KUMA_DEFAULTS_SKIP_TENANT_RESOURCES is set to true")
 		return nil
 	}
-	if !runtime.Config().IsFederatedZoneCP() { // Don't run defaults in Zone connected to global (it's done in Global)
-		defaultsComponent := NewDefaultsComponent(
-			runtime.Config().Defaults,
-			runtime.ResourceManager(),
-			runtime.ResourceStore(),
-			runtime.Extensions(),
-		)
 
-		zoneSigningKeyManager := tokens.NewSigningKeyManager(runtime.ResourceManager(), zone.SigningKeyPrefix)
-		if err := runtime.Add(tokens.NewDefaultSigningKeyComponent(
-			runtime.AppContext(),
-			zoneSigningKeyManager,
-			log.WithValues("secretPrefix", zone.SigningKeyPrefix),
-			runtime.Extensions(),
-		)); err != nil {
-			return err
-		}
-		if err := runtime.Add(defaultsComponent); err != nil {
-			return err
-		}
-	}
-
-	if runtime.Config().Mode != config_core.Global { // Envoy Admin CA is not synced in multizone and not needed in Global CP.
-		envoyAdminCaDefault := &EnvoyAdminCaDefaultComponent{
-			ResManager: runtime.ResourceManager(),
-			Extensions: runtime.Extensions(),
-		}
-		zoneDefault := &ZoneDefaultComponent{
-			ResManager: runtime.ResourceManager(),
-			Extensions: runtime.Extensions(),
-			ZoneName:   runtime.Config().Multizone.Zone.Name,
-		}
-		if err := runtime.Add(envoyAdminCaDefault, zoneDefault); err != nil {
-			return err
-		}
-	}
-	return nil
+	return runtime.Add(&DefaultComponent{
+		Extensions: runtime.Extensions(),
+		Funcs:      EnsureDefaultFuncs,
+		ResManager: runtime.ResourceManager(),
+		CpConfig:   runtime.Config(),
+	})
 }
 
-func NewDefaultsComponent(
-	config *kuma_cp.Defaults,
-	resManager core_manager.ResourceManager,
-	resStore store.ResourceStore,
-	extensions context.Context,
-) component.Component {
-	return &defaultsComponent{
-		config:     config,
-		resManager: resManager,
-		resStore:   resStore,
-		extensions: extensions,
+type DefaultComponent struct {
+	Extensions context.Context
+	Funcs      []EnsureDefaultFunc
+	ResManager core_manager.ResourceManager
+	CpConfig   kuma_cp.Config
+}
+
+var _ component.Component = &DefaultComponent{}
+
+func (e *DefaultComponent) Start(stop <-chan struct{}) error {
+	ctx, cancelFn := context.WithCancel(user.Ctx(context.Background(), user.ControlPlane))
+	defer cancelFn()
+	logger := kuma_log.AddFieldsFromCtx(log, ctx, e.Extensions)
+	errChan := make(chan error)
+	go func() {
+		errChan <- retry.Do(ctx, retry.WithMaxDuration(10*time.Minute, retry.NewConstant(5*time.Second)), func(ctx context.Context) error {
+			for _, fn := range e.Funcs {
+				if err := fn(ctx, e.ResManager, logger, e.CpConfig); err != nil {
+					logger.V(1).Info("could not ensure default resources. Retrying.", "err", err)
+					return retry.RetryableError(err)
+				}
+			}
+			return nil
+		})
+	}()
+	select {
+	case <-stop:
+		return nil
+	case err := <-errChan:
+		return err
 	}
 }
 
-var _ component.Component = &defaultsComponent{}
-
-type defaultsComponent struct {
-	config     *kuma_cp.Defaults
-	resManager core_manager.ResourceManager
-	resStore   store.ResourceStore
-	extensions context.Context
-}
-
-func (d *defaultsComponent) NeedLeaderElection() bool {
-	// If you spin many instances without default resources at once, many of them would create them, therefore only leader should create default resources.
+func (e DefaultComponent) NeedLeaderElection() bool {
 	return true
 }
 
-func (d *defaultsComponent) Start(stop <-chan struct{}) error {
-	// todo(jakubdyszkiewicz) once this https://github.com/kumahq/kuma/issues/1001 is done. Wait for all the components to be ready.
-	ctx, cancelFn := context.WithCancel(user.Ctx(context.Background(), user.ControlPlane))
-	defer cancelFn()
-	wg := &sync.WaitGroup{}
-	errChan := make(chan error)
-
-	if d.config.SkipMeshCreation {
-		log.V(1).Info("skipping default Mesh creation because KUMA_DEFAULTS_SKIP_MESH_CREATION is set to true")
-	} else {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			// if after this time we cannot create a resource - something is wrong and we should return an error which will restart CP.
-			err := retry.Do(ctx, retry.WithMaxDuration(10*time.Minute, retry.NewConstant(5*time.Second)), func(ctx context.Context) error {
-				return retry.RetryableError(func() error {
-					_, err := CreateMeshIfNotExist(ctx, d.resManager, d.extensions)
-					return err
-				}()) // retry all errors
-			})
-			if err != nil {
-				// Retry this operation since on Kubernetes Mesh needs to be validated and set default values.
-				// This code can execute before the control plane is ready therefore hooks can fail.
-				errChan <- errors.Wrap(err, "could not create the default Mesh")
-			}
-		}()
+func EnsureZoneTokenSigningKeyExists(ctx context.Context, resManager core_manager.ResourceManager, logger logr.Logger, cfg kuma_cp.Config) error {
+	if cfg.IsFederatedZoneCP() {
+		return nil
 	}
-
-	done := make(chan struct{})
-	go func() {
-		wg.Wait()
-		close(done)
-		close(errChan)
-	}()
-
-	var errs error
-	for {
-		select {
-		case <-stop:
-			return errs
-		case err := <-errChan:
-			errs = multierr.Append(errs, err)
-		case <-done:
-			return errs
-		}
-	}
+	return tokens.EnsureDefaultSigningKeyExist(zone.SigningKeyPrefix, ctx, resManager, logger)
 }

--- a/pkg/defaults/components_test.go
+++ b/pkg/defaults/components_test.go
@@ -23,12 +23,16 @@ var _ = Describe("Defaults Component", func() {
 		var manager core_manager.ResourceManager
 
 		BeforeEach(func() {
-			cfg := &kuma_cp.Defaults{
-				SkipMeshCreation: false,
-			}
+			cfg := kuma_cp.DefaultConfig()
+			cfg.Defaults.SkipMeshCreation = false
 			store := resources_memory.NewStore()
 			manager = core_manager.NewResourceManager(store)
-			component = defaults.NewDefaultsComponent(cfg, manager, store, context.Background())
+			component = &defaults.DefaultComponent{
+				Extensions: context.Background(),
+				Funcs:      []defaults.EnsureDefaultFunc{defaults.EnsureDefaultMeshExists},
+				ResManager: manager,
+				CpConfig:   cfg,
+			}
 		})
 
 		It("should create default mesh", func() {
@@ -76,12 +80,16 @@ var _ = Describe("Defaults Component", func() {
 		var manager core_manager.ResourceManager
 
 		BeforeEach(func() {
-			cfg := &kuma_cp.Defaults{
-				SkipMeshCreation: true,
-			}
+			cfg := kuma_cp.DefaultConfig()
+			cfg.Defaults.SkipMeshCreation = true
 			store := resources_memory.NewStore()
 			manager = core_manager.NewResourceManager(store)
-			component = defaults.NewDefaultsComponent(cfg, manager, store, context.Background())
+			component = &defaults.DefaultComponent{
+				Extensions: context.Background(),
+				Funcs:      []defaults.EnsureDefaultFunc{defaults.EnsureDefaultMeshExists},
+				ResManager: manager,
+				CpConfig:   cfg,
+			}
 		})
 
 		It("should not create default mesh", func() {

--- a/pkg/defaults/envoy_admin_ca_test.go
+++ b/pkg/defaults/envoy_admin_ca_test.go
@@ -3,9 +3,11 @@ package defaults_test
 import (
 	"context"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
 	core_system "github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
@@ -19,13 +21,9 @@ var _ = Describe("Envoy Admin CA defaults", func() {
 		// given
 		store := resources_memory.NewStore()
 		manager := core_manager.NewResourceManager(store)
-		component := defaults.EnvoyAdminCaDefaultComponent{
-			ResManager: manager,
-			Extensions: context.Background(),
-		}
 
 		// when
-		err := component.Start(nil)
+		err := defaults.EnsureEnvoyAdminCaExists(context.Background(), manager, logr.Discard(), kuma_cp.Config{})
 
 		// then
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/defaults/mesh.go
+++ b/pkg/defaults/mesh.go
@@ -3,36 +3,45 @@ package defaults
 import (
 	"context"
 
+	"github.com/go-logr/logr"
+
+	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
-	kuma_log "github.com/kumahq/kuma/pkg/log"
 )
 
 var defaultMeshKey = core_model.ResourceKey{
 	Name: core_model.DefaultMesh,
 }
 
-func CreateMeshIfNotExist(
+func EnsureDefaultMeshExists(
 	ctx context.Context,
 	resManager core_manager.ResourceManager,
-	extensions context.Context,
-) (*core_mesh.MeshResource, error) {
-	logger := kuma_log.AddFieldsFromCtx(log, ctx, extensions)
+	logger logr.Logger,
+	cfg kuma_cp.Config,
+) error {
+	if cfg.Defaults.SkipMeshCreation {
+		log.V(1).Info("skipping default Mesh creation because KUMA_DEFAULTS_SKIP_MESH_CREATION is set to true")
+		return nil
+	}
+	if cfg.IsFederatedZoneCP() {
+		return nil // Mesh should be synced from Global CP
+	}
 	mesh := core_mesh.NewMeshResource()
 	err := resManager.Get(ctx, mesh, core_store.GetBy(defaultMeshKey))
 	if err == nil {
 		logger.V(1).Info("default Mesh already exists. Skip creating default Mesh.")
-		return mesh, nil
+		return nil
 	}
 	if !core_store.IsResourceNotFound(err) {
-		return nil, err
+		return err
 	}
 	if err := resManager.Create(ctx, mesh, core_store.CreateBy(defaultMeshKey)); err != nil {
 		logger.V(1).Info("could not create default mesh", "err", err)
-		return nil, err
+		return err
 	}
 	logger.Info("default Mesh created")
-	return mesh, nil
+	return nil
 }

--- a/pkg/defaults/zone.go
+++ b/pkg/defaults/zone.go
@@ -2,62 +2,29 @@ package defaults
 
 import (
 	"context"
-	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
-	"github.com/sethvargo/go-retry"
 
+	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
+	config_core "github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
-	"github.com/kumahq/kuma/pkg/core/runtime/component"
-	"github.com/kumahq/kuma/pkg/core/user"
-	kuma_log "github.com/kumahq/kuma/pkg/log"
 )
-
-type ZoneDefaultComponent struct {
-	ResManager manager.ResourceManager
-	Extensions context.Context
-	ZoneName   string
-}
-
-var _ component.Component = &ZoneDefaultComponent{}
-
-func (e *ZoneDefaultComponent) Start(stop <-chan struct{}) error {
-	ctx, cancelFn := context.WithCancel(user.Ctx(context.Background(), user.ControlPlane))
-	defer cancelFn()
-	logger := kuma_log.AddFieldsFromCtx(log, ctx, e.Extensions)
-	errChan := make(chan error)
-	go func() {
-		errChan <- retry.Do(ctx, retry.WithMaxDuration(10*time.Minute, retry.NewConstant(5*time.Second)), func(ctx context.Context) error {
-			if err := EnsureOnlyOneZoneExists(ctx, e.ResManager, e.ZoneName, logger); err != nil {
-				log.V(1).Info("could not ensure that Zone exists. Retrying.", "err", err)
-				return retry.RetryableError(err)
-			}
-			return nil
-		})
-	}()
-	select {
-	case <-stop:
-		return nil
-	case err := <-errChan:
-		return err
-	}
-}
-
-func (e ZoneDefaultComponent) NeedLeaderElection() bool {
-	return true
-}
 
 func EnsureOnlyOneZoneExists(
 	ctx context.Context,
 	resManager manager.ResourceManager,
-	zoneName string,
 	logger logr.Logger,
+	cfg kuma_cp.Config,
 ) error {
-	logger.Info("ensuring Zone resource exists", "name", zoneName)
+	if cfg.Mode == config_core.Global {
+		return nil // Zone creation on Zone CP is local to the specific zone
+	}
+	zoneName := cfg.Multizone.Zone.Name
+	logger.V(1).Info("ensuring Zone resource exists", "name", zoneName)
 	zones := &system.ZoneResourceList{}
 	if err := resManager.List(ctx, zones); err != nil {
 		return errors.Wrap(err, "cannot list zones")
@@ -74,11 +41,13 @@ func EnsureOnlyOneZoneExists(
 		}
 	}
 	if !exists {
-		logger.Info("creating Zone resource", "name", zoneName)
 		zone := system.NewZoneResource()
 		if err := resManager.Create(ctx, zone, store.CreateByKey(zoneName, model.NoMesh)); err != nil {
 			return err
 		}
+		logger.Info("Zone resource created", "name", zoneName)
+	} else {
+		logger.V(1).Info("Zone resource already exist", "name", zoneName)
 	}
 	return nil
 }


### PR DESCRIPTION
### Checklist prior to review

Refactor Ensuring default resources.
I wanted to add a new default HostnameGenerators. However, I noticed that there is a lot of code duplication and inflexibility here.
1) Every ensuring default was a component, which adds a lot of code
2) The default Mesh component was weird (it had wait groups but only had one operation only?)
3) Adding a new default requires Kong's team to modify the code of Kong Mesh to execute the code to create a new resource when creating a new tenant in Konnect.

The refactor streamlines this code so that
1) You write `EnsureXResource` function that matches `EnsureDefaultFunc` signature
2) You add this to the `EnsureDefaultFuncs` list.

This way we don't duplicate the code of the component. In Kong Mesh, we can just iterate over list when we create a new tenant.

I also considered introducing an interface
```
type DefaultResourceCreator interface {
	Exist(ctx context.Context) (bool, error)
	Create(ctx context.Context) error
}
```
However, the approach in the PR gives more flexibility. For example, in case of creating a new Zone on Zone CP we also clean existing Zone after the rename.

xref #10510

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
