### PR TITLE
feat(MeshMultiZoneService): add support to MeshCircuitBreaker, MeshAccessLog, MeshHealthCheck, MeshRetry

### DIFF
--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/validator.go
@@ -61,6 +61,7 @@ func validateTo(to []To) validators.ValidationError {
 				common_api.Mesh,
 				common_api.MeshService,
 				common_api.MeshExternalService,
+				common_api.MeshMultiZoneService,
 			},
 		}))
 

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/validator_test.go
@@ -78,6 +78,19 @@ from:
     default:
       backends: []
 `),
+			Entry("MeshMultiZoneService", `
+targetRef:
+  kind: Mesh
+to:
+  - targetRef:
+      kind: MeshMultiZoneService
+      name: web-backend
+    default:
+      backends:
+        - type: File
+          file:
+            path: '/tmp/logs.txt'
+`),
 		)
 
 		type testCase struct {

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/validator.go
@@ -59,6 +59,7 @@ func validateTo(topTargetRef common_api.TargetRef, to []To) validators.Validatio
 				common_api.Mesh,
 				common_api.MeshService,
 				common_api.MeshExternalService,
+				common_api.MeshMultiZoneService,
 			},
 		}))
 		if toItem.TargetRef.Kind == common_api.MeshExternalService && topTargetRef.Kind != common_api.Mesh {

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/validator_test.go
@@ -237,6 +237,15 @@ to:
       name: web-backend
     default:
       connectionLimits: { }`),
+			Entry("with MeshMultiZoneService", `
+targetRef:
+  kind: Mesh
+to:
+  - targetRef:
+      kind: MeshMultiZoneService
+      name: web-backend
+    default:
+      connectionLimits: { }`),
 			Entry("gateway example", `
 targetRef:
   kind: MeshGateway

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/validator.go
@@ -37,6 +37,7 @@ func validateTo(topTargetRef common_api.TargetRef, to []To) validators.Validatio
 				common_api.Mesh,
 				common_api.MeshService,
 				common_api.MeshExternalService,
+				common_api.MeshMultiZoneService,
 			},
 		}))
 		if toItem.TargetRef.Kind == common_api.MeshExternalService && topTargetRef.Kind != common_api.Mesh {

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/validator_test.go
@@ -94,6 +94,18 @@ to:
       tcp: # it will pick the protocol as described in 'protocol selection' section
         disabled: true # new, default false, can be disabled for override
 `),
+			Entry("to level MeshMultiZoneService", `
+targetRef:
+  kind: Mesh
+to:
+  - targetRef:
+      kind: MeshMultiZoneService
+      name: web-backend
+    default:
+      interval: 10s
+      tcp: # it will pick the protocol as described in 'protocol selection' section
+        disabled: true # new, default false, can be disabled for override
+`),
 		)
 
 		type testCase struct {

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/validator.go
@@ -66,6 +66,7 @@ func validateTo(to []To, topLevelKind common_api.TargetRef) validators.Validatio
 				common_api.Mesh,
 				common_api.MeshService,
 				common_api.MeshExternalService,
+				common_api.MeshMultiZoneService,
 			}
 		}
 

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/validator_test.go
@@ -124,6 +124,17 @@ to:
       http:
         numRetries: 5
 `),
+			Entry("minimalistic to MeshMultiZoneService", `
+targetRef:
+  kind: Mesh
+to:
+  - targetRef:
+      kind: MeshMultiZoneService
+      name: web-backend
+    default:
+      http:
+        numRetries: 5
+`),
 			Entry("empty http arrays", `
 targetRef:
   kind: Mesh


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- #11042 
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
