### PR TITLE
feat(policy): add possibility to target real MeshService in MeshAccessLog policy

### DIFF
--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
@@ -6,8 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
-
 	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+
 	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -14,9 +16,9 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	core_rules "github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
-	policies_xds "github.com/kumahq/kuma/pkg/plugins/policies/core/xds"
 	api "github.com/kumahq/kuma/pkg/plugins/policies/meshaccesslog/api/v1alpha1"
 	plugin "github.com/kumahq/kuma/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1"
 	gateway_plugin "github.com/kumahq/kuma/pkg/plugins/runtime/gateway"
@@ -35,6 +37,17 @@ import (
 )
 
 var _ = Describe("MeshAccessLog", func() {
+	backendMeshServiceIdentifier := core_rules.UniqueResourceIdentifier{
+		ResourceIdentifier: core_model.ResourceIdentifier{
+			Name:      "backend",
+			Mesh:      "default",
+			Namespace: "backend-ns",
+			Zone:      "zone-1",
+		},
+		ResourceType: "MeshService",
+		SectionName:  "",
+	}
+
 	type sidecarTestCase struct {
 		resources         []core_xds.Resource
 		outbounds         core_xds.Outbounds
@@ -45,6 +58,7 @@ var _ = Describe("MeshAccessLog", func() {
 	}
 	DescribeTable("should generate proper Envoy config",
 		func(given sidecarTestCase) {
+			// given
 			resourceSet := core_xds.NewResourceSet()
 			for _, res := range given.resources {
 				r := res
@@ -77,11 +91,18 @@ var _ = Describe("MeshAccessLog", func() {
 					xds_builders.MatchedPolicies().WithPolicy(api.MeshAccessLogType, given.toRules, given.fromRules),
 				).
 				Build()
+
+			// when
 			plugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
 
+			// then
 			Expect(plugin.Apply(resourceSet, xdsCtx, proxy)).To(Succeed())
-			policies_xds.ResourceArrayShouldEqual(resourceSet.ListOf(envoy_resource.ListenerType), given.expectedListeners)
-			policies_xds.ResourceArrayShouldEqual(resourceSet.ListOf(envoy_resource.ClusterType), given.expectedClusters)
+			for i, expectedListener := range given.expectedListeners {
+				Expect(util_proto.ToYAML(resourceSet.ListOf(envoy_resource.ListenerType)[i].Resource)).To(matchers.MatchGoldenYAML(filepath.Join("testdata", expectedListener)))
+			}
+			for i, expectedCluster := range given.expectedClusters {
+				Expect(util_proto.ToYAML(resourceSet.ListOf(envoy_resource.ClusterType)[i].Resource)).To(matchers.MatchGoldenYAML(filepath.Join("testdata", expectedCluster)))
+			}
 		},
 		Entry("basic outbound route", sidecarTestCase{
 			resources: []core_xds.Resource{{
@@ -122,51 +143,50 @@ var _ = Describe("MeshAccessLog", func() {
 					},
 				},
 			},
-			expectedListeners: []string{
-				`
-            address:
-              socketAddress:
-                address: 127.0.0.1
-                portValue: 27777
-            filterChains:
-            - filters:
-              - name: envoy.filters.network.http_connection_manager
-                typedConfig:
-                  '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                  accessLog:
-                  - name: envoy.access_loggers.file
-                    typedConfig:
-                      '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
-                      logFormat:
-                          textFormatSource:
-                              inlineString: |
-                                [%START_TIME%] default "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-B3-TRACEID?X-DATADOG-TRACEID)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "backend" "other-service" "127.0.0.1" "%UPSTREAM_HOST%"
-                      path: /tmp/log
-                  httpFilters:
-                  - name: envoy.filters.http.router
-                    typedConfig:
-                      '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-                  routeConfig:
-                    name: outbound:backend
-                    validateClusters: false
-                    requestHeadersToAdd:
-                    - header:
-                        key: x-kuma-tags
-                        value: '&kuma.io/service=web&'
-                    virtualHosts:
-                    - domains:
-                      - '*'
-                      name: backend
-                      routes:
-                      - match:
-                          prefix: /
-                        route:
-                          cluster: backend
-                          timeout: 0s
-                  statPrefix: "127_0_0_1_27777"
-            name: outbound:127.0.0.1:27777
-            trafficDirection: OUTBOUND`,
+			expectedListeners: []string{"basic_outbound.listener.golden.yaml"},
+		}),
+		Entry("basic outbound route from real MeshService", sidecarTestCase{
+			resources: []core_xds.Resource{{
+				Name:   "outbound",
+				Origin: generator.OriginOutbound,
+				Resource: NewOutboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 27777, core_xds.SocketAddressProtocolTCP).
+					Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3, envoy_common.AnonymousResource).
+						Configure(HttpConnectionManager("127.0.0.1:27777", false)).
+						Configure(
+							HttpOutboundRoute(
+								"backend",
+								envoy_common.Routes{{
+									Clusters: []envoy_common.Cluster{envoy_common.NewCluster(
+										envoy_common.WithService("backend"),
+										envoy_common.WithWeight(100),
+									)},
+								}},
+								map[string]map[string]bool{
+									"kuma.io/service": {
+										"web": true,
+									},
+								},
+							),
+						),
+					)).MustBuild(),
+				ResourceOrigin: &backendMeshServiceIdentifier,
+			}},
+			toRules: core_rules.ToRules{
+				ResourceRules: map[core_rules.UniqueResourceIdentifier]core_rules.ResourceRule{
+					backendMeshServiceIdentifier: {
+						Conf: []interface{}{
+							api.Conf{
+								Backends: &[]api.Backend{{
+									File: &api.FileBackend{
+										Path: "/tmp/log",
+									},
+								}},
+							},
+						},
+					},
+				},
 			},
+			expectedListeners: []string{"basic_outbound_real_meshservice.listener.golden.yaml"},
 		}),
 		Entry("outbound tcpproxy with file backend and default format", sidecarTestCase{
 			resources: []core_xds.Resource{{
@@ -197,31 +217,7 @@ var _ = Describe("MeshAccessLog", func() {
 					},
 				},
 			},
-			expectedListeners: []string{
-				`
-            address:
-              socketAddress:
-                address: 127.0.0.1
-                portValue: 27777
-            filterChains:
-                - filters:
-                    - name: envoy.filters.network.tcp_proxy
-                      typedConfig:
-                        '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-                        accessLog:
-                            - name: envoy.access_loggers.file
-                              typedConfig:
-                                '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
-                                logFormat:
-                                    textFormatSource:
-                                        inlineString: |
-                                            [%START_TIME%] %RESPONSE_FLAGS% default 127.0.0.1(backend)->%UPSTREAM_HOST%(other-service) took %DURATION%ms, sent %BYTES_SENT% bytes, received: %BYTES_RECEIVED% bytes
-                                path: /tmp/log
-                        cluster: backend
-                        statPrefix: "127_0_0_1_27777"
-            name: outbound:127.0.0.1:27777
-            trafficDirection: OUTBOUND`,
-			},
+			expectedListeners: []string{"outbound_file_backend_default_format.listener.golden.yaml"},
 		}),
 		Entry("outbound tcpproxy with file backend and plain format", sidecarTestCase{
 			resources: []core_xds.Resource{{
@@ -255,31 +251,7 @@ var _ = Describe("MeshAccessLog", func() {
 					},
 				},
 			},
-			expectedListeners: []string{
-				`
-            address:
-              socketAddress:
-                address: 127.0.0.1
-                portValue: 27777
-            filterChains:
-                - filters:
-                    - name: envoy.filters.network.tcp_proxy
-                      typedConfig:
-                        '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-                        accessLog:
-                            - name: envoy.access_loggers.file
-                              typedConfig:
-                                '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
-                                logFormat:
-                                    textFormatSource:
-                                        inlineString: |
-                                            custom format [%START_TIME%] %RESPONSE_FLAGS%
-                                path: /tmp/log
-                        cluster: backend
-                        statPrefix: "127_0_0_1_27777"
-            name: outbound:127.0.0.1:27777
-            trafficDirection: OUTBOUND`,
-			},
+			expectedListeners: []string{"outbound_file_backend_plain_format.listener.golden.yaml"},
 		}),
 		Entry("outbound tcpproxy with file backend and json format", sidecarTestCase{
 			resources: []core_xds.Resource{{
@@ -316,31 +288,7 @@ var _ = Describe("MeshAccessLog", func() {
 					},
 				},
 			},
-			expectedListeners: []string{
-				`
-            address:
-              socketAddress:
-                address: 127.0.0.1
-                portValue: 27777
-            filterChains:
-                - filters:
-                    - name: envoy.filters.network.tcp_proxy
-                      typedConfig:
-                        '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-                        accessLog:
-                            - name: envoy.access_loggers.file
-                              typedConfig:
-                                '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
-                                logFormat:
-                                    jsonFormat:
-                                      duration: '%DURATION%'
-                                      protocol: '%PROTOCOL%'
-                                path: /tmp/log
-                        cluster: backend
-                        statPrefix: "127_0_0_1_27777"
-            name: outbound:127.0.0.1:27777
-            trafficDirection: OUTBOUND`,
-			},
+			expectedListeners: []string{"outbound_file_backend_json_format.listener.golden.yaml"},
 		}),
 		Entry("outbound tcpproxy with tcp backend and default format", sidecarTestCase{
 			resources: []core_xds.Resource{{
@@ -371,32 +319,7 @@ var _ = Describe("MeshAccessLog", func() {
 					},
 				},
 			},
-			expectedListeners: []string{
-				`
-            address:
-              socketAddress:
-                address: 127.0.0.1
-                portValue: 27777
-            filterChains:
-                - filters:
-                    - name: envoy.filters.network.tcp_proxy
-                      typedConfig:
-                        '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-                        accessLog:
-                            - name: envoy.access_loggers.file
-                              typedConfig:
-                                '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
-                                logFormat:
-                                    jsonFormat:
-                                        address: logging.backend
-                                        message: |
-                                            [%START_TIME%] %RESPONSE_FLAGS% default 127.0.0.1(backend)->%UPSTREAM_HOST%(other-service) took %DURATION%ms, sent %BYTES_SENT% bytes, received: %BYTES_RECEIVED% bytes
-                                path: /tmp/kuma-al-backend-default.sock
-                        cluster: backend
-                        statPrefix: "127_0_0_1_27777"
-            name: outbound:127.0.0.1:27777
-            trafficDirection: OUTBOUND`,
-			},
+			expectedListeners: []string{"outbound_tcp_backend_default_format.listener.golden.yaml"},
 		}),
 		Entry("outbound tcpproxy with opentelemetry backend and plain format", sidecarTestCase{
 			resources: []core_xds.Resource{{
@@ -505,132 +428,13 @@ var _ = Describe("MeshAccessLog", func() {
 				},
 			},
 			expectedClusters: []string{
-				`
-            altStatName: meshaccesslog_opentelemetry_0
-            connectTimeout: 5s
-            dnsLookupFamily: V4_ONLY
-            loadAssignment:
-                clusterName: meshaccesslog:opentelemetry:0
-                endpoints:
-                    - lbEndpoints:
-                        - endpoint:
-                            address:
-                                socketAddress:
-                                    address: otel-collector
-                                    portValue: 4317
-            name: meshaccesslog:opentelemetry:0
-            type: STRICT_DNS
-            typedExtensionProtocolOptions:
-                envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-                    '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-                    explicitHttpConfig:
-                        http2ProtocolOptions: {}
-            `, `
-            altStatName: meshaccesslog_opentelemetry_1
-            connectTimeout: 5s
-            dnsLookupFamily: V4_ONLY
-            loadAssignment:
-                clusterName: meshaccesslog:opentelemetry:1
-                endpoints:
-                    - lbEndpoints:
-                        - endpoint:
-                            address:
-                                socketAddress:
-                                    address: other-otel-collector
-                                    portValue: 5317
-            name: meshaccesslog:opentelemetry:1
-            type: STRICT_DNS
-            typedExtensionProtocolOptions:
-                envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-                    '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-                    explicitHttpConfig:
-                        http2ProtocolOptions: {}
-            `,
+				"outbound_otel_backend_plain_format.cluster.golden.yaml",
+				"outbound_otel_backend_plain_format_1.cluster.golden.yaml",
 			},
 			expectedListeners: []string{
-				`
-            address:
-              socketAddress:
-                address: 127.0.0.1
-                portValue: 27779
-            filterChains:
-                - filters:
-                    - name: envoy.filters.network.tcp_proxy
-                      typedConfig:
-                        '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-                        accessLog:
-                            - name: envoy.access_loggers.open_telemetry
-                              typedConfig:
-                                '@type': type.googleapis.com/envoy.extensions.access_loggers.open_telemetry.v3.OpenTelemetryAccessLogConfig
-                                body:
-                                    kvlistValue:
-                                        values:
-                                            - key: mesh
-                                              value:
-                                                  stringValue: default
-                                attributes: {}
-                                commonConfig:
-                                    grpcService:
-                                        envoyGrpc:
-                                            clusterName: meshaccesslog:opentelemetry:1
-                                    logName: MeshAccessLog
-                                    transportApiVersion: V3
-                        cluster: bar-service
-                        statPrefix: "127_0_0_1_27779"
-            name: outbound:127.0.0.1:27779
-            trafficDirection: OUTBOUND`, `
-            address:
-              socketAddress:
-                address: 127.0.0.1
-                portValue: 27778
-            filterChains:
-                - filters:
-                    - name: envoy.filters.network.tcp_proxy
-                      typedConfig:
-                        '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-                        accessLog:
-                            - name: envoy.access_loggers.open_telemetry
-                              typedConfig:
-                                '@type': type.googleapis.com/envoy.extensions.access_loggers.open_telemetry.v3.OpenTelemetryAccessLogConfig
-                                body:
-                                    stringValue: default
-                                attributes: {}
-                                commonConfig:
-                                    grpcService:
-                                        envoyGrpc:
-                                            clusterName: meshaccesslog:opentelemetry:0
-                                    logName: MeshAccessLog
-                                    transportApiVersion: V3
-                        cluster: foo-service
-                        statPrefix: "127_0_0_1_27778"
-            name: outbound:127.0.0.1:27778
-            trafficDirection: OUTBOUND`, `
-            address:
-              socketAddress:
-                address: 127.0.0.1
-                portValue: 27777
-            filterChains:
-                - filters:
-                    - name: envoy.filters.network.tcp_proxy
-                      typedConfig:
-                        '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-                        accessLog:
-                            - name: envoy.access_loggers.open_telemetry
-                              typedConfig:
-                                '@type': type.googleapis.com/envoy.extensions.access_loggers.open_telemetry.v3.OpenTelemetryAccessLogConfig
-                                body:
-                                    stringValue: '[%START_TIME%] %RESPONSE_FLAGS% default 127.0.0.1(backend)->%UPSTREAM_HOST%(other-service) took %DURATION%ms, sent %BYTES_SENT% bytes, received: %BYTES_RECEIVED% bytes'
-                                attributes: {}
-                                commonConfig:
-                                    grpcService:
-                                        envoyGrpc:
-                                            clusterName: meshaccesslog:opentelemetry:0
-                                    logName: MeshAccessLog
-                                    transportApiVersion: V3
-                        cluster: other-service
-                        statPrefix: "127_0_0_1_27777"
-            name: outbound:127.0.0.1:27777
-            trafficDirection: OUTBOUND`,
+				"outbound_otel_backend_plain_format.listener.golden.yaml",
+				"outbound_otel_backend_plain_format_1.listener.golden.yaml",
+				"outbound_otel_backend_plain_format_2.listener.golden.yaml",
 			},
 		}),
 		Entry("outbound tcpproxy with tcp backend and plain format", sidecarTestCase{
@@ -665,32 +469,7 @@ var _ = Describe("MeshAccessLog", func() {
 					},
 				},
 			},
-			expectedListeners: []string{
-				`
-            address:
-              socketAddress:
-                address: 127.0.0.1
-                portValue: 27777
-            filterChains:
-                - filters:
-                    - name: envoy.filters.network.tcp_proxy
-                      typedConfig:
-                        '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-                        accessLog:
-                            - name: envoy.access_loggers.file
-                              typedConfig:
-                                '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
-                                logFormat:
-                                    jsonFormat:
-                                        address: logging.backend
-                                        message: |
-                                            custom format [%START_TIME%] %RESPONSE_FLAGS%
-                                path: /tmp/kuma-al-backend-default.sock
-                        cluster: backend
-                        statPrefix: "127_0_0_1_27777"
-            name: outbound:127.0.0.1:27777
-            trafficDirection: OUTBOUND`,
-			},
+			expectedListeners: []string{"outbound_tcp_backend_plain_format.listener.golden.yaml"},
 		}),
 		Entry("outbound tcpproxy with tcp backend and json format", sidecarTestCase{
 			resources: []core_xds.Resource{{
@@ -727,33 +506,7 @@ var _ = Describe("MeshAccessLog", func() {
 					},
 				},
 			},
-			expectedListeners: []string{
-				`
-            address:
-              socketAddress:
-                address: 127.0.0.1
-                portValue: 27777
-            filterChains:
-                - filters:
-                    - name: envoy.filters.network.tcp_proxy
-                      typedConfig:
-                        '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-                        accessLog:
-                            - name: envoy.access_loggers.file
-                              typedConfig:
-                                '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
-                                logFormat:
-                                    jsonFormat:
-                                        address: logging.backend
-                                        message: 
-                                            duration: '%DURATION%'
-                                            protocol: '%PROTOCOL%'
-                                path: /tmp/kuma-al-backend-default.sock
-                        cluster: backend
-                        statPrefix: "127_0_0_1_27777"
-            name: outbound:127.0.0.1:27777
-            trafficDirection: OUTBOUND`,
-			},
+			expectedListeners: []string{"outbound_tcp_backend_json_format.listener.golden.yaml"},
 		}),
 		Entry("basic outbound route without match", sidecarTestCase{
 			resources: []core_xds.Resource{{
@@ -799,42 +552,7 @@ var _ = Describe("MeshAccessLog", func() {
 					},
 				},
 			},
-			expectedListeners: []string{
-				`
-            address:
-              socketAddress:
-                address: 127.0.0.1
-                portValue: 27777
-            filterChains:
-            - filters:
-              - name: envoy.filters.network.http_connection_manager
-                typedConfig:
-                  '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                  httpFilters:
-                  - name: envoy.filters.http.router
-                    typedConfig:
-                      '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-                  routeConfig:
-                    name: outbound:backend
-                    validateClusters: false
-                    requestHeadersToAdd:
-                    - header:
-                        key: x-kuma-tags
-                        value: '&kuma.io/service=web&'
-                    virtualHosts:
-                    - domains:
-                      - '*'
-                      name: backend
-                      routes:
-                      - match:
-                          prefix: /
-                        route:
-                          cluster: backend
-                          timeout: 0s
-                  statPrefix: "127_0_0_1_27777"
-            name: outbound:127.0.0.1:27777
-            trafficDirection: OUTBOUND`,
-			},
+			expectedListeners: []string{"outbound_route_without_match.listener.golden.yaml"},
 		}),
 		Entry("basic inbound route", sidecarTestCase{
 			resources: []core_xds.Resource{{
@@ -872,50 +590,7 @@ var _ = Describe("MeshAccessLog", func() {
 					}},
 				},
 			},
-			expectedListeners: []string{
-				`
-            address:
-              socketAddress:
-                address: 127.0.0.1
-                portValue: 17777
-            enableReusePort: false
-            filterChains:
-            - filters:
-              - name: envoy.filters.network.http_connection_manager
-                typedConfig:
-                  '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                  accessLog:
-                  - name: envoy.access_loggers.file
-                    typedConfig:
-                      '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
-                      logFormat:
-                          textFormatSource:
-                              inlineString: |
-                                [%START_TIME%] default "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-B3-TRACEID?X-DATADOG-TRACEID)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "unknown" "backend" "127.0.0.1" "%UPSTREAM_HOST%"
-                      path: /tmp/log
-                  httpFilters:
-                  - name: envoy.filters.http.router
-                    typedConfig:
-                      '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-                  routeConfig:
-                    name: inbound:backend
-                    validateClusters: false
-                    requestHeadersToRemove:
-                    - x-kuma-tags
-                    virtualHosts:
-                    - domains:
-                      - '*'
-                      name: backend
-                      routes:
-                      - match:
-                          prefix: /
-                        route:
-                          cluster: backend
-                          timeout: 0s
-                  statPrefix: "127_0_0_1_17777"
-            name: inbound:127.0.0.1:17777
-            trafficDirection: INBOUND`,
-			},
+			expectedListeners: []string{"inbound_route.listener.golden.yaml"},
 		}),
 	)
 	type gatewayTestCase struct {

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound.listener.golden.yaml
@@ -1,0 +1,42 @@
+address:
+  socketAddress:
+    address: 127.0.0.1
+    portValue: 27777
+filterChains:
+- filters:
+  - name: envoy.filters.network.http_connection_manager
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+      accessLog:
+      - name: envoy.access_loggers.file
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+          logFormat:
+            textFormatSource:
+              inlineString: |
+                [%START_TIME%] default "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-B3-TRACEID?X-DATADOG-TRACEID)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "backend" "other-service" "127.0.0.1" "%UPSTREAM_HOST%"
+          path: /tmp/log
+      httpFilters:
+      - name: envoy.filters.http.router
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+      routeConfig:
+        name: outbound:backend
+        requestHeadersToAdd:
+        - header:
+            key: x-kuma-tags
+            value: '&kuma.io/service=web&'
+        validateClusters: false
+        virtualHosts:
+        - domains:
+          - '*'
+          name: backend
+          routes:
+          - match:
+              prefix: /
+            route:
+              cluster: backend
+              timeout: 0s
+      statPrefix: "127_0_0_1_27777"
+name: outbound:127.0.0.1:27777
+trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound_real_meshservice.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound_real_meshservice.listener.golden.yaml
@@ -1,0 +1,42 @@
+address:
+  socketAddress:
+    address: 127.0.0.1
+    portValue: 27777
+filterChains:
+- filters:
+  - name: envoy.filters.network.http_connection_manager
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+      accessLog:
+      - name: envoy.access_loggers.file
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+          logFormat:
+            textFormatSource:
+              inlineString: |
+                [%START_TIME%] default "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-B3-TRACEID?X-DATADOG-TRACEID)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "backend" "backend" "127.0.0.1" "%UPSTREAM_HOST%"
+          path: /tmp/log
+      httpFilters:
+      - name: envoy.filters.http.router
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+      routeConfig:
+        name: outbound:backend
+        requestHeadersToAdd:
+        - header:
+            key: x-kuma-tags
+            value: '&kuma.io/service=web&'
+        validateClusters: false
+        virtualHosts:
+        - domains:
+          - '*'
+          name: backend
+          routes:
+          - match:
+              prefix: /
+            route:
+              cluster: backend
+              timeout: 0s
+      statPrefix: "127_0_0_1_27777"
+name: outbound:127.0.0.1:27777
+trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/inbound_route.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/inbound_route.listener.golden.yaml
@@ -1,0 +1,41 @@
+address:
+  socketAddress:
+    address: 127.0.0.1
+    portValue: 17777
+enableReusePort: false
+filterChains:
+- filters:
+  - name: envoy.filters.network.http_connection_manager
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+      accessLog:
+      - name: envoy.access_loggers.file
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+          logFormat:
+            textFormatSource:
+              inlineString: |
+                [%START_TIME%] default "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-B3-TRACEID?X-DATADOG-TRACEID)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "unknown" "backend" "127.0.0.1" "%UPSTREAM_HOST%"
+          path: /tmp/log
+      httpFilters:
+      - name: envoy.filters.http.router
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+      routeConfig:
+        name: inbound:backend
+        requestHeadersToRemove:
+        - x-kuma-tags
+        validateClusters: false
+        virtualHosts:
+        - domains:
+          - '*'
+          name: backend
+          routes:
+          - match:
+              prefix: /
+            route:
+              cluster: backend
+              timeout: 0s
+      statPrefix: "127_0_0_1_17777"
+name: inbound:127.0.0.1:17777
+trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_file_backend_default_format.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_file_backend_default_format.listener.golden.yaml
@@ -1,0 +1,22 @@
+address:
+  socketAddress:
+    address: 127.0.0.1
+    portValue: 27777
+filterChains:
+- filters:
+  - name: envoy.filters.network.tcp_proxy
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+      accessLog:
+      - name: envoy.access_loggers.file
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+          logFormat:
+            textFormatSource:
+              inlineString: |
+                [%START_TIME%] %RESPONSE_FLAGS% default 127.0.0.1(backend)->%UPSTREAM_HOST%(other-service) took %DURATION%ms, sent %BYTES_SENT% bytes, received: %BYTES_RECEIVED% bytes
+          path: /tmp/log
+      cluster: backend
+      statPrefix: "127_0_0_1_27777"
+name: outbound:127.0.0.1:27777
+trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_file_backend_json_format.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_file_backend_json_format.listener.golden.yaml
@@ -1,0 +1,22 @@
+address:
+  socketAddress:
+    address: 127.0.0.1
+    portValue: 27777
+filterChains:
+- filters:
+  - name: envoy.filters.network.tcp_proxy
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+      accessLog:
+      - name: envoy.access_loggers.file
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+          logFormat:
+            jsonFormat:
+              duration: '%DURATION%'
+              protocol: '%PROTOCOL%'
+          path: /tmp/log
+      cluster: backend
+      statPrefix: "127_0_0_1_27777"
+name: outbound:127.0.0.1:27777
+trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_file_backend_plain_format.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_file_backend_plain_format.listener.golden.yaml
@@ -1,0 +1,22 @@
+address:
+  socketAddress:
+    address: 127.0.0.1
+    portValue: 27777
+filterChains:
+- filters:
+  - name: envoy.filters.network.tcp_proxy
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+      accessLog:
+      - name: envoy.access_loggers.file
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+          logFormat:
+            textFormatSource:
+              inlineString: |
+                custom format [%START_TIME%] %RESPONSE_FLAGS%
+          path: /tmp/log
+      cluster: backend
+      statPrefix: "127_0_0_1_27777"
+name: outbound:127.0.0.1:27777
+trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_otel_backend_plain_format.cluster.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_otel_backend_plain_format.cluster.golden.yaml
@@ -1,0 +1,19 @@
+altStatName: meshaccesslog_opentelemetry_0
+connectTimeout: 5s
+dnsLookupFamily: V4_ONLY
+loadAssignment:
+  clusterName: meshaccesslog:opentelemetry:0
+  endpoints:
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: otel-collector
+            portValue: 4317
+name: meshaccesslog:opentelemetry:0
+type: STRICT_DNS
+typedExtensionProtocolOptions:
+  envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+    '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+    explicitHttpConfig:
+      http2ProtocolOptions: {}

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_otel_backend_plain_format.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_otel_backend_plain_format.listener.golden.yaml
@@ -1,0 +1,30 @@
+address:
+  socketAddress:
+    address: 127.0.0.1
+    portValue: 27779
+filterChains:
+- filters:
+  - name: envoy.filters.network.tcp_proxy
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+      accessLog:
+      - name: envoy.access_loggers.open_telemetry
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.access_loggers.open_telemetry.v3.OpenTelemetryAccessLogConfig
+          attributes: {}
+          body:
+            kvlistValue:
+              values:
+              - key: mesh
+                value:
+                  stringValue: default
+          commonConfig:
+            grpcService:
+              envoyGrpc:
+                clusterName: meshaccesslog:opentelemetry:1
+            logName: MeshAccessLog
+            transportApiVersion: V3
+      cluster: bar-service
+      statPrefix: "127_0_0_1_27779"
+name: outbound:127.0.0.1:27779
+trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_otel_backend_plain_format_1.cluster.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_otel_backend_plain_format_1.cluster.golden.yaml
@@ -1,0 +1,19 @@
+altStatName: meshaccesslog_opentelemetry_1
+connectTimeout: 5s
+dnsLookupFamily: V4_ONLY
+loadAssignment:
+  clusterName: meshaccesslog:opentelemetry:1
+  endpoints:
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: other-otel-collector
+            portValue: 5317
+name: meshaccesslog:opentelemetry:1
+type: STRICT_DNS
+typedExtensionProtocolOptions:
+  envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+    '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+    explicitHttpConfig:
+      http2ProtocolOptions: {}

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_otel_backend_plain_format_1.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_otel_backend_plain_format_1.listener.golden.yaml
@@ -1,0 +1,26 @@
+address:
+  socketAddress:
+    address: 127.0.0.1
+    portValue: 27778
+filterChains:
+- filters:
+  - name: envoy.filters.network.tcp_proxy
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+      accessLog:
+      - name: envoy.access_loggers.open_telemetry
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.access_loggers.open_telemetry.v3.OpenTelemetryAccessLogConfig
+          attributes: {}
+          body:
+            stringValue: default
+          commonConfig:
+            grpcService:
+              envoyGrpc:
+                clusterName: meshaccesslog:opentelemetry:0
+            logName: MeshAccessLog
+            transportApiVersion: V3
+      cluster: foo-service
+      statPrefix: "127_0_0_1_27778"
+name: outbound:127.0.0.1:27778
+trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_otel_backend_plain_format_2.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_otel_backend_plain_format_2.listener.golden.yaml
@@ -1,0 +1,28 @@
+address:
+  socketAddress:
+    address: 127.0.0.1
+    portValue: 27777
+filterChains:
+- filters:
+  - name: envoy.filters.network.tcp_proxy
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+      accessLog:
+      - name: envoy.access_loggers.open_telemetry
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.access_loggers.open_telemetry.v3.OpenTelemetryAccessLogConfig
+          attributes: {}
+          body:
+            stringValue: '[%START_TIME%] %RESPONSE_FLAGS% default 127.0.0.1(backend)->%UPSTREAM_HOST%(other-service)
+              took %DURATION%ms, sent %BYTES_SENT% bytes, received: %BYTES_RECEIVED%
+              bytes'
+          commonConfig:
+            grpcService:
+              envoyGrpc:
+                clusterName: meshaccesslog:opentelemetry:0
+            logName: MeshAccessLog
+            transportApiVersion: V3
+      cluster: other-service
+      statPrefix: "127_0_0_1_27777"
+name: outbound:127.0.0.1:27777
+trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_route_without_match.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_route_without_match.listener.golden.yaml
@@ -1,0 +1,33 @@
+address:
+  socketAddress:
+    address: 127.0.0.1
+    portValue: 27777
+filterChains:
+- filters:
+  - name: envoy.filters.network.http_connection_manager
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+      httpFilters:
+      - name: envoy.filters.http.router
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+      routeConfig:
+        name: outbound:backend
+        requestHeadersToAdd:
+        - header:
+            key: x-kuma-tags
+            value: '&kuma.io/service=web&'
+        validateClusters: false
+        virtualHosts:
+        - domains:
+          - '*'
+          name: backend
+          routes:
+          - match:
+              prefix: /
+            route:
+              cluster: backend
+              timeout: 0s
+      statPrefix: "127_0_0_1_27777"
+name: outbound:127.0.0.1:27777
+trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_tcp_backend_default_format.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_tcp_backend_default_format.listener.golden.yaml
@@ -1,0 +1,23 @@
+address:
+  socketAddress:
+    address: 127.0.0.1
+    portValue: 27777
+filterChains:
+- filters:
+  - name: envoy.filters.network.tcp_proxy
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+      accessLog:
+      - name: envoy.access_loggers.file
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+          logFormat:
+            jsonFormat:
+              address: logging.backend
+              message: |
+                [%START_TIME%] %RESPONSE_FLAGS% default 127.0.0.1(backend)->%UPSTREAM_HOST%(other-service) took %DURATION%ms, sent %BYTES_SENT% bytes, received: %BYTES_RECEIVED% bytes
+          path: /tmp/kuma-al-backend-default.sock
+      cluster: backend
+      statPrefix: "127_0_0_1_27777"
+name: outbound:127.0.0.1:27777
+trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_tcp_backend_json_format.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_tcp_backend_json_format.listener.golden.yaml
@@ -1,0 +1,24 @@
+address:
+  socketAddress:
+    address: 127.0.0.1
+    portValue: 27777
+filterChains:
+- filters:
+  - name: envoy.filters.network.tcp_proxy
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+      accessLog:
+      - name: envoy.access_loggers.file
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+          logFormat:
+            jsonFormat:
+              address: logging.backend
+              message:
+                duration: '%DURATION%'
+                protocol: '%PROTOCOL%'
+          path: /tmp/kuma-al-backend-default.sock
+      cluster: backend
+      statPrefix: "127_0_0_1_27777"
+name: outbound:127.0.0.1:27777
+trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_tcp_backend_plain_format.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_tcp_backend_plain_format.listener.golden.yaml
@@ -1,0 +1,23 @@
+address:
+  socketAddress:
+    address: 127.0.0.1
+    portValue: 27777
+filterChains:
+- filters:
+  - name: envoy.filters.network.tcp_proxy
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+      accessLog:
+      - name: envoy.access_loggers.file
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+          logFormat:
+            jsonFormat:
+              address: logging.backend
+              message: |
+                custom format [%START_TIME%] %RESPONSE_FLAGS%
+          path: /tmp/kuma-al-backend-default.sock
+      cluster: backend
+      statPrefix: "127_0_0_1_27777"
+name: outbound:127.0.0.1:27777
+trafficDirection: OUTBOUND

--- a/pkg/plugins/runtime/k8s/webhooks/validation.go
+++ b/pkg/plugins/runtime/k8s/webhooks/validation.go
@@ -16,6 +16,7 @@ import (
 	core_registry "github.com/kumahq/kuma/pkg/core/resources/registry"
 	"github.com/kumahq/kuma/pkg/core/validators"
 	k8s_common "github.com/kumahq/kuma/pkg/plugins/common/k8s"
+	meshaccesslog "github.com/kumahq/kuma/pkg/plugins/policies/meshaccesslog/api/v1alpha1"
 	meshcircuitbreaker "github.com/kumahq/kuma/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1"
 	meshhealthcheck "github.com/kumahq/kuma/pkg/plugins/policies/meshhealthcheck/api/v1alpha1"
 	meshhttproute "github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
@@ -56,6 +57,7 @@ var meshServiceSupportImplemented = map[core_model.ResourceType]bool{
 	meshhealthcheck.MeshHealthCheckType:       true,
 	meshhttproute.MeshHTTPRouteType:           true,
 	meshtcproute.MeshTCPRouteType:             true,
+	meshaccesslog.MeshAccessLogType:           true,
 }
 
 func (h *validatingHandler) InjectDecoder(d admission.Decoder) {

--- a/test/e2e_env/universal/meshaccesslog/meshaccesslog.go
+++ b/test/e2e_env/universal/meshaccesslog/meshaccesslog.go
@@ -27,6 +27,24 @@ func TestPlugin() {
 		return net.JoinHostPort(ip, strconv.Itoa(port))
 	}
 
+	uniServiceYAML := fmt.Sprintf(`
+type: MeshService
+name: test-server
+mesh: %s
+labels:
+  kuma.io/origin: zone
+  kuma.io/env: universal
+spec:
+  selector:
+    dataplaneTags:
+      kuma.io/service: test-server
+  ports:
+  - port: 80
+    targetPort: 80
+    appProtocol: http
+    name: main-port
+`, meshName)
+
 	BeforeAll(func() {
 		externalServiceDockerName = fmt.Sprintf("%s_%s-%s", universal.Cluster.Name(), meshName, "test-server")
 		tcpSinkDockerName = fmt.Sprintf("%s_%s_%s", universal.Cluster.Name(), meshName, AppModeTcpSink)
@@ -35,6 +53,17 @@ func TestPlugin() {
 			Install(TestServerUniversal(
 				"test-server", meshName, WithArgs([]string{"echo", "--instance", "echo-v1"}), WithDockerContainerName(externalServiceDockerName)),
 			).
+			Install(YamlUniversal(uniServiceYAML)).
+			Install(YamlUniversal(`
+type: HostnameGenerator
+name: uni-ms
+spec:
+  template: '{{ .DisplayName }}.universal.ms'
+  selector:
+    meshService:
+      matchLabels:
+        kuma.io/origin: zone
+        kuma.io/env: universal`)).
 			Install(GatewayProxyUniversal(meshName, "edge-gateway")).
 			Install(YamlUniversal(gateway.MkGateway("edge-gateway", meshName, "edge-gateway", false, "example.kuma.io", "test-server", 8080))).
 			Install(gateway.GatewayClientAppUniversal("gateway-client")).
@@ -122,6 +151,42 @@ spec:
 		makeRequest := func(g Gomega) {
 			_, err := client.CollectEchoResponse(
 				universal.Cluster, AppModeDemoClient, "test-server.mesh",
+			)
+			g.Expect(err).ToNot(HaveOccurred())
+		}
+		src, dst := expectTrafficLogged(makeRequest)
+
+		Expect(src).To(Equal(AppModeDemoClient))
+		Expect(dst).To(Equal("test-server"))
+	})
+
+	It("should log outgoing traffic to real MeshService", func() {
+		yaml := fmt.Sprintf(`
+type: MeshAccessLog
+name: client-outgoing-real-ms
+mesh: meshaccesslog
+spec:
+  targetRef:
+    kind: Mesh
+  to:
+    - targetRef:
+        kind: MeshService
+        name: test-server
+        sectionName: main-port
+      default:
+        backends:
+          - type: Tcp
+            tcp:
+              format:
+                type: Plain
+                plain: '%s'
+              address: "%s:9999"
+`, trafficLogFormat, tcpSinkDockerName)
+		Expect(YamlUniversal(yaml)(universal.Cluster)).To(Succeed())
+
+		makeRequest := func(g Gomega) {
+			_, err := client.CollectEchoResponse(
+				universal.Cluster, AppModeDemoClient, "test-server.universal.ms",
 			)
 			g.Expect(err).ToNot(HaveOccurred())
 		}


### PR DESCRIPTION
Fixes: #10994

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
