### PR TITLE
fix(meshexternalservice): generate correct sni for sidecar and egress 

### DIFF
--- a/pkg/plugins/policies/core/xds/meshroute/clusters.go
+++ b/pkg/plugins/policies/core/xds/meshroute/clusters.go
@@ -42,15 +42,28 @@ func GenerateClusters(
 
 			if meshCtx.IsExternalService(serviceName) {
 				if meshCtx.Resource.ZoneEgressEnabled() {
+					endpoints := meshCtx.EndpointMap[serviceName]
 					edsClusterBuilder.
-						Configure(envoy_clusters.EdsCluster()).
-						Configure(envoy_clusters.ClientSideMTLS(
-							proxy.SecretsTracker,
-							meshCtx.Resource,
-							mesh_proto.ZoneEgressServiceName,
-							tlsReady,
-							clusterTags,
-						))
+						Configure(envoy_clusters.EdsCluster())
+					if isMeshExternalService(endpoints) {
+						edsClusterBuilder.
+							Configure(envoy_clusters.ClientSideMTLSCustomSNI(
+								proxy.SecretsTracker,
+								meshCtx.Resource,
+								mesh_proto.ZoneEgressServiceName,
+								true,
+								SniForBackendRef(service.BackendRef(), meshCtx, systemNamespace),
+							))
+					} else {
+						edsClusterBuilder.
+							Configure(envoy_clusters.ClientSideMTLS(
+								proxy.SecretsTracker,
+								meshCtx.Resource,
+								mesh_proto.ZoneEgressServiceName,
+								tlsReady,
+								clusterTags,
+							))
+					}
 				} else {
 					endpoints := meshCtx.ExternalServicesEndpointMap[serviceName]
 					isIPv6 := proxy.Dataplane.IsIPv6()

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.clusters.golden.yaml
@@ -31,7 +31,7 @@ resources:
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
-        sni: example{mesh=default}
+        sni: afce62f771ed74b78.example.9090.default.mes
     type: EDS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.clusters.golden.yaml
@@ -31,7 +31,7 @@ resources:
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
-        sni: example{mesh=default}
+        sni: afce62f771ed74b78.example.0.default.mes
     type: EDS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.clusters.golden.yaml
@@ -31,7 +31,7 @@ resources:
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
-        sni: example{mesh=default}
+        sni: afce62f771ed74b78.example.9090.default.mes
     type: EDS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.clusters.golden.yaml
@@ -31,7 +31,7 @@ resources:
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
-        sni: example{mesh=default}
+        sni: afce62f771ed74b78.example.9090.default.mes
     type: EDS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.clusters.golden.yaml
@@ -31,7 +31,7 @@ resources:
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
-        sni: example{mesh=default}
+        sni: afce62f771ed74b78.example.9090.default.mes
     type: EDS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
@@ -481,7 +481,7 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 					Name:   "egress-listener",
 					Origin: egress.OriginEgress,
 					Resource: NewInboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 10002, core_xds.SocketAddressProtocolTCP).
-						Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3, envoy_common.AnonymousResource).
+						Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3, "mesh-1:meshexternalservice_external").
 							Configure(MatchTransportProtocol("tls")).
 							Configure(MatchServerNames("external{mesh=mesh-1}")).
 							Configure(HttpConnectionManager("127.0.0.1:10002", false)).

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/egress_meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/egress_meshexternalservice.listeners.golden.yaml
@@ -42,5 +42,6 @@ resources:
                       sourceIp: true
                   timeout: 0s
           statPrefix: "127_0_0_1_10002"
+      name: mesh-1:meshexternalservice_external
     name: inbound:127.0.0.1:10002
     trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.clusters.golden.yaml
@@ -70,5 +70,5 @@ resources:
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
-        sni: example{mesh=default}
+        sni: afce62f771ed74b78.example.9090.default.mes
     type: EDS

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.clusters.golden.yaml
@@ -70,5 +70,5 @@ resources:
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
-        sni: example2{mesh=default}
+        sni: a0ac70962fd61fdc0.example2.80.default.mes
     type: EDS

