### PR TITLE
perf(k8s): spec in k8s resource should be in deterministic order

### DIFF
--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/zz_generated.mesh.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/zz_generated.mesh.go
@@ -85,7 +85,7 @@ func (cb *CircuitBreaker) SetSpec(spec core_model.ResourceSpec) {
 		panic(fmt.Sprintf("unexpected protobuf message type %T", spec))
 	}
 
-	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSON(s)}
+	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSONSorted(s)}
 }
 
 func (cb *CircuitBreaker) GetStatus() (core_model.ResourceStatus, error) {
@@ -194,7 +194,7 @@ func (cb *Dataplane) SetSpec(spec core_model.ResourceSpec) {
 		panic(fmt.Sprintf("unexpected protobuf message type %T", spec))
 	}
 
-	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSON(s)}
+	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSONSorted(s)}
 }
 
 func (cb *Dataplane) GetStatus() (core_model.ResourceStatus, error) {
@@ -299,7 +299,7 @@ func (cb *DataplaneInsight) SetSpec(spec core_model.ResourceSpec) {
 		panic(fmt.Sprintf("unexpected protobuf message type %T", spec))
 	}
 
-	cb.Status = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSON(s)}
+	cb.Status = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSONSorted(s)}
 }
 
 func (cb *DataplaneInsight) GetStatus() (core_model.ResourceStatus, error) {
@@ -404,7 +404,7 @@ func (cb *ExternalService) SetSpec(spec core_model.ResourceSpec) {
 		panic(fmt.Sprintf("unexpected protobuf message type %T", spec))
 	}
 
-	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSON(s)}
+	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSONSorted(s)}
 }
 
 func (cb *ExternalService) GetStatus() (core_model.ResourceStatus, error) {
@@ -509,7 +509,7 @@ func (cb *FaultInjection) SetSpec(spec core_model.ResourceSpec) {
 		panic(fmt.Sprintf("unexpected protobuf message type %T", spec))
 	}
 
-	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSON(s)}
+	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSONSorted(s)}
 }
 
 func (cb *FaultInjection) GetStatus() (core_model.ResourceStatus, error) {
@@ -614,7 +614,7 @@ func (cb *HealthCheck) SetSpec(spec core_model.ResourceSpec) {
 		panic(fmt.Sprintf("unexpected protobuf message type %T", spec))
 	}
 
-	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSON(s)}
+	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSONSorted(s)}
 }
 
 func (cb *HealthCheck) GetStatus() (core_model.ResourceStatus, error) {
@@ -719,7 +719,7 @@ func (cb *Mesh) SetSpec(spec core_model.ResourceSpec) {
 		panic(fmt.Sprintf("unexpected protobuf message type %T", spec))
 	}
 
-	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSON(s)}
+	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSONSorted(s)}
 }
 
 func (cb *Mesh) GetStatus() (core_model.ResourceStatus, error) {
@@ -824,7 +824,7 @@ func (cb *MeshGateway) SetSpec(spec core_model.ResourceSpec) {
 		panic(fmt.Sprintf("unexpected protobuf message type %T", spec))
 	}
 
-	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSON(s)}
+	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSONSorted(s)}
 }
 
 func (cb *MeshGateway) GetStatus() (core_model.ResourceStatus, error) {
@@ -929,7 +929,7 @@ func (cb *MeshGatewayRoute) SetSpec(spec core_model.ResourceSpec) {
 		panic(fmt.Sprintf("unexpected protobuf message type %T", spec))
 	}
 
-	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSON(s)}
+	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSONSorted(s)}
 }
 
 func (cb *MeshGatewayRoute) GetStatus() (core_model.ResourceStatus, error) {
@@ -1034,7 +1034,7 @@ func (cb *MeshInsight) SetSpec(spec core_model.ResourceSpec) {
 		panic(fmt.Sprintf("unexpected protobuf message type %T", spec))
 	}
 
-	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSON(s)}
+	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSONSorted(s)}
 }
 
 func (cb *MeshInsight) GetStatus() (core_model.ResourceStatus, error) {
@@ -1139,7 +1139,7 @@ func (cb *ProxyTemplate) SetSpec(spec core_model.ResourceSpec) {
 		panic(fmt.Sprintf("unexpected protobuf message type %T", spec))
 	}
 
-	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSON(s)}
+	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSONSorted(s)}
 }
 
 func (cb *ProxyTemplate) GetStatus() (core_model.ResourceStatus, error) {
@@ -1244,7 +1244,7 @@ func (cb *RateLimit) SetSpec(spec core_model.ResourceSpec) {
 		panic(fmt.Sprintf("unexpected protobuf message type %T", spec))
 	}
 
-	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSON(s)}
+	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSONSorted(s)}
 }
 
 func (cb *RateLimit) GetStatus() (core_model.ResourceStatus, error) {
@@ -1349,7 +1349,7 @@ func (cb *Retry) SetSpec(spec core_model.ResourceSpec) {
 		panic(fmt.Sprintf("unexpected protobuf message type %T", spec))
 	}
 
-	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSON(s)}
+	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSONSorted(s)}
 }
 
 func (cb *Retry) GetStatus() (core_model.ResourceStatus, error) {
@@ -1454,7 +1454,7 @@ func (cb *ServiceInsight) SetSpec(spec core_model.ResourceSpec) {
 		panic(fmt.Sprintf("unexpected protobuf message type %T", spec))
 	}
 
-	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSON(s)}
+	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSONSorted(s)}
 }
 
 func (cb *ServiceInsight) GetStatus() (core_model.ResourceStatus, error) {
@@ -1559,7 +1559,7 @@ func (cb *Timeout) SetSpec(spec core_model.ResourceSpec) {
 		panic(fmt.Sprintf("unexpected protobuf message type %T", spec))
 	}
 
-	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSON(s)}
+	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSONSorted(s)}
 }
 
 func (cb *Timeout) GetStatus() (core_model.ResourceStatus, error) {
@@ -1664,7 +1664,7 @@ func (cb *TrafficLog) SetSpec(spec core_model.ResourceSpec) {
 		panic(fmt.Sprintf("unexpected protobuf message type %T", spec))
 	}
 
-	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSON(s)}
+	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSONSorted(s)}
 }
 
 func (cb *TrafficLog) GetStatus() (core_model.ResourceStatus, error) {
@@ -1769,7 +1769,7 @@ func (cb *TrafficPermission) SetSpec(spec core_model.ResourceSpec) {
 		panic(fmt.Sprintf("unexpected protobuf message type %T", spec))
 	}
 
-	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSON(s)}
+	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSONSorted(s)}
 }
 
 func (cb *TrafficPermission) GetStatus() (core_model.ResourceStatus, error) {
@@ -1874,7 +1874,7 @@ func (cb *TrafficRoute) SetSpec(spec core_model.ResourceSpec) {
 		panic(fmt.Sprintf("unexpected protobuf message type %T", spec))
 	}
 
-	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSON(s)}
+	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSONSorted(s)}
 }
 
 func (cb *TrafficRoute) GetStatus() (core_model.ResourceStatus, error) {
@@ -1979,7 +1979,7 @@ func (cb *TrafficTrace) SetSpec(spec core_model.ResourceSpec) {
 		panic(fmt.Sprintf("unexpected protobuf message type %T", spec))
 	}
 
-	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSON(s)}
+	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSONSorted(s)}
 }
 
 func (cb *TrafficTrace) GetStatus() (core_model.ResourceStatus, error) {
@@ -2084,7 +2084,7 @@ func (cb *VirtualOutbound) SetSpec(spec core_model.ResourceSpec) {
 		panic(fmt.Sprintf("unexpected protobuf message type %T", spec))
 	}
 
-	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSON(s)}
+	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSONSorted(s)}
 }
 
 func (cb *VirtualOutbound) GetStatus() (core_model.ResourceStatus, error) {
@@ -2190,7 +2190,7 @@ func (cb *ZoneEgress) SetSpec(spec core_model.ResourceSpec) {
 		panic(fmt.Sprintf("unexpected protobuf message type %T", spec))
 	}
 
-	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSON(s)}
+	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSONSorted(s)}
 }
 
 func (cb *ZoneEgress) GetStatus() (core_model.ResourceStatus, error) {
@@ -2295,7 +2295,7 @@ func (cb *ZoneEgressInsight) SetSpec(spec core_model.ResourceSpec) {
 		panic(fmt.Sprintf("unexpected protobuf message type %T", spec))
 	}
 
-	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSON(s)}
+	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSONSorted(s)}
 }
 
 func (cb *ZoneEgressInsight) GetStatus() (core_model.ResourceStatus, error) {
@@ -2401,7 +2401,7 @@ func (cb *ZoneIngress) SetSpec(spec core_model.ResourceSpec) {
 		panic(fmt.Sprintf("unexpected protobuf message type %T", spec))
 	}
 
-	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSON(s)}
+	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSONSorted(s)}
 }
 
 func (cb *ZoneIngress) GetStatus() (core_model.ResourceStatus, error) {
@@ -2506,7 +2506,7 @@ func (cb *ZoneIngressInsight) SetSpec(spec core_model.ResourceSpec) {
 		panic(fmt.Sprintf("unexpected protobuf message type %T", spec))
 	}
 
-	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSON(s)}
+	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSONSorted(s)}
 }
 
 func (cb *ZoneIngressInsight) GetStatus() (core_model.ResourceStatus, error) {

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/zz_generated.system.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/zz_generated.system.go
@@ -85,7 +85,7 @@ func (cb *Zone) SetSpec(spec core_model.ResourceSpec) {
 		panic(fmt.Sprintf("unexpected protobuf message type %T", spec))
 	}
 
-	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSON(s)}
+	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSONSorted(s)}
 }
 
 func (cb *Zone) GetStatus() (core_model.ResourceStatus, error) {
@@ -190,7 +190,7 @@ func (cb *ZoneInsight) SetSpec(spec core_model.ResourceSpec) {
 		panic(fmt.Sprintf("unexpected protobuf message type %T", spec))
 	}
 
-	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSON(s)}
+	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSONSorted(s)}
 }
 
 func (cb *ZoneInsight) GetStatus() (core_model.ResourceStatus, error) {

--- a/pkg/util/proto/proto_test.go
+++ b/pkg/util/proto/proto_test.go
@@ -1,0 +1,33 @@
+package proto_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	util_proto "github.com/kumahq/kuma/pkg/util/proto"
+)
+
+var _ = Describe("ToJson", func() {
+	It("test ordering", func() {
+		spec := &mesh_proto.Dataplane{
+			Networking: &mesh_proto.Dataplane_Networking{
+				Address: "123.11.11.11",
+				Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+					{
+						Port: 9090,
+					},
+				},
+				Admin: &mesh_proto.EnvoyAdmin{
+					Port: 9901,
+				},
+			},
+		}
+		messageSorted, err := util_proto.ToJSONSorted(spec)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(messageSorted).To(Equal([]byte(`{"networking":{"address":"123.11.11.11","admin":{"port":9901},"inbound":[{"port":9090}]}}`)))
+		messageNotSorted, err := util_proto.ToJSON(spec)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(messageNotSorted).To(Equal([]byte(`{"networking":{"address":"123.11.11.11","inbound":[{"port":9090}],"admin":{"port":9901}}}`)))
+	})
+})

--- a/tools/resource-gen/main.go
+++ b/tools/resource-gen/main.go
@@ -141,9 +141,9 @@ func (cb *{{.ResourceType}}) SetSpec(spec core_model.ResourceSpec) {
 	}
 
 {{ if eq .ResourceType "DataplaneInsight" }}
-	cb.Status = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSON(s)}
+	cb.Status = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSONSorted(s)}
 {{- else}}
-	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSON(s)}
+	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSONSorted(s)}
 {{- end}}
 }
 


### PR DESCRIPTION
### Checklist prior to review

This is a second approach for [this PR](https://github.com/kumahq/kuma/pull/11327). Instead of checking the Protobuf object directly, I created a new method called `MustMarshalJSONSorted` and replaced every call to `SetSpec` with it. Now, each call to `SetSpec` should produce the same order as the one returned by Kubernetes, allowing us to detect only actual changes.

The downside of this solution is that it involves:

* Marshalling Protobuf to JSON,
* Unmarshalling JSON to a map,
* Marshalling the map back to JSON.
`json.Marshal` function sorts the values, as described [here](https://pkg.go.dev/encoding/json#Marshal).

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
