### PR TITLE
feat(MeshService): automatically add port name when generating

### DIFF
--- a/pkg/core/resources/apis/meshservice/generate/generator.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 	"reflect"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -81,7 +82,12 @@ func (g *Generator) meshServicesForDataplane(dataplane *core_mesh.DataplaneResou
 		if !hasProtocol {
 			appProtocol = core_mesh.ProtocolTCP
 		}
+		portName := inbound.Name
+		if portName == "" {
+			portName = strconv.Itoa(int(inbound.Port))
+		}
 		port := meshservice_api.Port{
+			Name:        portName,
 			Port:        inbound.Port,
 			TargetPort:  intstr.FromInt(int(inbound.Port)),
 			AppProtocol: core_mesh.Protocol(appProtocol),

--- a/pkg/core/resources/apis/meshservice/generate/generator_test.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator_test.go
@@ -92,6 +92,32 @@ var _ = Describe("MeshService generator", func() {
 			g.Expect(resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))).To(Succeed())
 			g.Expect(ms.Spec.Ports).To(Equal([]meshservice_api.Port{
 				{
+					Name:        "80",
+					Port:        80,
+					TargetPort:  intstr.FromInt(80),
+					AppProtocol: core_mesh.ProtocolTCP,
+				},
+			}))
+		}, "2s", "100ms").Should(Succeed())
+	})
+
+	It("should generate MeshService from a single Dataplane with inbound name", func() {
+		err := samples.DataplaneBackendBuilder().WithoutInbounds().
+			AddInbound(
+				builders.Inbound().
+					WithPort(builders.FirstInboundPort).
+					WithServicePort(builders.FirstInboundServicePort).
+					WithName("main").
+					WithTags(map[string]string{mesh_proto.ServiceTag: "backend", mesh_proto.ProtocolTag: "tcp"}),
+			).Create(resManager)
+		Expect(err).ToNot(HaveOccurred())
+
+		Eventually(func(g Gomega) {
+			ms := meshservice_api.NewMeshServiceResource()
+			g.Expect(resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))).To(Succeed())
+			g.Expect(ms.Spec.Ports).To(Equal([]meshservice_api.Port{
+				{
+					Name:        "main",
 					Port:        80,
 					TargetPort:  intstr.FromInt(80),
 					AppProtocol: core_mesh.ProtocolTCP,
@@ -110,6 +136,7 @@ var _ = Describe("MeshService generator", func() {
 			g.Expect(resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))).To(Succeed())
 			g.Expect(ms.Spec.Ports).To(Equal([]meshservice_api.Port{
 				{
+					Name:        "80",
 					Port:        80,
 					TargetPort:  intstr.FromInt(80),
 					AppProtocol: core_mesh.ProtocolTCP,
@@ -133,6 +160,7 @@ var _ = Describe("MeshService generator", func() {
 			g.Expect(resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))).To(Succeed())
 			g.Expect(ms.Spec.Ports).To(Equal([]meshservice_api.Port{
 				{
+					Name:        "80",
 					Port:        80,
 					TargetPort:  intstr.FromInt(80),
 					AppProtocol: core_mesh.ProtocolTCP,
@@ -151,6 +179,7 @@ var _ = Describe("MeshService generator", func() {
 			g.Expect(resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))).To(Succeed())
 			g.Expect(ms.Spec.Ports).To(Equal([]meshservice_api.Port{
 				{
+					Name:        "80",
 					Port:        80,
 					TargetPort:  intstr.FromInt(80),
 					AppProtocol: core_mesh.ProtocolTCP,
@@ -168,6 +197,7 @@ var _ = Describe("MeshService generator", func() {
 			g.Expect(resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))).To(Succeed())
 			g.Expect(ms.Spec.Ports).To(Equal([]meshservice_api.Port{
 				{
+					Name:        "81",
 					Port:        81,
 					TargetPort:  intstr.FromInt(81),
 					AppProtocol: core_mesh.ProtocolTCP,
@@ -186,6 +216,7 @@ var _ = Describe("MeshService generator", func() {
 			g.Expect(resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))).To(Succeed())
 			g.Expect(ms.Spec.Ports).To(Equal([]meshservice_api.Port{
 				{
+					Name:        "80",
 					Port:        80,
 					TargetPort:  intstr.FromInt(80),
 					AppProtocol: core_mesh.ProtocolTCP,
@@ -223,6 +254,7 @@ var _ = Describe("MeshService generator", func() {
 			g.Expect(resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))).To(Succeed())
 			g.Expect(ms.Spec.Ports).To(Equal([]meshservice_api.Port{
 				{
+					Name:        "80",
 					Port:        80,
 					TargetPort:  intstr.FromInt(80),
 					AppProtocol: core_mesh.ProtocolTCP,
@@ -262,6 +294,7 @@ var _ = Describe("MeshService generator", func() {
 			g.Expect(resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))).To(Succeed())
 			g.Expect(ms.Spec.Ports).To(Equal([]meshservice_api.Port{
 				{
+					Name:        "80",
 					Port:        80,
 					TargetPort:  intstr.FromInt(80),
 					AppProtocol: core_mesh.ProtocolTCP,

--- a/pkg/plugins/runtime/k8s/controllers/meshservice_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/meshservice_controller.go
@@ -371,8 +371,12 @@ func (r *MeshServiceReconciler) manageMeshService(
 				unsupportedPorts = append(unsupportedPorts, portName)
 				continue
 			}
+			portName := port.Name
+			if portName == "" {
+				portName = strconv.Itoa(int(port.Port))
+			}
 			ms.Spec.Ports = append(ms.Spec.Ports, meshservice_api.Port{
-				Name:        port.Name,
+				Name:        portName,
 				Port:        uint32(port.Port),
 				TargetPort:  port.TargetPort,
 				AppProtocol: core_mesh.Protocol(pointer.DerefOr(port.AppProtocol, "tcp")),

--- a/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/02.meshservice.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/02.meshservice.yaml
@@ -18,9 +18,11 @@ items:
   spec:
     ports:
     - appProtocol: http
+      name: "80"
       port: 80
       targetPort: 8080
     - appProtocol: tcp
+      name: "443"
       port: 443
       targetPort: 8443
     selector:

--- a/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/headless.meshservice.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/headless.meshservice.yaml
@@ -20,9 +20,11 @@ items:
   spec:
     ports:
     - appProtocol: http
+      name: "80"
       port: 80
       targetPort: 8080
     - appProtocol: tcp
+      name: "443"
       port: 443
       targetPort: 8443
     selector:
@@ -54,9 +56,11 @@ items:
   spec:
     ports:
     - appProtocol: http
+      name: "80"
       port: 80
       targetPort: 8080
     - appProtocol: tcp
+      name: "443"
       port: 443
       targetPort: 8443
     selector:
@@ -86,9 +90,11 @@ items:
   spec:
     ports:
     - appProtocol: http
+      name: "80"
       port: 80
       targetPort: 8080
     - appProtocol: tcp
+      name: "443"
       port: 443
       targetPort: 8443
     selector:

--- a/pkg/test/resources/builders/dataplane_builder.go
+++ b/pkg/test/resources/builders/dataplane_builder.go
@@ -249,6 +249,11 @@ func (b *InboundBuilder) WithPort(port uint32) *InboundBuilder {
 	return b
 }
 
+func (b *InboundBuilder) WithName(name string) *InboundBuilder {
+	b.res.Name = name
+	return b
+}
+
 func (b *InboundBuilder) WithServicePort(port uint32) *InboundBuilder {
 	b.res.ServicePort = port
 	return b


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- Part of #11208
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
