### PR TITLE
chore(config/loader): remove logs when loading configs

### DIFF
--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -5,17 +5,13 @@ import (
 	"os"
 	"reflect"
 
-	"github.com/go-logr/logr"
 	"github.com/kelseyhightower/envconfig"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
-
-	"github.com/kumahq/kuma/pkg/core"
 )
 
 type Loader struct {
-	logger logr.Logger
-	cfg    Config
+	cfg Config
 
 	strict        bool
 	includeEnv    bool
@@ -24,10 +20,7 @@ type Loader struct {
 }
 
 func NewLoader(cfg Config) *Loader {
-	return &Loader{
-		logger: core.Log.WithName("config"),
-		cfg:    cfg,
-	}
+	return &Loader{cfg: cfg}
 }
 
 func (l *Loader) WithStrictParsing() *Loader {
@@ -59,7 +52,6 @@ func (l *Loader) Load(stdin io.Reader, content []byte, filename string) error {
 
 func (l *Loader) LoadFile(filename string) error {
 	if filename == "" {
-		l.logger.Info("no configuration file provided, skipping file-based config loading")
 		return l.postProcess()
 	}
 
@@ -81,7 +73,6 @@ func (l *Loader) LoadFile(filename string) error {
 
 func (l *Loader) LoadReader(r io.Reader) error {
 	if r == nil {
-		l.logger.Info("no configuration reader provided, skipping reader-based config loading")
 		return nil
 	}
 
@@ -99,7 +90,6 @@ func (l *Loader) LoadBytes(content []byte) error {
 	}
 
 	if content == nil {
-		l.logger.Info("no configuration content provided, skipping byte-based config loading")
 		return nil
 	}
 


### PR DESCRIPTION
These logs were unnecessary and could potentially cause deadlocks around initializing kubernetes loggers:

```sh
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
Detected at:
   >  goroutine 1 [running]:
   >  runtime/debug.Stack()
   >      runtime/debug/stack.go:26 +0x64
   >  sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
   >      sigs.k8s.io/controller-runtime@v0.19.0/pkg/log/log.go:60 +0xf4
   >  sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).WithName (0x4000215ec0, {0x2b84407, 0x6})
   >      sigs.k8s.io/controller-runtime@v0.19.0/pkg/log/deleg.go:147 +0x34
   >  github.com/go-logr/logr.Logger.WithName(...)
   >      github.com/go-logr/logr@v1.4.2/logr.go:345
   >  github.com/kumahq/kuma/pkg/config.NewLoader({0x41988a8, 0x400094e308})
   >      github.com/kumahq/kuma/pkg/config/loader.go:28 +0x60
   >  github.com/kumahq/kuma/app/kumactl/cmd/install.newInstallTransparentProxy()
   >      github.com/kumahq/kuma/app/kumactl/cmd/install/install_transparent_proxy.go:39 +0xa8
   >  github.com/kumahq/kuma/app/kumactl/cmd/install.NewInstallCmd(0x400094ce08)
   >      github.com/kumahq/kuma/app/kumactl/cmd/install/install.go:21 +0xf4
   >  github.com/kumahq/kuma/app/kumactl/cmd.NewRootCmd(0x400094ce08)
   >      github.com/kumahq/kuma/app/kumactl/cmd/root.go:111 +0x3bc
   >  github.com/kumahq/kuma/app/kumactl/cmd.DefaultRootCmd()
   >      github.com/kumahq/kuma/app/kumactl/cmd/root.go:120 +0x20
   >  github.com/kumahq/kuma/app/kumactl/cmd.Execute()
   >      github.com/kumahq/kuma/app/kumactl/cmd/root.go:126 +0x1c
   >  main.main()
   >      github.com/kumahq/kuma/app/kumactl/main.go:6 +0x1c
```

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - no relevant issues
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - it won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - tested locally
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - there is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - there is no need

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
