### PR TITLE
feat(meshloadbalancingstrategy): support for multizoneservice

### DIFF
--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator.go
@@ -43,6 +43,7 @@ func validateTo(to []To) validators.ValidationError {
 			SupportedKinds: []common_api.TargetRefKind{
 				common_api.Mesh,
 				common_api.MeshService,
+				common_api.MeshMultiZoneService,
 			},
 		}))
 		verr.AddErrorAt(path.Field("default"), validateConf(toItem.Default, toItem))

--- a/test/e2e_env/multizone/localityawarelb/meshmultizoneservice.go
+++ b/test/e2e_env/multizone/localityawarelb/meshmultizoneservice.go
@@ -1,0 +1,152 @@
+package localityawarelb
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/client"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
+	"github.com/kumahq/kuma/test/framework/deployments/testserver"
+	"github.com/kumahq/kuma/test/framework/envs/multizone"
+)
+
+func MeshMzService() {
+	namespace := "mlb-mzms"
+	meshName := "mlb-mzms"
+
+	BeforeAll(func() {
+		Expect(NewClusterSetup().
+			Install(MTLSMeshUniversal(meshName)).
+			Install(MeshTrafficPermissionAllowAllUniversal(meshName)).
+			Install(YamlUniversal(`
+type: MeshMultiZoneService
+name: test-server
+mesh: mlb-mzms
+labels:
+  test-name: mzmsconnectivity
+spec:
+  selector:
+    meshService:
+      matchLabels:
+        kuma.io/display-name: test-server
+        k8s.kuma.io/namespace: mlb-mzms
+  ports:
+  - name: "80"
+    port: 80
+    appProtocol: http
+`)).
+			Setup(multizone.Global)).To(Succeed())
+		Expect(WaitForMesh(meshName, multizone.Zones())).To(Succeed())
+
+		err := NewClusterSetup().
+			Install(NamespaceWithSidecarInjection(namespace)).
+			Install(testserver.Install(
+				testserver.WithNamespace(namespace),
+				testserver.WithMesh(meshName),
+				testserver.WithEchoArgs("echo", "--instance", "kube-test-server-1"),
+			)).
+			Setup(multizone.KubeZone1)
+		Expect(err).ToNot(HaveOccurred())
+		err = NewClusterSetup().
+			Install(NamespaceWithSidecarInjection(namespace)).
+			Install(democlient.Install(democlient.WithNamespace(namespace), democlient.WithMesh(meshName))).
+			Setup(multizone.KubeZone2)
+		Expect(err).ToNot(HaveOccurred())
+
+		uniServiceYAML := `
+type: MeshService
+name: test-server
+mesh: mlb-mzms
+labels:
+  kuma.io/origin: zone
+  kuma.io/env: universal
+  k8s.kuma.io/namespace: mlb-mzms # add a label to aggregate kube and uni service
+  kuma.io/display-name: test-server # add a label to aggregate kube and uni service
+spec:
+  selector:
+    dataplaneTags:
+      kuma.io/service: test-server
+  ports:
+  - port: 80
+    targetPort: 80
+    appProtocol: http
+`
+
+		err = NewClusterSetup().
+			Install(TestServerUniversal("test-server", meshName, WithArgs([]string{"echo", "--instance", "uni-test-server"}))).
+			Install(YamlUniversal(uniServiceYAML)).
+			Setup(multizone.UniZone1)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEachFailure(func() {
+		DebugUniversal(multizone.Global, meshName)
+		DebugUniversal(multizone.UniZone1, meshName)
+		DebugUniversal(multizone.UniZone2, meshName)
+		DebugKube(multizone.KubeZone1, meshName, namespace)
+		DebugKube(multizone.KubeZone2, meshName, namespace)
+	})
+
+	E2EAfterAll(func() {
+		Expect(multizone.KubeZone1.TriggerDeleteNamespace(namespace)).To(Succeed())
+		Expect(multizone.KubeZone2.TriggerDeleteNamespace(namespace)).To(Succeed())
+		Expect(multizone.UniZone1.DeleteMeshApps(meshName)).To(Succeed())
+		Expect(multizone.UniZone2.DeleteMeshApps(meshName)).To(Succeed())
+		Expect(multizone.Global.DeleteMesh(meshName)).To(Succeed())
+	})
+
+	responseFromInstance := func(cluster Cluster) func() (string, error) {
+		return func() (string, error) {
+			var opts []client.CollectResponsesOptsFn
+			if _, ok := cluster.(*K8sCluster); ok {
+				opts = append(opts, client.FromKubernetesPod(meshName, "demo-client"))
+			}
+			response, err := client.CollectEchoResponse(cluster, "demo-client", "http://test-server.mzsvc.mesh.local:80", opts...)
+			if err != nil {
+				return "", err
+			}
+			return response.Instance, nil
+		}
+	}
+
+	It("should fallback only to first zone", func() {
+		// given traffic to other zones
+		Eventually(responseFromInstance(multizone.KubeZone2), "30s", "1s").
+			MustPassRepeatedly(5).Should(Or(Equal("kube-test-server-1"), Equal("uni-test-server")))
+
+		// when
+		policy := `
+type: MeshLoadBalancingStrategy
+name: mlb-mzms
+mesh: mlb-mzms
+spec:
+  targetRef:
+    kind: Mesh
+  to:
+  - targetRef:
+      kind: MeshMultiZoneService
+      labels:
+        kuma.io/display-name: test-server 
+    default:
+      localityAwareness:
+        crossZone:
+          failover:
+          - to:
+              type: Only
+              zones:
+              - "kuma-1"
+          - to:
+              type: Any
+          failoverThreshold:
+            percentage: 100
+`
+		err := multizone.Global.Install(YamlUniversal(policy))
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+
+		Eventually(responseFromInstance(multizone.KubeZone2), "30s", "1s").
+			MustPassRepeatedly(5).Should(Equal("kube-test-server-1"))
+	})
+}

--- a/test/e2e_env/multizone/multizone_suite_test.go
+++ b/test/e2e_env/multizone/multizone_suite_test.go
@@ -76,6 +76,7 @@ var (
 	_ = Describe("MeshService Connectivity", meshservice.Connectivity, Ordered)
 	_ = Describe("Targeting real MeshService in policies", meshservice.MeshServiceTargeting, Ordered)
 	_ = Describe("MeshMultiZoneService Connectivity", meshmultizoneservice.Connectivity, Ordered)
+	_ = Describe("MeshMultiZoneService MeshLbStrategy", localityawarelb.MeshMzService, Ordered)
 	_ = Describe("Available services", connectivity.AvailableServices, Ordered)
 	_ = Describe("ReachableBackends", reachablebackends.ReachableBackends, Ordered)
 )


### PR DESCRIPTION
### Checklist prior to review

Mesh lbstrategy with MeshMultiZoneService

Fix #10935

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
