### PR TITLE
refactor(xds): reduce size of meshroute.DestinationService type

### DIFF
--- a/pkg/plugins/policies/core/xds/meshroute/listeners.go
+++ b/pkg/plugins/policies/core/xds/meshroute/listeners.go
@@ -59,10 +59,12 @@ func MakeHTTPSplit(
 }
 
 type DestinationService struct {
-	Outbound    *xds_types.Outbound
-	Protocol    core_mesh.Protocol
-	ServiceName string
-	BackendRef  common_api.BackendRef
+	OutboundInterface mesh_proto.OutboundInterface
+	Resource          *core_model.TypedResourceIdentifier
+	Tags              envoy_tags.Tags
+	Protocol          core_mesh.Protocol
+	ServiceName       string
+	BackendRef        common_api.BackendRef
 }
 
 func CollectServices(
@@ -110,7 +112,12 @@ func collectMeshService(
 		protocol = port.AppProtocol
 	}
 	return &DestinationService{
-		Outbound:    outbound,
+		OutboundInterface: mesh_proto.OutboundInterface{
+			DataplaneIP:   outbound.GetAddress(),
+			DataplanePort: outbound.GetPort(),
+		},
+		Tags:        outbound.LegacyOutbound.GetTags(),
+		Resource:    outbound.Resource,
 		Protocol:    protocol,
 		ServiceName: ms.DestinationName(port.Port),
 		BackendRef: common_api.BackendRef{
@@ -132,7 +139,12 @@ func collectMeshExternalService(
 		return nil
 	}
 	return &DestinationService{
-		Outbound:    outbound,
+		OutboundInterface: mesh_proto.OutboundInterface{
+			DataplaneIP:   outbound.GetAddress(),
+			DataplanePort: outbound.GetPort(),
+		},
+		Tags:        outbound.LegacyOutbound.GetTags(),
+		Resource:    outbound.Resource,
 		Protocol:    core_mesh.Protocol(mes.Spec.Match.Protocol),
 		ServiceName: mes.DestinationName(uint32(mes.Spec.Match.Port)),
 		BackendRef: common_api.BackendRef{
@@ -162,7 +174,12 @@ func collectMeshMultiZoneService(
 		protocol = port.AppProtocol
 	}
 	return &DestinationService{
-		Outbound:    outbound,
+		OutboundInterface: mesh_proto.OutboundInterface{
+			DataplaneIP:   outbound.GetAddress(),
+			DataplanePort: outbound.GetPort(),
+		},
+		Tags:        outbound.LegacyOutbound.GetTags(),
+		Resource:    outbound.Resource,
 		Protocol:    protocol,
 		ServiceName: svc.DestinationName(port.Port),
 		BackendRef: common_api.BackendRef{
@@ -181,7 +198,12 @@ func collectServiceTagService(
 ) *DestinationService {
 	serviceName := outbound.LegacyOutbound.GetService()
 	return &DestinationService{
-		Outbound:    outbound,
+		OutboundInterface: mesh_proto.OutboundInterface{
+			DataplaneIP:   outbound.GetAddress(),
+			DataplanePort: outbound.GetPort(),
+		},
+		Tags:        outbound.LegacyOutbound.GetTags(),
+		Resource:    outbound.Resource,
 		Protocol:    meshCtx.GetServiceProtocol(serviceName),
 		ServiceName: serviceName,
 		BackendRef: common_api.BackendRef{

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners_backendrefs.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners_backendrefs.go
@@ -24,8 +24,8 @@ func computeConf(toRules core_xds.ToRules, svc meshroute_xds.DestinationService,
 		}
 	}
 	// check if there is configuration for real MeshService and prioritize it
-	if svc.Outbound.Resource != nil {
-		resourceConf := toRules.ResourceRules.Compute(*svc.Outbound.Resource, meshCtx.Resources)
+	if svc.Resource != nil {
+		resourceConf := toRules.ResourceRules.Compute(*svc.Resource, meshCtx.Resources)
 		if resourceConf != nil && len(resourceConf.Conf) != 0 {
 			tcpConf = pointer.To(resourceConf.Conf[0].(api.Rule))
 			if o, ok := resourceConf.GetBackendRefOrigin(core_xds.EmptyMatches); ok {


### PR DESCRIPTION
We don't need the entire legacybackend here.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
