### PR TITLE
fix(MeshService): add mesh label to generated universal, use local zone in HostnameGenerator if zone label missing

### DIFF
--- a/pkg/core/resources/apis/meshexternalservice/hostname/generator.go
+++ b/pkg/core/resources/apis/meshexternalservice/hostname/generator.go
@@ -56,7 +56,7 @@ func (g *MeshExternalServiceHostnameGenerator) HasStatusChanged(resource model.R
 	return !reflect.DeepEqual(addresses, es.Status.Addresses) || !reflect.DeepEqual(generatorStatuses, es.Status.HostnameGenerators), nil
 }
 
-func (g *MeshExternalServiceHostnameGenerator) GenerateHostname(generator *hostnamegenerator_api.HostnameGeneratorResource, resource model.Resource) (string, error) {
+func (g *MeshExternalServiceHostnameGenerator) GenerateHostname(localZone string, generator *hostnamegenerator_api.HostnameGeneratorResource, resource model.Resource) (string, error) {
 	es, ok := resource.(*meshexternalservice_api.MeshExternalServiceResource)
 	if !ok {
 		return "", errors.Errorf("invalid resource type: expected=%T, got=%T", (*meshexternalservice_api.MeshExternalServiceResource)(nil), resource)
@@ -67,5 +67,5 @@ func (g *MeshExternalServiceHostnameGenerator) GenerateHostname(generator *hostn
 	if !generator.Spec.Selector.MeshExternalService.Matches(es.Meta.GetLabels()) {
 		return "", nil
 	}
-	return hostname.EvaluateTemplate(generator.Spec.Template, es.GetMeta())
+	return hostname.EvaluateTemplate(localZone, generator.Spec.Template, es.GetMeta())
 }

--- a/pkg/core/resources/apis/meshexternalservice/hostname/generator_test.go
+++ b/pkg/core/resources/apis/meshexternalservice/hostname/generator_test.go
@@ -31,7 +31,7 @@ var _ = Describe("MeshExternalService Hostname Generator", func() {
 		Expect(err).ToNot(HaveOccurred())
 		resManager = manager.NewResourceManager(memory.NewStore())
 		allocator, err := hostname.NewGenerator(
-			logr.Discard(), m, resManager, 50*time.Millisecond,
+			logr.Discard(), m, resManager, "", 50*time.Millisecond,
 			[]hostname.HostnameGenerator{mes_hostname.NewMeshExternalServiceHostnameGenerator(resManager)},
 		)
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/core/resources/apis/meshmultizoneservice/hostname/generator.go
+++ b/pkg/core/resources/apis/meshmultizoneservice/hostname/generator.go
@@ -57,7 +57,7 @@ func (g *MeshMultiZoneServiceHostnameGenerator) HasStatusChanged(resource model.
 	return !reflect.DeepEqual(addresses, service.Status.Addresses) || !reflect.DeepEqual(generatorStatuses, service.Status.HostnameGenerators), nil
 }
 
-func (g *MeshMultiZoneServiceHostnameGenerator) GenerateHostname(generator *hostnamegenerator_api.HostnameGeneratorResource, resource model.Resource) (string, error) {
+func (g *MeshMultiZoneServiceHostnameGenerator) GenerateHostname(localZone string, generator *hostnamegenerator_api.HostnameGeneratorResource, resource model.Resource) (string, error) {
 	service, ok := resource.(*meshmzservice_api.MeshMultiZoneServiceResource)
 	if !ok {
 		return "", errors.Errorf("invalid resource type: expected=%T, got=%T", (*meshmzservice_api.MeshMultiZoneServiceResource)(nil), resource)
@@ -68,5 +68,5 @@ func (g *MeshMultiZoneServiceHostnameGenerator) GenerateHostname(generator *host
 	if !generator.Spec.Selector.MeshMultiZoneService.Matches(service.Meta.GetLabels()) {
 		return "", nil
 	}
-	return hostname.EvaluateTemplate(generator.Spec.Template, service.GetMeta())
+	return hostname.EvaluateTemplate(localZone, generator.Spec.Template, service.GetMeta())
 }

--- a/pkg/core/resources/apis/meshmultizoneservice/hostname/generator_test.go
+++ b/pkg/core/resources/apis/meshmultizoneservice/hostname/generator_test.go
@@ -29,7 +29,7 @@ var _ = Describe("MeshMultiZoneService Hostname Generator", func() {
 		Expect(err).ToNot(HaveOccurred())
 		resManager = manager.NewResourceManager(memory.NewStore())
 		allocator, err := hostname.NewGenerator(
-			logr.Discard(), m, resManager, 50*time.Millisecond,
+			logr.Discard(), m, resManager, "", 50*time.Millisecond,
 			[]hostname.HostnameGenerator{mzms_hostname.NewMeshMultiZoneServiceHostnameGenerator(resManager)},
 		)
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/core/resources/apis/meshservice/generate/generator.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/runtime/component"
 	"github.com/kumahq/kuma/pkg/core/user"
 	core_metrics "github.com/kumahq/kuma/pkg/metrics"
+	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/metadata"
 	"github.com/kumahq/kuma/pkg/xds/cache/mesh"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 )
@@ -254,6 +255,7 @@ func (g *Generator) generate(ctx context.Context, mesh string, dataplanes []*cor
 			log.Info("Port conflict for a kuma.io/service tag, ports must be identical across Dataplane inbounds for a given kuma.io/service", "dps", dps)
 		}
 		if err := g.resManager.Create(ctx, meshService, store.CreateByKey(name, mesh), store.CreateWithLabels(map[string]string{
+			metadata.KumaMeshLabel:         mesh,
 			mesh_proto.ManagedByLabel:      managedByValue,
 			mesh_proto.EnvTag:              mesh_proto.UniversalEnvironment,
 			mesh_proto.ResourceOriginLabel: string(mesh_proto.ZoneResourceOrigin),

--- a/pkg/core/resources/apis/meshservice/hostname/generator.go
+++ b/pkg/core/resources/apis/meshservice/hostname/generator.go
@@ -57,7 +57,7 @@ func (g *MeshServiceHostnameGenerator) HasStatusChanged(resource model.Resource,
 	return !reflect.DeepEqual(addresses, service.Status.Addresses) || !reflect.DeepEqual(generatorStatuses, service.Status.HostnameGenerators), nil
 }
 
-func (g *MeshServiceHostnameGenerator) GenerateHostname(generator *hostnamegenerator_api.HostnameGeneratorResource, resource model.Resource) (string, error) {
+func (g *MeshServiceHostnameGenerator) GenerateHostname(localZone string, generator *hostnamegenerator_api.HostnameGeneratorResource, resource model.Resource) (string, error) {
 	service, ok := resource.(*meshservice_api.MeshServiceResource)
 	if !ok {
 		return "", errors.Errorf("invalid resource type: expected=%T, got=%T", (*meshservice_api.MeshServiceResource)(nil), resource)
@@ -68,5 +68,5 @@ func (g *MeshServiceHostnameGenerator) GenerateHostname(generator *hostnamegener
 	if !generator.Spec.Selector.MeshService.Matches(service.Meta.GetLabels()) {
 		return "", nil
 	}
-	return hostname.EvaluateTemplate(generator.Spec.Template, service.GetMeta())
+	return hostname.EvaluateTemplate(localZone, generator.Spec.Template, service.GetMeta())
 }

--- a/pkg/core/resources/apis/meshservice/hostname/generator_test.go
+++ b/pkg/core/resources/apis/meshservice/hostname/generator_test.go
@@ -31,7 +31,7 @@ var _ = Describe("MeshService Hostname Generator", func() {
 		Expect(err).ToNot(HaveOccurred())
 		resManager = manager.NewResourceManager(memory.NewStore())
 		allocator, err := hostname.NewGenerator(
-			logr.Discard(), m, resManager, 50*time.Millisecond,
+			logr.Discard(), m, resManager, "", 50*time.Millisecond,
 			[]hostname.HostnameGenerator{meshservice_hostname.NewMeshServiceHostnameGenerator(resManager)},
 		)
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/dns/hostname_generator.go
+++ b/pkg/dns/hostname_generator.go
@@ -29,6 +29,7 @@ func SetupHostnameGenerator(rt runtime.Runtime) error {
 		logger,
 		rt.Metrics(),
 		rt.ResourceManager(),
+		rt.Config().Multizone.Zone.Name,
 		rt.Config().IPAM.AllocationInterval.Duration,
 		[]hostname.HostnameGenerator{
 			mesGenerator, msGenerator, mzmsGenerator,


### PR DESCRIPTION
See https://github.com/kumahq/kuma/pull/11037 and then https://github.com/kumahq/kuma/pull/11104.
ComputeLabels isn't called in this case.
Also moved MeshService e2e tests to use the generated MeshServices.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
