### PR TITLE
ci(e2e/framework): don't fail when some debug commands will fail

### DIFF
--- a/test/framework/debug.go
+++ b/test/framework/debug.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"syscall"
 
@@ -39,7 +40,9 @@ func DebugUniversal(cluster Cluster, mesh string) {
 		debugUniversalInspectDPs(cluster, mesh, debugDir, kumactlOpts),
 	}
 
-	Expect(seenErrors).ToNot(ContainElement(true), "some debug commands failed")
+	if slices.Contains(seenErrors, true) {
+		Logf("[WARNING]: some debug commands failed")
+	}
 }
 
 func debugUniversalCopyLogs(debugPath string) bool {
@@ -202,9 +205,12 @@ func DebugKube(cluster Cluster, mesh string, namespaces ...string) {
 	}
 
 	exportFilePath := filepath.Join(debugPath, fmt.Sprintf("%s-export-%s", cluster.Name(), uuid.New().String()))
-	Expect(os.WriteFile(exportFilePath, []byte(out), 0o600)).To(Succeed())
-	Expect(errorSeen).NotTo(BeTrue(), "some debug commands failed")
 	Logf("saving export of cluster %q for mesh %q to a file %q", cluster.Name(), mesh, exportFilePath)
+	Expect(os.WriteFile(exportFilePath, []byte(out), 0o600)).To(Succeed())
+
+	if errorSeen {
+		Logf("[WARNING]: some debug commands failed")
+	}
 }
 
 func prepareDebugDir() string {


### PR DESCRIPTION
There are situations where we are calling `Debug*` helper e2e framework functions multiple times. So far if one of them would fail, it stops other from execution. This commit changes this behavior to just log warning in such situations.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - No relevant issues
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
