### PR TITLE
fix(xds): explicitly set initial fetch timeout to zero to keep Envoy wait for xds resources

### DIFF
--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic-gateway.gateway.cluster.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic-gateway.gateway.cluster.golden.yaml
@@ -2,6 +2,7 @@ connectTimeout: 5s
 edsClusterConfig:
   edsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
 name: backend-c58ee0574727fc94
 perConnectionBufferLimitBytes: 32768

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic-gateway.gateway.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic-gateway.gateway.listener.golden.yaml
@@ -56,6 +56,7 @@ filterChains:
       rds:
         configSource:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
         routeConfigName: gateway:HTTP:8080:*
       requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/basic.gateway_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/basic.gateway_cluster.golden.yaml
@@ -9,6 +9,7 @@ connectTimeout: 5s
 edsClusterConfig:
   edsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
 name: backend-26cb64fa4e85e7b7
 perConnectionBufferLimitBytes: 32768

--- a/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/testdata/gateway_basic_listener.golden.yaml
+++ b/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/testdata/gateway_basic_listener.golden.yaml
@@ -56,6 +56,7 @@ filterChains:
       rds:
         configSource:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
         routeConfigName: sample-gateway:HTTP:8080:*
       requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic-meshhttproute.gateway_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic-meshhttproute.gateway_cluster.golden.yaml
@@ -11,6 +11,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     healthChecks:
     - eventLogger:
@@ -67,6 +68,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-945e63bff332f46a
     perConnectionBufferLimitBytes: 32768

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic.gateway_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic.gateway_cluster.golden.yaml
@@ -11,6 +11,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     healthChecks:
     - eventLogger:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic.clusters.golden.yaml
@@ -5,6 +5,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend
     type: EDS
@@ -19,6 +20,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-c72efb5be46fae6b
     type: EDS

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.clusters.golden.yaml
@@ -5,6 +5,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend_svc_80
     transportSocket:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-route-outbound-with-tags-with-mtls.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-route-outbound-with-tags-with-mtls.clusters.golden.yaml
@@ -5,6 +5,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-c72efb5be46fae6b
     transportSocket:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-route.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-route.clusters.golden.yaml
@@ -5,6 +5,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend
     type: EDS

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.clusters.golden.yaml
@@ -6,6 +6,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-348a834721ead661
     perConnectionBufferLimitBytes: 32768
@@ -24,6 +25,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-6d0a1cf7605e8b1e
     perConnectionBufferLimitBytes: 32768
@@ -42,6 +44,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-a285094d9b0d7032
     perConnectionBufferLimitBytes: 32768
@@ -60,6 +63,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-dda53ef9426194b2
     perConnectionBufferLimitBytes: 32768
@@ -78,6 +82,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-ed49e74a1f66b25c
     perConnectionBufferLimitBytes: 32768
@@ -96,6 +101,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-wild-aac0221a73d6116a
     perConnectionBufferLimitBytes: 32768
@@ -114,6 +120,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-wild-dev-52ee11d917faac3e
     perConnectionBufferLimitBytes: 32768

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.listeners.golden.yaml
@@ -43,6 +43,7 @@ resources:
           rds:
             configSource:
               ads: {}
+              initialFetchTimeout: 0s
               resourceApiVersion: V3
             routeConfigName: sample-gateway:HTTP:8080:*
           requestHeadersTimeout: 0.500s
@@ -101,6 +102,7 @@ resources:
           rds:
             configSource:
               ads: {}
+              initialFetchTimeout: 0s
               resourceApiVersion: V3
             routeConfigName: sample-gateway:HTTP:8081:*
           requestHeadersTimeout: 0.500s
@@ -159,6 +161,7 @@ resources:
           rds:
             configSource:
               ads: {}
+              initialFetchTimeout: 0s
               resourceApiVersion: V3
             routeConfigName: sample-gateway:HTTP:8082:*
           requestHeadersTimeout: 0.500s
@@ -221,6 +224,7 @@ resources:
           rds:
             configSource:
               ads: {}
+              initialFetchTimeout: 0s
               resourceApiVersion: V3
             routeConfigName: sample-gateway:HTTPS:8083:*.secure.dev
           requestHeadersTimeout: 0.500s
@@ -283,6 +287,7 @@ resources:
           rds:
             configSource:
               ads: {}
+              initialFetchTimeout: 0s
               resourceApiVersion: V3
             routeConfigName: sample-gateway:HTTPS:8083:*.super-secure.dev
           requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-specific.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-specific.clusters.golden.yaml
@@ -6,6 +6,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-26cb64fa4e85e7b7
     perConnectionBufferLimitBytes: 32768

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-specific.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-specific.listeners.golden.yaml
@@ -43,6 +43,7 @@ resources:
           rds:
             configSource:
               ads: {}
+              initialFetchTimeout: 0s
               resourceApiVersion: V3
             routeConfigName: sample-gateway:HTTP:8080:*
           requestHeadersTimeout: 0.500s
@@ -101,6 +102,7 @@ resources:
           rds:
             configSource:
               ads: {}
+              initialFetchTimeout: 0s
               resourceApiVersion: V3
             routeConfigName: sample-gateway:HTTP:8081:*
           requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway.clusters.golden.yaml
@@ -6,6 +6,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-26cb64fa4e85e7b7
     perConnectionBufferLimitBytes: 32768

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway.listeners.golden.yaml
@@ -43,6 +43,7 @@ resources:
           rds:
             configSource:
               ads: {}
+              initialFetchTimeout: 0s
               resourceApiVersion: V3
             routeConfigName: sample-gateway:HTTP:8080:*
           requestHeadersTimeout: 0.500s
@@ -101,6 +102,7 @@ resources:
           rds:
             configSource:
               ads: {}
+              initialFetchTimeout: 0s
               resourceApiVersion: V3
             routeConfigName: sample-gateway:HTTP:8081:*
           requestHeadersTimeout: 0.500s
@@ -159,6 +161,7 @@ resources:
           rds:
             configSource:
               ads: {}
+              initialFetchTimeout: 0s
               resourceApiVersion: V3
             routeConfigName: sample-gateway:HTTP:8082:*
           requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/grpc-service.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/grpc-service.clusters.golden.yaml
