### PR TITLE
feat(meshtls): added builtin gateway implementation

### DIFF
--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/gateway-tls-version-and-cipher.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/gateway-tls-version-and-cipher.clusters.golden.yaml
@@ -1,0 +1,54 @@
+resources:
+- name: backend-26cb64fa4e85e7b7
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+        initialFetchTimeout: 0s
+        resourceApiVersion: V3
+    name: backend-26cb64fa4e85e7b7
+    perConnectionBufferLimitBytes: 32768
+    transportSocket:
+      name: envoy.transport_sockets.tls
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        commonTlsContext:
+          alpnProtocols:
+          - kuma
+          combinedValidationContext:
+            defaultValidationContext:
+              matchTypedSubjectAltNames:
+              - matcher:
+                  exact: spiffe://default/backend
+                sanType: URI
+            validationContextSdsSecretConfig:
+              name: mesh_ca:secret:default
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+          tlsCertificateSdsSecretConfigs:
+          - name: identity_cert:secret:default
+            sdsConfig:
+              ads: {}
+              resourceApiVersion: V3
+          tlsParams:
+            cipherSuites:
+            - ECDHE-ECDSA-AES128-GCM-SHA256
+            - ECDHE-ECDSA-AES256-GCM-SHA384
+            - ECDHE-ECDSA-CHACHA20-POLY1305
+            - ECDHE-RSA-AES128-GCM-SHA256
+            - ECDHE-RSA-AES256-GCM-SHA384
+            - ECDHE-RSA-CHACHA20-POLY1305
+            tlsMaximumProtocolVersion: TLSv1_3
+            tlsMinimumProtocolVersion: TLSv1_3
+        sni: backend{mesh=default}
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        commonHttpProtocolOptions:
+          idleTimeout: 0s
+        explicitHttpConfig:
+          httpProtocolOptions: {}

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/gateway-tls-version-and-cipher.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/gateway-tls-version-and-cipher.listeners.golden.yaml
@@ -1,0 +1,60 @@
+resources:
+- name: sample-gateway:HTTP:8080
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.1
+        portValue: 8080
+    enableReusePort: true
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          commonHttpProtocolOptions:
+            headersWithUnderscoresAction: REJECT_REQUEST
+            idleTimeout: 300s
+          http2ProtocolOptions:
+            allowConnect: true
+            initialConnectionWindowSize: 1048576
+            initialStreamWindowSize: 65536
+            maxConcurrentStreams: 100
+          httpFilters:
+          - name: envoy.filters.http.local_ratelimit
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              statPrefix: rate_limit
+          - name: gzip-compress
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+              compressorLibrary:
+                name: gzip
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+              responseDirectionConfig:
+                disableOnEtagHeader: true
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          mergeSlashes: true
+          normalizePath: true
+          pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
+          rds:
+            configSource:
+              ads: {}
+              initialFetchTimeout: 0s
+              resourceApiVersion: V3
+            routeConfigName: sample-gateway:HTTP:8080:*
+          requestHeadersTimeout: 0.500s
+          serverName: Kuma Gateway
+          statPrefix: sample-gateway
+          streamIdleTimeout: 5s
+          useRemoteAddress: true
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: sample-gateway:HTTP:8080
+    perConnectionBufferLimitBytes: 32768
+    trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/gateway-tls-version-and-cipher.policy.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/gateway-tls-version-and-cipher.policy.yaml
@@ -1,0 +1,16 @@
+targetRef:
+  kind: Mesh
+from:
+  - targetRef:
+      kind: Mesh
+    default:
+      tlsVersion:
+        min: TLS13
+        max: TLS13
+      tlsCiphers:
+        - "ECDHE-ECDSA-AES128-GCM-SHA256"
+        - "ECDHE-ECDSA-AES256-GCM-SHA384"
+        - "ECDHE-ECDSA-CHACHA20-POLY1305"
+        - "ECDHE-RSA-AES128-GCM-SHA256"
+        - "ECDHE-RSA-AES256-GCM-SHA384"
+        - "ECDHE-RSA-CHACHA20-POLY1305"

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/gateway-tls-version-and-cipher.routes.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/gateway-tls-version-and-cipher.routes.golden.yaml
@@ -1,0 +1,46 @@
+resources:
+- name: sample-gateway:HTTP:8080:*
+  resource:
+    '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+    ignorePortInHostMatching: true
+    name: sample-gateway:HTTP:8080:*
+    requestHeadersToRemove:
+    - x-kuma-tags
+    validateClusters: false
+    virtualHosts:
+    - domains:
+      - '*'
+      name: '*'
+      routes:
+      - match:
+          headers:
+          - name: :method
+            stringMatch:
+              exact: GET
+          path: /another-route
+        name: L2t9uuHxXPXUg5ULwRirUaoxN4BU/zlqyPK8peSWm2g=
+        route:
+          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+          idleTimeout: 5s
+          weightedClusters:
+            clusters:
+            - name: backend-26cb64fa4e85e7b7
+              requestHeadersToAdd:
+              - header:
+                  key: x-kuma-tags
+                  value: '&kuma.io/service=sample-gateway&'
+              weight: 100
+      - match:
+          path: /
+        name: JNNc6//C3P17nUsOJm5f4kqG+U3v8pXhS0od9C3+oss=
+        route:
+          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+          idleTimeout: 5s
+          weightedClusters:
+            clusters:
+            - name: backend-26cb64fa4e85e7b7
+              requestHeadersToAdd:
+              - header:
+                  key: x-kuma-tags
+                  value: '&kuma.io/service=sample-gateway&'
+              weight: 100

