### PR TITLE
fix(MeshService): don't exclude kuma.io/service if using reachableBackends

### DIFF
--- a/pkg/xds/sync/dataplane_proxy_builder.go
+++ b/pkg/xds/sync/dataplane_proxy_builder.go
@@ -128,9 +128,6 @@ func (p *DataplaneProxyBuilder) resolveVIPOutbounds(meshContext xds_context.Mesh
 	var legacyOutbounds []*mesh_proto.Dataplane_Networking_Outbound
 	for _, outbound := range meshContext.VIPOutbounds {
 		if outbound.LegacyOutbound != nil {
-			if reachableBackends != nil && len(reachableServices) == 0 {
-				continue
-			}
 			service := outbound.LegacyOutbound.GetService()
 			if len(reachableServices) != 0 {
 				if !reachableServices[service] {

--- a/test/e2e_env/multizone/multizone_suite_test.go
+++ b/test/e2e_env/multizone/multizone_suite_test.go
@@ -79,4 +79,5 @@ var (
 	_ = Describe("MeshMultiZoneService MeshLbStrategy", localityawarelb.MeshMzService, Ordered)
 	_ = Describe("Available services", connectivity.AvailableServices, Ordered)
 	_ = Describe("ReachableBackends", reachablebackends.ReachableBackends, Ordered)
+	_ = Describe("MeshServiceReachableBackends", reachablebackends.MeshServicesWithReachableBackendsOption, Ordered)
 )

--- a/test/e2e_env/multizone/reachablebackends/reachablebackends.go
+++ b/test/e2e_env/multizone/reachablebackends/reachablebackends.go
@@ -146,18 +146,21 @@ routing:
 				testserver.WithName("client-server"),
 				testserver.WithMesh(meshName),
 				testserver.WithNamespace(namespace),
+				testserver.WithReachableServices("dummy-service"),
 				testserver.WithReachableBackends(reachableBackends),
 			)).
 			Install(testserver.Install(
 				testserver.WithName("client-server-namespace"),
 				testserver.WithMesh(meshName),
 				testserver.WithNamespace(namespace),
+				testserver.WithReachableServices("dummy-service"),
 				testserver.WithReachableBackends(reachableBackendsNamespaceLabel),
 			)).
 			Install(testserver.Install(
 				testserver.WithName("client-server-no-access"),
 				testserver.WithMesh(meshName),
 				testserver.WithNamespace(namespace),
+				testserver.WithReachableServices("dummy-service"),
 				testserver.WithReachableBackends("{}"),
 			)).
 			Install(testserver.Install(
@@ -315,36 +318,44 @@ spec:
 			// then it fails because we don't encrypt traffic to unknown destination in the mesh
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(response.Exitcode).To(Or(Equal(52), Equal(56)))
+		}, "5s", "100ms").Should(Succeed())
 
+		Consistently(func(g Gomega) {
 			// when trying to connect to non-reachable services via Kuma DNS
-			response, err = client.CollectFailure(
+			response, err := client.CollectFailure(
 				multizone.KubeZone1, "client-server", "not-accessible-es.extsvc.mesh.local",
 				client.FromKubernetesPod(namespace, "client-server"),
 			)
 			// then it fails because Kuma DP has no such DNS
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(response.Exitcode).To(Equal(6))
+		}, "5s", "100ms").Should(Succeed())
 
+		Consistently(func(g Gomega) {
 			// when trying to connect to non-reachable service via Kubernetes DNS
-			response, err = client.CollectFailure(
+			response, err := client.CollectFailure(
 				multizone.KubeZone1, "client-server", "not-accessible-es.reachable-backends-non-mesh.svc.cluster.local",
 				client.FromKubernetesPod(namespace, "client-server"),
 			)
 			// then it fails because we don't encrypt traffic to unknown destination in the mesh
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(response.Exitcode).To(Or(Equal(52), Equal(56)))
+		}, "5s", "100ms").Should(Succeed())
 
+		Consistently(func(g Gomega) {
 			// when trying to connect to non-reachable mesh multizone service via Kuma DNS
-			response, err = client.CollectFailure(
+			response, err := client.CollectFailure(
 				multizone.KubeZone1, "client-server", "other-zone-not-accessible.mzsvc.mesh.local",
 				client.FromKubernetesPod(namespace, "client-server"),
 			)
 			// then it fails because we don't encrypt traffic to unknown destination in the mesh
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(response.Exitcode).To(Or(Equal(6)))
+		}, "5s", "100ms").Should(Succeed())
 
+		Consistently(func(g Gomega) {
 			// when trying to connect to non-reachable service via Kubernetes DNS
-			response, err = client.CollectFailure(
+			response, err := client.CollectFailure(
 				multizone.KubeZone1, "client-server-no-access", "second-test-server.reachable-backends.svc.cluster.local",
 				client.FromKubernetesPod(namespace, "client-server-no-access"),
 			)

--- a/test/e2e_env/multizone/reachablebackends/reachablebackends_meshservices.go
+++ b/test/e2e_env/multizone/reachablebackends/reachablebackends_meshservices.go
@@ -1,0 +1,179 @@
+package reachablebackends
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/client"
+	"github.com/kumahq/kuma/test/framework/deployments/testserver"
+	"github.com/kumahq/kuma/test/framework/envs/multizone"
+)
+
+func MeshServicesWithReachableBackendsOption() {
+	meshName := "mesh-service-reachable-backends"
+	namespace := "mesh-service-reachable-backends"
+	reachableBackends := `
+      refs:
+      - kind: MeshService
+        labels:
+          kuma.io/display-name: other-zone-test-server
+      - kind: MeshService
+        name: local-test-server
+`
+
+	mesh := fmt.Sprintf(`
+type: Mesh
+name: "%s"
+meshServices:
+  enabled: ReachableBackendRefs
+mtls:
+  enabledBackend: ca-1
+  backends:
+  - name: ca-1
+    type: builtin
+networking:
+  outbound:
+    passthrough: false
+routing:
+  zoneEgress: true
+`, meshName)
+
+	BeforeAll(func() {
+		// Global
+		err := NewClusterSetup().
+			Install(YamlUniversal(mesh)).
+			Install(MeshTrafficPermissionAllowAllUniversal(meshName)).
+			Setup(multizone.Global)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(WaitForMesh(meshName, multizone.Zones())).To(Succeed())
+
+		// Zone Kube1
+		err = NewClusterSetup().
+			Install(NamespaceWithSidecarInjection(namespace)).
+			Install(testserver.Install(
+				testserver.WithName("client-without-reachable"),
+				testserver.WithMesh(meshName),
+				testserver.WithNamespace(namespace),
+			)).
+			Install(testserver.Install(
+				testserver.WithName("client-with-reachable-backends-only"),
+				testserver.WithMesh(meshName),
+				testserver.WithNamespace(namespace),
+				testserver.WithReachableBackends(reachableBackends),
+			)).
+			Install(testserver.Install(
+				testserver.WithName("local-test-server"),
+				testserver.WithMesh(meshName),
+				testserver.WithNamespace(namespace),
+			)).
+			Install(YamlK8s(fmt.Sprintf(`
+apiVersion: kuma.io/v1alpha1
+kind: HostnameGenerator
+metadata:
+  name: local-k8s-mesh-services
+  namespace: %s
+  labels:
+    kuma.io/origin: zone
+spec:
+  template: '{{ .DisplayName }}.{{ .Namespace }}.svc.{{ .Zone }}.mesh.local'
+  selector:
+    meshService:
+      matchLabels:
+        kuma.io/origin: zone
+        kuma.io/env: kubernetes
+`, Config.KumaNamespace))).
+			Setup(multizone.KubeZone1)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = NewClusterSetup().
+			Install(NamespaceWithSidecarInjection(namespace)).
+			Install(testserver.Install(
+				testserver.WithName("other-zone-test-server"),
+				testserver.WithNamespace(namespace),
+				testserver.WithMesh(meshName),
+				testserver.WithEchoArgs("echo", "--instance", "other-zone-test-server"),
+			)).
+			Setup(multizone.KubeZone2)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEachFailure(func() {
+		DebugUniversal(multizone.Global, meshName)
+		DebugKube(multizone.KubeZone1, meshName, namespace)
+		DebugKube(multizone.KubeZone2, meshName, namespace)
+	})
+
+	E2EAfterAll(func() {
+		Expect(multizone.KubeZone1.TriggerDeleteNamespace(namespace)).To(Succeed())
+		Expect(multizone.KubeZone2.TriggerDeleteNamespace(namespace)).To(Succeed())
+		Expect(multizone.Global.DeleteMesh(meshName)).To(Succeed())
+	})
+
+	It("should be able to connect to k8s VIP, using legacy cluster, if reachable backends isn't set", func() {
+		Eventually(func(g Gomega) {
+			// when
+			resp, err := client.CollectEchoResponse(
+				multizone.KubeZone1, "client-without-reachable", "local-test-server.mesh-service-reachable-backends.svc.kuma-1.mesh.local",
+				client.FromKubernetesPod(namespace, "client-without-reachable"),
+			)
+			// then
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(resp.Instance).To(HavePrefix("local-test-server"))
+		}, "30s", "500ms", MustPassRepeatedly(10)).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			pod, err := PodNameOfApp(multizone.KubeZone1, "client-without-reachable", namespace)
+			g.Expect(err).ToNot(HaveOccurred())
+			stdout, err := multizone.KubeZone1.GetKumactlOptions().RunKumactlAndGetOutput("inspect", "dataplane", pod+"."+namespace, "--type=clusters", fmt.Sprintf("--mesh=%s", meshName))
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(stdout).To(ContainSubstring(fmt.Sprintf("local-test-server_%s_svc_80", namespace)))
+			g.Expect(stdout).ToNot(ContainSubstring("_msvc_"))
+		}, "10s", "1s").Should(Succeed())
+	})
+
+	It("should not be able to connect to cross-zone MeshService if reachable backends isn't set", func() {
+		Consistently(func(g Gomega) {
+			// when
+			resp, err := client.CollectFailure(
+				multizone.KubeZone1, "client-without-reachable", "other-zone-test-server.mesh-service-reachable-backends.svc.kuma-2.mesh.local",
+				client.FromKubernetesPod(namespace, "client-without-reachable"),
+			)
+			// then
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(resp.Exitcode).To(Equal(6))
+		}, "15s", "500ms", MustPassRepeatedly(10)).Should(Succeed())
+	})
+
+	It("should be able to connect if reachable backends is set", func() {
+		Eventually(func(g Gomega) {
+			// when
+			resp, err := client.CollectEchoResponse(
+				multizone.KubeZone1, "client-with-reachable-backends-only", "local-test-server.mesh-service-reachable-backends.svc.kuma-1.mesh.local",
+				client.FromKubernetesPod(namespace, "client-with-reachable-backends-only"),
+			)
+			// then
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(resp.Instance).To(HavePrefix("local-test-server"))
+
+			pod, err := PodNameOfApp(multizone.KubeZone1, "client-with-reachable-backends-only", namespace)
+			g.Expect(err).ToNot(HaveOccurred())
+			stdout, err := multizone.KubeZone1.GetKumactlOptions().RunKumactlAndGetOutput("inspect", "dataplane", pod+"."+namespace, "--type=clusters", fmt.Sprintf("--mesh=%s", meshName))
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(stdout).To(ContainSubstring(fmt.Sprintf("local-test-server_%s_msvc_80", namespace)))
+		}, "10s", "500ms", MustPassRepeatedly(10)).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			// when
+			resp, err := client.CollectEchoResponse(
+				multizone.KubeZone1, "client-with-reachable-backends-only", "other-zone-test-server.mesh-service-reachable-backends.svc.kuma-2.mesh.local",
+				client.FromKubernetesPod(namespace, "client-with-reachable-backends-only"),
+			)
+			// then
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(resp.Instance).To(HavePrefix("other-zone-test-server"))
+		}, "10s", "500ms", MustPassRepeatedly(10)).Should(Succeed())
+	})
+}


### PR DESCRIPTION
This also adds e2e tests for `meshServices.enabled: ReachableBackendRefs`.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- #11208 
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
