### PR TITLE
fix(kuma-cp): validation for explicit DPP outbounds with BackendRef

### DIFF
--- a/pkg/core/resources/apis/mesh/dataplane_validator.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator.go
@@ -233,8 +233,8 @@ func validateOutbound(outbound *mesh_proto.Dataplane_Networking_Outbound) valida
 		if _, allowed := allowedKinds[outbound.BackendRef.Kind]; !allowed {
 			result.AddViolation("backendRef.kind", fmt.Sprintf("invalid value. Available values are: %s", strings.Join(maps.SortedKeys(allowedKinds), ",")))
 		}
-		if outbound.BackendRef.Name == "" {
-			result.AddViolation("backendRef.name", "cannot be empty")
+		if outbound.BackendRef.Name == "" && len(outbound.BackendRef.Labels) == 0 {
+			result.AddViolation("backendRef", "either 'name' or 'labels' should be specified")
 		}
 		// for MeshExternalService the port does not matter because it's taken from endpoints
 		if outbound.BackendRef.Kind != string(common_api.MeshExternalService) {

--- a/pkg/core/resources/apis/mesh/dataplane_validator_test.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator_test.go
@@ -337,6 +337,25 @@ var _ = Describe("Dataplane", func() {
                     labels:
                       kuma.io/test: abc`,
 		),
+		Entry("dataplane with backend ref with labels", `
+            type: Dataplane
+            name: dp-1
+            mesh: default
+            networking:
+              address: 192.168.0.1
+              inbound:
+                - port: 8080
+                  tags:
+                    kuma.io/service: backend
+                    version: "1"
+              outbound:
+                - port: 3333
+                  backendRef:
+                    kind: MeshService
+                    labels:
+                      kuma.io/display-name: redis
+                    port: 8080`,
+		),
 	)
 
 	type testCase struct {
@@ -1237,8 +1256,8 @@ var _ = Describe("Dataplane", func() {
                 violations:
                 - field: networking.outbound[0].backendRef.kind
                   message: 'invalid value. Available values are: MeshExternalService,MeshMultiZoneService,MeshService'
-                - field: networking.outbound[0].backendRef.name
-                  message: cannot be empty
+                - field: networking.outbound[0].backendRef
+                  message:  either 'name' or 'labels' should be specified
                 - field: networking.outbound[0].backendRef.port
                   message: port must be in the range [1, 65535]`,
 		}),


### PR DESCRIPTION
Fix validation when `DPP.Outbound[].backendRef` has only `labels` (it used to require `name`).

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
