### PR TITLE
feat(meshservice): mitigate and handle resource conflicts

### DIFF
--- a/pkg/core/resources/apis/core/vip/allocator.go
+++ b/pkg/core/resources/apis/core/vip/allocator.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/runtime/component"
 	"github.com/kumahq/kuma/pkg/core/user"
 	core_metrics "github.com/kumahq/kuma/pkg/metrics"
+	util_time "github.com/kumahq/kuma/pkg/util/time"
 )
 
 type ResourceHoldingVIPs interface {
@@ -70,6 +71,8 @@ func NewAllocator(
 }
 
 func (a *Allocator) Start(stop <-chan struct{}) error {
+	// sleep to mitigate update conflicts with other components
+	util_time.SleepUpTo(a.interval)
 	a.logger.Info("starting")
 	ticker := time.NewTicker(a.interval)
 	ctx := user.Ctx(context.Background(), user.ControlPlane)

--- a/pkg/core/resources/apis/meshmultizoneservice/status_updater.go
+++ b/pkg/core/resources/apis/meshmultizoneservice/status_updater.go
@@ -14,9 +14,11 @@ import (
 	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/core/resources/store"
 	"github.com/kumahq/kuma/pkg/core/runtime/component"
 	"github.com/kumahq/kuma/pkg/core/user"
 	core_metrics "github.com/kumahq/kuma/pkg/metrics"
+	util_time "github.com/kumahq/kuma/pkg/util/time"
 )
 
 type StatusUpdater struct {
@@ -54,6 +56,8 @@ func NewStatusUpdater(
 }
 
 func (s *StatusUpdater) Start(stop <-chan struct{}) error {
+	// sleep to mitigate update conflicts with other components
+	util_time.SleepUpTo(s.interval)
 	s.logger.Info("starting")
 	ticker := time.NewTicker(s.interval)
 	ctx := user.Ctx(context.Background(), user.ControlPlane)
@@ -115,7 +119,11 @@ func (s *StatusUpdater) updateStatus(ctx context.Context) error {
 			mzSvc.Status.MeshServices = matched
 			log.Info("updating matched mesh services", "matchedMeshServices", matched)
 			if err := s.resManager.Update(ctx, mzSvc); err != nil {
-				log.Error(err, "could not update ports and mesh services")
+				if errors.Is(err, &store.ResourceConflictError{}) {
+					log.Info("couldn't update mesh multi zone service, because it was modified in another place. Will try again in the next interval", "interval", s.interval)
+				} else {
+					log.Error(err, "could not update matched mesh services mesh services")
+				}
 			}
 		}
 	}

--- a/pkg/core/resources/apis/meshservice/status/updater.go
+++ b/pkg/core/resources/apis/meshservice/status/updater.go
@@ -15,10 +15,12 @@ import (
 	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/core/resources/store"
 	"github.com/kumahq/kuma/pkg/core/runtime/component"
 	"github.com/kumahq/kuma/pkg/core/user"
 	core_metrics "github.com/kumahq/kuma/pkg/metrics"
 	"github.com/kumahq/kuma/pkg/util/maps"
+	util_time "github.com/kumahq/kuma/pkg/util/time"
 )
 
 type StatusUpdater struct {
@@ -59,6 +61,8 @@ func NewStatusUpdater(
 }
 
 func (s *StatusUpdater) Start(stop <-chan struct{}) error {
+	// sleep to mitigate update conflicts with other components
+	util_time.SleepUpTo(s.interval)
 	s.logger.Info("starting")
 	ticker := time.NewTicker(s.interval)
 	ctx := user.Ctx(context.Background(), user.ControlPlane)
@@ -147,7 +151,11 @@ func (s *StatusUpdater) updateStatus(ctx context.Context) error {
 		if len(changeReasons) > 0 {
 			log.Info("updating mesh service", "reason", changeReasons)
 			if err := s.resManager.Update(ctx, ms); err != nil {
-				log.Error(err, "could not update mesh service", "reason", changeReasons)
+				if errors.Is(err, &store.ResourceConflictError{}) {
+					log.Info("couldn't update mesh service, because it was modified in another place. Will try again in the next interval", "interval", s.interval)
+				} else {
+					log.Error(err, "could not update mesh service", "reason", changeReasons)
+				}
 			}
 		}
 	}

--- a/pkg/util/time/sleep.go
+++ b/pkg/util/time/sleep.go
@@ -1,0 +1,11 @@
+package time
+
+import (
+	"math/rand"
+	"time"
+)
+
+func SleepUpTo(duration time.Duration) {
+	// #nosec G404 - math rand is enough
+	time.Sleep(time.Duration(rand.Intn(int(duration.Milliseconds()))) * time.Millisecond)
+}


### PR DESCRIPTION
### Checklist prior to review

Fix #10511

I think the best strategy for now is to
* Introduce jitter so not all components start at once
* Log on info, not on ERROR

Lock might be too aggressive and batching updates are complicated to implement for now.
I noticed that in E2E jitter already solves a lot of such issues. We can revisit other strategies if needed

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
