### PR TITLE
refactor(test-framework): allow customizing args and probes to testserver deployments on Kubernetes

### DIFF
--- a/test/e2e_env/kubernetes/gateway/mtls.go
+++ b/test/e2e_env/kubernetes/gateway/mtls.go
@@ -364,7 +364,9 @@ spec:
 					testserver.WithMesh(meshName),
 					testserver.WithName("tcp-server"),
 					testserver.WithNamespace(namespace),
-					testserver.WithHealthCheckTCPArgs("health-check", "tcp", "--port", "80"),
+					testserver.WithArgs("health-check", "tcp", "--port", "80"),
+					testserver.WithProbe(testserver.LivenessProbe, testserver.ProbeTcpSocket, 80, ""),
+					testserver.WithProbe(testserver.ReadinessProbe, testserver.ProbeTcpSocket, 80, ""),
 				)).
 				Install(MeshTrafficPermissionAllowAllKubernetes(meshName)).
 				Setup(kubernetes.Cluster)
@@ -438,7 +440,9 @@ spec:
 					testserver.WithMesh(meshName),
 					testserver.WithName("tcp-server"),
 					testserver.WithNamespace(namespace),
-					testserver.WithHealthCheckTCPArgs("health-check", "tcp", "--port", "80"),
+					testserver.WithArgs("health-check", "tcp", "--port", "80"),
+					testserver.WithProbe(testserver.LivenessProbe, testserver.ProbeTcpSocket, 80, ""),
+					testserver.WithProbe(testserver.ReadinessProbe, testserver.ProbeTcpSocket, 80, ""),
 				)).
 				Install(MeshTrafficPermissionAllowAllKubernetes(meshName))
 			Expect(setup.Setup(kubernetes.Cluster)).To(Succeed())

--- a/test/framework/deployments/testserver/deployment.go
+++ b/test/framework/deployments/testserver/deployment.go
@@ -135,13 +135,15 @@ const (
 	ProbeGRPC      ProbeHandlerType = "grpc"
 )
 
-type ProbeHandlerType string
-type probeParams struct {
-	ProbeType   ProbeType
-	HandlerType ProbeHandlerType
-	Port        uint32
-	HttpGetPath string
-}
+type (
+	ProbeHandlerType string
+	probeParams      struct {
+		ProbeType   ProbeType
+		HandlerType ProbeHandlerType
+		Port        uint32
+		HttpGetPath string
+	}
+)
 
 func (p probeParams) toKubeProbe() *corev1.Probe {
 	switch p.HandlerType {

--- a/test/framework/deployments/testserver/deployment.go
+++ b/test/framework/deployments/testserver/deployment.go
@@ -3,6 +3,7 @@ package testserver
 import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/kumahq/kuma/test/framework"
 )
@@ -16,7 +17,8 @@ type DeploymentOpts struct {
 	WithStatefulSet     bool
 	ServiceAccount      string
 	echoArgs            []string
-	healthcheckTCPArgs  []string
+	args                []string
+	probes              []probeParams
 	Replicas            int32
 	WaitingToBeReady    bool
 	EnableProbes        bool
@@ -108,15 +110,90 @@ func WithoutWaitingToBeReady() DeploymentOptsFn {
 	}
 }
 
+// WithEchoArgs sets the arguments for the echo server, values will be appended the default echo arguments
 func WithEchoArgs(args ...string) DeploymentOptsFn {
 	return func(opts *DeploymentOpts) {
 		opts.echoArgs = args
 	}
 }
 
-func WithHealthCheckTCPArgs(args ...string) DeploymentOptsFn {
+// WithArgs sets the arguments for the test server, they take precedence over the echo arguments
+func WithArgs(args ...string) DeploymentOptsFn {
 	return func(opts *DeploymentOpts) {
-		opts.healthcheckTCPArgs = args
+		opts.args = args
+	}
+}
+
+type ProbeType string
+
+const (
+	ReadinessProbe ProbeType        = "readiness"
+	StartupProbe   ProbeType        = "startup"
+	LivenessProbe  ProbeType        = "liveness"
+	ProbeHttpGet   ProbeHandlerType = "httpGet"
+	ProbeTcpSocket ProbeHandlerType = "tcpSocket"
+	ProbeGRPC      ProbeHandlerType = "grpc"
+)
+
+type ProbeHandlerType string
+type probeParams struct {
+	ProbeType   ProbeType
+	HandlerType ProbeHandlerType
+	Port        uint32
+	HttpGetPath string
+}
+
+func (p probeParams) toKubeProbe() *corev1.Probe {
+	switch p.HandlerType {
+	case ProbeHttpGet:
+		return &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: p.HttpGetPath,
+					Port: intstr.FromInt32(int32(p.Port)),
+				},
+			},
+			InitialDelaySeconds: 3,
+			PeriodSeconds:       5,
+			TimeoutSeconds:      3,
+			FailureThreshold:    60,
+		}
+	case ProbeTcpSocket:
+		return &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				TCPSocket: &corev1.TCPSocketAction{
+					Port: intstr.FromInt32(int32(p.Port)),
+				},
+			},
+			InitialDelaySeconds: 3,
+			PeriodSeconds:       3,
+		}
+	case ProbeGRPC:
+		return &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				GRPC: &corev1.GRPCAction{
+					Port: int32(p.Port),
+				},
+			},
+			InitialDelaySeconds: 3,
+			PeriodSeconds:       3,
+		}
+	}
+	return nil
+}
+
+// WithProbe adds a probe to the deployment, this only works when the arguments are customize using WithArgs
+func WithProbe(probeType ProbeType, handlerType ProbeHandlerType, port uint32, httpGetPath string) DeploymentOptsFn {
+	return func(opts *DeploymentOpts) {
+		if opts.probes == nil {
+			opts.probes = []probeParams{}
+		}
+		opts.probes = append(opts.probes, probeParams{
+			ProbeType:   probeType,
+			HandlerType: handlerType,
+			Port:        port,
+			HttpGetPath: httpGetPath,
+		})
 	}
 }
 

