### PR TITLE
feat(kuma-cp): standarize cluster name for Mesh*Service

### DIFF
--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/helpers.go
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/helpers.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"fmt"
+
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/core/vip"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
@@ -9,7 +11,11 @@ import (
 )
 
 func (m *MeshExternalServiceResource) DestinationName(port uint32) string {
-	return m.GetMeta().GetName()
+	id := model.NewResourceIdentifier(m)
+	if port == 0 {
+		port = uint32(m.Spec.Match.Port)
+	}
+	return fmt.Sprintf("%s_%s_%s_%s_mextsvc_%d", id.Mesh, id.Name, id.Namespace, id.Zone, port)
 }
 
 func (m *MeshExternalServiceResource) IsReachableFromZone(zone string) bool {

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/helpers.go
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/helpers.go
@@ -15,7 +15,7 @@ func (m *MeshExternalServiceResource) DestinationName(port uint32) string {
 	if port == 0 {
 		port = uint32(m.Spec.Match.Port)
 	}
-	return fmt.Sprintf("%s_%s_%s_%s_mextsvc_%d", id.Mesh, id.Name, id.Namespace, id.Zone, port)
+	return fmt.Sprintf("%s_%s_%s_%s_extsvc_%d", id.Mesh, id.Name, id.Namespace, id.Zone, port)
 }
 
 func (m *MeshExternalServiceResource) IsReachableFromZone(zone string) bool {

--- a/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/helpers.go
+++ b/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/helpers.go
@@ -2,7 +2,6 @@ package v1alpha1
 
 import (
 	"fmt"
-	"strings"
 
 	core_vip "github.com/kumahq/kuma/pkg/core/resources/apis/core/vip"
 	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
@@ -49,7 +48,8 @@ func (m *MeshMultiZoneServiceResource) FindPortByName(name string) (meshservice_
 }
 
 func (m *MeshMultiZoneServiceResource) DestinationName(port uint32) string {
-	return fmt.Sprintf("%s_mzsvc_%d", strings.ReplaceAll(m.GetMeta().GetName(), ".", "_"), port)
+	id := model.NewResourceIdentifier(m)
+	return fmt.Sprintf("%s_%s_%s_%s_mzsvc_%d", id.Mesh, id.Name, id.Namespace, id.Zone, port)
 }
 
 func (m *MeshMultiZoneServiceResource) AsOutbounds() xds_types.Outbounds {

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/helpers.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/helpers.go
@@ -2,7 +2,6 @@ package v1alpha1
 
 import (
 	"fmt"
-	"strings"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_vip "github.com/kumahq/kuma/pkg/core/resources/apis/core/vip"
@@ -12,7 +11,8 @@ import (
 )
 
 func (m *MeshServiceResource) DestinationName(port uint32) string {
-	return fmt.Sprintf("%s_msvc_%d", strings.ReplaceAll(m.GetMeta().GetName(), ".", "_"), port)
+	id := model.NewResourceIdentifier(m)
+	return fmt.Sprintf("%s_%s_%s_%s_msvc_%d", id.Mesh, id.Name, id.Namespace, id.Zone, port)
 }
 
 func (m *MeshServiceResource) FindPort(port uint32) (Port, bool) {

--- a/pkg/core/resources/model/resource.go
+++ b/pkg/core/resources/model/resource.go
@@ -14,6 +14,7 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	config_core "github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/metadata"
+	"github.com/kumahq/kuma/pkg/util/pointer"
 )
 
 const (
@@ -715,6 +716,18 @@ func TargetRefToResourceIdentifier(meta ResourceMeta, tr common_api.TargetRef) R
 			Namespace: namespace,
 			Name:      tr.Name,
 		}
+	}
+}
+
+func ResourceToBackendRef(r Resource, resType ResourceType, port uint32) common_api.BackendRef {
+	id := NewResourceIdentifier(r)
+	return common_api.BackendRef{
+		TargetRef: common_api.TargetRef{
+			Kind:      common_api.TargetRefKind(resType),
+			Name:      id.Name,
+			Namespace: id.Namespace,
+		},
+		Port: pointer.To(port),
 	}
 }
 

--- a/pkg/plugins/policies/core/xds/meshroute/clusters.go
+++ b/pkg/plugins/policies/core/xds/meshroute/clusters.go
@@ -15,7 +15,6 @@ import (
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	envoy_clusters "github.com/kumahq/kuma/pkg/xds/envoy/clusters"
-	envoy_names "github.com/kumahq/kuma/pkg/xds/envoy/names"
 	envoy_tags "github.com/kumahq/kuma/pkg/xds/envoy/tags"
 	"github.com/kumahq/kuma/pkg/xds/envoy/tls"
 	"github.com/kumahq/kuma/pkg/xds/generator"
@@ -39,7 +38,6 @@ func GenerateClusters(
 			edsClusterBuilder := envoy_clusters.NewClusterBuilder(proxy.APIVersion, clusterName)
 
 			clusterTags := []envoy_tags.Tags{cluster.Tags()}
-
 			if meshCtx.IsExternalService(serviceName) {
 				if meshCtx.Resource.ZoneEgressEnabled() {
 					endpoints := meshCtx.EndpointMap[serviceName]
@@ -71,7 +69,7 @@ func GenerateClusters(
 					edsClusterBuilder.
 						Configure(envoy_clusters.ProvidedCustomEndpointCluster(isIPv6, isMeshExternalService(endpoints), endpoints...))
 					if isMeshExternalService(endpoints) {
-						edsClusterBuilder.WithName(envoy_names.GetMeshExternalServiceName(serviceName))
+						edsClusterBuilder.WithName(serviceName)
 						edsClusterBuilder.Configure(
 							envoy_clusters.MeshExternalServiceClientSideTLS(endpoints, proxy.Metadata.SystemCaPath, true),
 						)

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin.go
@@ -186,7 +186,8 @@ func applyToEgressRealResources(rs *core_xds.ResourceSet, proxy *core_xds.Proxy)
 	for _, meshResources := range proxy.ZoneEgressProxy.MeshResourcesList {
 		meshExternalServices := meshResources.ListOrEmpty(meshexternalservice_api.MeshExternalServiceType)
 		for _, mes := range meshExternalServices.GetItems() {
-			policies, ok := meshResources.Dynamic[mes.GetMeta().GetName()]
+			meshExtSvc := mes.(*meshexternalservice_api.MeshExternalServiceResource)
+			policies, ok := meshResources.Dynamic[meshExtSvc.DestinationName(uint32(meshExtSvc.Spec.Match.Port))]
 			if !ok {
 				continue
 			}

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin_test.go
@@ -481,6 +481,8 @@ var _ = Describe("MeshCircuitBreaker", func() {
 			Protocol:       core_mesh.ProtocolTCP,
 		})
 
+		mesDefault := samples.MeshExternalServiceExampleBuilder().WithName("external").WithMesh("default").Build()
+		mesMesh2 := samples.MeshExternalServiceExampleBuilder().WithName("external").WithMesh("mesh2").Build()
 		proxy := &core_xds.Proxy{
 			APIVersion: envoy_common.APIV3,
 			ZoneEgressProxy: &core_xds.ZoneEgressProxy{
@@ -499,13 +501,11 @@ var _ = Describe("MeshCircuitBreaker", func() {
 						Mesh: builders.Mesh().WithName("default").WithEnabledMTLSBackend("ca-1").WithBuiltinMTLSBackend("ca-1").Build(),
 						Resources: map[core_model.ResourceType]core_model.ResourceList{
 							meshexternalservice_api.MeshExternalServiceType: &meshexternalservice_api.MeshExternalServiceResourceList{
-								Items: []*meshexternalservice_api.MeshExternalServiceResource{
-									samples.MeshExternalServiceExampleBuilder().WithName("external").WithMesh("default").Build(),
-								},
+								Items: []*meshexternalservice_api.MeshExternalServiceResource{mesDefault},
 							},
 						},
 						Dynamic: core_xds.ExternalServiceDynamicPolicies{
-							"external": {
+							mesDefault.DestinationName(0): {
 								api.MeshCircuitBreakerType: core_xds.TypedMatchingPolicies{
 									ToRules: core_rules.ToRules{
 										ResourceRules: core_rules.ResourceRules{
@@ -527,13 +527,11 @@ var _ = Describe("MeshCircuitBreaker", func() {
 						Mesh: builders.Mesh().WithName("mesh2").WithEnabledMTLSBackend("ca-2").WithBuiltinMTLSBackend("ca-2").Build(),
 						Resources: map[core_model.ResourceType]core_model.ResourceList{
 							meshexternalservice_api.MeshExternalServiceType: &meshexternalservice_api.MeshExternalServiceResourceList{
-								Items: []*meshexternalservice_api.MeshExternalServiceResource{
-									samples.MeshExternalServiceExampleBuilder().WithName("external").WithMesh("mesh2").Build(),
-								},
+								Items: []*meshexternalservice_api.MeshExternalServiceResource{mesMesh2},
 							},
 						},
 						Dynamic: core_xds.ExternalServiceDynamicPolicies{
-							"external": {
+							mesMesh2.DestinationName(0): {
 								api.MeshCircuitBreakerType: core_xds.TypedMatchingPolicies{
 									ToRules: core_rules.ToRules{
 										ResourceRules: core_rules.ResourceRules{

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin.go
@@ -171,7 +171,8 @@ func applyToEgressRealResources(rs *core_xds.ResourceSet, proxy *core_xds.Proxy)
 	for _, meshResources := range proxy.ZoneEgressProxy.MeshResourcesList {
 		meshExternalServices := meshResources.ListOrEmpty(meshexternalservice_api.MeshExternalServiceType)
 		for _, mes := range meshExternalServices.GetItems() {
-			policies, ok := meshResources.Dynamic[mes.GetMeta().GetName()]
+			meshExtSvc := mes.(*meshexternalservice_api.MeshExternalServiceResource)
+			policies, ok := meshResources.Dynamic[meshExtSvc.DestinationName(uint32(meshExtSvc.Spec.Match.Port))]
 			if !ok {
 				continue
 			}

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
@@ -329,7 +329,7 @@ var _ = Describe("MeshHealthCheck", func() {
 							},
 						},
 						Dynamic: core_xds.ExternalServiceDynamicPolicies{
-							"external": {
+							"default_external___mextsvc_9000": {
 								api.MeshHealthCheckType: core_xds.TypedMatchingPolicies{
 									ToRules: core_rules.ToRules{
 										ResourceRules: core_rules.ResourceRules{
@@ -364,7 +364,7 @@ var _ = Describe("MeshHealthCheck", func() {
 							},
 						},
 						Dynamic: core_xds.ExternalServiceDynamicPolicies{
-							"external": {
+							"mesh-2_external___mextsvc_9000": {
 								api.MeshHealthCheckType: core_xds.TypedMatchingPolicies{
 									ToRules: core_rules.ToRules{
 										ResourceRules: core_rules.ResourceRules{

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
@@ -329,7 +329,7 @@ var _ = Describe("MeshHealthCheck", func() {
 							},
 						},
 						Dynamic: core_xds.ExternalServiceDynamicPolicies{
-							"default_external___mextsvc_9000": {
+							"default_external___extsvc_9000": {
 								api.MeshHealthCheckType: core_xds.TypedMatchingPolicies{
 									ToRules: core_rules.ToRules{
 										ResourceRules: core_rules.ResourceRules{
@@ -364,7 +364,7 @@ var _ = Describe("MeshHealthCheck", func() {
 							},
 						},
 						Dynamic: core_xds.ExternalServiceDynamicPolicies{
-							"mesh-2_external___mextsvc_9000": {
+							"mesh-2_external___extsvc_9000": {
 								api.MeshHealthCheckType: core_xds.TypedMatchingPolicies{
 									ToRules: core_rules.ToRules{
 										ResourceRules: core_rules.ResourceRules{

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
@@ -20,7 +20,6 @@ import (
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	envoy_listeners "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
 	envoy_listeners_v3 "github.com/kumahq/kuma/pkg/xds/envoy/listeners/v3"
-	envoy_names "github.com/kumahq/kuma/pkg/xds/envoy/names"
 	envoy_tags "github.com/kumahq/kuma/pkg/xds/envoy/tags"
 	"github.com/kumahq/kuma/pkg/xds/generator"
 )
@@ -38,13 +37,7 @@ func generateFromService(
 		Configure(envoy_listeners.TransparentProxying(proxy.Dataplane.Spec.Networking.GetTransparentProxying())).
 		Configure(envoy_listeners.TagsMetadata(envoy_tags.Tags(tags).WithoutTags(mesh_proto.MeshTag)))
 
-	var resourceName string
-	if svc.BackendRef.Kind == common_api.MeshExternalService {
-		resourceName = envoy_names.GetMeshExternalServiceName(svc.BackendRef.Name)
-		listenerBuilder.WithOverwriteName(resourceName)
-	} else {
-		resourceName = svc.ServiceName
-	}
+	resourceName := svc.ServiceName
 
 	filterChainBuilder := envoy_listeners.NewFilterChainBuilder(proxy.APIVersion, envoy_common.AnonymousResource).
 		Configure(envoy_listeners.AddFilterChainConfigurer(&envoy_listeners_v3.HttpConnectionManagerConfigurer{

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
@@ -195,12 +195,12 @@ var _ = Describe("MeshHTTPRoute", func() {
 		}()),
 		Entry("default-meshservice", func() outboundsTestCase {
 			outboundTargets := xds_builders.EndpointMap().
-				AddEndpoint("backend_msvc_80", xds_builders.Endpoint().
+				AddEndpoint("default_backend___msvc_80", xds_builders.Endpoint().
 					WithTarget("192.168.0.4").
 					WithPort(8084).
 					WithWeight(1).
 					WithTags(mesh_proto.ServiceTag, "backend", mesh_proto.ProtocolTag, core_mesh.ProtocolHTTP, "app", "backend")).
-				AddEndpoint("backend_msvc_80", xds_builders.Endpoint().
+				AddEndpoint("default_backend___msvc_80", xds_builders.Endpoint().
 					WithTarget("192.168.0.5").
 					WithPort(8084).
 					WithWeight(1).
@@ -236,7 +236,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 					WithMeshBuilder(builders.Mesh().WithBuiltinMTLSBackend("builtin").WithEnabledMTLSBackend("builtin")).
 					WithEndpointMap(outboundTargets).
 					WithResources(resources).
-					AddServiceProtocol("backend_svc_80", core_mesh.ProtocolHTTP).
+					AddServiceProtocol("default_backend___svc_80", core_mesh.ProtocolHTTP).
 					Build(),
 				proxy: xds_builders.Proxy().
 					WithSecretsTracker(envoy.NewSecretsTracker(core_model.DefaultMesh, nil)).
@@ -698,7 +698,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 				Items: []*meshservice_api.MeshServiceResource{&meshSvc},
 			}
 			outboundTargets := xds_builders.EndpointMap().
-				AddEndpoint("backend_msvc_80", xds_builders.Endpoint().
+				AddEndpoint("default_backend___msvc_80", xds_builders.Endpoint().
 					WithTarget("192.168.0.4").
 					WithPort(8084).
 					WithWeight(1).

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-labels.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-labels.clusters.golden.yaml
@@ -1,5 +1,5 @@
 resources:
-- name: backend-second_msvc_80
+- name: default_backend-second___msvc_80
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
@@ -7,7 +7,7 @@ resources:
         ads: {}
         initialFetchTimeout: 0s
         resourceApiVersion: V3
-    name: backend-second_msvc_80
+    name: default_backend-second___msvc_80
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:
@@ -38,7 +38,7 @@ resources:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         explicitHttpConfig:
           http2ProtocolOptions: {}
-- name: backend_msvc_80
+- name: default_backend___msvc_80
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
@@ -46,7 +46,7 @@ resources:
         ads: {}
         initialFetchTimeout: 0s
         resourceApiVersion: V3
-    name: backend_msvc_80
+    name: default_backend___msvc_80
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-labels.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-labels.endpoints.golden.yaml
@@ -1,9 +1,9 @@
 resources:
-- name: backend-second_msvc_80
+- name: default_backend-second___msvc_80
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: backend-second_msvc_80
-- name: backend_msvc_80
+    clusterName: default_backend-second___msvc_80
+- name: default_backend___msvc_80
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: backend_msvc_80
+    clusterName: default_backend___msvc_80

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-labels.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-labels.listeners.golden.yaml
@@ -17,7 +17,7 @@ resources:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           normalizePath: true
           routeConfig:
-            name: outbound:backend_msvc_80
+            name: outbound:default_backend___msvc_80
             requestHeadersToAdd:
             - header:
                 key: x-kuma-tags
@@ -26,39 +26,39 @@ resources:
             virtualHosts:
             - domains:
               - '*'
-              name: backend_msvc_80
+              name: default_backend___msvc_80
               routes:
               - match:
                   path: /version1
                 name: ExEgbKnY+1gXGsNYQ6CZ7dck4MNOIit5oX7HLROlnE4=
                 route:
-                  cluster: backend_msvc_80
+                  cluster: default_backend___msvc_80
                   timeout: 0s
               - match:
                   prefix: /version1/
                 name: ExEgbKnY+1gXGsNYQ6CZ7dck4MNOIit5oX7HLROlnE4=
                 route:
-                  cluster: backend_msvc_80
+                  cluster: default_backend___msvc_80
                   timeout: 0s
               - match:
                   path: /version2
                 name: mNuADh5d2QXFo3V0KWvZuj8EUfszOl6JoAaFFDm7ueU=
                 route:
-                  cluster: backend-second_msvc_80
+                  cluster: default_backend-second___msvc_80
                   timeout: 0s
               - match:
                   prefix: /version2/
                 name: mNuADh5d2QXFo3V0KWvZuj8EUfszOl6JoAaFFDm7ueU=
                 route:
-                  cluster: backend-second_msvc_80
+                  cluster: default_backend-second___msvc_80
                   timeout: 0s
               - match:
                   prefix: /
                 name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
                 route:
-                  cluster: backend_msvc_80
+                  cluster: default_backend___msvc_80
                   timeout: 0s
-          statPrefix: backend_msvc_80
+          statPrefix: default_backend___msvc_80
     metadata:
       filterMetadata:
         io.kuma.tags: {}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.clusters.golden.yaml
@@ -29,7 +29,7 @@ resources:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         explicitHttpConfig:
           http2ProtocolOptions: {}
-- name: backend_msvc_80
+- name: default_backend___msvc_80
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
@@ -37,7 +37,7 @@ resources:
         ads: {}
         initialFetchTimeout: 0s
         resourceApiVersion: V3
-    name: backend_msvc_80
+    name: default_backend___msvc_80
     type: EDS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.endpoints.golden.yaml
@@ -53,10 +53,10 @@ resources:
             envoy.transport_socket_match:
               kuma.io/protocol: http
               region: us
-- name: backend_msvc_80
+- name: default_backend___msvc_80
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: backend_msvc_80
+    clusterName: default_backend___msvc_80
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
@@ -17,7 +17,7 @@ resources:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           normalizePath: true
           routeConfig:
-            name: outbound:backend_msvc_80
+            name: outbound:default_backend___msvc_80
             requestHeadersToAdd:
             - header:
                 key: x-kuma-tags
@@ -26,7 +26,7 @@ resources:
             virtualHosts:
             - domains:
               - '*'
-              name: backend_msvc_80
+              name: default_backend___msvc_80
               routes:
               - match:
                   path: /v1
@@ -68,21 +68,21 @@ resources:
                   path: /v4
                 name: UszzxTjarAB0Egv5zi/OpbBLkZsjGV5NpM2+96fwVa8=
                 route:
-                  cluster: backend_msvc_80
+                  cluster: default_backend___msvc_80
                   timeout: 0s
               - match:
                   prefix: /v4/
                 name: UszzxTjarAB0Egv5zi/OpbBLkZsjGV5NpM2+96fwVa8=
                 route:
-                  cluster: backend_msvc_80
+                  cluster: default_backend___msvc_80
                   timeout: 0s
               - match:
                   prefix: /
                 name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
                 route:
-                  cluster: backend_msvc_80
+                  cluster: default_backend___msvc_80
                   timeout: 0s
-          statPrefix: backend_msvc_80
+          statPrefix: default_backend___msvc_80
     metadata:
       filterMetadata:
         io.kuma.tags: {}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.clusters.golden.yaml
@@ -1,5 +1,5 @@
 resources:
-- name: default_example___mextsvc_9090
+- name: default_example___extsvc_9090
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
@@ -7,7 +7,7 @@ resources:
         ads: {}
         initialFetchTimeout: 0s
         resourceApiVersion: V3
-    name: default_example___mextsvc_9090
+    name: default_example___extsvc_9090
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.clusters.golden.yaml
@@ -1,5 +1,5 @@
 resources:
-- name: meshexternalservice_example
+- name: default_example___mextsvc_9090
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
@@ -7,7 +7,7 @@ resources:
         ads: {}
         initialFetchTimeout: 0s
         resourceApiVersion: V3
-    name: meshexternalservice_example
+    name: default_example___mextsvc_9090
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.endpoints.golden.yaml
@@ -1,8 +1,8 @@
 resources:
-- name: default_example___mextsvc_9090
+- name: default_example___extsvc_9090
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: default_example___mextsvc_9090
+    clusterName: default_example___extsvc_9090
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.endpoints.golden.yaml
@@ -1,8 +1,8 @@
 resources:
-- name: meshexternalservice_example
+- name: default_example___mextsvc_9090
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: meshexternalservice_example
+    clusterName: default_example___mextsvc_9090
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.listeners.golden.yaml
@@ -1,5 +1,5 @@
 resources:
-- name: meshexternalservice_example
+- name: outbound:10.20.20.1:9090
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener
     address:
@@ -17,7 +17,7 @@ resources:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           normalizePath: true
           routeConfig:
-            name: meshexternalservice_example
+            name: default_example___mextsvc_9090
             requestHeadersToAdd:
             - header:
                 key: x-kuma-tags
@@ -26,18 +26,18 @@ resources:
             virtualHosts:
             - domains:
               - '*'
-              name: example
+              name: default_example___mextsvc_9090
               routes:
               - match:
                   prefix: /
                 name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
                 route:
                   autoHostRewrite: true
-                  cluster: meshexternalservice_example
+                  cluster: default_example___mextsvc_9090
                   timeout: 0s
-          statPrefix: meshexternalservice_example
+          statPrefix: default_example___mextsvc_9090
     metadata:
       filterMetadata:
         io.kuma.tags: {}
-    name: meshexternalservice_example
+    name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.listeners.golden.yaml
@@ -17,7 +17,7 @@ resources:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           normalizePath: true
           routeConfig:
-            name: default_example___mextsvc_9090
+            name: default_example___extsvc_9090
             requestHeadersToAdd:
             - header:
                 key: x-kuma-tags
@@ -26,16 +26,16 @@ resources:
             virtualHosts:
             - domains:
               - '*'
-              name: default_example___mextsvc_9090
+              name: default_example___extsvc_9090
               routes:
               - match:
                   prefix: /
                 name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
                 route:
                   autoHostRewrite: true
-                  cluster: default_example___mextsvc_9090
+                  cluster: default_example___extsvc_9090
                   timeout: 0s
-          statPrefix: default_example___mextsvc_9090
+          statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
         io.kuma.tags: {}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice.clusters.golden.yaml
@@ -1,5 +1,5 @@
 resources:
-- name: multi-backend_mzsvc_80
+- name: default_multi-backend___mzsvc_80
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
@@ -7,7 +7,7 @@ resources:
         ads: {}
         initialFetchTimeout: 0s
         resourceApiVersion: V3
-    name: multi-backend_mzsvc_80
+    name: default_multi-backend___mzsvc_80
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice.endpoints.golden.yaml
@@ -1,5 +1,5 @@
 resources:
-- name: multi-backend_mzsvc_80
+- name: default_multi-backend___mzsvc_80
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: multi-backend_mzsvc_80
+    clusterName: default_multi-backend___mzsvc_80

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice.listeners.golden.yaml
@@ -17,7 +17,7 @@ resources:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           normalizePath: true
           routeConfig:
-            name: outbound:multi-backend_mzsvc_80
+            name: outbound:default_multi-backend___mzsvc_80
             requestHeadersToAdd:
             - header:
                 key: x-kuma-tags
@@ -26,15 +26,15 @@ resources:
             virtualHosts:
             - domains:
               - '*'
-              name: multi-backend_mzsvc_80
+              name: default_multi-backend___mzsvc_80
               routes:
               - match:
                   prefix: /
                 name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
                 route:
-                  cluster: multi-backend_mzsvc_80
+                  cluster: default_multi-backend___mzsvc_80
                   timeout: 0s
-          statPrefix: multi-backend_mzsvc_80
+          statPrefix: default_multi-backend___mzsvc_80
     metadata:
       filterMetadata:
         io.kuma.tags: {}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.clusters.golden.yaml
@@ -1,5 +1,5 @@
 resources:
-- name: backend_msvc_80
+- name: default_backend___msvc_80
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
@@ -7,7 +7,7 @@ resources:
         ads: {}
         initialFetchTimeout: 0s
         resourceApiVersion: V3
-    name: backend_msvc_80
+    name: default_backend___msvc_80
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.endpoints.golden.yaml
@@ -1,8 +1,8 @@
 resources:
-- name: backend_msvc_80
+- name: default_backend___msvc_80
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: backend_msvc_80
+    clusterName: default_backend___msvc_80
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.listeners.golden.yaml
@@ -17,7 +17,7 @@ resources:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           normalizePath: true
           routeConfig:
-            name: outbound:backend_msvc_80
+            name: outbound:default_backend___msvc_80
             requestHeadersToAdd:
             - header:
                 key: x-kuma-tags
@@ -26,15 +26,15 @@ resources:
             virtualHosts:
             - domains:
               - '*'
-              name: backend_msvc_80
+              name: default_backend___msvc_80
               routes:
               - match:
                   prefix: /
                 name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
                 route:
-                  cluster: backend_msvc_80
+                  cluster: default_backend___msvc_80
                   timeout: 0s
-          statPrefix: backend_msvc_80
+          statPrefix: default_backend___msvc_80
     metadata:
       filterMetadata:
         io.kuma.tags: {}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-real-mesh-service.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-real-mesh-service.clusters.golden.yaml
@@ -1,5 +1,5 @@
 resources:
-- name: backend_msvc_80-6c7282d3d97450ca
+- name: default_backend___msvc_80-01804e3659fbd290
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
@@ -7,7 +7,7 @@ resources:
         ads: {}
         initialFetchTimeout: 0s
         resourceApiVersion: V3
-    name: backend_msvc_80-6c7282d3d97450ca
+    name: default_backend___msvc_80-01804e3659fbd290
     perConnectionBufferLimitBytes: 32768
     type: EDS
     typedExtensionProtocolOptions:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-real-mesh-service.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-real-mesh-service.endpoints.golden.yaml
@@ -1,13 +1,5 @@
 resources:
-- name: backend_msvc_80-6c7282d3d97450ca
+- name: default_backend___msvc_80-01804e3659fbd290
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: backend_msvc_80-6c7282d3d97450ca
-    endpoints:
-    - lbEndpoints:
-      - endpoint:
-          address:
-            socketAddress:
-              address: 192.168.0.4
-              portValue: 8080
-        loadBalancingWeight: 1
+    clusterName: default_backend___msvc_80-01804e3659fbd290

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-real-mesh-service.routes.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-real-mesh-service.routes.golden.yaml
@@ -20,7 +20,7 @@ resources:
           idleTimeout: 5s
           weightedClusters:
             clusters:
-            - name: backend_msvc_80-6c7282d3d97450ca
+            - name: default_backend___msvc_80-01804e3659fbd290
               requestHeadersToAdd:
               - header:
                   key: x-kuma-tags
@@ -34,7 +34,7 @@ resources:
           idleTimeout: 5s
           weightedClusters:
             clusters:
-            - name: backend_msvc_80-6c7282d3d97450ca
+            - name: default_backend___msvc_80-01804e3659fbd290
               requestHeadersToAdd:
               - header:
                   key: x-kuma-tags

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.clusters.golden.yaml
@@ -1,5 +1,5 @@
 resources:
-- name: default_example___mextsvc_9090
+- name: default_example___extsvc_9090
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
@@ -7,7 +7,7 @@ resources:
         ads: {}
         initialFetchTimeout: 0s
         resourceApiVersion: V3
-    name: default_example___mextsvc_9090
+    name: default_example___extsvc_9090
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.clusters.golden.yaml
@@ -1,5 +1,5 @@
 resources:
-- name: meshexternalservice_example
+- name: default_example___mextsvc_9090
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
@@ -7,7 +7,7 @@ resources:
         ads: {}
         initialFetchTimeout: 0s
         resourceApiVersion: V3
-    name: meshexternalservice_example
+    name: default_example___mextsvc_9090
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.endpoints.golden.yaml
@@ -1,8 +1,8 @@
 resources:
-- name: default_example___mextsvc_9090
+- name: default_example___extsvc_9090
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: default_example___mextsvc_9090
+    clusterName: default_example___extsvc_9090
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.endpoints.golden.yaml
@@ -1,8 +1,8 @@
 resources:
-- name: meshexternalservice_example
+- name: default_example___mextsvc_9090
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: meshexternalservice_example
+    clusterName: default_example___mextsvc_9090
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.listeners.golden.yaml
@@ -1,5 +1,5 @@
 resources:
-- name: meshexternalservice_example
+- name: outbound:10.20.20.1:9090
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener
     address:
@@ -17,7 +17,7 @@ resources:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           normalizePath: true
           routeConfig:
-            name: meshexternalservice_example
+            name: default_example___mextsvc_9090
             requestHeadersToAdd:
             - header:
                 key: x-kuma-tags
@@ -26,32 +26,32 @@ resources:
             virtualHosts:
             - domains:
               - '*'
-              name: example
+              name: default_example___mextsvc_9090
               routes:
               - match:
                   path: /v1
                 name: bzv64o+joRk33jfDADgGv5ar4QyONO0NEVKnoBfJW/E=
                 route:
                   autoHostRewrite: true
-                  cluster: meshexternalservice_example
+                  cluster: default_example___mextsvc_9090
                   timeout: 0s
               - match:
                   prefix: /v1/
                 name: bzv64o+joRk33jfDADgGv5ar4QyONO0NEVKnoBfJW/E=
                 route:
                   autoHostRewrite: true
-                  cluster: meshexternalservice_example
+                  cluster: default_example___mextsvc_9090
                   timeout: 0s
               - match:
                   prefix: /
                 name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
                 route:
                   autoHostRewrite: true
-                  cluster: meshexternalservice_example
+                  cluster: default_example___mextsvc_9090
                   timeout: 0s
-          statPrefix: meshexternalservice_example
+          statPrefix: default_example___mextsvc_9090
     metadata:
       filterMetadata:
         io.kuma.tags: {}
-    name: meshexternalservice_example
+    name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.listeners.golden.yaml
@@ -17,7 +17,7 @@ resources:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           normalizePath: true
           routeConfig:
-            name: default_example___mextsvc_9090
+            name: default_example___extsvc_9090
             requestHeadersToAdd:
             - header:
                 key: x-kuma-tags
@@ -26,30 +26,30 @@ resources:
             virtualHosts:
             - domains:
               - '*'
-              name: default_example___mextsvc_9090
+              name: default_example___extsvc_9090
               routes:
               - match:
                   path: /v1
                 name: bzv64o+joRk33jfDADgGv5ar4QyONO0NEVKnoBfJW/E=
                 route:
                   autoHostRewrite: true
-                  cluster: default_example___mextsvc_9090
+                  cluster: default_example___extsvc_9090
                   timeout: 0s
               - match:
                   prefix: /v1/
                 name: bzv64o+joRk33jfDADgGv5ar4QyONO0NEVKnoBfJW/E=
                 route:
                   autoHostRewrite: true
-                  cluster: default_example___mextsvc_9090
+                  cluster: default_example___extsvc_9090
                   timeout: 0s
               - match:
                   prefix: /
                 name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
                 route:
                   autoHostRewrite: true
-                  cluster: default_example___mextsvc_9090
+                  cluster: default_example___extsvc_9090
                   timeout: 0s
-          statPrefix: default_example___mextsvc_9090
+          statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
         io.kuma.tags: {}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.clusters.golden.yaml
@@ -1,5 +1,5 @@
 resources:
-- name: default_example___mextsvc_9090
+- name: default_example___extsvc_9090
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
@@ -7,7 +7,7 @@ resources:
         ads: {}
         initialFetchTimeout: 0s
         resourceApiVersion: V3
-    name: default_example___mextsvc_9090
+    name: default_example___extsvc_9090
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.clusters.golden.yaml
@@ -1,5 +1,5 @@
 resources:
-- name: meshexternalservice_example
+- name: default_example___mextsvc_9090
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
@@ -7,7 +7,7 @@ resources:
         ads: {}
         initialFetchTimeout: 0s
         resourceApiVersion: V3
-    name: meshexternalservice_example
+    name: default_example___mextsvc_9090
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.endpoints.golden.yaml
@@ -1,8 +1,8 @@
 resources:
-- name: default_example___mextsvc_9090
+- name: default_example___extsvc_9090
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: default_example___mextsvc_9090
+    clusterName: default_example___extsvc_9090
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.endpoints.golden.yaml
@@ -1,8 +1,8 @@
 resources:
-- name: meshexternalservice_example
+- name: default_example___mextsvc_9090
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: meshexternalservice_example
+    clusterName: default_example___mextsvc_9090
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.listeners.golden.yaml
@@ -1,5 +1,5 @@
 resources:
-- name: meshexternalservice_example
+- name: outbound:10.20.20.1:9090
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener
     address:
@@ -17,7 +17,7 @@ resources:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           normalizePath: true
           routeConfig:
-            name: meshexternalservice_example
+            name: default_example___mextsvc_9090
             requestHeadersToAdd:
             - header:
                 key: x-kuma-tags
@@ -26,18 +26,18 @@ resources:
             virtualHosts:
             - domains:
               - '*'
-              name: example
+              name: default_example___mextsvc_9090
               routes:
               - match:
                   prefix: /
                 name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
                 route:
                   autoHostRewrite: true
-                  cluster: meshexternalservice_example
+                  cluster: default_example___mextsvc_9090
                   timeout: 0s
-          statPrefix: meshexternalservice_example
+          statPrefix: default_example___mextsvc_9090
     metadata:
       filterMetadata:
         io.kuma.tags: {}
-    name: meshexternalservice_example
+    name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.listeners.golden.yaml
@@ -17,7 +17,7 @@ resources:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           normalizePath: true
           routeConfig:
-            name: default_example___mextsvc_9090
+            name: default_example___extsvc_9090
             requestHeadersToAdd:
             - header:
                 key: x-kuma-tags
@@ -26,16 +26,16 @@ resources:
             virtualHosts:
             - domains:
               - '*'
-              name: default_example___mextsvc_9090
+              name: default_example___extsvc_9090
               routes:
               - match:
                   prefix: /
                 name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
                 route:
                   autoHostRewrite: true
-                  cluster: default_example___mextsvc_9090
+                  cluster: default_example___extsvc_9090
                   timeout: 0s
-          statPrefix: default_example___mextsvc_9090
+          statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
         io.kuma.tags: {}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.clusters.golden.yaml
@@ -1,5 +1,5 @@
 resources:
-- name: default_example___mextsvc_9090
+- name: default_example___extsvc_9090
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
@@ -7,7 +7,7 @@ resources:
         ads: {}
         initialFetchTimeout: 0s
         resourceApiVersion: V3
-    name: default_example___mextsvc_9090
+    name: default_example___extsvc_9090
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.clusters.golden.yaml
@@ -1,5 +1,5 @@
 resources:
-- name: meshexternalservice_example
+- name: default_example___mextsvc_9090
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
@@ -7,7 +7,7 @@ resources:
         ads: {}
         initialFetchTimeout: 0s
         resourceApiVersion: V3
-    name: meshexternalservice_example
+    name: default_example___mextsvc_9090
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.endpoints.golden.yaml
@@ -1,8 +1,8 @@
 resources:
-- name: default_example___mextsvc_9090
+- name: default_example___extsvc_9090
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: default_example___mextsvc_9090
+    clusterName: default_example___extsvc_9090
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.endpoints.golden.yaml
@@ -1,8 +1,8 @@
 resources:
-- name: meshexternalservice_example
+- name: default_example___mextsvc_9090
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: meshexternalservice_example
+    clusterName: default_example___mextsvc_9090
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.listeners.golden.yaml
@@ -1,5 +1,5 @@
 resources:
-- name: meshexternalservice_example
+- name: outbound:10.20.20.1:9090
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener
     address:
@@ -17,7 +17,7 @@ resources:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           normalizePath: true
           routeConfig:
-            name: meshexternalservice_example
+            name: default_example___mextsvc_9090
             requestHeadersToAdd:
             - header:
                 key: x-kuma-tags
@@ -26,18 +26,18 @@ resources:
             virtualHosts:
             - domains:
               - '*'
-              name: example
+              name: default_example___mextsvc_9090
               routes:
               - match:
                   prefix: /
                 name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
                 route:
                   autoHostRewrite: true
-                  cluster: meshexternalservice_example
+                  cluster: default_example___mextsvc_9090
                   timeout: 0s
-          statPrefix: meshexternalservice_example
+          statPrefix: default_example___mextsvc_9090
     metadata:
       filterMetadata:
         io.kuma.tags: {}
-    name: meshexternalservice_example
+    name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.listeners.golden.yaml
@@ -17,7 +17,7 @@ resources:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           normalizePath: true
           routeConfig:
-            name: default_example___mextsvc_9090
+            name: default_example___extsvc_9090
             requestHeadersToAdd:
             - header:
                 key: x-kuma-tags
@@ -26,16 +26,16 @@ resources:
             virtualHosts:
             - domains:
               - '*'
-              name: default_example___mextsvc_9090
+              name: default_example___extsvc_9090
               routes:
               - match:
                   prefix: /
                 name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
                 route:
                   autoHostRewrite: true
-                  cluster: default_example___mextsvc_9090
+                  cluster: default_example___extsvc_9090
                   timeout: 0s
-          statPrefix: default_example___mextsvc_9090
+          statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
         io.kuma.tags: {}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.clusters.golden.yaml
@@ -1,5 +1,5 @@
 resources:
-- name: default_example___mextsvc_9090
+- name: default_example___extsvc_9090
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
@@ -7,7 +7,7 @@ resources:
         ads: {}
         initialFetchTimeout: 0s
         resourceApiVersion: V3
-    name: default_example___mextsvc_9090
+    name: default_example___extsvc_9090
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.clusters.golden.yaml
@@ -1,5 +1,5 @@
 resources:
-- name: meshexternalservice_example
+- name: default_example___mextsvc_9090
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
@@ -7,7 +7,7 @@ resources:
         ads: {}
         initialFetchTimeout: 0s
         resourceApiVersion: V3
-    name: meshexternalservice_example
+    name: default_example___mextsvc_9090
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.endpoints.golden.yaml
@@ -1,8 +1,8 @@
 resources:
-- name: default_example___mextsvc_9090
+- name: default_example___extsvc_9090
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: default_example___mextsvc_9090
+    clusterName: default_example___extsvc_9090
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.endpoints.golden.yaml
@@ -1,8 +1,8 @@
 resources:
-- name: meshexternalservice_example
+- name: default_example___mextsvc_9090
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: meshexternalservice_example
+    clusterName: default_example___mextsvc_9090
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.listeners.golden.yaml
@@ -1,5 +1,5 @@
 resources:
-- name: meshexternalservice_example
+- name: outbound:10.20.20.1:9090
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener
     address:
@@ -17,7 +17,7 @@ resources:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           normalizePath: true
           routeConfig:
-            name: meshexternalservice_example
+            name: default_example___mextsvc_9090
             requestHeadersToAdd:
             - header:
                 key: x-kuma-tags
@@ -26,18 +26,18 @@ resources:
             virtualHosts:
             - domains:
               - '*'
-              name: example
+              name: default_example___mextsvc_9090
               routes:
               - match:
                   prefix: /
                 name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
                 route:
                   autoHostRewrite: true
-                  cluster: meshexternalservice_example
+                  cluster: default_example___mextsvc_9090
                   timeout: 0s
-          statPrefix: meshexternalservice_example
+          statPrefix: default_example___mextsvc_9090
     metadata:
       filterMetadata:
         io.kuma.tags: {}
-    name: meshexternalservice_example
+    name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.listeners.golden.yaml
@@ -17,7 +17,7 @@ resources:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           normalizePath: true
           routeConfig:
-            name: default_example___mextsvc_9090
+            name: default_example___extsvc_9090
             requestHeadersToAdd:
             - header:
                 key: x-kuma-tags
@@ -26,16 +26,16 @@ resources:
             virtualHosts:
             - domains:
               - '*'
-              name: default_example___mextsvc_9090
+              name: default_example___extsvc_9090
               routes:
               - match:
                   prefix: /
                 name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
                 route:
                   autoHostRewrite: true
-                  cluster: default_example___mextsvc_9090
+                  cluster: default_example___extsvc_9090
                   timeout: 0s
-          statPrefix: default_example___mextsvc_9090
+          statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
         io.kuma.tags: {}

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
@@ -26,7 +26,6 @@ import (
 	"github.com/kumahq/kuma/pkg/util/pointer"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	v3 "github.com/kumahq/kuma/pkg/xds/envoy/listeners/v3"
-	"github.com/kumahq/kuma/pkg/xds/envoy/names"
 	envoy_names "github.com/kumahq/kuma/pkg/xds/envoy/names"
 	"github.com/kumahq/kuma/pkg/xds/generator"
 	"github.com/kumahq/kuma/pkg/xds/generator/egress"
@@ -193,6 +192,9 @@ func configureEndpoints(
 	egressEnabled bool,
 	origin string,
 ) error {
+	if cluster == nil {
+		return nil
+	}
 	if cluster.LoadAssignment != nil {
 		if err := ConfigureStaticEndpointsLocalityAware(tags, endpoints, cluster, conf, serviceName, localZone, apiVersion, egressEnabled, origin); err != nil {
 			return err
@@ -319,7 +321,9 @@ func (p plugin) configureEgress(rs *core_xds.ResourceSet, proxy *core_xds.Proxy)
 
 		meshExternalServices := meshResources.ListOrEmpty(meshexternalservice_api.MeshExternalServiceType)
 		for _, mes := range meshExternalServices.GetItems() {
-			policies, ok := meshResources.Dynamic[mes.GetMeta().GetName()]
+			meshExtSvc := mes.(*meshexternalservice_api.MeshExternalServiceResource)
+			destinationName := meshExtSvc.DestinationName(uint32(meshExtSvc.Spec.Match.Port))
+			policies, ok := meshResources.Dynamic[destinationName]
 			if !ok {
 				continue
 			}
@@ -344,7 +348,7 @@ func (p plugin) configureEgress(rs *core_xds.ResourceSet, proxy *core_xds.Proxy)
 						}
 					}
 				}
-				err := p.configureEgressListener(listeners.Egress, conf.Conf[0].(api.Conf), mesID.Name, mesID.Mesh)
+				err := p.configureEgressListener(listeners.Egress, conf.Conf[0].(api.Conf), destinationName)
 				if err != nil {
 					return err
 				}
@@ -427,8 +431,7 @@ func (p plugin) configureListener(
 func (p plugin) configureEgressListener(
 	l *envoy_listener.Listener,
 	conf api.Conf,
-	name string,
-	meshName string,
+	filterChainName string,
 ) error {
 	if conf.LoadBalancer == nil {
 		return nil
@@ -456,7 +459,7 @@ func (p plugin) configureEgressListener(
 	}
 
 	for _, chain := range l.FilterChains {
-		if chain.Name != names.GetEgressFilterChainName(name, meshName) {
+		if chain.Name != filterChainName {
 			continue
 		}
 		err := v3.UpdateHTTPConnectionManager(chain, func(hcm *envoy_hcm.HttpConnectionManager) error {

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
@@ -460,7 +460,7 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 		Entry("egress_meshexternalservice", testCase{
 			resources: []core_xds.Resource{
 				{
-					Name:   "mesh-1_external___mextsvc_9000",
+					Name:   "mesh-1_external___extsvc_9000",
 					Origin: egress.OriginEgress,
 					Resource: clusters.NewClusterBuilder(envoy_common.APIV3, "mesh-1:external").
 						Configure(clusters.EdsCluster()).
@@ -482,7 +482,7 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 					Name:   "egress-listener",
 					Origin: egress.OriginEgress,
 					Resource: NewInboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 10002, core_xds.SocketAddressProtocolTCP).
-						Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3, "mesh-1_external___mextsvc_9000").
+						Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3, "mesh-1_external___extsvc_9000").
 							Configure(MatchTransportProtocol("tls")).
 							Configure(MatchServerNames(tls.SNIForResource("external", "mesh-1", meshexternalservice_api.MeshExternalServiceType, 9000, nil))).
 							Configure(HttpConnectionManager("127.0.0.1:10002", false)).
@@ -508,7 +508,7 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 						{
 							Mesh: builders.Mesh().WithName("mesh-1").Build(),
 							Dynamic: core_xds.ExternalServiceDynamicPolicies{
-								"mesh-1_external___mextsvc_9000": {
+								"mesh-1_external___extsvc_9000": {
 									v1alpha1.MeshLoadBalancingStrategyType: core_xds.TypedMatchingPolicies{
 										ToRules: core_rules.ToRules{
 											ResourceRules: core_rules.ResourceRules{

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/kumahq/kuma/pkg/xds/envoy/clusters"
 	"github.com/kumahq/kuma/pkg/xds/envoy/endpoints/v3"
 	. "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
-	"github.com/kumahq/kuma/pkg/xds/envoy/names"
+	"github.com/kumahq/kuma/pkg/xds/envoy/tls"
 	"github.com/kumahq/kuma/pkg/xds/generator"
 	"github.com/kumahq/kuma/pkg/xds/generator/egress"
 )
@@ -460,7 +460,7 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 		Entry("egress_meshexternalservice", testCase{
 			resources: []core_xds.Resource{
 				{
-					Name:   "mesh-1:external",
+					Name:   "mesh-1_external___mextsvc_9000",
 					Origin: egress.OriginEgress,
 					Resource: clusters.NewClusterBuilder(envoy_common.APIV3, "mesh-1:external").
 						Configure(clusters.EdsCluster()).
@@ -482,9 +482,9 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 					Name:   "egress-listener",
 					Origin: egress.OriginEgress,
 					Resource: NewInboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 10002, core_xds.SocketAddressProtocolTCP).
-						Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3, names.GetEgressFilterChainName("external", "mesh-1")).
+						Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3, "mesh-1_external___mextsvc_9000").
 							Configure(MatchTransportProtocol("tls")).
-							Configure(MatchServerNames("external{mesh=mesh-1}")).
+							Configure(MatchServerNames(tls.SNIForResource("external", "mesh-1", meshexternalservice_api.MeshExternalServiceType, 9000, nil))).
 							Configure(HttpConnectionManager("127.0.0.1:10002", false)).
 							Configure(
 								HttpInboundRoutes(
@@ -508,7 +508,7 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 						{
 							Mesh: builders.Mesh().WithName("mesh-1").Build(),
 							Dynamic: core_xds.ExternalServiceDynamicPolicies{
-								"external": {
+								"mesh-1_external___mextsvc_9000": {
 									v1alpha1.MeshLoadBalancingStrategyType: core_xds.TypedMatchingPolicies{
 										ToRules: core_rules.ToRules{
 											ResourceRules: core_rules.ResourceRules{

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/egress_meshexternalservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/egress_meshexternalservice.clusters.golden.yaml
@@ -1,5 +1,5 @@
 resources:
-- name: mesh-1_external___mextsvc_9000
+- name: mesh-1_external___extsvc_9000
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: mesh-1_external

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/egress_meshexternalservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/egress_meshexternalservice.clusters.golden.yaml
@@ -1,5 +1,5 @@
 resources:
-- name: mesh-1:external
+- name: mesh-1_external___mextsvc_9000
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: mesh-1_external

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/egress_meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/egress_meshexternalservice.listeners.golden.yaml
@@ -10,7 +10,7 @@ resources:
     filterChains:
     - filterChainMatch:
         serverNames:
-        - external{mesh=mesh-1}
+        - ad098e6a3e7e807e1.external.9000.mesh-1.mes
         transportProtocol: tls
       filters:
       - name: envoy.filters.network.http_connection_manager
@@ -42,6 +42,6 @@ resources:
                       sourceIp: true
                   timeout: 0s
           statPrefix: "127_0_0_1_10002"
-      name: external_mesh-1
+      name: mesh-1_external___mextsvc_9000
     name: inbound:127.0.0.1:10002
     trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/egress_meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/egress_meshexternalservice.listeners.golden.yaml
@@ -42,6 +42,6 @@ resources:
                       sourceIp: true
                   timeout: 0s
           statPrefix: "127_0_0_1_10002"
-      name: mesh-1_external___mextsvc_9000
+      name: mesh-1_external___extsvc_9000
     name: inbound:127.0.0.1:10002
     trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
@@ -479,7 +479,7 @@ var _ = Describe("MeshTCPRoute", func() {
 											{
 												TargetRef: builders.TargetRefMeshExternalService("example2"),
 												Weight:    pointer.To(uint(100)),
-												Port:      pointer.To(uint32(80)),
+												Port:      pointer.To(uint32(9090)),
 											},
 										},
 									},
@@ -580,14 +580,14 @@ var _ = Describe("MeshTCPRoute", func() {
 				Items: []*meshservice_api.MeshServiceResource{&meshSvc},
 			}
 			outboundTargets := xds_builders.EndpointMap().
-				AddEndpoint("backend_msvc_80", xds_builders.Endpoint().
+				AddEndpoint("default_backend___msvc_80", xds_builders.Endpoint().
 					WithTarget("192.168.0.4").
 					WithPort(8084).
 					WithWeight(1).
 					WithTags(mesh_proto.ServiceTag, "backend", mesh_proto.ProtocolTag, core_mesh.ProtocolHTTP, "app", "backend"))
 			return outboundsTestCase{
 				xdsContext: *xds_builders.Context().WithEndpointMap(outboundTargets).
-					AddServiceProtocol("backend", core_mesh.ProtocolHTTP).
+					AddServiceProtocol("default_backend___msvc_80", core_mesh.ProtocolHTTP).
 					WithResources(resources).
 					Build(),
 				proxy: xds_builders.Proxy().

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-real-meshservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-real-meshservice.clusters.golden.yaml
@@ -1,5 +1,5 @@
 resources:
-- name: backend_msvc_80
+- name: default_backend___msvc_80
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
@@ -7,7 +7,7 @@ resources:
         ads: {}
         initialFetchTimeout: 0s
         resourceApiVersion: V3
-    name: backend_msvc_80
+    name: default_backend___msvc_80
     type: EDS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-real-meshservice.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-real-meshservice.endpoints.golden.yaml
@@ -1,8 +1,8 @@
 resources:
-- name: backend_msvc_80
+- name: default_backend___msvc_80
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: backend_msvc_80
+    clusterName: default_backend___msvc_80
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
@@ -11,8 +11,8 @@ resources:
       - name: envoy.filters.network.tcp_proxy
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: backend_msvc_80
-          statPrefix: backend_msvc_80
+          cluster: default_backend___msvc_80
+          statPrefix: default_backend___msvc_80
     metadata:
       filterMetadata:
         io.kuma.tags: {}

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.clusters.golden.yaml
@@ -38,7 +38,7 @@ resources:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         explicitHttpConfig:
           http2ProtocolOptions: {}
-- name: meshexternalservice_example
+- name: default_example___mextsvc_9090
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
@@ -46,7 +46,7 @@ resources:
         ads: {}
         initialFetchTimeout: 0s
         resourceApiVersion: V3
-    name: meshexternalservice_example
+    name: default_example___mextsvc_9090
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.clusters.golden.yaml
@@ -38,7 +38,7 @@ resources:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         explicitHttpConfig:
           http2ProtocolOptions: {}
-- name: default_example___mextsvc_9090
+- name: default_example___extsvc_9090
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
@@ -46,7 +46,7 @@ resources:
         ads: {}
         initialFetchTimeout: 0s
         resourceApiVersion: V3
-    name: default_example___mextsvc_9090
+    name: default_example___extsvc_9090
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.endpoints.golden.yaml
@@ -3,10 +3,10 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
     clusterName: backend
-- name: meshexternalservice_example
+- name: default_example___mextsvc_9090
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: meshexternalservice_example
+    clusterName: default_example___mextsvc_9090
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.endpoints.golden.yaml
@@ -3,10 +3,10 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
     clusterName: backend
-- name: default_example___mextsvc_9090
+- name: default_example___extsvc_9090
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: default_example___mextsvc_9090
+    clusterName: default_example___extsvc_9090
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.listeners.golden.yaml
@@ -11,8 +11,8 @@ resources:
       - name: envoy.filters.network.tcp_proxy
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: meshexternalservice_example
-          statPrefix: example
+          cluster: default_example___mextsvc_9090
+          statPrefix: default_example___mextsvc_9090
     metadata:
       filterMetadata:
         io.kuma.tags: {}

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.listeners.golden.yaml
@@ -11,8 +11,8 @@ resources:
       - name: envoy.filters.network.tcp_proxy
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: default_example___mextsvc_9090
-          statPrefix: default_example___mextsvc_9090
+          cluster: default_example___extsvc_9090
+          statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
         io.kuma.tags: {}

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.clusters.golden.yaml
@@ -38,7 +38,7 @@ resources:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         explicitHttpConfig:
           http2ProtocolOptions: {}
-- name: meshexternalservice_example2
+- name: default_example2___mextsvc_9090
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
@@ -46,7 +46,7 @@ resources:
         ads: {}
         initialFetchTimeout: 0s
         resourceApiVersion: V3
-    name: meshexternalservice_example2
+    name: default_example2___mextsvc_9090
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:
@@ -70,5 +70,5 @@ resources:
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
-        sni: a0ac70962fd61fdc0.example2.80.default.mes
+        sni: a0ac70962fd61fdc0.example2.9090.default.mes
     type: EDS

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.clusters.golden.yaml
@@ -38,7 +38,7 @@ resources:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         explicitHttpConfig:
           http2ProtocolOptions: {}
-- name: default_example2___mextsvc_9090
+- name: default_example2___extsvc_9090
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
@@ -46,7 +46,7 @@ resources:
         ads: {}
         initialFetchTimeout: 0s
         resourceApiVersion: V3
-    name: default_example2___mextsvc_9090
+    name: default_example2___extsvc_9090
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.endpoints.golden.yaml
@@ -3,10 +3,10 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
     clusterName: backend
-- name: default_example2___mextsvc_9090
+- name: default_example2___extsvc_9090
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: default_example2___mextsvc_9090
+    clusterName: default_example2___extsvc_9090
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.endpoints.golden.yaml
@@ -3,10 +3,10 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
     clusterName: backend
-- name: meshexternalservice_example2
+- name: default_example2___mextsvc_9090
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: meshexternalservice_example2
+    clusterName: default_example2___mextsvc_9090
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.listeners.golden.yaml
@@ -11,8 +11,8 @@ resources:
       - name: envoy.filters.network.tcp_proxy
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: meshexternalservice_example2
-          statPrefix: example
+          cluster: default_example2___mextsvc_9090
+          statPrefix: default_example___mextsvc_9090
     metadata:
       filterMetadata:
         io.kuma.tags: {}
@@ -30,8 +30,8 @@ resources:
       - name: envoy.filters.network.tcp_proxy
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: meshexternalservice_example2
-          statPrefix: example2
+          cluster: default_example2___mextsvc_9090
+          statPrefix: default_example2___mextsvc_9090
     metadata:
       filterMetadata:
         io.kuma.tags: {}

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.listeners.golden.yaml
@@ -11,8 +11,8 @@ resources:
       - name: envoy.filters.network.tcp_proxy
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: default_example2___mextsvc_9090
-          statPrefix: default_example___mextsvc_9090
+          cluster: default_example2___extsvc_9090
+          statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
         io.kuma.tags: {}
@@ -30,8 +30,8 @@ resources:
       - name: envoy.filters.network.tcp_proxy
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: default_example2___mextsvc_9090
-          statPrefix: default_example2___mextsvc_9090
+          cluster: default_example2___extsvc_9090
+          statPrefix: default_example2___extsvc_9090
     metadata:
       filterMetadata:
         io.kuma.tags: {}

--- a/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin.go
@@ -142,10 +142,9 @@ func (p plugin) configureEgress(rs *core_xds.ResourceSet, proxy *core_xds.Proxy)
 		}
 		// egress is configured for all meshes so we cannot use mesh context in this case
 		mesNames := []string{}
-		if _, found := resource.Resources[meshexternalservice_api.MeshExternalServiceType]; found {
-			for _, mes := range resource.Resources[meshexternalservice_api.MeshExternalServiceType].GetItems() {
-				mesNames = append(mesNames, mes.GetMeta().GetName())
-			}
+		for _, mes := range resource.ListOrEmpty(meshexternalservice_api.MeshExternalServiceType).GetItems() {
+			meshExtSvc := mes.(*meshexternalservice_api.MeshExternalServiceResource)
+			mesNames = append(mesNames, meshExtSvc.DestinationName(uint32(meshExtSvc.Spec.Match.Port)))
 		}
 
 		for _, esName := range esNames {
@@ -201,7 +200,7 @@ func (p plugin) configureEgress(rs *core_xds.ResourceSet, proxy *core_xds.Proxy)
 					Mesh:      meshName,
 				}
 				for _, filterChain := range listeners.Egress.FilterChains {
-					if filterChain.Name == names.GetEgressFilterChainName(mesName, meshName) {
+					if filterChain.Name == mesName {
 						if err := configurer.Configure(filterChain); err != nil {
 							return err
 						}

--- a/pkg/xds/envoy/names/resource_names.go
+++ b/pkg/xds/envoy/names/resource_names.go
@@ -142,11 +142,3 @@ func GetSecretName(category string, scope string, identifier string) string {
 func GetEgressFilterChainName(serviceName string, meshName string) string {
 	return fmt.Sprintf("%s_%s", serviceName, meshName)
 }
-
-func GetMeshExternalServiceName(resourceName string) string {
-	return fmt.Sprintf("meshexternalservice_%s", resourceName)
-}
-
-func GetEgressMeshExternalServiceName(meshName, resourceName string) string {
-	return GetMeshClusterName(meshName, GetMeshExternalServiceName(resourceName))
-}

--- a/pkg/xds/generator/egress/internal_services_generator.go
+++ b/pkg/xds/generator/egress/internal_services_generator.go
@@ -36,6 +36,7 @@ func (g *InternalServicesGenerator) Generate(
 		nil, // todo(jakubdyszkiewicz) add support for MeshService + egress
 		nil,
 		"",
+		xdsCtx.Mesh.ResolveResourceIdentifier,
 	)
 
 	services := zoneproxy.AddFilterChains(availableServices, proxy.APIVersion, listenerBuilder, destinations, meshResources.EndpointMap)

--- a/pkg/xds/generator/egress/testdata/01.externalservice-only.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/01.externalservice-only.golden.yaml
@@ -30,14 +30,13 @@ resources:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         explicitHttpConfig:
           httpProtocolOptions: {}
-- name: meshexternalservice-1
+- name: mesh-1_meshexternalservice-1___mextsvc_9090
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    altStatName: mesh-1_meshexternalservice_meshexternalservice-1
     connectTimeout: 5s
     dnsLookupFamily: V4_ONLY
     loadAssignment:
-      clusterName: mesh-1:meshexternalservice_meshexternalservice-1
+      clusterName: mesh-1_meshexternalservice-1___mextsvc_9090
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -64,7 +63,7 @@ resources:
                 mesh: mesh-1
               envoy.transport_socket_match:
                 mesh: mesh-1
-    name: mesh-1:meshexternalservice_meshexternalservice-1
+    name: mesh-1_meshexternalservice-1___mextsvc_9090
     type: STRICT_DNS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
@@ -164,21 +163,21 @@ resources:
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           routeConfig:
-            name: mesh-1:meshexternalservice_meshexternalservice-1
+            name: mesh-1_meshexternalservice-1___mextsvc_9090
             validateClusters: false
             virtualHosts:
             - domains:
               - '*'
-              name: meshexternalservice-1
+              name: mesh-1_meshexternalservice-1___mextsvc_9090
               routes:
               - match:
                   prefix: /
                 route:
                   autoHostRewrite: true
-                  cluster: mesh-1:meshexternalservice_meshexternalservice-1
+                  cluster: mesh-1_meshexternalservice-1___mextsvc_9090
                   timeout: 0s
-          statPrefix: meshexternalservice-1
-      name: meshexternalservice-1_mesh-1
+          statPrefix: mesh-1_meshexternalservice-1___mextsvc_9090
+      name: mesh-1_meshexternalservice-1___mextsvc_9090
       transportSocket:
         name: envoy.transport_sockets.tls
         typedConfig:

--- a/pkg/xds/generator/egress/testdata/01.externalservice-only.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/01.externalservice-only.golden.yaml
@@ -30,13 +30,13 @@ resources:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         explicitHttpConfig:
           httpProtocolOptions: {}
-- name: mesh-1_meshexternalservice-1___mextsvc_9090
+- name: mesh-1_meshexternalservice-1___extsvc_9090
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     connectTimeout: 5s
     dnsLookupFamily: V4_ONLY
     loadAssignment:
-      clusterName: mesh-1_meshexternalservice-1___mextsvc_9090
+      clusterName: mesh-1_meshexternalservice-1___extsvc_9090
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -63,7 +63,7 @@ resources:
                 mesh: mesh-1
               envoy.transport_socket_match:
                 mesh: mesh-1
-    name: mesh-1_meshexternalservice-1___mextsvc_9090
+    name: mesh-1_meshexternalservice-1___extsvc_9090
     type: STRICT_DNS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
@@ -163,21 +163,21 @@ resources:
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           routeConfig:
-            name: mesh-1_meshexternalservice-1___mextsvc_9090
+            name: mesh-1_meshexternalservice-1___extsvc_9090
             validateClusters: false
             virtualHosts:
             - domains:
               - '*'
-              name: mesh-1_meshexternalservice-1___mextsvc_9090
+              name: mesh-1_meshexternalservice-1___extsvc_9090
               routes:
               - match:
                   prefix: /
                 route:
                   autoHostRewrite: true
-                  cluster: mesh-1_meshexternalservice-1___mextsvc_9090
+                  cluster: mesh-1_meshexternalservice-1___extsvc_9090
                   timeout: 0s
-          statPrefix: mesh-1_meshexternalservice-1___mextsvc_9090
-      name: mesh-1_meshexternalservice-1___mextsvc_9090
+          statPrefix: mesh-1_meshexternalservice-1___extsvc_9090
+      name: mesh-1_meshexternalservice-1___extsvc_9090
       transportSocket:
         name: envoy.transport_sockets.tls
         typedConfig:

--- a/pkg/xds/generator/ingress_generator.go
+++ b/pkg/xds/generator/ingress_generator.go
@@ -58,6 +58,7 @@ func (i IngressGenerator) Generate(
 			meshResources.MeshMultiZoneServices().Items,
 			nil,
 			xdsCtx.ControlPlane.SystemNamespace,
+			xdsCtx.Mesh.ResolveResourceIdentifier,
 		)
 
 		services := zoneproxy.AddFilterChains(availableSvcsByMesh[meshName], proxy.APIVersion, listenerBuilder, dest, mr.EndpointMap)

--- a/pkg/xds/generator/testdata/ingress/mesh-service.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/mesh-service.envoy.golden.yaml
@@ -1,36 +1,34 @@
 resources:
-- name: mesh1:backend2_msvc_80
+- name: default_backend___msvc_80
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    altStatName: mesh1_backend2_msvc_80
     connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}
         initialFetchTimeout: 0s
         resourceApiVersion: V3
-    name: mesh1:backend2_msvc_80
+    name: default_backend___msvc_80
     type: EDS
-- name: mesh1:backend_msvc_80
+- name: default_backend__east_msvc_80
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    altStatName: mesh1_backend_msvc_80
     connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}
         initialFetchTimeout: 0s
         resourceApiVersion: V3
-    name: mesh1:backend_msvc_80
+    name: default_backend__east_msvc_80
     type: EDS
-- name: mesh1:backend2_msvc_80
+- name: default_backend___msvc_80
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: mesh1:backend2_msvc_80
-- name: mesh1:backend_msvc_80
+    clusterName: default_backend___msvc_80
+- name: default_backend__east_msvc_80
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: mesh1:backend_msvc_80
+    clusterName: default_backend__east_msvc_80
 - name: inbound:10.0.0.1:10001
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener
@@ -48,8 +46,8 @@ resources:
       - name: envoy.filters.network.tcp_proxy
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: default:backend_msvc_80
-          statPrefix: default_backend_msvc_80
+          cluster: default_backend__east_msvc_80
+          statPrefix: default_backend__east_msvc_80
     - filterChainMatch:
         serverNames:
         - aec60634adf0f45d6.backend2.80.default.ms
@@ -58,8 +56,8 @@ resources:
       - name: envoy.filters.network.tcp_proxy
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: default:backend2_msvc_80
-          statPrefix: default_backend2_msvc_80
+          cluster: default_backend___msvc_80
+          statPrefix: default_backend___msvc_80
     listenerFilters:
     - name: envoy.filters.listener.tls_inspector
       typedConfig:

--- a/pkg/xds/topology/ingress_outbound_test.go
+++ b/pkg/xds/topology/ingress_outbound_test.go
@@ -313,7 +313,7 @@ var _ = Describe("IngressTrafficRoute", func() {
 							ExternalService: nil,
 						},
 					},
-					"kong_kong-system_msvc_8080": []core_xds.Endpoint{
+					"default_kong.kong-system___msvc_8080": []core_xds.Endpoint{
 						{
 							Target:         "192.168.0.2",
 							UnixDomainPath: "",
@@ -340,7 +340,7 @@ var _ = Describe("IngressTrafficRoute", func() {
 							ExternalService: nil,
 						},
 					},
-					"redis_msvc_6379": []core_xds.Endpoint{
+					"default_redis___msvc_6379": []core_xds.Endpoint{
 						{
 							Target:         "192.168.0.1",
 							UnixDomainPath: "",
@@ -353,7 +353,7 @@ var _ = Describe("IngressTrafficRoute", func() {
 							ExternalService: nil,
 						},
 					},
-					"redis-0_msvc_6379": []core_xds.Endpoint{
+					"default_redis-0___msvc_6379": []core_xds.Endpoint{
 						{
 							Target: "192.168.0.1",
 							Port:   6379,
@@ -375,7 +375,7 @@ var _ = Describe("IngressTrafficRoute", func() {
 							ExternalService: nil,
 						},
 					},
-					"kong_kong-system_msvc_8081": []core_xds.Endpoint{
+					"default_kong.kong-system___msvc_8081": []core_xds.Endpoint{
 						{
 							Target:         "192.168.0.2",
 							UnixDomainPath: "",

--- a/pkg/xds/topology/outbound.go
+++ b/pkg/xds/topology/outbound.go
@@ -650,7 +650,7 @@ func createMeshExternalServiceEndpoint(
 	zone string,
 ) error {
 	es := &core_xds.ExternalService{
-		Protocol:      core_mesh.ParseProtocol(string(mes.Spec.Match.Protocol)),
+		Protocol:      mes.Spec.Match.Protocol,
 		OwnerResource: pointer.To(core_rules.UniqueKey(mes, "")),
 	}
 	tags := maps.Clone(mes.Meta.GetLabels())
@@ -658,7 +658,6 @@ func createMeshExternalServiceEndpoint(
 		tags = map[string]string{}
 	}
 	meshName := mesh.GetMeta().GetName()
-	name := mes.Meta.GetName()
 	tls := mes.Spec.Tls
 	if tls != nil && tls.Enabled {
 		var caCert, clientCert, clientKey []byte
@@ -741,7 +740,7 @@ func createMeshExternalServiceEndpoint(
 			Tags:            tags,
 			Locality:        GetLocality(zone, getZone(tags), mesh.LocalityAwareLbEnabled()),
 		}
-		outbounds[name] = append(outbounds[name], *outboundEndpoint)
+		outbounds[mes.DestinationName(uint32(mes.Spec.Match.Port))] = append(outbounds[mes.DestinationName(uint32(mes.Spec.Match.Port))], *outboundEndpoint)
 	}
 	return nil
 }
@@ -799,7 +798,7 @@ func fillExternalServicesOutboundsThroughEgress(
 	for _, mes := range meshExternalServices {
 		// deep copy map to not modify tags in ExternalService.
 		serviceTags := maps.Clone(mes.Meta.GetLabels())
-		serviceName := mes.Meta.GetName()
+		serviceName := mes.DestinationName(uint32(mes.Spec.Match.Port))
 		locality := GetLocality(localZone, getZone(serviceTags), mesh.LocalityAwareLbEnabled())
 
 		for _, ze := range zoneEgresses {
@@ -816,7 +815,7 @@ func fillExternalServicesOutboundsThroughEgress(
 				Weight:   1,
 				Locality: locality,
 				ExternalService: &core_xds.ExternalService{
-					Protocol:      core_mesh.ParseProtocol(string(mes.Spec.Match.Protocol)),
+					Protocol:      mes.Spec.Match.Protocol,
 					OwnerResource: pointer.To(core_rules.UniqueKey(mes, "")),
 				},
 			}

--- a/pkg/xds/topology/outbound_test.go
+++ b/pkg/xds/topology/outbound_test.go
@@ -1259,7 +1259,7 @@ var _ = Describe("TrafficRoute", func() {
 							Weight:   1,
 						},
 					},
-					"redis_msvc_6379": []core_xds.Endpoint{
+					"default_redis___msvc_6379": []core_xds.Endpoint{
 						{
 							Target:   "192.168.0.1",
 							Port:     6379,
@@ -1268,7 +1268,7 @@ var _ = Describe("TrafficRoute", func() {
 							Weight:   1,
 						},
 					},
-					"redis-0_msvc_6379": []core_xds.Endpoint{
+					"default_redis-0___msvc_6379": []core_xds.Endpoint{
 						{
 							Target:   "192.168.0.1",
 							Port:     6379,
@@ -1286,7 +1286,7 @@ var _ = Describe("TrafficRoute", func() {
 							Weight:   1,
 						},
 					},
-					"kong_kong-system_msvc_8080": []core_xds.Endpoint{
+					"default_kong.kong-system___msvc_8080": []core_xds.Endpoint{
 						{
 							Target:   "192.168.0.2",
 							Port:     80,
@@ -1304,7 +1304,7 @@ var _ = Describe("TrafficRoute", func() {
 							Weight:   1,
 						},
 					},
-					"kong_kong-system_msvc_8081": []core_xds.Endpoint{
+					"default_kong.kong-system___msvc_8081": []core_xds.Endpoint{
 						{
 							Target:   "192.168.0.2",
 							Port:     8001,
@@ -1423,7 +1423,7 @@ var _ = Describe("TrafficRoute", func() {
 				},
 				mesh: defaultMeshWithMTLSAndZoneEgress,
 				expected: core_xds.EndpointMap{
-					"another-mes": []core_xds.Endpoint{
+					"default_another-mes___mextsvc_10000": []core_xds.Endpoint{
 						{
 							Target: "1.1.1.1",
 							Port:   10002,
@@ -1445,7 +1445,7 @@ var _ = Describe("TrafficRoute", func() {
 							},
 						},
 					},
-					"example-mes": []core_xds.Endpoint{
+					"default_example-mes___mextsvc_10000": []core_xds.Endpoint{
 						{
 							Target:   "1.1.1.1",
 							Port:     10002,
@@ -1555,7 +1555,7 @@ var _ = Describe("TrafficRoute", func() {
 							Weight: 1,
 						},
 					},
-					"backend_msvc_80": []core_xds.Endpoint{
+					"default_backend___msvc_80": []core_xds.Endpoint{
 						{
 							Target: "192.168.0.1",
 							Port:   80,
@@ -1565,19 +1565,19 @@ var _ = Describe("TrafficRoute", func() {
 							Weight: 1,
 						},
 					},
-					"backend-4v44xv7dwv4v8z2d_msvc_80": []core_xds.Endpoint{
+					"default_backend__east_msvc_80": []core_xds.Endpoint{
 						{
 							Target: "192.168.0.100",
 							Port:   12345,
 							Tags: map[string]string{
-								"kuma.io/service": "backend-4v44xv7dwv4v8z2d_msvc_80",
+								"kuma.io/service": "default_backend__east_msvc_80",
 								"kuma.io/zone":    "east",
 							},
 							Weight:   1,
 							Locality: &core_xds.Locality{Zone: "east", SubZone: "", Priority: 1, Weight: 0},
 						},
 					},
-					"backend_mzsvc_80": []core_xds.Endpoint{
+					"default_backend___mzsvc_80": []core_xds.Endpoint{
 						{
 							Target: "192.168.0.1",
 							Port:   80,
@@ -1590,7 +1590,7 @@ var _ = Describe("TrafficRoute", func() {
 							Target: "192.168.0.100",
 							Port:   12345,
 							Tags: map[string]string{
-								"kuma.io/service": "backend-4v44xv7dwv4v8z2d_msvc_80",
+								"kuma.io/service": "default_backend__east_msvc_80",
 								"kuma.io/zone":    "east",
 							},
 							Weight:   1,
@@ -1701,7 +1701,7 @@ var _ = Describe("TrafficRoute", func() {
 								ExternalService: &core_xds.ExternalService{TLSEnabled: false},
 							},
 						},
-						"example": []core_xds.Endpoint{
+						"default_example___mextsvc_443": []core_xds.Endpoint{
 							{
 								Target: "192.168.1.1",
 								Port:   10000,

--- a/pkg/xds/topology/outbound_test.go
+++ b/pkg/xds/topology/outbound_test.go
@@ -1423,7 +1423,7 @@ var _ = Describe("TrafficRoute", func() {
 				},
 				mesh: defaultMeshWithMTLSAndZoneEgress,
 				expected: core_xds.EndpointMap{
-					"default_another-mes___mextsvc_10000": []core_xds.Endpoint{
+					"default_another-mes___extsvc_10000": []core_xds.Endpoint{
 						{
 							Target: "1.1.1.1",
 							Port:   10002,
@@ -1445,7 +1445,7 @@ var _ = Describe("TrafficRoute", func() {
 							},
 						},
 					},
-					"default_example-mes___mextsvc_10000": []core_xds.Endpoint{
+					"default_example-mes___extsvc_10000": []core_xds.Endpoint{
 						{
 							Target:   "1.1.1.1",
 							Port:     10002,
@@ -1701,7 +1701,7 @@ var _ = Describe("TrafficRoute", func() {
 								ExternalService: &core_xds.ExternalService{TLSEnabled: false},
 							},
 						},
-						"default_example___mextsvc_443": []core_xds.Endpoint{
+						"default_example___extsvc_443": []core_xds.Endpoint{
 							{
 								Target: "192.168.1.1",
 								Port:   10000,

--- a/test/e2e/reachableservices/auto_reachable_mesh_services_k8s.go
+++ b/test/e2e/reachableservices/auto_reachable_mesh_services_k8s.go
@@ -96,7 +96,7 @@ spec:
 			g.Expect(err).ToNot(HaveOccurred())
 			stdout, err := k8sCluster.GetKumactlOptions().RunKumactlAndGetOutput("inspect", "dataplane", pod+"."+namespace, "--type=clusters", fmt.Sprintf("--mesh=%s", meshName))
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(stdout).To(Not(ContainSubstring(fmt.Sprintf("first-test-server_%s_msvc_80", namespace))))
+			g.Expect(stdout).To(Not(ContainSubstring(fmt.Sprintf("%s_first-test-server_%s_defaul_msvc_80", meshName, namespace))))
 		}, "30s", "1s").Should(Succeed())
 
 		Eventually(func(g Gomega) {
@@ -104,7 +104,7 @@ spec:
 			g.Expect(err).ToNot(HaveOccurred())
 			stdout, err := k8sCluster.GetKumactlOptions().RunKumactlAndGetOutput("inspect", "dataplane", pod+"."+namespace, "--type=clusters", fmt.Sprintf("--mesh=%s", meshName))
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(stdout).To(ContainSubstring(fmt.Sprintf("first-test-server_%s_msvc_80", namespace)))
+			g.Expect(stdout).To(ContainSubstring(fmt.Sprintf("%s_first-test-server_%s_default_msvc_80", meshName, namespace)))
 		}, "30s", "1s").Should(Succeed())
 
 		Consistently(func(g Gomega) {

--- a/test/e2e_env/kubernetes/meshexternalservice/meshexternalservice.go
+++ b/test/e2e_env/kubernetes/meshexternalservice/meshexternalservice.go
@@ -94,9 +94,9 @@ spec:
 		})
 
 		filter := fmt.Sprintf(
-			"cluster.%s_%s_%s.upstream_rq_total",
+			"cluster.%s_%s_%s_default_mextsvc_80.upstream_rq_total",
 			meshName,
-			"meshexternalservice_http-external-service",
+			"http-external-service",
 			Config.KumaNamespace,
 		)
 
@@ -152,9 +152,9 @@ spec:
 `, Config.KumaNamespace, meshNameEgress)
 
 		filter := fmt.Sprintf(
-			"cluster.%s_%s_%s.upstream_rq_total",
+			"cluster.%s_%s_%s_default_mextsvc_80.upstream_rq_total",
 			meshNameEgress,
-			"meshexternalservice_mesh-external-service-egress",
+			"mesh-external-service-egress",
 			Config.KumaNamespace,
 		)
 		BeforeAll(func() {
@@ -220,9 +220,9 @@ spec:
       port: 80
 `, Config.KumaNamespace, meshName)
 		filter := fmt.Sprintf(
-			"cluster.%s_%s_%s.upstream_rq_total",
+			"cluster.%s_%s_%s_default_mextsvc_80.upstream_rq_total",
 			meshName,
-			"meshexternalservice_tcp-external-service",
+			"tcp-external-service",
 			Config.KumaNamespace,
 		)
 		BeforeAll(func() {
@@ -290,9 +290,9 @@ spec:
       mode: SkipCA # test-server certificate is not signed by a CA that is in the system trust store
 `, Config.KumaNamespace, meshName)
 		filter := fmt.Sprintf(
-			"cluster.%s_%s_%s.upstream_rq_total", // cx
+			"cluster.%s_%s_%s_default_mextsvc_80.upstream_rq_total", // cx
 			meshName,
-			"meshexternalservice_tls-external-service",
+			"tls-external-service",
 			Config.KumaNamespace,
 		)
 		BeforeAll(func() {

--- a/test/e2e_env/kubernetes/meshexternalservice/meshexternalservice.go
+++ b/test/e2e_env/kubernetes/meshexternalservice/meshexternalservice.go
@@ -94,7 +94,7 @@ spec:
 		})
 
 		filter := fmt.Sprintf(
-			"cluster.%s_%s_%s_default_mextsvc_80.upstream_rq_total",
+			"cluster.%s_%s_%s_default_extsvc_80.upstream_rq_total",
 			meshName,
 			"http-external-service",
 			Config.KumaNamespace,
@@ -152,7 +152,7 @@ spec:
 `, Config.KumaNamespace, meshNameEgress)
 
 		filter := fmt.Sprintf(
-			"cluster.%s_%s_%s_default_mextsvc_80.upstream_rq_total",
+			"cluster.%s_%s_%s_default_extsvc_80.upstream_rq_total",
 			meshNameEgress,
 			"mesh-external-service-egress",
 			Config.KumaNamespace,
@@ -220,7 +220,7 @@ spec:
       port: 80
 `, Config.KumaNamespace, meshName)
 		filter := fmt.Sprintf(
-			"cluster.%s_%s_%s_default_mextsvc_80.upstream_rq_total",
+			"cluster.%s_%s_%s_default_extsvc_80.upstream_rq_total",
 			meshName,
 			"tcp-external-service",
 			Config.KumaNamespace,
@@ -290,7 +290,7 @@ spec:
       mode: SkipCA # test-server certificate is not signed by a CA that is in the system trust store
 `, Config.KumaNamespace, meshName)
 		filter := fmt.Sprintf(
-			"cluster.%s_%s_%s_default_mextsvc_80.upstream_rq_total", // cx
+			"cluster.%s_%s_%s_default_extsvc_80.upstream_rq_total", // cx
 			meshName,
 			"tls-external-service",
 			Config.KumaNamespace,

--- a/test/e2e_env/multizone/reachablebackends/reachablebackends.go
+++ b/test/e2e_env/multizone/reachablebackends/reachablebackends.go
@@ -328,7 +328,7 @@ spec:
 			)
 			// then it fails because Kuma DP has no such DNS
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(response.Exitcode).To(Equal(6))
+			g.Expect(response.Exitcode).To(Or(Equal(6), Equal(28)))
 		}, "5s", "100ms").Should(Succeed())
 
 		Consistently(func(g Gomega) {
@@ -350,7 +350,7 @@ spec:
 			)
 			// then it fails because we don't encrypt traffic to unknown destination in the mesh
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(response.Exitcode).To(Or(Equal(6)))
+			g.Expect(response.Exitcode).To(Or(Equal(6), Equal(28)))
 		}, "5s", "100ms").Should(Succeed())
 
 		Consistently(func(g Gomega) {

--- a/test/e2e_env/multizone/reachablebackends/reachablebackends_meshservices.go
+++ b/test/e2e_env/multizone/reachablebackends/reachablebackends_meshservices.go
@@ -143,8 +143,8 @@ spec:
 			)
 			// then
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(resp.Exitcode).To(Equal(6))
-		}, "15s", "500ms", MustPassRepeatedly(10)).Should(Succeed())
+			g.Expect(resp.Exitcode).To(Or(Equal(6), Equal(28)))
+		}, "15s", "500ms", MustPassRepeatedly(5)).Should(Succeed())
 	})
 
 	It("should be able to connect if reachable backends is set", func() {
@@ -162,8 +162,8 @@ spec:
 			g.Expect(err).ToNot(HaveOccurred())
 			stdout, err := multizone.KubeZone1.GetKumactlOptions().RunKumactlAndGetOutput("inspect", "dataplane", pod+"."+namespace, "--type=clusters", fmt.Sprintf("--mesh=%s", meshName))
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(stdout).To(ContainSubstring(fmt.Sprintf("local-test-server_%s_msvc_80", namespace)))
-		}, "10s", "500ms", MustPassRepeatedly(10)).Should(Succeed())
+			g.Expect(stdout).To(ContainSubstring(fmt.Sprintf("%s_local-test-server_%s_kuma-1_msvc_80", meshName, namespace)))
+		}, "10s", "500ms", MustPassRepeatedly(5)).Should(Succeed())
 
 		Eventually(func(g Gomega) {
 			// when
@@ -174,6 +174,6 @@ spec:
 			// then
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(resp.Instance).To(HavePrefix("other-zone-test-server"))
-		}, "10s", "500ms", MustPassRepeatedly(10)).Should(Succeed())
+		}, "10s", "500ms", MustPassRepeatedly(5)).Should(Succeed())
 	})
 }

--- a/test/e2e_env/universal/meshexternalservice/meshexternalservice.go
+++ b/test/e2e_env/universal/meshexternalservice/meshexternalservice.go
@@ -660,7 +660,7 @@ spec:
 			Eventually(func(g Gomega) {
 				egressClusters, err := universal.Cluster.GetZoneEgressEnvoyTunnel().GetClusters()
 				g.Expect(err).ToNot(HaveOccurred())
-				cluster := egressClusters.GetCluster(fmt.Sprintf("%s:meshexternalservice_mes-health-check", meshNameNoDefaults))
+				cluster := egressClusters.GetCluster(fmt.Sprintf("%s_mes-health-check__kuma-3_mextsvc_80", meshNameNoDefaults))
 				g.Expect(cluster).ToNot(BeNil())
 				g.Expect(cluster.HostStatuses).To(HaveLen(1))
 				g.Expect(cluster.HostStatuses[0].HealthStatus.FailedActiveHealthCheck).To(BeTrue())

--- a/test/e2e_env/universal/meshexternalservice/meshexternalservice.go
+++ b/test/e2e_env/universal/meshexternalservice/meshexternalservice.go
@@ -660,7 +660,7 @@ spec:
 			Eventually(func(g Gomega) {
 				egressClusters, err := universal.Cluster.GetZoneEgressEnvoyTunnel().GetClusters()
 				g.Expect(err).ToNot(HaveOccurred())
-				cluster := egressClusters.GetCluster(fmt.Sprintf("%s_mes-health-check__kuma-3_mextsvc_80", meshNameNoDefaults))
+				cluster := egressClusters.GetCluster(fmt.Sprintf("%s_mes-health-check__kuma-3_extsvc_80", meshNameNoDefaults))
 				g.Expect(cluster).ToNot(BeNil())
 				g.Expect(cluster.HostStatuses).To(HaveLen(1))
 				g.Expect(cluster.HostStatuses[0].HealthStatus.FailedActiveHealthCheck).To(BeTrue())

--- a/test/e2e_env/universal/meshservice/meshservice.go
+++ b/test/e2e_env/universal/meshservice/meshservice.go
@@ -127,8 +127,8 @@ mtls:
 				universal.Cluster, "demo-client", "http://localhost:9901/stats",
 			)
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(stdout).To(ContainSubstring("cluster.backend_msvc_80.ssl.handshake"))
-			g.Expect(stdout).ToNot(ContainSubstring("cluster.backend_msvc_80.ssl.handshake: 0"))
+			g.Expect(stdout).To(ContainSubstring(fmt.Sprintf("cluster.%s_backend__kuma-3_msvc_80.ssl.handshake", meshName)))
+			g.Expect(stdout).ToNot(ContainSubstring(fmt.Sprintf("cluster.%s_backend__kuma-3_msvc_80.ssl.handshake: 0", meshName)))
 		}, "30s", "1s").Should(Succeed())
 		Expect(reqError.Load()).To(BeNil())
 


### PR DESCRIPTION
### Checklist prior to review

For a Mesh*Service I've chosen the following naming convention

`mesh_name_namespace_zone_msvc/mextsvc/mzsvc_port`

if there is no namespace or zone, the value has an empty place `default_backend___msvc_8080`

* commit 1 actual change
  * when backendRef has an empty port for MES, use port from MES
  * use DestinationName in outbound map
  * avoid double wrapping Protocol
* commit 2 test adjustments

- [ ] [Link to relevant issue][1] as well as docs and UI issues -- fix: https://github.com/kumahq/kuma/issues/11292
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
