### PR TITLE
feat(meshexternalservice): use common protocol field

### DIFF
--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/meshexternalservice.go
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/meshexternalservice.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kumahq/kuma/api/common/v1alpha1"
 	common_tls "github.com/kumahq/kuma/api/common/v1alpha1/tls"
 	hostnamegenerator_api "github.com/kumahq/kuma/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 )
 
 // MeshExternalService
@@ -31,16 +32,6 @@ const (
 	HostnameGeneratorType MatchType = "HostnameGenerator"
 )
 
-// +kubebuilder:validation:Enum=tcp;grpc;http;http2
-type ProtocolType string
-
-const (
-	TcpProtocol   ProtocolType = "tcp"
-	GrpcProtocol  ProtocolType = "grpc"
-	HttpProtocol  ProtocolType = "http"
-	Http2Protocol ProtocolType = "http2"
-)
-
 type Match struct {
 	// Type of the match, only `HostnameGenerator` is available at the moment.
 	// +kubebuilder:default=HostnameGenerator
@@ -49,7 +40,8 @@ type Match struct {
 	Port Port `json:"port"`
 	// Protocol defines a protocol of the communication. Possible values: `tcp`, `grpc`, `http`, `http2`.
 	// +kubebuilder:default=tcp
-	Protocol ProtocolType `json:"protocol,omitempty"`
+	// +kubebuilder:validation:Enum=tcp;grpc;http;http2
+	Protocol core_mesh.Protocol `json:"protocol,omitempty"`
 }
 
 type Extension struct {

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/validator.go
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/validator.go
@@ -8,12 +8,13 @@ import (
 	"github.com/asaskevich/govalidator"
 
 	common_tls "github.com/kumahq/kuma/api/common/v1alpha1/tls"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/validators"
 	"github.com/kumahq/kuma/pkg/util/pointer"
 )
 
 var (
-	allMatchProtocols    = []string{string(TcpProtocol), string(GrpcProtocol), string(HttpProtocol), string(Http2Protocol)}
+	allMatchProtocols    = []string{core_mesh.ProtocolTCP, core_mesh.ProtocolGRPC, core_mesh.ProtocolHTTP, core_mesh.ProtocolHTTP2}
 	allVerificationModes = []string{string(TLSVerificationSkipSAN), string(TLSVerificationSkipCA), string(TLSVerificationSkipAll), string(TLSVerificationSecured)}
 	allSANMatchTypes     = []string{string(SANMatchPrefix), string(SANMatchExact)}
 )

--- a/pkg/plugins/policies/core/xds/meshroute/listeners.go
+++ b/pkg/plugins/policies/core/xds/meshroute/listeners.go
@@ -145,7 +145,7 @@ func collectMeshExternalService(
 		},
 		Tags:        outbound.LegacyOutbound.GetTags(),
 		Resource:    outbound.Resource,
-		Protocol:    core_mesh.Protocol(mes.Spec.Match.Protocol),
+		Protocol:    mes.Spec.Match.Protocol,
 		ServiceName: mes.DestinationName(uint32(mes.Spec.Match.Port)),
 		BackendRef: common_api.BackendRef{
 			TargetRef: common_api.TargetRef{

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
@@ -353,7 +353,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 					Match: meshexternalservice_api.Match{
 						Type:     pointer.To(meshexternalservice_api.HostnameGeneratorType),
 						Port:     9090,
-						Protocol: meshexternalservice_api.HttpProtocol,
+						Protocol: core_mesh.ProtocolHTTP,
 					},
 					Endpoints: []meshexternalservice_api.Endpoint{
 						{
@@ -385,7 +385,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 					Match: meshexternalservice_api.Match{
 						Type:     pointer.To(meshexternalservice_api.HostnameGeneratorType),
 						Port:     9090,
-						Protocol: meshexternalservice_api.HttpProtocol,
+						Protocol: core_mesh.ProtocolHTTP,
 					},
 					Endpoints: []meshexternalservice_api.Endpoint{
 						{
@@ -456,7 +456,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 					Match: meshexternalservice_api.Match{
 						Type:     pointer.To(meshexternalservice_api.HostnameGeneratorType),
 						Port:     9090,
-						Protocol: meshexternalservice_api.HttpProtocol,
+						Protocol: core_mesh.ProtocolHTTP,
 					},
 					Endpoints: []meshexternalservice_api.Endpoint{
 						{
@@ -491,7 +491,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 					Match: meshexternalservice_api.Match{
 						Type:     pointer.To(meshexternalservice_api.HostnameGeneratorType),
 						Port:     9090,
-						Protocol: meshexternalservice_api.HttpProtocol,
+						Protocol: core_mesh.ProtocolHTTP,
 					},
 					Endpoints: []meshexternalservice_api.Endpoint{
 						{
@@ -529,7 +529,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 					Match: meshexternalservice_api.Match{
 						Type:     pointer.To(meshexternalservice_api.HostnameGeneratorType),
 						Port:     9090,
-						Protocol: meshexternalservice_api.HttpProtocol,
+						Protocol: core_mesh.ProtocolHTTP,
 					},
 					Endpoints: []meshexternalservice_api.Endpoint{
 						{

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
@@ -364,7 +364,7 @@ var _ = Describe("MeshTCPRoute", func() {
 					Match: meshexternalservice_api.Match{
 						Type:     pointer.To(meshexternalservice_api.HostnameGeneratorType),
 						Port:     9090,
-						Protocol: meshexternalservice_api.TcpProtocol,
+						Protocol: core_mesh.ProtocolTCP,
 					},
 					Endpoints: []meshexternalservice_api.Endpoint{
 						{
@@ -403,7 +403,7 @@ var _ = Describe("MeshTCPRoute", func() {
 					Match: meshexternalservice_api.Match{
 						Type:     pointer.To(meshexternalservice_api.HostnameGeneratorType),
 						Port:     9090,
-						Protocol: meshexternalservice_api.TcpProtocol,
+						Protocol: core_mesh.ProtocolTCP,
 					},
 					Endpoints: []meshexternalservice_api.Endpoint{
 						{
@@ -431,7 +431,7 @@ var _ = Describe("MeshTCPRoute", func() {
 					Match: meshexternalservice_api.Match{
 						Type:     pointer.To(meshexternalservice_api.HostnameGeneratorType),
 						Port:     9090,
-						Protocol: meshexternalservice_api.TcpProtocol,
+						Protocol: core_mesh.ProtocolTCP,
 					},
 					Endpoints: []meshexternalservice_api.Endpoint{
 						{

--- a/pkg/test/resources/builders/meshexternalservice_builder.go
+++ b/pkg/test/resources/builders/meshexternalservice_builder.go
@@ -3,6 +3,7 @@ package builders
 import (
 	"context"
 
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
@@ -25,7 +26,7 @@ func MeshExternalService() *MeshExternalServiceBuilder {
 				Match: v1alpha1.Match{
 					Type:     pointer.To(v1alpha1.HostnameGeneratorType),
 					Port:     9000,
-					Protocol: v1alpha1.HttpProtocol,
+					Protocol: core_mesh.ProtocolHTTP,
 				},
 				Endpoints: []v1alpha1.Endpoint{
 					{

--- a/pkg/xds/topology/outbound_test.go
+++ b/pkg/xds/topology/outbound_test.go
@@ -1326,7 +1326,7 @@ var _ = Describe("TrafficRoute", func() {
 							Match: meshexternalservice_api.Match{
 								Type:     pointer.To(meshexternalservice_api.HostnameGeneratorType),
 								Port:     10000,
-								Protocol: meshexternalservice_api.HttpProtocol,
+								Protocol: core_mesh.ProtocolHTTP,
 							},
 							Endpoints: []meshexternalservice_api.Endpoint{
 								{
@@ -1379,7 +1379,7 @@ var _ = Describe("TrafficRoute", func() {
 							Match: meshexternalservice_api.Match{
 								Type:     pointer.To(meshexternalservice_api.HostnameGeneratorType),
 								Port:     10000,
-								Protocol: meshexternalservice_api.TcpProtocol,
+								Protocol: core_mesh.ProtocolTCP,
 							},
 							Endpoints: []meshexternalservice_api.Endpoint{
 								{
@@ -1463,7 +1463,7 @@ var _ = Describe("TrafficRoute", func() {
 							Match: meshexternalservice_api.Match{
 								Type:     pointer.To(meshexternalservice_api.HostnameGeneratorType),
 								Port:     10000,
-								Protocol: meshexternalservice_api.HttpProtocol,
+								Protocol: core_mesh.ProtocolHTTP,
 							},
 							Endpoints: []meshexternalservice_api.Endpoint{
 								{
@@ -1647,7 +1647,7 @@ var _ = Describe("TrafficRoute", func() {
 								Match: meshexternalservice_api.Match{
 									Type:     pointer.To(meshexternalservice_api.HostnameGeneratorType),
 									Port:     443,
-									Protocol: meshexternalservice_api.TcpProtocol,
+									Protocol: core_mesh.ProtocolTCP,
 								},
 								Endpoints: []meshexternalservice_api.Endpoint{
 									{

--- a/test/e2e_env/universal/meshexternalservice/meshexternalservice.go
+++ b/test/e2e_env/universal/meshexternalservice/meshexternalservice.go
@@ -12,6 +12,7 @@ import (
 	"github.com/onsi/gomega/types"
 
 	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	meshexternalservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
 	meshaccesslog_api "github.com/kumahq/kuma/pkg/plugins/policies/meshaccesslog/api/v1alpha1"
 	meshcircuitbreaker_api "github.com/kumahq/kuma/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1"
@@ -61,7 +62,7 @@ routing:
 				Match: meshexternalservice_api.Match{
 					Type:     pointer.To(meshexternalservice_api.HostnameGeneratorType),
 					Port:     80,
-					Protocol: meshexternalservice_api.HttpProtocol,
+					Protocol: core_mesh.ProtocolHTTP,
 				},
 				Endpoints: []meshexternalservice_api.Endpoint{{
 					Address: host,


### PR DESCRIPTION
needed for or related to https://github.com/kumahq/kuma/pull/11361

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