@@ -5,6 +5,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend
     type: EDS

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/headers-match.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/headers-match.clusters.golden.yaml
@@ -5,6 +5,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend
     type: EDS

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/match-priority.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/match-priority.clusters.golden.yaml
@@ -5,6 +5,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend
     type: EDS

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/mixed-tcp-and-http-outbounds.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/mixed-tcp-and-http-outbounds.clusters.golden.yaml
@@ -5,6 +5,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend
     type: EDS

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/request-header-modifiers.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/request-header-modifiers.clusters.golden.yaml
@@ -5,6 +5,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend
     type: EDS

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/request-mirror.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/request-mirror.clusters.golden.yaml
@@ -5,6 +5,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend
     type: EDS
@@ -19,6 +20,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: payments-9f43ffb3c22f8c19
     type: EDS

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/request-redirect.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/request-redirect.clusters.golden.yaml
@@ -5,6 +5,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend
     type: EDS

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/response-header-modifiers.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/response-header-modifiers.clusters.golden.yaml
@@ -5,6 +5,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend
     type: EDS

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/url-rewrite.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/url-rewrite.clusters.golden.yaml
@@ -5,6 +5,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend
     type: EDS

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/basic.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/basic.clusters.golden.yaml
@@ -5,6 +5,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbPolicy: RANDOM
     name: backend

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/basic.gateway.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/basic.gateway.clusters.golden.yaml
@@ -6,6 +6,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbPolicy: RING_HASH
     name: backend-d230d75c0fcb71dc

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/basic.gateway.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/basic.gateway.listeners.golden.yaml
@@ -43,6 +43,7 @@ resources:
           rds:
             configSource:
               ads: {}
+              initialFetchTimeout: 0s
               resourceApiVersion: V3
             routeConfigName: sample-gateway:HTTP:8080:*
           requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/egress.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/egress.clusters.golden.yaml
@@ -6,6 +6,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh-1:eds-cluster
     type: EDS

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/egress_basic.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/egress_basic.clusters.golden.yaml
@@ -6,6 +6,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh-1:eds-cluster
     type: EDS

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware.gateway.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware.gateway.clusters.golden.yaml
@@ -8,6 +8,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-d230d75c0fcb71dc
     perConnectionBufferLimitBytes: 32768

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware.gateway.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware.gateway.listeners.golden.yaml
@@ -43,6 +43,7 @@ resources:
           rds:
             configSource:
               ads: {}
+              initialFetchTimeout: 0s
               resourceApiVersion: V3
             routeConfigName: sample-gateway:HTTP:8080:*
           requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware_basic.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware_basic.clusters.golden.yaml
@@ -7,6 +7,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbPolicy: RANDOM
     name: backend

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware_basic_egress_enabled.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware_basic_egress_enabled.clusters.golden.yaml
@@ -7,6 +7,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbPolicy: RANDOM
     name: backend

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware_cross_zone.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware_cross_zone.clusters.golden.yaml
@@ -5,6 +5,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbPolicy: RANDOM
     name: backend

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware_no_cross_zone.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware_no_cross_zone.clusters.golden.yaml
@@ -7,6 +7,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbPolicy: RANDOM
     name: backend

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware_split.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware_split.clusters.golden.yaml
@@ -7,6 +7,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbPolicy: RANDOM
     name: backend-bb38a94289f18fb9
@@ -19,6 +20,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbPolicy: RANDOM
     name: backend-c72efb5be46fae6b

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/no-cross-zone.gateway.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/no-cross-zone.gateway.clusters.golden.yaml
@@ -6,6 +6,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-d230d75c0fcb71dc
     perConnectionBufferLimitBytes: 32768

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/no-cross-zone.gateway.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/no-cross-zone.gateway.listeners.golden.yaml
@@ -43,6 +43,7 @@ resources:
           rds:
             configSource:
               ads: {}
+              initialFetchTimeout: 0s
               resourceApiVersion: V3
             routeConfigName: sample-gateway:HTTP:8080:*
           requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/testdata/basic.gateway.listener.golden.yaml
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/testdata/basic.gateway.listener.golden.yaml
@@ -39,6 +39,7 @@ filterChains:
       rds:
         configSource:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
         routeConfigName: sample-gateway:HTTP:8080:*
       requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/testdata/http-route.gateway.listener.golden.yaml
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/testdata/http-route.gateway.listener.golden.yaml
@@ -39,6 +39,7 @@ filterChains:
       rds:
         configSource:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
         routeConfigName: sample-gateway:HTTP:8080:*
       requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/testdata/gateway.http.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/testdata/gateway.http.listeners.golden.yaml
@@ -39,6 +39,7 @@ filterChains:
       rds:
         configSource:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
         routeConfigName: sample-gateway:HTTP:8080:*
       requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/testdata/per-route-configuration.gateway.http.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/testdata/per-route-configuration.gateway.http.listeners.golden.yaml
@@ -39,6 +39,7 @@ filterChains:
       rds:
         configSource:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
         routeConfigName: sample-gateway:HTTP:8080:*
       requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-no-policies.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-no-policies.clusters.golden.yaml
@@ -5,6 +5,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend
     type: EDS

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.clusters.golden.yaml
@@ -5,6 +5,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend
     type: EDS

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/gateway.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/gateway.clusters.golden.yaml
@@ -6,6 +6,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-26cb64fa4e85e7b7
     perConnectionBufferLimitBytes: 32768
@@ -17,6 +18,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: go-backend-1-a3e0f78d6b8a9607
     perConnectionBufferLimitBytes: 32768
@@ -28,6 +30,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: go-backend-2-3568c8790af04ca0
     perConnectionBufferLimitBytes: 32768
@@ -39,6 +42,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: other-backend-d14e06e801b3b5d6
     perConnectionBufferLimitBytes: 32768

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/kafka.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/kafka.clusters.golden.yaml
@@ -5,6 +5,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-bb38a94289f18fb9
     type: EDS
@@ -19,6 +20,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-c72efb5be46fae6b
     type: EDS

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/meshhttproute-clash-http-destination.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/meshhttproute-clash-http-destination.clusters.golden.yaml
@@ -5,6 +5,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: tcp-backend
     type: EDS

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/meshhttproute-clash-tcp-destination.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/meshhttproute-clash-tcp-destination.clusters.golden.yaml
@@ -5,6 +5,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: tcp-backend
     type: EDS

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/redirect-traffic.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/redirect-traffic.clusters.golden.yaml
@@ -5,6 +5,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: tcp-backend
     type: EDS

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/split-traffic.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/split-traffic.clusters.golden.yaml
@@ -5,6 +5,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-bb38a94289f18fb9
     type: EDS
@@ -19,6 +20,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-c72efb5be46fae6b
     type: EDS
