### PR TITLE
fix(injector): set allowPrivilegeEscalation: false on `kuma-validation` container

### DIFF
--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
@@ -495,7 +495,8 @@ func (i *KumaInjector) NewValidationContainer(ipFamilyMode, inboundRedirectPort 
 					"ALL",
 				},
 			},
-			ReadOnlyRootFilesystem: pointer.To(true),
+			ReadOnlyRootFilesystem:   pointer.To(true),
+			AllowPrivilegeEscalation: pointer.To(false),
 		},
 		Resources: kube_core.ResourceRequirements{
 			Limits: kube_core.ResourceList{

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.34.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.34.golden.yaml
@@ -148,6 +148,7 @@ spec:
         cpu: 20m
         memory: 20M
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.34.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.34.golden.yaml
@@ -53,6 +53,7 @@ spec:
         cpu: 20m
         memory: 20M
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL


### PR DESCRIPTION
Since kuma CNI is designed to allow the pods to run with less privileges, and the pod already doesn't run as root, also set `allowPrivilegeEscalation: false` to better lock down the validator container.

Closes https://github.com/kumahq/kuma/issues/11176

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
