### PR TITLE
fix(HostnameGenerator): consistently order resources

### DIFF
--- a/pkg/core/resources/apis/meshservice/hostname/generator_test.go
+++ b/pkg/core/resources/apis/meshservice/hostname/generator_test.go
@@ -201,6 +201,13 @@ var _ = Describe("MeshService Hostname Generator", func() {
 
 	It("should not generate hostname when selector is not MeshService", func() {
 		// when
+		Expect(builders.HostnameGenerator().
+			WithName("mes-generator").
+			WithTemplate("{{ .DisplayName }}.mesh").
+			WithMeshExternalServiceMatchLabels(map[string]string{"test": "true"}).
+			Create(resManager),
+		).To(Succeed())
+
 		Expect(samples.MeshServiceBackendBuilder().
 			WithLabels(map[string]string{"test": "true"}).
 			Create(resManager),

--- a/pkg/core/resources/apis/meshservice/hostname/generator_test.go
+++ b/pkg/core/resources/apis/meshservice/hostname/generator_test.go
@@ -24,14 +24,12 @@ import (
 
 var _ = Describe("MeshService Hostname Generator", func() {
 	var stopChSend chan<- struct{}
-	var store core_store.ResourceStore
 	var resManager manager.ResourceManager
 
 	BeforeEach(func() {
 		m, err := core_metrics.NewMetrics("")
 		Expect(err).ToNot(HaveOccurred())
-		store = memory.NewStore()
-		resManager = manager.NewResourceManager(store)
+		resManager = manager.NewResourceManager(memory.NewStore())
 		allocator, err := hostname.NewGenerator(
 			logr.Discard(), m, resManager, 50*time.Millisecond,
 			[]hostname.HostnameGenerator{meshservice_hostname.NewMeshServiceHostnameGenerator(resManager)},

--- a/pkg/test/resources/builders/meshservice_builder.go
+++ b/pkg/test/resources/builders/meshservice_builder.go
@@ -115,10 +115,11 @@ func (m *MeshServiceBuilder) Build() *v1alpha1.MeshServiceResource {
 	return m.res
 }
 
-func (m *MeshServiceBuilder) Create(s store.ResourceStore) error {
+func (m *MeshServiceBuilder) Create(s store.ResourceStore, moreOpts ...store.CreateOptionsFunc) error {
 	opts := []store.CreateOptionsFunc{
 		store.CreateBy(m.Key()),
 	}
+	opts = append(opts, moreOpts...)
 	if ls := m.res.GetMeta().GetLabels(); len(ls) > 0 {
 		opts = append(opts, store.CreateWithLabels(ls))
 	}


### PR DESCRIPTION
- https://github.com/kumahq/kuma/pull/11009

We weren't sorting the resources before running the HostnameGenerators

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- Closes #10989 
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