@@ -59,6 +61,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: other-backend
     type: EDS

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/basic.gateway.cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/basic.gateway.cluster.golden.yaml
@@ -2,6 +2,7 @@ connectTimeout: 10s
 edsClusterConfig:
   edsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
 name: backend-26cb64fa4e85e7b7
 perConnectionBufferLimitBytes: 32768

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/basic.gateway.listener.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/basic.gateway.listener.golden.yaml
@@ -39,6 +39,7 @@ filterChains:
       rds:
         configSource:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
         routeConfigName: sample-gateway:HTTP:8080:*
       requestHeadersTimeout: 99s

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/no-default-idle-timeout.gateway.cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/no-default-idle-timeout.gateway.cluster.golden.yaml
@@ -2,6 +2,7 @@ connectTimeout: 10s
 edsClusterConfig:
   edsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
 name: backend-26cb64fa4e85e7b7
 perConnectionBufferLimitBytes: 32768

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/no-default-idle-timeout.gateway.listener.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/no-default-idle-timeout.gateway.listener.golden.yaml
@@ -39,6 +39,7 @@ filterChains:
       rds:
         configSource:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
         routeConfigName: sample-gateway:HTTP:8080:*
       requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/no-route-level-timeouts.gateway.cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/no-route-level-timeouts.gateway.cluster.golden.yaml
@@ -2,6 +2,7 @@ connectTimeout: 5s
 edsClusterConfig:
   edsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
 name: backend-26cb64fa4e85e7b7
 perConnectionBufferLimitBytes: 32768

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/no-route-level-timeouts.gateway.listener.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/no-route-level-timeouts.gateway.listener.golden.yaml
@@ -39,6 +39,7 @@ filterChains:
       rds:
         configSource:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
         routeConfigName: sample-gateway:HTTP:8080:*
       requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/route-level-timeouts.gateway.cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/route-level-timeouts.gateway.cluster.golden.yaml
@@ -2,6 +2,7 @@ connectTimeout: 5s
 edsClusterConfig:
   edsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
 name: backend-26cb64fa4e85e7b7
 perConnectionBufferLimitBytes: 32768

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/route-level-timeouts.gateway.listener.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/route-level-timeouts.gateway.listener.golden.yaml
@@ -39,6 +39,7 @@ filterChains:
       rds:
         configSource:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
         routeConfigName: sample-gateway:HTTP:8080:*
       requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/simple-gateway.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/simple-gateway.listeners.golden.yaml
@@ -39,6 +39,7 @@ filterChains:
       rds:
         configSource:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
         routeConfigName: sample-gateway:HTTP:8080:*
       requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/01-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/01-gateway-listener.yaml
@@ -46,6 +46,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/02-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/02-gateway-listener.yaml
@@ -46,6 +46,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s
@@ -102,6 +103,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:9090:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/03-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/03-gateway-listener.yaml
@@ -61,6 +61,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: tracing-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/04-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/04-gateway-listener.yaml
@@ -55,6 +55,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: logging-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/05-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/05-gateway-listener.yaml
@@ -50,6 +50,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: default-gateway:HTTPS:443:bar.example.com
             requestHeadersTimeout: 0.500s
@@ -112,6 +113,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: default-gateway:HTTPS:443:foo.example.com
             requestHeadersTimeout: 0.500s
@@ -174,6 +176,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: default-gateway:HTTPS:443:*.example.com
             requestHeadersTimeout: 0.500s
@@ -234,6 +237,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: default-gateway:HTTPS:443:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -86,6 +87,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -86,6 +87,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -86,6 +87,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-mirror-90205ae37cc0294e
       perConnectionBufferLimitBytes: 32768
@@ -35,6 +36,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -112,6 +114,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/05-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/05-gateway-route.yaml
@@ -46,6 +46,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-mirror-90205ae37cc0294e
       perConnectionBufferLimitBytes: 32768
@@ -35,6 +36,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -112,6 +114,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -86,6 +87,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: exact-service-6c25eaca226749f3
       perConnectionBufferLimitBytes: 32768
@@ -35,6 +36,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: prefix-service-bfa07e23a84b267b
       perConnectionBufferLimitBytes: 32768
@@ -126,6 +128,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -86,6 +87,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: absent-header-match-327fbb6df03159bd
       perConnectionBufferLimitBytes: 32768
@@ -35,6 +36,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: exact-header-match-d7c910a2e5559eda
       perConnectionBufferLimitBytes: 32768
@@ -59,6 +61,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: present-header-match-b3e34381a1779ec6
       perConnectionBufferLimitBytes: 32768
@@ -83,6 +86,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: regex-header-match-70561bb2da83c870
       perConnectionBufferLimitBytes: 32768
@@ -206,6 +210,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: exact-query-match-36212e4e8ec491f1
       perConnectionBufferLimitBytes: 32768
@@ -35,6 +36,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: regex-query-match-2c070f45017d23a5
       perConnectionBufferLimitBytes: 32768
@@ -126,6 +128,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -86,6 +87,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-exact-0c6c646106bd51f3
       perConnectionBufferLimitBytes: 32768
@@ -35,6 +36,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-prefix-1d3cd70bb04bf6e2
       perConnectionBufferLimitBytes: 32768
@@ -59,6 +61,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-regex-197ed2f99640f307
       perConnectionBufferLimitBytes: 32768
@@ -166,6 +169,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -86,6 +87,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: api-service-4508437668c35ed8
       perConnectionBufferLimitBytes: 32768
@@ -33,6 +34,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-mirror-3dd740a2de879d4c
       perConnectionBufferLimitBytes: 32768
@@ -55,6 +57,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -160,6 +163,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/16-gateway-route.yaml
@@ -8,6 +8,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: api-service-4508437668c35ed8
       outlierDetection:
@@ -37,6 +38,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-mirror-3dd740a2de879d4c
       outlierDetection:
@@ -66,6 +68,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       outlierDetection:
@@ -181,6 +184,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       healthChecks:
       - healthyThreshold: 2
@@ -41,6 +42,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       healthChecks:
       - healthyThreshold: 3
@@ -71,6 +73,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       healthChecks:
       - healthyThreshold: 1
@@ -184,6 +187,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/18-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/18-gateway-route.yaml
@@ -83,6 +83,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/19-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/19-gateway-route.yaml
@@ -97,6 +97,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-4d89cd662308223d
       perConnectionBufferLimitBytes: 32768
@@ -33,6 +34,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-11405a82852416ac
       perConnectionBufferLimitBytes: 32768