--- a/test/e2e_env/kubernetes/gateway/gateway.go
+++ b/test/e2e_env/kubernetes/gateway/gateway.go
@@ -1039,6 +1039,101 @@ spec:
 		})
 	})
 
+	Context("MeshTLS", func() {
+		httpRoute := fmt.Sprintf(`
+apiVersion: kuma.io/v1alpha1
+kind: MeshHTTPRoute
+metadata:
+  name: http-route-1-mtls
+  namespace: %s
+  labels:
+    kuma.io/mesh: %s
+spec:
+  targetRef:
+    kind: MeshGateway
+    name: simple-gateway
+  to:
+  - targetRef:
+      kind: Mesh
+    rules:
+    - matches:
+      - path:
+          type: PathPrefix
+          value: "/test"
+      default:
+        backendRefs:
+        - kind: MeshService
+          name: "echo-server_simple-gateway_svc_80"`, Config.KumaNamespace, meshName)
+
+		meshTls := fmt.Sprintf(`
+apiVersion: kuma.io/v1alpha1
+kind: MeshTLS
+metadata:
+  name: mesh-tls-1-gateway
+  namespace: %s
+  labels:
+    kuma.io/mesh: %s
+spec:
+  targetRef:
+    kind: Mesh
+  from:
+    - targetRef:
+        kind: Mesh
+      default:
+        tlsVersion:
+          min: TLS13
+          max: TLS13`, Config.KumaNamespace, meshName)
+
+		BeforeAll(func() {
+			err := NewClusterSetup().
+				Install(YamlK8s(httpRoute)).
+				Setup(kubernetes.Cluster)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterAll(func() {
+			err := NewClusterSetup().
+				Install(DeleteYamlK8s(meshTls)).
+				Install(DeleteYamlK8s(httpRoute)).
+				Setup(kubernetes.Cluster)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should not break traffic", func() {
+			// then
+			// can access test-server from a gateway
+			Eventually(func(g Gomega) {
+				response, err := client.CollectEchoResponse(
+					kubernetes.Cluster, "demo-client",
+					"http://simple-gateway.simple-gateway:8080/test",
+					client.WithHeader("host", "example.kuma.io"),
+					client.FromKubernetesPod(clientNamespace, "demo-client"),
+				)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(response.Received.Headers["Host"]).To(HaveLen(1))
+				g.Expect(response.Received.Headers["Host"]).To(ContainElements("example.kuma.io"))
+			}, "30s", "1s").Should(Succeed())
+
+			// when
+			// applied MeshTLS policy to set 1.3 version on all dataplanes
+			Expect(kubernetes.Cluster.Install(YamlK8s(meshTls))).To(Succeed())
+
+			// then
+			// still can access test-server from the gateway
+			Eventually(func(g Gomega) {
+				response, err := client.CollectEchoResponse(
+					kubernetes.Cluster, "demo-client",
+					"http://simple-gateway.simple-gateway:8080/test",
+					client.WithHeader("host", "example.kuma.io"),
+					client.FromKubernetesPod(clientNamespace, "demo-client"),
+				)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(response.Received.Headers["Host"]).To(HaveLen(1))
+				g.Expect(response.Received.Headers["Host"]).To(ContainElements("example.kuma.io"))
+			}, "30s", "1s").MustPassRepeatedly(5).Should(Succeed())
+		})
+	})
+
 	Context("External Service", func() {
 		externalService := `
 apiVersion: kuma.io/v1alpha1


### PR DESCRIPTION
### Checklist prior to review

While testing, I noticed that the built-in gateway isn't supported. This PR adds support for configuring Gateway clusters with TLS versions and ciphers.

d8b489d4e304bfcc4e9dac9bb3ccadbc02dc41f0 implementation 
fdc419a824a97961dfbb6843fbc1ceea600f2a2b unit test + golden files 
4b2c978538d052c1b62f3a3da59868bbe9e30123 e2e test


- [ ] [Link to relevant issue][1] as well as docs and UI issues -- fix: https://github.com/kumahq/kuma/issues/11424
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
