### PR TITLE
feat(meshexternalservice): remove unix support

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,12 @@ does not have any particular instructions.
 
 ## Upgrade to `2.9.x`
 
+### MeshExternalService
+
+#### Removal of unix sockets support
+
+It's no longer possible to define a unix domain socket on the `address` field.
+
 ### Upgrading Transparent Proxy Configuration
 
 #### Removal of Deprecated IPv6 Redirection Flag and Annotation

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -295,9 +295,8 @@ spec:
                   properties:
                     address:
                       description: Address defines an address to which a user want
-                        to send a request. Is possible to provide `domain`, `ip` and
-                        `unix` sockets.
-                      example: unix:///tmp/example.sock
+                        to send a request. Is possible to provide `domain`, `ip`.
+                      example: example.com
                       minLength: 1
                       type: string
                     port:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -295,9 +295,8 @@ spec:
                   properties:
                     address:
                       description: Address defines an address to which a user want
-                        to send a request. Is possible to provide `domain`, `ip` and
-                        `unix` sockets.
-                      example: unix:///tmp/example.sock
+                        to send a request. Is possible to provide `domain`, `ip`.
+                      example: example.com
                       minLength: 1
                       type: string
                     port:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -315,9 +315,8 @@ spec:
                   properties:
                     address:
                       description: Address defines an address to which a user want
-                        to send a request. Is possible to provide `domain`, `ip` and
-                        `unix` sockets.
-                      example: unix:///tmp/example.sock
+                        to send a request. Is possible to provide `domain`, `ip`.
+                      example: example.com
                       minLength: 1
                       type: string
                     port:

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -1901,9 +1901,8 @@ spec:
                   properties:
                     address:
                       description: Address defines an address to which a user want
-                        to send a request. Is possible to provide `domain`, `ip` and
-                        `unix` sockets.
-                      example: unix:///tmp/example.sock
+                        to send a request. Is possible to provide `domain`, `ip`.
+                      example: example.com
                       minLength: 1
                       type: string
                     port:

--- a/deployments/charts/kuma/crds/kuma.io_meshexternalservices.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshexternalservices.yaml
@@ -48,9 +48,8 @@ spec:
                   properties:
                     address:
                       description: Address defines an address to which a user want
-                        to send a request. Is possible to provide `domain`, `ip` and
-                        `unix` sockets.
-                      example: unix:///tmp/example.sock
+                        to send a request. Is possible to provide `domain`, `ip`.
+                      example: example.com
                       minLength: 1
                       type: string
                     port:

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -11171,9 +11171,8 @@ components:
                   address:
                     description: >-
                       Address defines an address to which a user want to send a
-                      request. Is possible to provide `domain`, `ip` and `unix`
-                      sockets.
-                    example: unix:///tmp/example.sock
+                      request. Is possible to provide `domain`, `ip`.
+                    example: example.com
                     minLength: 1
                     type: string
                   port:

--- a/docs/generated/raw/crds/kuma.io_meshexternalservices.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshexternalservices.yaml
@@ -48,9 +48,8 @@ spec:
                   properties:
                     address:
                       description: Address defines an address to which a user want
