### PR TITLE
test(framework): print original stdout from cURL when collecting failures form test requests

### DIFF
--- a/test/e2e_env/multizone/reachablebackends/reachablebackends_meshservices.go
+++ b/test/e2e_env/multizone/reachablebackends/reachablebackends_meshservices.go
@@ -137,10 +137,11 @@ spec:
 	It("should not be able to connect to cross-zone MeshService if reachable backends isn't set", func() {
 		Consistently(func(g Gomega) {
 			// when
-			resp, err := client.CollectFailure(
+			resp, stdout, err := client.CollectFailureRaw(
 				multizone.KubeZone1, "client-without-reachable", "other-zone-test-server.mesh-service-reachable-backends.svc.kuma-2.mesh.local",
 				client.FromKubernetesPod(namespace, "client-without-reachable"),
 			)
+			Logf("cURL stdout: %s", stdout)
 			// then
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(resp.Exitcode).To(Equal(6))


### PR DESCRIPTION
More information, like `errormsg` is available in cURL generated JSON, so let's print it to help diagnose isues.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - N/A
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS 
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) 
  - Manually tested
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? 
  - Don't
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) 

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
