### PR TITLE
chore(kuma-cp): deprecate top-level targetRef kind 'MeshService'

### DIFF
--- a/pkg/plugins/policies/core/jsonpatch/validators/validator.go
+++ b/pkg/plugins/policies/core/jsonpatch/validators/validator.go
@@ -2,14 +2,16 @@ package validators
 
 import (
 	"encoding/json"
+	"fmt"
 
-	"github.com/kumahq/kuma/api/common/v1alpha1"
+	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/validators"
 )
 
 func ValidateJsonPatchBlock(
 	rootPath validators.PathBuilder,
-	patchBlock []v1alpha1.JsonPatchBlock,
+	patchBlock []common_api.JsonPatchBlock,
 ) validators.ValidationError {
 	var err validators.ValidationError
 
@@ -115,4 +117,16 @@ func validatePath(path *string, op string) validators.ValidationError {
 	}
 
 	return err
+}
+
+func TopLevelTargetRefDeprecations(targetRef *common_api.TargetRef) []string {
+	if targetRef == nil {
+		return nil
+	}
+	if targetRef.Kind == common_api.MeshService {
+		return []string{
+			fmt.Sprintf("%s value for 'targetRef.kind' is deprecated, use %s with '%s' tag instead", common_api.MeshService, common_api.MeshSubset, mesh_proto.ServiceTag),
+		}
+	}
+	return nil
 }

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/deprecated.go
@@ -1,0 +1,9 @@
+package v1alpha1
+
+import (
+	"github.com/kumahq/kuma/pkg/plugins/policies/core/jsonpatch/validators"
+)
+
+func (t *MeshAccessLogResource) Deprecations() []string {
+	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
+}

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/deprecated.go
@@ -1,0 +1,9 @@
+package v1alpha1
+
+import (
+	"github.com/kumahq/kuma/pkg/plugins/policies/core/jsonpatch/validators"
+)
+
+func (t *MeshCircuitBreakerResource) Deprecations() []string {
+	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
+}

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/deprecated.go
@@ -1,12 +1,16 @@
 package v1alpha1
 
-import "github.com/kumahq/kuma/api/common/v1alpha1"
+import (
+	"github.com/kumahq/kuma/api/common/v1alpha1"
+	"github.com/kumahq/kuma/pkg/plugins/policies/core/jsonpatch/validators"
+)
 
 func (t *MeshFaultInjectionResource) Deprecations() []string {
+	deprecations := validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
 	for _, f := range t.Spec.From {
 		if f.GetTargetRef().Kind == v1alpha1.MeshService {
-			return []string{"MeshService value for 'from[].targetRef.kind' is deprecated, use MeshSubset with 'kuma.io/service' instead"}
+			deprecations = append(deprecations, "MeshService value for 'from[].targetRef.kind' is deprecated, use MeshSubset with 'kuma.io/service' instead")
 		}
 	}
-	return nil
+	return deprecations
 }

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/deprecated.go
@@ -1,0 +1,9 @@
+package v1alpha1
+
+import (
+	"github.com/kumahq/kuma/pkg/plugins/policies/core/jsonpatch/validators"
+)
+
+func (t *MeshHealthCheckResource) Deprecations() []string {
+	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
+}

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/deprecated.go
@@ -1,0 +1,9 @@
+package v1alpha1
+
+import (
+	"github.com/kumahq/kuma/pkg/plugins/policies/core/jsonpatch/validators"
+)
+
+func (t *MeshHTTPRouteResource) Deprecations() []string {
+	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
+}

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/deprecated.go
@@ -1,0 +1,9 @@
+package v1alpha1
+
+import (
+	"github.com/kumahq/kuma/pkg/plugins/policies/core/jsonpatch/validators"
+)
+
+func (t *MeshLoadBalancingStrategyResource) Deprecations() []string {
+	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
+}

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/deprecated.go
@@ -1,0 +1,9 @@
+package v1alpha1
+
+import (
+	"github.com/kumahq/kuma/pkg/plugins/policies/core/jsonpatch/validators"
+)
+
+func (t *MeshMetricResource) Deprecations() []string {
+	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
+}

--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/deprecated.go
@@ -1,0 +1,9 @@
+package v1alpha1
+
+import (
+	"github.com/kumahq/kuma/pkg/plugins/policies/core/jsonpatch/validators"
+)
+
+func (t *MeshProxyPatchResource) Deprecations() []string {
+	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
+}

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/deprecated.go
@@ -1,0 +1,9 @@
+package v1alpha1
+
+import (
+	"github.com/kumahq/kuma/pkg/plugins/policies/core/jsonpatch/validators"
+)
+
+func (t *MeshRateLimitResource) Deprecations() []string {
+	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
+}

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/deprecated.go
@@ -1,0 +1,9 @@
+package v1alpha1
+
+import (
+	"github.com/kumahq/kuma/pkg/plugins/policies/core/jsonpatch/validators"
+)
+
+func (t *MeshRetryResource) Deprecations() []string {
+	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
+}

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/deprecated.go
@@ -1,0 +1,9 @@
+package v1alpha1
+
+import (
+	"github.com/kumahq/kuma/pkg/plugins/policies/core/jsonpatch/validators"
+)
+
+func (t *MeshTCPRouteResource) Deprecations() []string {
+	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
+}

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/deprecated.go
@@ -1,0 +1,9 @@
+package v1alpha1
+
+import (
+	"github.com/kumahq/kuma/pkg/plugins/policies/core/jsonpatch/validators"
+)
+
+func (t *MeshTimeoutResource) Deprecations() []string {
+	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
+}

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/deprecated.go
@@ -1,0 +1,9 @@
+package v1alpha1
+
+import (
+	"github.com/kumahq/kuma/pkg/plugins/policies/core/jsonpatch/validators"
+)
+
+func (t *MeshTraceResource) Deprecations() []string {
+	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
+}

