### PR TITLE
fix(meshexternalservice): map from/to policy to resource rule for Egress

### DIFF
--- a/pkg/plugins/policies/core/matchers/egress.go
+++ b/pkg/plugins/policies/core/matchers/egress.go
@@ -53,6 +53,10 @@ func EgressMatchedPolicies(rType core_model.ResourceType, tags map[string]string
 		// Picking "from" rules works for us today, because there is only MeshFaultInjection policy that has both "to"
 		// and "from" and is applied on zone egress. In the future, we might want to move the strategy down to the policy plugins.
 		fr, err = processFromRules(tags, policies)
+		if err != nil {
+			return core_xds.TypedMatchingPolicies{}, err
+		}
+		tr, err = processToResourceRules(policies, resources)
 	case isFrom:
 		fr, err = processFromRules(tags, policies)
 	case isTo:

--- a/pkg/plugins/policies/core/matchers/testdata/egressmatchedpolicies/meshexternalservice/fromtorules/mes-with-mcb-policy-on-egress.golden.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/egressmatchedpolicies/meshexternalservice/fromtorules/mes-with-mcb-policy-on-egress.golden.yaml
@@ -1,0 +1,73 @@
+DataplanePolicies: null
+FromRules:
+  Rules:
+    :0: []
+GatewayRules:
+  FromRules: null
+  ToRules:
+    ByListener: null
+    ByListenerAndHostname: null
+InboundPolicies: null
+OutboundPolicies: null
+ServicePolicies: null
+SingleItemRules:
+  Rules: null
+ToRules:
+  ResourceRules:
+    mesh:name/mesh-1:
+      BackendRefOriginIndex: {}
+      Conf:
+      - connectionLimits:
+          maxConnectionPools: 99
+          maxConnections: 99
+          maxPendingRequests: 99
+          maxRequests: 99
+          maxRetries: 99
+      Origin:
+      - Resource:
+          creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: mcb-2
+          type: MeshCircuitBreaker
+        RuleIndex: 0
+      Resource:
+        creationTime: "0001-01-01T00:00:00Z"
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: mesh-1
+        type: Mesh
+      ResourceSectionName: ""
+    meshexternalservice:mesh/mesh-1:name/mes:
+      BackendRefOriginIndex: {}
+      Conf:
+      - connectionLimits:
+          maxConnectionPools: 99
+          maxConnections: 99
+          maxPendingRequests: 1
+          maxRequests: 1
+          maxRetries: 1
+      Origin:
+      - Resource:
+          creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: mcb-2
+          type: MeshCircuitBreaker
+        RuleIndex: 0
+      - Resource:
+          creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: mcb-1
+          type: MeshCircuitBreaker
+        RuleIndex: 0
+      Resource:
+        creationTime: "0001-01-01T00:00:00Z"
+        mesh: mesh-1
+        modificationTime: "0001-01-01T00:00:00Z"
+        name: mes
+        type: MeshExternalService
+      ResourceSectionName: ""
+  Rules: null
+Type: MeshCircuitBreaker
+Warnings: null

--- a/pkg/plugins/policies/core/matchers/testdata/egressmatchedpolicies/meshexternalservice/fromtorules/mes-with-mcb-policy-on-egress.input.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/egressmatchedpolicies/meshexternalservice/fromtorules/mes-with-mcb-policy-on-egress.input.yaml
@@ -1,0 +1,49 @@
+# MeshExternalService from/to policy with targeting egress
+type: MeshCircuitBreaker
+name: mcb-1
+mesh: mesh-1
+spec:
+  targetRef:
+    kind: Mesh
+  to:
+    - targetRef:
+        kind: MeshExternalService
+        name: mes
+      default:
+        connectionLimits:
+          maxPendingRequests: 1
+          maxRequests: 1
+          maxRetries: 1
+---
+type: MeshCircuitBreaker
+name: mcb-2
+mesh: mesh-1
+spec:
+  targetRef:
+    kind: Mesh
+  to:
+    - targetRef:
+        kind: Mesh
+      default:
+        connectionLimits:
+          maxConnectionPools: 99
+          maxConnections: 99
+          maxPendingRequests: 99
+          maxRequests: 99
+          maxRetries: 99
+
+---
+type: MeshExternalService
+mesh: mesh-1
+name: mes
+spec:
+  match:
+    type: HostnameGenerator
+    port: 80
+    protocol: http
+  endpoints:
+    - address: my-es.io
+      port: 80
+---
+type: Mesh
+name: mesh-1


### PR DESCRIPTION
### Checklist prior to review

We were not mapping correctly from/to policy to resource rule for egress
- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
