### PR TITLE
fix(MeshPassthrough): don't only route /

### DIFF
--- a/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/testdata/basic.listener.golden.yaml
+++ b/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/testdata/basic.listener.golden.yaml
@@ -125,7 +125,7 @@ resources:
               name: 192.168.19.1
               routes:
               - match:
-                  path: /
+                  prefix: /
                 route:
                   cluster: meshpassthrough_192.168.19.1_10000
             - domains:
@@ -162,7 +162,7 @@ resources:
               name: example.com
               routes:
               - match:
-                  path: /
+                  prefix: /
                 route:
                   cluster: meshpassthrough_example.com_8080
             - domains:
@@ -170,7 +170,7 @@ resources:
               name: http2.com
               routes:
               - match:
-                  path: /
+                  prefix: /
                 route:
                   cluster: meshpassthrough_http2.com_8080
             - domains:
@@ -178,7 +178,7 @@ resources:
               name: other.com
               routes:
               - match:
-                  path: /
+                  prefix: /
                 route:
                   cluster: meshpassthrough_other.com_8080
             - domains:
@@ -219,7 +219,7 @@ resources:
               name: grpcdomain.com
               routes:
               - match:
-                  path: /
+                  prefix: /
                 route:
                   cluster: meshpassthrough_grpcdomain.com_19000
             - domains:
@@ -398,7 +398,7 @@ resources:
               name: example.com
               routes:
               - match:
-                  path: /
+                  prefix: /
                 route:
                   cluster: meshpassthrough_example.com_8080
             - domains:
@@ -406,7 +406,7 @@ resources:
               name: http2.com
               routes:
               - match:
-                  path: /
+                  prefix: /
                 route:
                   cluster: meshpassthrough_http2.com_8080
             - domains:
@@ -414,7 +414,7 @@ resources:
               name: other.com
               routes:
               - match:
-                  path: /
+                  prefix: /
                 route:
                   cluster: meshpassthrough_other.com_8080
             - domains:
@@ -455,7 +455,7 @@ resources:
               name: grpcdomain.com
               routes:
               - match:
-                  path: /
+                  prefix: /
                 route:
                   cluster: meshpassthrough_grpcdomain.com_19000
             - domains:

--- a/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/testdata/simple.listener.golden.yaml
+++ b/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/testdata/simple.listener.golden.yaml
@@ -41,7 +41,7 @@ resources:
               name: api.example.com
               routes:
               - match:
-                  path: /
+                  prefix: /
                 route:
                   cluster: meshpassthrough_api.example.com_80
             - domains:
@@ -95,7 +95,7 @@ resources:
               name: api.example.com
               routes:
               - match:
-                  path: /
+                  prefix: /
                 route:
                   cluster: meshpassthrough_api.example.com_80
             - domains:

--- a/pkg/xds/envoy/virtualhosts/route_configurer.go
+++ b/pkg/xds/envoy/virtualhosts/route_configurer.go
@@ -64,8 +64,8 @@ type VirtualHostBasicRouteConfigurer struct {
 func (c VirtualHostBasicRouteConfigurer) Configure(virtualHost *envoy_config_route_v3.VirtualHost) error {
 	virtualHost.Routes = append(virtualHost.Routes, &envoy_config_route_v3.Route{
 		Match: &envoy_config_route_v3.RouteMatch{
-			PathSpecifier: &envoy_config_route_v3.RouteMatch_Path{
-				Path: "/",
+			PathSpecifier: &envoy_config_route_v3.RouteMatch_Prefix{
+				Prefix: "/",
 			},
 		},
 		Action: &envoy_config_route_v3.Route_Route{


### PR DESCRIPTION
The basic route configurer is only used by MeshPassthrough

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- Fixes https://github.com/kumahq/kuma/issues/11201
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
