### PR TITLE
ci(deps): improve handling OSV_SCANNER_ADDITIONAL_OPTS env var

### DIFF
--- a/tools/ci/update-vulnerable-dependencies/update-vulnerable-dependencies.sh
+++ b/tools/ci/update-vulnerable-dependencies/update-vulnerable-dependencies.sh
@@ -8,7 +8,20 @@ command -v jq >/dev/null 2>&1 || { echo >&2 "jq not installed!"; exit 1; }
 SCRIPT_PATH="${BASH_SOURCE[0]:-$0}";
 SCRIPT_DIR="$(dirname -- "$SCRIPT_PATH")"
 
-for dep in $(osv-scanner "${OSV_SCANNER_ADDITIONAL_OPTS[@]}" --lockfile=go.mod --json | jq -c '.results[].packages[] | .package.name as $vulnerablePackage | {
+OSV_FLAGS=(--lockfile=go.mod --json)
+
+# Loop over the array, add only non-empty values to the new array
+for i in "${OSV_SCANNER_ADDITIONAL_OPTS[@]}"; do
+   # Skip null items
+   if [ -z "$i" ]; then
+     continue
+   fi
+
+   # Add the rest of the elements to an array
+   OSV_FLAGS+=("${i}")
+done
+
+for dep in $(osv-scanner "${OSV_FLAGS[@]}" | jq -c '.results[].packages[] | .package.name as $vulnerablePackage | {
   name: $vulnerablePackage,
   current: .package.version,
   fixedVersions: [.vulnerabilities[].affected[] | select(.package.name == $vulnerablePackage) | .ranges[].events |


### PR DESCRIPTION
Earlier try didn't fix the issue when provided `OSV_SCANNER_ADDITIONAL_OPTS` env var war empty (as it's in the case of our CI). Now we are handling explicitly parsing of this env var, which should fix `update-vulnerable-dependencies.sh` script.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - https://github.com/kumahq/kuma/pull/11181
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Manually tested
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