@@ -55,6 +57,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-ff1f8bb571f3bfa4
       perConnectionBufferLimitBytes: 32768
@@ -160,6 +163,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: gateway-multihost:HTTP:9080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/21-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/21-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: api-service-4508437668c35ed8
       perConnectionBufferLimitBytes: 32768
@@ -35,6 +36,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-mirror-3dd740a2de879d4c
       perConnectionBufferLimitBytes: 32768
@@ -59,6 +61,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -166,6 +169,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/22-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/22-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: api-service-ebbb1519109a5d70
       perConnectionBufferLimitBytes: 32768
@@ -35,6 +36,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-b70526a3f546ce4f
       perConnectionBufferLimitBytes: 32768
@@ -126,6 +128,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/23-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/23-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: api-service-ebbb1519109a5d70
       perConnectionBufferLimitBytes: 32768
@@ -35,6 +36,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-86192ff3ecc578b7
       perConnectionBufferLimitBytes: 32768
@@ -59,6 +61,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-b70526a3f546ce4f
       perConnectionBufferLimitBytes: 32768
@@ -166,6 +169,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/24-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/24-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: api-service-4508437668c35ed8
       perConnectionBufferLimitBytes: 32768
@@ -35,6 +36,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -126,6 +128,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/25-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/25-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: external-http2-httpbin-b70cd456b09f96ac
       perConnectionBufferLimitBytes: 32768
@@ -110,6 +111,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/26-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/26-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: external-http2-httpbin-b70cd456b09f96ac
       perConnectionBufferLimitBytes: 32768
@@ -94,6 +95,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/cross-mesh-gateway.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/cross-mesh-gateway.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-0ec9724567ed6087
       perConnectionBufferLimitBytes: 32768
@@ -59,6 +60,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-8acee1c4ccf209c2
       perConnectionBufferLimitBytes: 32768
@@ -107,6 +109,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-bfae5b64a0fe8b74
       perConnectionBufferLimitBytes: 32768
@@ -395,6 +398,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s
@@ -473,6 +477,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8081:*
             requestHeadersTimeout: 0.500s
@@ -551,6 +556,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8082:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/drop-prefix-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/drop-prefix-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -86,6 +87,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/external-service-with-timeout-no-egress.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/external-service-with-timeout-no-egress.yaml
@@ -96,6 +96,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/external-service-without-default-traffic-permission.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/external-service-without-default-traffic-permission.yaml
@@ -83,6 +83,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/http-tcp-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/http-tcp-route.yaml
@@ -46,6 +46,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/no-timeout.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/no-timeout.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -84,6 +85,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/response-header-set-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/response-header-set-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -86,6 +87,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/retry-policy.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/retry-policy.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: api-service-4508437668c35ed8
       perConnectionBufferLimitBytes: 32768
@@ -35,6 +36,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-mirror-3dd740a2de879d4c
       perConnectionBufferLimitBytes: 32768
@@ -59,6 +61,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -166,6 +169,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -86,6 +87,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-root-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-root-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -86,6 +87,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-trailing-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-trailing-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -86,6 +87,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/sni-isolation-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/sni-isolation-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-4d89cd662308223d
       perConnectionBufferLimitBytes: 32768
@@ -35,6 +36,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-ff1f8bb571f3bfa4
       perConnectionBufferLimitBytes: 32768
@@ -126,6 +128,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: gateway-multihost:HTTP:9080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/unresolved-backend.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/unresolved-backend.yaml
@@ -46,6 +46,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -86,6 +87,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -86,6 +87,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -90,6 +91,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-mirror-90205ae37cc0294e
       perConnectionBufferLimitBytes: 32768
@@ -35,6 +36,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -116,6 +118,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/05-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/05-gateway-route.yaml
@@ -50,6 +50,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-mirror-90205ae37cc0294e
       perConnectionBufferLimitBytes: 32768
@@ -35,6 +36,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -116,6 +118,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -90,6 +91,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: exact-service-6c25eaca226749f3
       perConnectionBufferLimitBytes: 32768
@@ -35,6 +36,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: prefix-service-bfa07e23a84b267b
       perConnectionBufferLimitBytes: 32768
@@ -130,6 +132,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -90,6 +91,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: absent-header-match-327fbb6df03159bd
       perConnectionBufferLimitBytes: 32768
@@ -35,6 +36,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: exact-header-match-d7c910a2e5559eda
       perConnectionBufferLimitBytes: 32768
@@ -59,6 +61,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: present-header-match-b3e34381a1779ec6
       perConnectionBufferLimitBytes: 32768
@@ -83,6 +86,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: regex-header-match-70561bb2da83c870
       perConnectionBufferLimitBytes: 32768
@@ -210,6 +214,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: exact-query-match-36212e4e8ec491f1
       perConnectionBufferLimitBytes: 32768
@@ -35,6 +36,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: regex-query-match-2c070f45017d23a5
       perConnectionBufferLimitBytes: 32768
@@ -130,6 +132,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -90,6 +91,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-exact-0c6c646106bd51f3
       perConnectionBufferLimitBytes: 32768
@@ -35,6 +36,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-prefix-1d3cd70bb04bf6e2
       perConnectionBufferLimitBytes: 32768
@@ -59,6 +61,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-regex-197ed2f99640f307
       perConnectionBufferLimitBytes: 32768
@@ -170,6 +173,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -90,6 +91,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: api-service-4508437668c35ed8
       perConnectionBufferLimitBytes: 32768
@@ -33,6 +34,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-mirror-3dd740a2de879d4c
       perConnectionBufferLimitBytes: 32768
@@ -55,6 +57,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -164,6 +167,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
@@ -8,6 +8,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: api-service-4508437668c35ed8
       outlierDetection:
@@ -37,6 +38,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-mirror-3dd740a2de879d4c
       outlierDetection:
@@ -66,6 +68,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       outlierDetection:
@@ -185,6 +188,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       healthChecks:
       - healthyThreshold: 2
@@ -41,6 +42,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       healthChecks:
       - healthyThreshold: 3
@@ -71,6 +73,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       healthChecks:
       - healthyThreshold: 1
@@ -188,6 +191,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
@@ -87,6 +87,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
@@ -101,6 +101,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-4d89cd662308223d
       perConnectionBufferLimitBytes: 32768
@@ -33,6 +34,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-11405a82852416ac
       perConnectionBufferLimitBytes: 32768
@@ -55,6 +57,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-ff1f8bb571f3bfa4
       perConnectionBufferLimitBytes: 32768
@@ -164,6 +167,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: gateway-multihost:HTTPS:9443:one.example.com
             requestHeadersTimeout: 0.500s
