### PR TITLE
feat(transparent-proxy): allow to use tproxy config from configmap in kubernetes

### DIFF
--- a/app/cni/pkg/cni/annotations_linux.go
+++ b/app/cni/pkg/cni/annotations_linux.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 )
 
+// Deprecated
 const (
 	defaultProxyStatusPort     = "9901"
 	defaultOutboundPort        = "15001"
@@ -20,6 +21,7 @@ const (
 	defaultRedirectExcludePort = defaultProxyStatusPort
 )
 
+// Deprecated
 var annotationRegistry = map[string]*annotationParam{
 	"inject":                      {"kuma.io/sidecar-injection", "", alwaysValidFunc},
 	"ports":                       {"kuma.io/envoy-admin-port", "", validatePortList},
@@ -40,6 +42,7 @@ var annotationRegistry = map[string]*annotationParam{
 	"applicationProbeProxyPort":   {"kuma.io/application-probe-proxy-port", defaultAppProbeProxyPort, validateSinglePort},
 }
 
+// Deprecated
 type IntermediateConfig struct {
 	// while https://github.com/kumahq/kuma/issues/8324 is not implemented, when changing the config,
 	// keep in mind to update all other places listed in the issue
@@ -60,22 +63,27 @@ type IntermediateConfig struct {
 	excludeOutboundIPs          string
 }
 
+// Deprecated
 type annotationValidationFunc func(value string) error
 
+// Deprecated
 type annotationParam struct {
 	key        string
 	defaultVal string
 	validator  annotationValidationFunc
 }
 
+// Deprecated
 func alwaysValidFunc(_ string) error {
 	return nil
 }
 
+// Deprecated
 func splitPorts(portsString string) []string {
 	return strings.Split(portsString, ",")
 }
 
+// Deprecated
 func parsePort(portStr string) (uint16, error) {
 	port, err := strconv.ParseUint(strings.TrimSpace(portStr), 10, 16)
 	if err != nil {
@@ -84,6 +92,7 @@ func parsePort(portStr string) (uint16, error) {
 	return uint16(port), nil
 }
 
+// Deprecated
 func parsePorts(portsString string) ([]int, error) {
 	portsString = strings.TrimSpace(portsString)
 	ports := make([]int, 0)
@@ -110,6 +119,8 @@ func parsePorts(portsString string) ([]int, error) {
 // Returns:
 //   - error: An error if the input string is empty or if any of the IP
 //     addresses or CIDR blocks are invalid.
+//
+// Deprecated
 func validateIPs(addresses string) error {
 	addresses = strings.TrimSpace(addresses)
 
@@ -143,6 +154,7 @@ func validateIPs(addresses string) error {
 	return nil
 }
 
+// Deprecated
 func validatePortList(ports string) error {
 	if _, err := parsePorts(ports); err != nil {
 		return errors.Wrapf(err, "portList %q", ports)
@@ -150,6 +162,7 @@ func validatePortList(ports string) error {
 	return nil
 }
 
+// Deprecated
 func validateSinglePort(portString string) error {
 	if _, err := parsePort(portString); err != nil {
 		return err
@@ -157,6 +170,7 @@ func validateSinglePort(portString string) error {
 	return nil
 }
 
+// Deprecated
 func validateIpFamilyMode(val string) error {
 	if val == "" {
 		return errors.New("value is empty")
@@ -171,6 +185,7 @@ func validateIpFamilyMode(val string) error {
 	return errors.New(fmt.Sprintf("value '%s' is not a valid IP family mode", val))
 }
 
+// Deprecated
 func getAnnotationOrDefault(name string, annotations map[string]string) (string, error) {
 	if _, ok := annotationRegistry[name]; !ok {
 		return "", errors.Errorf("no registered annotation with name %s", name)
@@ -188,6 +203,7 @@ func getAnnotationOrDefault(name string, annotations map[string]string) (string,
 }
 
 // NewIntermediateConfig returns a new IntermediateConfig Object constructed from a list of ports and annotations
+// Deprecated
 func NewIntermediateConfig(annotations map[string]string) (*IntermediateConfig, error) {
 	intermediateConfig := &IntermediateConfig{}
 	valDefaultProbeProxyPort := defaultAppProbeProxyPort
@@ -220,6 +236,7 @@ func NewIntermediateConfig(annotations map[string]string) (*IntermediateConfig, 
 	return intermediateConfig, nil
 }
 
+// Deprecated
 func mapAnnotation(annotations map[string]string, field *string, fieldName string) error {
 	val, err := getAnnotationOrDefault(fieldName, annotations)
 	if err != nil {
@@ -229,6 +246,7 @@ func mapAnnotation(annotations map[string]string, field *string, fieldName strin
 	return nil
 }
 
+// Deprecated
 func excludeAppProbeProxyPort(allFields map[string]*string) {
 	inboundPortsToExclude := allFields["excludeInboundPorts"]
 	applicationProbeProxyPort := *allFields["applicationProbeProxyPort"]

--- a/app/cni/pkg/cni/injector_linux.go
+++ b/app/cni/pkg/cni/injector_linux.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kumahq/kuma/pkg/transparentproxy/config"
 )
 
+// Deprecated
 func convertToUint16(field string, value string) (uint16, error) {
 	converted, err := strconv.ParseUint(value, 10, 16)
 	if err != nil {
@@ -23,6 +24,7 @@ func convertToUint16(field string, value string) (uint16, error) {
 	return uint16(converted), nil
 }
 
+// Deprecated
 func convertCommaSeparatedString(list string) (config.Ports, error) {
 	split := strings.Split(list, ",")
 	mapped := make(config.Ports, len(split))
@@ -38,7 +40,8 @@ func convertCommaSeparatedString(list string) (config.Ports, error) {
 	return mapped, nil
 }
 
-func Inject(ctx context.Context, netns string, intermediateConfig *IntermediateConfig, logger logr.Logger) error {
+// Deprecated
+func legacyInjectIptables(ctx context.Context, netns string, intermediateConfig *IntermediateConfig, logger logr.Logger) error {
 	var logBuffer bytes.Buffer
 	logWriter := bufio.NewWriter(&logBuffer)
 	cfg, err := mapToConfig(intermediateConfig, logWriter)
@@ -73,6 +76,7 @@ func Inject(ctx context.Context, netns string, intermediateConfig *IntermediateC
 	})
 }
 
+// Deprecated
 func mapToConfig(intermediateConfig *IntermediateConfig, logWriter *bufio.Writer) (*config.Config, error) {
 	cfg := config.DefaultConfig()
 
@@ -155,6 +159,7 @@ func mapToConfig(intermediateConfig *IntermediateConfig, logWriter *bufio.Writer
 	return &cfg, nil
 }
 
+// Deprecated
 func GetEnabled(value string) (bool, error) {
 	switch strings.ToLower(value) {
 	case "enabled", "true":

--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -721,6 +721,117 @@ hooks:
     containerSecurityContext:
       readOnlyRootFilesystem: false
 
+transparentProxy:
+  # -- The name of the ConfigMap used to store the transparent proxy configuration
+  configMapName: kuma-transparent-proxy-config
+  config:
+    # -- The username or UID of the user that will run kuma-dp. If not provided, the system will
+    # use the default UID ("5678") or the default username ("kuma-dp")
+    kumaDPUser: "5678"
+    # -- The IP family mode used for configuring traffic redirection in the transparent proxy
+    # Supports "dualstack" (for both IPv4 and IPv6) and "ipv4" modes
+    ipFamilyMode: dualstack
+    redirect:
+      dns:
+        # -- Enables DNS redirection in the transparent proxy
+        enabled: true
+        # -- Redirect all DNS queries
+        captureAll: true
+        # -- The port on which the DNS server listens
+        port: 15053
+        # -- Path to the system's resolv.conf file
+        resolvConfigPath: /etc/resolv.conf
+        # -- Disables conntrack zone splitting, which can prevent potential DNS issues
+        skipConntrackZoneSplit: false
+      inbound:
+        # -- Enables inbound traffic redirection
+        enabled: true
+        # -- Port used for redirecting inbound traffic
+        port: 15006
+        # -- List of ports to exclude from inbound traffic redirection
+        excludePorts: []
+        # -- List of IP addresses to exclude from inbound traffic redirection for specific ports
+        excludePortsForIPs: []
+        # -- List of UIDs to exclude from inbound traffic redirection for specific ports
+        excludePortsForUIDs: []
+        # -- List of ports to include in inbound traffic redirection
+        includePorts: []
+        # -- Inserts the redirection rule at the beginning of the chain instead of appending it
+        insertRedirectInsteadOfAppend: false
+      outbound:
+        # -- Enables outbound traffic redirection
+        enabled: true
+        # -- Port used for redirecting outbound traffic
+        port: 15001
+        # -- List of ports to exclude from outbound traffic redirection
+        excludePorts: []
+        # -- List of IP addresses to exclude from outbound traffic redirection for specific ports
+        excludePortsForIPs: []
+        # -- List of UIDs to exclude from outbound traffic redirection for specific ports
+        excludePortsForUIDs: []
+        # -- List of ports to include in outbound traffic redirection
+        includePorts: []
+        # -- Inserts the redirection rule at the beginning of the chain instead of appending it
+        insertRedirectInsteadOfAppend: false
+      vnet:
+        # -- Specifies virtual networks using the format interfaceName:CIDR
+        # Allows matching traffic on specific network interfaces
+        # Examples:
+        # - "docker0:172.17.0.0/16"
+        # - "br+:172.18.0.0/16" (matches any interface starting with "br")
+        # - "iface:::1/64" (for IPv6)
+        networks: []
+    ebpf:
+      # -- Enables eBPF support for handling traffic redirection in the transparent proxy
+      enabled: false
+      # -- The path of the BPF filesystem
+      bpffsPath: /run/kuma/bpf
+      # -- The path of cgroup2
+      cgroupPath: /sys/fs/cgroup
+      # -- The name of the environment variable containing the IP address of the instance (pod/vm)
+      # where transparent proxy will be installed
+      instanceIPEnvVarName: ""
+      # -- Path where compiled eBPF programs and other necessary files for eBPF mode can be found
+      programsSourcePath: /tmp/kuma-ebpf
+      # -- The network interface for TC eBPF programs to bind to. If not provided, it will be
+      # automatically determined
+      tcAttachIface: ""
+    retry:
+      # -- The maximum number of retry attempts for operations
+      maxRetries: 4
+      # -- The time duration to wait between retry attempts
+      sleepBetweenRetries: 2s
+    iptablesExecutables:
+      # -- Custom path for the iptables executable (IPv4)
+      iptables: ""
+      # -- Custom path for the iptables-save executable (IPv4)
+      iptables-save: ""
+      # -- Custom path for the iptables-restore executable (IPv4)
+      iptables-restore: ""
+      # -- Custom path for the ip6tables executable (IPv6)
+      ip6tables: ""
+      # -- Custom path for the ip6tables-save executable (IPv6)
+      ip6tables-save: ""
+      # -- Custom path for the ip6tables-restore executable (IPv6)
+      ip6tables-restore: ""
+    log:
+      # -- Enables logging of iptables rules for diagnostics and monitoring
+      enabled: false
+    comments:
+      # -- Disables comments in the generated iptables rules
+      disabled: false
+    # -- Time in seconds to wait for acquiring the xtables lock before failing
+    # Value 0 means wait indefinitely
+    wait: 5
+    # -- Time interval between retries to acquire the xtables lock in seconds
+    waitInterval: 0
+    # -- Drops invalid packets to avoid connection resets in high-throughput scenarios
+    dropInvalidPackets: false
+    # -- Enables firewalld support to store iptables rules
+    storeFirewalld: false
+    # -- Enables verbose mode with longer argument/flag names and additional comments
+    verbose: false
+
 experimental:
   # Configuration for the experimental ebpf mode for transparent proxy
   ebpf:
@@ -739,6 +850,10 @@ experimental:
   # -- If true, enable native Kubernetes sidecars. This requires at least
   # Kubernetes v1.29
   sidecarContainers: false
+  transparentProxy:
+    # -- If true, enables the use of a ConfigMap to manage transparent proxy configuration
+    # instead of directly configuring it within the Kuma system
+    configMap: false
 
 # Postgres' settings for universal control plane on k8s
 postgres:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -722,115 +722,119 @@ hooks:
       readOnlyRootFilesystem: false
 
 transparentProxy:
-  # -- The name of the ConfigMap used to store the transparent proxy configuration
-  configMapName: kuma-transparent-proxy-config
-  config:
-    # -- The username or UID of the user that will run kuma-dp. If not provided, the system will
-    # use the default UID ("5678") or the default username ("kuma-dp")
-    kumaDPUser: "5678"
-    # -- The IP family mode used for configuring traffic redirection in the transparent proxy
-    # Supports "dualstack" (for both IPv4 and IPv6) and "ipv4" modes
-    ipFamilyMode: dualstack
-    redirect:
-      dns:
-        # -- Enables DNS redirection in the transparent proxy
-        enabled: true
-        # -- Redirect all DNS queries
-        captureAll: true
-        # -- The port on which the DNS server listens
-        port: 15053
-        # -- Path to the system's resolv.conf file
-        resolvConfigPath: /etc/resolv.conf
-        # -- Disables conntrack zone splitting, which can prevent potential DNS issues
-        skipConntrackZoneSplit: false
-      inbound:
-        # -- Enables inbound traffic redirection
-        enabled: true
-        # -- Port used for redirecting inbound traffic
-        port: 15006
-        # -- List of ports to exclude from inbound traffic redirection
-        excludePorts: []
-        # -- List of IP addresses to exclude from inbound traffic redirection for specific ports
-        excludePortsForIPs: []
-        # -- List of UIDs to exclude from inbound traffic redirection for specific ports
-        excludePortsForUIDs: []
-        # -- List of ports to include in inbound traffic redirection
-        includePorts: []
-        # -- Inserts the redirection rule at the beginning of the chain instead of appending it
-        insertRedirectInsteadOfAppend: false
-      outbound:
-        # -- Enables outbound traffic redirection
-        enabled: true
-        # -- Port used for redirecting outbound traffic
-        port: 15001
-        # -- List of ports to exclude from outbound traffic redirection
-        excludePorts: []
-        # -- List of IP addresses to exclude from outbound traffic redirection for specific ports
-        excludePortsForIPs: []
-        # -- List of UIDs to exclude from outbound traffic redirection for specific ports
-        excludePortsForUIDs: []
-        # -- List of ports to include in outbound traffic redirection
-        includePorts: []
-        # -- Inserts the redirection rule at the beginning of the chain instead of appending it
-        insertRedirectInsteadOfAppend: false
-      vnet:
-        # -- Specifies virtual networks using the format interfaceName:CIDR
-        # Allows matching traffic on specific network interfaces
-        # Examples:
-        # - "docker0:172.17.0.0/16"
-        # - "br+:172.18.0.0/16" (matches any interface starting with "br")
-        # - "iface:::1/64" (for IPv6)
-        networks: []
-    ebpf:
-      # -- Enables eBPF support for handling traffic redirection in the transparent proxy
-      enabled: false
-      # -- The path of the BPF filesystem
-      bpffsPath: /run/kuma/bpf
-      # -- The path of cgroup2
-      cgroupPath: /sys/fs/cgroup
-      # -- The name of the environment variable containing the IP address of the instance (pod/vm)
-      # where transparent proxy will be installed
-      instanceIPEnvVarName: ""
-      # -- Path where compiled eBPF programs and other necessary files for eBPF mode can be found
-      programsSourcePath: /tmp/kuma-ebpf
-      # -- The network interface for TC eBPF programs to bind to. If not provided, it will be
-      # automatically determined
-      tcAttachIface: ""
-    retry:
-      # -- The maximum number of retry attempts for operations
-      maxRetries: 4
-      # -- The time duration to wait between retry attempts
-      sleepBetweenRetries: 2s
-    iptablesExecutables:
-      # -- Custom path for the iptables executable (IPv4)
-      iptables: ""
-      # -- Custom path for the iptables-save executable (IPv4)
-      iptables-save: ""
-      # -- Custom path for the iptables-restore executable (IPv4)
-      iptables-restore: ""
-      # -- Custom path for the ip6tables executable (IPv6)
-      ip6tables: ""
-      # -- Custom path for the ip6tables-save executable (IPv6)
-      ip6tables-save: ""
-      # -- Custom path for the ip6tables-restore executable (IPv6)
-      ip6tables-restore: ""
-    log:
-      # -- Enables logging of iptables rules for diagnostics and monitoring
-      enabled: false
-    comments:
-      # -- Disables comments in the generated iptables rules
-      disabled: false
-    # -- Time in seconds to wait for acquiring the xtables lock before failing
-    # Value 0 means wait indefinitely
-    wait: 5
-    # -- Time interval between retries to acquire the xtables lock in seconds
-    waitInterval: 0
-    # -- Drops invalid packets to avoid connection resets in high-throughput scenarios
-    dropInvalidPackets: false
-    # -- Enables firewalld support to store iptables rules
-    storeFirewalld: false
-    # -- Enables verbose mode with longer argument/flag names and additional comments
-    verbose: false
+  configMap:
+    # -- If true, enables the use of a ConfigMap to manage transparent proxy configuration
+    # instead of directly configuring it within the Kuma system
+    enabled: false
+    # -- The name of the ConfigMap used to store the transparent proxy configuration
+    name: kuma-transparent-proxy-config
+    config:
+      # -- The username or UID of the user that will run kuma-dp. If not provided, the system will
+      # use the default UID ("5678") or the default username ("kuma-dp")
+      kumaDPUser: "5678"
+      # -- The IP family mode used for configuring traffic redirection in the transparent proxy
+      # Supports "dualstack" (for both IPv4 and IPv6) and "ipv4" modes
+      ipFamilyMode: dualstack
+      redirect:
+        dns:
+          # -- Enables DNS redirection in the transparent proxy
+          enabled: true
+          # -- Redirect all DNS queries
+          captureAll: true
+          # -- The port on which the DNS server listens
+          port: 15053
+          # -- Path to the system's resolv.conf file
+          resolvConfigPath: /etc/resolv.conf
+          # -- Disables conntrack zone splitting, which can prevent potential DNS issues
+          skipConntrackZoneSplit: false
+        inbound:
+          # -- Enables inbound traffic redirection
+          enabled: true
+          # -- Port used for redirecting inbound traffic
+          port: 15006
+          # -- List of ports to exclude from inbound traffic redirection
+          excludePorts: []
+          # -- List of IP addresses to exclude from inbound traffic redirection for specific ports
+          excludePortsForIPs: []
+          # -- List of UIDs to exclude from inbound traffic redirection for specific ports
+          excludePortsForUIDs: []
+          # -- List of ports to include in inbound traffic redirection
+          includePorts: []
+          # -- Inserts the redirection rule at the beginning of the chain instead of appending it
+          insertRedirectInsteadOfAppend: false
+        outbound:
+          # -- Enables outbound traffic redirection
+          enabled: true
+          # -- Port used for redirecting outbound traffic
+          port: 15001
+          # -- List of ports to exclude from outbound traffic redirection
+          excludePorts: []
+          # -- List of IP addresses to exclude from outbound traffic redirection for specific ports
+          excludePortsForIPs: []
+          # -- List of UIDs to exclude from outbound traffic redirection for specific ports
+          excludePortsForUIDs: []
+          # -- List of ports to include in outbound traffic redirection
+          includePorts: []
+          # -- Inserts the redirection rule at the beginning of the chain instead of appending it
+          insertRedirectInsteadOfAppend: false
+        vnet:
+          # -- Specifies virtual networks using the format interfaceName:CIDR
+          # Allows matching traffic on specific network interfaces
+          # Examples:
+          # - "docker0:172.17.0.0/16"
+          # - "br+:172.18.0.0/16" (matches any interface starting with "br")
+          # - "iface:::1/64" (for IPv6)
+          networks: []
+      ebpf:
+        # -- Enables eBPF support for handling traffic redirection in the transparent proxy
+        enabled: false
+        # -- The path of the BPF filesystem
+        bpffsPath: /run/kuma/bpf
+        # -- The path of cgroup2
+        cgroupPath: /sys/fs/cgroup
+        # -- The name of the environment variable containing the IP address of the instance (pod/vm)
+        # where transparent proxy will be installed
+        instanceIPEnvVarName: ""
+        # -- Path where compiled eBPF programs and other necessary files for eBPF mode can be found
+        programsSourcePath: /tmp/kuma-ebpf
+        # -- The network interface for TC eBPF programs to bind to. If not provided, it will be
+        # automatically determined
+        tcAttachIface: ""
+      retry:
+        # -- The maximum number of retry attempts for operations
+        maxRetries: 4
+        # -- The time duration to wait between retry attempts
+        sleepBetweenRetries: 2s
+      iptablesExecutables:
+        # -- Custom path for the iptables executable (IPv4)
+        iptables: ""
+        # -- Custom path for the iptables-save executable (IPv4)
+        iptables-save: ""
+        # -- Custom path for the iptables-restore executable (IPv4)
+        iptables-restore: ""
+        # -- Custom path for the ip6tables executable (IPv6)
+        ip6tables: ""
+        # -- Custom path for the ip6tables-save executable (IPv6)
+        ip6tables-save: ""
+        # -- Custom path for the ip6tables-restore executable (IPv6)
+        ip6tables-restore: ""
+      log:
+        # -- Enables logging of iptables rules for diagnostics and monitoring
+        enabled: false
+      comments:
+        # -- Disables comments in the generated iptables rules
+        disabled: false
+      # -- Time in seconds to wait for acquiring the xtables lock before failing
+      # Value 0 means wait indefinitely
+      wait: 5
+      # -- Time interval between retries to acquire the xtables lock in seconds
+      waitInterval: 0
+      # -- Drops invalid packets to avoid connection resets in high-throughput scenarios
+      dropInvalidPackets: false
+      # -- Enables firewalld support to store iptables rules
+      storeFirewalld: false
+      # -- Enables verbose mode with longer argument/flag names and additional comments
+      verbose: false
 
 experimental:
   # Configuration for the experimental ebpf mode for transparent proxy
@@ -850,10 +854,6 @@ experimental:
   # -- If true, enable native Kubernetes sidecars. This requires at least
   # Kubernetes v1.29
   sidecarContainers: false
-  transparentProxy:
-    # -- If true, enables the use of a ConfigMap to manage transparent proxy configuration
-    # instead of directly configuring it within the Kuma system
-    configMap: false
 
 # Postgres' settings for universal control plane on k8s
 postgres:

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -215,6 +215,50 @@ A Helm chart for the Kuma Control Plane
 | hooks.ebpfCleanup | object | `{"containerSecurityContext":{"readOnlyRootFilesystem":false},"podSecurityContext":{"runAsNonRoot":false}}` | ebpf-cleanup hook needs write access to the root filesystem to clean ebpf programs Changing below values will potentially break ebpf cleanup completely, so be cautious when doing so. |
 | hooks.ebpfCleanup.podSecurityContext | object | `{"runAsNonRoot":false}` | Security context at the pod level for crd/webhook/cleanup-ebpf |
 | hooks.ebpfCleanup.containerSecurityContext | object | `{"readOnlyRootFilesystem":false}` | Security context at the container level for crd/webhook/cleanup-ebpf |
+| transparentProxy.configMapName | string | `"kuma-transparent-proxy-config"` | The name of the ConfigMap used to store the transparent proxy configuration |
+| transparentProxy.config.kumaDPUser | string | `"5678"` | The username or UID of the user that will run kuma-dp. If not provided, the system will use the default UID ("5678") or the default username ("kuma-dp") |
+| transparentProxy.config.ipFamilyMode | string | `"dualstack"` | The IP family mode used for configuring traffic redirection in the transparent proxy Supports "dualstack" (for both IPv4 and IPv6) and "ipv4" modes |
+| transparentProxy.config.redirect.dns.enabled | bool | `true` | Enables DNS redirection in the transparent proxy |
+| transparentProxy.config.redirect.dns.captureAll | bool | `true` | Redirect all DNS queries |
+| transparentProxy.config.redirect.dns.port | int | `15053` | The port on which the DNS server listens |
+| transparentProxy.config.redirect.dns.resolvConfigPath | string | `"/etc/resolv.conf"` | Path to the system's resolv.conf file |
+| transparentProxy.config.redirect.dns.skipConntrackZoneSplit | bool | `false` | Disables conntrack zone splitting, which can prevent potential DNS issues |
+| transparentProxy.config.redirect.inbound.enabled | bool | `true` | Enables inbound traffic redirection |
+| transparentProxy.config.redirect.inbound.port | int | `15006` | Port used for redirecting inbound traffic |
+| transparentProxy.config.redirect.inbound.excludePorts | list | `[]` | List of ports to exclude from inbound traffic redirection |
+| transparentProxy.config.redirect.inbound.excludePortsForIPs | list | `[]` | List of IP addresses to exclude from inbound traffic redirection for specific ports |
+| transparentProxy.config.redirect.inbound.excludePortsForUIDs | list | `[]` | List of UIDs to exclude from inbound traffic redirection for specific ports |
+| transparentProxy.config.redirect.inbound.includePorts | list | `[]` | List of ports to include in inbound traffic redirection |
+| transparentProxy.config.redirect.inbound.insertRedirectInsteadOfAppend | bool | `false` | Inserts the redirection rule at the beginning of the chain instead of appending it |
+| transparentProxy.config.redirect.outbound.enabled | bool | `true` | Enables outbound traffic redirection |
+| transparentProxy.config.redirect.outbound.port | int | `15001` | Port used for redirecting outbound traffic |
+| transparentProxy.config.redirect.outbound.excludePorts | list | `[]` | List of ports to exclude from outbound traffic redirection |
+| transparentProxy.config.redirect.outbound.excludePortsForIPs | list | `[]` | List of IP addresses to exclude from outbound traffic redirection for specific ports |
+| transparentProxy.config.redirect.outbound.excludePortsForUIDs | list | `[]` | List of UIDs to exclude from outbound traffic redirection for specific ports |
+| transparentProxy.config.redirect.outbound.includePorts | list | `[]` | List of ports to include in outbound traffic redirection |
+| transparentProxy.config.redirect.outbound.insertRedirectInsteadOfAppend | bool | `false` | Inserts the redirection rule at the beginning of the chain instead of appending it |
+| transparentProxy.config.redirect.vnet.networks | list | `[]` | Specifies virtual networks using the format interfaceName:CIDR Allows matching traffic on specific network interfaces Examples: - "docker0:172.17.0.0/16" - "br+:172.18.0.0/16" (matches any interface starting with "br") - "iface:::1/64" (for IPv6) |
+| transparentProxy.config.ebpf.enabled | bool | `false` | Enables eBPF support for handling traffic redirection in the transparent proxy |
+| transparentProxy.config.ebpf.bpffsPath | string | `"/run/kuma/bpf"` | The path of the BPF filesystem |
+| transparentProxy.config.ebpf.cgroupPath | string | `"/sys/fs/cgroup"` | The path of cgroup2 |
+| transparentProxy.config.ebpf.instanceIPEnvVarName | string | `""` | The name of the environment variable containing the IP address of the instance (pod/vm) where transparent proxy will be installed |
+| transparentProxy.config.ebpf.programsSourcePath | string | `"/tmp/kuma-ebpf"` | Path where compiled eBPF programs and other necessary files for eBPF mode can be found |
+| transparentProxy.config.ebpf.tcAttachIface | string | `""` | The network interface for TC eBPF programs to bind to. If not provided, it will be automatically determined |
+| transparentProxy.config.retry.maxRetries | int | `4` | The maximum number of retry attempts for operations |
+| transparentProxy.config.retry.sleepBetweenRetries | string | `"2s"` | The time duration to wait between retry attempts |
+| transparentProxy.config.iptablesExecutables.iptables | string | `""` | Custom path for the iptables executable (IPv4) |
+| transparentProxy.config.iptablesExecutables.iptables-save | string | `""` | Custom path for the iptables-save executable (IPv4) |
+| transparentProxy.config.iptablesExecutables.iptables-restore | string | `""` | Custom path for the iptables-restore executable (IPv4) |
+| transparentProxy.config.iptablesExecutables.ip6tables | string | `""` | Custom path for the ip6tables executable (IPv6) |
+| transparentProxy.config.iptablesExecutables.ip6tables-save | string | `""` | Custom path for the ip6tables-save executable (IPv6) |
+| transparentProxy.config.iptablesExecutables.ip6tables-restore | string | `""` | Custom path for the ip6tables-restore executable (IPv6) |
+| transparentProxy.config.log.enabled | bool | `false` | Enables logging of iptables rules for diagnostics and monitoring |
+| transparentProxy.config.comments.disabled | bool | `false` | Disables comments in the generated iptables rules |
+| transparentProxy.config.wait | int | `5` | Time in seconds to wait for acquiring the xtables lock before failing Value 0 means wait indefinitely |
+| transparentProxy.config.waitInterval | int | `0` | Time interval between retries to acquire the xtables lock in seconds |
+| transparentProxy.config.dropInvalidPackets | bool | `false` | Drops invalid packets to avoid connection resets in high-throughput scenarios |
+| transparentProxy.config.storeFirewalld | bool | `false` | Enables firewalld support to store iptables rules |
+| transparentProxy.config.verbose | bool | `false` | Enables verbose mode with longer argument/flag names and additional comments |
 | experimental.ebpf.enabled | bool | `false` | If true, ebpf will be used instead of using iptables to install/configure transparent proxy |
 | experimental.ebpf.instanceIPEnvVarName | string | `"INSTANCE_IP"` | Name of the environmental variable which will contain the IP address of a pod |
 | experimental.ebpf.bpffsPath | string | `"/sys/fs/bpf"` | Path where BPF file system should be mounted |
@@ -222,6 +266,7 @@ A Helm chart for the Kuma Control Plane
 | experimental.ebpf.tcAttachIface | string | `""` | Name of the network interface which TC programs should be attached to, we'll try to automatically determine it if empty |
 | experimental.ebpf.programsSourcePath | string | `"/tmp/kuma-ebpf"` | Path where compiled eBPF programs which will be installed can be found |
 | experimental.sidecarContainers | bool | `false` | If true, enable native Kubernetes sidecars. This requires at least Kubernetes v1.29 |
+| experimental.transparentProxy.configMap | bool | `false` | If true, enables the use of a ConfigMap to manage transparent proxy configuration instead of directly configuring it within the Kuma system |
 | postgres.port | string | `"5432"` | Postgres port, password should be provided as a secret reference in "controlPlane.secrets" with the Env value "KUMA_STORE_POSTGRES_PASSWORD". Example: controlPlane:   secrets:     - Secret: postgres-postgresql       Key: postgresql-password       Env: KUMA_STORE_POSTGRES_PASSWORD |
 | postgres.tls.mode | string | `"disable"` | Mode of TLS connection. Available values are: "disable", "verifyNone", "verifyCa", "verifyFull" |
 | postgres.tls.disableSSLSNI | bool | `false` | Whether to disable SNI the postgres `sslsni` option. |

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -215,50 +215,51 @@ A Helm chart for the Kuma Control Plane
 | hooks.ebpfCleanup | object | `{"containerSecurityContext":{"readOnlyRootFilesystem":false},"podSecurityContext":{"runAsNonRoot":false}}` | ebpf-cleanup hook needs write access to the root filesystem to clean ebpf programs Changing below values will potentially break ebpf cleanup completely, so be cautious when doing so. |
 | hooks.ebpfCleanup.podSecurityContext | object | `{"runAsNonRoot":false}` | Security context at the pod level for crd/webhook/cleanup-ebpf |
 | hooks.ebpfCleanup.containerSecurityContext | object | `{"readOnlyRootFilesystem":false}` | Security context at the container level for crd/webhook/cleanup-ebpf |
-| transparentProxy.configMapName | string | `"kuma-transparent-proxy-config"` | The name of the ConfigMap used to store the transparent proxy configuration |
-| transparentProxy.config.kumaDPUser | string | `"5678"` | The username or UID of the user that will run kuma-dp. If not provided, the system will use the default UID ("5678") or the default username ("kuma-dp") |
-| transparentProxy.config.ipFamilyMode | string | `"dualstack"` | The IP family mode used for configuring traffic redirection in the transparent proxy Supports "dualstack" (for both IPv4 and IPv6) and "ipv4" modes |
-| transparentProxy.config.redirect.dns.enabled | bool | `true` | Enables DNS redirection in the transparent proxy |
-| transparentProxy.config.redirect.dns.captureAll | bool | `true` | Redirect all DNS queries |
-| transparentProxy.config.redirect.dns.port | int | `15053` | The port on which the DNS server listens |
-| transparentProxy.config.redirect.dns.resolvConfigPath | string | `"/etc/resolv.conf"` | Path to the system's resolv.conf file |
-| transparentProxy.config.redirect.dns.skipConntrackZoneSplit | bool | `false` | Disables conntrack zone splitting, which can prevent potential DNS issues |
-| transparentProxy.config.redirect.inbound.enabled | bool | `true` | Enables inbound traffic redirection |
-| transparentProxy.config.redirect.inbound.port | int | `15006` | Port used for redirecting inbound traffic |
-| transparentProxy.config.redirect.inbound.excludePorts | list | `[]` | List of ports to exclude from inbound traffic redirection |
-| transparentProxy.config.redirect.inbound.excludePortsForIPs | list | `[]` | List of IP addresses to exclude from inbound traffic redirection for specific ports |
-| transparentProxy.config.redirect.inbound.excludePortsForUIDs | list | `[]` | List of UIDs to exclude from inbound traffic redirection for specific ports |
-| transparentProxy.config.redirect.inbound.includePorts | list | `[]` | List of ports to include in inbound traffic redirection |
-| transparentProxy.config.redirect.inbound.insertRedirectInsteadOfAppend | bool | `false` | Inserts the redirection rule at the beginning of the chain instead of appending it |
-| transparentProxy.config.redirect.outbound.enabled | bool | `true` | Enables outbound traffic redirection |
-| transparentProxy.config.redirect.outbound.port | int | `15001` | Port used for redirecting outbound traffic |
-| transparentProxy.config.redirect.outbound.excludePorts | list | `[]` | List of ports to exclude from outbound traffic redirection |
-| transparentProxy.config.redirect.outbound.excludePortsForIPs | list | `[]` | List of IP addresses to exclude from outbound traffic redirection for specific ports |
-| transparentProxy.config.redirect.outbound.excludePortsForUIDs | list | `[]` | List of UIDs to exclude from outbound traffic redirection for specific ports |
-| transparentProxy.config.redirect.outbound.includePorts | list | `[]` | List of ports to include in outbound traffic redirection |
-| transparentProxy.config.redirect.outbound.insertRedirectInsteadOfAppend | bool | `false` | Inserts the redirection rule at the beginning of the chain instead of appending it |
-| transparentProxy.config.redirect.vnet.networks | list | `[]` | Specifies virtual networks using the format interfaceName:CIDR Allows matching traffic on specific network interfaces Examples: - "docker0:172.17.0.0/16" - "br+:172.18.0.0/16" (matches any interface starting with "br") - "iface:::1/64" (for IPv6) |
-| transparentProxy.config.ebpf.enabled | bool | `false` | Enables eBPF support for handling traffic redirection in the transparent proxy |
-| transparentProxy.config.ebpf.bpffsPath | string | `"/run/kuma/bpf"` | The path of the BPF filesystem |
-| transparentProxy.config.ebpf.cgroupPath | string | `"/sys/fs/cgroup"` | The path of cgroup2 |
-| transparentProxy.config.ebpf.instanceIPEnvVarName | string | `""` | The name of the environment variable containing the IP address of the instance (pod/vm) where transparent proxy will be installed |
-| transparentProxy.config.ebpf.programsSourcePath | string | `"/tmp/kuma-ebpf"` | Path where compiled eBPF programs and other necessary files for eBPF mode can be found |
-| transparentProxy.config.ebpf.tcAttachIface | string | `""` | The network interface for TC eBPF programs to bind to. If not provided, it will be automatically determined |
-| transparentProxy.config.retry.maxRetries | int | `4` | The maximum number of retry attempts for operations |
-| transparentProxy.config.retry.sleepBetweenRetries | string | `"2s"` | The time duration to wait between retry attempts |
-| transparentProxy.config.iptablesExecutables.iptables | string | `""` | Custom path for the iptables executable (IPv4) |
-| transparentProxy.config.iptablesExecutables.iptables-save | string | `""` | Custom path for the iptables-save executable (IPv4) |
-| transparentProxy.config.iptablesExecutables.iptables-restore | string | `""` | Custom path for the iptables-restore executable (IPv4) |
-| transparentProxy.config.iptablesExecutables.ip6tables | string | `""` | Custom path for the ip6tables executable (IPv6) |
-| transparentProxy.config.iptablesExecutables.ip6tables-save | string | `""` | Custom path for the ip6tables-save executable (IPv6) |
-| transparentProxy.config.iptablesExecutables.ip6tables-restore | string | `""` | Custom path for the ip6tables-restore executable (IPv6) |
-| transparentProxy.config.log.enabled | bool | `false` | Enables logging of iptables rules for diagnostics and monitoring |
-| transparentProxy.config.comments.disabled | bool | `false` | Disables comments in the generated iptables rules |
-| transparentProxy.config.wait | int | `5` | Time in seconds to wait for acquiring the xtables lock before failing Value 0 means wait indefinitely |
-| transparentProxy.config.waitInterval | int | `0` | Time interval between retries to acquire the xtables lock in seconds |
-| transparentProxy.config.dropInvalidPackets | bool | `false` | Drops invalid packets to avoid connection resets in high-throughput scenarios |
-| transparentProxy.config.storeFirewalld | bool | `false` | Enables firewalld support to store iptables rules |
-| transparentProxy.config.verbose | bool | `false` | Enables verbose mode with longer argument/flag names and additional comments |
+| transparentProxy.configMap.enabled | bool | `false` | If true, enables the use of a ConfigMap to manage transparent proxy configuration instead of directly configuring it within the Kuma system |
+| transparentProxy.configMap.name | string | `"kuma-transparent-proxy-config"` | The name of the ConfigMap used to store the transparent proxy configuration |
+| transparentProxy.configMap.config.kumaDPUser | string | `"5678"` | The username or UID of the user that will run kuma-dp. If not provided, the system will use the default UID ("5678") or the default username ("kuma-dp") |
+| transparentProxy.configMap.config.ipFamilyMode | string | `"dualstack"` | The IP family mode used for configuring traffic redirection in the transparent proxy Supports "dualstack" (for both IPv4 and IPv6) and "ipv4" modes |
+| transparentProxy.configMap.config.redirect.dns.enabled | bool | `true` | Enables DNS redirection in the transparent proxy |
+| transparentProxy.configMap.config.redirect.dns.captureAll | bool | `true` | Redirect all DNS queries |
+| transparentProxy.configMap.config.redirect.dns.port | int | `15053` | The port on which the DNS server listens |
+| transparentProxy.configMap.config.redirect.dns.resolvConfigPath | string | `"/etc/resolv.conf"` | Path to the system's resolv.conf file |
+| transparentProxy.configMap.config.redirect.dns.skipConntrackZoneSplit | bool | `false` | Disables conntrack zone splitting, which can prevent potential DNS issues |
+| transparentProxy.configMap.config.redirect.inbound.enabled | bool | `true` | Enables inbound traffic redirection |
+| transparentProxy.configMap.config.redirect.inbound.port | int | `15006` | Port used for redirecting inbound traffic |
+| transparentProxy.configMap.config.redirect.inbound.excludePorts | list | `[]` | List of ports to exclude from inbound traffic redirection |
+| transparentProxy.configMap.config.redirect.inbound.excludePortsForIPs | list | `[]` | List of IP addresses to exclude from inbound traffic redirection for specific ports |
+| transparentProxy.configMap.config.redirect.inbound.excludePortsForUIDs | list | `[]` | List of UIDs to exclude from inbound traffic redirection for specific ports |
+| transparentProxy.configMap.config.redirect.inbound.includePorts | list | `[]` | List of ports to include in inbound traffic redirection |
+| transparentProxy.configMap.config.redirect.inbound.insertRedirectInsteadOfAppend | bool | `false` | Inserts the redirection rule at the beginning of the chain instead of appending it |
+| transparentProxy.configMap.config.redirect.outbound.enabled | bool | `true` | Enables outbound traffic redirection |
+| transparentProxy.configMap.config.redirect.outbound.port | int | `15001` | Port used for redirecting outbound traffic |
+| transparentProxy.configMap.config.redirect.outbound.excludePorts | list | `[]` | List of ports to exclude from outbound traffic redirection |
+| transparentProxy.configMap.config.redirect.outbound.excludePortsForIPs | list | `[]` | List of IP addresses to exclude from outbound traffic redirection for specific ports |
+| transparentProxy.configMap.config.redirect.outbound.excludePortsForUIDs | list | `[]` | List of UIDs to exclude from outbound traffic redirection for specific ports |
+| transparentProxy.configMap.config.redirect.outbound.includePorts | list | `[]` | List of ports to include in outbound traffic redirection |
+| transparentProxy.configMap.config.redirect.outbound.insertRedirectInsteadOfAppend | bool | `false` | Inserts the redirection rule at the beginning of the chain instead of appending it |
+| transparentProxy.configMap.config.redirect.vnet.networks | list | `[]` | Specifies virtual networks using the format interfaceName:CIDR Allows matching traffic on specific network interfaces Examples: - "docker0:172.17.0.0/16" - "br+:172.18.0.0/16" (matches any interface starting with "br") - "iface:::1/64" (for IPv6) |
+| transparentProxy.configMap.config.ebpf.enabled | bool | `false` | Enables eBPF support for handling traffic redirection in the transparent proxy |
+| transparentProxy.configMap.config.ebpf.bpffsPath | string | `"/run/kuma/bpf"` | The path of the BPF filesystem |
+| transparentProxy.configMap.config.ebpf.cgroupPath | string | `"/sys/fs/cgroup"` | The path of cgroup2 |
+| transparentProxy.configMap.config.ebpf.instanceIPEnvVarName | string | `""` | The name of the environment variable containing the IP address of the instance (pod/vm) where transparent proxy will be installed |
+| transparentProxy.configMap.config.ebpf.programsSourcePath | string | `"/tmp/kuma-ebpf"` | Path where compiled eBPF programs and other necessary files for eBPF mode can be found |
+| transparentProxy.configMap.config.ebpf.tcAttachIface | string | `""` | The network interface for TC eBPF programs to bind to. If not provided, it will be automatically determined |
+| transparentProxy.configMap.config.retry.maxRetries | int | `4` | The maximum number of retry attempts for operations |
+| transparentProxy.configMap.config.retry.sleepBetweenRetries | string | `"2s"` | The time duration to wait between retry attempts |
+| transparentProxy.configMap.config.iptablesExecutables.iptables | string | `""` | Custom path for the iptables executable (IPv4) |
+| transparentProxy.configMap.config.iptablesExecutables.iptables-save | string | `""` | Custom path for the iptables-save executable (IPv4) |
+| transparentProxy.configMap.config.iptablesExecutables.iptables-restore | string | `""` | Custom path for the iptables-restore executable (IPv4) |
+| transparentProxy.configMap.config.iptablesExecutables.ip6tables | string | `""` | Custom path for the ip6tables executable (IPv6) |
+| transparentProxy.configMap.config.iptablesExecutables.ip6tables-save | string | `""` | Custom path for the ip6tables-save executable (IPv6) |
+| transparentProxy.configMap.config.iptablesExecutables.ip6tables-restore | string | `""` | Custom path for the ip6tables-restore executable (IPv6) |
+| transparentProxy.configMap.config.log.enabled | bool | `false` | Enables logging of iptables rules for diagnostics and monitoring |
+| transparentProxy.configMap.config.comments.disabled | bool | `false` | Disables comments in the generated iptables rules |
+| transparentProxy.configMap.config.wait | int | `5` | Time in seconds to wait for acquiring the xtables lock before failing Value 0 means wait indefinitely |
+| transparentProxy.configMap.config.waitInterval | int | `0` | Time interval between retries to acquire the xtables lock in seconds |
+| transparentProxy.configMap.config.dropInvalidPackets | bool | `false` | Drops invalid packets to avoid connection resets in high-throughput scenarios |
+| transparentProxy.configMap.config.storeFirewalld | bool | `false` | Enables firewalld support to store iptables rules |
+| transparentProxy.configMap.config.verbose | bool | `false` | Enables verbose mode with longer argument/flag names and additional comments |
 | experimental.ebpf.enabled | bool | `false` | If true, ebpf will be used instead of using iptables to install/configure transparent proxy |
 | experimental.ebpf.instanceIPEnvVarName | string | `"INSTANCE_IP"` | Name of the environmental variable which will contain the IP address of a pod |
 | experimental.ebpf.bpffsPath | string | `"/sys/fs/bpf"` | Path where BPF file system should be mounted |
@@ -266,7 +267,6 @@ A Helm chart for the Kuma Control Plane
 | experimental.ebpf.tcAttachIface | string | `""` | Name of the network interface which TC programs should be attached to, we'll try to automatically determine it if empty |
 | experimental.ebpf.programsSourcePath | string | `"/tmp/kuma-ebpf"` | Path where compiled eBPF programs which will be installed can be found |
 | experimental.sidecarContainers | bool | `false` | If true, enable native Kubernetes sidecars. This requires at least Kubernetes v1.29 |
-| experimental.transparentProxy.configMap | bool | `false` | If true, enables the use of a ConfigMap to manage transparent proxy configuration instead of directly configuring it within the Kuma system |
 | postgres.port | string | `"5432"` | Postgres port, password should be provided as a secret reference in "controlPlane.secrets" with the Env value "KUMA_STORE_POSTGRES_PASSWORD". Example: controlPlane:   secrets:     - Secret: postgres-postgresql       Key: postgresql-password       Env: KUMA_STORE_POSTGRES_PASSWORD |
 | postgres.tls.mode | string | `"disable"` | Mode of TLS connection. Available values are: "disable", "verifyNone", "verifyCa", "verifyFull" |
 | postgres.tls.disableSSLSNI | bool | `false` | Whether to disable SNI the postgres `sslsni` option. |

--- a/deployments/charts/kuma/templates/_helpers.tpl
+++ b/deployments/charts/kuma/templates/_helpers.tpl
@@ -221,8 +221,8 @@ returns: formatted image string
 {{- end -}}
 
 {{- define "kuma.transparentProxyConfigMapName" -}}
-{{- if .Values.transparentProxy.configMapName }}
-{{- .Values.transparentProxy.configMapName | trunc 253 | trimSuffix "-" }}
+{{- if .Values.transparentProxy.configMap.name }}
+{{- .Values.transparentProxy.configMap.name | trunc 253 | trimSuffix "-" }}
 {{- else }}
 {{- printf "%s-transparent-proxy-config" .Chart.Name }}
 {{- end }}
@@ -265,7 +265,7 @@ env:
 - name: KUMA_RUNTIME_KUBERNETES_INJECTOR_BUILTIN_DNS_LOGGING
   value: "true"
 {{- end }}
-{{- if and .Values.experimental.transparentProxy.configMap .Values.transparentProxy.config }}
+{{- if and .Values.transparentProxy.configMap.enabled .Values.transparentProxy.configMap.config }}
 - name: KUMA_RUNTIME_KUBERNETES_INJECTOR_TRANSPARENT_PROXY_CONFIGMAP_NAME
   value: {{ include "kuma.transparentProxyConfigMapName" . | quote }}
 {{- end }}

--- a/deployments/charts/kuma/templates/_helpers.tpl
+++ b/deployments/charts/kuma/templates/_helpers.tpl
@@ -220,6 +220,14 @@ returns: formatted image string
 {{ join "," $list }}
 {{- end -}}
 
+{{- define "kuma.transparentProxyConfigMapName" -}}
+{{- if .Values.transparentProxy.configMapName }}
+{{- .Values.transparentProxy.configMapName | trunc 253 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-transparent-proxy-config" .Chart.Name }}
+{{- end }}
+{{- end }}
+
 {{- define "kuma.defaultEnv" -}}
 env:
 {{ include "kuma.parentEnv" . }}
@@ -256,6 +264,10 @@ env:
 {{- if .Values.dataPlane.dnsLogging }}
 - name: KUMA_RUNTIME_KUBERNETES_INJECTOR_BUILTIN_DNS_LOGGING
   value: "true"
+{{- end }}
+{{- if and .Values.experimental.transparentProxy.configMap .Values.transparentProxy.config }}
+- name: KUMA_RUNTIME_KUBERNETES_INJECTOR_TRANSPARENT_PROXY_CONFIGMAP_NAME
+  value: {{ include "kuma.transparentProxyConfigMapName" . | quote }}
 {{- end }}
 - name: KUMA_RUNTIME_KUBERNETES_INJECTOR_CA_CERT_FILE
   value: /var/run/secrets/kuma.io/tls-cert/ca.crt

--- a/deployments/charts/kuma/templates/cp-configmap.yaml
+++ b/deployments/charts/kuma/templates/cp-configmap.yaml
@@ -31,7 +31,7 @@ data:
   {{- end }}
 {{- end }}
 {{- end }}
-{{- if and .Values.experimental.transparentProxy.configMap .Values.transparentProxy.config }}
+{{- if and .Values.transparentProxy.configMap.enabled .Values.transparentProxy.configMap.config }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -42,5 +42,5 @@ metadata:
     {{- $kumaCpLabels | nindent 4 }}
 data:
   config.yaml: |
-    {{- .Values.transparentProxy.config | toYaml | nindent 4 }}
+    {{- .Values.transparentProxy.configMap.config | toYaml | nindent 4 }}
 {{- end }}

--- a/deployments/charts/kuma/templates/cp-configmap.yaml
+++ b/deployments/charts/kuma/templates/cp-configmap.yaml
@@ -31,3 +31,16 @@ data:
   {{- end }}
 {{- end }}
 {{- end }}
+{{- if and .Values.experimental.transparentProxy.configMap .Values.transparentProxy.config }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kuma.transparentProxyConfigMapName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- $kumaCpLabels | nindent 4 }}
+data:
+  config.yaml: |
+    {{- .Values.transparentProxy.config | toYaml | nindent 4 }}
+{{- end }}

--- a/deployments/charts/kuma/templates/cp-rbac.yaml
+++ b/deployments/charts/kuma/templates/cp-rbac.yaml
@@ -27,7 +27,7 @@ rules:
     resources:
       - namespaces
       - pods
-{{- if not (and .Values.experimental.transparentProxy.configMap .Values.transparentProxy.config) }}
+{{- if not (and .Values.transparentProxy.configMap.enabled .Values.transparentProxy.configMap.config) }}
       - configmaps
 {{- end }}
       - nodes
@@ -122,7 +122,7 @@ rules:
       - ""
     resources:
       - services
-{{- if and .Values.experimental.transparentProxy.configMap .Values.transparentProxy.config }}
+{{- if and .Values.transparentProxy.configMap.enabled .Values.transparentProxy.configMap.config }}
       - configmaps
 {{- end }}
     verbs:

--- a/deployments/charts/kuma/templates/cp-rbac.yaml
+++ b/deployments/charts/kuma/templates/cp-rbac.yaml
@@ -27,7 +27,9 @@ rules:
     resources:
       - namespaces
       - pods
+{{- if not (and .Values.experimental.transparentProxy.configMap .Values.transparentProxy.config) }}
       - configmaps
+{{- end }}
       - nodes
 {{- if .Values.controlPlane.supportGatewaySecretsInAllNamespaces }}
       - secrets
@@ -120,6 +122,9 @@ rules:
       - ""
     resources:
       - services
+{{- if and .Values.experimental.transparentProxy.configMap .Values.transparentProxy.config }}
+      - configmaps
+{{- end }}
     verbs:
       - get
       - delete

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -721,6 +721,117 @@ hooks:
     containerSecurityContext:
       readOnlyRootFilesystem: false
 
+transparentProxy:
+  # -- The name of the ConfigMap used to store the transparent proxy configuration
+  configMapName: kuma-transparent-proxy-config
+  config:
+    # -- The username or UID of the user that will run kuma-dp. If not provided, the system will
+    # use the default UID ("5678") or the default username ("kuma-dp")
+    kumaDPUser: "5678"
+    # -- The IP family mode used for configuring traffic redirection in the transparent proxy
+    # Supports "dualstack" (for both IPv4 and IPv6) and "ipv4" modes
+    ipFamilyMode: dualstack
+    redirect:
+      dns:
+        # -- Enables DNS redirection in the transparent proxy
+        enabled: true
+        # -- Redirect all DNS queries
+        captureAll: true
+        # -- The port on which the DNS server listens
+        port: 15053
+        # -- Path to the system's resolv.conf file
+        resolvConfigPath: /etc/resolv.conf
+        # -- Disables conntrack zone splitting, which can prevent potential DNS issues
+        skipConntrackZoneSplit: false
+      inbound:
+        # -- Enables inbound traffic redirection
+        enabled: true
+        # -- Port used for redirecting inbound traffic
+        port: 15006
+        # -- List of ports to exclude from inbound traffic redirection
+        excludePorts: []
+        # -- List of IP addresses to exclude from inbound traffic redirection for specific ports
+        excludePortsForIPs: []
+        # -- List of UIDs to exclude from inbound traffic redirection for specific ports
+        excludePortsForUIDs: []
+        # -- List of ports to include in inbound traffic redirection
+        includePorts: []
+        # -- Inserts the redirection rule at the beginning of the chain instead of appending it
+        insertRedirectInsteadOfAppend: false
+      outbound:
+        # -- Enables outbound traffic redirection
+        enabled: true
+        # -- Port used for redirecting outbound traffic
+        port: 15001
+        # -- List of ports to exclude from outbound traffic redirection
+        excludePorts: []
+        # -- List of IP addresses to exclude from outbound traffic redirection for specific ports
+        excludePortsForIPs: []
+        # -- List of UIDs to exclude from outbound traffic redirection for specific ports
+        excludePortsForUIDs: []
+        # -- List of ports to include in outbound traffic redirection
+        includePorts: []
+        # -- Inserts the redirection rule at the beginning of the chain instead of appending it
+        insertRedirectInsteadOfAppend: false
+      vnet:
+        # -- Specifies virtual networks using the format interfaceName:CIDR
+        # Allows matching traffic on specific network interfaces
+        # Examples:
+        # - "docker0:172.17.0.0/16"
+        # - "br+:172.18.0.0/16" (matches any interface starting with "br")
+        # - "iface:::1/64" (for IPv6)
+        networks: []
+    ebpf:
+      # -- Enables eBPF support for handling traffic redirection in the transparent proxy
+      enabled: false
+      # -- The path of the BPF filesystem
+      bpffsPath: /run/kuma/bpf
+      # -- The path of cgroup2
+      cgroupPath: /sys/fs/cgroup
+      # -- The name of the environment variable containing the IP address of the instance (pod/vm)
+      # where transparent proxy will be installed
+      instanceIPEnvVarName: ""
+      # -- Path where compiled eBPF programs and other necessary files for eBPF mode can be found
+      programsSourcePath: /tmp/kuma-ebpf
+      # -- The network interface for TC eBPF programs to bind to. If not provided, it will be
+      # automatically determined
+      tcAttachIface: ""
+    retry:
+      # -- The maximum number of retry attempts for operations
+      maxRetries: 4
+      # -- The time duration to wait between retry attempts
+      sleepBetweenRetries: 2s
+    iptablesExecutables:
+      # -- Custom path for the iptables executable (IPv4)
+      iptables: ""
+      # -- Custom path for the iptables-save executable (IPv4)
+      iptables-save: ""
+      # -- Custom path for the iptables-restore executable (IPv4)
+      iptables-restore: ""
+      # -- Custom path for the ip6tables executable (IPv6)
+      ip6tables: ""
+      # -- Custom path for the ip6tables-save executable (IPv6)
+      ip6tables-save: ""
+      # -- Custom path for the ip6tables-restore executable (IPv6)
+      ip6tables-restore: ""
+    log:
+      # -- Enables logging of iptables rules for diagnostics and monitoring
+      enabled: false
+    comments:
+      # -- Disables comments in the generated iptables rules
+      disabled: false
+    # -- Time in seconds to wait for acquiring the xtables lock before failing
+    # Value 0 means wait indefinitely
+    wait: 5
+    # -- Time interval between retries to acquire the xtables lock in seconds
+    waitInterval: 0
+    # -- Drops invalid packets to avoid connection resets in high-throughput scenarios
+    dropInvalidPackets: false
+    # -- Enables firewalld support to store iptables rules
+    storeFirewalld: false
+    # -- Enables verbose mode with longer argument/flag names and additional comments
+    verbose: false
+
 experimental:
   # Configuration for the experimental ebpf mode for transparent proxy
   ebpf:
@@ -739,6 +850,10 @@ experimental:
   # -- If true, enable native Kubernetes sidecars. This requires at least
   # Kubernetes v1.29
   sidecarContainers: false
+  transparentProxy:
+    # -- If true, enables the use of a ConfigMap to manage transparent proxy configuration
+    # instead of directly configuring it within the Kuma system
+    configMap: false
 
 # Postgres' settings for universal control plane on k8s
 postgres:

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -722,115 +722,119 @@ hooks:
       readOnlyRootFilesystem: false
 
 transparentProxy:
-  # -- The name of the ConfigMap used to store the transparent proxy configuration
-  configMapName: kuma-transparent-proxy-config
-  config:
-    # -- The username or UID of the user that will run kuma-dp. If not provided, the system will
-    # use the default UID ("5678") or the default username ("kuma-dp")
-    kumaDPUser: "5678"
-    # -- The IP family mode used for configuring traffic redirection in the transparent proxy
-    # Supports "dualstack" (for both IPv4 and IPv6) and "ipv4" modes
-    ipFamilyMode: dualstack
-    redirect:
-      dns:
-        # -- Enables DNS redirection in the transparent proxy
-        enabled: true
-        # -- Redirect all DNS queries
-        captureAll: true
-        # -- The port on which the DNS server listens
-        port: 15053
-        # -- Path to the system's resolv.conf file
-        resolvConfigPath: /etc/resolv.conf
-        # -- Disables conntrack zone splitting, which can prevent potential DNS issues
-        skipConntrackZoneSplit: false
-      inbound:
-        # -- Enables inbound traffic redirection
-        enabled: true
-        # -- Port used for redirecting inbound traffic
-        port: 15006
-        # -- List of ports to exclude from inbound traffic redirection
-        excludePorts: []
-        # -- List of IP addresses to exclude from inbound traffic redirection for specific ports
-        excludePortsForIPs: []
-        # -- List of UIDs to exclude from inbound traffic redirection for specific ports
-        excludePortsForUIDs: []
-        # -- List of ports to include in inbound traffic redirection
-        includePorts: []
-        # -- Inserts the redirection rule at the beginning of the chain instead of appending it
-        insertRedirectInsteadOfAppend: false
-      outbound:
-        # -- Enables outbound traffic redirection
-        enabled: true
-        # -- Port used for redirecting outbound traffic
-        port: 15001
-        # -- List of ports to exclude from outbound traffic redirection
-        excludePorts: []
-        # -- List of IP addresses to exclude from outbound traffic redirection for specific ports
-        excludePortsForIPs: []
-        # -- List of UIDs to exclude from outbound traffic redirection for specific ports
-        excludePortsForUIDs: []
-        # -- List of ports to include in outbound traffic redirection
-        includePorts: []
-        # -- Inserts the redirection rule at the beginning of the chain instead of appending it
-        insertRedirectInsteadOfAppend: false
-      vnet:
-        # -- Specifies virtual networks using the format interfaceName:CIDR
-        # Allows matching traffic on specific network interfaces
-        # Examples:
-        # - "docker0:172.17.0.0/16"
-        # - "br+:172.18.0.0/16" (matches any interface starting with "br")
-        # - "iface:::1/64" (for IPv6)
-        networks: []
-    ebpf:
-      # -- Enables eBPF support for handling traffic redirection in the transparent proxy
-      enabled: false
-      # -- The path of the BPF filesystem
-      bpffsPath: /run/kuma/bpf
-      # -- The path of cgroup2
-      cgroupPath: /sys/fs/cgroup
-      # -- The name of the environment variable containing the IP address of the instance (pod/vm)
-      # where transparent proxy will be installed
-      instanceIPEnvVarName: ""
-      # -- Path where compiled eBPF programs and other necessary files for eBPF mode can be found
-      programsSourcePath: /tmp/kuma-ebpf
-      # -- The network interface for TC eBPF programs to bind to. If not provided, it will be
-      # automatically determined
-      tcAttachIface: ""
-    retry:
-      # -- The maximum number of retry attempts for operations
-      maxRetries: 4
-      # -- The time duration to wait between retry attempts
-      sleepBetweenRetries: 2s
-    iptablesExecutables:
-      # -- Custom path for the iptables executable (IPv4)
-      iptables: ""
-      # -- Custom path for the iptables-save executable (IPv4)
-      iptables-save: ""
-      # -- Custom path for the iptables-restore executable (IPv4)
-      iptables-restore: ""
-      # -- Custom path for the ip6tables executable (IPv6)
-      ip6tables: ""
-      # -- Custom path for the ip6tables-save executable (IPv6)
-      ip6tables-save: ""
-      # -- Custom path for the ip6tables-restore executable (IPv6)
-      ip6tables-restore: ""
-    log:
-      # -- Enables logging of iptables rules for diagnostics and monitoring
-      enabled: false
-    comments:
-      # -- Disables comments in the generated iptables rules
-      disabled: false
-    # -- Time in seconds to wait for acquiring the xtables lock before failing
-    # Value 0 means wait indefinitely
-    wait: 5
-    # -- Time interval between retries to acquire the xtables lock in seconds
-    waitInterval: 0
-    # -- Drops invalid packets to avoid connection resets in high-throughput scenarios
-    dropInvalidPackets: false
-    # -- Enables firewalld support to store iptables rules
-    storeFirewalld: false
-    # -- Enables verbose mode with longer argument/flag names and additional comments
-    verbose: false
+  configMap:
+    # -- If true, enables the use of a ConfigMap to manage transparent proxy configuration
+    # instead of directly configuring it within the Kuma system
+    enabled: false
+    # -- The name of the ConfigMap used to store the transparent proxy configuration
+    name: kuma-transparent-proxy-config
+    config:
+      # -- The username or UID of the user that will run kuma-dp. If not provided, the system will
+      # use the default UID ("5678") or the default username ("kuma-dp")
+      kumaDPUser: "5678"
+      # -- The IP family mode used for configuring traffic redirection in the transparent proxy
+      # Supports "dualstack" (for both IPv4 and IPv6) and "ipv4" modes
+      ipFamilyMode: dualstack
+      redirect:
+        dns:
+          # -- Enables DNS redirection in the transparent proxy
+          enabled: true
+          # -- Redirect all DNS queries
+          captureAll: true
+          # -- The port on which the DNS server listens
+          port: 15053
+          # -- Path to the system's resolv.conf file
+          resolvConfigPath: /etc/resolv.conf
+          # -- Disables conntrack zone splitting, which can prevent potential DNS issues
+          skipConntrackZoneSplit: false
+        inbound:
+          # -- Enables inbound traffic redirection
+          enabled: true
+          # -- Port used for redirecting inbound traffic
+          port: 15006
+          # -- List of ports to exclude from inbound traffic redirection
+          excludePorts: []
+          # -- List of IP addresses to exclude from inbound traffic redirection for specific ports
+          excludePortsForIPs: []
+          # -- List of UIDs to exclude from inbound traffic redirection for specific ports
+          excludePortsForUIDs: []
+          # -- List of ports to include in inbound traffic redirection
+          includePorts: []
+          # -- Inserts the redirection rule at the beginning of the chain instead of appending it
+          insertRedirectInsteadOfAppend: false
+        outbound:
+          # -- Enables outbound traffic redirection
+          enabled: true
+          # -- Port used for redirecting outbound traffic
+          port: 15001
+          # -- List of ports to exclude from outbound traffic redirection
+          excludePorts: []
+          # -- List of IP addresses to exclude from outbound traffic redirection for specific ports
+          excludePortsForIPs: []
+          # -- List of UIDs to exclude from outbound traffic redirection for specific ports
+          excludePortsForUIDs: []
+          # -- List of ports to include in outbound traffic redirection
+          includePorts: []
+          # -- Inserts the redirection rule at the beginning of the chain instead of appending it
+          insertRedirectInsteadOfAppend: false
+        vnet:
+          # -- Specifies virtual networks using the format interfaceName:CIDR
+          # Allows matching traffic on specific network interfaces
+          # Examples:
+          # - "docker0:172.17.0.0/16"
+          # - "br+:172.18.0.0/16" (matches any interface starting with "br")
+          # - "iface:::1/64" (for IPv6)
+          networks: []
+      ebpf:
+        # -- Enables eBPF support for handling traffic redirection in the transparent proxy
+        enabled: false
+        # -- The path of the BPF filesystem
+        bpffsPath: /run/kuma/bpf
+        # -- The path of cgroup2
+        cgroupPath: /sys/fs/cgroup
+        # -- The name of the environment variable containing the IP address of the instance (pod/vm)
+        # where transparent proxy will be installed
+        instanceIPEnvVarName: ""
+        # -- Path where compiled eBPF programs and other necessary files for eBPF mode can be found
+        programsSourcePath: /tmp/kuma-ebpf
+        # -- The network interface for TC eBPF programs to bind to. If not provided, it will be
+        # automatically determined
+        tcAttachIface: ""
+      retry:
+        # -- The maximum number of retry attempts for operations
+        maxRetries: 4
+        # -- The time duration to wait between retry attempts
+        sleepBetweenRetries: 2s
+      iptablesExecutables:
+        # -- Custom path for the iptables executable (IPv4)
+        iptables: ""
+        # -- Custom path for the iptables-save executable (IPv4)
+        iptables-save: ""
+        # -- Custom path for the iptables-restore executable (IPv4)
+        iptables-restore: ""
+        # -- Custom path for the ip6tables executable (IPv6)
+        ip6tables: ""
+        # -- Custom path for the ip6tables-save executable (IPv6)
+        ip6tables-save: ""
+        # -- Custom path for the ip6tables-restore executable (IPv6)
+        ip6tables-restore: ""
+      log:
+        # -- Enables logging of iptables rules for diagnostics and monitoring
+        enabled: false
+      comments:
+        # -- Disables comments in the generated iptables rules
+        disabled: false
+      # -- Time in seconds to wait for acquiring the xtables lock before failing
+      # Value 0 means wait indefinitely
+      wait: 5
+      # -- Time interval between retries to acquire the xtables lock in seconds
+      waitInterval: 0
+      # -- Drops invalid packets to avoid connection resets in high-throughput scenarios
+      dropInvalidPackets: false
+      # -- Enables firewalld support to store iptables rules
+      storeFirewalld: false
+      # -- Enables verbose mode with longer argument/flag names and additional comments
+      verbose: false
 
 experimental:
   # Configuration for the experimental ebpf mode for transparent proxy
@@ -850,10 +854,6 @@ experimental:
   # -- If true, enable native Kubernetes sidecars. This requires at least
   # Kubernetes v1.29
   sidecarContainers: false
-  transparentProxy:
-    # -- If true, enables the use of a ConfigMap to manage transparent proxy configuration
-    # instead of directly configuring it within the Kuma system
-    configMap: false
 
 # Postgres' settings for universal control plane on k8s
 postgres:

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -721,6 +721,117 @@ hooks:
     containerSecurityContext:
       readOnlyRootFilesystem: false
 
+transparentProxy:
+  # -- The name of the ConfigMap used to store the transparent proxy configuration
+  configMapName: kuma-transparent-proxy-config
+  config:
+    # -- The username or UID of the user that will run kuma-dp. If not provided, the system will
+    # use the default UID ("5678") or the default username ("kuma-dp")
+    kumaDPUser: "5678"
+    # -- The IP family mode used for configuring traffic redirection in the transparent proxy
+    # Supports "dualstack" (for both IPv4 and IPv6) and "ipv4" modes
+    ipFamilyMode: dualstack
+    redirect:
+      dns:
+        # -- Enables DNS redirection in the transparent proxy
+        enabled: true
+        # -- Redirect all DNS queries
+        captureAll: true
+        # -- The port on which the DNS server listens
+        port: 15053
+        # -- Path to the system's resolv.conf file
+        resolvConfigPath: /etc/resolv.conf
+        # -- Disables conntrack zone splitting, which can prevent potential DNS issues
+        skipConntrackZoneSplit: false
+      inbound:
+        # -- Enables inbound traffic redirection
+        enabled: true
+        # -- Port used for redirecting inbound traffic
+        port: 15006
+        # -- List of ports to exclude from inbound traffic redirection
+        excludePorts: []
+        # -- List of IP addresses to exclude from inbound traffic redirection for specific ports
+        excludePortsForIPs: []
+        # -- List of UIDs to exclude from inbound traffic redirection for specific ports
+        excludePortsForUIDs: []
+        # -- List of ports to include in inbound traffic redirection
+        includePorts: []
+        # -- Inserts the redirection rule at the beginning of the chain instead of appending it
+        insertRedirectInsteadOfAppend: false
+      outbound:
+        # -- Enables outbound traffic redirection
+        enabled: true
+        # -- Port used for redirecting outbound traffic
+        port: 15001
+        # -- List of ports to exclude from outbound traffic redirection
+        excludePorts: []
+        # -- List of IP addresses to exclude from outbound traffic redirection for specific ports
+        excludePortsForIPs: []
+        # -- List of UIDs to exclude from outbound traffic redirection for specific ports
+        excludePortsForUIDs: []
+        # -- List of ports to include in outbound traffic redirection
+        includePorts: []
+        # -- Inserts the redirection rule at the beginning of the chain instead of appending it
+        insertRedirectInsteadOfAppend: false
+      vnet:
+        # -- Specifies virtual networks using the format interfaceName:CIDR
+        # Allows matching traffic on specific network interfaces
+        # Examples:
+        # - "docker0:172.17.0.0/16"
+        # - "br+:172.18.0.0/16" (matches any interface starting with "br")
+        # - "iface:::1/64" (for IPv6)
+        networks: []
+    ebpf:
+      # -- Enables eBPF support for handling traffic redirection in the transparent proxy
+      enabled: false
+      # -- The path of the BPF filesystem
+      bpffsPath: /run/kuma/bpf
+      # -- The path of cgroup2
+      cgroupPath: /sys/fs/cgroup
+      # -- The name of the environment variable containing the IP address of the instance (pod/vm)
+      # where transparent proxy will be installed
+      instanceIPEnvVarName: ""
+      # -- Path where compiled eBPF programs and other necessary files for eBPF mode can be found
+      programsSourcePath: /tmp/kuma-ebpf
+      # -- The network interface for TC eBPF programs to bind to. If not provided, it will be
+      # automatically determined
+      tcAttachIface: ""
+    retry:
+      # -- The maximum number of retry attempts for operations
+      maxRetries: 4
+      # -- The time duration to wait between retry attempts
+      sleepBetweenRetries: 2s
+    iptablesExecutables:
+      # -- Custom path for the iptables executable (IPv4)
+      iptables: ""
+      # -- Custom path for the iptables-save executable (IPv4)
+      iptables-save: ""
+      # -- Custom path for the iptables-restore executable (IPv4)
+      iptables-restore: ""
+      # -- Custom path for the ip6tables executable (IPv6)
+      ip6tables: ""
+      # -- Custom path for the ip6tables-save executable (IPv6)
+      ip6tables-save: ""
+      # -- Custom path for the ip6tables-restore executable (IPv6)
+      ip6tables-restore: ""
+    log:
+      # -- Enables logging of iptables rules for diagnostics and monitoring
+      enabled: false
+    comments:
+      # -- Disables comments in the generated iptables rules
+      disabled: false
+    # -- Time in seconds to wait for acquiring the xtables lock before failing
+    # Value 0 means wait indefinitely
+    wait: 5
+    # -- Time interval between retries to acquire the xtables lock in seconds
+    waitInterval: 0
+    # -- Drops invalid packets to avoid connection resets in high-throughput scenarios
+    dropInvalidPackets: false
+    # -- Enables firewalld support to store iptables rules
+    storeFirewalld: false
+    # -- Enables verbose mode with longer argument/flag names and additional comments
+    verbose: false
+
 experimental:
   # Configuration for the experimental ebpf mode for transparent proxy
   ebpf:
@@ -739,6 +850,10 @@ experimental:
   # -- If true, enable native Kubernetes sidecars. This requires at least
   # Kubernetes v1.29
   sidecarContainers: false
+  transparentProxy:
+    # -- If true, enables the use of a ConfigMap to manage transparent proxy configuration
+    # instead of directly configuring it within the Kuma system
+    configMap: false
 
 # Postgres' settings for universal control plane on k8s
 postgres:

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -722,115 +722,119 @@ hooks:
       readOnlyRootFilesystem: false
 
 transparentProxy:
-  # -- The name of the ConfigMap used to store the transparent proxy configuration
-  configMapName: kuma-transparent-proxy-config
-  config:
-    # -- The username or UID of the user that will run kuma-dp. If not provided, the system will
-    # use the default UID ("5678") or the default username ("kuma-dp")
-    kumaDPUser: "5678"
-    # -- The IP family mode used for configuring traffic redirection in the transparent proxy
-    # Supports "dualstack" (for both IPv4 and IPv6) and "ipv4" modes
-    ipFamilyMode: dualstack
-    redirect:
-      dns:
-        # -- Enables DNS redirection in the transparent proxy
-        enabled: true
-        # -- Redirect all DNS queries
-        captureAll: true
-        # -- The port on which the DNS server listens
-        port: 15053
-        # -- Path to the system's resolv.conf file
-        resolvConfigPath: /etc/resolv.conf
-        # -- Disables conntrack zone splitting, which can prevent potential DNS issues
-        skipConntrackZoneSplit: false
-      inbound:
-        # -- Enables inbound traffic redirection
-        enabled: true
-        # -- Port used for redirecting inbound traffic
-        port: 15006
-        # -- List of ports to exclude from inbound traffic redirection
-        excludePorts: []
-        # -- List of IP addresses to exclude from inbound traffic redirection for specific ports
-        excludePortsForIPs: []
-        # -- List of UIDs to exclude from inbound traffic redirection for specific ports
-        excludePortsForUIDs: []
-        # -- List of ports to include in inbound traffic redirection
-        includePorts: []
-        # -- Inserts the redirection rule at the beginning of the chain instead of appending it
-        insertRedirectInsteadOfAppend: false
-      outbound:
-        # -- Enables outbound traffic redirection
-        enabled: true
-        # -- Port used for redirecting outbound traffic
-        port: 15001
-        # -- List of ports to exclude from outbound traffic redirection
-        excludePorts: []
-        # -- List of IP addresses to exclude from outbound traffic redirection for specific ports
-        excludePortsForIPs: []
-        # -- List of UIDs to exclude from outbound traffic redirection for specific ports
-        excludePortsForUIDs: []
-        # -- List of ports to include in outbound traffic redirection
-        includePorts: []
-        # -- Inserts the redirection rule at the beginning of the chain instead of appending it
-        insertRedirectInsteadOfAppend: false
-      vnet:
-        # -- Specifies virtual networks using the format interfaceName:CIDR
-        # Allows matching traffic on specific network interfaces
-        # Examples:
-        # - "docker0:172.17.0.0/16"
-        # - "br+:172.18.0.0/16" (matches any interface starting with "br")
-        # - "iface:::1/64" (for IPv6)
-        networks: []
-    ebpf:
-      # -- Enables eBPF support for handling traffic redirection in the transparent proxy
-      enabled: false
-      # -- The path of the BPF filesystem
-      bpffsPath: /run/kuma/bpf
-      # -- The path of cgroup2
-      cgroupPath: /sys/fs/cgroup
-      # -- The name of the environment variable containing the IP address of the instance (pod/vm)
-      # where transparent proxy will be installed
-      instanceIPEnvVarName: ""
-      # -- Path where compiled eBPF programs and other necessary files for eBPF mode can be found
-      programsSourcePath: /tmp/kuma-ebpf
-      # -- The network interface for TC eBPF programs to bind to. If not provided, it will be
-      # automatically determined
-      tcAttachIface: ""
-    retry:
-      # -- The maximum number of retry attempts for operations
-      maxRetries: 4
-      # -- The time duration to wait between retry attempts
-      sleepBetweenRetries: 2s
-    iptablesExecutables:
-      # -- Custom path for the iptables executable (IPv4)
-      iptables: ""
-      # -- Custom path for the iptables-save executable (IPv4)
-      iptables-save: ""
-      # -- Custom path for the iptables-restore executable (IPv4)
-      iptables-restore: ""
-      # -- Custom path for the ip6tables executable (IPv6)
-      ip6tables: ""
-      # -- Custom path for the ip6tables-save executable (IPv6)
-      ip6tables-save: ""
-      # -- Custom path for the ip6tables-restore executable (IPv6)
-      ip6tables-restore: ""
-    log:
-      # -- Enables logging of iptables rules for diagnostics and monitoring
-      enabled: false
-    comments:
-      # -- Disables comments in the generated iptables rules
-      disabled: false
-    # -- Time in seconds to wait for acquiring the xtables lock before failing
-    # Value 0 means wait indefinitely
-    wait: 5
-    # -- Time interval between retries to acquire the xtables lock in seconds
-    waitInterval: 0
-    # -- Drops invalid packets to avoid connection resets in high-throughput scenarios
-    dropInvalidPackets: false
-    # -- Enables firewalld support to store iptables rules
-    storeFirewalld: false
-    # -- Enables verbose mode with longer argument/flag names and additional comments
-    verbose: false
+  configMap:
+    # -- If true, enables the use of a ConfigMap to manage transparent proxy configuration
+    # instead of directly configuring it within the Kuma system
+    enabled: false
+    # -- The name of the ConfigMap used to store the transparent proxy configuration
+    name: kuma-transparent-proxy-config
+    config:
+      # -- The username or UID of the user that will run kuma-dp. If not provided, the system will
+      # use the default UID ("5678") or the default username ("kuma-dp")
+      kumaDPUser: "5678"
+      # -- The IP family mode used for configuring traffic redirection in the transparent proxy
+      # Supports "dualstack" (for both IPv4 and IPv6) and "ipv4" modes
+      ipFamilyMode: dualstack
+      redirect:
+        dns:
+          # -- Enables DNS redirection in the transparent proxy
+          enabled: true
+          # -- Redirect all DNS queries
+          captureAll: true
+          # -- The port on which the DNS server listens
+          port: 15053
+          # -- Path to the system's resolv.conf file
+          resolvConfigPath: /etc/resolv.conf
+          # -- Disables conntrack zone splitting, which can prevent potential DNS issues
+          skipConntrackZoneSplit: false
+        inbound:
+          # -- Enables inbound traffic redirection
+          enabled: true
+          # -- Port used for redirecting inbound traffic
+          port: 15006
+          # -- List of ports to exclude from inbound traffic redirection
+          excludePorts: []
+          # -- List of IP addresses to exclude from inbound traffic redirection for specific ports
+          excludePortsForIPs: []
+          # -- List of UIDs to exclude from inbound traffic redirection for specific ports
+          excludePortsForUIDs: []
+          # -- List of ports to include in inbound traffic redirection
+          includePorts: []
+          # -- Inserts the redirection rule at the beginning of the chain instead of appending it
+          insertRedirectInsteadOfAppend: false
+        outbound:
+          # -- Enables outbound traffic redirection
+          enabled: true
+          # -- Port used for redirecting outbound traffic
+          port: 15001
+          # -- List of ports to exclude from outbound traffic redirection
+          excludePorts: []
+          # -- List of IP addresses to exclude from outbound traffic redirection for specific ports
+          excludePortsForIPs: []
+          # -- List of UIDs to exclude from outbound traffic redirection for specific ports
+          excludePortsForUIDs: []
+          # -- List of ports to include in outbound traffic redirection
+          includePorts: []
+          # -- Inserts the redirection rule at the beginning of the chain instead of appending it
+          insertRedirectInsteadOfAppend: false
+        vnet:
+          # -- Specifies virtual networks using the format interfaceName:CIDR
+          # Allows matching traffic on specific network interfaces
+          # Examples:
+          # - "docker0:172.17.0.0/16"
+          # - "br+:172.18.0.0/16" (matches any interface starting with "br")
+          # - "iface:::1/64" (for IPv6)
+          networks: []
+      ebpf:
+        # -- Enables eBPF support for handling traffic redirection in the transparent proxy
+        enabled: false
+        # -- The path of the BPF filesystem
+        bpffsPath: /run/kuma/bpf
+        # -- The path of cgroup2
+        cgroupPath: /sys/fs/cgroup
+        # -- The name of the environment variable containing the IP address of the instance (pod/vm)
+        # where transparent proxy will be installed
+        instanceIPEnvVarName: ""
+        # -- Path where compiled eBPF programs and other necessary files for eBPF mode can be found
+        programsSourcePath: /tmp/kuma-ebpf
+        # -- The network interface for TC eBPF programs to bind to. If not provided, it will be
+        # automatically determined
+        tcAttachIface: ""
+      retry:
+        # -- The maximum number of retry attempts for operations
+        maxRetries: 4
+        # -- The time duration to wait between retry attempts
+        sleepBetweenRetries: 2s
+      iptablesExecutables:
+        # -- Custom path for the iptables executable (IPv4)
+        iptables: ""
+        # -- Custom path for the iptables-save executable (IPv4)
+        iptables-save: ""
+        # -- Custom path for the iptables-restore executable (IPv4)
+        iptables-restore: ""
+        # -- Custom path for the ip6tables executable (IPv6)
+        ip6tables: ""
+        # -- Custom path for the ip6tables-save executable (IPv6)
+        ip6tables-save: ""
+        # -- Custom path for the ip6tables-restore executable (IPv6)
+        ip6tables-restore: ""
+      log:
+        # -- Enables logging of iptables rules for diagnostics and monitoring
+        enabled: false
+      comments:
+        # -- Disables comments in the generated iptables rules
+        disabled: false
+      # -- Time in seconds to wait for acquiring the xtables lock before failing
+      # Value 0 means wait indefinitely
+      wait: 5
+      # -- Time interval between retries to acquire the xtables lock in seconds
+      waitInterval: 0
+      # -- Drops invalid packets to avoid connection resets in high-throughput scenarios
+      dropInvalidPackets: false
+      # -- Enables firewalld support to store iptables rules
+      storeFirewalld: false
+      # -- Enables verbose mode with longer argument/flag names and additional comments
+      verbose: false
 
 experimental:
   # Configuration for the experimental ebpf mode for transparent proxy
@@ -850,10 +854,6 @@ experimental:
   # -- If true, enable native Kubernetes sidecars. This requires at least
   # Kubernetes v1.29
   sidecarContainers: false
-  transparentProxy:
-    # -- If true, enables the use of a ConfigMap to manage transparent proxy configuration
-    # instead of directly configuring it within the Kuma system
-    configMap: false
 
 # Postgres' settings for universal control plane on k8s
 postgres:

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -225,6 +225,7 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.Runtime.Kubernetes.Injector.EBPF.ProgramsSourcePath).To(Equal("/kuma/baz"))
 			Expect(cfg.Runtime.Kubernetes.Injector.IgnoredServiceSelectorLabels).To(Equal([]string{"x", "y"}))
 			Expect(cfg.Runtime.Kubernetes.Injector.NodeLabelsToCopy).To(Equal([]string{"label-1", "label-2"}))
+			Expect(cfg.Runtime.Kubernetes.Injector.TransparentProxyConfigMapName).To(Equal("foo"))
 			Expect(cfg.Runtime.Kubernetes.NodeTaintController.CniNamespace).To(Equal("kuma-system"))
 			Expect(cfg.Runtime.Kubernetes.ControllersConcurrency.PodController).To(Equal(10))
 			Expect(cfg.Runtime.Kubernetes.ClientConfig.Qps).To(Equal(100))
@@ -579,6 +580,7 @@ runtime:
         programsSourcePath: /kuma/baz
       ignoredServiceSelectorLabels: ["x", "y"]
       nodeLabelsToCopy: ["label-1", "label-2"]
+      transparentProxyConfigMap: foo
     controllersConcurrency: 
       podController: 10
     clientConfig:
@@ -918,6 +920,7 @@ meshService:
 				"KUMA_RUNTIME_KUBERNETES_INJECTOR_EBPF_TC_ATTACH_IFACE":                                    "veth1",
 				"KUMA_RUNTIME_KUBERNETES_INJECTOR_EBPF_PROGRAMS_SOURCE_PATH":                               "/kuma/baz",
 				"KUMA_RUNTIME_KUBERNETES_INJECTOR_IGNORED_SERVICE_SELECTOR_LABELS":                         "x,y",
+				"KUMA_RUNTIME_KUBERNETES_INJECTOR_TRANSPARENT_PROXY_CONFIGMAP_NAME":                        "foo",
 				"KUMA_RUNTIME_KUBERNETES_INJECTOR_NODE_LABELS_TO_COPY":                                     "label-1,label-2",
 				"KUMA_RUNTIME_KUBERNETES_VIRTUAL_PROBES_ENABLED":                                           "false",
 				"KUMA_RUNTIME_KUBERNETES_VIRTUAL_PROBES_PORT":                                              "1111",

--- a/pkg/config/plugins/runtime/k8s/config.go
+++ b/pkg/config/plugins/runtime/k8s/config.go
@@ -233,6 +233,10 @@ type Injector struct {
 	IgnoredServiceSelectorLabels []string `json:"ignoredServiceSelectorLabels" envconfig:"KUMA_RUNTIME_KUBERNETES_INJECTOR_IGNORED_SERVICE_SELECTOR_LABELS"`
 	// NodeLabelsToCopy defines a list of node labels that should be copied to the Pod.
 	NodeLabelsToCopy []string `json:"nodeLabelsToCopy" envconfig:"KUMA_RUNTIME_KUBERNETES_INJECTOR_NODE_LABELS_TO_COPY"`
+	// TransparentProxyConfigMapName is used to specify the name of the ConfigMap that contains transparent proxy
+	// configuration. If this value is left empty, the transparent proxy configuration will not be loaded from
+	// a ConfigMap. The actual value is expected to be provided via an environment variable
+	TransparentProxyConfigMapName string `json:"transparentProxyConfigMap" envconfig:"kuma_runtime_kubernetes_injector_transparent_proxy_configmap_name"`
 }
 
 // Exceptions defines list of exceptions for Kuma injection

--- a/pkg/config/plugins/runtime/k8s/testdata/default-config.golden.yaml
+++ b/pkg/config/plugins/runtime/k8s/testdata/default-config.golden.yaml
@@ -71,6 +71,7 @@ injector:
     excludeInboundPorts: []
     excludeOutboundIPs: []
     excludeOutboundPorts: []
+  transparentProxyConfigMap: ""
   virtualProbesEnabled: true
   virtualProbesPort: 9000
 leaderElection:

--- a/pkg/plugins/runtime/k8s/metadata/annotations.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations.go
@@ -82,14 +82,19 @@ const (
 	// KumaTrafficTransparentProxyConfig is an annotation used to pass a YAML with the transparent proxy
 	// configuration in CNI mode, allowing the new logic to retrieve the config from the annotation
 	// instead of processing the ConfigMap explicitly
-	KumaTrafficTransparentProxyConfig      = "traffic.kuma.io/transparent-proxy-config"
-	KumaTrafficExcludeInboundPorts         = "traffic.kuma.io/exclude-inbound-ports"
-	KumaTrafficExcludeOutboundPorts        = "traffic.kuma.io/exclude-outbound-ports"
-	KumaTrafficExcludeOutboundPortsForUIDs = "traffic.kuma.io/exclude-outbound-ports-for-uids"
-	KumaTrafficDropInvalidPackets          = "traffic.kuma.io/drop-invalid-packets"
-	KumaTrafficIptablesLogs                = "traffic.kuma.io/iptables-logs"
-	KumaTrafficExcludeInboundIPs           = "traffic.kuma.io/exclude-inbound-ips"
-	KumaTrafficExcludeOutboundIPs          = "traffic.kuma.io/exclude-outbound-ips"
+	KumaTrafficTransparentProxyConfig = "traffic.kuma.io/transparent-proxy-config"
+	// KumaTrafficTransparentProxyConfigMapName is an annotation used to specify the name of the
+	// ConfigMap containing the transparent proxy configuration. This allows the configuration to be
+	// retrieved by referencing the ConfigMap's name, enabling flexible and dynamic assignment of
+	// proxy settings
+	KumaTrafficTransparentProxyConfigMapName = "traffic.kuma.io/transparent-proxy-configmap-name"
+	KumaTrafficExcludeInboundPorts           = "traffic.kuma.io/exclude-inbound-ports"
+	KumaTrafficExcludeOutboundPorts          = "traffic.kuma.io/exclude-outbound-ports"
+	KumaTrafficExcludeOutboundPortsForUIDs   = "traffic.kuma.io/exclude-outbound-ports-for-uids"
+	KumaTrafficDropInvalidPackets            = "traffic.kuma.io/drop-invalid-packets"
+	KumaTrafficIptablesLogs                  = "traffic.kuma.io/iptables-logs"
+	KumaTrafficExcludeInboundIPs             = "traffic.kuma.io/exclude-inbound-ips"
+	KumaTrafficExcludeOutboundIPs            = "traffic.kuma.io/exclude-outbound-ips"
 
 	// KumaSidecarTokenVolumeAnnotation allows to specify which volume contains the service account token
 	KumaSidecarTokenVolumeAnnotation = "kuma.io/service-account-token-volume"

--- a/pkg/plugins/runtime/k8s/metadata/annotations.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations.go
@@ -79,6 +79,10 @@ const (
 	KumaBuiltinDNSPort    = "kuma.io/builtin-dns-port"
 	KumaBuiltinDNSLogging = "kuma.io/builtin-dns-logging"
 
+	// KumaTrafficTransparentProxyConfig is an annotation used to pass a YAML with the transparent proxy
+	// configuration in CNI mode, allowing the new logic to retrieve the config from the annotation
+	// instead of processing the ConfigMap explicitly
+	KumaTrafficTransparentProxyConfig      = "traffic.kuma.io/transparent-proxy-config"
 	KumaTrafficExcludeInboundPorts         = "traffic.kuma.io/exclude-inbound-ports"
 	KumaTrafficExcludeOutboundPorts        = "traffic.kuma.io/exclude-outbound-ports"
 	KumaTrafficExcludeOutboundPortsForUIDs = "traffic.kuma.io/exclude-outbound-ports-for-uids"

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
@@ -597,6 +597,7 @@ func (i *KumaInjector) NewValidationContainer(ipFamilyMode, inboundRedirectPort 
 	return container
 }
 
+// Deprecated
 func (i *KumaInjector) NewAnnotations(pod *kube_core.Pod, mesh string, logger logr.Logger) (map[string]string, error) {
 	portOutbound := i.cfg.SidecarContainer.RedirectPortOutbound
 	portInbound := i.cfg.SidecarContainer.RedirectPortInbound
@@ -792,6 +793,7 @@ func (i *KumaInjector) NewAnnotations(pod *kube_core.Pod, mesh string, logger lo
 	return result, nil
 }
 
+// Deprecated
 func portsToAnnotationValue(ports []uint32) string {
 	stringPorts := make([]string, len(ports))
 	for i, port := range ports {

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
@@ -17,7 +17,9 @@ import (
 	kube_types "k8s.io/apimachinery/pkg/types"
 	kube_podcmd "k8s.io/kubectl/pkg/cmd/util/podcmd"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 
+	core_config "github.com/kumahq/kuma/pkg/config"
 	runtime_k8s "github.com/kumahq/kuma/pkg/config/plugins/runtime/k8s"
 	"github.com/kumahq/kuma/pkg/core"
 	k8s_common "github.com/kumahq/kuma/pkg/plugins/common/k8s"
@@ -27,7 +29,8 @@ import (
 	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/probes"
 	k8s_util "github.com/kumahq/kuma/pkg/plugins/runtime/k8s/util"
 	tproxy_config "github.com/kumahq/kuma/pkg/transparentproxy/config"
-	tp_k8s "github.com/kumahq/kuma/pkg/transparentproxy/kubernetes"
+	tproxy_consts "github.com/kumahq/kuma/pkg/transparentproxy/consts"
+	tproxy_k8s "github.com/kumahq/kuma/pkg/transparentproxy/kubernetes"
 	"github.com/kumahq/kuma/pkg/util/pointer"
 )
 
@@ -137,12 +140,83 @@ func (i *KumaInjector) InjectKuma(ctx context.Context, pod *kube_core.Pod) error
 		pod.Annotations[kube_podcmd.DefaultContainerAnnotationName] = pod.Spec.Containers[0].Name
 	}
 
-	annotations, err := i.NewAnnotations(pod, meshName, logger)
-	if err != nil {
-		return errors.Wrap(err, "could not generate annotations for pod")
-	}
-	for key, value := range annotations {
-		pod.Annotations[key] = value
+	var annotations map[string]string
+	var injectedInitContainer kube_core.Container
+
+	if i.cfg.TransparentProxyConfigMapName != "" {
+		tproxyCfg, err := i.getTransparentProxyConfig(ctx, logger, pod.Annotations)
+		if err != nil {
+			return err
+		}
+
+		tproxyCfgYAMLBytes, err := yaml.Marshal(tproxyCfg)
+		if err != nil {
+			return err
+		}
+		tproxyCfgYAML := string(tproxyCfgYAMLBytes)
+
+		if annotations, err = tproxy_k8s.ConfigToAnnotations(
+			tproxyCfg,
+			i.cfg,
+			pod.Annotations,
+			meshName,
+			i.defaultAdminPort,
+		); err != nil {
+			return errors.Wrap(err, "could not generate annotations for pod")
+		}
+
+		for key, value := range annotations {
+			pod.Annotations[key] = value
+		}
+
+		switch {
+		case !tproxyCfg.CNIMode:
+			initContainer := i.NewInitContainer([]string{"--config", tproxyCfgYAML})
+			injectedInitContainer, err = i.applyCustomPatches(logger, initContainer, initPatches)
+			if err != nil {
+				return err
+			}
+		case tproxyCfg.Redirect.Inbound.Enabled:
+			ipFamilyMode := tproxyCfg.IPFamilyMode.String()
+			inboundPort := tproxyCfg.Redirect.Inbound.Port.String()
+			validationContainer := i.NewValidationContainer(ipFamilyMode, inboundPort, sidecarTmp.Name)
+			injectedInitContainer, err = i.applyCustomPatches(logger, validationContainer, initPatches)
+			if err != nil {
+				return err
+			}
+			fallthrough
+		default:
+			pod.Annotations[metadata.KumaTrafficTransparentProxyConfig] = tproxyCfgYAML
+		}
+	} else { // this is legacy and deprecated - will be removed soon
+		if annotations, err = i.NewAnnotations(pod, meshName, logger); err != nil {
+			return errors.Wrap(err, "could not generate annotations for pod")
+		}
+
+		for key, value := range annotations {
+			pod.Annotations[key] = value
+		}
+
+		podRedirect, err := tproxy_k8s.NewPodRedirectFromAnnotations(pod.Annotations)
+		if err != nil {
+			return err
+		}
+
+		if !i.cfg.CNIEnabled {
+			initContainer := i.NewInitContainer(podRedirect.AsKumactlCommandLine())
+			injectedInitContainer, err = i.applyCustomPatches(logger, initContainer, initPatches)
+			if err != nil {
+				return err
+			}
+		} else if podRedirect.RedirectInbound {
+			ipFamilyMode := podRedirect.IpFamilyMode
+			inboundPort := fmt.Sprintf("%d", podRedirect.RedirectPortInbound)
+			validationContainer := i.NewValidationContainer(ipFamilyMode, inboundPort, sidecarTmp.Name)
+			injectedInitContainer, err = i.applyCustomPatches(logger, validationContainer, initPatches)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	if i.cfg.EBPF.Enabled {
@@ -163,42 +237,18 @@ func (i *KumaInjector) InjectKuma(ctx context.Context, pod *kube_core.Pod) error
 		})
 	}
 
-	podRedirect, err := tp_k8s.NewPodRedirectForPod(pod)
-	if err != nil {
-		return err
-	}
 	initFirst, _, err := metadata.Annotations(pod.Annotations).GetEnabled(metadata.KumaInitFirst)
 	if err != nil {
 		return err
-	}
-
-	var injectedInitContainers []kube_core.Container
-	if !i.cfg.CNIEnabled {
-		ic, err := i.NewInitContainer(podRedirect)
-		if err != nil {
-			return err
-		}
-		patchedIc, err := i.applyCustomPatches(logger, ic, initPatches)
-		if err != nil {
-			return err
-		}
-		injectedInitContainers = append(injectedInitContainers, patchedIc)
-	} else if podRedirect.RedirectInbound {
-		ic := i.NewValidationContainer(podRedirect.IpFamilyMode, fmt.Sprintf("%d", podRedirect.RedirectPortInbound), sidecarTmp.Name)
-		patchedIc, err := i.applyCustomPatches(logger, ic, initPatches)
-		if err != nil {
-			return err
-		}
-		injectedInitContainers = append(injectedInitContainers, patchedIc)
 	}
 
 	var prependInitContainers []kube_core.Container
 	var appendInitContainers []kube_core.Container
 
 	if initFirst || i.sidecarContainersEnabled {
-		prependInitContainers = append(prependInitContainers, injectedInitContainers...)
+		prependInitContainers = append(prependInitContainers, injectedInitContainer)
 	} else {
-		appendInitContainers = append(appendInitContainers, injectedInitContainers...)
+		appendInitContainers = append(appendInitContainers, injectedInitContainer)
 	}
 
 	if i.sidecarContainersEnabled {
@@ -295,6 +345,33 @@ func (i *KumaInjector) loadContainerPatches(
 	}
 
 	return sidecarPatches, initPatches, nil
+}
+
+func (i *KumaInjector) getTransparentProxyConfig(
+	ctx context.Context,
+	logger logr.Logger,
+	annotations map[string]string,
+) (tproxy_config.Config, error) {
+	if i.cfg.TransparentProxyConfigMapName == "" {
+		return tproxy_config.Config{}, nil
+	}
+
+	cfg := tproxy_config.DefaultConfig()
+	loader := core_config.NewLoader(&cfg)
+	cm := &kube_core.ConfigMap{}
+
+	if err := i.client.Get(ctx, kube_types.NamespacedName{
+		Name:      i.cfg.TransparentProxyConfigMapName,
+		Namespace: i.systemNamespace,
+	}, cm); err == nil {
+		if c := cm.Data[tproxy_consts.KubernetesConfigMapDataKey]; c != "" {
+			if err := loader.LoadBytes([]byte(c)); err != nil {
+				return tproxy_config.Config{}, err
+			}
+		}
+	}
+
+	return tproxy_k8s.ConfigForKubernetes(cfg, i.cfg, annotations, logger)
 }
 
 // applyCustomPatches applies the block of patches to the given container and returns a new,
@@ -403,13 +480,13 @@ func (i *KumaInjector) FindServiceAccountToken(podSpec *kube_core.PodSpec) *kube
 	return nil
 }
 
-func (i *KumaInjector) NewInitContainer(podRedirect *tp_k8s.PodRedirect) (kube_core.Container, error) {
+func (i *KumaInjector) NewInitContainer(args []string) kube_core.Container {
 	container := kube_core.Container{
 		Name:            k8s_util.KumaInitContainerName,
 		Image:           i.cfg.InitContainer.Image,
 		ImagePullPolicy: kube_core.PullIfNotPresent,
 		Command:         []string{"/usr/bin/kumactl", "install", "transparent-proxy"},
-		Args:            podRedirect.AsKumactlCommandLine(),
+		Args:            args,
 		Env: []kube_core.EnvVar{
 			// iptables needs this lock file to be writable:
 			// source: https://git.netfilter.org/iptables/tree/iptables/xshared.c?h=v1.8.7#n258
@@ -475,7 +552,7 @@ func (i *KumaInjector) NewInitContainer(podRedirect *tp_k8s.PodRedirect) (kube_c
 		)
 	}
 
-	return container, nil
+	return container
 }
 
 func (i *KumaInjector) NewValidationContainer(ipFamilyMode, inboundRedirectPort string, tmpVolumeName string) kube_core.Container {
@@ -687,18 +764,6 @@ func (i *KumaInjector) NewAnnotations(pod *kube_core.Pod, mesh string, logger lo
 		result[metadata.KumaTransparentProxyingIPFamilyMode] = v
 	} else {
 		result[metadata.KumaTransparentProxyingIPFamilyMode] = string(tproxy_config.IPFamilyModeDualStack)
-	}
-
-	if v, _, err := annotations.GetBoolean(metadata.KumaTrafficDropInvalidPackets); err != nil {
-		return nil, err
-	} else if v {
-		result[metadata.KumaTrafficDropInvalidPackets] = metadata.AnnotationTrue
-	}
-
-	if v, _, err := annotations.GetBoolean(metadata.KumaTrafficIptablesLogs); err != nil {
-		return nil, err
-	} else if v {
-		result[metadata.KumaTrafficIptablesLogs] = metadata.AnnotationTrue
 	}
 
 	if v, _, err := annotations.GetUint32WithDefault(

--- a/pkg/transparentproxy/config/config.go
+++ b/pkg/transparentproxy/config/config.go
@@ -88,7 +88,14 @@ func (p *Ports) Type() string { return "uint16[,...]" }
 
 func (p *Ports) Set(s string) error {
 	*p = nil
+	return p.append(s)
+}
 
+func (p *Ports) Append(s string) error {
+	return p.append(s)
+}
+
+func (p *Ports) append(s string) error {
 	if s = strings.TrimSpace(s); s == "" {
 		return nil
 	}

--- a/pkg/transparentproxy/config/config.go
+++ b/pkg/transparentproxy/config/config.go
@@ -341,6 +341,30 @@ type Redirect struct {
 	VNet       VNet        `json:"vnet"`
 }
 
+// Custom Marshal logic to omit the VNet field from the JSON output if it contains
+// no networks. This approach ensures that empty fields are not rendered, since
+// we're working with a value type (Redirect) and not pointers, and we only include
+// VNet when it has meaningful data
+func (c Redirect) MarshalJSON() ([]byte, error) {
+	type ConfigAlias Redirect
+
+	type ConfigAliasOmitEmpty struct {
+		ConfigAlias
+		VNet any `json:"vnet,omitempty"`
+	}
+
+	result := ConfigAliasOmitEmpty{
+		ConfigAlias: ConfigAlias(c),
+		VNet:        c.VNet,
+	}
+
+	if len(c.VNet.Networks) == 0 {
+		result.VNet = nil
+	}
+
+	return json.Marshal(result)
+}
+
 type InitializedRedirect struct {
 	Redirect
 	DNS      InitializedDNS
@@ -570,6 +594,53 @@ type Config struct {
 	// the correct iptables rules are applied for the specified IP family
 	IPFamilyMode IPFamilyMode `json:"ipFamilyMode" envconfig:"ip_family_mode"` // KUMA_TRANSPARENT_PROXY_IP_FAMILY_MODE
 	CNIMode      bool         `json:"cniMode,omitempty" envconfig:"cni_mode"`  // KUMA_TRANSPARENT_PROXY_CNI_MODE
+}
+
+func (c Config) WithStdout(stdout io.Writer) Config {
+	c.RuntimeStdout = stdout
+	return c
+}
+
+// Custom Marshal logic to avoid rendering empty values for specific fields.
+// Since we're working with a value type (Config) rather than pointers, this approach
+// ensures that unnecessary fields (like ebpf, comments, log, and executables) are omitted
+// from the JSON output when they are not enabled or contain no meaningful data
+func (c Config) MarshalJSON() ([]byte, error) {
+	type ConfigAlias Config
+
+	type ConfigAliasOmitEmpty struct {
+		ConfigAlias
+		Ebpf        any `json:"ebpf,omitempty"`
+		Comments    any `json:"comments,omitempty"`
+		Log         any `json:"log,omitempty"`
+		Executables any `json:"iptablesExecutables,omitempty"`
+	}
+
+	result := ConfigAliasOmitEmpty{
+		ConfigAlias: ConfigAlias(c),
+		Ebpf:        c.Ebpf,
+		Comments:    c.Comments,
+		Log:         c.Log,
+		Executables: c.Executables,
+	}
+
+	if !c.Ebpf.Enabled {
+		result.Ebpf = nil
+	}
+
+	if !c.Comments.Disabled {
+		result.Comments = nil
+	}
+
+	if !c.Log.Enabled {
+		result.Log = nil
+	}
+
+	if len(getNonEmptyPaths(&c.Executables)) == 0 {
+		result.Executables = nil
+	}
+
+	return json.Marshal(result)
 }
 
 func (c Config) InitializeKumaDPUser() (string, error) {

--- a/pkg/transparentproxy/consts/consts.go
+++ b/pkg/transparentproxy/consts/consts.go
@@ -212,3 +212,8 @@ const (
 	PathDevNull           = "/dev/null"
 	PathNSSwitchConf      = "/etc/nsswitch.conf"
 )
+
+// KubernetesConfigMapDataKey is the key used in Kubernetes ConfigMap to store
+// the transparent proxy configuration. It must match the key defined in
+// deployments/charts/kuma/templates/cp-configmap.yaml to ensure consistency
+const KubernetesConfigMapDataKey = "config.yaml"

--- a/pkg/transparentproxy/kubernetes/kubernetes.go
+++ b/pkg/transparentproxy/kubernetes/kubernetes.go
@@ -26,6 +26,7 @@ import (
 	tproxy_consts "github.com/kumahq/kuma/pkg/transparentproxy/consts"
 )
 
+// Deprecated
 type PodRedirect struct {
 	// while https://github.com/kumahq/kuma/issues/8324 is not implemented, when changing the config,
 	// keep in mind to update all other places listed in the issue
@@ -52,6 +53,7 @@ type PodRedirect struct {
 	ExcludeOutboundIPs                       string
 }
 
+// Deprecated
 func NewPodRedirectFromAnnotations(annotations metadata.Annotations) (*PodRedirect, error) {
 	var err error
 	var pr PodRedirect
@@ -157,6 +159,7 @@ func NewPodRedirectFromAnnotations(annotations metadata.Annotations) (*PodRedire
 	return &pr, nil
 }
 
+// Deprecated
 func excludeApplicationProbeProxyPort(annotations map[string]string) string {
 	// the annotations are validated/defaulted in a previous step in injector.NewAnnotations, so we can safely ignore the errors here
 	inboundPortsToExclude, _ := metadata.Annotations(annotations).GetString(metadata.KumaTrafficExcludeInboundPorts)
@@ -172,6 +175,7 @@ func excludeApplicationProbeProxyPort(annotations map[string]string) string {
 	return fmt.Sprintf("%s,%s", inboundPortsToExclude, appProbeProxyPort)
 }
 
+// Deprecated
 func flag[T string | bool | uint32](name string, values ...T) []string {
 	var result []string
 
@@ -188,6 +192,7 @@ func flag[T string | bool | uint32](name string, values ...T) []string {
 	return result
 }
 
+// Deprecated
 func flagsIf[T string | bool](condition T, flags ...[]string) []string {
 	if condition == *new(T) {
 		return nil
@@ -196,6 +201,7 @@ func flagsIf[T string | bool](condition T, flags ...[]string) []string {
 	return slices.Concat(flags...)
 }
 
+// Deprecated
 func (pr *PodRedirect) AsKumactlCommandLine() []string {
 	defaultConfig := tproxy_config.DefaultConfig()
 

--- a/pkg/transparentproxy/kubernetes/kubernetes.go
+++ b/pkg/transparentproxy/kubernetes/kubernetes.go
@@ -21,8 +21,6 @@ import (
 	"slices"
 	"strings"
 
-	kube_core "k8s.io/api/core/v1"
-
 	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/metadata"
 	tproxy_config "github.com/kumahq/kuma/pkg/transparentproxy/config"
 	tproxy_consts "github.com/kumahq/kuma/pkg/transparentproxy/consts"
@@ -54,11 +52,9 @@ type PodRedirect struct {
 	ExcludeOutboundIPs                       string
 }
 
-func NewPodRedirectForPod(pod *kube_core.Pod) (*PodRedirect, error) {
+func NewPodRedirectFromAnnotations(annotations metadata.Annotations) (*PodRedirect, error) {
 	var err error
 	var pr PodRedirect
-
-	annotations := metadata.Annotations(pod.Annotations)
 
 	pr.BuiltinDNSEnabled, _, err = annotations.GetEnabled(metadata.KumaBuiltinDNS)
 	if err != nil {
@@ -90,7 +86,7 @@ func NewPodRedirectForPod(pod *kube_core.Pod) (*PodRedirect, error) {
 		pr.RedirectInbound = false
 	}
 
-	pr.ExcludeInboundPorts = excludeApplicationProbeProxyPort(pod.Annotations)
+	pr.ExcludeInboundPorts = excludeApplicationProbeProxyPort(annotations)
 	pr.RedirectPortInbound, _, err = annotations.GetUint32(metadata.KumaTransparentProxyingInboundPortAnnotation)
 	if err != nil {
 		return nil, err

--- a/pkg/transparentproxy/kubernetes/kubernetes_config.go
+++ b/pkg/transparentproxy/kubernetes/kubernetes_config.go
@@ -1,0 +1,646 @@
+package kubernetes
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+
+	core_config "github.com/kumahq/kuma/pkg/config"
+	"github.com/kumahq/kuma/pkg/config/plugins/runtime/k8s"
+	k8s_metadata "github.com/kumahq/kuma/pkg/plugins/runtime/k8s/metadata"
+	k8s_probes "github.com/kumahq/kuma/pkg/plugins/runtime/k8s/probes"
+	tproxy_config "github.com/kumahq/kuma/pkg/transparentproxy/config"
+)
+
+const (
+	warningTProxyConfigMismatch              = "[WARNING]: provided value in the transparent proxy configuration ConfigMap cannot be modified independently and must align with the value specified in the runtime configuration"
+	warningAnnotationValueMismatch           = "[WARNING]: annotation cannot be modified directly and must be consistent with the value specified in the runtime configuration"
+	warningInvalidAnnotationAndValueMismatch = warningAnnotationValueMismatch + "additionally, provided value is invalid"
+	warningDisablingTProxyAnnotation         = "[WARNING]: disabling transparent proxying is not supported in Kubernetes environments; the annotation will be ignored"
+)
+
+type trafficKind string
+
+const (
+	trafficKindOutbound trafficKind = "outbound"
+	trafficKindInbound  trafficKind = "inbound"
+	trafficKindDNS      trafficKind = "dns"
+)
+
+func (c trafficKind) capitalize() string {
+	if c == "" {
+		return ""
+	}
+
+	return strings.ToUpper(string(c)[:1]) + string(c)[1:]
+}
+
+type configurer struct {
+	logger      logr.Logger
+	config      tproxy_config.Config
+	runtime     k8s.Injector
+	annotations k8s_metadata.Annotations
+}
+
+func (c configurer) kumaDPUser() string {
+	annotation := k8s_metadata.KumaSidecarUID
+
+	valueDefault := tproxy_config.DefaultConfig().KumaDPUser
+	valueCurrent := c.config.KumaDPUser
+	valueRuntime := fmt.Sprintf("%d", c.runtime.SidecarContainer.UID)
+
+	pathConfigMap := c.pathConfigMapf("kumaDPUser")
+	pathRuntime := c.pathRuntimef("sidecarContainer.uid")
+
+	l := c.logger.WithValues(
+		"default", valueDefault,
+		pathConfigMap, valueCurrent,
+		pathRuntime, valueRuntime,
+	)
+
+	if valueCurrent != valueRuntime && valueCurrent != valueDefault {
+		l.Info(warningTProxyConfigMismatch)
+	}
+
+	if v, exists := c.annotations.GetString(annotation); exists && v != valueRuntime {
+		l.Info(warningAnnotationValueMismatch)
+	}
+
+	return valueRuntime
+}
+
+func (c configurer) redirectPort(kind trafficKind) tproxy_config.Port {
+	var annotation string
+
+	var valueDefault tproxy_config.Port
+	var valueCurrent tproxy_config.Port
+	var valueRuntime tproxy_config.Port
+
+	pathRuntime := c.pathRuntimef("sidecarContainer.redirectPort%s", kind.capitalize())
+
+	switch kind {
+	case trafficKindOutbound:
+		annotation = k8s_metadata.KumaTransparentProxyingOutboundPortAnnotation
+		valueDefault = tproxy_config.DefaultConfig().Redirect.Outbound.Port
+		valueCurrent = c.config.Redirect.Outbound.Port
+		valueRuntime = tproxy_config.Port(c.runtime.SidecarContainer.RedirectPortOutbound)
+	case trafficKindInbound:
+		annotation = k8s_metadata.KumaTransparentProxyingInboundPortAnnotation
+		valueDefault = tproxy_config.DefaultConfig().Redirect.Inbound.Port
+		valueCurrent = c.config.Redirect.Inbound.Port
+		valueRuntime = tproxy_config.Port(c.runtime.SidecarContainer.RedirectPortInbound)
+	case trafficKindDNS:
+		annotation = k8s_metadata.KumaBuiltinDNSPort
+		valueDefault = tproxy_config.DefaultConfig().Redirect.DNS.Port
+		valueCurrent = c.config.Redirect.DNS.Port
+		valueRuntime = tproxy_config.Port(c.runtime.BuiltinDNS.Port)
+		pathRuntime = c.pathRuntimef("builtinDNS.port")
+	default:
+		return 0
+	}
+
+	pathConfigMap := c.pathConfigMapf("redirect.%s.port", kind)
+
+	l := c.logger.WithValues(
+		"default", valueDefault,
+		pathConfigMap, valueCurrent,
+		pathRuntime, valueRuntime,
+	)
+
+	if valueCurrent != valueRuntime && valueCurrent != valueDefault {
+		l.Info(warningTProxyConfigMismatch)
+	}
+
+	if v, exists, err := c.annotations.GetUint32(annotation); err != nil {
+		l.Info(warningInvalidAnnotationAndValueMismatch, annotation, err)
+	} else if exists && tproxy_config.Port(v) != valueRuntime {
+		l.Info(warningAnnotationValueMismatch, annotation, v)
+	}
+
+	return valueRuntime
+}
+
+func (c configurer) redirectExcludePorts(kind trafficKind) (tproxy_config.Ports, error) {
+	var annotation string
+
+	var valueDefault tproxy_config.Ports
+	var valueRuntime tproxy_config.Ports
+	var valueCurrent tproxy_config.Ports
+	var valueAnnotation tproxy_config.Ports
+
+	var err error
+
+	switch kind {
+	case trafficKindOutbound:
+		annotation = k8s_metadata.KumaTrafficExcludeOutboundPorts
+		valueDefault = tproxy_config.DefaultConfig().Redirect.Outbound.ExcludePorts
+		runtimeExcludePorts := c.runtime.SidecarTraffic.ExcludeOutboundPorts
+		if valueRuntime, err = convertToPorts(runtimeExcludePorts); err != nil {
+			return tproxy_config.Ports{}, err
+		}
+		valueCurrent = c.config.Redirect.Outbound.ExcludePorts
+	case trafficKindInbound:
+		annotation = k8s_metadata.KumaTrafficExcludeInboundPorts
+		valueDefault = tproxy_config.DefaultConfig().Redirect.Inbound.ExcludePorts
+		runtimeExcludePorts := c.runtime.SidecarTraffic.ExcludeInboundPorts
+		if valueRuntime, err = convertToPorts(runtimeExcludePorts); err != nil {
+			return tproxy_config.Ports{}, err
+		}
+		valueCurrent = c.config.Redirect.Inbound.ExcludePorts
+	default:
+		return tproxy_config.Ports{}, nil
+	}
+
+	if v, exists := c.annotations.GetString(annotation); exists {
+		if valueAnnotation, err = convertToPorts(v); err != nil {
+			return tproxy_config.Ports{}, err
+		}
+	}
+
+	pathRuntime := c.pathRuntimef("sidecarTraffic.exclude%sPorts", kind.capitalize())
+	pathConfigMap := c.pathConfigMapf("redirect.%s.excludePorts", kind)
+
+	l := c.logger.WithValues(
+		"default", valueDefault,
+		pathRuntime, valueRuntime,
+		pathConfigMap, valueCurrent,
+		annotation, valueAnnotation,
+	)
+
+	logDebugUsageAndReturn := func(
+		source string,
+		value tproxy_config.Ports,
+	) (tproxy_config.Ports, error) {
+		l.V(1).Info(fmt.Sprintf("using exclude %s ports from the %s", kind, source))
+		return value, nil
+	}
+
+	switch {
+	case len(valueAnnotation) > 0:
+		return logDebugUsageAndReturn("annotation", valueAnnotation)
+	case len(valueCurrent) > 0:
+		return logDebugUsageAndReturn("transparent proxy ConfigMap", valueCurrent)
+	case len(valueRuntime) > 0:
+		return logDebugUsageAndReturn("runtime configuration", valueRuntime)
+	default:
+		return logDebugUsageAndReturn("default configuration", valueDefault)
+	}
+}
+
+func (c configurer) redirectExcludePortsForIPs(kind trafficKind) []string {
+	var annotation string
+
+	var valueDefault []string
+	var valueRuntime []string
+	var valueCurrent []string
+	var valueAnnotation []string
+
+	switch kind {
+	case trafficKindOutbound:
+		annotation = k8s_metadata.KumaTrafficExcludeOutboundIPs
+		valueDefault = tproxy_config.DefaultConfig().Redirect.Outbound.ExcludePortsForIPs
+		valueRuntime = c.runtime.SidecarTraffic.ExcludeOutboundIPs
+		valueCurrent = c.config.Redirect.Outbound.ExcludePortsForIPs
+	case trafficKindInbound:
+		annotation = k8s_metadata.KumaTrafficExcludeInboundIPs
+		valueDefault = tproxy_config.DefaultConfig().Redirect.Inbound.ExcludePortsForIPs
+		valueRuntime = c.runtime.SidecarTraffic.ExcludeInboundIPs
+		valueCurrent = c.config.Redirect.Inbound.ExcludePortsForIPs
+	default:
+		return nil
+	}
+
+	if v, exists := c.annotations.GetList(annotation); exists {
+		valueAnnotation = v
+	}
+
+	pathRuntime := c.pathRuntimef("sidecarTraffic.exclude%sIPs", kind.capitalize())
+	pathConfigMap := c.pathConfigMapf("redirect.%s.excludePortsForIPs", kind)
+
+	l := c.logger.WithValues(
+		"default", valueDefault,
+		pathRuntime, valueRuntime,
+		pathConfigMap, valueCurrent,
+		annotation, valueAnnotation,
+	)
+
+	logDebugUsageAndReturn := func(source string, value []string) []string {
+		l.V(1).Info(fmt.Sprintf("using exclude %s IPs from the %s", kind, source))
+		return value
+	}
+
+	switch {
+	case len(valueAnnotation) > 0:
+		return logDebugUsageAndReturn("annotation", valueAnnotation)
+	case len(valueCurrent) > 0:
+		return logDebugUsageAndReturn("transparent proxy ConfigMap", valueCurrent)
+	case len(valueRuntime) > 0:
+		return logDebugUsageAndReturn("runtime configuration", valueRuntime)
+	default:
+		return logDebugUsageAndReturn("default configuration", valueDefault)
+	}
+}
+
+func (c configurer) ipFamilyMode() (tproxy_config.IPFamilyMode, error) {
+	annotation := k8s_metadata.KumaTransparentProxyingIPFamilyMode
+
+	valueDefault := tproxy_config.DefaultConfig().IPFamilyMode
+	valueCurrent := c.config.IPFamilyMode
+	valueRuntimeRaw := c.runtime.SidecarContainer.IpFamilyMode
+
+	var valueRuntime tproxy_config.IPFamilyMode
+	var valueAnnotation tproxy_config.IPFamilyMode
+
+	if valueRuntimeRaw != "" && valueDefault.String() != valueRuntimeRaw {
+		if err := valueRuntime.Set(valueRuntimeRaw); err != nil {
+			return "", errors.Wrapf(
+				err,
+				"invalid IP Family Mode in runtime configuration: %s",
+				valueRuntimeRaw,
+			)
+		}
+	}
+
+	if v, exists := c.annotations.GetString(annotation); exists {
+		if err := valueAnnotation.Set(v); err != nil {
+			return "", errors.Wrapf(
+				err,
+				"invalid IP Family Mode in annotation '%s': %s",
+				annotation,
+				v,
+			)
+		}
+	}
+
+	pathConfigMap := c.pathConfigMapf("ipFamilyMode")
+	pathRuntime := c.pathRuntimef("ipFamilyMode")
+
+	l := c.logger.WithValues(
+		"default", valueDefault,
+		pathRuntime, valueRuntime,
+		pathConfigMap, valueCurrent,
+		annotation, valueAnnotation,
+	)
+
+	logDebugUsageAndReturn := func(
+		source string,
+		value tproxy_config.IPFamilyMode,
+	) (tproxy_config.IPFamilyMode, error) {
+		l.V(1).Info(fmt.Sprintf("using IP Family Mode from the %s", source))
+		return value, nil
+	}
+
+	switch {
+	case len(valueAnnotation) > 0:
+		return logDebugUsageAndReturn("annotation", valueAnnotation)
+	case len(valueCurrent) > 0:
+		return logDebugUsageAndReturn("transparent proxy ConfigMap", valueCurrent)
+	case len(valueRuntime) > 0:
+		return logDebugUsageAndReturn("runtime configuration", valueRuntime)
+	default:
+		return logDebugUsageAndReturn("default configuration", valueDefault)
+	}
+}
+
+func (c configurer) redirectDNSEnabled() bool {
+	annotation := k8s_metadata.KumaBuiltinDNS
+
+	valueCurrent := c.config.Redirect.DNS.Enabled
+	valueDefault := tproxy_config.DefaultConfig().Redirect.DNS.Enabled
+	valueRuntime := c.runtime.BuiltinDNS.Enabled
+
+	pathConfigMap := c.pathConfigMapf("redirect.dns.enabled")
+	pathRuntime := c.pathRuntimef("builtinDNS.enabled")
+
+	l := c.logger.WithValues(
+		"default", valueDefault,
+		pathConfigMap, valueCurrent,
+		pathRuntime, valueRuntime,
+	)
+
+	if valueCurrent != valueRuntime && valueCurrent != valueDefault {
+		l.Info(warningTProxyConfigMismatch)
+	}
+
+	if v, exists, err := c.annotations.GetEnabled(annotation); err != nil {
+		l.Info(warningInvalidAnnotationAndValueMismatch, annotation, err)
+	} else if exists && v != valueRuntime {
+		l.Info(warningAnnotationValueMismatch, annotation, v)
+	}
+
+	return valueCurrent
+}
+
+func (c configurer) pathConfigMapf(format string, a ...any) string {
+	return fmt.Sprintf(
+		"configmap/%s/%s",
+		c.runtime.TransparentProxyConfigMapName,
+		fmt.Sprintf(format, a...),
+	)
+}
+
+func (c configurer) pathRuntimef(format string, a ...any) string {
+	return "runtime.injector." + fmt.Sprintf(format, a...)
+}
+
+func ConfigForKubernetes(
+	cfg tproxy_config.Config,
+	runtimeCfg k8s.Injector,
+	annotations k8s_metadata.Annotations,
+	logger logr.Logger,
+) (tproxy_config.Config, error) {
+	l := logger.WithName("transparentproxy.config")
+
+	k8sConfigurer := configurer{
+		config:      cfg,
+		runtime:     runtimeCfg,
+		annotations: annotations,
+		logger:      l,
+	}
+
+	if v, exists, _ := annotations.GetEnabled(k8s_metadata.KumaTransparentProxyingAnnotation); exists && !v {
+		l.Info(
+			warningDisablingTProxyAnnotation,
+			"annotation", k8s_metadata.KumaTransparentProxyingAnnotation,
+		)
+	}
+
+	cfg.KumaDPUser = k8sConfigurer.kumaDPUser()
+	cfg.CNIMode = runtimeCfg.CNIEnabled
+
+	if v, err := k8sConfigurer.ipFamilyMode(); err != nil {
+		return tproxy_config.Config{}, err
+	} else {
+		cfg.IPFamilyMode = v
+	}
+
+	if v, exists, err := annotations.GetBoolean(k8s_metadata.KumaTrafficDropInvalidPackets); err != nil {
+		return cfg, err
+	} else if exists {
+		cfg.DropInvalidPackets = v
+	}
+
+	if v, exists, err := annotations.GetBoolean(k8s_metadata.KumaTrafficIptablesLogs); err != nil {
+		return cfg, err
+	} else if exists {
+		cfg.Log.Enabled = v
+	}
+
+	cfg.Redirect.DNS.Enabled = k8sConfigurer.redirectDNSEnabled()
+	cfg.Redirect.DNS.Port = k8sConfigurer.redirectPort(trafficKindDNS)
+
+	cfg.Redirect.Outbound.Port = k8sConfigurer.redirectPort(trafficKindOutbound)
+
+	if v, err := k8sConfigurer.redirectExcludePorts(trafficKindOutbound); err != nil {
+		return cfg, err
+	} else {
+		cfg.Redirect.Outbound.ExcludePorts = v
+	}
+
+	if v, exists := annotations.GetString(k8s_metadata.KumaTrafficExcludeOutboundPortsForUIDs); exists {
+		cfg.Redirect.Outbound.ExcludePortsForUIDs = strings.Split(v, ";")
+	}
+
+	cfg.Redirect.Outbound.ExcludePortsForIPs = k8sConfigurer.redirectExcludePortsForIPs(trafficKindOutbound)
+
+	if v, exists, err := annotations.GetEnabled(k8s_metadata.KumaGatewayAnnotation); err != nil {
+		return cfg, err
+	} else if exists && v {
+		cfg.Redirect.Inbound.Enabled = false
+	}
+
+	if cfg.Redirect.Inbound.Enabled {
+		cfg.Redirect.Inbound.Port = k8sConfigurer.redirectPort(trafficKindInbound)
+		cfg.Redirect.Inbound.ExcludePortsForIPs = k8sConfigurer.redirectExcludePortsForIPs(trafficKindInbound)
+
+		if v, err := k8sConfigurer.redirectExcludePorts(trafficKindInbound); err != nil {
+			return cfg, err
+		} else {
+			cfg.Redirect.Inbound.ExcludePorts = v
+		}
+
+		if v, err := k8s_probes.GetApplicationProbeProxyPort(
+			annotations,
+			runtimeCfg.ApplicationProbeProxyPort,
+		); err != nil {
+			return cfg, err
+		} else if v != 0 {
+			if err := cfg.Redirect.Inbound.ExcludePorts.Append(fmt.Sprintf("%d", v)); err != nil {
+				return cfg, err
+			}
+		}
+	}
+
+	if v, exists, err := annotations.GetEnabled(k8s_metadata.KumaTransparentProxyingEbpf); err != nil {
+		return cfg, err
+	} else if exists {
+		cfg.Ebpf.Enabled = v
+	}
+
+	if cfg.Ebpf.Enabled {
+		if v, _ := annotations.GetStringWithDefault(
+			runtimeCfg.EBPF.BPFFSPath,
+			k8s_metadata.KumaTransparentProxyingEbpfBPFFSPath,
+		); v != "" {
+			cfg.Ebpf.BPFFSPath = v
+		}
+
+		if v, _ := annotations.GetStringWithDefault(
+			runtimeCfg.EBPF.CgroupPath,
+			k8s_metadata.KumaTransparentProxyingEbpfCgroupPath,
+		); v != "" {
+			cfg.Ebpf.CgroupPath = v
+		}
+
+		if v, _ := annotations.GetStringWithDefault(
+			runtimeCfg.EBPF.TCAttachIface,
+			k8s_metadata.KumaTransparentProxyingEbpfTCAttachIface,
+		); v != "" {
+			cfg.Ebpf.TCAttachIface = v
+		}
+
+		if v, _ := annotations.GetStringWithDefault(
+			runtimeCfg.EBPF.InstanceIPEnvVarName,
+			k8s_metadata.KumaTransparentProxyingEbpfInstanceIPEnvVarName,
+		); v != "" {
+			cfg.Ebpf.InstanceIPEnvVarName = v
+		}
+
+		if v, _ := annotations.GetStringWithDefault(
+			runtimeCfg.EBPF.ProgramsSourcePath,
+			k8s_metadata.KumaTransparentProxyingEbpfProgramsSourcePath,
+		); v != "" {
+			cfg.Ebpf.ProgramsSourcePath = v
+		}
+	}
+
+	return cfg, nil
+}
+
+func ConfigToAnnotations(
+	cfg tproxy_config.Config,
+	runtimeCfg k8s.Injector,
+	annotations map[string]string,
+	mesh string,
+	defaultAdminPort uint32,
+) (map[string]string, error) {
+	result := map[string]string{
+		k8s_metadata.KumaSidecarInjectedAnnotation:                 k8s_metadata.AnnotationTrue,
+		k8s_metadata.KumaTransparentProxyingAnnotation:             k8s_metadata.AnnotationEnabled,
+		k8s_metadata.KumaMeshAnnotation:                            mesh, // either user-defined value or default
+		k8s_metadata.KumaSidecarUID:                                cfg.KumaDPUser,
+		k8s_metadata.KumaTransparentProxyingOutboundPortAnnotation: cfg.Redirect.Outbound.Port.String(),
+		k8s_metadata.KumaTransparentProxyingInboundPortAnnotation:  cfg.Redirect.Inbound.Port.String(),
+		k8s_metadata.KumaTransparentProxyingIPFamilyMode:           cfg.IPFamilyMode.String(),
+	}
+
+	if cfg.CNIMode {
+		result[k8s_metadata.CNCFNetworkAnnotation] = k8s_metadata.KumaCNI
+	}
+
+	if cfg.DropInvalidPackets {
+		result[k8s_metadata.KumaTrafficDropInvalidPackets] = k8s_metadata.AnnotationTrue
+	}
+
+	if cfg.Log.Enabled {
+		result[k8s_metadata.KumaTrafficIptablesLogs] = k8s_metadata.AnnotationTrue
+	}
+
+	if cfg.Ebpf.Enabled {
+		result[k8s_metadata.KumaTransparentProxyingEbpf] = k8s_metadata.AnnotationEnabled
+		result[k8s_metadata.KumaTransparentProxyingEbpfBPFFSPath] = cfg.Ebpf.BPFFSPath
+		result[k8s_metadata.KumaTransparentProxyingEbpfCgroupPath] = cfg.Ebpf.CgroupPath
+		result[k8s_metadata.KumaTransparentProxyingEbpfTCAttachIface] = cfg.Ebpf.TCAttachIface
+		result[k8s_metadata.KumaTransparentProxyingEbpfProgramsSourcePath] = cfg.Ebpf.ProgramsSourcePath
+		result[k8s_metadata.KumaTransparentProxyingEbpfInstanceIPEnvVarName] = cfg.Ebpf.InstanceIPEnvVarName
+	}
+
+	if len(cfg.Redirect.Outbound.ExcludePorts) > 0 {
+		result[k8s_metadata.KumaTrafficExcludeOutboundPorts] = cfg.Redirect.Outbound.ExcludePorts.String()
+	}
+
+	if len(cfg.Redirect.Outbound.ExcludePortsForIPs) > 0 {
+		result[k8s_metadata.KumaTrafficExcludeOutboundIPs] = strings.Join(cfg.Redirect.Outbound.ExcludePortsForIPs, ",")
+	}
+
+	if len(cfg.Redirect.Inbound.ExcludePorts) > 0 {
+		result[k8s_metadata.KumaTrafficExcludeInboundPorts] = cfg.Redirect.Inbound.ExcludePorts.String()
+	}
+
+	if len(cfg.Redirect.Inbound.ExcludePortsForIPs) > 0 {
+		result[k8s_metadata.KumaTrafficExcludeInboundIPs] = strings.Join(cfg.Redirect.Inbound.ExcludePortsForIPs, ",")
+	}
+
+	if cfg.Redirect.DNS.Enabled {
+		result[k8s_metadata.KumaBuiltinDNS] = k8s_metadata.AnnotationEnabled
+		result[k8s_metadata.KumaBuiltinDNSPort] = cfg.Redirect.DNS.Port.String()
+
+		if v, _, err := k8s_metadata.Annotations(result).GetEnabledWithDefault(
+			runtimeCfg.BuiltinDNS.Logging,
+			k8s_metadata.KumaBuiltinDNSLogging,
+		); err != nil {
+			return nil, err
+		} else {
+			result[k8s_metadata.KumaBuiltinDNSLogging] = strconv.FormatBool(v)
+		}
+	}
+
+	if err := k8s_probes.SetVirtualProbesEnabledAnnotation(
+		result,
+		annotations,
+		runtimeCfg.VirtualProbesEnabled,
+	); err != nil {
+		return nil, errors.Wrapf(err, "unable to set %s", k8s_metadata.KumaVirtualProbesAnnotation)
+	}
+
+	if v, _, err := k8s_metadata.Annotations(result).GetUint32WithDefault(
+		runtimeCfg.VirtualProbesPort,
+		k8s_metadata.KumaVirtualProbesPortAnnotation,
+	); err != nil {
+		return nil, errors.Wrapf(err, "unable to set %s", k8s_metadata.KumaVirtualProbesPortAnnotation)
+	} else {
+		result[k8s_metadata.KumaVirtualProbesPortAnnotation] = fmt.Sprintf("%d", v)
+	}
+
+	if v, err := k8s_probes.GetApplicationProbeProxyPort(
+		annotations,
+		runtimeCfg.ApplicationProbeProxyPort,
+	); err != nil {
+		return nil, errors.Wrapf(err, "unable to set %s", k8s_metadata.KumaApplicationProbeProxyPortAnnotation)
+	} else {
+		result[k8s_metadata.KumaApplicationProbeProxyPortAnnotation] = fmt.Sprintf("%d", v)
+	}
+
+	if v, _, err := k8s_metadata.Annotations(result).GetUint32WithDefault(
+		defaultAdminPort,
+		k8s_metadata.KumaEnvoyAdminPort,
+	); err != nil {
+		return nil, err
+	} else {
+		result[k8s_metadata.KumaEnvoyAdminPort] = fmt.Sprintf("%d", v)
+	}
+
+	return result, nil
+}
+
+func ConfigFromAnnotations(annotations k8s_metadata.Annotations) (tproxy_config.Config, error) {
+	annotation := k8s_metadata.KumaTrafficTransparentProxyConfig
+
+	if cfgYAML, ok := annotations.GetString(annotation); ok && cfgYAML != "" {
+		cfg := tproxy_config.DefaultConfig()
+
+		if err := core_config.NewLoader(&cfg).LoadBytes([]byte(cfgYAML)); err != nil {
+			return tproxy_config.Config{}, errors.Wrapf(
+				err,
+				"failed to load transparent proxy configuration from '%s' annotation",
+				annotation,
+			)
+		}
+
+		return cfg, nil
+	}
+
+	return tproxy_config.Config{}, errors.Errorf(
+		"annotation '%s' is either missing or does not contain a valid transparent proxy configuration",
+		annotation,
+	)
+}
+
+func convertUint32SliceToPorts(values []uint32) (tproxy_config.Ports, error) {
+	result := tproxy_config.Ports{}
+	portStrings := make([]string, len(values))
+
+	for i, port := range values {
+		portStrings[i] = fmt.Sprintf("%d", port)
+	}
+
+	if err := result.Set(strings.Join(portStrings, ",")); err != nil {
+		return tproxy_config.Ports{}, err
+	}
+
+	return result, nil
+}
+
+func convertStringToPorts(values string) (tproxy_config.Ports, error) {
+	result := tproxy_config.Ports{}
+
+	if err := result.Set(values); err != nil {
+		return tproxy_config.Ports{}, err
+	}
+
+	return result, nil
+}
+
+func convertToPorts[T []uint32 | string](v T) (tproxy_config.Ports, error) {
+	switch v := any(v).(type) {
+	case []uint32:
+		return convertUint32SliceToPorts(v)
+	case string:
+		return convertStringToPorts(v)
+	default:
+		return tproxy_config.Ports{}, errors.Errorf("unsupported type %T", v)
+	}
+}

--- a/pkg/transparentproxy/kubernetes/kubernetes_test.go
+++ b/pkg/transparentproxy/kubernetes/kubernetes_test.go
@@ -33,7 +33,7 @@ var _ = Describe("kubernetes", func() {
 	}
 
 	DescribeTable("should generate kumactl command line", func(given testCaseKumactl) {
-		podRedirect, err := kubernetes.NewPodRedirectForPod(given.pod)
+		podRedirect, err := kubernetes.NewPodRedirectFromAnnotations(given.pod.Annotations)
 		Expect(err).ToNot(HaveOccurred())
 
 		commandLine := podRedirect.AsKumactlCommandLine()


### PR DESCRIPTION
This update enables Kubernetes deployments to use the transparent proxy feature, allowing the configuration to be provided via the `--config` or `--config-file` CLI flags. When `--set transparentProxy.configMap.enabled=true` is set, the configuration will be stored in a ConfigMap. Additionally, you can use the `traffic.kuma.io/transparent-proxy-configmap-name` annotation to specify a different ConfigMap for specific workloads.

Closes: https://github.com/kumahq/kuma/issues/8324

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - https://github.com/kumahq/kuma/issues/8324
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - it won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - necessary unit tests updated
  - tested locally on k3d cluster with CNI and init containers
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - there is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - there is no need

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
