### PR TITLE
fix(kuma-dp): don't fail if internal version is not semver

### DIFF
--- a/app/kuma-dp/cmd/run.go
+++ b/app/kuma-dp/cmd/run.go
@@ -171,7 +171,7 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 				return errors.Wrap(err, "failed to get Envoy version")
 			}
 
-			if envoyVersion.KumaDpCompatible, err = envoy.VersionCompatible("~"+kuma_version.Envoy, envoyVersion.Version); err != nil {
+			if envoyVersion.KumaDpCompatible, err = envoy.VersionCompatible(kuma_version.Envoy, envoyVersion.Version); err != nil {
 				runLog.Error(err, "cannot determine envoy version compatibility")
 			} else if !envoyVersion.KumaDpCompatible {
 				runLog.Info("Envoy version incompatible", "expected", kuma_version.Envoy, "current", envoyVersion.Version)

--- a/app/kuma-dp/pkg/dataplane/envoy/compatibility.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/compatibility.go
@@ -8,6 +8,10 @@ import (
 // VersionCompatible returns true if the given version of
 // envoy is compatible with this DP, false otherwise, expectedVersion is in Masterminds/semver/v3 format.
 func VersionCompatible(expectedVersion string, envoyVersion string) (bool, error) {
+	if expectedVersion == envoyVersion {
+		return true, nil
+	}
+	expectedVersion = "~" + expectedVersion
 	ver, err := semver.NewVersion(envoyVersion)
 	if err != nil {
 		return false, errors.Wrapf(err, "unable to parse envoy version %s", envoyVersion)
@@ -16,7 +20,7 @@ func VersionCompatible(expectedVersion string, envoyVersion string) (bool, error
 	constraint, err := semver.NewConstraint(expectedVersion)
 	if err != nil {
 		// Programmer error
-		panic(errors.Wrapf(err, "Invalid envoy compatibility constraint %s", expectedVersion))
+		return false, errors.Wrapf(err, "Invalid envoy compatibility constraint %s", expectedVersion)
 	}
 
 	return constraint.Check(ver), nil

--- a/app/kuma-dp/pkg/dataplane/envoy/compatibility_test.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/compatibility_test.go
@@ -11,44 +11,54 @@ import (
 
 var _ = Describe("Compatibility", func() {
 	It("Should be ok by default", func() {
-		r, err := envoy.VersionCompatible("~1.21.1", "1.21.1")
+		r, err := envoy.VersionCompatible("1.21.1", "1.21.1")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(r).To(BeTrue())
 	})
 	It("Should fail with old version", func() {
-		r, err := envoy.VersionCompatible("~1.21.1", "1.17.1")
+		r, err := envoy.VersionCompatible("1.21.1", "1.17.1")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(r).To(BeFalse())
 	})
 	It("Should fail with too recent", func() {
-		r, err := envoy.VersionCompatible("~1.21.1", "10.17.1") // Let's guess envoy 10 will never happen
+		r, err := envoy.VersionCompatible("1.21.1", "10.17.1") // Let's guess envoy 10 will never happen
 		Expect(err).ToNot(HaveOccurred())
 		Expect(r).To(BeFalse())
 	})
 	It("Should be ok with higher patch", func() {
-		r, err := envoy.VersionCompatible("~1.21.1", "1.21.2")
+		r, err := envoy.VersionCompatible("1.21.1", "1.21.2")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(r).To(BeTrue())
 	})
 	It("Should fail with lower patch", func() {
-		r, err := envoy.VersionCompatible("~1.21.1", "1.21.0")
+		r, err := envoy.VersionCompatible("1.21.1", "1.21.0")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(r).To(BeFalse())
 	})
 	It("Should fail with higher minor", func() {
-		r, err := envoy.VersionCompatible("~1.21.1", "1.22.1")
+		r, err := envoy.VersionCompatible("1.21.1", "1.22.1")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(r).To(BeFalse())
 	})
 	It("Should fail with lower minor", func() {
-		r, err := envoy.VersionCompatible("~1.21.1", "1.20.1")
+		r, err := envoy.VersionCompatible("1.21.1", "1.20.1")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(r).To(BeFalse())
 	})
 	It("Should err with bad version", func() {
-		r, err := envoy.VersionCompatible("~1.21.1", "funky")
+		r, err := envoy.VersionCompatible("1.21.1", "funky")
 		Expect(err).To(HaveOccurred())
 		Expect(r).To(BeFalse())
+	})
+	It("Should err with bad expected version", func() {
+		r, err := envoy.VersionCompatible("xyz", "1.20.1")
+		Expect(err).To(HaveOccurred())
+		Expect(r).To(BeFalse())
+	})
+	It("Should work on exact versions that aren't semver", func() {
+		r, err := envoy.VersionCompatible("xyz", "xyz")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(r).To(BeTrue())
 	})
 	It("Works with actual build version", func() {
 		r, err := envoy.VersionCompatible("~"+version.Envoy, version.Envoy)

--- a/app/kuma-dp/pkg/dataplane/envoy/compatibility_test.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/compatibility_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Compatibility", func() {
 		Expect(r).To(BeTrue())
 	})
 	It("Works with actual build version", func() {
-		r, err := envoy.VersionCompatible("~"+version.Envoy, version.Envoy)
+		r, err := envoy.VersionCompatible(version.Envoy, version.Envoy)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(r).To(BeTrue())
 	}, test.LabelBuildCheck)


### PR DESCRIPTION
In compatibility checks we checked that the version matched our version constraints.
We used to panic if the build envoy version isn't a valid semver. We now allow this and an error log will show up

Also if the version isn't semver we check lexicographic equality.

fix #11086

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
