### PR TITLE
test(unit): regenerate golden files after merge

### DIFF
--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshexternalservice/01.golden.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshexternalservice/01.golden.yaml
@@ -1,5 +1,6 @@
 ResourceRules:
   meshexternalservice:mesh/mesh-1:name/mes:
+    BackendRefOriginIndex: {}
     Conf:
     - http:
         numRetries: 5
@@ -21,7 +22,8 @@ ResourceRules:
       type: MeshExternalService
     ResourceSectionName: ""
 Rules:
-- Conf:
+- BackendRefOriginIndex: {}
+  Conf:
     http:
       numRetries: 3
   Origin:

--- a/pkg/plugins/policies/core/rules/testdata/resourcerules/mretry_with_mes.global-k8s-2-zone-k8s.golden.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/resourcerules/mretry_with_mes.global-k8s-2-zone-k8s.golden.yaml
@@ -1,4 +1,5 @@
 mesh:name/mesh-1:
+  BackendRefOriginIndex: {}
   Conf:
   - http:
       backOff:
@@ -29,6 +30,7 @@ mesh:name/mesh-1:
     type: Mesh
   ResourceSectionName: ""
 meshexternalservice:mesh/mesh-1:namespace/ns-k8s:name/external:
+  BackendRefOriginIndex: {}
   Conf:
   - http:
       backOff:

--- a/pkg/plugins/policies/core/rules/testdata/resourcerules/mretry_with_mes.global-k8s-2-zone-uni.golden.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/resourcerules/mretry_with_mes.global-k8s-2-zone-uni.golden.yaml
@@ -1,4 +1,5 @@
 mesh:name/mesh-1:
+  BackendRefOriginIndex: {}
   Conf:
   - http:
       backOff:
@@ -27,6 +28,7 @@ mesh:name/mesh-1:
     type: Mesh
   ResourceSectionName: ""
 meshexternalservice:mesh/mesh-1:namespace/ns-k8s:name/external:
+  BackendRefOriginIndex: {}
   Conf:
   - http:
       backOff:

--- a/pkg/plugins/policies/core/rules/testdata/resourcerules/mretry_with_mes.global-k8s.golden.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/resourcerules/mretry_with_mes.global-k8s.golden.yaml
@@ -1,4 +1,5 @@
 mesh:name/mesh-1:
+  BackendRefOriginIndex: {}
   Conf:
   - http:
       backOff:
@@ -29,6 +30,7 @@ mesh:name/mesh-1:
     type: Mesh
   ResourceSectionName: ""
 meshexternalservice:mesh/mesh-1:namespace/ns-k8s:name/external:
+  BackendRefOriginIndex: {}
   Conf:
   - http:
       backOff:

--- a/pkg/plugins/policies/core/rules/testdata/resourcerules/mretry_with_mes.global-uni-2-zone-k8s.golden.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/resourcerules/mretry_with_mes.global-uni-2-zone-k8s.golden.yaml
@@ -1,4 +1,5 @@
 mesh:name/mesh-1:
+  BackendRefOriginIndex: {}
   Conf:
   - http:
       backOff:
@@ -27,6 +28,7 @@ mesh:name/mesh-1:
     type: Mesh
   ResourceSectionName: ""
 meshexternalservice:mesh/mesh-1:name/external:
+  BackendRefOriginIndex: {}
   Conf:
   - http:
       backOff:

--- a/pkg/plugins/policies/core/rules/testdata/resourcerules/mretry_with_mes.global-uni-2-zone-uni.golden.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/resourcerules/mretry_with_mes.global-uni-2-zone-uni.golden.yaml
@@ -1,4 +1,5 @@
 mesh:name/mesh-1:
+  BackendRefOriginIndex: {}
   Conf:
   - http:
       backOff:
@@ -25,6 +26,7 @@ mesh:name/mesh-1:
     type: Mesh
   ResourceSectionName: ""
 meshexternalservice:mesh/mesh-1:name/external:
