### PR TITLE
perf(xds): do not include tags in CLA

### DIFF
--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic.endpoints.golden.yaml
@@ -11,28 +11,12 @@ resources:
               address: 192.168.0.4
               portValue: 8084
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-              region: eu
-            envoy.transport_socket_match:
-              kuma.io/protocol: http
-              region: eu
       - endpoint:
           address:
             socketAddress:
               address: 192.168.0.5
               portValue: 8084
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-              region: us
-            envoy.transport_socket_match:
-              kuma.io/protocol: http
-              region: us
 - name: backend-c72efb5be46fae6b
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
@@ -45,11 +29,3 @@ resources:
               address: 192.168.0.5
               portValue: 8084
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-              region: us
-            envoy.transport_socket_match:
-              kuma.io/protocol: http
-              region: us

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.endpoints.golden.yaml
@@ -11,25 +11,9 @@ resources:
               address: 192.168.0.4
               portValue: 8084
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              app: backend
-              kuma.io/protocol: http
-            envoy.transport_socket_match:
-              app: backend
-              kuma.io/protocol: http
       - endpoint:
           address:
             socketAddress:
               address: 192.168.0.5
               portValue: 8084
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              app: backend
-              kuma.io/protocol: http
-            envoy.transport_socket_match:
-              app: backend
-              kuma.io/protocol: http

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-route-outbound-with-tags-with-mtls.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-route-outbound-with-tags-with-mtls.endpoints.golden.yaml
@@ -11,11 +11,3 @@ resources:
               address: 192.168.0.4
               portValue: 8084
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-              region: us
-            envoy.transport_socket_match:
-              kuma.io/protocol: http
-              region: us

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-route.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-route.endpoints.golden.yaml
@@ -11,11 +11,3 @@ resources:
               address: 192.168.0.4
               portValue: 8084
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-              region: us
-            envoy.transport_socket_match:
-              kuma.io/protocol: http
-              region: us

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.endpoints.golden.yaml
@@ -11,14 +11,6 @@ resources:
               address: 192.168.0.4
               portValue: 8084
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-              region: us
-            envoy.transport_socket_match:
-              kuma.io/protocol: http
-              region: us
 - name: backend-6d0a1cf7605e8b1e
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
@@ -31,14 +23,6 @@ resources:
               address: 192.168.0.4
               portValue: 8084
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-              region: us
-            envoy.transport_socket_match:
-              kuma.io/protocol: http
-              region: us
 - name: backend-a285094d9b0d7032
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
@@ -51,14 +35,6 @@ resources:
               address: 192.168.0.4
               portValue: 8084
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-              region: us
-            envoy.transport_socket_match:
-              kuma.io/protocol: http
-              region: us
 - name: backend-dda53ef9426194b2
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
@@ -71,14 +47,6 @@ resources:
               address: 192.168.0.4
               portValue: 8084
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-              region: us
-            envoy.transport_socket_match:
-              kuma.io/protocol: http
-              region: us
 - name: backend-ed49e74a1f66b25c
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
@@ -91,14 +59,6 @@ resources:
               address: 192.168.0.4
               portValue: 8084
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-              region: us
-            envoy.transport_socket_match:
-              kuma.io/protocol: http
-              region: us
 - name: backend-wild-aac0221a73d6116a
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-specific.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-specific.endpoints.golden.yaml
@@ -11,11 +11,3 @@ resources:
               address: 192.168.0.4
               portValue: 8084
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-              region: us
-            envoy.transport_socket_match:
-              kuma.io/protocol: http
-              region: us

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway.endpoints.golden.yaml
@@ -11,11 +11,3 @@ resources:
               address: 192.168.0.4
               portValue: 8084
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-              region: us
-            envoy.transport_socket_match:
-              kuma.io/protocol: http
-              region: us

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/grpc-service.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/grpc-service.endpoints.golden.yaml
@@ -11,11 +11,3 @@ resources:
               address: 192.168.0.4
               portValue: 8084
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: grpc
-              region: us
-            envoy.transport_socket_match:
-              kuma.io/protocol: grpc
-              region: us

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/headers-match.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/headers-match.endpoints.golden.yaml
@@ -11,11 +11,3 @@ resources:
               address: 192.168.0.4
               portValue: 8084
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-              region: us
-            envoy.transport_socket_match:
-              kuma.io/protocol: http
-              region: us

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/match-priority.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/match-priority.endpoints.golden.yaml
@@ -11,25 +11,9 @@ resources:
               address: 192.168.0.4
               portValue: 8084
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-              region: eu
-            envoy.transport_socket_match:
-              kuma.io/protocol: http
-              region: eu
       - endpoint:
           address:
             socketAddress:
               address: 192.168.0.5
               portValue: 8084
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-              region: us
-            envoy.transport_socket_match:
-              kuma.io/protocol: http
-              region: us

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/mixed-tcp-and-http-outbounds.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/mixed-tcp-and-http-outbounds.endpoints.golden.yaml
@@ -11,25 +11,9 @@ resources:
               address: 192.168.0.4
               portValue: 8084
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-              region: eu
-            envoy.transport_socket_match:
-              kuma.io/protocol: http
-              region: eu
       - endpoint:
           address:
             socketAddress:
               address: 192.168.0.5
               portValue: 8084
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-              region: us
-            envoy.transport_socket_match:
-              kuma.io/protocol: http
-              region: us

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/request-header-modifiers.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/request-header-modifiers.endpoints.golden.yaml
@@ -11,11 +11,3 @@ resources:
               address: 192.168.0.4
               portValue: 8084
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-              region: us
-            envoy.transport_socket_match:
-              kuma.io/protocol: http
-              region: us

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/request-mirror.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/request-mirror.endpoints.golden.yaml
@@ -11,14 +11,6 @@ resources:
               address: 192.168.0.4
               portValue: 8084
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-              region: us
-            envoy.transport_socket_match:
-              kuma.io/protocol: http
-              region: us
 - name: payments-9f43ffb3c22f8c19
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
@@ -31,15 +23,3 @@ resources:
               address: 192.168.0.6
               portValue: 8086
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              env: dev
-              kuma.io/protocol: http
-              region: us
-              version: v1
-            envoy.transport_socket_match:
-              env: dev
-              kuma.io/protocol: http
-              region: us
-              version: v1

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/request-redirect.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/request-redirect.endpoints.golden.yaml
@@ -11,11 +11,3 @@ resources:
               address: 192.168.0.4
               portValue: 8084
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-              region: us
-            envoy.transport_socket_match:
-              kuma.io/protocol: http
-              region: us

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/response-header-modifiers.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/response-header-modifiers.endpoints.golden.yaml
@@ -11,11 +11,3 @@ resources:
               address: 192.168.0.4
               portValue: 8084
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-              region: us
-            envoy.transport_socket_match:
-              kuma.io/protocol: http
-              region: us

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/url-rewrite.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/url-rewrite.endpoints.golden.yaml
@@ -11,11 +11,3 @@ resources:
               address: 192.168.0.4
               portValue: 8084
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-              region: us
-            envoy.transport_socket_match:
-              kuma.io/protocol: http
-              region: us

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-no-policies.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-no-policies.endpoints.golden.yaml
@@ -11,25 +11,9 @@ resources:
               address: 192.168.0.4
               portValue: 8004
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: tcp
-              region: eu
-            envoy.transport_socket_match:
-              kuma.io/protocol: tcp
-              region: eu
       - endpoint:
           address:
             socketAddress:
               address: 192.168.0.5
               portValue: 8005
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-              region: us
-            envoy.transport_socket_match:
-              kuma.io/protocol: http
-              region: us

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/gateway.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/gateway.endpoints.golden.yaml
@@ -11,14 +11,6 @@ resources:
               address: 192.168.0.4
               portValue: 8084
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: tcp
-              region: us
-            envoy.transport_socket_match:
-              kuma.io/protocol: tcp
-              region: us
 - name: go-backend-1-a3e0f78d6b8a9607
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/kafka.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/kafka.endpoints.golden.yaml
@@ -11,14 +11,6 @@ resources:
               address: 192.168.0.4
               portValue: 8004
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: kafka
-              region: eu
-            envoy.transport_socket_match:
-              kuma.io/protocol: kafka
-              region: eu
 - name: backend-c72efb5be46fae6b
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
@@ -31,11 +23,3 @@ resources:
               address: 192.168.0.5
               portValue: 8005
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: kafka
-              region: us
-            envoy.transport_socket_match:
-              kuma.io/protocol: kafka
-              region: us

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/meshhttproute-clash-http-destination.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/meshhttproute-clash-http-destination.endpoints.golden.yaml
@@ -11,9 +11,3 @@ resources:
               address: 192.168.0.5
               portValue: 8005
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: tcp
-            envoy.transport_socket_match:
-              kuma.io/protocol: tcp

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/meshhttproute-clash-tcp-destination.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/meshhttproute-clash-tcp-destination.endpoints.golden.yaml
@@ -11,9 +11,3 @@ resources:
               address: 192.168.0.5
               portValue: 8005
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: tcp
-            envoy.transport_socket_match:
-              kuma.io/protocol: tcp

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/redirect-traffic.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/redirect-traffic.endpoints.golden.yaml
@@ -11,9 +11,3 @@ resources:
               address: 192.168.0.5
               portValue: 8005
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: tcp
-            envoy.transport_socket_match:
-              kuma.io/protocol: tcp

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/split-traffic.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/split-traffic.endpoints.golden.yaml
@@ -11,14 +11,6 @@ resources:
               address: 192.168.0.4
               portValue: 8004
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: tcp
-              region: eu
-            envoy.transport_socket_match:
-              kuma.io/protocol: tcp
-              region: eu
 - name: backend-c72efb5be46fae6b
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
@@ -31,14 +23,6 @@ resources:
               address: 192.168.0.5
               portValue: 8005
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-              region: us
-            envoy.transport_socket_match:
-              kuma.io/protocol: http
-              region: us
 - name: other-backend
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
@@ -51,9 +35,3 @@ resources:
               address: 192.168.0.6
               portValue: 8006
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-            envoy.transport_socket_match:
-              kuma.io/protocol: http

