### PR TITLE
fix(MeshLoadBalancingStrategy): validation for real MeshService

### DIFF
--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator.go
@@ -63,11 +63,7 @@ func validateLocalityAwareness(localityAwareness *LocalityAwareness, to To) vali
 		return verr
 	}
 	verr.AddError("localZone", validateLocalZone(localityAwareness.LocalZone))
-	if to.TargetRef.Kind == common_api.MeshService && (to.TargetRef.SectionName != "" || len(to.TargetRef.Labels) > 0) {
-		verr.AddViolationAt(validators.RootedAt("crossZone"), fmt.Sprintf("%s: MeshService traffic is local", validators.MustNotBeSet))
-	} else {
-		verr.AddError("crossZone", validateCrossZone(localityAwareness.CrossZone))
-	}
+	verr.AddError("crossZone", validateCrossZone(localityAwareness.CrossZone, to))
 	return verr
 }
 
@@ -95,10 +91,13 @@ func validateLocalZone(localZone *LocalZone) validators.ValidationError {
 	return verr
 }
 
-func validateCrossZone(crossZone *CrossZone) validators.ValidationError {
+func validateCrossZone(crossZone *CrossZone, to To) validators.ValidationError {
 	var verr validators.ValidationError
 	if crossZone == nil {
 		return verr
+	}
+	if to.TargetRef.Kind == common_api.MeshService && (to.TargetRef.SectionName != "" || len(to.TargetRef.Labels) > 0) {
+		verr.AddViolationAt(validators.Root(), fmt.Sprintf("%s: MeshService traffic is local", validators.MustNotBeSet))
 	}
 
 	for idx, failover := range crossZone.Failover {

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator_test.go
@@ -37,6 +37,9 @@ to: []
 			[]validators.Violation{{
 				Field:   "spec.to[0].targetRef.kind",
 				Message: "value is not supported",
+			}, {
+				Field:   "spec.to[1].default.localityAwareness.crossZone",
+				Message: "must not be set: MeshService traffic is local",
 			}},
 			`
 type: MeshLoadBalancingStrategy
@@ -55,7 +58,8 @@ to:
       kind: MeshService
       name: real-mesh-service
       sectionName: http
-      default:
+    default:
+      localityAwareness:
         crossZone: {}
 `),
 		ErrorCases(


### PR DESCRIPTION
Forgot to add the test condition in https://github.com/kumahq/kuma/pull/11173

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- Part of #10935
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
