### PR TITLE
feat(MeshService): add grace period before deleting generated MeshServices on universal

### DIFF
--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -827,4 +827,4 @@ meshService:
   # How often we check whether MeshServices need to be generated from Dataplanes
   generationInterval: 2s # ENV: KUMA_MESH_SERVICE_GENERATION_INTERVAL
   # How long we wait before deleting a MeshService if all Dataplanes are gone
-  deletionGracePeriod: 10s # ENV: KUMA_MESH_SERVICE_DELETION_GRACE_PERIOD
+  deletionGracePeriod: 1h # ENV: KUMA_MESH_SERVICE_DELETION_GRACE_PERIOD

--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -827,4 +827,4 @@ meshService:
   # How often we check whether MeshServices need to be generated from Dataplanes
   generationInterval: 2s # ENV: KUMA_MESH_SERVICE_GENERATION_INTERVAL
   # How long we wait before deleting a MeshService if all Dataplanes are gone
-  gracePeriod: 10s # ENV: KUMA_MESH_SERVICE_GRACE_PERIOD
+  deletionGracePeriod: 10s # ENV: KUMA_MESH_SERVICE_DELETION_GRACE_PERIOD

--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -826,3 +826,5 @@ ipam:
 meshService:
   # How often we check whether MeshServices need to be generated from Dataplanes
   generationInterval: 2s # ENV: KUMA_MESH_SERVICE_GENERATION_INTERVAL
+  # How long we wait before deleting a MeshService if all Dataplanes are gone
+  gracePeriod: 10s # ENV: KUMA_MESH_SERVICE_GRACE_PERIOD

--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -296,7 +296,7 @@ var DefaultConfig = func() Config {
 		},
 		MeshService: MeshServiceConfig{
 			GenerationInterval:  config_types.Duration{Duration: 2 * time.Second},
-			DeletionGracePeriod: config_types.Duration{Duration: 10 * time.Second},
+			DeletionGracePeriod: config_types.Duration{Duration: 1 * time.Hour},
 		},
 	}
 }

--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -295,8 +295,8 @@ var DefaultConfig = func() Config {
 			AllocationInterval: config_types.Duration{Duration: 5 * time.Second},
 		},
 		MeshService: MeshServiceConfig{
-			GenerationInterval: config_types.Duration{Duration: 2 * time.Second},
-			GracePeriod:        config_types.Duration{Duration: 10 * time.Second},
+			GenerationInterval:  config_types.Duration{Duration: 2 * time.Second},
+			DeletionGracePeriod: config_types.Duration{Duration: 10 * time.Second},
 		},
 	}
 }
@@ -543,7 +543,7 @@ type MeshServiceConfig struct {
 	// Dataplanes
 	GenerationInterval config_types.Duration `json:"generationInterval" envconfig:"KUMA_MESH_SERVICE_GENERATION_INTERVAL"`
 	// How long we wait before deleting a MeshService if all Dataplanes are gone
-	GracePeriod config_types.Duration `json:"gracePeriod" envconfig:"KUMA_MESH_SERVICE_GRACE_PERIOD"`
+	DeletionGracePeriod config_types.Duration `json:"deletionGracePeriod" envconfig:"KUMA_MESH_SERVICE_DELETION_GRACE_PERIOD"`
 }
 
 func (i MeshServiceConfig) Validate() error {

--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -296,6 +296,7 @@ var DefaultConfig = func() Config {
 		},
 		MeshService: MeshServiceConfig{
 			GenerationInterval: config_types.Duration{Duration: 2 * time.Second},
+			GracePeriod:        config_types.Duration{Duration: 10 * time.Second},
 		},
 	}
 }