--- a/pkg/xds/cache/cla/cache_test.go
+++ b/pkg/xds/cache/cla/cache_test.go
@@ -116,7 +116,9 @@ var _ = Describe("ClusterLoadAssignment CachedRetriever", func() {
 
 		// then
 		Expect(err).ToNot(HaveOccurred())
-		expectedCla := envoy_endpoints.CreateClusterLoadAssignment("backend", []xds.Endpoint{endpointMap["backend"][0]})
+		ep := endpointMap["backend"][0]
+		ep.Tags = nil
+		expectedCla := envoy_endpoints.CreateClusterLoadAssignment("backend", []xds.Endpoint{ep})
 		Expect(claV1).To(matchers.MatchProto(expectedCla))
 
 		// when
@@ -128,7 +130,9 @@ var _ = Describe("ClusterLoadAssignment CachedRetriever", func() {
 
 		// then
 		Expect(err).ToNot(HaveOccurred())
-		expectedCla = envoy_endpoints.CreateClusterLoadAssignment("backend", []xds.Endpoint{endpointMap["backend"][1]})
+		ep = endpointMap["backend"][1]
+		ep.Tags = nil
+		expectedCla = envoy_endpoints.CreateClusterLoadAssignment("backend", []xds.Endpoint{ep})
 		Expect(claV2).To(matchers.MatchProto(expectedCla))
 	})
 })