@@ -226,6 +230,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: gateway-multihost:HTTPS:9443:three.example.com
             requestHeadersTimeout: 0.500s
@@ -288,6 +293,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: gateway-multihost:HTTPS:9443:two.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/21-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/21-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: api-service-4508437668c35ed8
       perConnectionBufferLimitBytes: 32768
@@ -35,6 +36,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-mirror-3dd740a2de879d4c
       perConnectionBufferLimitBytes: 32768
@@ -59,6 +61,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -170,6 +173,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/22-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/22-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: api-service-ebbb1519109a5d70
       perConnectionBufferLimitBytes: 32768
@@ -35,6 +36,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-b70526a3f546ce4f
       perConnectionBufferLimitBytes: 32768
@@ -126,6 +128,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/23-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/23-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: api-service-ebbb1519109a5d70
       perConnectionBufferLimitBytes: 32768
@@ -35,6 +36,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-86192ff3ecc578b7
       perConnectionBufferLimitBytes: 32768
@@ -59,6 +61,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-b70526a3f546ce4f
       perConnectionBufferLimitBytes: 32768
@@ -166,6 +169,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/24-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/24-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: api-service-4508437668c35ed8
       perConnectionBufferLimitBytes: 32768
@@ -35,6 +36,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -126,6 +128,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/25-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/25-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: external-http2-httpbin-b70cd456b09f96ac
       perConnectionBufferLimitBytes: 32768
@@ -114,6 +115,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/26-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/26-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: external-http2-httpbin-b70cd456b09f96ac
       perConnectionBufferLimitBytes: 32768
@@ -98,6 +99,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/cross-mesh-gateway.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/cross-mesh-gateway.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-0ec9724567ed6087
       perConnectionBufferLimitBytes: 32768
@@ -59,6 +60,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-8acee1c4ccf209c2
       perConnectionBufferLimitBytes: 32768
@@ -107,6 +109,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-bfae5b64a0fe8b74
       perConnectionBufferLimitBytes: 32768
@@ -395,6 +398,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s
@@ -473,6 +477,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8081:*
             requestHeadersTimeout: 0.500s
@@ -551,6 +556,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8082:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/drop-prefix-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/drop-prefix-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -90,6 +91,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/external-service-with-timeout-no-egress.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/external-service-with-timeout-no-egress.yaml
@@ -96,6 +96,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/external-service-without-default-traffic-permission.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/external-service-without-default-traffic-permission.yaml
@@ -87,6 +87,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/http-tcp-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/http-tcp-route.yaml
@@ -50,6 +50,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/no-timeout.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/no-timeout.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -88,6 +89,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/response-header-set-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/response-header-set-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -90,6 +91,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/retry-policy.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/retry-policy.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: api-service-4508437668c35ed8
       perConnectionBufferLimitBytes: 32768
@@ -35,6 +36,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-mirror-3dd740a2de879d4c
       perConnectionBufferLimitBytes: 32768
@@ -59,6 +61,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -170,6 +173,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -90,6 +91,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-root-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-root-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -90,6 +91,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-trailing-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-trailing-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -90,6 +91,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/sni-isolation-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/sni-isolation-gateway-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-4d89cd662308223d
       perConnectionBufferLimitBytes: 32768
@@ -35,6 +36,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-ff1f8bb571f3bfa4
       perConnectionBufferLimitBytes: 32768
@@ -130,6 +132,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: gateway-multihost:HTTPS:9443:one.example.com
             requestHeadersTimeout: 0.500s
@@ -192,6 +195,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: gateway-multihost:HTTPS:9443:three.example.com
             requestHeadersTimeout: 0.500s
@@ -254,6 +258,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: gateway-multihost:HTTPS:9443:two.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/unresolved-backend.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/unresolved-backend.yaml
@@ -50,6 +50,7 @@ Listeners:
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/tcp/tcp-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/tcp/tcp-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: api-service-4508437668c35ed8
       perConnectionBufferLimitBytes: 32768
@@ -50,6 +51,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -89,6 +91,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: external-no-protocol-httpbin-6a3325e78573377c
       perConnectionBufferLimitBytes: 32768

--- a/pkg/plugins/runtime/gateway/testdata/tls/tcp-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/tls/tcp-route.yaml
@@ -11,6 +11,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: api-service-ec4b46e15b91ec0d
       perConnectionBufferLimitBytes: 32768
@@ -50,6 +51,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-6376c7d971a22370
       perConnectionBufferLimitBytes: 32768
@@ -89,6 +91,7 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
+          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: external-tcp-httpbin-bcf553986bd60283
       perConnectionBufferLimitBytes: 32768

