### PR TITLE
fix(tproxy/validator): refactor and make validation to work on IPv6

### DIFF
--- a/pkg/transparentproxy/config/config.go
+++ b/pkg/transparentproxy/config/config.go
@@ -640,10 +640,14 @@ func (e *IPFamilyMode) Set(v string) error {
 	case string(IPFamilyModeDualStack), string(IPFamilyModeIPv4):
 		*e = IPFamilyMode(v)
 	default:
-		return errors.Errorf("must be one of '%s' or '%s'", IPFamilyModeDualStack, IPFamilyModeIPv4)
+		return errors.Errorf("must be one of %s", AllowedIPFamilyModes())
 	}
 
 	return nil
+}
+
+func AllowedIPFamilyModes() string {
+	return fmt.Sprintf("'%s' or '%s'", IPFamilyModeDualStack, IPFamilyModeIPv4)
 }
 
 // InitializedConfigIPvX extends the Config struct by adding fields that require
@@ -773,7 +777,7 @@ func (c Config) Initialize(ctx context.Context) (InitializedConfig, error) {
 		return initialized, nil
 	}
 
-	if ok, err := hasLocalIPv6(); !ok || err != nil {
+	if ok, err := HasLocalIPv6(); !ok || err != nil {
 		if c.Verbose {
 			loggerIPv6.Warn("IPv6 initialization skipped due to missing or faulty IPv6 support:", err)
 		}

--- a/pkg/transparentproxy/config/utils.go
+++ b/pkg/transparentproxy/config/utils.go
@@ -210,10 +210,10 @@ func parseUint16(port string) (uint16, error) {
 	return uint16(parsedPort), nil
 }
 
-// hasLocalIPv6 checks if the local system has an active non-loopback IPv6
+// HasLocalIPv6 checks if the local system has an active non-loopback IPv6
 // address. It scans through all network interfaces to find any IPv6 address
 // that is not a loopback address.
-func hasLocalIPv6() (bool, error) {
+func HasLocalIPv6() (bool, error) {
 	addrs, err := net.InterfaceAddrs()
 	if err != nil {
 		return false, err

--- a/pkg/transparentproxy/transparentproxy.go
+++ b/pkg/transparentproxy/transparentproxy.go
@@ -2,61 +2,11 @@ package transparentproxy
 
 import (
 	"context"
-	"fmt"
-	"net"
-	"strconv"
-	"strings"
 
 	"github.com/kumahq/kuma/pkg/transparentproxy/config"
 	"github.com/kumahq/kuma/pkg/transparentproxy/ebpf"
 	"github.com/kumahq/kuma/pkg/transparentproxy/iptables"
 )
-
-func HasLocalIPv6() (bool, error) {
-	addrs, err := net.InterfaceAddrs()
-	if err != nil {
-		return false, err
-	}
-
-	for _, a := range addrs {
-		if ipnet, ok := a.(*net.IPNet); ok &&
-			!ipnet.IP.IsLoopback() &&
-			ipnet.IP.To4() == nil {
-			return true, nil
-		}
-	}
-
-	return false, nil
-}
-
-func ParseUint16(port string) (uint16, error) {
-	parsedPort, err := strconv.ParseUint(port, 10, 16)
-	if err != nil {
-		return 0, fmt.Errorf("value '%s', is not valid uint16", port)
-	}
-
-	return uint16(parsedPort), nil
-}
-
-func SplitPorts(ports string) ([]uint16, error) {
-	ports = strings.TrimSpace(ports)
-	if ports == "" {
-		return nil, nil
-	}
-
-	var result []uint16
-
-	for _, port := range strings.Split(ports, ",") {
-		p, err := ParseUint16(port)
-		if err != nil {
-			return nil, err
-		}
-
-		result = append(result, p)
-	}
-
-	return result, nil
-}
 
 func Setup(ctx context.Context, cfg config.InitializedConfig) (string, error) {
 	if cfg.IPv4.Ebpf.Enabled {

--- a/pkg/transparentproxy/validate/validator.go
+++ b/pkg/transparentproxy/validate/validator.go
@@ -10,177 +10,204 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 	"github.com/sethvargo/go-retry"
 )
 
 const (
-	ValidationServerPort uint16 = 15006
-	validationRetries           = 10
-	validationInterval          = 1 * time.Second
+	ServerPort      uint16 = 15006
+	retries                = 10
+	retriesInterval        = time.Second
 )
 
 type Validator struct {
-	Config *Config
-	Logger logr.Logger
-}
-
-type Config struct {
+	Logger              logr.Logger
 	ServerListenIP      netip.Addr
 	ServerListenPort    uint16
 	ClientConnectIP     netip.Addr
 	ClientRetryInterval time.Duration
 }
 
-func NewValidator(useIpv6 bool, port uint16, logger logr.Logger) *Validator {
-	// Traffic to lo (but not 127.0.0.1) by sidecar will be redirected to  KUMA_MESH_INBOUND_REDIRECT, so:
-	// connect to 127.0.0.6 should be redirected to 127.0.0.1
-	// connect to ::6       should be redirected to ::1
-	serverListenIP := netip.MustParseAddr("127.0.0.1")
-	clientConnectIP := netip.MustParseAddr("127.0.0.6")
-
-	if useIpv6 {
-		serverListenIP = netip.MustParseAddr("::1")
-		clientConnectIP = netip.MustParseAddr("::6")
-	}
-
-	return &Validator{
-		Config: &Config{
-			ServerListenIP:      serverListenIP,
-			ServerListenPort:    port,
-			ClientConnectIP:     clientConnectIP,
-			ClientRetryInterval: validationInterval,
-		},
-		Logger: logger,
-	}
+func (v *Validator) getServerAddress() string {
+	return net.JoinHostPort(
+		v.ServerListenIP.String(),
+		fmt.Sprintf("%d", v.ServerListenPort),
+	)
 }
 
-func (validator *Validator) RunServer(sExit chan struct{}) (uint16, error) {
-	validator.Logger.Info("starting iptables validation")
-
-	s := LocalServer{
-		logger: validator.Logger,
-		config: validator.Config,
+func NewValidator(useIpv6 bool, port uint16, logger logr.Logger) *Validator {
+	v := Validator{
+		Logger: logger,
+		// Traffic to lo (but not 127.0.0.1) by sidecar will be redirected to
+		// KUMA_MESH_INBOUND_REDIRECT, so:
+		// connect to 127.0.0.6 should be redirected to 127.0.0.1
+		// connect to ::6       should be redirected to ::1
+		ServerListenIP:      netip.MustParseAddr("127.0.0.1"),
+		ClientConnectIP:     netip.MustParseAddr("127.0.0.6"),
+		ServerListenPort:    port,
+		ClientRetryInterval: retriesInterval,
 	}
 
-	sReady := make(chan struct{}, 1)
-	sError := make(chan error, 1)
+	if useIpv6 {
+		v.ServerListenIP = netip.MustParseAddr("::1")
+		v.ClientConnectIP = netip.MustParseAddr("::6")
+	}
+
+	return &v
+}
+
+func (v *Validator) RunServer(
+	ctx context.Context,
+	exitC chan struct{},
+) (uint16, error) {
+	v.Logger.Info("starting iptables validation")
+
+	s := LocalServer{
+		logger:   v.Logger.WithValues("address", v.getServerAddress()),
+		listenIP: []byte(v.ServerListenIP.String()),
+		address:  v.getServerAddress(),
+	}
+
+	readyC := make(chan struct{}, 1)
+	errorC := make(chan error, 1)
+
 	go func() {
-		sError <- s.Run(sReady, sExit)
+		errorC <- s.Run(ctx, readyC, exitC)
 	}()
 
-	<-sReady
+	<-readyC
+
 	select {
-	case serverErr := <-sError:
-		if serverErr == nil {
-			serverErr = fmt.Errorf("server exited unexpectedly")
+	case err := <-errorC:
+		if err != nil {
+			return 0, err
 		}
-		serverErr = fmt.Errorf("validation failed: %w", serverErr)
-		return 0, serverErr
+
+		return 0, errors.New("server exited unexpectedly")
 	default:
-		return s.listenedPort, nil
+		return s.port, nil
 	}
 }
 
 type LocalServer struct {
-	logger       logr.Logger
-	config       *Config
-	listenedPort uint16
+	logger   logr.Logger
+	port     uint16
+	address  string
+	listenIP []byte
 }
 
-func (s *LocalServer) Run(readiness chan struct{}, exit chan struct{}) error {
-	addr := net.JoinHostPort(s.config.ServerListenIP.String(), fmt.Sprintf("%d", s.config.ServerListenPort))
-	s.logger.Info(fmt.Sprintf("listening on %v", addr))
+func (s *LocalServer) Run(
+	ctx context.Context,
+	readyC chan struct{},
+	exitC chan struct{},
+) error {
+	s.logger.Info("server is listening")
 
 	config := &net.ListenConfig{}
-	l, err := config.Listen(context.Background(), "tcp", addr)
+
+	l, err := config.Listen(ctx, "tcp", s.address)
 	if err != nil {
-		close(readiness)
+		close(readyC)
 		return err
 	}
-	s.listenedPort = uint16(l.Addr().(*net.TCPAddr).Port)
 
-	go s.handleTcpConnections(l, exit)
+	s.port = uint16(l.Addr().(*net.TCPAddr).Port)
 
-	close(readiness)
-	<-exit
+	go s.handleTcpConnections(l, exitC)
+	close(readyC)
+	<-exitC
 	_ = l.Close()
+
 	return nil
 }
 
-func (s *LocalServer) handleTcpConnections(l net.Listener, cExit chan struct{}) {
+func (s *LocalServer) handleTcpConnections(l net.Listener, exitC chan struct{}) {
 	for {
 		conn, err := l.Accept()
 		if err != nil {
-			s.logger.Error(err, "listener failed to accept connection")
+			s.logger.Error(err, "failed to accept TCP connection")
 			return
 		}
 
-		s.logger.Info("server: a connection has been established")
-		_, _ = conn.Write([]byte(s.config.ServerListenIP.String()))
+		s.logger.Info("connection established")
+
+		_, _ = conn.Write(s.listenIP)
 		_ = conn.Close()
 
 		select {
-		case <-cExit:
+		case <-exitC:
 			return
 		default:
 		}
 	}
 }
 
-func (validator *Validator) RunClient(serverPort uint16, sExit chan struct{}) error {
-	defer close(sExit)
+func (v *Validator) RunClient(
+	ctx context.Context,
+	serverPort uint16,
+	exitC chan struct{},
+) error {
+	defer close(exitC)
 
-	c := LocalClient{ServerIP: validator.Config.ClientConnectIP, ServerPort: serverPort}
-	backoff := retry.WithMaxRetries(validationRetries, retry.NewConstant(validator.Config.ClientRetryInterval))
-	clientErr := retry.Do(context.Background(), backoff, func(ctx context.Context) error {
-		e := c.Run()
-		if e != nil {
-			validator.Logger.Info(fmt.Sprintf("[WARNING] client failed to connect to server: %v", e.Error()))
-			return retry.RetryableError(e)
+	if err := retry.Do(
+		ctx,
+		retry.WithMaxRetries(retries, retry.NewConstant(v.ClientRetryInterval)), // backoff
+		func(context.Context) error {
+			if err := runLocalClient(v.ClientConnectIP, serverPort); err != nil {
+				v.Logger.Info("failed to connect to the server, retrying...", "error", err)
+				return retry.RetryableError(err)
+			}
+			v.Logger.Info("client successfully connected to the server")
+			return nil
+		},
+	); err != nil {
+		return errors.Wrap(err, "client failed to connect to the verification server after retries")
+	}
+
+	v.Logger.Info("validation successful, iptables rules applied correctly")
+
+	return nil
+}
+
+func runLocalClient(serverIP netip.Addr, serverPort uint16) error {
+	var serverAddress string
+	var laddr *net.TCPAddr
+	var err error
+
+	switch {
+	case serverIP.Is6():
+		if laddr, err = net.ResolveTCPAddr("tcp", "[::1]:0"); err != nil {
+			return err
 		}
-		validator.Logger.Info("client: connection established")
-		return nil
-	})
-
-	if clientErr != nil {
-		clientErr = fmt.Errorf("validation failed, client failed to connect to the verification server: %w", clientErr)
-		return clientErr
-	} else {
-		validator.Logger.Info("validation passed, iptables rules applied correctly")
-		return nil
-	}
-}
-
-type LocalClient struct {
-	ServerIP   netip.Addr
-	ServerPort uint16
-}
-
-func (c *LocalClient) Run() error {
-	laddr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
-	if err != nil {
-		return err
-	}
-	if c.ServerIP.Is6() {
-		laddr, err = net.ResolveTCPAddr("tcp", "[::1]:0")
-		if err != nil {
+	default:
+		if laddr, err = net.ResolveTCPAddr("tcp", "127.0.0.1:0"); err != nil {
 			return err
 		}
 	}
 
-	// connections to all ports should be redirected to the server
-	// we support a pre-configured port for testing purposes
-	if c.ServerPort == 0 {
-		randPort, _ := rand.Int(rand.Reader, big.NewInt(10000))
-		c.ServerPort = uint16(20000 + randPort.Int64())
-	}
-	serverAddr := net.JoinHostPort(c.ServerIP.String(), fmt.Sprintf("%d", c.ServerPort))
+	dialer := net.Dialer{LocalAddr: laddr, Timeout: 50 * time.Millisecond}
 
-	dailer := net.Dialer{LocalAddr: laddr, Timeout: 50 * time.Millisecond}
-	conn, err := dailer.Dial("tcp", serverAddr)
+	// connections to all ports should be redirected to the server we support
+	// a pre-configured port for testing purposes
+	switch serverPort {
+	case 0:
+		randPort, _ := rand.Int(rand.Reader, big.NewInt(10000))
+		serverAddress = net.JoinHostPort(
+			serverIP.String(),
+			fmt.Sprintf("%d", 20000+randPort.Int64()),
+		)
+	default:
+		serverAddress = net.JoinHostPort(
+			serverIP.String(),
+			fmt.Sprintf("%d", serverPort),
+		)
+	}
+
+	conn, err := dialer.Dial("tcp", serverAddress)
 	if err != nil {
 		return err
 	}
-	_ = conn.Close()
+	defer conn.Close()
+
 	return nil
 }


### PR DESCRIPTION
IPv6 validation never worked and this PR prepares validation code to be reused after installation of tproxy

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - no relevant issues
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - it won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - locally tested
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - there is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - there is no need

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
