### PR TITLE
fix(transparent-proxy): check DNS related CLI flags earlier

### DIFF
--- a/app/kumactl/cmd/install/install_transparent_proxy_test.go
+++ b/app/kumactl/cmd/install/install_transparent_proxy_test.go
@@ -203,7 +203,7 @@ var _ = Context("kumactl install transparent proxy", func() {
 				"--redirect-all-dns-traffic",
 			},
 			goldenFile:   "install-transparent-proxy.defaults.golden.txt",
-			errorMatcher: Equal("Error: one of --redirect-dns or --redirect-all-dns-traffic should be specified\n"),
+			errorMatcher: Equal("Error: only one of '--redirect-dns' or '--redirect-all-dns-traffic' should be specified\n"),
 		}),
 		Entry("should error out on invalid port value", testCase{
 			extraArgs: []string{


### PR DESCRIPTION
If both values `redirect.dns.enabled` and `redirect.dns.captureAll` would be provided in the config yaml via `--config` or `--config-file`, so far we would fail, but it's a correct scenario. We should check if `--redirect-dns` and `--redirect-all-dns-traffic` are not provided together, so we should do it before we'll load config from file.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - no relevant issues
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - it won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - tested locally
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - there is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - there is no need

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
