### PR TITLE
test(e2e): add cross-zone MeshGateway + MeshService labels test

### DIFF
--- a/test/e2e_env/multizone/meshservice/connectivity.go
+++ b/test/e2e_env/multizone/meshservice/connectivity.go
@@ -125,6 +125,18 @@ spec:
                 namespace: %s
                 port: 80
                 weight: 1
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /uni-2
+          default:
+            backendRefs:
+              - kind: MeshService
+                labels:
+                  kuma.io/display-name: test-server
+                  kuma.io/zone: kuma-5
+                port: 80
+                weight: 1
 `, Config.KumaNamespace, meshName, namespace)
 		err := NewClusterSetup().
 			Install(NamespaceWithSidecarInjection(namespace)).
@@ -245,7 +257,7 @@ spec:
 			address:          func() string { return "/local" },
 			expectedInstance: "kube-test-server-1",
 		}),
-		XEntry("should access service in the a Universal cluster", testCase{
+		Entry("should access service in the a Universal cluster", testCase{
 			address:          func() string { return "/uni-2" },
 			expectedInstance: "uni-test-server",
 		}),


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