--- a/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/deprecated.go
@@ -1,12 +1,16 @@
 package v1alpha1
 
-import "github.com/kumahq/kuma/api/common/v1alpha1"
+import (
+	"github.com/kumahq/kuma/api/common/v1alpha1"
+	"github.com/kumahq/kuma/pkg/plugins/policies/core/jsonpatch/validators"
+)
 
 func (t *MeshTrafficPermissionResource) Deprecations() []string {
+	deprecations := validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
 	for _, f := range t.Spec.From {
 		if f.GetTargetRef().Kind == v1alpha1.MeshService {
-			return []string{"MeshService value for 'from[].targetRef.kind' is deprecated, use MeshSubset with 'kuma.io/service' instead"}
+			deprecations = append(deprecations, "MeshService value for 'from[].targetRef.kind' is deprecated, use MeshSubset with 'kuma.io/service' instead")
 		}
 	}
-	return nil
+	return deprecations
 }

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtp.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtp.global.golden.yaml
@@ -5,5 +5,7 @@ status:
   metadata: {}
 uid: "12345"
 warnings:
+- MeshService value for 'targetRef.kind' is deprecated, use MeshSubset with 'kuma.io/service'
+  tag instead
 - MeshService value for 'from[].targetRef.kind' is deprecated, use MeshSubset with
   'kuma.io/service' instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtp.non-federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtp.non-federated.golden.yaml
@@ -5,5 +5,7 @@ status:
   metadata: {}
 uid: "12345"
 warnings:
+- MeshService value for 'targetRef.kind' is deprecated, use MeshSubset with 'kuma.io/service'
+  tag instead
 - MeshService value for 'from[].targetRef.kind' is deprecated, use MeshSubset with
   'kuma.io/service' instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_zone-mtp.federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_zone-mtp.federated.golden.yaml
@@ -5,5 +5,7 @@ status:
   metadata: {}
 uid: "12345"
 warnings:
+- MeshService value for 'targetRef.kind' is deprecated, use MeshSubset with 'kuma.io/service'
+  tag instead
 - MeshService value for 'from[].targetRef.kind' is deprecated, use MeshSubset with
   'kuma.io/service' instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_zone-mtp.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_zone-mtp.global.golden.yaml
@@ -5,5 +5,7 @@ status:
   metadata: {}
 uid: "12345"
 warnings:
+- MeshService value for 'targetRef.kind' is deprecated, use MeshSubset with 'kuma.io/service'
+  tag instead
 - MeshService value for 'from[].targetRef.kind' is deprecated, use MeshSubset with
   'kuma.io/service' instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_zone-mtp.non-federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_zone-mtp.non-federated.golden.yaml
@@ -5,5 +5,7 @@ status:
   metadata: {}
 uid: "12345"
 warnings:
+- MeshService value for 'targetRef.kind' is deprecated, use MeshSubset with 'kuma.io/service'
+  tag instead
 - MeshService value for 'from[].targetRef.kind' is deprecated, use MeshSubset with
   'kuma.io/service' instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mtp.federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mtp.federated.golden.yaml
@@ -5,5 +5,7 @@ status:
   metadata: {}
 uid: "12345"
 warnings:
+- MeshService value for 'targetRef.kind' is deprecated, use MeshSubset with 'kuma.io/service'
+  tag instead
 - MeshService value for 'from[].targetRef.kind' is deprecated, use MeshSubset with
   'kuma.io/service' instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mtp.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mtp.global.golden.yaml
@@ -5,5 +5,7 @@ status:
   metadata: {}
 uid: "12345"
 warnings:
+- MeshService value for 'targetRef.kind' is deprecated, use MeshSubset with 'kuma.io/service'
+  tag instead
 - MeshService value for 'from[].targetRef.kind' is deprecated, use MeshSubset with
   'kuma.io/service' instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mtp.non-federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mtp.non-federated.golden.yaml
@@ -5,5 +5,7 @@ status:
   metadata: {}
 uid: "12345"
 warnings:
+- MeshService value for 'targetRef.kind' is deprecated, use MeshSubset with 'kuma.io/service'
+  tag instead
 - MeshService value for 'from[].targetRef.kind' is deprecated, use MeshSubset with
   'kuma.io/service' instead


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues -- Fix https://github.com/kumahq/kuma/issues/11019
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
