### PR TITLE
fix(policy): don't fail once cannot map MES to tags rules

### DIFF
--- a/api/common/v1alpha1/ref.go
+++ b/api/common/v1alpha1/ref.go
@@ -55,6 +55,8 @@ func (k TargetRefKind) IsRealResource() bool {
 	}
 }
 
+// These are the kinds that can be used in Kuma policies before support for 
+// actual resources (e.g., MeshExternalService, MeshMultiZoneService, and MeshService) was introduced.
 func (k TargetRefKind) IsOldKind() bool {
 	switch k {
 	case Mesh, MeshSubset, MeshServiceSubset, MeshService, MeshGateway, MeshHTTPRoute:

--- a/api/common/v1alpha1/ref.go
+++ b/api/common/v1alpha1/ref.go
@@ -55,7 +55,7 @@ func (k TargetRefKind) IsRealResource() bool {
 	}
 }
 
-// These are the kinds that can be used in Kuma policies before support for 
+// These are the kinds that can be used in Kuma policies before support for
 // actual resources (e.g., MeshExternalService, MeshMultiZoneService, and MeshService) was introduced.
 func (k TargetRefKind) IsOldKind() bool {
 	switch k {

--- a/api/common/v1alpha1/ref.go
+++ b/api/common/v1alpha1/ref.go
@@ -55,6 +55,15 @@ func (k TargetRefKind) IsRealResource() bool {
 	}
 }
 
+func (k TargetRefKind) IsOldKind() bool {
+	switch k {
+	case Mesh, MeshSubset, MeshServiceSubset, MeshService, MeshGateway, MeshHTTPRoute:
+		return true
+	default:
+		return false
+	}
+}
+
 func AllTargetRefKinds() []TargetRefKind {
 	keys := maps.Keys(order)
 	sort.Sort(TargetRefKindSlice(keys))

--- a/pkg/plugins/policies/core/rules/rules.go
+++ b/pkg/plugins/policies/core/rules/rules.go
@@ -635,6 +635,8 @@ func asSubset(tr common_api.TargetRef) (Subset, error) {
 			ss = append(ss, Tag{Key: k, Value: v})
 		}
 		return ss, nil
+	case common_api.MeshExternalService:
+		return Subset{}, nil
 	default:
 		return nil, errors.Errorf("can't represent %s as tags", tr.Kind)
 	}

--- a/pkg/plugins/policies/core/rules/rules.go
+++ b/pkg/plugins/policies/core/rules/rules.go
@@ -496,10 +496,19 @@ func BuildSingleItemRules(matchedPolicies []core_model.Resource) (SingleItemRule
 // See the detailed algorithm description in docs/madr/decisions/007-mesh-traffic-permission.md
 func BuildRules(list []PolicyItemWithMeta) (Rules, error) {
 	rules := Rules{}
+	oldKindsItems := []PolicyItemWithMeta{}
+	for _, item := range list {
+		if item.PolicyItem.GetTargetRef().Kind.IsOldKind() {
+			oldKindsItems = append(oldKindsItems, item)
+		}
+	}
+	if len(oldKindsItems) == 0 {
+		return rules, nil
+	}
 
 	// 1. Convert list of rules into the list of subsets
 	var subsets []Subset
-	for _, item := range list {
+	for _, item := range oldKindsItems {
 		ss, err := asSubset(item.GetTargetRef())
 		if err != nil {
 			return nil, err
@@ -560,8 +569,8 @@ func BuildRules(list []PolicyItemWithMeta) (Rules, error) {
 			// 5. For each combination determine a configuration
 			confs := []interface{}{}
 			distinctOrigins := map[core_model.ResourceKey]core_model.ResourceMeta{}
-			for i := 0; i < len(list); i++ {
-				item := list[i]
+			for i := 0; i < len(oldKindsItems); i++ {
+				item := oldKindsItems[i]
 				itemSubset, err := asSubset(item.GetTargetRef())
 				if err != nil {
 					return nil, err
@@ -635,8 +644,6 @@ func asSubset(tr common_api.TargetRef) (Subset, error) {
 			ss = append(ss, Tag{Key: k, Value: v})
 		}
 		return ss, nil
-	case common_api.MeshExternalService:
-		return Subset{}, nil
 	default:
 		return nil, errors.Errorf("can't represent %s as tags", tr.Kind)
 	}


### PR DESCRIPTION
### Checklist prior to review

`BuildToRules` calls two methods: `BuildRules` and `BuildResourceRules`. `BuildRules` maps kinds to tags, but for `MeshExternalService`, it cannot be mapped to a specific tag because it's a different type. Previously, we were returning an error and didn't attempt to run `BuildResourceRules`, which caused the policy to not match the dataplane (DP).

Note: I will add a test once MeshExternalService is supported by one of the policies, as it currently does not pass the validator.

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
