### PR TITLE
fix(kuma-cp): couldn't use `to[].targetRef: Mesh` on non-federated zones

### DIFF
--- a/pkg/api-server/testdata/resources/crud/put_circuitbreaker_01.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_circuitbreaker_01.golden.json
@@ -5,10 +5,7 @@
  "creationTime": "0001-01-01T00:00:00Z",
  "modificationTime": "0001-01-01T00:00:00Z",
  "labels": {
-  "kuma.io/env": "universal",
-  "kuma.io/mesh": "default",
-  "kuma.io/origin": "zone",
-  "kuma.io/zone": "default"
+  "kuma.io/mesh": "default"
  },
  "sources": [
   {

--- a/pkg/api-server/testdata/resources/crud/put_faultinjection_01.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_faultinjection_01.golden.json
@@ -5,10 +5,7 @@
  "creationTime": "0001-01-01T00:00:00Z",
  "modificationTime": "0001-01-01T00:00:00Z",
  "labels": {
-  "kuma.io/env": "universal",
-  "kuma.io/mesh": "default",
-  "kuma.io/origin": "zone",
-  "kuma.io/zone": "default"
+  "kuma.io/mesh": "default"
  },
  "sources": [
   {

--- a/pkg/api-server/testdata/resources/crud/put_globalsecret_01.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_globalsecret_01.golden.json
@@ -3,10 +3,5 @@
  "name": "sec-1",
  "creationTime": "0001-01-01T00:00:00Z",
  "modificationTime": "0001-01-01T00:00:00Z",
- "labels": {
-  "kuma.io/env": "universal",
-  "kuma.io/origin": "zone",
-  "kuma.io/zone": "default"
- },
  "data": "dGVzdAo="
 }

--- a/pkg/api-server/testdata/resources/crud/put_healthcheck_01.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_healthcheck_01.golden.json
@@ -5,10 +5,7 @@
  "creationTime": "0001-01-01T00:00:00Z",
  "modificationTime": "0001-01-01T00:00:00Z",
  "labels": {
-  "kuma.io/env": "universal",
-  "kuma.io/mesh": "default",
-  "kuma.io/origin": "zone",
-  "kuma.io/zone": "default"
+  "kuma.io/mesh": "default"
  },
  "sources": [
   {

--- a/pkg/api-server/testdata/resources/crud/put_secret_01.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_secret_01.golden.json
@@ -5,10 +5,7 @@
  "creationTime": "0001-01-01T00:00:00Z",
  "modificationTime": "0001-01-01T00:00:00Z",
  "labels": {
-  "kuma.io/env": "universal",
-  "kuma.io/mesh": "default",
-  "kuma.io/origin": "zone",
-  "kuma.io/zone": "default"
+  "kuma.io/mesh": "default"
  },
  "data": "dGVzdAo="
 }

--- a/pkg/api-server/testdata/resources/crud/put_trafficroute_01.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_trafficroute_01.golden.json
@@ -5,10 +5,7 @@
  "creationTime": "0001-01-01T00:00:00Z",
  "modificationTime": "0001-01-01T00:00:00Z",
  "labels": {
-  "kuma.io/env": "universal",
-  "kuma.io/mesh": "default",
-  "kuma.io/origin": "zone",
-  "kuma.io/zone": "default"
+  "kuma.io/mesh": "default"
  },
  "sources": [
   {

--- a/pkg/api-server/testdata/resources/crud/put_traffictrace_01.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_traffictrace_01.golden.json
@@ -5,10 +5,7 @@
  "creationTime": "0001-01-01T00:00:00Z",
  "modificationTime": "0001-01-01T00:00:00Z",
  "labels": {
-  "kuma.io/env": "universal",
-  "kuma.io/mesh": "default",
-  "kuma.io/origin": "zone",
-  "kuma.io/zone": "default"
+  "kuma.io/mesh": "default"
  },
  "selectors": [
   {

--- a/pkg/core/resources/model/resource.go
+++ b/pkg/core/resources/model/resource.go
@@ -482,7 +482,12 @@ func ComputeLabels(r Resource, mode config_core.CpMode, isK8s bool, systemNamesp
 	if mode == config_core.Zone {
 		setIfNotExist(mesh_proto.ResourceOriginLabel, string(mesh_proto.ZoneResourceOrigin))
 		if labels[mesh_proto.ResourceOriginLabel] != string(mesh_proto.GlobalResourceOrigin) {
-			setIfNotExist(mesh_proto.ZoneTag, localZone)
+			// If resource can't be created on Zone (like Mesh), there is no point in adding 'kuma.io/zone'
+			// even if the zone is non-federated
+			if r.Descriptor().KDSFlags.Has(AllowedOnZoneSelector) {
+				setIfNotExist(mesh_proto.ZoneTag, localZone)
+			}
+
 			env := mesh_proto.UniversalEnvironment
 			if isK8s {
 				env = mesh_proto.KubernetesEnvironment

--- a/pkg/core/resources/model/resource.go
+++ b/pkg/core/resources/model/resource.go
@@ -480,19 +480,18 @@ func ComputeLabels(r Resource, mode config_core.CpMode, isK8s bool, systemNamesp
 	}
 
 	if mode == config_core.Zone {
-		setIfNotExist(mesh_proto.ResourceOriginLabel, string(mesh_proto.ZoneResourceOrigin))
-		if labels[mesh_proto.ResourceOriginLabel] != string(mesh_proto.GlobalResourceOrigin) {
-			// If resource can't be created on Zone (like Mesh), there is no point in adding 'kuma.io/zone'
-			// even if the zone is non-federated
-			if r.Descriptor().KDSFlags.Has(AllowedOnZoneSelector) {
+		// If resource can't be created on Zone (like Mesh), there is no point in adding
+		// 'kuma.io/zone', 'kuma.io/origin' and 'kuma.io/env' labels even if the zone is non-federated
+		if r.Descriptor().KDSFlags.Has(AllowedOnZoneSelector) {
+			setIfNotExist(mesh_proto.ResourceOriginLabel, string(mesh_proto.ZoneResourceOrigin))
+			if labels[mesh_proto.ResourceOriginLabel] != string(mesh_proto.GlobalResourceOrigin) {
 				setIfNotExist(mesh_proto.ZoneTag, localZone)
+				env := mesh_proto.UniversalEnvironment
+				if isK8s {
+					env = mesh_proto.KubernetesEnvironment
+				}
+				setIfNotExist(mesh_proto.EnvTag, env)
 			}
-
-			env := mesh_proto.UniversalEnvironment
-			if isK8s {
-				env = mesh_proto.KubernetesEnvironment
-			}
-			setIfNotExist(mesh_proto.EnvTag, env)
 		}
 	}
 

--- a/pkg/core/resources/model/resource_test.go
+++ b/pkg/core/resources/model/resource_test.go
@@ -10,12 +10,15 @@ import (
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/pkg/config/core"
+	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/kds"
 	"github.com/kumahq/kuma/pkg/kds/context"
 	reconcile_v2 "github.com/kumahq/kuma/pkg/kds/v2/reconcile"
 	policies_api "github.com/kumahq/kuma/pkg/plugins/policies/meshaccesslog/api/v1alpha1"
 	meshtimeout_api "github.com/kumahq/kuma/pkg/plugins/policies/meshtimeout/api/v1alpha1"
+	"github.com/kumahq/kuma/pkg/test/kds/samples"
 	"github.com/kumahq/kuma/pkg/test/resources/builders"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
 )
@@ -258,6 +261,86 @@ var _ = Describe("ComputePolicyRole", func() {
 				Build().Spec,
 			namespace:    "kuma-demo",
 			expectedRole: mesh_proto.WorkloadOwnerPolicyRole,
+		}),
+	)
+})
+
+var _ = Describe("ComputeLabels", func() {
+	type testCase struct {
+		r              core_model.Resource
+		mode           core.CpMode
+		isK8s          bool
+		localZone      string
+		expectedLabels map[string]string
+	}
+
+	DescribeTable("should return correct label map",
+		func(given testCase) {
+			labels, err := core_model.ComputeLabels(given.r, given.mode, given.isK8s, "kuma-system", given.localZone)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(labels).To(Equal(given.expectedLabels))
+		},
+		Entry("plugin originated policy on zone-k8s", testCase{
+			mode:      core.Zone,
+			isK8s:     true,
+			localZone: "zone-1",
+			r: builders.MeshTimeout().
+				WithMesh("mesh-1").WithName("idle-timeout").
+				WithTargetRef(builders.TargetRefMesh()).
+				AddTo(builders.TargetRefMesh(), meshtimeout_api.Conf{
+					IdleTimeout: &kube_meta.Duration{Duration: 123 * time.Second},
+				}).
+				Build(),
+			expectedLabels: map[string]string{
+				"kuma.io/env":    "kubernetes",
+				"kuma.io/mesh":   "mesh-1",
+				"kuma.io/origin": "zone",
+				"kuma.io/zone":   "zone-1",
+			},
+		}),
+		Entry("source/destination policy on zone-k8s", testCase{
+			mode:      core.Zone,
+			isK8s:     true,
+			localZone: "zone-1",
+			r: &mesh.TimeoutResource{
+				Spec: samples.Timeout,
+				Meta: &test_model.ResourceMeta{Mesh: "mesh-1", Name: "sample-timeout"},
+			},
+			expectedLabels: map[string]string{
+				"kuma.io/mesh": "mesh-1",
+			},
+		}),
+		Entry("mesh resource on non-federated zone", testCase{
+			mode:      core.Zone,
+			isK8s:     true,
+			localZone: "zone-1",
+			r: &mesh.MeshResource{
+				Spec: samples.Mesh1,
+				Meta: &test_model.ResourceMeta{Mesh: core_model.NoMesh, Name: "mesh-1"},
+			},
+			expectedLabels: map[string]string{},
+		}),
+		Entry("plugin originated policy on zone-k8s on custom namespace", testCase{
+			mode:      core.Zone,
+			isK8s:     true,
+			localZone: "zone-1",
+			r: builders.MeshTimeout().
+				WithMesh("mesh-1").
+				WithName("idle-timeout").
+				WithNamespace("custom-ns").
+				WithTargetRef(builders.TargetRefMesh()).
+				AddTo(builders.TargetRefMesh(), meshtimeout_api.Conf{
+					IdleTimeout: &kube_meta.Duration{Duration: 123 * time.Second},
+				}).
+				Build(),
+			expectedLabels: map[string]string{
+				"k8s.kuma.io/namespace": "custom-ns",
+				"kuma.io/policy-role":   "consumer",
+				"kuma.io/mesh":          "mesh-1",
+				"kuma.io/origin":        "zone",
+				"kuma.io/zone":          "zone-1",
+				"kuma.io/env":           "kubernetes",
+			},
 		}),
 	)
 })

--- a/pkg/test/resources/builders/meshtimeout_builder.go
+++ b/pkg/test/resources/builders/meshtimeout_builder.go
@@ -2,6 +2,7 @@ package builders
 
 import (
 	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
+	"github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	meshtimeout_api "github.com/kumahq/kuma/pkg/plugins/policies/meshtimeout/api/v1alpha1"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
@@ -36,6 +37,14 @@ func (m *MeshTimeoutBuilder) WithName(name string) *MeshTimeoutBuilder {
 
 func (m *MeshTimeoutBuilder) WithMesh(mesh string) *MeshTimeoutBuilder {
 	m.res.Meta.(*test_model.ResourceMeta).Mesh = mesh
+	return m
+}
+
+func (m *MeshTimeoutBuilder) WithNamespace(namespace string) *MeshTimeoutBuilder {
+	if m.res.Meta.(*test_model.ResourceMeta).NameExtensions == nil {
+		m.res.Meta.(*test_model.ResourceMeta).NameExtensions = core_model.ResourceNameExtensions{}
+	}
+	m.res.Meta.(*test_model.ResourceMeta).NameExtensions[v1alpha1.KubeNamespaceTag] = namespace
 	return m
 }
 


### PR DESCRIPTION
Changes:
* stop adding `kuma.io/zone`, `kuma.io/origin` and `kuma.io/env` label to resources that can't be originated on zone (like Mesh and old source/destination policies)

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
