### PR TITLE
feat(kuma-dp): statically respond readiness of Envoy as READY

### DIFF
--- a/pkg/xds/envoy/types.go
+++ b/pkg/xds/envoy/types.go
@@ -257,4 +257,11 @@ type StaticEndpointPath struct {
 	RewritePath      string
 	Header           string
 	HeaderExactMatch string
+
+	DirectResponse *StaticEndpointDirectResponse
+}
+
+type StaticEndpointDirectResponse struct {
+	StatusCode uint32
+	Response   string
 }

--- a/pkg/xds/generator/testdata/admin/01.envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/admin/01.envoy-config.golden.yaml
@@ -39,11 +39,12 @@ resources:
               - '*'
               name: kuma:envoy:admin
               routes:
-              - match:
+              - directResponse:
+                  body:
+                    inlineString: READY
+                  status: 200
+                match:
                   prefix: /ready
-                route:
-                  cluster: kuma:envoy:admin
-                  prefixRewrite: /ready
           statPrefix: kuma_envoy_admin
     - filterChainMatch:
         transportProtocol: tls
@@ -62,6 +63,12 @@ resources:
               - '*'
               name: kuma:envoy:admin
               routes:
+              - directResponse:
+                  body:
+                    inlineString: READY
+                  status: 200
+                match:
+                  prefix: /ready
               - match:
                   prefix: /
                 route:

--- a/pkg/xds/generator/testdata/admin/02.envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/admin/02.envoy-config.golden.yaml
@@ -39,11 +39,12 @@ resources:
               - '*'
               name: kuma:envoy:admin
               routes:
-              - match:
+              - directResponse:
+                  body:
+                    inlineString: READY
+                  status: 200
+                match:
                   prefix: /ready
-                route:
-                  cluster: kuma:envoy:admin
-                  prefixRewrite: /ready
           statPrefix: kuma_envoy_admin
     - filterChainMatch:
         transportProtocol: tls
@@ -62,6 +63,12 @@ resources:
               - '*'
               name: kuma:envoy:admin
               routes:
+              - directResponse:
+                  body:
+                    inlineString: READY
+                  status: 200
+                match:
+                  prefix: /ready
               - match:
                   prefix: /
                 route:

--- a/pkg/xds/generator/testdata/admin/03.envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/admin/03.envoy-config.golden.yaml
@@ -39,11 +39,12 @@ resources:
               - '*'
               name: kuma:envoy:admin
               routes:
-              - match:
+              - directResponse:
+                  body:
+                    inlineString: READY
+                  status: 200
+                match:
                   prefix: /ready
-                route:
-                  cluster: kuma:envoy:admin
-                  prefixRewrite: /ready
           statPrefix: kuma_envoy_admin
     - filterChainMatch:
         transportProtocol: tls
@@ -62,6 +63,12 @@ resources:
               - '*'
               name: kuma:envoy:admin
               routes:
+              - directResponse:
+                  body:
+                    inlineString: READY
+                  status: 200
+                match:
+                  prefix: /ready
               - match:
                   prefix: /
                 route:

--- a/pkg/xds/generator/testdata/admin/04.envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/admin/04.envoy-config.golden.yaml
@@ -39,11 +39,12 @@ resources:
               - '*'
               name: kuma:envoy:admin
               routes:
-              - match:
+              - directResponse:
+                  body:
+                    inlineString: READY
+                  status: 200
+                match:
                   prefix: /ready
-                route:
-                  cluster: kuma:envoy:admin
-                  prefixRewrite: /ready
           statPrefix: kuma_envoy_admin
     - filterChainMatch:
         transportProtocol: tls
@@ -62,6 +63,12 @@ resources:
               - '*'
               name: kuma:envoy:admin
               routes:
+              - directResponse:
+                  body:
+                    inlineString: READY
+                  status: 200
+                match:
+                  prefix: /ready
               - match:
                   prefix: /
                 route:

--- a/pkg/xds/generator/testdata/admin/05.envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/admin/05.envoy-config.golden.yaml
@@ -39,11 +39,12 @@ resources:
               - '*'
               name: kuma:envoy:admin
               routes:
