### PR TITLE
test(e2e/debug): add kumactl inspect result when universal e2e test fail

### DIFF
--- a/test/framework/debug.go
+++ b/test/framework/debug.go
@@ -181,7 +181,7 @@ func DebugKube(cluster Cluster, mesh string, namespaces ...string) {
 
 	exportFilePath := filepath.Join(Config.DebugDir, fmt.Sprintf("%s-export-%s", cluster.Name(), uuid.New().String()))
 	Expect(os.WriteFile(exportFilePath, []byte(out), 0o600)).To(Succeed())
-	Expect(errorSeen).To(BeTrue(), "some debug commands failed")
+	Expect(errorSeen).NotTo(BeTrue(), "some debug commands failed")
 	Logf("saving export of cluster %q for mesh %q to a file %q", cluster.Name(), mesh, exportFilePath)
 }
 

--- a/test/framework/debug.go
+++ b/test/framework/debug.go
@@ -9,7 +9,10 @@ import (
 	"github.com/google/uuid"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/test/framework/kumactl"
 )
 
 // DebugUniversal prints state of the cluster. Useful in case of failure.
@@ -17,27 +20,112 @@ import (
 // * XDS / Stats / Clusters of all DPPs (ideally in form of command that we can use on prod as well)
 // * CP logs (although we print this already on failure)
 func DebugUniversal(cluster Cluster, mesh string) {
-	ensureDebugDir()
-	errorSeen := false
+	ginkgo.GinkgoHelper()
+
+	Expect(ensureDebugDir()).To(Succeed())
+
+	id := uuid.New().String()
+
 	Logf("printing debug information of cluster %q for mesh %q", cluster.Name(), mesh)
 	// we don't have command to print policies for given mesh, so it's better to print all than none.
 	kumactlOpts := *cluster.GetKumactlOptions()
 	kumactlOpts.Verbose = false
+
+	seenErrors := []bool{
+		debugUniversalExport(cluster, mesh, id, kumactlOpts),
+		debugUniversalInspectDPs(cluster, mesh, id, kumactlOpts),
+	}
+
+	Expect(seenErrors).ToNot(ContainElement(true), "some debug commands failed")
+}
+
+func debugUniversalExport(
+	cluster Cluster,
+	mesh string,
+	id string,
+	kumactlOpts kumactl.KumactlOptions,
+) bool {
+	var errorSeen bool
+
+	filePath := filepath.Join(
+		Config.DebugDir,
+		fmt.Sprintf("%s-export-%s.yaml", cluster.Name(), id),
+	)
+
+	logMsg := fmt.Sprintf("saving export of cluster %q for mesh %q to a file %q", cluster.Name(), mesh, filePath)
+
+	Logf(logMsg)
+
 	out, err := kumactlOpts.RunKumactlAndGetOutput("export", "--profile", "all")
 	if err != nil {
 		// We don't want to fail in the middle.
-		out = fmt.Sprintf("kumactl export failed with error: %s", err)
 		errorSeen = true
+		msg := fmt.Sprintf("kumactl export --profile all failed with error: %s", err)
+		out = fmt.Sprintf("# %s", msg)
+		Logf(fmt.Sprintf("%s failed: %s", logMsg, msg))
 	}
 
-	exportFilePath := filepath.Join(Config.DebugDir, fmt.Sprintf("%s-export-%s", cluster.Name(), uuid.New().String()))
-	Expect(os.WriteFile(exportFilePath, []byte(out), 0o600)).To(Succeed())
-	Expect(errorSeen).ToNot(BeTrue(), "some debug commands failed")
-	Logf("saving export of cluster %q for mesh %q to a file %q", cluster.Name(), mesh, exportFilePath)
+	if err := os.WriteFile(filePath, []byte(out), 0o600); err != nil {
+		errorSeen = true
+		Logf("%s failed with error: %s", logMsg, err)
+	}
+
+	return errorSeen
+}
+
+func debugUniversalInspectDPs(
+	cluster Cluster,
+	mesh string,
+	id string,
+	kumactlOpts kumactl.KumactlOptions,
+) bool {
+	var errorSeen bool
+
+	Logf("saving dataplane inspections from cluster %q for mesh %q", cluster.Name(), mesh)
+
+	for _, dpName := range cluster.(*UniversalCluster).GetDataplanes() {
+		for typ, extension := range map[string]string{
+			"config-dump": ".json",
+			"config":      ".json",
+			"policies":    "",
+			"stats":       "",
+			"clusters":    "",
+		} {
+			var out string
+			var err error
+
+			if out, err = kumactlOpts.RunKumactlAndGetOutput(
+				"inspect", "dataplane", dpName,
+				"--mesh", mesh,
+				"--type", typ,
+			); err != nil {
+				// We don't want to fail in the middle.
+				errorSeen = true
+				msg := fmt.Sprintf("kumactl inspect dataplane %s --mesh %s --type %s failed with error: %s", dpName, mesh, typ, err)
+				out = fmt.Sprintf("%q", msg)
+				Logf(msg)
+			}
+
+			filePath := filepath.Join(
+				Config.DebugDir,
+				fmt.Sprintf("%s-inspect-dataplane-%s-%s-%s%s", cluster.Name(), typ, dpName, id, extension),
+			)
+
+			if err := os.WriteFile(filePath, []byte(out), 0o600); err != nil {
+				errorSeen = true
+				Logf("saving %q for dataplane %q to file %q failed with error: %s", typ, dpName, filePath, err)
+			}
+		}
+	}
+
+	return errorSeen
 }
 
 func DebugKube(cluster Cluster, mesh string, namespaces ...string) {
-	ensureDebugDir()
+	ginkgo.GinkgoHelper()
+
+	Expect(ensureDebugDir()).To(Succeed())
+
 	errorSeen := false
 
 	Logf("debug nodes and print resource usage of cluster %q", cluster.Name())
@@ -97,12 +185,11 @@ func DebugKube(cluster Cluster, mesh string, namespaces ...string) {
 	Logf("saving export of cluster %q for mesh %q to a file %q", cluster.Name(), mesh, exportFilePath)
 }
 
-func ensureDebugDir() {
-	err := os.MkdirAll(Config.DebugDir, 0o755)
-	if err == nil || os.IsNotExist(err) {
-		return
+func ensureDebugDir() error {
+	if err := os.MkdirAll(Config.DebugDir, 0o755); err != nil && !os.IsNotExist(err) {
+		return err
 	}
-	Expect(err).ToNot(HaveOccurred())
+	return nil
 }
 
 func CpRestarted(cluster Cluster) bool {

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"slices"
 	"time"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
@@ -45,6 +46,7 @@ type UniversalCluster struct {
 	apps           map[string]*UniversalApp
 	verbose        bool
 	deployments    map[string]Deployment
+	dataplanes     []string
 	defaultTimeout time.Duration
 	defaultRetries int
 	opts           kumaDeploymentOptions
@@ -250,6 +252,7 @@ func (c *UniversalCluster) CreateDP(app *UniversalApp, name, mesh, ip, dpyaml, t
 	cpIp := c.controlplane.Networking().IP
 	cpAddress := "https://" + net.JoinHostPort(cpIp, "5678")
 	app.CreateDP(token, cpAddress, name, mesh, ip, dpyaml, builtindns, "", concurrency, app.dpEnv)
+	c.dataplanes = append(c.dataplanes, name)
 	return app.dpApp.Start()
 }
 
@@ -392,6 +395,10 @@ func (c *UniversalCluster) GetApp(appName string) *UniversalApp {
 	return c.apps[appName]
 }
 
+func (c *UniversalCluster) GetDataplanes() []string {
+	return c.dataplanes
+}
+
 func (c *UniversalCluster) DeleteApp(appname string) error {
 	app, ok := c.apps[appname]
 	if !ok {
@@ -401,6 +408,9 @@ func (c *UniversalCluster) DeleteApp(appname string) error {
 		return err
 	}
 	delete(c.apps, appname)
+	c.dataplanes = slices.DeleteFunc(c.dataplanes, func(s string) bool {
+		return s == appname
+	})
 	return nil
 }
 


### PR DESCRIPTION
We currently can see a lot of flakes in universal e2e tests, and we don't have enough data to debug it, especially that we cannot reproduce it locally. This commit adds results of `kumactl inspect dataplane ...` when any of these tests will fail.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - There is no relevant issues
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Locally tested on few e2e tests
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - Only to release-2.8

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
