### PR TITLE
refactor(MeshGateway): don't call unused FromTargetRef

### DIFF
--- a/pkg/plugins/policies/core/xds/meshroute/gateway/gateway.go
+++ b/pkg/plugins/policies/core/xds/meshroute/gateway/gateway.go
@@ -30,7 +30,7 @@ type listenersHostnames struct {
 }
 
 type MapGatewayRulesToHosts func(
-	meshCtx xds_context.MeshContext,
+	meshLocalResources xds_context.ResourceMap,
 	rules rules.GatewayRules,
 	address string,
 	port uint32,
@@ -99,7 +99,7 @@ func CollectListenerInfos(
 		}
 
 		hostInfos := mapRules(
-			meshCtx,
+			meshCtx.Resources.MeshLocalResources,
 			rawRules,
 			networking.Address,
 			listener.listener.GetPort(),

--- a/pkg/plugins/policies/core/xds/meshroute/gateway/gateway.go
+++ b/pkg/plugins/policies/core/xds/meshroute/gateway/gateway.go
@@ -30,7 +30,7 @@ type listenersHostnames struct {
 }
 
 type MapGatewayRulesToHosts func(
-	resources xds_context.ResourceMap,
+	meshCtx xds_context.MeshContext,
 	rules rules.GatewayRules,
 	address string,
 	port uint32,
@@ -99,7 +99,7 @@ func CollectListenerInfos(
 		}
 
 		hostInfos := mapRules(
-			meshCtx.Resources.MeshLocalResources,
+			meshCtx,
 			rawRules,
 			networking.Address,
 			listener.listener.GetPort(),

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/gateway_routes.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/gateway_routes.go
@@ -28,7 +28,7 @@ type ruleByHostname struct {
 }
 
 func sortRulesToHosts(
-	meshCtx xds_context.MeshContext,
+	meshLocalResources xds_context.ResourceMap,
 	rawRules rules.GatewayRules,
 	address string,
 	port uint32,
@@ -147,7 +147,7 @@ func sortRulesToHosts(
 			for _, t := range plugin_gateway.ConnectionPolicyTypes {
 				matches := match.ConnectionPoliciesBySource(
 					host.Tags,
-					match.ToConnectionPolicies(meshCtx.Resources.MeshLocalResources[t]))
+					match.ToConnectionPolicies(meshLocalResources[t]))
 				host.Policies[t] = matches
 			}
 			hostInfo := plugin_gateway.GatewayHostInfo{

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/gateway.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/gateway.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/pkg/errors"
 
+	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
 	api "github.com/kumahq/kuma/pkg/plugins/policies/meshtcproute/api/v1alpha1"
@@ -67,7 +69,11 @@ func generateGatewayClusters(
 	return resources, nil
 }
 
-func generateEnvoyRouteEntries(host plugin_gateway.GatewayHost, toRules rules.Rules) []route.Entry {
+func generateEnvoyRouteEntries(
+	host plugin_gateway.GatewayHost,
+	toRules rules.Rules,
+	resolver model.LabelResourceIdentifierResolver,
+) []route.Entry {
 	var entries []route.Entry
 
 	for _, rule := range toRules {
@@ -76,25 +82,49 @@ func generateEnvoyRouteEntries(host plugin_gateway.GatewayHost, toRules rules.Ru
 			names = append(names, orig.GetName())
 		}
 		slices.Sort(names)
-		entries = append(entries, makeTcpRouteEntry(strings.Join(names, "_"), rule.Conf.(api.Rule)))
+
+		backendRefOrigin := map[common_api.MatchesHash]model.ResourceMeta{}
+		for hash := range rule.BackendRefOriginIndex {
+			if origin, ok := rule.GetBackendRefOrigin(rules.EmptyMatches); ok {
+				backendRefOrigin[hash] = origin
+			}
+		}
+		entries = append(
+			entries,
+			makeTcpRouteEntry(strings.Join(names, "_"), rule.Conf.(api.Rule), backendRefOrigin, resolver),
+		)
 	}
 
 	return plugin_gateway.HandlePrefixMatchesAndPopulatePolicies(host, nil, nil, entries)
 }
 
-func makeTcpRouteEntry(name string, rule api.Rule) route.Entry {
+func makeTcpRouteEntry(
+	name string,
+	rule api.Rule,
+	backendRefToOrigin map[common_api.MatchesHash]model.ResourceMeta,
+	resolver model.LabelResourceIdentifierResolver,
+) route.Entry {
 	entry := route.Entry{
 		Route: name,
 	}
 
 	for _, b := range rule.Default.BackendRefs {
-		dest, ok := tags.FromTargetRef(b.TargetRef)
-		if !ok {
-			// This should be caught by validation
-			continue
+		var ref *model.ResolvedBackendRef
+		if origin, ok := backendRefToOrigin[rules.EmptyMatches]; ok {
+			ref = model.ResolveBackendRef(origin, b, resolver)
+		}
+		var dest map[string]string
+		if ref == nil || ref.Resource == nil {
+			var ok bool
+			dest, ok = tags.FromLegacyTargetRef(b.TargetRef)
+			if !ok {
+				// This should be caught by validation
+				continue
+			}
 		}
 		target := route.Destination{
 			Destination:   dest,
+			BackendRef:    ref,
 			Weight:        uint32(*b.Weight),
 			Policies:      nil,
 			RouteProtocol: core_mesh.ProtocolTCP,

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin.go
@@ -157,13 +157,13 @@ func ApplyToGateway(
 }
 
 func sortRulesToHosts(
-	meshLocalResources xds_context.ResourceMap,
+	meshCtx xds_context.MeshContext,
 	rawRules rules.GatewayRules,
 	address string,
 	port uint32,
 	protocol mesh_proto.MeshGateway_Listener_Protocol,
 	sublisteners []meshroute_gateway.Sublistener,
-	_ model.LabelResourceIdentifierResolver,
+	resolver model.LabelResourceIdentifierResolver,
 ) []plugin_gateway.GatewayListenerHostname {
 	hostInfosByHostname := map[string]plugin_gateway.GatewayListenerHostname{}
 	for _, hostnameTag := range sublisteners {
@@ -185,7 +185,7 @@ func sortRulesToHosts(
 		if !ok {
 			continue
 		}
-		hostInfo.AppendEntries(generateEnvoyRouteEntries(host, rulesForListener))
+		hostInfo.AppendEntries(generateEnvoyRouteEntries(host, rulesForListener, resolver))
 		meshroute_gateway.AddToListenerByHostname(
 			hostInfosByHostname,
 			protocol,

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin.go
@@ -157,7 +157,7 @@ func ApplyToGateway(
 }
 
 func sortRulesToHosts(
-	meshCtx xds_context.MeshContext,
+	_ xds_context.ResourceMap,
 	rawRules rules.GatewayRules,
 	address string,
 	port uint32,

--- a/pkg/plugins/runtime/gateway/cluster_generator.go
+++ b/pkg/plugins/runtime/gateway/cluster_generator.go
@@ -179,7 +179,7 @@ func (c *ClusterGenerator) generateRealBackendRefCluster(
 		edsClusterBuilder.Configure(clusters.Http())
 	default:
 	}
-	// Note: these tags are just used to get a hash!
+	// Note: these tags are just used to get a cluster name!
 	tags := map[string]string{
 		mesh_proto.ServiceTag: service,
 	}

--- a/pkg/xds/envoy/tags/match.go
+++ b/pkg/xds/envoy/tags/match.go
@@ -109,14 +109,12 @@ func (t Tags) String() string {
 	return strings.Join(pairs, ",")
 }
 
-func FromTargetRef(targetRef common_api.TargetRef) (Tags, bool) {
+func FromLegacyTargetRef(targetRef common_api.TargetRef) (Tags, bool) {
 	var service string
 	tags := Tags{}
 
 	switch targetRef.Kind {
 	case common_api.MeshService:
-		service = targetRef.Name
-	case common_api.MeshExternalService:
 		service = targetRef.Name
 	case common_api.MeshServiceSubset:
 		service = targetRef.Name

--- a/pkg/xds/generator/zoneproxy/destinations.go
+++ b/pkg/xds/generator/zoneproxy/destinations.go
@@ -245,7 +245,7 @@ func addMeshHTTPRouteDestinations(
 	// iterating through them.
 	for _, policy := range policies {
 		for _, to := range policy.Spec.To {
-			if toTags, ok := tags.FromTargetRef(to.TargetRef); ok {
+			if toTags, ok := tags.FromLegacyTargetRef(to.TargetRef); ok {
 				addMeshHTTPRouteToDestinations(to.Rules, toTags, destinations)
 			}
 		}
@@ -266,7 +266,7 @@ func addMeshTCPRouteDestinations(
 	// iterating through them.
 	for _, policy := range policies {
 		for _, to := range policy.Spec.To {
-			if toTags, ok := tags.FromTargetRef(to.TargetRef); ok {
+			if toTags, ok := tags.FromLegacyTargetRef(to.TargetRef); ok {
 				addMeshTCPRouteToDestinations(to.Rules, toTags, destinations)
 			}
 		}
@@ -285,7 +285,7 @@ func addMeshHTTPRouteToDestinations(
 		}
 
 		for _, backendRef := range pointer.Deref(rule.Default.BackendRefs) {
-			if tags, ok := tags.FromTargetRef(backendRef.TargetRef); ok {
+			if tags, ok := tags.FromLegacyTargetRef(backendRef.TargetRef); ok {
 				addDestination(tags, destinations)
 			}
 		}
@@ -304,7 +304,7 @@ func addMeshTCPRouteToDestinations(
 		}
 
 		for _, backendRef := range rule.Default.BackendRefs {
-			if tags, ok := tags.FromTargetRef(backendRef.TargetRef); ok {
+			if tags, ok := tags.FromLegacyTargetRef(backendRef.TargetRef); ok {
 				addDestination(tags, destinations)
 			}
 		}

--- a/test/e2e_env/kubernetes/gateway/gateway.go
+++ b/test/e2e_env/kubernetes/gateway/gateway.go
@@ -3,6 +3,8 @@ package gateway
 import (
 	"encoding/base64"
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 	"time"
 
@@ -1218,6 +1220,9 @@ spec:
 
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(responses).To(HaveLen(1))
+				g.Expect(responses).To(HaveKey(HavePrefix("mes-echo-server")))
+				counts := slices.Collect(maps.Values(responses))
+				g.Expect(counts[0]).To(Equal(10))
 			}, "30s", "1s").MustPassRepeatedly(5).Should(Succeed())
 		})
 	})


### PR DESCRIPTION
By _not_ requiring the call to `FromTargetRef`, this enables `MeshMultiZoneService`.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- #11325
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
