### PR TITLE
fix(MeshService): add kuma.io/display-name label to generated MeshService on universal

### DIFF
--- a/pkg/core/resources/apis/meshservice/generate/generator.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator.go
@@ -256,6 +256,7 @@ func (g *Generator) generate(ctx context.Context, mesh string, dataplanes []*cor
 		}
 		if err := g.resManager.Create(ctx, meshService, store.CreateByKey(name, mesh), store.CreateWithLabels(map[string]string{
 			metadata.KumaMeshLabel:         mesh,
+			mesh_proto.DisplayName:         name,
 			mesh_proto.ManagedByLabel:      managedByValue,
 			mesh_proto.EnvTag:              mesh_proto.UniversalEnvironment,
 			mesh_proto.ResourceOriginLabel: string(mesh_proto.ZoneResourceOrigin),

--- a/test/e2e_env/multizone/meshmultizoneservice/connectivity.go
+++ b/test/e2e_env/multizone/meshmultizoneservice/connectivity.go
@@ -49,28 +49,6 @@ spec:
 			Setup(multizone.KubeZone1)
 		Expect(err).ToNot(HaveOccurred())
 
-		kubeServiceYAML := `
-apiVersion: kuma.io/v1alpha1
-kind: MeshService
-metadata:
-  name: test-server
-  namespace: mzmsconnectivity
-  labels:
-    kuma.io/origin: zone
-    kuma.io/mesh: mzmsconnectivity
-    kuma.io/managed-by: k8s-controller
-    k8s.kuma.io/is-headless-service: "false"
-spec:
-  selector:
-    dataplaneTags:
-      app: test-server
-      k8s.kuma.io/namespace: mzmsconnectivity
-  ports:
-  - port: 80
-    name: main
-    targetPort: main
-    appProtocol: http
-`
 		err = NewClusterSetup().
 			Install(NamespaceWithSidecarInjection(namespace)).
 			Install(testserver.Install(
@@ -78,7 +56,6 @@ spec:
 				testserver.WithMesh(meshName),
 				testserver.WithEchoArgs("echo", "--instance", "kube-test-server-2"),
 			)).
-			Install(YamlK8s(kubeServiceYAML)).
 			Setup(multizone.KubeZone2)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e_env/multizone/meshmultizoneservice/connectivity.go
+++ b/test/e2e_env/multizone/meshmultizoneservice/connectivity.go
@@ -30,7 +30,6 @@ spec:
     meshService:
       matchLabels:
         kuma.io/display-name: test-server
-        k8s.kuma.io/namespace: mzmsconnectivity
   ports:
   - port: 80
     appProtocol: http
@@ -59,29 +58,9 @@ spec:
 			Setup(multizone.KubeZone2)
 		Expect(err).ToNot(HaveOccurred())
 
-		uniServiceYAML := `
-type: MeshService
-name: test-server
-mesh: mzmsconnectivity
-labels:
-  kuma.io/origin: zone
-  kuma.io/env: universal
-  k8s.kuma.io/namespace: mzmsconnectivity # add a label to aggregate kube and uni service
-  kuma.io/display-name: test-server # add a label to aggregate kube and uni service
-spec:
-  selector:
-    dataplaneTags:
-      kuma.io/service: test-server
-  ports:
-  - port: 80
-    targetPort: 80
-    appProtocol: http
-`
-
 		err = NewClusterSetup().
 			Install(DemoClientUniversal("demo-client", meshName, WithTransparentProxy(true))).
 			Install(TestServerUniversal("test-server", meshName, WithArgs([]string{"echo", "--instance", "uni-test-server"}))).
-			Install(YamlUniversal(uniServiceYAML)).
 			Setup(multizone.UniZone1)
 		Expect(err).ToNot(HaveOccurred())
 	})


### PR DESCRIPTION
These aren't added otherwise. `ComputeLabels` isn't called when using the store directly.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
