### PR TITLE
Revert "fix(kuma-cp): don't add namespace labels when resource was synced from universal zone (#10913)"

### DIFF
--- a/pkg/core/resources/model/resource.go
+++ b/pkg/core/resources/model/resource.go
@@ -408,13 +408,13 @@ func IsReferenced(refMeta ResourceMeta, refName string, resourceMeta ResourceMet
 	return refName == GetDisplayName(resourceMeta)
 }
 
-func IsLocallyOriginated(mode config_core.CpMode, labels map[string]string) bool {
+func IsLocallyOriginated(mode config_core.CpMode, r Resource) bool {
 	switch mode {
 	case config_core.Global:
-		origin, ok := resourceOrigin(labels)
+		origin, ok := ResourceOrigin(r.GetMeta())
 		return !ok || origin == mesh_proto.GlobalResourceOrigin
 	case config_core.Zone:
-		origin, _ := resourceOrigin(labels)
+		origin, _ := ResourceOrigin(r.GetMeta())
 		return origin == mesh_proto.ZoneResourceOrigin
 	default:
 		return true
@@ -432,14 +432,7 @@ func GetDisplayName(rm ResourceMeta) string {
 }
 
 func ResourceOrigin(rm ResourceMeta) (mesh_proto.ResourceOrigin, bool) {
-	if rm == nil {
-		return "", false
-	}
-	return resourceOrigin(rm.GetLabels())
-}
-
-func resourceOrigin(labels map[string]string) (mesh_proto.ResourceOrigin, bool) {
-	if labels != nil && labels[mesh_proto.ResourceOriginLabel] != "" {
+	if labels := rm.GetLabels(); labels != nil && labels[mesh_proto.ResourceOriginLabel] != "" {
 		return mesh_proto.ResourceOrigin(labels[mesh_proto.ResourceOriginLabel]), true
 	}
 	return "", false
@@ -468,14 +461,7 @@ func ComputeLabels(r Resource, mode config_core.CpMode, isK8s bool, systemNamesp
 		}
 	}
 
-	if isK8s && IsLocallyOriginated(mode, labels) {
-		ns, ok := r.GetMeta().GetNameExtensions()[mesh_proto.KubeNamespaceTag]
-		if ok && ns != "" {
-			setIfNotExist(mesh_proto.KubeNamespaceTag, ns)
-		}
-	}
-
-	if ns, ok := r.GetMeta().GetNameExtensions()[mesh_proto.KubeNamespaceTag]; ok && r.Descriptor().IsPolicy && r.Descriptor().IsPluginOriginated {
+	if ns, ok := labels[mesh_proto.KubeNamespaceTag]; ok && r.Descriptor().IsPolicy && r.Descriptor().IsPluginOriginated {
 		var role mesh_proto.PolicyRole
 		switch ns {
 		case systemNamespace:

--- a/pkg/kds/context/context.go
+++ b/pkg/kds/context/context.go
@@ -263,7 +263,7 @@ func GlobalProvidedFilter(rm manager.ResourceManager, configs map[string]bool) r
 
 			return zone.Spec.IsEnabled()
 		default:
-			return core_model.IsLocallyOriginated(config_core.Global, r.GetMeta().GetLabels())
+			return core_model.IsLocallyOriginated(config_core.Global, r)
 		}
 	}
 }
@@ -277,5 +277,5 @@ func ZoneProvidedFilter(_ context.Context, localZone string, _ kds.Features, r c
 		// todo: remove in 2 releases after 2.6.x
 		return !zi.IsRemoteIngress(localZone)
 	}
-	return core_model.IsLocallyOriginated(config_core.Zone, r.GetMeta().GetLabels()) || r.Descriptor().KDSFlags == core_model.ZoneToGlobalFlag
+	return core_model.IsLocallyOriginated(config_core.Zone, r) || r.Descriptor().KDSFlags == core_model.ZoneToGlobalFlag
 }

--- a/pkg/kds/v2/store/sync.go
+++ b/pkg/kds/v2/store/sync.go
@@ -311,7 +311,7 @@ func ZoneSyncCallback(ctx context.Context, configToSync map[string]bool, syncer 
 					// todo: remove in 2 releases after 2.6.x
 					return zi.IsRemoteIngress(localZone)
 				}
-				return !core_model.IsLocallyOriginated(config_core.Zone, r.GetMeta().GetLabels()) || !isExpectedOnZoneCP(r.Descriptor())
+				return !core_model.IsLocallyOriginated(config_core.Zone, r) || !isExpectedOnZoneCP(r.Descriptor())
 			}))
 		},
 	}

--- a/pkg/plugins/resources/k8s/store.go
+++ b/pkg/plugins/resources/k8s/store.go
@@ -298,6 +298,9 @@ func (m *KubernetesMetaAdapter) GetLabels() map[string]string {
 	} else {
 		labels[v1alpha1.DisplayName] = m.GetObjectMeta().GetName()
 	}
+	if _, ok := labels[v1alpha1.KubeNamespaceTag]; !ok && m.Namespace != "" {
+		labels[v1alpha1.KubeNamespaceTag] = m.Namespace
+	}
 	return labels
 }
 

--- a/pkg/plugins/runtime/k8s/webhooks/defaulter_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/defaulter_test.go
@@ -357,6 +357,7 @@ var _ = Describe("Defaulter", func() {
                 "name": "empty",
                 "creationTimestamp": null,
                 "labels": {
+                  "k8s.kuma.io/namespace": "example",
                   "kuma.io/mesh": "default",
                   "kuma.io/origin": "global",
                   "kuma.io/policy-role": "workload-owner"
@@ -503,52 +504,6 @@ var _ = Describe("Defaulter", func() {
                   "k8s.kuma.io/namespace": "example",
                   "kuma.io/mesh": "default",
                   "kuma.io/policy-role": "workload-owner"
-                },
-                "annotations": {
-                  "kuma.io/display-name": "empty"
-                }
-              },
-              "spec": {
-                "targetRef": {}
-              }
-            }
-`,
-		}),
-		Entry("should not add namespace label when resource originates from universal zone", testCase{
-			checker: globalChecker(),
-			kind:    string(v1alpha1.MeshTrafficPermissionType),
-			inputObject: `
-            {
-              "apiVersion": "kuma.io/v1alpha1",
-              "kind": "MeshTrafficPermission",
-              "metadata": {
-                "namespace": "kuma-system",
-                "name": "empty",
-                "creationTimestamp": null,
-                "labels": {
-                  "kuma.io/mesh": "default",
-                  "kuma.io/origin": "zone",
-                  "kuma.io/zone": "zone-1"
-                }
-              },
-              "spec": {
-                "targetRef": {}
-              }
-            }
-`,
-			expected: `
-            {
-              "apiVersion": "kuma.io/v1alpha1",
-              "kind": "MeshTrafficPermission",
-              "metadata": {
-                "namespace": "kuma-system",
-                "name": "empty",
-                "creationTimestamp": null,
-                "labels": {
-                  "kuma.io/mesh": "default",
-                  "kuma.io/origin": "zone",
-                  "kuma.io/zone": "zone-1",
-                  "kuma.io/policy-role": "system"
                 },
                 "annotations": {
                   "kuma.io/display-name": "empty"


### PR DESCRIPTION


This reverts commit 51a5b55153f2a8729f6a7c5f710812c7676b5025.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
