### PR TITLE
refactor(xds): use type for matches hash more

### DIFF
--- a/api/common/v1alpha1/ref.go
+++ b/api/common/v1alpha1/ref.go
@@ -140,6 +140,10 @@ func (b BackendRef) ReferencesRealObject() bool {
 	}
 }
 
+// MatchesHash is used to hash route matches to determine the origin resource
+// for a ref
+type MatchesHash string
+
 type BackendRefHash string
 
 // Hash returns a hash of the BackendRef

--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -14,6 +14,7 @@ import (
 	"github.com/emicklei/go-restful/v3"
 	"k8s.io/apimachinery/pkg/util/validation"
 
+	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	api_types "github.com/kumahq/kuma/api/openapi/types"
 	api_common "github.com/kumahq/kuma/api/openapi/types/common"
@@ -861,7 +862,7 @@ func (r *resourceEndpoints) rulesForResource() restful.RouteFunction {
 			CrossMeshResources: map[core_xds.MeshName]xds_context.ResourceMap{},
 			MeshLocalResources: baseMeshContext.ResourceMap,
 		}
-		matchesByHash := map[string][]meshhttproute_api.Match{}
+		matchesByHash := map[common_api.MatchesHash][]meshhttproute_api.Match{}
 		// Get all the matching policies
 		allPlugins := core_plugins.Plugins().PolicyPlugins(ordered.Policies)
 		rules := []api_common.InspectRule{}
@@ -963,7 +964,7 @@ func (r *resourceEndpoints) rulesForResource() restful.RouteFunction {
 		for k, v := range matchesByHash {
 			httpMatches = append(httpMatches, api_common.HttpMatch{
 				Match: v,
-				Hash:  k,
+				Hash:  string(k),
 			})
 		}
 		sort.Slice(httpMatches, func(i, j int) bool {

--- a/pkg/plugins/policies/core/rules/resourcerules.go
+++ b/pkg/plugins/policies/core/rules/resourcerules.go
@@ -31,7 +31,7 @@ type ResourceRule struct {
 	BackendRefOriginIndex BackendRefOriginIndex
 }
 
-func (r *ResourceRule) GetBackendRefOrigin(hash MatchesHash) (core_model.ResourceMeta, bool) {
+func (r *ResourceRule) GetBackendRefOrigin(hash common_api.MatchesHash) (core_model.ResourceMeta, bool) {
 	if r == nil {
 		return nil, false
 	}
@@ -48,7 +48,7 @@ func (r *ResourceRule) GetBackendRefOrigin(hash MatchesHash) (core_model.Resourc
 	return r.Origin[index].Resource, true
 }
 
-type BackendRefOriginIndex map[MatchesHash]int
+type BackendRefOriginIndex map[common_api.MatchesHash]int
 
 func (originIndex BackendRefOriginIndex) Update(conf interface{}, newIndex int) {
 	switch conf := conf.(type) {
@@ -60,7 +60,7 @@ func (originIndex BackendRefOriginIndex) Update(conf interface{}, newIndex int) 
 		for _, rule := range conf.Rules {
 			if rule.Default.BackendRefs != nil {
 				hash := meshhttproute_api.HashMatches(rule.Matches)
-				originIndex[MatchesHash(hash)] = newIndex
+				originIndex[hash] = newIndex
 			}
 		}
 	default:
@@ -68,9 +68,7 @@ func (originIndex BackendRefOriginIndex) Update(conf interface{}, newIndex int) 
 	}
 }
 
-type MatchesHash string
-
-var EmptyMatches MatchesHash = ""
+var EmptyMatches common_api.MatchesHash = ""
 
 type Origin struct {
 	Resource core_model.ResourceMeta

--- a/pkg/plugins/policies/core/rules/rules.go
+++ b/pkg/plugins/policies/core/rules/rules.go
@@ -271,7 +271,7 @@ type Rule struct {
 	BackendRefOriginIndex BackendRefOriginIndex
 }
 
-func (r *Rule) GetBackendRefOrigin(hash MatchesHash) (core_model.ResourceMeta, bool) {
+func (r *Rule) GetBackendRefOrigin(hash common_api.MatchesHash) (core_model.ResourceMeta, bool) {
 	if r == nil {
 		return nil, false
 	}
@@ -440,7 +440,7 @@ func buildToList(p core_model.Resource, httpRoutes []core_model.Resource) ([]cor
 					targetRef = common_api.TargetRef{
 						Kind: common_api.MeshSubset,
 						Tags: map[string]string{
-							RuleMatchesHashTag: matchesHash,
+							RuleMatchesHashTag: string(matchesHash),
 						},
 					}
 				default:
@@ -448,7 +448,7 @@ func buildToList(p core_model.Resource, httpRoutes []core_model.Resource) ([]cor
 						Kind: common_api.MeshServiceSubset,
 						Name: mhrRules.TargetRef.Name,
 						Tags: map[string]string{
-							RuleMatchesHashTag: matchesHash,
+							RuleMatchesHashTag: string(matchesHash),
 						},
 					}
 				}

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/compare.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/compare.go
@@ -95,7 +95,7 @@ type Route struct {
 	Match       Match
 	Filters     []Filter
 	BackendRefs []core_model.ResolvedBackendRef
-	Hash        string
+	Hash        common_api.MatchesHash
 }
 
 // SortRules orders the rules according to Gateway API precedence:
@@ -104,7 +104,7 @@ type Route struct {
 // same as prefix matches, the longer length match has priority.
 func SortRules(
 	rules []Rule,
-	backendRefToOrigin map[string]core_model.ResourceMeta,
+	backendRefToOrigin map[common_api.MatchesHash]core_model.ResourceMeta,
 	labelResolver core_model.LabelResourceIdentifierResolver,
 ) []Route {
 	type keyed struct {

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/meshhttproute.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/meshhttproute.go
@@ -52,10 +52,10 @@ type Rule struct {
 	Default RuleConf `json:"default"`
 }
 
-func HashMatches(m []Match) string {
+func HashMatches(m []Match) common_api.MatchesHash {
 	bytes, _ := json.Marshal(m)
 	h := sha256.Hash(string(bytes))
-	return h
+	return common_api.MatchesHash(h)
 }
 
 type Match struct {

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/gateway_routes.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/gateway_routes.go
@@ -66,10 +66,10 @@ func sortRulesToHosts(
 		for _, rawRule := range rawRules {
 			conf := rawRule.Conf.(api.PolicyDefault)
 
-			backendRefOrigin := map[string]model.ResourceMeta{}
+			backendRefOrigin := map[common_api.MatchesHash]model.ResourceMeta{}
 			for hash := range rawRule.BackendRefOriginIndex {
 				if origin, ok := rawRule.GetBackendRefOrigin(hash); ok {
-					backendRefOrigin[string(hash)] = origin
+					backendRefOrigin[hash] = origin
 				}
 			}
 			rule := ToRouteRule{
@@ -201,7 +201,7 @@ func generateEnvoyRouteEntries(
 			for _, m := range rule.Matches {
 				routeEntry := entry // Shallow copy.
 				routeEntry.Match = makeRouteMatch(m)
-				routeEntry.Name = hashedMatches
+				routeEntry.Name = string(hashedMatches)
 
 				switch {
 				case routeEntry.Match.ExactPath != "":
@@ -221,7 +221,7 @@ func generateEnvoyRouteEntries(
 func makeHttpRouteEntry(
 	name string,
 	rule api.Rule,
-	backendRefToOrigin map[string]model.ResourceMeta,
+	backendRefToOrigin map[common_api.MatchesHash]model.ResourceMeta,
 	resolver model.LabelResourceIdentifierResolver,
 ) route.Entry {
 	entry := route.Entry{

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
@@ -142,17 +142,17 @@ func generateListeners(
 	return resources, nil
 }
 
-func ComputeHTTPRouteConf(toRules rules.ToRules, svc meshroute_xds.DestinationService, meshCtx xds_context.MeshContext) (*api.PolicyDefault, map[string]core_model.ResourceMeta) {
+func ComputeHTTPRouteConf(toRules rules.ToRules, svc meshroute_xds.DestinationService, meshCtx xds_context.MeshContext) (*api.PolicyDefault, map[common_api.MatchesHash]core_model.ResourceMeta) {
 	// compute for old MeshService
 	var conf *api.PolicyDefault
-	backendRefOrigin := map[string]core_model.ResourceMeta{}
+	backendRefOrigin := map[common_api.MatchesHash]core_model.ResourceMeta{}
 
 	ruleHTTP := toRules.Rules.Compute(core_rules.MeshService(svc.ServiceName))
 	if ruleHTTP != nil {
 		conf = pointer.To(ruleHTTP.Conf.(api.PolicyDefault))
 		for hash := range ruleHTTP.BackendRefOriginIndex {
 			if origin, ok := ruleHTTP.GetBackendRefOrigin(hash); ok {
-				backendRefOrigin[string(hash)] = origin
+				backendRefOrigin[hash] = origin
 			}
 		}
 	}
@@ -163,7 +163,7 @@ func ComputeHTTPRouteConf(toRules rules.ToRules, svc meshroute_xds.DestinationSe
 			conf = pointer.To(resourceConf.Conf[0].(api.PolicyDefault))
 			for hash := range resourceConf.BackendRefOriginIndex {
 				if origin, ok := resourceConf.GetBackendRefOrigin(hash); ok {
-					backendRefOrigin[string(hash)] = origin
+					backendRefOrigin[hash] = origin
 				}
 			}
 		}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/merge_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/merge_test.go
@@ -141,9 +141,9 @@ var _ = DescribeTable("MatchedPolicies", func(given policiesTestCase) {
 						Name: "route-2",
 					},
 				},
-				BackendRefOriginIndex: map[core_rules.MatchesHash]int{
-					core_rules.MatchesHash(api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/v1"}}})): 1,
-					core_rules.MatchesHash(api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/v2"}}})): 1,
+				BackendRefOriginIndex: map[common_api.MatchesHash]int{
+					api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/v1"}}}): 1,
+					api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/v2"}}}): 1,
 				},
 			},
 		},
@@ -238,8 +238,8 @@ var _ = DescribeTable("MatchedPolicies", func(given policiesTestCase) {
 						Name: "a-route",
 					},
 				},
-				BackendRefOriginIndex: map[core_rules.MatchesHash]int{
-					core_rules.MatchesHash(api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/v1"}}})): 1,
+				BackendRefOriginIndex: map[common_api.MatchesHash]int{
+					api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/v1"}}}): 1,
 				},
 			},
 		},
@@ -490,13 +490,13 @@ var _ = DescribeTable("MatchedPolicies", func(given policiesTestCase) {
 						Name: "a-route",
 					},
 				},
-				BackendRefOriginIndex: map[core_rules.MatchesHash]int{
-					core_rules.MatchesHash(api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/a-first-prefix"}}})):                 1,
-					core_rules.MatchesHash(api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/a-second-prefix"}}})):                1,
-					core_rules.MatchesHash(api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/b-first-prefix"}}})):                 0,
-					core_rules.MatchesHash(api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/b-second-prefix"}}})):                0,
-					core_rules.MatchesHash(api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/should-be-first-shared-prefix"}}})):  1,
-					core_rules.MatchesHash(api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/should-be-second-shared-prefix"}}})): 1,
+				BackendRefOriginIndex: map[common_api.MatchesHash]int{
+					api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/a-first-prefix"}}}):                 1,
+					api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/a-second-prefix"}}}):                1,
+					api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/b-first-prefix"}}}):                 0,
+					api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/b-second-prefix"}}}):                0,
+					api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/should-be-first-shared-prefix"}}}):  1,
+					api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/should-be-second-shared-prefix"}}}): 1,
 				},
 			},
 		},

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
@@ -29,7 +30,7 @@ type ToRouteRule struct {
 	Hostnames []string
 
 	Origins          []core_model.ResourceMeta
-	BackendRefOrigin map[string]core_model.ResourceMeta
+	BackendRefOrigin map[common_api.MatchesHash]core_model.ResourceMeta
 }
 
 type plugin struct{}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
@@ -499,8 +499,8 @@ var _ = Describe("MeshHTTPRoute", func() {
 							Origin: []core_rules.Origin{
 								{Resource: &test_model.ResourceMeta{Mesh: "default", Name: "http-route"}},
 							},
-							BackendRefOriginIndex: map[core_rules.MatchesHash]int{
-								core_rules.MatchesHash(api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/v1"}}})): 0,
+							BackendRefOriginIndex: map[common_api.MatchesHash]int{
+								api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/v1"}}}): 0,
 							},
 							Conf: []interface{}{
 								api.PolicyDefault{
@@ -827,13 +827,13 @@ var _ = Describe("MeshHTTPRoute", func() {
 										Origin: []core_rules.Origin{
 											{Resource: &test_model.ResourceMeta{Mesh: "default", Name: "http-route"}},
 										},
-										BackendRefOriginIndex: map[core_rules.MatchesHash]int{
-											core_rules.MatchesHash(api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/v1"}}})): 0,
-											core_rules.MatchesHash(api.HashMatches([]api.Match{
+										BackendRefOriginIndex: map[common_api.MatchesHash]int{
+											api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/v1"}}}): 0,
+											api.HashMatches([]api.Match{
 												{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/v2"}},
 												{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/v3"}},
-											})): 0,
-											core_rules.MatchesHash(api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/v4"}}})): 0,
+											}): 0,
+											api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/v4"}}}): 0,
 										},
 										Conf: []interface{}{
 											api.PolicyDefault{
@@ -1013,9 +1013,9 @@ var _ = Describe("MeshHTTPRoute", func() {
 										Origin: []core_rules.Origin{
 											{Resource: &test_model.ResourceMeta{Mesh: "default", Name: "http-route"}},
 										},
-										BackendRefOriginIndex: map[core_rules.MatchesHash]int{
-											core_rules.MatchesHash(api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/version1"}}})): 0,
-											core_rules.MatchesHash(api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/version2"}}})): 0,
+										BackendRefOriginIndex: map[common_api.MatchesHash]int{
+											api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/version1"}}}): 0,
+											api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/version2"}}}): 0,
 										},
 										Resource: meshSvc.Meta,
 										Conf: []interface{}{
@@ -1881,8 +1881,8 @@ var _ = Describe("MeshHTTPRoute", func() {
 					Origin: []core_model.ResourceMeta{
 						&test_model.ResourceMeta{Mesh: "default", Name: "http-route"},
 					},
-					BackendRefOriginIndex: map[core_rules.MatchesHash]int{
-						core_rules.MatchesHash(api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/"}}})): 0,
+					BackendRefOriginIndex: map[common_api.MatchesHash]int{
+						api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/"}}}): 0,
 					},
 					Conf: api.PolicyDefault{
 						Rules: []api.Rule{{

--- a/pkg/plugins/policies/meshhttproute/xds/builder.go
+++ b/pkg/plugins/policies/meshhttproute/xds/builder.go
@@ -14,7 +14,7 @@ import (
 )
 
 type OutboundRoute struct {
-	Hash                    string
+	Hash                    common_api.MatchesHash
 	Match                   api.Match
 	Filters                 []api.Filter
 	Split                   []envoy_common.Split

--- a/pkg/plugins/policies/meshhttproute/xds/configurer.go
+++ b/pkg/plugins/policies/meshhttproute/xds/configurer.go
@@ -15,7 +15,7 @@ import (
 )
 
 type RoutesConfigurer struct {
-	Hash                    string
+	Hash                    common_api.MatchesHash
 	Match                   api.Match
 	Filters                 []api.Filter
 	Split                   []envoy_common.Split
@@ -26,7 +26,7 @@ func (c RoutesConfigurer) Configure(virtualHost *envoy_route.VirtualHost) error 
 	matches := c.routeMatch(c.Match)
 
 	for _, match := range matches {
-		rb := envoy_routes.NewRouteBuilder(envoy_common.APIV3, c.Hash).
+		rb := envoy_routes.NewRouteBuilder(envoy_common.APIV3, string(c.Hash)).
 			Configure(envoy_routes.RouteMustConfigureFunc(func(envoyRoute *envoy_route.Route) {
 				// todo: create configurers for Match and Action
 				envoyRoute.Match = match.routeMatch

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
@@ -190,7 +190,7 @@ var _ = Describe("MeshTCPRoute", func() {
 								Name: "route-2",
 							},
 						},
-						BackendRefOriginIndex: map[core_rules.MatchesHash]int{
+						BackendRefOriginIndex: map[common_api.MatchesHash]int{
 							core_rules.EmptyMatches: 1,
 						},
 					},
@@ -469,7 +469,7 @@ var _ = Describe("MeshTCPRoute", func() {
 							Origin: []core_rules.Origin{
 								{Resource: &test_model.ResourceMeta{Mesh: "default", Name: "tcp-route"}},
 							},
-							BackendRefOriginIndex: map[core_rules.MatchesHash]int{
+							BackendRefOriginIndex: map[common_api.MatchesHash]int{
 								core_rules.EmptyMatches: 0,
 							},
 							Conf: []interface{}{
@@ -612,7 +612,7 @@ var _ = Describe("MeshTCPRoute", func() {
 										Origin: []core_rules.Origin{
 											{Resource: &test_model.ResourceMeta{Mesh: "default", Name: "tcp-route"}},
 										},
-										BackendRefOriginIndex: map[core_rules.MatchesHash]int{
+										BackendRefOriginIndex: map[common_api.MatchesHash]int{
 											core_rules.EmptyMatches: 0,
 										},
 										Conf: []interface{}{


### PR DESCRIPTION
Just an improvement I noticed, helpful for understanding semantics of the values passed around.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
