### PR TITLE
fix(inspect-api): `toResourceRules[].origin` contains wrong resource type

### DIFF
--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -934,7 +934,7 @@ func (r *resourceEndpoints) rulesForResource() restful.RouteFunction {
 			for itemIdentifier, resourceRuleItem := range res.ToRules.ResourceRules {
 				toResourceRules = append(toResourceRules, api_common.ResourceRule{
 					Conf:                resourceRuleItem.Conf,
-					Origin:              oapi_helpers.OriginListToResourceRuleOrigin(itemIdentifier.ResourceType, resourceRuleItem.Origin),
+					Origin:              oapi_helpers.OriginListToResourceRuleOrigin(res.Type, resourceRuleItem.Origin),
 					ResourceMeta:        oapi_helpers.ResourceMetaToMeta(itemIdentifier.ResourceType, resourceRuleItem.Resource),
 					ResourceSectionName: &resourceRuleItem.ResourceSectionName,
 				})

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/meshgateway.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/meshgateway.golden.json
@@ -32,7 +32,7 @@
         },
         "mesh": "default",
         "name": "mt-on-gateway",
-        "type": "Mesh"
+        "type": "MeshTimeout"
        },
        "ruleIndex": 0
       }

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/overriding_meshtimeout.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/overriding_meshtimeout.golden.json
@@ -61,7 +61,7 @@
         "labels": {},
         "mesh": "default",
         "name": "default",
-        "type": "Mesh"
+        "type": "MeshTimeout"
        },
        "ruleIndex": 0
       }

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/resource_rule_meshtimeout.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/resource_rule_meshtimeout.golden.json
@@ -26,7 +26,7 @@
         "labels": {},
         "mesh": "mesh-1",
         "name": "matched-for-rules-mt-1",
-        "type": "MeshService"
+        "type": "MeshTimeout"
        },
        "ruleIndex": 0
       }
@@ -57,7 +57,7 @@
         "labels": {},
         "mesh": "mesh-1",
         "name": "matched-for-rules-mt-1",
-        "type": "MeshService"
+        "type": "MeshTimeout"
        },
        "ruleIndex": 0
       }

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/resource_rule_meshtimeout_index.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/resource_rule_meshtimeout_index.golden.json
@@ -26,7 +26,7 @@
         "labels": {},
         "mesh": "mesh-1",
         "name": "matched-for-rules-mt-1",
-        "type": "MeshService"
+        "type": "MeshTimeout"
        },
        "ruleIndex": 1
       }

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/resource_rule_meshtimeout_section.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/resource_rule_meshtimeout_section.golden.json
@@ -26,7 +26,7 @@
         "labels": {},
         "mesh": "mesh-1",
         "name": "matched-for-rules-mt-1",
-        "type": "MeshService"
+        "type": "MeshTimeout"
        },
        "ruleIndex": 0
       }

--- a/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshgateway.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshgateway.golden.json
@@ -32,7 +32,7 @@
         },
         "mesh": "default",
         "name": "mt-on-gateway",
-        "type": "Mesh"
+        "type": "MeshTimeout"
        },
        "ruleIndex": 0
       }

--- a/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshgateway2.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshgateway2.golden.json
@@ -151,7 +151,7 @@
         },
         "mesh": "default",
         "name": "http-route-3",
-        "type": "Mesh"
+        "type": "MeshHTTPRoute"
        },
        "ruleIndex": 0
       },
@@ -163,7 +163,7 @@
         },
         "mesh": "default",
         "name": "http-route-2",
-        "type": "Mesh"
+        "type": "MeshHTTPRoute"
        },
        "ruleIndex": 0
       },
@@ -175,7 +175,7 @@
         },
         "mesh": "default",
         "name": "http-route-1",
-        "type": "Mesh"
+        "type": "MeshHTTPRoute"
        },
        "ruleIndex": 0
       }

--- a/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshhttproute.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshhttproute.golden.json
@@ -101,7 +101,7 @@
         },
         "mesh": "default",
         "name": "the-other-http-route",
-        "type": "Mesh"
+        "type": "MeshHTTPRoute"
        },
        "ruleIndex": 0
       },
@@ -113,7 +113,7 @@
         },
         "mesh": "default",
         "name": "the-http-route",
-        "type": "Mesh"
+        "type": "MeshHTTPRoute"
        },
        "ruleIndex": 0
       }


### PR DESCRIPTION
Should be the resource type of the policy, no the type of targetRef. See changes in golden files for better understanding.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
