### PR TITLE
feat(autoreachableservices): support kuma.io/service in mesh subset

### DIFF
--- a/pkg/plugins/policies/meshtrafficpermission/graph/reachable_services_graph_test.go
+++ b/pkg/plugins/policies/meshtrafficpermission/graph/reachable_services_graph_test.go
@@ -282,6 +282,7 @@ var _ = Describe("Reachable Services Graph", func() {
 					mesh_proto.KubeNamespaceTag: "kuma-demo",
 					mesh_proto.KubeServiceTag:   "a",
 					mesh_proto.KubePortTag:      "1234",
+					mesh_proto.ServiceTag:       "a_kuma-demo_svc_1234",
 				},
 				"b": map[string]string{},
 			}
@@ -311,6 +312,7 @@ var _ = Describe("Reachable Services Graph", func() {
 		Entry("MeshSubset by kube namespace", builders.TargetRefMeshSubset(mesh_proto.KubeNamespaceTag, "kuma-demo")),
 		Entry("MeshSubset by kube service name", builders.TargetRefMeshSubset(mesh_proto.KubeServiceTag, "a")),
 		Entry("MeshSubset by kube service port", builders.TargetRefMeshSubset(mesh_proto.KubePortTag, "1234")),
+		Entry("MeshSubset by kuma.io/service", builders.TargetRefMeshSubset(mesh_proto.ServiceTag, "a_kuma-demo_svc_1234")),
 		Entry("MeshServiceSubset by kube namespace", builders.TargetRefServiceSubset("a_kuma-demo_svc_1234", mesh_proto.KubeNamespaceTag, "kuma-demo")),
 		Entry("MeshServiceSubset by kube service name", builders.TargetRefServiceSubset("a_kuma-demo_svc_1234", mesh_proto.KubeServiceTag, "a")),
 		Entry("MeshServiceSubset by kube service port", builders.TargetRefServiceSubset("a_kuma-demo_svc_1234", mesh_proto.KubePortTag, "1234")),
@@ -384,12 +386,23 @@ var _ = Describe("Reachable Services Graph", func() {
 				mesh_proto.KubeNamespaceTag: "kuma-demo",
 				mesh_proto.KubeServiceTag:   "a",
 				mesh_proto.KubePortTag:      "1234",
+				mesh_proto.ServiceTag:       "a_kuma-demo_svc_1234",
 			},
-			"b":    map[string]string{},
-			"c":    map[string]string{},
-			"d":    map[string]string{},
-			"e":    map[string]string{},
-			"es-1": map[string]string{},
+			"b": map[string]string{
+				mesh_proto.ServiceTag: "b",
+			},
+			"c": map[string]string{
+				mesh_proto.ServiceTag: "c",
+			},
+			"d": map[string]string{
+				mesh_proto.ServiceTag: "d",
+			},
+			"e": map[string]string{
+				mesh_proto.ServiceTag: "e",
+			},
+			"es-1": map[string]string{
+				mesh_proto.ServiceTag: "es-1",
+			},
 		}))
 	})
 })

--- a/pkg/plugins/policies/meshtrafficpermission/graph/services/reachable_services_graph.go
+++ b/pkg/plugins/policies/meshtrafficpermission/graph/services/reachable_services_graph.go
@@ -17,6 +17,7 @@ var SupportedTags = map[string]struct{}{
 	mesh_proto.KubeNamespaceTag: {},
 	mesh_proto.KubeServiceTag:   {},
 	mesh_proto.KubePortTag:      {},
+	mesh_proto.ServiceTag:       {},
 }
 
 // BuildServices we could just take result of xds_topology.VIPOutbounds, however it does not have a context of additional tags


### PR DESCRIPTION
### Checklist prior to review

We do not recommend using MeshService anymore in top level target ref, but autoreachable services do not work with kuma.io/service in MeshSubset. This PR adds kuma.io/service to supported list of tags for MeshSubset

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
