### PR TITLE
fix(transparent-proxy): fix pod delay when CNI on GKE with OS Login

### DIFF
--- a/app/cni/pkg/cni/injector_linux.go
+++ b/app/cni/pkg/cni/injector_linux.go
@@ -90,6 +90,7 @@ func mapToConfig(intermediateConfig *IntermediateConfig, logWriter *bufio.Writer
 		excludePortsForUIDs = strings.Split(intermediateConfig.excludeOutboundPortsForUIDs, ";")
 	}
 
+	cfg.CNIMode = true
 	cfg.Verbose = true
 	cfg.RuntimeStdout = logWriter
 	cfg.Owner.UID = intermediateConfig.noRedirectUID

--- a/pkg/transparentproxy/config/config.go
+++ b/pkg/transparentproxy/config/config.go
@@ -492,6 +492,7 @@ type Config struct {
 	// crucial for environments where both IP families are in use, ensuring that
 	// the correct iptables rules are applied for the specified IP family.
 	IPFamilyMode IPFamilyMode
+	CNIMode      bool
 }
 
 type IPFamilyMode string

--- a/pkg/transparentproxy/config/config_executables_linux.go
+++ b/pkg/transparentproxy/config/config_executables_linux.go
@@ -1,0 +1,150 @@
+package config
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"runtime"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+
+	. "github.com/kumahq/kuma/pkg/transparentproxy/iptables/consts"
+)
+
+func mount(src string, dest string, flags uintptr) error {
+	if err := unix.Mount(src, dest, "", flags, ""); err != nil {
+		return errors.Wrapf(err, "failed to mount %s to %s", src, dest)
+	}
+
+	return nil
+}
+
+func setupSandbox(netns ns.NetNS, needLock bool) error {
+	// Unshare the current process's mount namespace to isolate it from other processes
+	if err := unix.Unshare(unix.CLONE_NEWNS); err != nil {
+		return errors.Wrap(err, "failed to unshare mount namespace")
+	}
+
+	if err := netns.Set(); err != nil {
+		return fmt.Errorf("failed to reset network namespace: %v", err)
+	}
+
+	// Remount the root filesystem as a private mount. This ensures that any mounts
+	// we perform do not affect the global namespace
+	// More info: https://unix.stackexchange.com/questions/246312/why-is-my-bind-mount-visible-outside-its-mount-namespace
+	if err := mount("", "/", unix.MS_PRIVATE|unix.MS_REC); err != nil {
+		return errors.Wrap(err, "failed to remount root filesystem as private")
+	}
+
+	if needLock {
+		// The abbility to change the xtables lock path using the XTABLES_LOCKFILE
+		// environment variable was introduced in iptables-legacy version 1.8.6.
+		// However, it is safe to mount /run/xtables.lock even when XTABLES_LOCKFILE
+		// is set, as the path specified by XTABLES_LOCKFILE will take precedence
+		// over /run/xtables.lock
+		if err := mount(netns.Path(), PathLegacyXtablesLock, unix.MS_BIND|unix.MS_RDONLY); err != nil {
+			return err
+		}
+	}
+
+	// Bind mount /dev/null over /etc/nsswitch.conf to prevent NSS from making network calls
+	// in the partially initialized network namespace. This prevents issues with iptables
+	// which might use the `xt_owner` module that can trigger the `passwd` service lookup
+	// More info: https://github.com/kumahq/kuma/issues/11038
+	if err := mount(PathDevNull, PathNSSwitchConf, unix.MS_BIND|unix.MS_RDONLY); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// runInSandbox sets up a lightweight sandbox ("container") to create an appropriate environment
+// for running iptables commands. This is particularly useful in CNI, where commands are executed
+// from the host but within the container's network namespace
+func runInSandbox(l Logger, needLock bool, c *exec.Cmd) error {
+	var executed bool
+	chErr := make(chan error, 1)
+
+	n, nerr := ns.GetCurrentNS()
+	if nerr != nil {
+		return errors.Wrap(nerr, "failed to get current network namespace")
+	}
+
+	if needLock {
+		// The ability to change the xtables lock path using the XTABLES_LOCKFILE environment
+		// variable was introduced in iptables-legacy version 1.8.6. However, it is safe to
+		// set this environment variable without checking the version, as earlier versions
+		// will simply ignore it
+		c.Env = append(
+			c.Env,
+			fmt.Sprintf("%s=%s", EnvVarXtablesLockfile, n.Path()),
+		)
+	}
+
+	// Once unshare(CLONE_NEWNS) is called, it cannot be undone explicitly.
+	// Therefore, we must perform the unshare operation on a specific thread.
+	// When we are done, we rely on the Go runtime to terminate the thread.
+	// However, creating a new thread breaks out of the previously entered network namespace,
+	// so we must also ensure that the network namespace is restored
+	go func() {
+		chErr <- func() error {
+			// Lock the current goroutine to the OS thread to ensure namespace isolation.
+			// Note: Do not call UnlockOSThread!
+			runtime.LockOSThread()
+
+			if err := setupSandbox(n, needLock); err != nil {
+				return err
+			}
+
+			// Mark that the command has been executed to distinguish between
+			// setupSandbox() and fn() errors
+			executed = true
+
+			// Execute the provided function within the sandbox
+			return c.Run()
+		}()
+	}()
+
+	err := <-chErr
+
+	if err != nil && !executed {
+		// If setting up the environment fails, continue in a best-effort approach
+		// to handle environments with restrictive access controls
+		l.Warnf("failed to set up the sandbox environment. This may be due to restrictive access controls (e.g., SELinux). Attempting to continue without the sandbox: %v", err)
+
+		return c.Run()
+	}
+
+	return err
+}
+
+func execCmd(
+	ctx context.Context,
+	l Logger,
+	cniMode bool,
+	needLock bool,
+	path string,
+	args ...string,
+) (*bytes.Buffer, *bytes.Buffer, error) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	// #nosec G204
+	cmd := exec.CommandContext(ctx, path, args...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	run := func(c *exec.Cmd) error { return c.Run() }
+
+	if cniMode {
+		run = func(c *exec.Cmd) error { return runInSandbox(l, needLock, c) }
+	}
+
+	if err := run(cmd); err != nil {
+		return nil, nil, handleRunError(err, &stderr)
+	}
+
+	return &stdout, &stderr, nil
+}

--- a/pkg/transparentproxy/config/config_executables_unspecified.go
+++ b/pkg/transparentproxy/config/config_executables_unspecified.go
@@ -1,0 +1,32 @@
+//go:build !linux
+// +build !linux
+
+package config
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+)
+
+func execCmd(
+	ctx context.Context,
+	_ Logger,
+	_ bool,
+	_ bool,
+	path string,
+	args ...string,
+) (*bytes.Buffer, *bytes.Buffer, error) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	// #nosec G204
+	cmd := exec.CommandContext(ctx, path, args...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return nil, nil, handleRunError(err, &stderr)
+	}
+
+	return &stdout, &stderr, nil
+}

