### PR TITLE
docs(meshtls): design of MeshTLS

### DIFF
--- a/docs/madr/decisions/061-meshtls.md
+++ b/docs/madr/decisions/061-meshtls.md
@@ -1,0 +1,7 @@
+# {short title of solved problem and solution}
+
+* Status: accepted
+
+Technical Story: https://github.com/kumahq/kuma/issues/4622
+
+Contents: https://docs.google.com/document/d/1zA1q1hD3PN7c1EsnxkwggtBR08-8i5voZG3yNJyjQfI/edit#heading=h.n6cmlf1eel2z


### PR DESCRIPTION
### Checklist prior to review

https://docs.google.com/document/d/1zA1q1hD3PN7c1EsnxkwggtBR08-8i5voZG3yNJyjQfI/edit#heading=h.n6cmlf1eel2z

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues -- closes https://github.com/kumahq/kuma/issues/4622
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
