### PR TITLE
refactor(kuma-cp): simplify function signature for Gateway API conversion

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -227,11 +227,11 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 					}},
 				}
 			case attachment.Service:
-				var svc kube_core.Service
+				var parent kube_core.Service
 				if err := r.Client.Get(ctx, kube_types.NamespacedName{
 					Name:      string(ref.Name),
 					Namespace: namespace,
-				}, &svc); err != nil {
+				}, &parent); err != nil {
 					if !kube_apierrs.IsNotFound(err) {
 						return nil, nil, err
 					}
@@ -242,11 +242,11 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 					"%s-%s-%s.%s",
 					route.Name,
 					route.Namespace,
-					svc.GetName(),
-					svc.GetNamespace(),
+					parent.GetName(),
+					parent.GetNamespace(),
 				)
 
-				routes[routeSubName] = r.gapiServiceToMeshRoute(route, rules, &svc, ref.Port)
+				routes[routeSubName] = r.gapiServiceToMeshRoute(route.Namespace, rules, &parent, ref.Port)
 			}
 		}
 


### PR DESCRIPTION
Just noticed this improvement randomly, we don't need the whole route

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