-                        to send a request. Is possible to provide `domain`, `ip` and
-                        `unix` sockets.
-                      example: unix:///tmp/example.sock
+                        to send a request. Is possible to provide `domain`, `ip`.
+                      example: example.com
                       minLength: 1
                       type: string
                     port:

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/meshexternalservice.go
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/meshexternalservice.go
@@ -64,10 +64,9 @@ type Extension struct {
 type Port int
 
 type Endpoint struct {
-	// Address defines an address to which a user want to send a request. Is possible to provide `domain`, `ip` and `unix` sockets.
+	// Address defines an address to which a user want to send a request. Is possible to provide `domain`, `ip`.
 	// +kubebuilder:example="127.0.0.1"
 	// +kubebuilder:example="example.com"
-	// +kubebuilder:example="unix:///tmp/example.sock"
 	// +kubebuilder:validation:MinLength=1
 	Address string `json:"address"`
 	// Port of the endpoint

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/schema.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/schema.yaml
@@ -26,8 +26,8 @@ properties:
         items:
           properties:
             address:
-              description: Address defines an address to which a user want to send a request. Is possible to provide `domain`, `ip` and `unix` sockets.
-              example: unix:///tmp/example.sock
+              description: Address defines an address to which a user want to send a request. Is possible to provide `domain`, `ip`.
+              example: example.com
               minLength: 1
               type: string
             port:

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/testdata/full-invalid.input.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/testdata/full-invalid.input.yaml
@@ -7,8 +7,6 @@ endpoints:
   - address: 1.1.1.2
     port: 999999
   - address: example.com
-  - address: unix:///tmp/example.sock
-    port: 80
   - port: 90
 tls:
   version:

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/testdata/full-invalid.output.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/testdata/full-invalid.output.yaml
@@ -11,10 +11,8 @@ violations:
   message: port must be a valid (1-65535)
 - field: spec.endpoints[2].port
   message: must be defined when endpoint is a hostname
-- field: spec.endpoints[3].port
-  message: must not be defined when endpoint is a unix path
-- field: spec.endpoints[4].address
-  message: address has to be a valid IP or hostname or a unix path
+- field: spec.endpoints[3].address
+  message: address has to be a valid IP or hostname
 - field: spec.tls.version.min
   message: '"min" must be one of ["TLSAuto", "TLS10", "TLS11", "TLS12", "TLS13"]'
 - field: spec.tls.version.max

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/testdata/full-without-extension-valid.input.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/testdata/full-without-extension-valid.input.yaml
@@ -7,7 +7,6 @@ endpoints:
     port: 12345
   - address: example.com
     port: 80
-  - address: unix:///tmp/example.sock
 tls:
   version:
     min: TLS12

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/validator.go
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/validator.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math"
 	"slices"
-	"strings"
 
 	"github.com/asaskevich/govalidator"
 
@@ -106,32 +105,16 @@ func validateEndpoints(endpoints []Endpoint) validators.ValidationError {
 			}
 		}
 
-		if isValidUnixPath(endpoint.Address) {
-			if endpoint.Port != nil {
-				verr.AddViolationAt(validators.Root().Index(i).Field("port"), validators.MustNotBeDefined+" when endpoint is a unix path")
-			}
-		}
-
 		if govalidator.IsDNSName(endpoint.Address) {
 			if endpoint.Port == nil {
 				verr.AddViolationAt(validators.Root().Index(i).Field("port"), validators.MustBeDefined+" when endpoint is a hostname")
 			}
 		}
 
-		if !(govalidator.IsIP(endpoint.Address) || govalidator.IsDNSName(endpoint.Address) || isValidUnixPath(endpoint.Address)) {
-			verr.AddViolationAt(validators.Root().Index(i).Field("address"), "address has to be a valid IP or hostname or a unix path")
+		if !(govalidator.IsIP(endpoint.Address) || govalidator.IsDNSName(endpoint.Address)) {
+			verr.AddViolationAt(validators.Root().Index(i).Field("address"), "address has to be a valid IP or hostname")
 		}
 	}
 
 	return verr
-}
-
-func isValidUnixPath(path string) bool {
-	if strings.HasPrefix(path, "unix://") {
-		parts := strings.Split(path, "unix://")
-		filePath := parts[1]
-		return govalidator.IsUnixFilePath(filePath)
-	} else {
-		return false
-	}
 }

--- a/pkg/core/resources/apis/meshexternalservice/k8s/crd/kuma.io_meshexternalservices.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/k8s/crd/kuma.io_meshexternalservices.yaml
@@ -48,9 +48,8 @@ spec:
                   properties:
                     address:
                       description: Address defines an address to which a user want