+  BackendRefOriginIndex: {}
   Conf:
   - http:
       backOff:

--- a/pkg/plugins/policies/core/rules/testdata/resourcerules/mretry_with_mes.global-uni.golden.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/resourcerules/mretry_with_mes.global-uni.golden.yaml
@@ -1,4 +1,5 @@
 mesh:name/mesh-1:
+  BackendRefOriginIndex: {}
   Conf:
   - http:
       backOff:
@@ -25,6 +26,7 @@ mesh:name/mesh-1:
     type: Mesh
   ResourceSectionName: ""
 meshexternalservice:mesh/mesh-1:name/external:
+  BackendRefOriginIndex: {}
   Conf:
   - http:
       backOff:

--- a/pkg/plugins/policies/core/rules/testdata/resourcerules/mretry_with_mes.zone-k8s-2-global-k8s.golden.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/resourcerules/mretry_with_mes.zone-k8s-2-global-k8s.golden.yaml
@@ -1,4 +1,5 @@
 mesh:name/mesh-1:
+  BackendRefOriginIndex: {}
   Conf:
   - http:
       backOff:
@@ -30,6 +31,7 @@ mesh:name/mesh-1:
     type: Mesh
   ResourceSectionName: ""
 meshexternalservice:mesh/mesh-1:zone/zone-k8s:namespace/ns-k8s:name/external:
+  BackendRefOriginIndex: {}
   Conf:
   - http:
       backOff:

--- a/pkg/plugins/policies/core/rules/testdata/resourcerules/mretry_with_mes.zone-k8s-2-global-uni.golden.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/resourcerules/mretry_with_mes.zone-k8s-2-global-uni.golden.yaml
@@ -1,4 +1,5 @@
 mesh:name/mesh-1:
+  BackendRefOriginIndex: {}
   Conf:
   - http:
       backOff:
@@ -28,6 +29,7 @@ mesh:name/mesh-1:
     type: Mesh
   ResourceSectionName: ""
 meshexternalservice:mesh/mesh-1:zone/zone-k8s:namespace/ns-k8s:name/external:
+  BackendRefOriginIndex: {}
   Conf:
   - http:
       backOff:

--- a/pkg/plugins/policies/core/rules/testdata/resourcerules/mretry_with_mes.zone-k8s-2-zone-k8s.golden.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/resourcerules/mretry_with_mes.zone-k8s-2-zone-k8s.golden.yaml
@@ -1,4 +1,5 @@
 mesh:name/mesh-1:
+  BackendRefOriginIndex: {}
   Conf:
   - http:
       backOff:
@@ -30,6 +31,7 @@ mesh:name/mesh-1:
     type: Mesh
   ResourceSectionName: ""
 meshexternalservice:mesh/mesh-1:zone/zone-k8s:namespace/ns-k8s:name/external:
+  BackendRefOriginIndex: {}
   Conf:
   - http:
       backOff:

--- a/pkg/plugins/policies/core/rules/testdata/resourcerules/mretry_with_mes.zone-k8s-2-zone-uni.golden.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/resourcerules/mretry_with_mes.zone-k8s-2-zone-uni.golden.yaml
@@ -1,4 +1,5 @@
 mesh:name/mesh-1:
+  BackendRefOriginIndex: {}
   Conf:
   - http:
       backOff:
@@ -28,6 +29,7 @@ mesh:name/mesh-1:
     type: Mesh
   ResourceSectionName: ""
 meshexternalservice:mesh/mesh-1:zone/zone-k8s:namespace/ns-k8s:name/external:
+  BackendRefOriginIndex: {}
   Conf:
   - http:
       backOff:

--- a/pkg/plugins/policies/core/rules/testdata/resourcerules/mretry_with_mes.zone-k8s.golden.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/resourcerules/mretry_with_mes.zone-k8s.golden.yaml
@@ -1,4 +1,5 @@
 mesh:name/mesh-1:
