### PR TITLE
fix(meshhttproute): deref pointer to weight or use default 1

### DIFF
--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/gateway_routes.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/gateway_routes.go
@@ -217,7 +217,7 @@ func makeHttpRouteEntry(name string, rule api.Rule) route.Entry {
 		}
 		target := route.Destination{
 			Destination:   dest,
-			Weight:        uint32(*b.Weight),
+			Weight:        uint32(pointer.DerefOr(b.Weight, 1)),
 			Policies:      nil,
 			RouteProtocol: core_mesh.ProtocolHTTP,
 		}


### PR DESCRIPTION
### Checklist prior to review

Kubebuilder generates OpenAPI spec with defaults; once we don't set it, it is set to the default from the spec. Unfortunately, it doesn't work on Universal, and the value might not be set correctly. Because of this once dereferencing weight, we hit the nil pointer. https://github.com/kumahq/kuma/issues/6070

Logs 
```
	OnTick() failed	{"dataplaneKey": {"Mesh":"default","Name":"gateway-instance-1"}, "error": "runtime error: invalid memory address or nil pointer dereference", "errorVerbose": "runtime error: invalid memory address or nil pointer dereference\ngithub.com/kumahq/kuma/pkg/util/watchdog.(*SimpleWatchdog).onTick.func1\n\tgithub.com/kumahq/kuma/pkg/util/watchdog/watchdog.go:62\nruntime.gopanic\n\truntime/panic.go:770\nruntime.panicmem\n\truntime/panic.go:261\nruntime.sigpanic\n\truntime/signal_unix.go:881\ngithub.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/plugin/v1alpha1.makeHttpRouteEntry\n\tgithub.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/gateway_routes.go:220\ngithub.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/plugin/v1alpha1.generateEnvoyRouteEntries\n\tgithub.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/gateway_routes.go:180\ngithub.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/plugin/v1alpha1.sortRulesToHosts\n\tgithub.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/gateway_routes.go:147\ngithub.com/kumahq/kuma/pkg/plugins/policies/core/xds/meshroute.CollectListenerInfos\n\tgithub.com/kumahq/kuma/pkg/plugins/policies/core/xds/meshroute/gateway.go:100\ngithub.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/plugin/v1alpha1.ApplyToGateway\n\tgithub.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin.go:126\ngithub.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/plugin/v1alpha1.plugin.Apply\n\tgithub.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin.go:62\ngithub.com/kumahq/kuma/pkg/plugins/policies/core/generator.generator.Generate\n\tgithub.com/kumahq/kuma/pkg/plugins/policies/core/generator/generator.go:23\ngithub.com/kumahq/kuma/pkg/xds/generator/core.CompositeResourceGenerator.Generate\n\tgithub.com/kumahq/kuma/pkg/xds/generator/core/resource_generator.go:22\ngithub.com/kumahq/kuma/pkg/xds/generator.(*ProxyTemplateProfileSource).Generate\n\tgithub.com/kumahq/kuma/pkg/xds/generator/proxy_template.go:76\ngithub.com/kumahq/kuma/pkg/xds/generator.(*ProxyTemplateGenerator).Generate\n\tgithub.com/kumahq/kuma/pkg/xds/generator/proxy_template.go:28\ngithub.com/kumahq/kuma/pkg/xds/server/v3.(*TemplateSnapshotGenerator).GenerateSnapshot\n\tgithub.com/kumahq/kuma/pkg/xds/server/v3/reconcile.go:167\ngithub.com/kumahq/kuma/pkg/xds/server/v3.(*reconciler).Reconcile\n\tgithub.com/kumahq/kuma/pkg/xds/server/v3/reconcile.go:55\ngithub.com/kumahq/kuma/pkg/xds/sync.(*DataplaneWatchdog).syncDataplane\n\tgithub.com/kumahq/kuma/pkg/xds/sync/dataplane_watchdog.go:166\ngithub.com/kumahq/kuma/pkg/xds/sync.(*DataplaneWatchdog).Sync\n\tgithub.com/kumahq/kuma/pkg/xds/sync/dataplane_watchdog.go:80\ngithub.com/kumahq/kuma/pkg/xds/sync.(*dataplaneWatchdogFactory).New.func2\n\tgithub.com/kumahq/kuma/pkg/xds/sync/dataplane_watchdog_factory.go:43\ngithub.com/kumahq/kuma/pkg/util/watchdog.(*SimpleWatchdog).onTick\n\tgithub.com/kumahq/kuma/pkg/util/watchdog/watchdog.go:70\ngithub.com/kumahq/kuma/pkg/util/watchdog.(*SimpleWatchdog).Start\n\tgithub.com/kumahq/kuma/pkg/util/watchdog/watchdog.go:40\nruntime.goexit\n\truntime/asm_arm64.s:1222"}
```

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