--- a/pkg/xds/generator/testdata/outbound-proxy/03.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/03.envoy.golden.yaml
@@ -146,12 +146,6 @@ resources:
               address: 192.168.0.4
               portValue: 8089
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: grpc
-            envoy.transport_socket_match:
-              kuma.io/protocol: grpc
 - name: api-http
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
@@ -164,28 +158,12 @@ resources:
               address: 192.168.0.4
               portValue: 8084
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-              region: us
-            envoy.transport_socket_match:
-              kuma.io/protocol: http
-              region: us
       - endpoint:
           address:
             socketAddress:
               address: 192.168.0.5
               portValue: 8085
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-              region: eu
-            envoy.transport_socket_match:
-              kuma.io/protocol: http
-              region: eu
 - name: api-http2
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
@@ -198,12 +176,6 @@ resources:
               address: 192.168.0.4
               portValue: 8088
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http2
-            envoy.transport_socket_match:
-              kuma.io/protocol: http2
 - name: api-tcp
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
@@ -216,26 +188,12 @@ resources:
               address: 192.168.0.6
               portValue: 8086
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-              region: us
-            envoy.transport_socket_match:
-              kuma.io/protocol: http
-              region: us
       - endpoint:
           address:
             socketAddress:
               address: 192.168.0.7
               portValue: 8087
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              region: eu
-            envoy.transport_socket_match:
-              region: eu
 - name: backend
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
@@ -248,12 +206,6 @@ resources:
               address: 192.168.0.1
               portValue: 8081
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              region: us
-            envoy.transport_socket_match:
-              region: us
       - endpoint:
           address:
             socketAddress:
@@ -272,12 +224,6 @@ resources:
               address: 192.168.0.3
               portValue: 5433
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              role: replica
-            envoy.transport_socket_match:
-              role: replica
 - name: db-f7d9086d4169338b
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
@@ -290,12 +236,6 @@ resources:
               address: 192.168.0.3
               portValue: 5432
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              role: master
-            envoy.transport_socket_match:
-              role: master
 - name: outbound:127.0.0.1:18080
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener

--- a/pkg/xds/generator/testdata/outbound-proxy/04.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/04.envoy.golden.yaml
@@ -223,28 +223,12 @@ resources:
               address: 192.168.0.4
               portValue: 8084
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-              region: us
-            envoy.transport_socket_match:
-              kuma.io/protocol: http
-              region: us
       - endpoint:
           address:
             socketAddress:
               address: 192.168.0.5
               portValue: 8085
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-              region: eu
-            envoy.transport_socket_match:
-              kuma.io/protocol: http
-              region: eu
 - name: api-tcp
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
@@ -257,26 +241,12 @@ resources:
               address: 192.168.0.6
               portValue: 8086
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-              region: us
-            envoy.transport_socket_match:
-              kuma.io/protocol: http
-              region: us
       - endpoint:
           address:
             socketAddress:
               address: 192.168.0.7
               portValue: 8087
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              region: eu
-            envoy.transport_socket_match:
-              region: eu
 - name: backend
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
@@ -289,12 +259,6 @@ resources:
               address: 192.168.0.1
               portValue: 8081
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              region: us
-            envoy.transport_socket_match:
-              region: us
       - endpoint:
           address:
             socketAddress:
@@ -313,12 +277,6 @@ resources:
               address: 192.168.0.3
               portValue: 5433
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              role: replica
-            envoy.transport_socket_match:
-              role: replica
 - name: db-f7d9086d4169338b
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
@@ -331,12 +289,6 @@ resources:
               address: 192.168.0.3
               portValue: 5432
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              role: master
-            envoy.transport_socket_match:
-              role: master
 - name: outbound:127.0.0.1:18080
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener

--- a/pkg/xds/generator/testdata/outbound-proxy/09.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/09.envoy.golden.yaml
@@ -59,14 +59,6 @@ resources:
               address: 192.168.0.6
               portValue: 8086
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-              region: eu
-            envoy.transport_socket_match:
-              kuma.io/protocol: http
-              region: eu
 - name: outbound:127.0.0.1:30001
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener

--- a/pkg/xds/generator/testdata/outbound-proxy/10.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/10.envoy.golden.yaml
@@ -52,12 +52,6 @@ resources:
               address: 192.168.0.1
               portValue: 8081
         loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              region: us
-            envoy.transport_socket_match:
-              region: us
       - endpoint:
           address:
             socketAddress:


### PR DESCRIPTION
### Checklist prior to review

Draft to test CI first but xref https://github.com/kumahq/kuma/issues/11065
CLA cache is for service to service communication. We still build endpoint differently for ext services as well as for zone proxies.

MeshLoadbalancingStrategy breaks this. We can try to add this as a hook, so that we remove the tags after all plugins run

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