@@ -541,6 +542,8 @@ type MeshServiceConfig struct {
 	// How often we check whether MeshServices need to be generated from
 	// Dataplanes
 	GenerationInterval config_types.Duration `json:"generationInterval" envconfig:"KUMA_MESH_SERVICE_GENERATION_INTERVAL"`
+	// How long we wait before deleting a MeshService if all Dataplanes are gone
+	GracePeriod config_types.Duration `json:"gracePeriod" envconfig:"KUMA_MESH_SERVICE_GRACE_PERIOD"`
 }
 
 func (i MeshServiceConfig) Validate() error {

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -827,4 +827,4 @@ meshService:
   # How often we check whether MeshServices need to be generated from Dataplanes
   generationInterval: 2s # ENV: KUMA_MESH_SERVICE_GENERATION_INTERVAL
   # How long we wait before deleting a MeshService if all Dataplanes are gone
-  deletionGracePeriod: 10s # ENV: KUMA_MESH_SERVICE_DELETION_GRACE_PERIOD
+  deletionGracePeriod: 1h # ENV: KUMA_MESH_SERVICE_DELETION_GRACE_PERIOD

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -827,4 +827,4 @@ meshService:
   # How often we check whether MeshServices need to be generated from Dataplanes
   generationInterval: 2s # ENV: KUMA_MESH_SERVICE_GENERATION_INTERVAL
   # How long we wait before deleting a MeshService if all Dataplanes are gone
-  gracePeriod: 10s # ENV: KUMA_MESH_SERVICE_GRACE_PERIOD
+  deletionGracePeriod: 10s # ENV: KUMA_MESH_SERVICE_DELETION_GRACE_PERIOD

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -826,3 +826,5 @@ ipam:
 meshService:
   # How often we check whether MeshServices need to be generated from Dataplanes
   generationInterval: 2s # ENV: KUMA_MESH_SERVICE_GENERATION_INTERVAL
+  # How long we wait before deleting a MeshService if all Dataplanes are gone
+  gracePeriod: 10s # ENV: KUMA_MESH_SERVICE_GRACE_PERIOD

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -379,6 +379,7 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.IPAM.MeshMultiZoneService.CIDR).To(Equal("253.0.0.0/8"))
 			Expect(cfg.IPAM.AllocationInterval.Duration).To(Equal(7 * time.Second))
 			Expect(cfg.MeshService.GenerationInterval.Duration).To(Equal(8 * time.Second))
+			Expect(cfg.MeshService.GracePeriod.Duration).To(Equal(11 * time.Second))
 
 			Expect(cfg.CoreResources.Enabled).To(Equal([]string{"meshservice"}))
 			Expect(cfg.CoreResources.Status.MeshServiceInterval.Duration).To(Equal(6 * time.Second))
@@ -782,6 +783,7 @@ ipam:
   allocationInterval: 7s
 meshService:
   generationInterval: 8s
+  gracePeriod: 11s
 `,
 		}),
 		Entry("from env variables", testCase{
@@ -1069,6 +1071,7 @@ meshService:
 				"KUMA_IPAM_MESH_MULTI_ZONE_SERVICE_CIDR":                                                   "253.0.0.0/8",
 				"KUMA_IPAM_ALLOCATION_INTERVAL":                                                            "7s",
 				"KUMA_MESH_SERVICE_GENERATION_INTERVAL":                                                    "8s",
+				"KUMA_MESH_SERVICE_GRACE_PERIOD":                                                           "11s",
 			},
 			yamlFileConfig: "",
 		}),

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -379,7 +379,7 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.IPAM.MeshMultiZoneService.CIDR).To(Equal("253.0.0.0/8"))
 			Expect(cfg.IPAM.AllocationInterval.Duration).To(Equal(7 * time.Second))
 			Expect(cfg.MeshService.GenerationInterval.Duration).To(Equal(8 * time.Second))
-			Expect(cfg.MeshService.GracePeriod.Duration).To(Equal(11 * time.Second))
+			Expect(cfg.MeshService.DeletionGracePeriod.Duration).To(Equal(11 * time.Second))
 
 			Expect(cfg.CoreResources.Enabled).To(Equal([]string{"meshservice"}))
 			Expect(cfg.CoreResources.Status.MeshServiceInterval.Duration).To(Equal(6 * time.Second))
@@ -783,7 +783,7 @@ ipam:
   allocationInterval: 7s
 meshService:
   generationInterval: 8s
-  gracePeriod: 11s
+  deletionGracePeriod: 11s
 `,
 		}),
 		Entry("from env variables", testCase{
@@ -1071,7 +1071,7 @@ meshService:
 				"KUMA_IPAM_MESH_MULTI_ZONE_SERVICE_CIDR":                                                   "253.0.0.0/8",
 				"KUMA_IPAM_ALLOCATION_INTERVAL":                                                            "7s",
 				"KUMA_MESH_SERVICE_GENERATION_INTERVAL":                                                    "8s",
-				"KUMA_MESH_SERVICE_GRACE_PERIOD":                                                           "11s",
+				"KUMA_MESH_SERVICE_DELETION_GRACE_PERIOD":                                                  "11s",
 			},
 			yamlFileConfig: "",
 		}),

