### PR TITLE
test(framework): introduce `debug` switch and collect more deploy details on gateway API failures

### DIFF
--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -78,6 +78,9 @@ jobs:
         env:
           DOCKERHUB_PULL_CREDENTIAL: ${{ secrets.DOCKERHUB_PULL_CREDENTIAL }}
         run: |
+          if [[ "${{ runner.debug }}" == "1" ]]; then
+            export KUMA_DEBUG=true
+          fi
           if [[ "${{ env.E2E_PARAM_K8S_VERSION }}" == "kindIpv6" ]]; then
             export IPV6=true
             export K8S_CLUSTER_TOOL=kind

--- a/test/e2e_env/gatewayapi/conformance_test.go
+++ b/test/e2e_env/gatewayapi/conformance_test.go
@@ -3,9 +3,11 @@ package gatewayapi_test
 import (
 	"context"
 	"fmt"
+	"io/fs"
+	"testing"
+
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	. "github.com/onsi/gomega"
-	"io/fs"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -19,7 +21,6 @@ import (
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
 	"sigs.k8s.io/gateway-api/pkg/features"
 	"sigs.k8s.io/yaml"
-	"testing"
 
 	config_core "github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/metadata"

--- a/test/e2e_env/gatewayapi/conformance_test.go
+++ b/test/e2e_env/gatewayapi/conformance_test.go
@@ -3,10 +3,9 @@ package gatewayapi_test
 import (
 	"context"
 	"fmt"
-	"io/fs"
-	"testing"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	. "github.com/onsi/gomega"
+	"io/fs"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -20,6 +19,7 @@ import (
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
 	"sigs.k8s.io/gateway-api/pkg/features"
 	"sigs.k8s.io/yaml"
+	"testing"
 
 	config_core "github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/metadata"
@@ -50,7 +50,7 @@ func TestConformance(t *testing.T) {
 	opts := cluster.GetKubectlOptions()
 
 	t.Cleanup(func() {
-		if t.Failed() {
+		if t.Failed() || Config.Debug {
 			var namespaces []string
 			clientset, err := k8s.GetKubernetesClientFromOptionsE(t, opts)
 			if err == nil {
@@ -102,7 +102,7 @@ func TestConformance(t *testing.T) {
 		Clientset:            clientset,
 		GatewayClassName:     "kuma",
 		CleanupBaseResources: true,
-		Debug:                false,
+		Debug:                Config.Debug,
 		NamespaceLabels: map[string]string{
 			metadata.KumaSidecarInjectionAnnotation: metadata.AnnotationEnabled,
 		},

--- a/test/e2e_env/gatewayapi/conformance_test.go
+++ b/test/e2e_env/gatewayapi/conformance_test.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
-
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	. "github.com/onsi/gomega"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientgo_kube "k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/test/e2e_env/gatewayapi/conformance_test.go
+++ b/test/e2e_env/gatewayapi/conformance_test.go
@@ -66,7 +66,11 @@ func TestConformance(t *testing.T) {
 			}
 
 			if len(namespaces) > 0 {
-				DebugKube(cluster, "default", namespaces...)
+				g.Expect(func() error { //nolint:unparam  // we need this return type to be included in the Expect block
+					RegisterFailHandler(g.Fail)
+					DebugKube(cluster, "default", namespaces...)
+					return nil
+				}()).To(Succeed())
 			}
 		}
 

--- a/test/framework/config.go
+++ b/test/framework/config.go
@@ -61,6 +61,7 @@ type E2eConfig struct {
 	CleanupLogsOnSuccess              bool              `json:"cleanupLogsOnSuccess,omitempty" envconfig:"CLEANUP_LOGS_ON_SUCCESS"`
 	VersionsYamlPath                  string            `json:"versionsYamlPath,omitempty" envconfig:"VERSIONS_YAML_PATH"`
 	KumaExperimentalSidecarContainers bool              `json:"kumaSidecarContainers,omitempty" envconfig:"KUMA_EXPERIMENTAL_SIDECAR_CONTAINERS"`
+	Debug                             bool              `json:"debug" envconfig:"KUMA_DEBUG"`
 	DebugDir                          string            `json:"debugDir" envconfig:"KUMA_DEBUG_DIR"`
 
 	SuiteConfig SuiteConfig `json:"suites,omitempty"`

--- a/test/framework/debug.go
+++ b/test/framework/debug.go
@@ -2,6 +2,7 @@ package framework
 
 import (
 	"fmt"
+	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 	"path/filepath"
 	"slices"
@@ -168,9 +169,23 @@ func DebugKube(cluster Cluster, mesh string, namespaces ...string) {
 		kubeOptions.Logger = logger.Discard                  // to not print on stdout
 		out, err := k8s.RunKubectlAndGetOutputE(cluster.GetTesting(), &kubeOptions, "get", "all,kuma", "-oyaml")
 		if err != nil {
-			out = fmt.Sprintf("kubectl get for namespace %s failed with error: %s", namespace, err)
+			out = fmt.Sprintf("kubectl get for namespace %s failed with error: %s", namespace, err.Error())
 			errorSeen = true
 		}
+
+		deployments, err := k8s.ListDeploymentsE(cluster.GetTesting(), &kubeOptions, kube_meta.ListOptions{})
+		if err == nil {
+			for _, deployment := range deployments {
+				if !k8s.IsDeploymentAvailable(&deployment) {
+					deployDetails := ExtractDeploymentDetails(cluster.GetTesting(), &kubeOptions, deployment.Name)
+					out += MarshalObjectDetails(deployDetails)
+				}
+			}
+		} else {
+			out += fmt.Sprintf("failed to list deployments in namespace %s with error: %s", namespace, err.Error())
+			errorSeen = true
+		}
+
 		// Ignore it if we don't have Gateway API resources installed
 		gatewayAPIOut, err := k8s.RunKubectlAndGetOutputE(cluster.GetTesting(), &kubeOptions, "get", "gateway-api", "-oyaml")
 		if err == nil {

--- a/test/framework/debug.go
+++ b/test/framework/debug.go
@@ -2,7 +2,6 @@ package framework
 
 import (
 	"fmt"
-	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 	"path/filepath"
 	"slices"
@@ -14,6 +13,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
+	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kumahq/kuma/test/framework/kumactl"
 	"github.com/kumahq/kuma/test/framework/universal_logs"

--- a/test/framework/k8s.go
+++ b/test/framework/k8s.go
@@ -136,16 +136,21 @@ type K8sDecoratedError struct {
 }
 
 func (e *K8sDecoratedError) Error() string {
+	detailStr := MarshalObjectDetails(e.Details)
+	return fmt.Sprintf("sourceError: %s K8sDetails: %q", e.Err.Error(), detailStr)
+}
+
+func MarshalObjectDetails(e *ObjectDetails) string {
 	details := "none"
-	if e.Details != nil {
-		b, err := json.Marshal(*e.Details)
+	if e != nil {
+		b, err := json.Marshal(*e)
 		if err != nil {
-			details = "failed to marshal details"
+			details = fmt.Sprintf("failed to marshal details, err: %v", err)
 		} else {
 			details = string(b)
 		}
 	}
-	return fmt.Sprintf("sourceError: %s K8sDetails:%q", e.Err.Error(), details)
+	return details
 }
 
 func ExtractDeploymentDetails(testingT testing.TestingT,


### PR DESCRIPTION
* Introduce a `debug` switch on E2E config
* Print pod details for un-available deployments in `DebugKube`
* Add DebugKube for GatewayAPI specs
* Add context info for "App Probe Proxy" specs

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues 
  - N/A
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS 
  - Confirmed
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? 
  - No
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) 
  - No


> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