+  BackendRefOriginIndex: {}
   Conf:
   - http:
       backOff:
@@ -30,6 +31,7 @@ mesh:name/mesh-1:
     type: Mesh
   ResourceSectionName: ""
 meshexternalservice:mesh/mesh-1:zone/zone-k8s:namespace/ns-k8s:name/external:
+  BackendRefOriginIndex: {}
   Conf:
   - http:
       backOff:

--- a/pkg/plugins/policies/core/rules/testdata/resourcerules/mretry_with_mes.zone-uni-2-global-k8s.golden.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/resourcerules/mretry_with_mes.zone-uni-2-global-k8s.golden.yaml
@@ -1,4 +1,5 @@
 mesh:name/mesh-1:
+  BackendRefOriginIndex: {}
   Conf:
   - http:
       backOff:
@@ -28,6 +29,7 @@ mesh:name/mesh-1:
     type: Mesh
   ResourceSectionName: ""
 meshexternalservice:mesh/mesh-1:zone/zone-uni:name/external:
+  BackendRefOriginIndex: {}
   Conf:
   - http:
       backOff:

--- a/pkg/plugins/policies/core/rules/testdata/resourcerules/mretry_with_mes.zone-uni-2-global-uni.golden.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/resourcerules/mretry_with_mes.zone-uni-2-global-uni.golden.yaml
@@ -1,4 +1,5 @@
 mesh:name/mesh-1:
+  BackendRefOriginIndex: {}
   Conf:
   - http:
       backOff:
@@ -26,6 +27,7 @@ mesh:name/mesh-1:
     type: Mesh
   ResourceSectionName: ""
 meshexternalservice:mesh/mesh-1:zone/zone-uni:name/external:
+  BackendRefOriginIndex: {}
   Conf:
   - http:
       backOff:

--- a/pkg/plugins/policies/core/rules/testdata/resourcerules/mretry_with_mes.zone-uni-2-zone-k8s.golden.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/resourcerules/mretry_with_mes.zone-uni-2-zone-k8s.golden.yaml
@@ -1,4 +1,5 @@
 mesh:name/mesh-1:
+  BackendRefOriginIndex: {}
   Conf:
   - http:
       backOff:
@@ -28,6 +29,7 @@ mesh:name/mesh-1:
     type: Mesh
   ResourceSectionName: ""
 meshexternalservice:mesh/mesh-1:zone/zone-uni:name/external:
+  BackendRefOriginIndex: {}
   Conf:
   - http:
       backOff:

--- a/pkg/plugins/policies/core/rules/testdata/resourcerules/mretry_with_mes.zone-uni-2-zone-uni.golden.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/resourcerules/mretry_with_mes.zone-uni-2-zone-uni.golden.yaml
@@ -1,4 +1,5 @@
 mesh:name/mesh-1:
+  BackendRefOriginIndex: {}
   Conf:
   - http:
       backOff:
@@ -26,6 +27,7 @@ mesh:name/mesh-1:
     type: Mesh
   ResourceSectionName: ""
 meshexternalservice:mesh/mesh-1:zone/zone-uni:name/external:
+  BackendRefOriginIndex: {}
   Conf:
   - http:
       backOff:

--- a/pkg/plugins/policies/core/rules/testdata/resourcerules/mretry_with_mes.zone-uni.golden.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/resourcerules/mretry_with_mes.zone-uni.golden.yaml
@@ -1,4 +1,5 @@
 mesh:name/mesh-1:
+  BackendRefOriginIndex: {}
   Conf:
   - http:
       backOff:
@@ -26,6 +27,7 @@ mesh:name/mesh-1:
     type: Mesh
   ResourceSectionName: ""
 meshexternalservice:mesh/mesh-1:zone/zone-uni:name/external:
+  BackendRefOriginIndex: {}
   Conf:
   - http:
       backOff:


### PR DESCRIPTION
### Checklist prior to review

After a merge files needs to be regenerated.

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
