### PR TITLE
feat(transparent-proxy): check for existing iptables rules when picking executables

### DIFF
--- a/pkg/transparentproxy/config/config_executables.go
+++ b/pkg/transparentproxy/config/config_executables.go
@@ -500,20 +500,13 @@ func (c ExecutablesNftLegacy) Initialize(
 	}
 
 	switch {
-	// Dry-run mode when no valid iptables executables are found.
 	case len(errs) == 2 && cfg.DryRun:
-		l.Warn("[dry-run]: no valid iptables executables found. The generated iptables rules may differ from those generated in an environment with valid iptables executables")
+		l.Warn("[dry-run]: no valid iptables executables found; the generated iptables rules may differ from those generated in an environment with valid iptables executables")
 		return InitializedExecutables{}, nil
-	// Regular mode when no vaild iptables executables are found
 	case len(errs) == 2:
-		return InitializedExecutables{}, errors.Wrap(
-			std_errors.Join(errs...),
-			"failed to find valid nft or legacy executables",
-		)
-	// No valid legacy executables
+		return InitializedExecutables{}, errors.Wrap(std_errors.Join(errs...), "failed to find valid nft or legacy executables")
 	case legacyErr != nil:
 		return nft, nil
-	// No valid nft executables
 	case nftErr != nil:
 		return legacy, nil
 	case nft.hasExistingRules() && legacy.hasExistingRules():


### PR DESCRIPTION
In cases where both iptables-legacy and iptables-nft are available, this PR improves the selection process by checking which executable contains existing rules or custom chains and prioritizing that one for use.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - No relevant issues
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Existing transparent-proxy tests are passing
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - There is no need

> Changelog: feat(transparent-proxy): check for existing rules or custom chains when picking iptables executables

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
