### PR TITLE
fix(e2e): reproducing gatewayapi tests

### DIFF
--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -137,3 +137,6 @@ jobs:
           path: |
             /tmp/e2e-debug/
           retention-days: ${{ github.event_name == 'pull_request' && 1 || 30 }}
+      - name: Setup tmate session
+        if: failure()
+        uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -78,7 +78,7 @@ jobs:
         env:
           DOCKERHUB_PULL_CREDENTIAL: ${{ secrets.DOCKERHUB_PULL_CREDENTIAL }}
         run: |
-          if [[ "${{ runner.debug }}" == "1" ]]; then
+          if [[ "${{ runner.debug }}" == "1" ]] || [[ "${{ vars.E2E_DEBUG_ENABLED }}" == "true" ]]; then
             export KUMA_DEBUG=true
           fi
           if [[ "${{ env.E2E_PARAM_K8S_VERSION }}" == "kindIpv6" ]]; then
@@ -137,6 +137,3 @@ jobs:
           path: |
             /tmp/e2e-debug/
           retention-days: ${{ github.event_name == 'pull_request' && 1 || 30 }}
-      - name: Setup tmate session
-        if: failure()
-        uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -82,7 +82,7 @@ jobs:
           # You can modify the include to run one of test suites on PRs (though you'd need to then remove it)
           OVERRIDE_JQ_CMD: |-
             .test_e2e = false
-            | .test_e2e_env.include = []
+            | .test_e2e_env.include = [{"k8sVersion": "${{ env.K8S_MAX_VERSION }}", "target": "gatewayapi", "arch": "amd64"}]
             | .test_e2e_env.exclude += [{"arch": "arm64"}, {"k8sVersion": "kindIpv6"}, {"k8sVersion": "${{ inputs.K8S_MIN_VERSION}}"}]
         run: |-
           BASE_MATRIX_ALL='${{ env.BASE_MATRIX }}'

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -17,7 +17,7 @@ env:
 jobs:
   test_unit:
     timeout-minutes: 20
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -57,8 +57,8 @@ jobs:
                 "sidecarContainers": [""]
               },
               "test_e2e_env": {
-                "target": ["kubernetes", "universal", "multizone"],
-                "k8sVersion": ["kind", "kindIpv6", "${{ env.K8S_MIN_VERSION }}", "${{ env.K8S_MAX_VERSION }}"],
+                "target": ["gatewayapi"],
+                "k8sVersion": ["${{ env.K8S_MAX_VERSION }}"],
                 "arch": ["amd64"],
                 "parallelism": [1],
                 "cniNetworkPlugin": ["flannel"],
@@ -82,7 +82,7 @@ jobs:
           # You can modify the include to run one of test suites on PRs (though you'd need to then remove it)
           OVERRIDE_JQ_CMD: |-
             .test_e2e = false
-            | .test_e2e_env.include = [{"k8sVersion": "${{ env.K8S_MAX_VERSION }}", "target": "gatewayapi", "arch": "amd64"}]
+            | .test_e2e_env.include = []
             | .test_e2e_env.exclude += [{"arch": "arm64"}, {"k8sVersion": "kindIpv6"}, {"k8sVersion": "${{ inputs.K8S_MIN_VERSION}}"}]
         run: |-
           BASE_MATRIX_ALL='${{ env.BASE_MATRIX }}'

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -49,23 +49,28 @@ jobs:
           go-version-file: go.mod
           cache: false
       - uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
+        if: false
         with:
           args: --fix=false --verbose
           version: v1.60.3
       - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        if: false
         with:
           path: |
             ${{ env.CI_TOOLS_DIR }}
           key: ${{ runner.os }}-${{ runner.arch }}-devtools-${{ hashFiles('mk/dependencies/deps.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-devtools
-      - run: |
+      - if: false
+        run: |
           make dev/tools
       - run: |
           make clean
-      - run: |
+      - if: false
+        run: |
           make check
       - id: sca-project
+        if: false
         uses: Kong/public-shared-actions/security-actions/sca@d4d6b2a7e202398f62eb37c554df9732b27d9d84 # v2.5.1
         with:
           dir: .
@@ -92,7 +97,7 @@ jobs:
       id-token: write
     needs: ["check", "test"]
     uses: ./.github/workflows/_build_publish.yaml
-    if: ${{ fromJSON(needs.check.outputs.BUILD) }}
+    if: false
     with:
       FULL_MATRIX: ${{ needs.check.outputs.FULL_MATRIX }}
       ALLOW_PUSH: ${{ needs.check.outputs.ALLOW_PUSH }}
@@ -105,7 +110,7 @@ jobs:
     secrets: inherit
   provenance:
     needs: ["check", "build_publish"]
-    if: ${{ github.ref_type == 'tag' }}
+    if: false
     uses: ./.github/workflows/_provenance.yaml
     secrets: inherit
     permissions:

--- a/test/e2e_env/gatewayapi/conformance_test.go
+++ b/test/e2e_env/gatewayapi/conformance_test.go
@@ -74,14 +74,14 @@ func TestConformance(t *testing.T) {
 		}
 		//}
 
-		g.Expect(cluster.DeleteKuma()).To(Succeed())
-		g.Expect(cluster.DismissCluster()).To(Succeed())
+		//g.Expect(cluster.DeleteKuma()).To(Succeed())
+		//g.Expect(cluster.DismissCluster()).To(Succeed())
 	})
 
 	g.Expect(cluster.Install(GatewayAPICRDs)).To(Succeed())
 	g.Eventually(func() error {
 		return NewClusterSetup().Install(Kuma(config_core.Zone,
-			WithEnv("KUMA_RUNTIME_KUBERNETES_INJECTOR_SIDECAR_CONTAINER_ENV_VARS", "KUMA_DATAPLANE_RUNTIME_ENVOY_LOG_LEVEL=debug"))).Setup(cluster)
+			WithEnv("KUMA_RUNTIME_KUBERNETES_INJECTOR_SIDECAR_CONTAINER_ENV_VARS", "KUMA_DATAPLANE_RUNTIME_ENVOY_LOG_LEVEL:debug"))).Setup(cluster)
 	}, "90s", "3s").Should(Succeed())
 
 	configPath, err := opts.GetConfigPath(t)