--- a/pkg/xds/envoy/clusters/configurers.go
+++ b/pkg/xds/envoy/clusters/configurers.go
@@ -36,6 +36,20 @@ func ClientSideMTLS(tracker core_xds.SecretsTracker, mesh *core_mesh.MeshResourc
 	})
 }
 
+func ClientSideMTLSCustomSNI(tracker core_xds.SecretsTracker, mesh *core_mesh.MeshResource, upstreamService string, upstreamTLSReady bool, sni string) ClusterBuilderOpt {
+	return ClusterBuilderOptFunc(func(builder *ClusterBuilder) {
+		builder.AddConfigurer(&v3.ClientSideMTLSConfigurer{
+			SecretsTracker:   tracker,
+			UpstreamMesh:     mesh,
+			UpstreamService:  upstreamService,
+			LocalMesh:        mesh,
+			Tags:             nil,
+			UpstreamTLSReady: upstreamTLSReady,
+			SNI:              sni,
+		})
+	})
+}
+
 func ClientSideMultiIdentitiesMTLS(tracker core_xds.SecretsTracker, mesh *core_mesh.MeshResource, upstreamTLSReady bool, sni string, identities []string) ClusterBuilderOpt {
 	return ClusterBuilderOptFunc(func(builder *ClusterBuilder) {
 		builder.AddConfigurer(&v3.ClientSideMTLSConfigurer{

--- a/pkg/xds/generator/egress/external_services_generator.go
+++ b/pkg/xds/generator/egress/external_services_generator.go
@@ -5,7 +5,6 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	meshexternalservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
@@ -33,18 +32,20 @@ func (g *ExternalServicesGenerator) Generate(
 	resources := core_xds.NewResourceSet()
 	apiVersion := proxy.APIVersion
 	endpointMap := meshResources.EndpointMap
+	localResources := xds_context.Resources{MeshLocalResources: meshResources.Resources}
 	destinations := zoneproxy.BuildMeshDestinations(
 		nil,
-		xds_context.Resources{MeshLocalResources: meshResources.Resources},
+		localResources,
 		nil,
 		nil,
+		localResources.MeshExternalServices().Items,
 		"",
 	)
 	services := g.buildServices(endpointMap, zone, meshResources)
 
 	g.addFilterChains(
 		apiVersion,
-		destinations.KumaIoServices,
+		destinations,
 		endpointMap,
 		meshResources,
 		listenerBuilder,
@@ -161,7 +162,7 @@ func (*ExternalServicesGenerator) buildServices(
 
 func (g *ExternalServicesGenerator) addFilterChains(
 	apiVersion core_xds.APIVersion,
-	destinationsPerService map[string][]tags.Tags,
+	meshDestinations zoneproxy.MeshDestinations,
 	endpointMap core_xds.EndpointMap,
 	meshResources *core_xds.MeshResources,
 	listenerBuilder *envoy_listeners.ListenerBuilder,
@@ -175,20 +176,14 @@ func (g *ExternalServicesGenerator) addFilterChains(
 	for _, es := range meshResources.ExternalServices {
 		esNames = append(esNames, es.Spec.GetService())
 	}
-	if val, found := meshResources.Resources[meshexternalservice_api.MeshExternalServiceType]; found {
-		for _, mes := range val.GetItems() {
-			esNames = append(esNames, mes.GetMeta().GetName())
-		}
-	}
 
 	for _, esName := range esNames {
 		if !services[esName] {
 			continue
 		}
-
 		endpoints := endpointMap[esName]
-		destinations := destinationsPerService[esName]
-		destinations = append(destinations, destinationsPerService[mesh_proto.MatchAllTag]...)
+		destinations := meshDestinations.KumaIoServices[esName]
+		destinations = append(destinations, meshDestinations.KumaIoServices[mesh_proto.MatchAllTag]...)
 
 		for _, destination := range destinations {
 			meshDestination := destination.
@@ -196,89 +191,134 @@ func (g *ExternalServicesGenerator) addFilterChains(
 				WithTags("mesh", meshName)
 
 			sni := tls.SNIFromTags(meshDestination)
-
 			if sniUsed[sni] {
 				continue
 			}
 
 			sniUsed[sni] = true
 
-			// There is a case where multiple meshes contain services with
-			// the same names, so we cannot use just "serviceName" as a cluster
-			// name as we would overwrite some clusters with the latest one
-			var clusterName string
-			if isMeshExternalService(endpoints) {
-				clusterName = envoy_names.GetEgressMeshExternalServiceName(meshName, esName)
-			} else {
-				clusterName = envoy_names.GetMeshClusterName(meshName, esName)
-			}
-
-			cluster := envoy_common.NewCluster(
-				envoy_common.WithName(clusterName),
-				envoy_common.WithService(esName),
-				envoy_common.WithTags(meshDestination.WithoutTags(mesh_proto.ServiceTag)),
-				envoy_common.WithExternalService(true),
+			g.configureFilterChain(
+				apiVersion,
+				esName,
+				sni,
+				meshName,
+				endpoints,
+				meshDestination,
+				meshResources,
+				secretsTracker,
+				listenerBuilder,
 			)
-
-			filterChainBuilder := envoy_listeners.NewFilterChainBuilder(apiVersion, names.GetEgressFilterChainName(esName, meshName)).Configure(
-				envoy_listeners.ServerSideMTLS(meshResources.Mesh, secretsTracker, nil, nil),
-				envoy_listeners.MatchTransportProtocol("tls"),
-				envoy_listeners.MatchServerNames(sni),
-				envoy_listeners.NetworkRBAC(
-					esName,
-					// Zone Egress will configure these filter chains only for
-					// meshes with mTLS enabled, so we can safely pass here true
-					true,
-					meshResources.ExternalServicePermissionMap[esName],
-				),
-			)
-			protocol := endpoints[0].Protocol()
-
-			switch protocol {
-			case core_mesh.ProtocolHTTP, core_mesh.ProtocolHTTP2, core_mesh.ProtocolGRPC:
-				routes := envoy_common.Routes{}
-
-				for _, rl := range meshResources.ExternalServiceRateLimits[esName] {
-					if rl.Spec.GetConf().GetHttp() == nil {
-						continue
-					}
-
-					routes = append(routes, envoy_common.NewRoute(
-						envoy_common.WithCluster(cluster),
-						envoy_common.WithMatchHeaderRegex(tags.TagsHeaderName, tags.MatchSourceRegex(rl)),
-						envoy_common.WithRateLimit(rl.Spec),
-					))
-				}
-
-				// Add the default fall-back route
-				routes = append(routes, envoy_common.NewRoute(envoy_common.WithCluster(cluster)))
-
-				var routeConfigName string
-				if isMeshExternalService(endpoints) {
-					routeConfigName = envoy_names.GetEgressMeshExternalServiceName(meshName, esName)
-				} else {
-					routeConfigName = envoy_names.GetOutboundRouteName(esName)
-				}
-
-				filterChainBuilder.
-					Configure(envoy_listeners.HttpConnectionManager(esName, false)).
-					Configure(envoy_listeners.FaultInjection(meshResources.ExternalServiceFaultInjections[esName]...)).
-					Configure(envoy_listeners.RateLimit(meshResources.ExternalServiceRateLimits[esName])).
-					Configure(envoy_listeners.AddFilterChainConfigurer(&v3.HttpOutboundRouteConfigurer{
-						Name:    routeConfigName,
-						Service: esName,
-						Routes:  routes,
-						DpTags:  nil,
-					}))
-			default:
-				filterChainBuilder.Configure(
-					envoy_listeners.TcpProxyDeprecatedWithMetadata(esName, cluster),
-				)
-			}
-
-			listenerBuilder.Configure(envoy_listeners.FilterChain(filterChainBuilder))
 		}
 	}
+
+	for _, mes := range meshDestinations.BackendRefs {
+		if !services[mes.DestinationName] {
+			return
+		}
+		endpoints := endpointMap[mes.DestinationName]
+		if sniUsed[mes.SNI] {
+			continue
+		}
+		sniUsed[mes.SNI] = true
+		relevantTags := tags.Tags{}
+		g.configureFilterChain(
+			apiVersion,
+			mes.DestinationName,
+			mes.SNI,
+			meshName,
+			endpoints,
+			relevantTags,
+			meshResources,
+			secretsTracker,
+			listenerBuilder,
+		)
+	}
+}
+
+func (*ExternalServicesGenerator) configureFilterChain(
+	apiVersion core_xds.APIVersion,
+	esName string,
+	sni string,
+	meshName string,
+	endpoints []core_xds.Endpoint,
+	meshDestination tags.Tags,
+	meshResources *core_xds.MeshResources,
+	secretsTracker core_xds.SecretsTracker,
+	listenerBuilder *envoy_listeners.ListenerBuilder,
+) {
+	// There is a case where multiple meshes contain services with
+	// the same names, so we cannot use just "serviceName" as a cluster
+	// name as we would overwrite some clusters with the latest one
+	var clusterName string
+	if isMeshExternalService(endpoints) {
+		clusterName = envoy_names.GetEgressMeshExternalServiceName(meshName, esName)
+	} else {
+		clusterName = envoy_names.GetMeshClusterName(meshName, esName)
+	}
+
+	cluster := envoy_common.NewCluster(
+		envoy_common.WithName(clusterName),
+		envoy_common.WithService(esName),
+		envoy_common.WithTags(meshDestination.WithoutTags(mesh_proto.ServiceTag)),
+		envoy_common.WithExternalService(true),
+	)
+
+	filterChainBuilder := envoy_listeners.NewFilterChainBuilder(apiVersion, names.GetEgressFilterChainName(esName, meshName)).Configure(
+		envoy_listeners.ServerSideMTLS(meshResources.Mesh, secretsTracker, nil, nil),
+		envoy_listeners.MatchTransportProtocol("tls"),
+		envoy_listeners.MatchServerNames(sni),
+		envoy_listeners.NetworkRBAC(
+			esName,
+			// Zone Egress will configure these filter chains only for
+			// meshes with mTLS enabled, so we can safely pass here true
+			true,
+			meshResources.ExternalServicePermissionMap[esName],
+		),
+	)
+	protocol := endpoints[0].Protocol()
+
+	switch protocol {
+	case core_mesh.ProtocolHTTP, core_mesh.ProtocolHTTP2, core_mesh.ProtocolGRPC:
+		routes := envoy_common.Routes{}
+
+		for _, rl := range meshResources.ExternalServiceRateLimits[esName] {
+			if rl.Spec.GetConf().GetHttp() == nil {
+				continue
+			}
+
+			routes = append(routes, envoy_common.NewRoute(
+				envoy_common.WithCluster(cluster),
+				envoy_common.WithMatchHeaderRegex(tags.TagsHeaderName, tags.MatchSourceRegex(rl)),
+				envoy_common.WithRateLimit(rl.Spec),
+			))
+		}
+
+		// Add the default fall-back route
+		routes = append(routes, envoy_common.NewRoute(envoy_common.WithCluster(cluster)))
+
+		var routeConfigName string
+		if isMeshExternalService(endpoints) {
+			routeConfigName = envoy_names.GetEgressMeshExternalServiceName(meshName, esName)
+		} else {
+			routeConfigName = envoy_names.GetOutboundRouteName(esName)
+		}
+
+		filterChainBuilder.
+			Configure(envoy_listeners.HttpConnectionManager(esName, false)).
+			Configure(envoy_listeners.FaultInjection(meshResources.ExternalServiceFaultInjections[esName]...)).
+			Configure(envoy_listeners.RateLimit(meshResources.ExternalServiceRateLimits[esName])).
+			Configure(envoy_listeners.AddFilterChainConfigurer(&v3.HttpOutboundRouteConfigurer{
+				Name:    routeConfigName,
+				Service: esName,
+				Routes:  routes,
+				DpTags:  nil,
+			}))
+	default:
+		filterChainBuilder.Configure(
+			envoy_listeners.TcpProxyDeprecatedWithMetadata(esName, cluster),
+		)
+	}
+	listenerBuilder.Configure(envoy_listeners.FilterChain(filterChainBuilder))
 }
 
 func isMeshExternalService(endpoints []core_xds.Endpoint) bool {

--- a/pkg/xds/generator/egress/internal_services_generator.go
+++ b/pkg/xds/generator/egress/internal_services_generator.go
@@ -34,6 +34,7 @@ func (g *InternalServicesGenerator) Generate(
 		xds_context.Resources{MeshLocalResources: meshResources.Resources},
 		nil, // todo(jakubdyszkiewicz) add support for MeshService + egress
 		nil, // todo(jakubdyszkiewicz) add support for MeshService + egress
+		nil,
 		"",
 	)
 

--- a/pkg/xds/generator/egress/testdata/01.externalservice-only.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/01.externalservice-only.golden.yaml
@@ -143,7 +143,7 @@ resources:
           requireClientCertificate: true
     - filterChainMatch:
         serverNames:
-        - meshexternalservice-1{mesh=mesh-1}
+        - a45e197ed7825551b.meshexternalservice-1.9090.mesh-1.mes
         transportProtocol: tls
       filters:
       - name: envoy.filters.network.http_connection_manager

--- a/pkg/xds/generator/ingress_generator.go
+++ b/pkg/xds/generator/ingress_generator.go
@@ -56,6 +56,7 @@ func (i IngressGenerator) Generate(
 			meshResources,
 			localMs,
 			meshResources.MeshMultiZoneServices().Items,
+			nil,
 			xdsCtx.ControlPlane.SystemNamespace,
 		)
 

--- a/pkg/xds/topology/outbound.go
+++ b/pkg/xds/topology/outbound.go
@@ -816,7 +816,8 @@ func fillExternalServicesOutboundsThroughEgress(
 				Weight:   1,
 				Locality: locality,
 				ExternalService: &core_xds.ExternalService{
-					Protocol: core_mesh.ParseProtocol(string(mes.Spec.Match.Protocol)),
+					Protocol:      core_mesh.ParseProtocol(string(mes.Spec.Match.Protocol)),
+					OwnerResource: pointer.To(core_rules.UniqueKey(mes, "")),
 				},
 			}
 

--- a/pkg/xds/topology/outbound_test.go
+++ b/pkg/xds/topology/outbound_test.go
@@ -1435,6 +1435,13 @@ var _ = Describe("TrafficRoute", func() {
 							ExternalService: &core_xds.ExternalService{
 								Protocol:   core_mesh.ProtocolTCP,
 								TLSEnabled: false,
+								OwnerResource: &core_model.TypedResourceIdentifier{
+									ResourceIdentifier: core_model.ResourceIdentifier{
+										Name: "another-mes",
+										Mesh: "default",
+									},
+									ResourceType: meshexternalservice_api.MeshExternalServiceType,
+								},
 							},
 						},
 					},
@@ -1447,6 +1454,13 @@ var _ = Describe("TrafficRoute", func() {
 							ExternalService: &core_xds.ExternalService{
 								Protocol:   core_mesh.ProtocolHTTP,
 								TLSEnabled: false,
+								OwnerResource: &core_model.TypedResourceIdentifier{
+									ResourceIdentifier: core_model.ResourceIdentifier{
+										Name: "example-mes",
+										Mesh: "default",
+									},
+									ResourceType: meshexternalservice_api.MeshExternalServiceType,
+								},
 							},
 						},
 					},


### PR DESCRIPTION
### Checklist prior to review

Generated SNI for MeshExternalService wasn't consistent and once MeshHTTPRoute was applied it didn't work correctly. Fixed the way how we set the SNI for egress/sidecar default and with Mesh*Route

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
