### PR TITLE
test(e2e): use helm --wait in federation tests

### DIFF
--- a/test/e2e/federation/federation_kubernetes.go
+++ b/test/e2e/federation/federation_kubernetes.go
@@ -57,6 +57,7 @@ func FederateKubeZoneCPToKubeGlobal() {
 	AfterEachFailure(func() {
 		DebugKube(global, "default", Config.KumaNamespace)
 		DebugKube(zone, "default", TestNamespace)
+		PrintLogs(global, zone)
 	})
 
 	E2EAfterAll(func() {

--- a/test/e2e/federation/federation_kubernetes.go
+++ b/test/e2e/federation/federation_kubernetes.go
@@ -84,7 +84,6 @@ func FederateKubeZoneCPToKubeGlobal() {
 			Expect(err).ToNot(HaveOccurred())
 			err = zone.(*K8sCluster).UpgradeKuma(core.Zone,
 				WithHelmReleaseName(releaseName),
-				WithHelmWait(),
 				WithGlobalAddress(global.GetKuma().GetKDSServerAddress()),
 			)
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/federation/federation_kubernetes.go
+++ b/test/e2e/federation/federation_kubernetes.go
@@ -83,6 +83,7 @@ func FederateKubeZoneCPToKubeGlobal() {
 			Expect(err).ToNot(HaveOccurred())
 			err = zone.(*K8sCluster).UpgradeKuma(core.Zone,
 				WithHelmReleaseName(releaseName),
+				WithHelmWait(),
 				WithGlobalAddress(global.GetKuma().GetKDSServerAddress()),
 			)
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/federation/federation_kubernetes.go
+++ b/test/e2e/federation/federation_kubernetes.go
@@ -35,7 +35,7 @@ func FederateKubeZoneCPToKubeGlobal() {
 			Install(Kuma(core.Global,
 				WithInstallationMode(HelmInstallationMode),
 				WithHelmReleaseName(releaseName),
-				WithEnv("KUMA_DEFAULTS_SKIP_MESH_CREATION", "true"),
+				WithSkipDefaultMesh(true),
 			)).
 			Setup(global)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/federation/federation_kubernetes.go
+++ b/test/e2e/federation/federation_kubernetes.go
@@ -70,6 +70,7 @@ func FederateKubeZoneCPToKubeGlobal() {
 
 	Context("on federation", func() {
 		BeforeAll(func() {
+			By("checking that the client is reachable on the zone")
 			Eventually(func(g Gomega) {
 				_, err := client.CollectEchoResponse(zone, "demo-client", "test-server",
 					client.FromKubernetesPod(TestNamespace, "demo-client"),
@@ -77,9 +78,11 @@ func FederateKubeZoneCPToKubeGlobal() {
 				g.Expect(err).ToNot(HaveOccurred())
 			}, "30s", "1s").Should(Succeed())
 
+			By("exporting the zone")
 			out, err := zone.GetKumactlOptions().RunKumactlAndGetOutput("export", "--profile", "federation", "--format", "kubernetes")
 			Expect(err).ToNot(HaveOccurred())
 
+			By("applying the exported zone resources to global")
 			err = k8s.KubectlApplyFromStringE(global.GetTesting(), global.GetKubectlOptions(), out)
 			Expect(err).ToNot(HaveOccurred())
 			err = zone.(*K8sCluster).UpgradeKuma(core.Zone,

--- a/test/e2e/federation/federation_suite_test.go
+++ b/test/e2e/federation/federation_suite_test.go
@@ -14,6 +14,6 @@ func TestE2E(t *testing.T) {
 }
 
 var (
-	_ = Describe("Federation with Kube Global", Label("job-3"), federation.FederateKubeZoneCPToKubeGlobal, Ordered)
-	_ = Describe("Federation with Universal Global", Label("job-3"), federation.FederateKubeZoneCPToUniversalGlobal, Ordered)
+	_ = FDescribe("Federation with Kube Global", Label("job-3"), federation.FederateKubeZoneCPToKubeGlobal, Ordered)
+	_ = FDescribe("Federation with Universal Global", Label("job-3"), federation.FederateKubeZoneCPToUniversalGlobal, Ordered)
 )

--- a/test/e2e/federation/federation_universal.go
+++ b/test/e2e/federation/federation_universal.go
@@ -76,6 +76,7 @@ func FederateKubeZoneCPToUniversalGlobal() {
 			Expect(global.GetKumactlOptions().RunKumactl("apply", "-f", tmpfile.Name())).To(Succeed())
 			err = zone.(*K8sCluster).UpgradeKuma(core.Zone,
 				WithHelmReleaseName(releaseName),
+				WithHelmWait(),
 				WithGlobalAddress(global.GetKuma().GetKDSServerAddress()),
 			)
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/federation/federation_universal.go
+++ b/test/e2e/federation/federation_universal.go
@@ -30,7 +30,9 @@ func FederateKubeZoneCPToUniversalGlobal() {
 		releaseName = fmt.Sprintf("kuma-%s", strings.ToLower(random.UniqueId()))
 
 		err := NewClusterSetup().
-			Install(Kuma(core.Global, WithEnv("KUMA_DEFAULTS_SKIP_MESH_CREATION", "true"))).
+			Install(Kuma(core.Global,
+				WithSkipDefaultMesh(true),
+			)).
 			Setup(global)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/federation/federation_universal.go
+++ b/test/e2e/federation/federation_universal.go
@@ -84,7 +84,6 @@ func FederateKubeZoneCPToUniversalGlobal() {
 			Expect(global.GetKumactlOptions().RunKumactl("apply", "-f", tmpfile.Name())).To(Succeed())
 			err = zone.(*K8sCluster).UpgradeKuma(core.Zone,
 				WithHelmReleaseName(releaseName),
-				WithHelmWait(),
 				WithGlobalAddress(global.GetKuma().GetKDSServerAddress()),
 			)
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/federation/federation_universal.go
+++ b/test/e2e/federation/federation_universal.go
@@ -48,6 +48,12 @@ func FederateKubeZoneCPToUniversalGlobal() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEachFailure(func() {
+		DebugUniversal(global, "default")
+		DebugKube(zone, "default", TestNamespace)
+		PrintLogs(global, zone)
+	})
+
 	E2EAfterAll(func() {
 		Expect(zone.DeleteNamespace(TestNamespace)).To(Succeed())
 		Expect(zone.DeleteKuma()).To(Succeed())

--- a/test/e2e/federation/utils.go
+++ b/test/e2e/federation/utils.go
@@ -1,0 +1,17 @@
+package federation
+
+import (
+	. "github.com/kumahq/kuma/test/framework"
+)
+
+func PrintLogs(clusters ...Cluster) {
+	for _, cluster := range clusters {
+		Logf("\n\n\n\n\nCP logs of: " + cluster.Name())
+		logs, err := cluster.GetKumaCPLogs()
+		if err != nil {
+			Logf("could not retrieve cp logs")
+		} else {
+			Logf(logs)
+		}
+	}
+}

--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -36,6 +36,7 @@ type kumaDeploymentOptions struct {
 	helmChartVersion            string
 	helmOpts                    map[string]string
 	noHelmOpts                  []string
+	helmWait                    bool
 	env                         map[string]string
 	zoneIngress                 bool
 	zoneIngressEnvoyAdminTunnel bool
@@ -249,6 +250,12 @@ func WithHelmOpt(name, value string) KumaDeploymentOption {
 			o.helmOpts = map[string]string{}
 		}
 		o.helmOpts[name] = value
+	})
+}
+
+func WithHelmWait() KumaDeploymentOption {
+	return KumaOptionFunc(func(o *kumaDeploymentOptions) {
+		o.helmWait = true
 	})
 }
 

--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -36,7 +36,6 @@ type kumaDeploymentOptions struct {
 	helmChartVersion            string
 	helmOpts                    map[string]string
 	noHelmOpts                  []string
-	helmWait                    bool
 	env                         map[string]string
 	zoneIngress                 bool
 	zoneIngressEnvoyAdminTunnel bool
@@ -250,12 +249,6 @@ func WithHelmOpt(name, value string) KumaDeploymentOption {
 			o.helmOpts = map[string]string{}
 		}
 		o.helmOpts[name] = value
-	})
-}
-
-func WithHelmWait() KumaDeploymentOption {
-	return KumaOptionFunc(func(o *kumaDeploymentOptions) {
-		o.helmWait = true
 	})
 }
 

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -397,6 +397,10 @@ func (c *K8sCluster) genValues(mode string) map[string]string {
 		values["controlPlane.envVars.KUMA_IPAM_MESH_MULTI_ZONE_SERVICE_CIDR"] = "fd00:fd03::/64"
 	}
 
+	for key, value := range c.opts.env {
+		values[fmt.Sprintf("controlPlane.envVars.%s", key)] = value
+	}
+
 	switch mode {
 	case core.Global:
 		if !Config.UseLoadBalancer {

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -437,9 +437,17 @@ func (c *K8sCluster) processViaHelm(mode string, fn helmFn) error {
 
 	values := c.genValues(mode)
 
+	var extraArgs map[string][]string
+	if c.opts.helmWait {
+		extraArgs = map[string][]string{
+			"install": {"--wait"},
+			"upgrade": {"--wait"},
+		}
+	}
 	helmOpts := &helm.Options{
 		SetValues:      values,
 		KubectlOptions: c.GetKubectlOptions(Config.KumaNamespace),
+		ExtraArgs:      extraArgs,
 	}
 
 	if c.opts.helmChartVersion != "" {

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -437,17 +437,9 @@ func (c *K8sCluster) processViaHelm(mode string, fn helmFn) error {
 
 	values := c.genValues(mode)
 
-	var extraArgs map[string][]string
-	if c.opts.helmWait {
-		extraArgs = map[string][]string{
-			"install": {"--wait"},
-			"upgrade": {"--wait"},
-		}
-	}
 	helmOpts := &helm.Options{
 		SetValues:      values,
 		KubectlOptions: c.GetKubectlOptions(Config.KumaNamespace),
-		ExtraArgs:      extraArgs,
 	}
 
 	if c.opts.helmChartVersion != "" {


### PR DESCRIPTION
xrel https://github.com/kumahq/kuma/issues/11420

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