--- a/test/framework/deployments/testserver/kubernetes.go
+++ b/test/framework/deployments/testserver/kubernetes.go
@@ -23,7 +23,8 @@ func (k *k8SDeployment) Name() string {
 
 func (k *k8SDeployment) service() *corev1.Service {
 	appProtocol := k.opts.protocol
-	if len(k.opts.healthcheckTCPArgs) > 0 || k.opts.tlsKey != "" {
+	isTcpHealthCheck := len(k.opts.args) > 2 && k.opts.args[0] == "health-check" && k.opts.args[1] == "tcp"
+	if isTcpHealthCheck || k.opts.tlsKey != "" {
 		appProtocol = "tcp"
 	}
 	servicePort := 80
@@ -120,31 +121,27 @@ func (k *k8SDeployment) statefulSet() *appsv1.StatefulSet {
 
 func (k *k8SDeployment) podSpec() corev1.PodTemplateSpec {
 	var args []string
-	var liveness *corev1.Probe
-	var readiness *corev1.Probe
+	var livenessProbe *corev1.Probe
+	var readinessProbe *corev1.Probe
+	var startupProbe *corev1.Probe
 	var volumeMounts []corev1.VolumeMount
 	var volumes []corev1.Volume
 	switch {
-	case len(k.opts.healthcheckTCPArgs) > 0:
-		args = k.opts.healthcheckTCPArgs
-		liveness = &corev1.Probe{
-			ProbeHandler: corev1.ProbeHandler{
-				TCPSocket: &corev1.TCPSocketAction{
-					Port: intstr.FromInt(80),
-				},
-			},
-			InitialDelaySeconds: 3,
-			PeriodSeconds:       3,
+	case len(k.opts.args) > 0:
+		args = k.opts.args
+		if len(k.opts.probes) > 0 {
+			for _, probe := range k.opts.probes {
+				switch probe.ProbeType {
+				case ReadinessProbe:
+					readinessProbe = probe.toKubeProbe()
+				case LivenessProbe:
+					livenessProbe = probe.toKubeProbe()
+				case StartupProbe:
+					startupProbe = probe.toKubeProbe()
+				}
+			}
 		}
-		readiness = &corev1.Probe{
-			ProbeHandler: corev1.ProbeHandler{
-				TCPSocket: &corev1.TCPSocketAction{
-					Port: intstr.FromInt(80),
-				},
-			},
-			InitialDelaySeconds: 3,
-			PeriodSeconds:       3,
-		}
+
 	case k.opts.tlsKey != "":
 		args = append([]string{"echo", "--port", "443", "--tls", "--key", "/etc/tls/tls.key", "--crt", "/etc/tls/tls.crt"}, k.opts.echoArgs...)
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
@@ -162,11 +159,11 @@ func (k *k8SDeployment) podSpec() corev1.PodTemplateSpec {
 		})
 	default:
 		args = append([]string{"echo", "--port", "80", "--probes"}, k.opts.echoArgs...)
-		liveness = &corev1.Probe{
+		livenessProbe = &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
 					Path: `/probes?type=liveness`,
-					Port: intstr.FromInt(80),
+					Port: intstr.FromInt32(80),
 				},
 			},
 			InitialDelaySeconds: 3,
@@ -174,11 +171,11 @@ func (k *k8SDeployment) podSpec() corev1.PodTemplateSpec {
 			TimeoutSeconds:      3,
 			FailureThreshold:    60,
 		}
-		readiness = &corev1.Probe{
+		readinessProbe = &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
 					Path: `/probes?type=readiness`,
-					Port: intstr.FromInt(80),
+					Port: intstr.FromInt32(80),
 				},
 			},
 			InitialDelaySeconds: 3,
@@ -188,8 +185,9 @@ func (k *k8SDeployment) podSpec() corev1.PodTemplateSpec {
 		}
 	}
 	if !k.opts.EnableProbes {
-		liveness = nil
-		readiness = nil
+		livenessProbe = nil
+		readinessProbe = nil
+		startupProbe = nil
 	}
 	containerPort := 80
 	if k.opts.tlsKey != "" {
@@ -207,8 +205,9 @@ func (k *k8SDeployment) podSpec() corev1.PodTemplateSpec {
 				{
 					Name:            k.Name(),
 					ImagePullPolicy: "IfNotPresent",
-					ReadinessProbe:  readiness,
-					LivenessProbe:   liveness,
+					ReadinessProbe:  readinessProbe,
+					LivenessProbe:   livenessProbe,
+					StartupProbe:    startupProbe,
 					Image:           framework.Config.GetUniversalImage(),
 					Ports: []corev1.ContainerPort{
 						{


### PR DESCRIPTION
Improving existing testserver deployment DSL to allow allow customizing args and adding more Kubernetes probes

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues 
  - A dependency of https://github.com/kumahq/kuma/issues/11122
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS 
  - Confirmed
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) 
  - N/A
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? 
  - No
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) 
  - No

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
