### PR TITLE
feat(MeshService): create different clusters for real MeshServices

### DIFF
--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/helpers.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/helpers.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (m *MeshServiceResource) DestinationName(port uint32) string {
-	return fmt.Sprintf("%s_svc_%d", strings.ReplaceAll(m.GetMeta().GetName(), ".", "_"), port)
+	return fmt.Sprintf("%s_msvc_%d", strings.ReplaceAll(m.GetMeta().GetName(), ".", "_"), port)
 }
 
 func (m *MeshServiceResource) FindPort(port uint32) (Port, bool) {

--- a/pkg/plugins/policies/core/xds/meshroute/listeners.go
+++ b/pkg/plugins/policies/core/xds/meshroute/listeners.go
@@ -265,6 +265,12 @@ func makeSplit(
 			clusterName = envoy_names.GetMeshExternalServiceName(ref.Name) // todo shouldn't this be in destination name?
 		case common_api.MeshMultiZoneService:
 			clusterName = meshCtx.MeshMultiZoneServiceByName[ref.Name].DestinationName(*ref.Port)
+		case common_api.MeshService:
+			if ref.Port != nil {
+				clusterName = meshCtx.MeshServiceByName[ref.Name].DestinationName(*ref.Port)
+				break
+			}
+			fallthrough
 		default:
 			clusterName, _ = envoy_tags.Tags(ref.Tags).
 				WithTags(mesh_proto.ServiceTag, service).

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
@@ -194,12 +194,12 @@ var _ = Describe("MeshHTTPRoute", func() {
 		}()),
 		Entry("default-meshservice", func() outboundsTestCase {
 			outboundTargets := xds_builders.EndpointMap().
-				AddEndpoint("backend_svc_80", xds_builders.Endpoint().
+				AddEndpoint("backend_msvc_80", xds_builders.Endpoint().
 					WithTarget("192.168.0.4").
 					WithPort(8084).
 					WithWeight(1).
 					WithTags(mesh_proto.ServiceTag, "backend", mesh_proto.ProtocolTag, core_mesh.ProtocolHTTP, "app", "backend")).
-				AddEndpoint("backend_svc_80", xds_builders.Endpoint().
+				AddEndpoint("backend_msvc_80", xds_builders.Endpoint().
 					WithTarget("192.168.0.5").
 					WithPort(8084).
 					WithWeight(1).
@@ -685,7 +685,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 				Items: []*meshservice_api.MeshServiceResource{&meshSvc},
 			}
 			outboundTargets := xds_builders.EndpointMap().
-				AddEndpoint("backend_svc_80", xds_builders.Endpoint().
+				AddEndpoint("backend_msvc_80", xds_builders.Endpoint().
 					WithTarget("192.168.0.4").
 					WithPort(8084).
 					WithWeight(1).

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.clusters.golden.yaml
@@ -29,7 +29,7 @@ resources:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         explicitHttpConfig:
           http2ProtocolOptions: {}
-- name: backend_svc_80
+- name: backend_msvc_80
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
@@ -37,7 +37,7 @@ resources:
         ads: {}
         initialFetchTimeout: 0s
         resourceApiVersion: V3
-    name: backend_svc_80
+    name: backend_msvc_80
     type: EDS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.endpoints.golden.yaml
@@ -53,10 +53,10 @@ resources:
             envoy.transport_socket_match:
               kuma.io/protocol: http
               region: us
-- name: backend_svc_80
+- name: backend_msvc_80
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: backend_svc_80
+    clusterName: backend_msvc_80
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
@@ -17,7 +17,7 @@ resources:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           normalizePath: true
           routeConfig:
-            name: outbound:backend_svc_80
+            name: outbound:backend_msvc_80
             requestHeadersToAdd:
             - header:
                 key: x-kuma-tags
@@ -26,7 +26,7 @@ resources:
             virtualHosts:
             - domains:
               - '*'
-              name: backend_svc_80
+              name: backend_msvc_80
               routes:
               - match:
                   path: /v1
@@ -68,21 +68,21 @@ resources:
                   path: /v4
                 name: UszzxTjarAB0Egv5zi/OpbBLkZsjGV5NpM2+96fwVa8=
                 route:
-                  cluster: backend_svc_80
+                  cluster: backend_msvc_80
                   timeout: 0s
               - match:
                   prefix: /v4/
                 name: UszzxTjarAB0Egv5zi/OpbBLkZsjGV5NpM2+96fwVa8=
                 route:
-                  cluster: backend_svc_80
+                  cluster: backend_msvc_80
                   timeout: 0s
               - match:
                   prefix: /
                 name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
                 route:
-                  cluster: backend_svc_80
+                  cluster: backend_msvc_80
                   timeout: 0s
-          statPrefix: backend_svc_80
+          statPrefix: backend_msvc_80
     metadata:
       filterMetadata:
         io.kuma.tags: {}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.clusters.golden.yaml
@@ -1,5 +1,5 @@
 resources:
-- name: backend_svc_80
+- name: backend_msvc_80
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
@@ -7,7 +7,7 @@ resources:
         ads: {}
         initialFetchTimeout: 0s
         resourceApiVersion: V3
-    name: backend_svc_80
+    name: backend_msvc_80
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.endpoints.golden.yaml
@@ -1,8 +1,8 @@
 resources:
-- name: backend_svc_80
+- name: backend_msvc_80
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: backend_svc_80
+    clusterName: backend_msvc_80
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.listeners.golden.yaml
@@ -17,7 +17,7 @@ resources:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           normalizePath: true
           routeConfig:
-            name: outbound:backend_svc_80
+            name: outbound:backend_msvc_80
             requestHeadersToAdd:
             - header:
                 key: x-kuma-tags
@@ -26,15 +26,15 @@ resources:
             virtualHosts:
             - domains:
               - '*'
-              name: backend_svc_80
+              name: backend_msvc_80
               routes:
               - match:
                   prefix: /
                 name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
                 route:
-                  cluster: backend_svc_80
+                  cluster: backend_msvc_80
                   timeout: 0s
-          statPrefix: backend_svc_80
+          statPrefix: backend_msvc_80
     metadata:
       filterMetadata:
         io.kuma.tags: {}

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
@@ -573,7 +573,7 @@ var _ = Describe("MeshTCPRoute", func() {
 				Items: []*meshservice_api.MeshServiceResource{&meshSvc},
 			}
 			outboundTargets := xds_builders.EndpointMap().
-				AddEndpoint("backend_svc_80", xds_builders.Endpoint().
+				AddEndpoint("backend_msvc_80", xds_builders.Endpoint().
 					WithTarget("192.168.0.4").
 					WithPort(8084).
 					WithWeight(1).

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-real-meshservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-real-meshservice.clusters.golden.yaml
@@ -1,5 +1,5 @@
 resources:
-- name: backend_svc_80
+- name: backend_msvc_80
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
@@ -7,7 +7,7 @@ resources:
         ads: {}
         initialFetchTimeout: 0s
         resourceApiVersion: V3
-    name: backend_svc_80
+    name: backend_msvc_80
     type: EDS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-real-meshservice.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-real-meshservice.endpoints.golden.yaml
@@ -1,8 +1,8 @@
 resources:
-- name: backend_svc_80
+- name: backend_msvc_80
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: backend_svc_80
+    clusterName: backend_msvc_80
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
@@ -11,8 +11,8 @@ resources:
       - name: envoy.filters.network.tcp_proxy
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: backend_svc_80
-          statPrefix: backend_svc_80
+          cluster: backend_msvc_80
+          statPrefix: backend_msvc_80
     metadata:
       filterMetadata:
         io.kuma.tags: {}

--- a/pkg/xds/generator/testdata/ingress/mesh-service.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/mesh-service.envoy.golden.yaml
@@ -1,36 +1,36 @@
 resources:
-- name: mesh1:backend2_svc_80
+- name: mesh1:backend2_msvc_80
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    altStatName: mesh1_backend2_svc_80
+    altStatName: mesh1_backend2_msvc_80
     connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}
         initialFetchTimeout: 0s
         resourceApiVersion: V3
-    name: mesh1:backend2_svc_80
+    name: mesh1:backend2_msvc_80
     type: EDS
-- name: mesh1:backend_svc_80
+- name: mesh1:backend_msvc_80
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    altStatName: mesh1_backend_svc_80
+    altStatName: mesh1_backend_msvc_80
     connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}
         initialFetchTimeout: 0s
         resourceApiVersion: V3
-    name: mesh1:backend_svc_80
+    name: mesh1:backend_msvc_80
     type: EDS
-- name: mesh1:backend2_svc_80
+- name: mesh1:backend2_msvc_80
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: mesh1:backend2_svc_80
-- name: mesh1:backend_svc_80
+    clusterName: mesh1:backend2_msvc_80
+- name: mesh1:backend_msvc_80
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: mesh1:backend_svc_80
+    clusterName: mesh1:backend_msvc_80
 - name: inbound:10.0.0.1:10001
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener
@@ -48,8 +48,8 @@ resources:
       - name: envoy.filters.network.tcp_proxy
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: default:backend_svc_80
-          statPrefix: default_backend_svc_80
+          cluster: default:backend_msvc_80
+          statPrefix: default_backend_msvc_80
     - filterChainMatch:
         serverNames:
         - aec60634adf0f45d6.backend2.80.default.ms
@@ -58,8 +58,8 @@ resources:
       - name: envoy.filters.network.tcp_proxy
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: default:backend2_svc_80
-          statPrefix: default_backend2_svc_80
+          cluster: default:backend2_msvc_80
+          statPrefix: default_backend2_msvc_80
     listenerFilters:
     - name: envoy.filters.listener.tls_inspector
       typedConfig:

--- a/pkg/xds/topology/ingress_outbound_test.go
+++ b/pkg/xds/topology/ingress_outbound_test.go
@@ -313,7 +313,7 @@ var _ = Describe("IngressTrafficRoute", func() {
 							ExternalService: nil,
 						},
 					},
-					"kong_kong-system_svc_8080": []core_xds.Endpoint{
+					"kong_kong-system_msvc_8080": []core_xds.Endpoint{
 						{
 							Target:         "192.168.0.2",
 							UnixDomainPath: "",
@@ -340,7 +340,20 @@ var _ = Describe("IngressTrafficRoute", func() {
 							ExternalService: nil,
 						},
 					},
-					"redis-0_svc_6379": []core_xds.Endpoint{
+					"redis_msvc_6379": []core_xds.Endpoint{
+						{
+							Target:         "192.168.0.1",
+							UnixDomainPath: "",
+							Port:           6379,
+							Tags: map[string]string{
+								"kuma.io/service": "redis_svc_6379",
+							},
+							Weight:          1,
+							Locality:        nil,
+							ExternalService: nil,
+						},
+					},
+					"redis-0_msvc_6379": []core_xds.Endpoint{
 						{
 							Target: "192.168.0.1",
 							Port:   6379,
@@ -362,7 +375,7 @@ var _ = Describe("IngressTrafficRoute", func() {
 							ExternalService: nil,
 						},
 					},
-					"kong_kong-system_svc_8081": []core_xds.Endpoint{
+					"kong_kong-system_msvc_8081": []core_xds.Endpoint{
 						{
 							Target:         "192.168.0.2",
 							UnixDomainPath: "",

--- a/pkg/xds/topology/outbound_test.go
+++ b/pkg/xds/topology/outbound_test.go
@@ -1241,6 +1241,16 @@ var _ = Describe("TrafficRoute", func() {
 				expected: core_xds.EndpointMap{
 					"redis_svc_6379": []core_xds.Endpoint{
 						{
+							Target: "192.168.0.100",
+							Port:   12345,
+							Tags: map[string]string{
+								"kuma.io/service": "redis_svc_6379",
+								"version":         "v1",
+							},
+							Weight:   1,
+							Locality: nil,
+						},
+						{
 							Target:   "192.168.0.1",
 							Port:     6379,
 							Tags:     map[string]string{mesh_proto.ServiceTag: "redis_svc_6379", "version": "v1"},
@@ -1248,7 +1258,16 @@ var _ = Describe("TrafficRoute", func() {
 							Weight:   1,
 						},
 					},
-					"redis-0_svc_6379": []core_xds.Endpoint{
+					"redis_msvc_6379": []core_xds.Endpoint{
+						{
+							Target:   "192.168.0.1",
+							Port:     6379,
+							Tags:     map[string]string{mesh_proto.ServiceTag: "redis_svc_6379", "version": "v1"},
+							Locality: nil,
+							Weight:   1,
+						},
+					},
+					"redis-0_msvc_6379": []core_xds.Endpoint{
 						{
 							Target:   "192.168.0.1",
 							Port:     6379,
@@ -1266,7 +1285,7 @@ var _ = Describe("TrafficRoute", func() {
 							Weight:   1,
 						},
 					},
-					"kong_kong-system_svc_8080": []core_xds.Endpoint{
+					"kong_kong-system_msvc_8080": []core_xds.Endpoint{
 						{
 							Target:   "192.168.0.2",
 							Port:     80,
@@ -1284,7 +1303,7 @@ var _ = Describe("TrafficRoute", func() {
 							Weight:   1,
 						},
 					},
-					"kong_kong-system_svc_8081": []core_xds.Endpoint{
+					"kong_kong-system_msvc_8081": []core_xds.Endpoint{
 						{
 							Target:   "192.168.0.2",
 							Port:     8001,
@@ -1551,7 +1570,7 @@ var _ = Describe("TrafficRoute", func() {
 							Weight: 1,
 						},
 					},
-					"backend_svc_80": []core_xds.Endpoint{
+					"backend_msvc_80": []core_xds.Endpoint{
 						{
 							Target: "192.168.0.1",
 							Port:   80,
@@ -1561,12 +1580,12 @@ var _ = Describe("TrafficRoute", func() {
 							Weight: 1,
 						},
 					},
-					"backend-4v44xv7dwv4v8z2d_svc_80": []core_xds.Endpoint{
+					"backend-4v44xv7dwv4v8z2d_msvc_80": []core_xds.Endpoint{
 						{
 							Target: "192.168.0.100",
 							Port:   12345,
 							Tags: map[string]string{
-								"kuma.io/service": "backend-4v44xv7dwv4v8z2d_svc_80",
+								"kuma.io/service": "backend-4v44xv7dwv4v8z2d_msvc_80",
 								"kuma.io/zone":    "east",
 							},
 							Weight:   1,
@@ -1586,7 +1605,7 @@ var _ = Describe("TrafficRoute", func() {
 							Target: "192.168.0.100",
 							Port:   12345,
 							Tags: map[string]string{
-								"kuma.io/service": "backend-4v44xv7dwv4v8z2d_svc_80",
+								"kuma.io/service": "backend-4v44xv7dwv4v8z2d_msvc_80",
 								"kuma.io/zone":    "east",
 							},
 							Weight:   1,

--- a/test/e2e_env/universal/meshservice/meshservice.go
+++ b/test/e2e_env/universal/meshservice/meshservice.go
@@ -127,8 +127,8 @@ mtls:
 				universal.Cluster, "demo-client", "http://localhost:9901/stats",
 			)
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(stdout).To(ContainSubstring("cluster.backend_svc_80.ssl.handshake"))
-			g.Expect(stdout).ToNot(ContainSubstring("cluster.backend_svc_80.ssl.handshake: 0"))
+			g.Expect(stdout).To(ContainSubstring("cluster.backend_msvc_80.ssl.handshake"))
+			g.Expect(stdout).ToNot(ContainSubstring("cluster.backend_msvc_80.ssl.handshake: 0"))
 		}, "30s", "1s").Should(Succeed())
 		Expect(reqError.Load()).To(BeNil())
 


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- #11208 
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
