### PR TITLE
fix(MeshService): don't sync deletion grace period label

### DIFF
--- a/api/mesh/v1alpha1/dataplane_helpers.go
+++ b/api/mesh/v1alpha1/dataplane_helpers.go
@@ -66,6 +66,10 @@ const (
 
 	// ManagedByLabel is used when a MeshService is auto-generated
 	ManagedByLabel = "kuma.io/managed-by"
+
+	// DeletionGracePeriodStartedLabel is used when generating MeshServices on
+	// universal, it's here to avoid import cycles
+	DeletionGracePeriodStartedLabel string = "kuma.io/deletion-grace-period-started-at"
 )
 
 type ResourceOrigin string

--- a/pkg/core/resources/apis/meshservice/generate/generator.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator.go
@@ -26,8 +26,7 @@ import (
 )
 
 const (
-	managedByValue                  string = "meshservice-generator"
-	deletionGracePeriodStartedLabel string = "kuma.io/deletion-grace-period-started-at"
+	managedByValue string = "meshservice-generator"
 )
 
 // Generator generates MeshService objects from Dataplane resources created on
@@ -180,7 +179,7 @@ func (g *Generator) generate(ctx context.Context, mesh string, dataplanes []*cor
 			log.Info("Port conflict for a kuma.io/service tag, ports must be identical across Dataplane inbounds for a given kuma.io/service", "dps", dps)
 		}
 		delete(meshservicesByName, meshService.GetMeta().GetName())
-		gracePeriodStartedAtText, hasGracePeriodLabel := meshService.GetMeta().GetLabels()[deletionGracePeriodStartedLabel]
+		gracePeriodStartedAtText, hasGracePeriodLabel := meshService.GetMeta().GetLabels()[mesh_proto.DeletionGracePeriodStartedLabel]
 
 		servicesDiffer := newMeshService != nil && servicesDiffer(meshService.Spec, newMeshService)
 		if newMeshService != nil && (servicesDiffer || hasGracePeriodLabel) {
@@ -191,7 +190,7 @@ func (g *Generator) generate(ctx context.Context, mesh string, dataplanes []*cor
 
 			// Unset the grace period by deleting the label
 			newLabels := maps.Clone(meshService.GetMeta().GetLabels())
-			delete(newLabels, deletionGracePeriodStartedLabel)
+			delete(newLabels, mesh_proto.DeletionGracePeriodStartedLabel)
 
 			if err := g.resManager.Update(ctx, meshService, store.UpdateWithLabels(newLabels)); err != nil {
 				log.Error(err, "couldn't update MeshService")
@@ -227,7 +226,7 @@ func (g *Generator) generate(ctx context.Context, mesh string, dataplanes []*cor
 					continue
 				}
 				newLabels := maps.Clone(meshService.GetMeta().GetLabels())
-				newLabels[deletionGracePeriodStartedLabel] = string(nowText)
+				newLabels[mesh_proto.DeletionGracePeriodStartedLabel] = string(nowText)
 				if err := g.resManager.Update(ctx, meshService, store.UpdateWithLabels(newLabels)); err != nil {
 					log.Error(err, "couldn't update MeshService")
 					continue

--- a/pkg/kds/context/context.go
+++ b/pkg/kds/context/context.go
@@ -95,6 +95,7 @@ func DefaultContext(
 		UpdateResourceMeta(
 			util.WithLabel(mesh_proto.ResourceOriginLabel, string(mesh_proto.ZoneResourceOrigin)),
 			util.WithLabel(mesh_proto.ZoneTag, cfg.Multizone.Zone.Name),
+			util.WithoutLabel(mesh_proto.DeletionGracePeriodStartedLabel),
 		),
 		MapInsightResourcesZeroGeneration,
 		reconcile.If(

--- a/pkg/kds/util/meta.go
+++ b/pkg/kds/util/meta.go
@@ -34,6 +34,12 @@ func WithLabel(key, value string) CloneResourceMetaOpt {
 	}
 }
 
+func WithoutLabel(key string) CloneResourceMetaOpt {
+	return func(m *resourceMeta) {
+		delete(m.labels, key)
+	}
+}
+
 func CloneResourceMeta(m model.ResourceMeta, fs ...CloneResourceMetaOpt) model.ResourceMeta {
 	labels := maps.Clone(m.GetLabels())
 	if labels == nil {


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x]  [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