@@ -107,7 +107,7 @@ func TestConformance(t *testing.T) {
 		RestConfig:           clientConfig,
 		Clientset:            clientset,
 		GatewayClassName:     "kuma",
-		CleanupBaseResources: true,
+		CleanupBaseResources: false,
 		Debug:                true,
 		NamespaceLabels: map[string]string{
 			metadata.KumaSidecarInjectionAnnotation: metadata.AnnotationEnabled,
@@ -137,6 +137,7 @@ func TestConformance(t *testing.T) {
 	}
 
 	conformanceSuite, err := suite.NewConformanceTestSuite(options)
+	conformanceSuite.Cleanup = false
 	g.Expect(err).ToNot(HaveOccurred())
 
 	conformanceSuite.Setup(t, tests.ConformanceTests)

--- a/test/e2e_env/gatewayapi/conformance_test.go
+++ b/test/e2e_env/gatewayapi/conformance_test.go
@@ -107,7 +107,7 @@ func TestConformance(t *testing.T) {
 		Clientset:            clientset,
 		GatewayClassName:     "kuma",
 		CleanupBaseResources: true,
-		Debug:                Config.Debug,
+		Debug:                true,
 		NamespaceLabels: map[string]string{
 			metadata.KumaSidecarInjectionAnnotation: metadata.AnnotationEnabled,
 		},

--- a/test/e2e_env/gatewayapi/conformance_test.go
+++ b/test/e2e_env/gatewayapi/conformance_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"slices"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
@@ -139,8 +140,14 @@ func TestConformance(t *testing.T) {
 	conformanceSuite, err := suite.NewConformanceTestSuite(options)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	conformanceSuite.Setup(t, tests.ConformanceTests)
-	g.Expect(conformanceSuite.Run(t, tests.ConformanceTests)).To(Succeed())
+	allTests := tests.ConformanceTests
+	idx := slices.IndexFunc(allTests, func(t suite.ConformanceTest) bool {
+		return t.ShortName == tests.HTTPRouteServiceTypes.ShortName
+	})
+	allTests = append(allTests[:idx], allTests[idx+1:]...)
+
+	conformanceSuite.Setup(t, allTests)
+	g.Expect(conformanceSuite.Run(t, allTests)).To(Succeed())
 
 	rep, err := conformanceSuite.Report()
 	g.Expect(err).ToNot(HaveOccurred())

--- a/test/e2e_env/gatewayapi/conformance_test.go
+++ b/test/e2e_env/gatewayapi/conformance_test.go
@@ -52,7 +52,7 @@ func TestConformance(t *testing.T) {
 
 	t.Cleanup(func() {
 		//if t.Failed() || Config.Debug {
-		var namespaces []string
+		namespaces := []string{Config.KumaNamespace}
 		clientset, err := k8s.GetKubernetesClientFromOptionsE(t, opts)
 		if err == nil {
 			if nsList, err := clientset.CoreV1().Namespaces().List(context.Background(),
@@ -137,7 +137,6 @@ func TestConformance(t *testing.T) {
 	}
 
 	conformanceSuite, err := suite.NewConformanceTestSuite(options)
-	conformanceSuite.Cleanup = false
 	g.Expect(err).ToNot(HaveOccurred())
 
 	conformanceSuite.Setup(t, tests.ConformanceTests)

--- a/test/framework/debug.go
+++ b/test/framework/debug.go
@@ -164,6 +164,11 @@ func DebugKube(cluster Cluster, mesh string, namespaces ...string) {
 		}
 	}
 
+	cpNamespace := Config.KumaNamespace
+	if !cpNamespaceExported(debugPath, cluster.Name(), cpNamespace) {
+		namespaces = append(namespaces, cpNamespace)
+	}
+
 	Logf("printing debug information of cluster %q for mesh %q and namespaces %q", cluster.Name(), mesh, namespaces)
 	for _, namespace := range namespaces {
 		kubeOptions := *cluster.GetKubectlOptions(namespace) // copy to not override fields globally
@@ -250,6 +255,21 @@ func prepareDebugDir() string {
 	))
 
 	return path
+}
+
+func cpNamespaceExported(path string, clusterName string, namespace string) bool {
+	files, err := os.ReadDir(path)
+	if err != nil {
+		return false
+	}
+
+	prefix := fmt.Sprintf("%s-namespace-%s-.json", clusterName, namespace)
+	for _, file := range files {
+		if !file.IsDir() && strings.HasPrefix(file.Name(), prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func CpRestarted(cluster Cluster) bool {

--- a/test/framework/debug.go
+++ b/test/framework/debug.go
@@ -176,10 +176,8 @@ func DebugKube(cluster Cluster, mesh string, namespaces ...string) {
 		deployments, err := k8s.ListDeploymentsE(cluster.GetTesting(), &kubeOptions, kube_meta.ListOptions{})
 		if err == nil {
 			for _, deployment := range deployments {
-				if !k8s.IsDeploymentAvailable(&deployment) {
-					deployDetails := ExtractDeploymentDetails(cluster.GetTesting(), &kubeOptions, deployment.Name)
-					out += MarshalObjectDetails(deployDetails)
-				}
+				deployDetails := ExtractDeploymentDetails(cluster.GetTesting(), &kubeOptions, deployment.Name)
+				out += MarshalObjectDetails(deployDetails)
 			}
 		} else {
 			out += fmt.Sprintf("failed to list deployments in namespace %s with error: %s", namespace, err.Error())

--- a/test/framework/debug.go
+++ b/test/framework/debug.go
@@ -232,7 +232,7 @@ func DebugKube(cluster Cluster, mesh string, namespaces ...string) {
 				dpInspectOut += fmt.Sprintf("'kumactl inspect dataplane %s --mesh %s --type config-dump' failed with error: %s",
 					dpObj.Name, dpObj.Mesh, err.Error())
 			} else {
-				dpXdsFilePath := filepath.Join(debugPath, fmt.Sprintf("%s-dp-xds-%s-%s-%s", cluster.Name(), dpObj.Name, dpObj.Mesh, randomId))
+				dpXdsFilePath := filepath.Join(debugPath, fmt.Sprintf("%s-xds-%s-%s-%s.json", cluster.Name(), dpObj.Name, dpObj.Mesh, randomId))
 				Logf("saving DP xds of dp %q from cluster %q for mesh %q to a file %q", dpObj.Name, cluster.Name(), mesh, dpXdsFilePath)
 				Expect(os.WriteFile(dpXdsFilePath, []byte(configDumpResp), 0o600)).To(Succeed())
 			}

--- a/test/framework/k8s.go
+++ b/test/framework/k8s.go
@@ -15,6 +15,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/yaml"
@@ -171,7 +172,7 @@ func ExtractDeploymentDetails(testingT testing.TestingT,
 	}
 
 	replicaSets, err := k8s.ListReplicaSetsE(testingT, kubectlOptions, metav1.ListOptions{
-		LabelSelector: "app=" + name,
+		LabelSelector: labels.SelectorFromSet(deploy.Spec.Selector.MatchLabels).String(),
 	})
 	if err != nil {
 		deployDetails.RetrievalError = err
@@ -185,7 +186,7 @@ func ExtractDeploymentDetails(testingT testing.TestingT,
 	}
 
 	pods, err := k8s.ListPodsE(testingT, kubectlOptions, metav1.ListOptions{
-		LabelSelector: "app=" + name,
+		LabelSelector: labels.SelectorFromSet(deploy.Spec.Selector.MatchLabels).String(),
 	})
 	if err != nil {
 		deployDetails.RetrievalError = err

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -343,6 +343,10 @@ func (c *K8sCluster) yamlForKumaViaKubectl(mode string) (string, error) {
 		args = append(args, "--env-var", "KUMA_IPAM_MESH_MULTI_ZONE_SERVICE_CIDR=fd00:fd03::/64")
 	}
 
+	if Config.Debug {
+		args = append(args, "--set", fmt.Sprintf("%scontrolPlane.logLevel=debug", Config.HelmSubChartPrefix))
+	}
+
 	for k, v := range c.opts.env {
 		args = append(args, "--env-var", fmt.Sprintf("%s=%s", k, v))
 	}
@@ -395,6 +399,10 @@ func (c *K8sCluster) genValues(mode string) map[string]string {
 		values["controlPlane.envVars.KUMA_IPAM_MESH_SERVICE_CIDR"] = "fd00:fd01::/64"
 		values["controlPlane.envVars.KUMA_IPAM_MESH_EXTERNAL_SERVICE_CIDR"] = "fd00:fd02::/64"
 		values["controlPlane.envVars.KUMA_IPAM_MESH_MULTI_ZONE_SERVICE_CIDR"] = "fd00:fd03::/64"
+	}
+
+	if Config.Debug {
+		values["controlPlane.logLevel"] = "debug"
 	}
 
 	switch mode {
@@ -494,6 +502,16 @@ func (c *K8sCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOption) e
 	switch mode {
 	case core.Zone:
 		c.opts.env["KUMA_MULTIZONE_ZONE_KDS_TLS_SKIP_VERIFY"] = "true"
+	}
+
+	if Config.Debug {
+		dpEnvVarKey := "KUMA_RUNTIME_KUBERNETES_INJECTOR_SIDECAR_CONTAINER_ENV_VARS"
+		debugEnv := "KUMA_DATAPLANE_RUNTIME_ENVOY_LOG_LEVEL:debug"
+		if envVars, ok := c.opts.env[dpEnvVarKey]; ok {
+			c.opts.env[dpEnvVarKey] = envVars + "," + debugEnv
+		} else {
+			c.opts.env[dpEnvVarKey] = debugEnv
+		}
 	}
 
 	var err error


### PR DESCRIPTION
Don't merge this, and don't review the changes. 
Just used for reproducing gatewayapi tests.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
