### PR TITLE
fix(meshgatewayinstance): remove required since we generate serviceName

### DIFF
--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/mesh_gateway_instance.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/mesh_gateway_instance.go
@@ -30,8 +30,7 @@ type MeshGatewayInstanceSpec struct {
 	// since is auto-generated, and should match exactly one Gateway
 	// resource.
 	//
-	// +required
-	// +kubebuilder:validation:MinLen=1
+	// +optional
 	Tags map[string]string `json:"tags,omitempty"`
 }
 

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/mesh_gateway_instance.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/mesh_gateway_instance.go
@@ -31,6 +31,7 @@ type MeshGatewayInstanceSpec struct {
 	// resource.
 	//
 	// +optional
+	// +kubebuilder:validation:MinLen=1
 	Tags map[string]string `json:"tags,omitempty"`
 }
 


### PR DESCRIPTION
### Checklist prior to review

While debugging https://github.com/kumahq/kuma/pull/11137, I discovered that after upgrading the Kubernetes libraries, the gateway tests were failing. The issue was due to the `kuma.io/service` label being required, even though it's autogenerated and we don't allow it to be set manually since 2.9.x(https://github.com/kumahq/kuma/pull/10968). To resolve this, I changed the label's status from required to optional.

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