--- a/pkg/xds/bootstrap/template_v3.go
+++ b/pkg/xds/bootstrap/template_v3.go
@@ -1,6 +1,7 @@
 package bootstrap
 
 import (
+	"google.golang.org/protobuf/types/known/durationpb"
 	"net"
 	"strconv"
 	"time"
@@ -158,10 +159,12 @@ func genConfig(parameters configParameters, proxyConfig xds.Proxy, enableReloada
 		DynamicResources: &envoy_bootstrap_v3.Bootstrap_DynamicResources{
 			LdsConfig: &envoy_core_v3.ConfigSource{
 				ConfigSourceSpecifier: &envoy_core_v3.ConfigSource_Ads{Ads: &envoy_core_v3.AggregatedConfigSource{}},
+				InitialFetchTimeout:   durationpb.New(0),
 				ResourceApiVersion:    envoy_core_v3.ApiVersion_V3,
 			},
 			CdsConfig: &envoy_core_v3.ConfigSource{
 				ConfigSourceSpecifier: &envoy_core_v3.ConfigSource_Ads{Ads: &envoy_core_v3.AggregatedConfigSource{}},
+				InitialFetchTimeout:   durationpb.New(0),
 				ResourceApiVersion:    envoy_core_v3.ApiVersion_V3,
 			},
 			AdsConfig: &envoy_core_v3.ApiConfigSource{

--- a/pkg/xds/bootstrap/template_v3.go
+++ b/pkg/xds/bootstrap/template_v3.go
@@ -1,7 +1,6 @@
 package bootstrap
 
 import (
-	"google.golang.org/protobuf/types/known/durationpb"
 	"net"
 	"strconv"
 	"time"
@@ -21,6 +20,7 @@ import (
 	envoy_tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	envoy_type_matcher_v3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"github.com/pkg/errors"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/kumahq/kuma/pkg/config/xds"

--- a/pkg/xds/bootstrap/testdata/bootstrap.gateway.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.gateway.golden.yaml
@@ -15,9 +15,11 @@ dynamicResources:
     transportApiVersion: V3
   cdsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
   ldsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
 hdsConfig:
   apiType: GRPC

--- a/pkg/xds/bootstrap/testdata/bootstrap.k8s.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.k8s.golden.yaml
@@ -15,9 +15,11 @@ dynamicResources:
     transportApiVersion: V3
   cdsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
   ldsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
 hdsConfig:
   apiType: GRPC

--- a/pkg/xds/bootstrap/testdata/bootstrap.overridden.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.overridden.golden.yaml
@@ -25,9 +25,11 @@ dynamicResources:
     transportApiVersion: V3
   cdsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
   ldsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
 hdsConfig:
   apiType: GRPC

--- a/pkg/xds/bootstrap/testdata/bootstrap.universal.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.universal.golden.yaml
@@ -15,9 +15,11 @@ dynamicResources:
     transportApiVersion: V3
   cdsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
   ldsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
 hdsConfig:
   apiType: GRPC

--- a/pkg/xds/bootstrap/testdata/generator.custom-config-minimal-request.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.custom-config-minimal-request.golden.yaml
@@ -22,9 +22,11 @@ dynamicResources:
     transportApiVersion: V3
   cdsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
   ldsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
 hdsConfig:
   apiType: GRPC

--- a/pkg/xds/bootstrap/testdata/generator.custom-config.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.custom-config.golden.yaml
@@ -25,9 +25,11 @@ dynamicResources:
     transportApiVersion: V3
   cdsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
   ldsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
 hdsConfig:
   apiType: GRPC

--- a/pkg/xds/bootstrap/testdata/generator.default-config-minimal-request.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config-minimal-request.golden.yaml
@@ -12,9 +12,11 @@ dynamicResources:
     transportApiVersion: V3
   cdsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
   ldsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
 hdsConfig:
   apiType: GRPC

--- a/pkg/xds/bootstrap/testdata/generator.default-config-token-path.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config-token-path.golden.yaml
@@ -35,9 +35,11 @@ dynamicResources:
     transportApiVersion: V3
   cdsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
   ldsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
 hdsConfig:
   apiType: GRPC

--- a/pkg/xds/bootstrap/testdata/generator.default-config.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config.golden.yaml
@@ -25,9 +25,11 @@ dynamicResources:
     transportApiVersion: V3
   cdsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
   ldsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
 hdsConfig:
   apiType: GRPC

--- a/pkg/xds/bootstrap/testdata/generator.default-config.kubernetes.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config.kubernetes.golden.yaml
@@ -25,9 +25,11 @@ dynamicResources:
     transportApiVersion: V3
   cdsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
   ldsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
 layeredRuntime:
   layers:

--- a/pkg/xds/bootstrap/testdata/generator.default-config.kubernetes.ipv6.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config.kubernetes.ipv6.golden.yaml
@@ -25,9 +25,11 @@ dynamicResources:
     transportApiVersion: V3
   cdsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
   ldsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
 layeredRuntime:
   layers:

--- a/pkg/xds/bootstrap/testdata/generator.gateway.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.gateway.golden.yaml
@@ -25,9 +25,11 @@ dynamicResources:
     transportApiVersion: V3
   cdsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
   ldsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
 hdsConfig:
   apiType: GRPC

--- a/pkg/xds/bootstrap/testdata/generator.metrics-config.kubernetes.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.metrics-config.kubernetes.golden.yaml
@@ -25,9 +25,11 @@ dynamicResources:
     transportApiVersion: V3
   cdsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
   ldsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
 layeredRuntime:
   layers:

--- a/pkg/xds/bootstrap/testdata/generator.system-cert-config.kubernetes.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.system-cert-config.kubernetes.golden.yaml
@@ -25,9 +25,11 @@ dynamicResources:
     transportApiVersion: V3
   cdsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
   ldsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
 layeredRuntime:
   layers:

--- a/pkg/xds/envoy/clusters/v3/circuit_breaker_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/circuit_breaker_configurer_test.go
@@ -59,6 +59,7 @@ var _ = Describe("CircuitBreakerConfigurer", func() {
         edsClusterConfig:
           edsConfig:
             ads: {}
+            initialFetchTimeout: 0s
             resourceApiVersion: V3
         name: backend
         type: EDS`,

--- a/pkg/xds/envoy/clusters/v3/client_side_mtls_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/client_side_mtls_configurer_test.go
@@ -64,6 +64,7 @@ var _ = Describe("EdsClusterConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             name: testCluster
             transportSocket:
@@ -125,6 +126,7 @@ var _ = Describe("EdsClusterConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             name: testCluster
             transportSocketMatches:
@@ -214,6 +216,7 @@ var _ = Describe("EdsClusterConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             name: testCluster
             transportSocket:

--- a/pkg/xds/envoy/clusters/v3/client_side_tls_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/client_side_tls_configurer_test.go
@@ -65,6 +65,7 @@ var _ = Describe("ClientSideTLSConfigurer", func() {
         edsClusterConfig:
           edsConfig:
             ads: {}
+            initialFetchTimeout: 0s
             resourceApiVersion: V3
         name: testCluster
         transportSocketMatches:
@@ -97,6 +98,7 @@ var _ = Describe("ClientSideTLSConfigurer", func() {
         edsClusterConfig:
           edsConfig:
             ads: {}
+            initialFetchTimeout: 0s
             resourceApiVersion: V3
         name: testCluster
         transportSocketMatches:
@@ -135,6 +137,7 @@ var _ = Describe("ClientSideTLSConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             name: testCluster
             transportSocketMatches:
@@ -193,6 +196,7 @@ var _ = Describe("ClientSideTLSConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             name: testCluster
             transportSocketMatches:
@@ -254,6 +258,7 @@ var _ = Describe("ClientSideTLSConfigurer", func() {
               connectTimeout: 5s
               edsClusterConfig:
                   edsConfig:
+                      initialFetchTimeout: 0s
                       ads: {}
                       resourceApiVersion: V3
               name: testCluster

--- a/pkg/xds/envoy/clusters/v3/eds_cluster_configurer.go
+++ b/pkg/xds/envoy/clusters/v3/eds_cluster_configurer.go
@@ -3,6 +3,7 @@ package clusters
 import (
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 type EdsClusterConfigurer struct{}
@@ -17,6 +18,7 @@ func (e *EdsClusterConfigurer) Configure(c *envoy_cluster.Cluster) error {
 			ConfigSourceSpecifier: &envoy_core.ConfigSource_Ads{
 				Ads: &envoy_core.AggregatedConfigSource{},
 			},
+			InitialFetchTimeout: durationpb.New(0),
 		},
 	}
 	return nil

--- a/pkg/xds/envoy/clusters/v3/eds_cluster_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/eds_cluster_configurer_test.go
@@ -20,6 +20,7 @@ var _ = Describe("EdsClusterConfigurer", func() {
         edsClusterConfig:
           edsConfig:
             ads: {}
+            initialFetchTimeout: 0s
             resourceApiVersion: V3
         name: test:cluster
         type: EDS`

--- a/pkg/xds/envoy/clusters/v3/health_check_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/health_check_configurer_test.go
@@ -45,6 +45,7 @@ var _ = Describe("HealthCheckConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             name: testCluster
             type: EDS`,
@@ -73,6 +74,7 @@ var _ = Describe("HealthCheckConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             healthChecks:
             - healthyThreshold: 2
@@ -116,6 +118,7 @@ var _ = Describe("HealthCheckConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             healthChecks:
             - healthyThreshold: 2
@@ -158,6 +161,7 @@ var _ = Describe("HealthCheckConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             healthChecks:
             - healthyThreshold: 2
@@ -210,6 +214,7 @@ var _ = Describe("HealthCheckConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             healthChecks:
             - healthyThreshold: 2
@@ -278,6 +283,7 @@ var _ = Describe("HealthCheckConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             healthChecks:
             - healthyThreshold: 2
@@ -335,6 +341,7 @@ var _ = Describe("HealthCheckConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             healthChecks:
             - healthyThreshold: 2
@@ -375,6 +382,7 @@ var _ = Describe("HealthCheckConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             healthChecks:
             - healthyThreshold: 2
@@ -415,6 +423,7 @@ var _ = Describe("HealthCheckConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             healthChecks:
             - healthyThreshold: 2
@@ -451,6 +460,7 @@ var _ = Describe("HealthCheckConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             healthChecks:
             - alwaysLogHealthCheckFailures: true

--- a/pkg/xds/envoy/clusters/v3/lb_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/lb_configurer_test.go
@@ -44,6 +44,7 @@ var _ = Describe("Lb", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             name: backend
             type: EDS`,
@@ -62,6 +63,7 @@ var _ = Describe("Lb", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             lbPolicy: LEAST_REQUEST
             leastRequestLbConfig:
@@ -79,6 +81,7 @@ var _ = Describe("Lb", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             lbPolicy: LEAST_REQUEST
             leastRequestLbConfig:
@@ -102,6 +105,7 @@ var _ = Describe("Lb", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             lbPolicy: RING_HASH
             name: backend
@@ -121,6 +125,7 @@ var _ = Describe("Lb", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             lbPolicy: RANDOM
             name: backend
@@ -136,6 +141,7 @@ var _ = Describe("Lb", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             lbPolicy: MAGLEV
             name: backend

--- a/pkg/xds/envoy/clusters/v3/lb_subset_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/lb_subset_configurer_test.go
@@ -42,6 +42,7 @@ var _ = Describe("LbSubset", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             name: backend
             type: EDS`,
@@ -57,6 +58,7 @@ var _ = Describe("LbSubset", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             lbSubsetConfig:
               fallbackPolicy: ANY_ENDPOINT

--- a/pkg/xds/envoy/clusters/v3/outlier_detection_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/outlier_detection_configurer_test.go
@@ -50,6 +50,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             name: backend
             outlierDetection:
@@ -76,6 +77,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             name: backend
             outlierDetection:
@@ -102,6 +104,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             name: backend
             outlierDetection:
@@ -130,6 +133,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             name: backend
             outlierDetection:
@@ -159,6 +163,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             name: backend
             outlierDetection:
@@ -190,6 +195,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             name: backend
             outlierDetection:
@@ -220,6 +226,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             name: backend
             outlierDetection:
@@ -251,6 +258,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             name: backend
             outlierDetection:

--- a/pkg/xds/envoy/clusters/v3/timeout_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/timeout_configurer_test.go
@@ -95,6 +95,7 @@ connectTimeout: 100s
 edsClusterConfig:
   edsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
 name: backend
 type: EDS
@@ -112,6 +113,7 @@ connectTimeout: 5s
 edsClusterConfig:
   edsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
 name: backend
 type: EDS
@@ -128,6 +130,7 @@ connectTimeout: 100s
 edsClusterConfig:
   edsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
 name: backend
 type: EDS
@@ -162,6 +165,7 @@ connectTimeout: 100s
 edsClusterConfig:
   edsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
 name: backend
 type: EDS
@@ -179,6 +183,7 @@ connectTimeout: 5s
 edsClusterConfig:
   edsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
 name: backend
 type: EDS
@@ -195,6 +200,7 @@ connectTimeout: 100s
 edsClusterConfig:
   edsConfig:
     ads: {}
+    initialFetchTimeout: 0s
     resourceApiVersion: V3
 name: backend
 type: EDS

--- a/pkg/xds/envoy/listeners/v3/http_route_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/http_route_configurer.go
@@ -6,6 +6,7 @@ import (
 	envoy_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/pkg/errors"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	envoy_routes "github.com/kumahq/kuma/pkg/xds/envoy/routes"
 )
@@ -52,6 +53,7 @@ func (c *HttpDynamicRouteConfigurer) Configure(filterChain *envoy_listener.Filte
 					ConfigSourceSpecifier: &envoy_core.ConfigSource_Ads{
 						Ads: &envoy_core.AggregatedConfigSource{},
 					},
+					InitialFetchTimeout: durationpb.New(0),
 				},
 			},
 		}

--- a/pkg/xds/envoy/listeners/v3/http_route_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_route_configurer_test.go
@@ -44,6 +44,7 @@ var _ = Describe("HttpDynamicRouteConfigurer", func() {
             rds:
               configSource:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: routes/inbound
             statPrefix: inbound

--- a/pkg/xds/generator/egress/testdata/02.internalservice-only.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/02.internalservice-only.golden.yaml
@@ -7,6 +7,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh-1:service-in-zone-2
     type: EDS

--- a/pkg/xds/generator/egress/testdata/03.mixed-services.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/03.mixed-services.golden.yaml
@@ -93,6 +93,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh-1:service-1-zone-2
     type: EDS
@@ -104,6 +105,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh-1:service-2-zone-2
     type: EDS

--- a/pkg/xds/generator/egress/testdata/05.mixed-services-with-custom-trafficpermissions.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/05.mixed-services-with-custom-trafficpermissions.golden.yaml
@@ -93,6 +93,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh-1:service-1-zone-2
     type: EDS
@@ -104,6 +105,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh-1:service-2-zone-2
     type: EDS

--- a/pkg/xds/generator/egress/testdata/06.mixed-services-with-external-in-other-zone.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/06.mixed-services-with-external-in-other-zone.golden.yaml
@@ -38,6 +38,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh-1:externalservice-2
     type: EDS
@@ -49,6 +50,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh-1:service-1-zone-2
     type: EDS
@@ -60,6 +62,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh-1:service-2-zone-2
     type: EDS

--- a/pkg/xds/generator/egress/testdata/subsets-with-meshhttproute.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/subsets-with-meshhttproute.golden.yaml
@@ -7,6 +7,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbSubsetConfig:
       fallbackPolicy: ANY_ENDPOINT

--- a/pkg/xds/generator/egress/testdata/traffic-by-default-meshhttproute.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/traffic-by-default-meshhttproute.golden.yaml
@@ -7,6 +7,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh-1:service-in-zone-2
     type: EDS

--- a/pkg/xds/generator/testdata/ingress/01.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/01.envoy.golden.yaml
@@ -7,6 +7,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh1:backend
     type: EDS

--- a/pkg/xds/generator/testdata/ingress/03.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/03.envoy.golden.yaml
@@ -7,6 +7,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbSubsetConfig:
       fallbackPolicy: ANY_ENDPOINT

--- a/pkg/xds/generator/testdata/ingress/04.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/04.envoy.golden.yaml
@@ -7,6 +7,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbSubsetConfig:
       fallbackPolicy: ANY_ENDPOINT
@@ -27,6 +28,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh2:backend
     type: EDS
@@ -38,6 +40,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbSubsetConfig:
       fallbackPolicy: ANY_ENDPOINT

--- a/pkg/xds/generator/testdata/ingress/05.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/05.envoy.golden.yaml
@@ -7,6 +7,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh1:backend
     type: EDS

--- a/pkg/xds/generator/testdata/ingress/mesh-service.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/mesh-service.envoy.golden.yaml
@@ -7,6 +7,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh1:backend2_svc_80
     type: EDS
@@ -18,6 +19,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh1:backend_svc_80
     type: EDS

--- a/pkg/xds/generator/testdata/ingress/meshgateway.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/meshgateway.envoy.golden.yaml
@@ -7,6 +7,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh1:backend
     type: EDS
@@ -18,6 +19,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh2:mesh-gateway
     type: EDS

--- a/pkg/xds/generator/testdata/ingress/virtual-outbound.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/virtual-outbound.envoy.golden.yaml
@@ -7,6 +7,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbSubsetConfig:
       fallbackPolicy: ANY_ENDPOINT

--- a/pkg/xds/generator/testdata/ingress/with-meshhttproute-subset.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/with-meshhttproute-subset.envoy.golden.yaml
@@ -7,6 +7,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbSubsetConfig:
       fallbackPolicy: ANY_ENDPOINT

--- a/pkg/xds/generator/testdata/ingress/with-meshhttproute.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/with-meshhttproute.envoy.golden.yaml
@@ -7,6 +7,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbSubsetConfig:
       fallbackPolicy: ANY_ENDPOINT

--- a/pkg/xds/generator/testdata/ingress/with-meshtcproute-subset.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/with-meshtcproute-subset.envoy.golden.yaml
@@ -7,6 +7,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbSubsetConfig:
       fallbackPolicy: ANY_ENDPOINT

--- a/pkg/xds/generator/testdata/outbound-proxy/03.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/03.envoy.golden.yaml
@@ -6,6 +6,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbPolicy: RANDOM
     name: api-grpc
@@ -25,6 +26,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: api-http
     outlierDetection:
@@ -48,6 +50,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbPolicy: RING_HASH
     name: api-http2
@@ -70,6 +73,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbPolicy: LEAST_REQUEST
     leastRequestLbConfig:
@@ -88,6 +92,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbPolicy: MAGLEV
     name: backend
@@ -104,6 +109,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: db-c182dd9f4bf584d7
     type: EDS
@@ -119,6 +125,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: db-f7d9086d4169338b
     type: EDS

--- a/pkg/xds/generator/testdata/outbound-proxy/04.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/04.envoy.golden.yaml
@@ -6,6 +6,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: api-http
     outlierDetection:
@@ -53,6 +54,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbPolicy: LEAST_REQUEST
     leastRequestLbConfig:
@@ -95,6 +97,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbPolicy: MAGLEV
     name: backend
@@ -135,6 +138,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: db-c182dd9f4bf584d7
     transportSocket:
@@ -174,6 +178,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: db-f7d9086d4169338b
     transportSocket:

--- a/pkg/xds/generator/testdata/outbound-proxy/09.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/09.envoy.golden.yaml
@@ -6,6 +6,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: api-http-5637c619d2781fec_mesh2
     outlierDetection:

--- a/pkg/xds/generator/testdata/outbound-proxy/10.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/10.envoy.golden.yaml
@@ -6,6 +6,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbPolicy: MAGLEV
     name: backend

--- a/pkg/xds/generator/testdata/outbound-proxy/cluster-dots.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/cluster-dots.envoy.golden.yaml
@@ -7,6 +7,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend.kuma-system
     type: EDS
@@ -22,6 +23,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: db-104dbb63d60dfdfa
     type: EDS

--- a/pkg/xds/generator/testdata/profile-source/1-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/1-envoy-config.golden.yaml
@@ -6,6 +6,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: db
     transportSocket:
@@ -45,6 +46,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     healthChecks:
     - healthyThreshold: 2

--- a/pkg/xds/generator/testdata/profile-source/2-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/2-envoy-config.golden.yaml
@@ -6,6 +6,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: db
     transportSocket:
@@ -45,6 +46,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     healthChecks:
     - healthyThreshold: 2

--- a/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
@@ -6,6 +6,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: db
     transportSocket:
@@ -45,6 +46,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     healthChecks:
     - healthyThreshold: 2

--- a/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
@@ -6,6 +6,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: db
     transportSocket:
@@ -45,6 +46,7 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
+        initialFetchTimeout: 0s
         resourceApiVersion: V3
     healthChecks:
     - healthyThreshold: 2


### PR DESCRIPTION

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues 
  - fixes https://github.com/kumahq/kuma/issues/11023
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS 
  - Confirmed
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) 
  - Tested
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? 
  - No
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) 
  - yes

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
