### PR TITLE
test(topology): make test resource ports consistent with each other

### DIFF
--- a/pkg/xds/topology/ingress_outbound_test.go
+++ b/pkg/xds/topology/ingress_outbound_test.go
@@ -267,7 +267,7 @@ var _ = Describe("IngressTrafficRoute", func() {
 								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
 									{
 										Tags:        map[string]string{mesh_proto.ServiceTag: "kong_kong-system_svc_80", "app": "kong"},
-										Port:        8080,
+										Port:        80,
 										ServicePort: 18080,
 									},
 									{
@@ -284,8 +284,8 @@ var _ = Describe("IngressTrafficRoute", func() {
 					builders.MeshService().
 						WithName("kong.kong-system").
 						WithDataplaneTagsSelectorKV("app", "kong").
-						AddIntPort(80, 8080, "http").
-						AddIntPort(81, 8081, "http").
+						AddIntPort(8080, 80, "http").
+						AddIntPort(8081, 8001, "http").
 						Build(),
 					builders.MeshService().
 						WithName("redis").
@@ -303,7 +303,21 @@ var _ = Describe("IngressTrafficRoute", func() {
 						{
 							Target:         "192.168.0.2",
 							UnixDomainPath: "",
-							Port:           8080,
+							Port:           80,
+							Tags: map[string]string{
+								"kuma.io/service": "kong_kong-system_svc_80",
+								"app":             "kong",
+							},
+							Weight:          1,
+							Locality:        nil,
+							ExternalService: nil,
+						},
+					},
+					"kong_kong-system_svc_8080": []core_xds.Endpoint{
+						{
+							Target:         "192.168.0.2",
+							UnixDomainPath: "",
+							Port:           80,
 							Tags: map[string]string{
 								"kuma.io/service": "kong_kong-system_svc_80",
 								"app":             "kong",
@@ -335,6 +349,20 @@ var _ = Describe("IngressTrafficRoute", func() {
 						},
 					},
 					"kong_kong-system_svc_8001": []core_xds.Endpoint{
+						{
+							Target:         "192.168.0.2",
+							UnixDomainPath: "",
+							Port:           8001,
+							Tags: map[string]string{
+								"kuma.io/service": "kong_kong-system_svc_8001",
+								"app":             "kong",
+							},
+							Weight:          1,
+							Locality:        nil,
+							ExternalService: nil,
+						},
+					},
+					"kong_kong-system_svc_8081": []core_xds.Endpoint{
 						{
 							Target:         "192.168.0.2",
 							UnixDomainPath: "",

--- a/pkg/xds/topology/outbound_test.go
+++ b/pkg/xds/topology/outbound_test.go
@@ -5,7 +5,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/util/intstr"
 
 	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
 	common_tls "github.com/kumahq/kuma/api/common/v1alpha1/tls"
@@ -1207,7 +1206,7 @@ var _ = Describe("TrafficRoute", func() {
 								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
 									{
 										Tags:        map[string]string{mesh_proto.ServiceTag: "kong_kong-system_svc_80", "app": "kong"},
-										Port:        8080,
+										Port:        80,
 										ServicePort: 18080,
 									},
 									{
@@ -1221,69 +1220,22 @@ var _ = Describe("TrafficRoute", func() {
 					},
 				},
 				meshServices: []*meshservice_api.MeshServiceResource{
-					{
-						Meta: &test_model.ResourceMeta{
-							Mesh: "default",
-							Name: "kong.kong-system",
-						},
-						Spec: &meshservice_api.MeshService{
-							Selector: meshservice_api.Selector{
-								DataplaneTags: map[string]string{
-									"app": "kong",
-								},
-							},
-							Ports: []meshservice_api.Port{
-								{
-									Port:        80,
-									TargetPort:  intstr.FromInt(8080),
-									AppProtocol: "http",
-								},
-								{
-									Port:        8081,
-									TargetPort:  intstr.FromInt(8081),
-									AppProtocol: "http",
-								},
-							},
-						},
-					},
-					{
-						Meta: &test_model.ResourceMeta{
-							Mesh: "default",
-							Name: "redis",
-						},
-						Spec: &meshservice_api.MeshService{
-							Selector: meshservice_api.Selector{
-								DataplaneTags: map[string]string{
-									mesh_proto.ServiceTag: "redis_svc_6379",
-								},
-							},
-							Ports: []meshservice_api.Port{
-								{
-									Port:       6379,
-									TargetPort: intstr.FromInt(6379),
-								},
-							},
-						},
-					},
-					{
-						Meta: &test_model.ResourceMeta{
-							Mesh: "default",
-							Name: "redis-0",
-						},
-						Spec: &meshservice_api.MeshService{
-							Selector: meshservice_api.Selector{
-								DataplaneRef: &meshservice_api.DataplaneRef{
-									Name: "redis-0",
-								},
-							},
-							Ports: []meshservice_api.Port{
-								{
-									Port:       6379,
-									TargetPort: intstr.FromInt(6379),
-								},
-							},
-						},
-					},
+					builders.MeshService().
+						WithName("kong.kong-system").
+						WithDataplaneTagsSelectorKV("app", "kong").
+						AddIntPort(8080, 80, "http").
+						AddIntPort(8081, 8001, "http").
+						Build(),
+					builders.MeshService().
+						WithName("redis").
+						WithDataplaneTagsSelectorKV(mesh_proto.ServiceTag, "redis_svc_6379").
+						AddIntPort(6379, 6379, "tcp").
+						Build(),
+					builders.MeshService().
+						WithName("redis-0").
+						WithDataplaneRefNameSelector("redis-0").
+						AddIntPort(6379, 6379, "tcp").
+						Build(),
 				},
 				mesh: defaultMeshWithMTLS,
 				expected: core_xds.EndpointMap{
@@ -1308,13 +1260,31 @@ var _ = Describe("TrafficRoute", func() {
 					"kong_kong-system_svc_80": []core_xds.Endpoint{
 						{
 							Target:   "192.168.0.2",
-							Port:     8080,
+							Port:     80,
+							Tags:     map[string]string{mesh_proto.ServiceTag: "kong_kong-system_svc_80", "app": "kong"},
+							Locality: nil,
+							Weight:   1,
+						},
+					},
+					"kong_kong-system_svc_8080": []core_xds.Endpoint{
+						{
+							Target:   "192.168.0.2",
+							Port:     80,
 							Tags:     map[string]string{mesh_proto.ServiceTag: "kong_kong-system_svc_80", "app": "kong"},
 							Locality: nil,
 							Weight:   1,
 						},
 					},
 					"kong_kong-system_svc_8001": []core_xds.Endpoint{
+						{
+							Target:   "192.168.0.2",
+							Port:     8001,
+							Tags:     map[string]string{mesh_proto.ServiceTag: "kong_kong-system_svc_8001", "app": "kong"},
+							Locality: nil,
+							Weight:   1,
+						},
+					},
+					"kong_kong-system_svc_8081": []core_xds.Endpoint{
 						{
 							Target:   "192.168.0.2",
 							Port:     8001,


### PR DESCRIPTION
These tests are changing in a later PR but I think they don't quite make sense as is when it comes to the ports.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