-                        to send a request. Is possible to provide `domain`, `ip` and
-                        `unix` sockets.
-                      example: unix:///tmp/example.sock
+                        to send a request. Is possible to provide `domain`, `ip`.
+                      example: example.com
                       minLength: 1
                       type: string
                     port:

--- a/pkg/xds/topology/outbound.go
+++ b/pkg/xds/topology/outbound.go
@@ -5,7 +5,6 @@ import (
 	"maps"
 	"net"
 	"strconv"
-	"strings"
 
 	"github.com/asaskevich/govalidator"
 	"github.com/pkg/errors"
@@ -734,24 +733,13 @@ func createMeshExternalServiceEndpoint(
 		if i == 0 && es.ServerName == "" && govalidator.IsDNSName(endpoint.Address) && tls != nil && tls.Enabled {
 			es.ServerName = endpoint.Address
 		}
-		var outboundEndpoint *core_xds.Endpoint
-		if strings.HasPrefix(endpoint.Address, "unix://") {
-			outboundEndpoint = &core_xds.Endpoint{
-				UnixDomainPath:  endpoint.Address,
-				Weight:          1,
-				ExternalService: es,
-				Tags:            tags,
-				Locality:        GetLocality(zone, getZone(tags), mesh.LocalityAwareLbEnabled()),
-			}
-		} else {
-			outboundEndpoint = &core_xds.Endpoint{
-				Target:          endpoint.Address,
-				Port:            uint32(*endpoint.Port),
-				Weight:          1,
-				ExternalService: es,
-				Tags:            tags,
-				Locality:        GetLocality(zone, getZone(tags), mesh.LocalityAwareLbEnabled()),
-			}
+		outboundEndpoint := &core_xds.Endpoint{
+			Target:          endpoint.Address,
+			Port:            uint32(*endpoint.Port),
+			Weight:          1,
+			ExternalService: es,
+			Tags:            tags,
+			Locality:        GetLocality(zone, getZone(tags), mesh.LocalityAwareLbEnabled()),
 		}
 		outbounds[name] = append(outbounds[name], *outboundEndpoint)
 	}

--- a/pkg/xds/topology/outbound_test.go
+++ b/pkg/xds/topology/outbound_test.go
@@ -1406,24 +1406,6 @@ var _ = Describe("TrafficRoute", func() {
 							},
 						},
 					},
-					{
-						Meta: &test_model.ResourceMeta{
-							Mesh: "default",
-							Name: "no-tls-mes",
-						},
-						Spec: &meshexternalservice_api.MeshExternalService{
-							Match: meshexternalservice_api.Match{
-								Type:     pointer.To(meshexternalservice_api.HostnameGeneratorType),
-								Port:     10000,
-								Protocol: meshexternalservice_api.GrpcProtocol,
-							},
-							Endpoints: []meshexternalservice_api.Endpoint{
-								{
-									Address: "unix://no-tls-mes",
-								},
-							},
-						},
-					},
 				},
 				zoneEgresses: []*core_mesh.ZoneEgressResource{
 					{
@@ -1452,18 +1434,6 @@ var _ = Describe("TrafficRoute", func() {
 							Weight:   1,
 							ExternalService: &core_xds.ExternalService{
 								Protocol:   core_mesh.ProtocolTCP,
-								TLSEnabled: false,
-							},
-						},
-					},
-					"no-tls-mes": []core_xds.Endpoint{
-						{
-							Target:   "1.1.1.1",
-							Port:     10002,
-							Locality: nil,
-							Weight:   1,
-							ExternalService: &core_xds.ExternalService{
-								Protocol:   core_mesh.ProtocolGRPC,
 								TLSEnabled: false,
 							},
 						},


### PR DESCRIPTION
closes https://github.com/kumahq/kuma/issues/11132

It's in experimental until 2.9 so we're ok to remove it.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
