### PR TITLE
fix(kuma-cp): handle cases when requested BackendRefIdentifier contains ports

### DIFF
--- a/pkg/plugins/policies/meshtrafficpermission/graph/reachable_graph.go
+++ b/pkg/plugins/policies/meshtrafficpermission/graph/reachable_graph.go
@@ -41,7 +41,11 @@ func (r *Graph) CanReachBackend(fromTags map[string]string, backendIdentifier co
 	if backendIdentifier.ResourceType == core_model.ResourceType(common_api.MeshExternalService) {
 		return true
 	}
-	rule := r.backendRules[backendIdentifier].Compute(core_rules.SubsetFromTags(fromTags))
+	noPort := core_model.TypedResourceIdentifier{
+		ResourceIdentifier: backendIdentifier.ResourceIdentifier,
+		ResourceType:       backendIdentifier.ResourceType,
+	}
+	rule := r.backendRules[noPort].Compute(core_rules.SubsetFromTags(fromTags))
 	if rule == nil {
 		return false
 	}


### PR DESCRIPTION
Fixes e2e failure https://github.com/kumahq/kuma/actions/runs/10661894136/job/29548513074#step:12:3062

Map in reachable_graph.go contains MeshServices without port. That's why we have to remove ports before the lookup.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
