### PR TITLE
chore(deps): upgrade envoy to 1.28.5

### DIFF
--- a/tools/releases/version.sh
+++ b/tools/releases/version.sh
@@ -8,7 +8,7 @@ function envoy_version() {
   # - if ENVOY_TAG is a real git tag like 'v1.20.0' then the version is equal to '1.20.0' (without the first letter 'v').
   # - if ENVOY_TAG is a commit hash then the version will look like '1.20.1-dev-b16d390f'
 
-  ENVOY_TAG=${ENVOY_TAG:-"v1.27.7-k.1"}
+  ENVOY_TAG=${ENVOY_TAG:-"v1.28.5-k.1"}
 
   if [[ "${ENVOY_TAG}" =~ ^v[0-9]*\.[0-9]*\.[0-9]* ]]; then
     echo "${ENVOY_TAG#v}"


### PR DESCRIPTION
### Checklist prior to review

Since 1.27 is deprecated we should upgrade to the next version

- [ ] [Link to relevant issue][1] as well as docs and UI issues -- fix: https://github.com/kumahq/kuma/issues/11087
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