--- a/pkg/core/resources/apis/meshservice/generate/component.go
+++ b/pkg/core/resources/apis/meshservice/generate/component.go
@@ -2,7 +2,6 @@ package generate
 
 import (
 	"slices"
-	"time"
 
 	config_core "github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/pkg/config/core/resources/store"
@@ -26,7 +25,7 @@ func Setup(rt runtime.Runtime) error {
 	generator, err := New(
 		logger,
 		rt.Config().MeshService.GenerationInterval.Duration,
-		1*time.Minute, // TODO
+		rt.Config().MeshService.GracePeriod.Duration,
 		rt.Metrics(),
 		rt.ResourceManager(),
 		rt.MeshCache(),

--- a/pkg/core/resources/apis/meshservice/generate/component.go
+++ b/pkg/core/resources/apis/meshservice/generate/component.go
@@ -2,6 +2,7 @@ package generate
 
 import (
 	"slices"
+	"time"
 
 	config_core "github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/pkg/config/core/resources/store"
@@ -25,6 +26,7 @@ func Setup(rt runtime.Runtime) error {
 	generator, err := New(
 		logger,
 		rt.Config().MeshService.GenerationInterval.Duration,
+		1*time.Minute, // TODO
 		rt.Metrics(),
 		rt.ResourceManager(),
 		rt.MeshCache(),

--- a/pkg/core/resources/apis/meshservice/generate/component.go
+++ b/pkg/core/resources/apis/meshservice/generate/component.go
@@ -25,7 +25,7 @@ func Setup(rt runtime.Runtime) error {
 	generator, err := New(
 		logger,
 		rt.Config().MeshService.GenerationInterval.Duration,
-		rt.Config().MeshService.GracePeriod.Duration,
+		rt.Config().MeshService.DeletionGracePeriod.Duration,
 		rt.Metrics(),
 		rt.ResourceManager(),
 		rt.MeshCache(),

--- a/pkg/core/resources/apis/meshservice/generate/generator.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator.go
@@ -2,6 +2,7 @@ package generate
 
 import (
 	"context"
+	"maps"
 	"reflect"
 	"slices"
 	"strings"
@@ -25,17 +26,19 @@ import (
 )
 
 const (
-	managedByValue string = "meshservice-generator"
+	managedByValue          string = "meshservice-generator"
+	gracePeriodStartedLabel string = "kuma.io/grace-period-started-at"
 )
 
 // Generator generates MeshService objects from Dataplane resources created on
 // universal.
 type Generator struct {
-	logger           logr.Logger
-	generateInterval time.Duration
-	metric           prometheus.Summary
-	resManager       manager.ResourceManager
-	meshCache        *mesh.Cache
+	logger              logr.Logger
+	generateInterval    time.Duration
+	gracePeriodInterval time.Duration
+	metric              prometheus.Summary
+	resManager          manager.ResourceManager
+	meshCache           *mesh.Cache
 }
 
 var _ component.Component = &Generator{}
@@ -43,6 +46,7 @@ var _ component.Component = &Generator{}
 func New(
 	logger logr.Logger,
 	generateInterval time.Duration,
+	gracePeriodInterval time.Duration,
 	metrics core_metrics.Metrics,
 	resManager manager.ResourceManager,
 	meshCache *mesh.Cache,
@@ -56,11 +60,12 @@ func New(
 		return nil, err
 	}
 	return &Generator{
-		logger:           logger,
-		generateInterval: generateInterval,
-		metric:           metric,
-		resManager:       resManager,
-		meshCache:        meshCache,
+		logger:              logger,
+		generateInterval:    generateInterval,
+		gracePeriodInterval: gracePeriodInterval,
+		metric:              metric,
+		resManager:          resManager,
+		meshCache:           meshCache,
 	}, nil
 }
 
@@ -175,22 +180,51 @@ func (g *Generator) generate(ctx context.Context, mesh string, dataplanes []*cor
 			log.Info("Port conflict for a kuma.io/service tag, ports must be identical across Dataplane inbounds for a given kuma.io/service", "dps", dps)
 		}
 		delete(meshservicesByName, meshService.GetMeta().GetName())
-		if newMeshService != nil && servicesDiffer(meshService.Spec, newMeshService) {
+		gracePeriodStartedAtText, hasGracePeriodLabel := meshService.GetMeta().GetLabels()[gracePeriodStartedLabel]
+
+		if newMeshService != nil && (servicesDiffer(meshService.Spec, newMeshService) || hasGracePeriodLabel) {
 			meta := meshService.GetMeta()
 			meshService = meshservice_api.NewMeshServiceResource()
 			meshService.Meta = meta
 			meshService.Spec = newMeshService
-			if err := g.resManager.Update(ctx, meshService); err != nil {
+
+			// Unset the grace period by deleting the label
+			newLabels := maps.Clone(meshService.GetMeta().GetLabels())
+			delete(newLabels, gracePeriodStartedLabel)
+
+			if err := g.resManager.Update(ctx, meshService, store.UpdateWithLabels(newLabels)); err != nil {
 				log.Error(err, "couldn't update MeshService")
 				continue
 			}
 			log.Info("updated MeshService")
 		} else if newMeshService == nil {
-			if err := g.resManager.Delete(ctx, meshservice_api.NewMeshServiceResource(), store.DeleteBy(model.MetaToResourceKey(meshService.GetMeta()))); err != nil {
-				log.Error(err, "couldn't delete MeshService")
-				continue
+			gracePeriodStartedAt, err := time.Parse(time.RFC3339, gracePeriodStartedAtText)
+			if hasGracePeriodLabel && err == nil {
+				// If we have a valid grace period set, check if it's expired
+				if time.Since(gracePeriodStartedAt) > g.gracePeriodInterval {
+					if err := g.resManager.Delete(ctx, meshservice_api.NewMeshServiceResource(), store.DeleteBy(model.MetaToResourceKey(meshService.GetMeta()))); err != nil {
+						log.Error(err, "couldn't delete MeshService")
+						continue
+					}
+					log.Info("deleted MeshService")
+				}
+			} else {
+				// Start the grace period if we don't have the label or it's invalid
+				if hasGracePeriodLabel && err != nil {
+					log.Info("couldn't parse grace period label, ignoring", "value", gracePeriodStartedAtText)
+				}
+				nowText, err := time.Now().MarshalText()
+				if err != nil {
+					log.Error(err, "couldn't marshal time.Now as text, this shouldn't be possible")
+					continue
+				}
+				newLabels := maps.Clone(meshService.GetMeta().GetLabels())
+				newLabels[gracePeriodStartedLabel] = string(nowText)
+				if err := g.resManager.Update(ctx, meshService, store.UpdateWithLabels(newLabels)); err != nil {
+					log.Error(err, "couldn't update MeshService")
+					continue
+				}
 			}
-			log.Info("deleted MeshService")
 		}
 	}
 	for name, meshServices := range meshservicesByName {

--- a/pkg/core/resources/apis/meshservice/generate/generator.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator.go
@@ -31,18 +31,18 @@ const (
 // Generator generates MeshService objects from Dataplane resources created on
 // universal.
 type Generator struct {
-	logger     logr.Logger
-	interval   time.Duration
-	metric     prometheus.Summary
-	resManager manager.ResourceManager
-	meshCache  *mesh.Cache
+	logger           logr.Logger
+	generateInterval time.Duration
+	metric           prometheus.Summary
+	resManager       manager.ResourceManager
+	meshCache        *mesh.Cache
 }
 
 var _ component.Component = &Generator{}
 
 func New(
 	logger logr.Logger,
-	interval time.Duration,
+	generateInterval time.Duration,
 	metrics core_metrics.Metrics,
 	resManager manager.ResourceManager,
 	meshCache *mesh.Cache,
@@ -56,11 +56,11 @@ func New(
 		return nil, err
 	}
 	return &Generator{
-		logger:     logger,
-		interval:   interval,
-		metric:     metric,
-		resManager: resManager,
-		meshCache:  meshCache,
+		logger:           logger,
+		generateInterval: generateInterval,
+		metric:           metric,
+		resManager:       resManager,
+		meshCache:        meshCache,
 	}, nil
 }
 
@@ -222,7 +222,7 @@ func (g *Generator) NeedLeaderElection() bool {
 
 func (g *Generator) Start(stop <-chan struct{}) error {
 	g.logger.Info("starting")
-	ticker := time.NewTicker(g.interval)
+	ticker := time.NewTicker(g.generateInterval)
 	ctx := user.Ctx(context.Background(), user.ControlPlane)
 
 	for {

--- a/pkg/core/resources/apis/meshservice/generate/generator.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator.go
@@ -33,12 +33,12 @@ const (
 // Generator generates MeshService objects from Dataplane resources created on
 // universal.
 type Generator struct {
-	logger              logr.Logger
-	generateInterval    time.Duration
-	gracePeriodInterval time.Duration
-	metric              prometheus.Summary
-	resManager          manager.ResourceManager
-	meshCache           *mesh.Cache
+	logger           logr.Logger
+	generateInterval time.Duration
+	gracePeriod      time.Duration
+	metric           prometheus.Summary
+	resManager       manager.ResourceManager
+	meshCache        *mesh.Cache
 }
 
 var _ component.Component = &Generator{}
@@ -60,12 +60,12 @@ func New(
 		return nil, err
 	}
 	return &Generator{
-		logger:              logger,
-		generateInterval:    generateInterval,
-		gracePeriodInterval: gracePeriodInterval,
-		metric:              metric,
-		resManager:          resManager,
-		meshCache:           meshCache,
+		logger:           logger,
+		generateInterval: generateInterval,
+		gracePeriod:      gracePeriodInterval,
+		metric:           metric,
+		resManager:       resManager,
+		meshCache:        meshCache,
 	}, nil
 }
 
@@ -201,7 +201,7 @@ func (g *Generator) generate(ctx context.Context, mesh string, dataplanes []*cor
 			gracePeriodStartedAt, err := time.Parse(time.RFC3339, gracePeriodStartedAtText)
 			if hasGracePeriodLabel && err == nil {
 				// If we have a valid grace period set, check if it's expired
-				if time.Since(gracePeriodStartedAt) > g.gracePeriodInterval {
+				if time.Since(gracePeriodStartedAt) > g.gracePeriod {
 					if err := g.resManager.Delete(ctx, meshservice_api.NewMeshServiceResource(), store.DeleteBy(model.MetaToResourceKey(meshService.GetMeta()))); err != nil {
 						log.Error(err, "couldn't delete MeshService")
 						continue

--- a/pkg/core/resources/apis/meshservice/generate/generator_test.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator_test.go
@@ -236,7 +236,7 @@ var _ = Describe("MeshService generator", func() {
 		// Wait until the MeshService has been marked with grace period start
 		Eventually(func(g Gomega) {
 			g.Expect(resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))).To(Succeed())
-			g.Expect(ms.GetMeta().GetLabels()).To(HaveKey("kuma.io/grace-period-started-at"))
+			g.Expect(ms.GetMeta().GetLabels()).To(HaveKey("kuma.io/deletion-grace-period-started-at"))
 		}, "2s", "100ms").Should(Succeed())
 		labelExistedSince := time.Now()
 
@@ -275,7 +275,7 @@ var _ = Describe("MeshService generator", func() {
 		// Wait until the MeshService has been marked with grace period start
 		Eventually(func(g Gomega) {
 			g.Expect(resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))).To(Succeed())
-			g.Expect(ms.GetMeta().GetLabels()).To(HaveKey("kuma.io/grace-period-started-at"))
+			g.Expect(ms.GetMeta().GetLabels()).To(HaveKey("kuma.io/deletion-grace-period-started-at"))
 		}, "2s", "100ms").Should(Succeed())
 
 		Expect(


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- Closes https://github.com/kumahq/kuma/issues/10975
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
