### PR TITLE
fix(kuma-dp): fix build failures on Windows because of TCP socket options on SO_LINGER

### DIFF
--- a/app/kuma-dp/pkg/dataplane/probes/component.go
+++ b/app/kuma-dp/pkg/dataplane/probes/component.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"regexp"
 	"strconv"
-	"syscall"
 	"time"
 
 	"github.com/bakito/go-log-logr-adapter/adapter"
@@ -178,28 +177,6 @@ func getScheme(req *http.Request) kube_core.URIScheme {
 
 func getGRPCService(req *http.Request) string {
 	return req.Header.Get(probes.HeaderNameGRPCService)
-}
-
-// copied from https://github.com/kubernetes/kubernetes/blob/v1.27.0-alpha.1/pkg/probe/dialer_others.go#L27
-// createProbeDialer returns a dialer optimized for probes to avoid lingering sockets on TIME-WAIT state.
-// The dialer reduces the TIME-WAIT period to 1 seconds instead of the OS default of 60 seconds.
-// Using 1 second instead of 0 because SO_LINGER socket option to 0 causes pending data to be
-// discarded and the connection to be aborted with an RST rather than for the pending data to be
-// transmitted and the connection closed cleanly with a FIN.
-// Ref: https://issues.k8s.io/89898
-func createProbeDialer(isIPv6 bool) *net.Dialer {
-	dialer := &net.Dialer{
-		Control: func(network, address string, c syscall.RawConn) error {
-			return c.Control(func(fd uintptr) {
-				_ = syscall.SetsockoptLinger(int(fd), syscall.SOL_SOCKET, syscall.SO_LINGER, &syscall.Linger{Onoff: 1, Linger: 1})
-			})
-		},
-	}
-	dialer.LocalAddr = LocalAddrIPv4
-	if isIPv6 {
-		dialer.LocalAddr = LocalAddrIPv6
-	}
-	return dialer
 }
 
 func writeProbeResult(writer http.ResponseWriter, result string) {

--- a/app/kuma-dp/pkg/dataplane/probes/probe_dialer_others.go
+++ b/app/kuma-dp/pkg/dataplane/probes/probe_dialer_others.go
@@ -1,0 +1,30 @@
+//go:build !windows
+
+package probes
+
+import (
+	"net"
+	"syscall"
+)
+
+// copied from https://github.com/kubernetes/kubernetes/blob/v1.27.0-alpha.1/pkg/probe/dialer_others.go#L27
+// createProbeDialer returns a dialer optimized for probes to avoid lingering sockets on TIME-WAIT state.
+// The dialer reduces the TIME-WAIT period to 1 seconds instead of the OS default of 60 seconds.
+// Using 1 second instead of 0 because SO_LINGER socket option to 0 causes pending data to be
+// discarded and the connection to be aborted with an RST rather than for the pending data to be
+// transmitted and the connection closed cleanly with a FIN.
+// Ref: https://issues.k8s.io/89898
+func createProbeDialer(isIPv6 bool) *net.Dialer {
+	dialer := &net.Dialer{
+		Control: func(network, address string, c syscall.RawConn) error {
+			return c.Control(func(fd uintptr) {
+				_ = syscall.SetsockoptLinger(int(fd), syscall.SOL_SOCKET, syscall.SO_LINGER, &syscall.Linger{Onoff: 1, Linger: 1})
+			})
+		},
+	}
+	dialer.LocalAddr = LocalAddrIPv4
+	if isIPv6 {
+		dialer.LocalAddr = LocalAddrIPv6
+	}
+	return dialer
+}

--- a/app/kuma-dp/pkg/dataplane/probes/probe_dialer_windows.go
+++ b/app/kuma-dp/pkg/dataplane/probes/probe_dialer_windows.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package probes
+
+import (
+	"net"
+	"syscall"
+)
+
+// copied from https://github.com/kubernetes/kubernetes/blob/v1.27.0-alpha.1/pkg/probe/dialer_windows.go
+// createProbeDialer returns a dialer optimized for probes to avoid lingering sockets on TIME-WAIT state.
+// The dialer reduces the TIME-WAIT period to 1 seconds instead of the OS default of 60 seconds.
+// Using 1 second instead of 0 because SO_LINGER socket option to 0 causes pending data to be
+// discarded and the connection to be aborted with an RST rather than for the pending data to be
+// transmitted and the connection closed cleanly with a FIN.
+// Ref: https://issues.k8s.io/89898
+func createProbeDialer(isIPv6 bool) *net.Dialer {
+	dialer := &net.Dialer{
+		Control: func(network, address string, c syscall.RawConn) error {
+			return c.Control(func(fd uintptr) {
+				_ = syscall.SetsockoptLinger(syscall.Handle(fd), syscall.SOL_SOCKET, syscall.SO_LINGER, &syscall.Linger{Onoff: 1, Linger: 1})
+			})
+		},
+	}
+	dialer.LocalAddr = LocalAddrIPv4
+	if isIPv6 {
+		dialer.LocalAddr = LocalAddrIPv6
+	}
+	return dialer
+}


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues 
  - Fix failed CI on child repos.
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - Confirmed
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) 
  - Manual tested
  - Don't forget `ci/` labels to run additional/fewer tests
    - Added
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? 
  - No
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) 
  - No

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
