### PR TITLE
fix(api-server): method not allowed error

### DIFF
--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -32,6 +32,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/registry"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	rest_errors "github.com/kumahq/kuma/pkg/core/rest/errors"
+	"github.com/kumahq/kuma/pkg/core/rest/errors/types"
 	"github.com/kumahq/kuma/pkg/core/user"
 	"github.com/kumahq/kuma/pkg/core/validators"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
@@ -124,9 +125,10 @@ func (r *resourceEndpoints) addFindEndpoint(ws *restful.WebService, pathPrefix s
 			Returns(200, "OK", nil).
 			Returns(404, "Not found", nil))
 		if r.mode == config_core.Global {
-			ws.Route(ws.GET(pathPrefix+"/{name}/_config").To(r.methodNotAllowed("")).
-				Doc("Not allowed on Global CP.").
-				Returns(http.StatusMethodNotAllowed, "Not allowed on Global CP.", restful.ServiceError{}))
+			msg := "Not allowed on global CP"
+			ws.Route(ws.GET(pathPrefix+"/{name}/_config").To(r.methodNotAllowed(msg)).
+				Doc(msg).
+				Returns(http.StatusMethodNotAllowed, msg, restful.ServiceError{}))
 		} else {
 			ws.Route(ws.GET(pathPrefix+"/{name}/_config").To(r.configForProxy()).
 				Doc(fmt.Sprintf("Get proxy config%s", r.descriptor.Name)).
@@ -137,9 +139,14 @@ func (r *resourceEndpoints) addFindEndpoint(ws *restful.WebService, pathPrefix s
 	}
 }
 
-func (r *resourceEndpoints) methodNotAllowed(title string) func(request *restful.Request, response *restful.Response) {
+func (r *resourceEndpoints) methodNotAllowed(detail string) func(request *restful.Request, response *restful.Response) {
 	return func(request *restful.Request, response *restful.Response) {
-		rest_errors.HandleError(request.Request.Context(), response, &rest_errors.MethodNotAllowed{}, title)
+		err := &types.Error{
+			Status: 405,
+			Title:  "Method not allowed",
+			Detail: detail,
+		}
+		rest_errors.HandleError(request.Request.Context(), response, err, "")
 	}
 }
 


### PR DESCRIPTION
Now looks like:

```
{
 "type": "/std-errors",
 "status": 405,
 "title": "Method not allowed",
 "detail": "On global control plane you can not modify dataplane resources with 'kumactl apply' or via the HTTP API. You can still use 'kumactl' or the HTTP API to modify them on the zone control plane.\n",
 "details": "On global control plane you can not modify dataplane resources with 'kumactl apply' or via the HTTP API. You can still use 'kumactl' or the HTTP API to modify them on the zone control plane.\n"
}
```

`HandleError` is kind of strange, a lot of the cases don't even use the `title` parameter, which is more like `details` in a lot of cases.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- Closes https://github.com/kumahq/kuma/issues/10434
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