--- a/pkg/transparentproxy/iptables/consts/consts.go
+++ b/pkg/transparentproxy/iptables/consts/consts.go
@@ -195,3 +195,15 @@ const (
 	OwnerDefaultUID      = "5678"
 	OwnerDefaultUsername = "kuma-dp"
 )
+
+// EnvVarXtablesLockfile is the name of the environment variable that specifies
+// the path to the lock file used by iptables-legacy version 1.8.6 and later.
+const EnvVarXtablesLockfile = "XTABLES_LOCKFILE"
+
+const (
+	// Before iptables-legacy v1.8.6 iptables were using hardcoded path to lock
+	// file which was /run/xtables.lock
+	PathLegacyXtablesLock = "/run/xtables.lock"
+	PathDevNull           = "/dev/null"
+	PathNSSwitchConf      = "/etc/nsswitch.conf"
+)


### PR DESCRIPTION
A bug resulting in pod start being delayed by 30-60s occurs in the following situation:

- Kuma CNI plugin is used
- GKE is new enough to have a recent GKE Metadata Server, which is more restrictive
- OS Login is enabled in GCE

The issue arises due to a circular dependency during the pod initialization process. When a pod starts, `kuma-cni` gets invoked. At this moment, the pod exists, but its containers are not yet running. `kuma-cni` essentially runs a command similar to `nsenter <POD> -- iptables-restore`. This command uses the `xt_owner` module with the `-m owner` flag, which makes a call to `getpwnam` (reference here: https://git.netfilter.org/iptables/tree/extensions/libxt_owner.c#n150). This call triggers the PAM authentication process.

In environments where OS Login is enabled on a GCE machine, a specific PAM module from Google's guest-oslogin: https://github.com/GoogleCloudPlatform/guest-oslogin gets loaded. This module attempts to contact the metadata server with a request like `/computeMetadata/v1/oslogin/users?username=...`.

The GKE Metadata Server treats this as a request originating from the pod. Since the pod's containers are not yet running, the server denies the request. The PAM module retries the request several times before it eventually times out and allows the initial process to continue.

This commit fixes the issue by running iptables commands in a sandbox with the root filesystem remounted (as in CNI context, network namespaces for pods are separate, but the filesystem is the same) and mounting `/etc/nsswitch.conf` to `/dev/null`. This prevents the PAM authentication process from being triggered, thereby stopping requests from being sent to the Metadata server.

Closes https://github.com/kumahq/kuma/issues/11038

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - https://github.com/kumahq/kuma/issues/11038
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Manually tested on
    - [x] Local k3d cluster
      - [x] kuma-cni
      - [x] kuma-init
    - [x] GKE (COS) with OS Login
      - [x] kuma-cni
      - [x] kuma-init
    - [x] GKE (Ubuntu) with OS Login
      - [x] kuma-cni
      - [x] kuma-init
    - [x] EKS
      - [x] kuma-cni
      - [x] kuma-init
    - [x] AKS (Azure CNI Overlay)
      - [x] kuma-cni
      - [x] kuma-init
    - [x] AKS (Azure CNI)
      - [x] kuma-cni
      - [x] kuma-init
    - [x] OpenShift 4 - local
      - [x] kuma-cni
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - There is no need

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
