### PR TITLE
feat(MeshLoadBalancingStrategy): only allow localZone for real MeshService

### DIFF
--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator.go
@@ -45,25 +45,29 @@ func validateTo(to []To) validators.ValidationError {
 				common_api.MeshService,
 			},
 		}))
-		verr.AddErrorAt(path.Field("default"), validateDefault(toItem.Default))
+		verr.AddErrorAt(path.Field("default"), validateConf(toItem.Default, toItem))
 	}
 	return verr
 }
 
-func validateDefault(conf Conf) validators.ValidationError {
+func validateConf(conf Conf, to To) validators.ValidationError {
 	var verr validators.ValidationError
 	verr.AddError("loadBalancer", validateLoadBalancer(conf.LoadBalancer))
-	verr.AddError("localityAwareness", validateLocalityAwareness(conf.LocalityAwareness))
+	verr.AddError("localityAwareness", validateLocalityAwareness(conf.LocalityAwareness, to))
 	return verr
 }
 
-func validateLocalityAwareness(localityAwareness *LocalityAwareness) validators.ValidationError {
+func validateLocalityAwareness(localityAwareness *LocalityAwareness, to To) validators.ValidationError {
 	var verr validators.ValidationError
 	if localityAwareness == nil {
 		return verr
 	}
 	verr.AddError("localZone", validateLocalZone(localityAwareness.LocalZone))
-	verr.AddError("crossZone", validateCrossZone(localityAwareness.CrossZone))
+	if to.TargetRef.Kind == common_api.MeshService && (to.TargetRef.SectionName != "" || len(to.TargetRef.Labels) > 0) {
+		verr.AddViolationAt(validators.RootedAt("crossZone"), fmt.Sprintf("%s: MeshService traffic is local", validators.MustNotBeSet))
+	} else {
+		verr.AddError("crossZone", validateCrossZone(localityAwareness.CrossZone))
+	}
 	return verr
 }
 

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator_test.go
@@ -51,6 +51,12 @@ to:
       name: svc-2
       tags:
         version: v1
+  - targetRef:
+      kind: MeshService
+      name: real-mesh-service
+      sectionName: http
+      default:
+        crossZone: {}
 `),
 		ErrorCases(
 			"ringHash error",


### PR DESCRIPTION
Part of https://github.com/kumahq/kuma/issues/10935

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