-              - match:
+              - directResponse:
+                  body:
+                    inlineString: READY
+                  status: 200
+                match:
                   prefix: /ready
-                route:
-                  cluster: kuma:envoy:admin
-                  prefixRewrite: /ready
           statPrefix: kuma_envoy_admin
     - filterChainMatch:
         transportProtocol: tls
@@ -62,6 +63,12 @@ resources:
               - '*'
               name: kuma:envoy:admin
               routes:
+              - directResponse:
+                  body:
+                    inlineString: READY
+                  status: 200
+                match:
+                  prefix: /ready
               - match:
                   prefix: /
                 route:

--- a/pkg/xds/generator/testdata/profile-source/1-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/1-envoy-config.golden.yaml
@@ -220,11 +220,12 @@ resources:
               - '*'
               name: kuma:envoy:admin
               routes:
-              - match:
+              - directResponse:
+                  body:
+                    inlineString: READY
+                  status: 200
+                match:
                   prefix: /ready
-                route:
-                  cluster: kuma:envoy:admin
-                  prefixRewrite: /ready
           statPrefix: kuma_envoy_admin
     - filterChainMatch:
         transportProtocol: tls
@@ -243,6 +244,12 @@ resources:
               - '*'
               name: kuma:envoy:admin
               routes:
+              - directResponse:
+                  body:
+                    inlineString: READY
+                  status: 200
+                match:
+                  prefix: /ready
               - match:
                   prefix: /
                 route:

--- a/pkg/xds/generator/testdata/profile-source/2-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/2-envoy-config.golden.yaml
@@ -263,11 +263,12 @@ resources:
               - '*'
               name: kuma:envoy:admin
               routes:
-              - match:
+              - directResponse:
+                  body:
+                    inlineString: READY
+                  status: 200
+                match:
                   prefix: /ready
-                route:
-                  cluster: kuma:envoy:admin
-                  prefixRewrite: /ready
           statPrefix: kuma_envoy_admin
     - filterChainMatch:
         transportProtocol: tls
@@ -286,6 +287,12 @@ resources:
               - '*'
               name: kuma:envoy:admin
               routes:
+              - directResponse:
+                  body:
+                    inlineString: READY
+                  status: 200
+                match:
+                  prefix: /ready
               - match:
                   prefix: /
                 route:

--- a/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
@@ -265,11 +265,12 @@ resources:
               - '*'
               name: kuma:envoy:admin
               routes:
-              - match:
+              - directResponse:
+                  body:
+                    inlineString: READY
+                  status: 200
+                match:
                   prefix: /ready
-                route:
-                  cluster: kuma:envoy:admin
-                  prefixRewrite: /ready
           statPrefix: kuma_envoy_admin
     - filterChainMatch:
         transportProtocol: tls
@@ -288,6 +289,12 @@ resources:
               - '*'
               name: kuma:envoy:admin
               routes:
+              - directResponse:
+                  body:
+                    inlineString: READY
+                  status: 200
+                match:
+                  prefix: /ready
               - match:
                   prefix: /
                 route:

--- a/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
@@ -308,11 +308,12 @@ resources:
               - '*'
               name: kuma:envoy:admin
               routes:
-              - match:
+              - directResponse:
+                  body:
+                    inlineString: READY
+                  status: 200
+                match:
                   prefix: /ready
-                route:
-                  cluster: kuma:envoy:admin
-                  prefixRewrite: /ready
           statPrefix: kuma_envoy_admin
     - filterChainMatch:
         transportProtocol: tls
@@ -331,6 +332,12 @@ resources:
               - '*'
               name: kuma:envoy:admin
               routes:
+              - directResponse:
+                  body:
+                    inlineString: READY
+                  status: 200
+                match:
+                  prefix: /ready
               - match:
                   prefix: /
                 route:


### PR DESCRIPTION
### Checklist prior to review

This is an alternative solution and replaces https://github.com/kumahq/kuma/pull/11107

- [x] [Link to relevant issue][1] as well as docs and UI issues 
  -  fixes https://github.com/kumahq/kuma/issues/11034
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS 
  - Confirmed
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) 
  - Added
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? 
  - No
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

> Changelog: statically respond readiness of Envoy as `READY` instead of using Envoy admin API

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
