### PR TITLE
EXPERIMENTAL: just check if golangci-lint action works

### DIFF
--- a/pkg/core/resources/model/resource.go
+++ b/pkg/core/resources/model/resource.go
@@ -756,19 +756,20 @@ func ResourceToBackendRef(r Resource, resType ResourceType, port uint32) common_
 type LabelResourceIdentifierResolver func(ResourceType, map[string]string) *ResourceIdentifier
 
 func ResolveBackendRef(meta ResourceMeta, br common_api.BackendRef, resolver LabelResourceIdentifierResolver) *ResolvedBackendRef {
-	resolved := ResolvedBackendRef{LegacyBackendRef: &br}
-
 	switch {
 	case br.Kind == common_api.MeshService && br.ReferencesRealObject():
 	case br.Kind == common_api.MeshExternalService:
 	case br.Kind == common_api.MeshMultiZoneService:
 	default:
-		return &resolved
+		return &ResolvedBackendRef{Ref: pointer.To(LegacyBackendRef(br))}
 	}
 
-	resolved.Resource = &TypedResourceIdentifier{
-		ResourceIdentifier: TargetRefToResourceIdentifier(meta, br.TargetRef),
-		ResourceType:       ResourceType(br.Kind),
+	rr := RealResourceBackendRef{
+		Resource: &TypedResourceIdentifier{
+			ResourceIdentifier: TargetRefToResourceIdentifier(meta, br.TargetRef),
+			ResourceType:       ResourceType(br.Kind),
+		},
+		Weight: pointer.DerefOr(br.Weight, 1),
 	}
 
 	if len(br.Labels) > 0 {
@@ -776,14 +777,14 @@ func ResolveBackendRef(meta ResourceMeta, br common_api.BackendRef, resolver Lab
 		if ri == nil {
 			return nil
 		}
-		resolved.Resource.ResourceIdentifier = *ri
+		rr.Resource.ResourceIdentifier = *ri
 	}
 
 	if br.Port != nil {
-		resolved.Resource.SectionName = fmt.Sprintf("%d", *br.Port)
+		rr.Resource.SectionName = fmt.Sprintf("%d", *br.Port)
 	}
 
-	return &resolved
+	return &ResolvedBackendRef{Ref: &rr}
 }
 
 func (r ResourceIdentifier) String() string {
@@ -810,10 +811,61 @@ type TypedResourceIdentifier struct {
 	SectionName  string
 }
 
-type ResolvedBackendRef struct {
-	LegacyBackendRef *common_api.BackendRef
-	Resource         *TypedResourceIdentifier
+type IsResolvedBackendRef interface {
+	isResolvedBackendRef()
 }
+
+type ResolvedBackendRef struct {
+	// Ref is either LegacyBackendRef or RealResourceBackendRef
+	Ref IsResolvedBackendRef
+}
+
+func NewResolvedBackendRef(r IsResolvedBackendRef) *ResolvedBackendRef {
+	return &ResolvedBackendRef{Ref: r}
+}
+
+func (rbr *ResolvedBackendRef) ReferencesRealResource() bool {
+	if rbr == nil {
+		return false
+	}
+	if rbr.Ref == nil {
+		return false
+	}
+	_, ok := rbr.Ref.(*RealResourceBackendRef)
+	return ok
+}
+
+func (rbr *ResolvedBackendRef) Kind() common_api.TargetRefKind {
+	if rbr.ReferencesRealResource() {
+		return common_api.TargetRefKind(rbr.RealResourceBackendRef().Resource.ResourceType)
+	}
+	return rbr.LegacyBackendRef().Kind
+}
+
+func (rbr *ResolvedBackendRef) LegacyBackendRef() *LegacyBackendRef {
+	if lbr, ok := rbr.Ref.(*LegacyBackendRef); ok {
+		return lbr
+	}
+	return nil
+}
+
+func (rbr *ResolvedBackendRef) RealResourceBackendRef() *RealResourceBackendRef {
+	if rr, ok := rbr.Ref.(*RealResourceBackendRef); ok {
+		return rr
+	}
+	return nil
+}
+
+type LegacyBackendRef common_api.BackendRef
+
+func (lbr *LegacyBackendRef) isResolvedBackendRef() {}
+
+type RealResourceBackendRef struct {
+	Resource *TypedResourceIdentifier
+	Weight   uint
+}
+
+func (rbr *RealResourceBackendRef) isResolvedBackendRef() {}
 
 type NewTypedResourceIdentifierFunc func(id *TypedResourceIdentifier)
 

--- a/pkg/plugins/policies/core/xds/meshroute/clusters.go
+++ b/pkg/plugins/policies/core/xds/meshroute/clusters.go
@@ -9,7 +9,6 @@ import (
 	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
-	core_rules "github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
 	util_maps "github.com/kumahq/kuma/pkg/util/maps"
 	"github.com/kumahq/kuma/pkg/util/pointer"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
@@ -50,7 +49,7 @@ func GenerateClusters(
 								meshCtx.Resource,
 								mesh_proto.ZoneEgressServiceName,
 								true,
-								SniForBackendRef(service.BackendRef(), meshCtx, systemNamespace),
+								SniForBackendRef(service.BackendRef().RealResourceBackendRef(), meshCtx, systemNamespace),
 							))
 					} else {
 						edsClusterBuilder.
@@ -103,9 +102,9 @@ func GenerateClusters(
 						}
 					}
 				} else {
-					if service.BackendRef().LegacyBackendRef.ReferencesRealObject() {
-						if service.BackendRef().LegacyBackendRef.Kind == common_api.MeshService {
-							if ms := meshCtx.MeshServiceByIdentifier[pointer.Deref(service.BackendRef().Resource).ResourceIdentifier]; ms != nil {
+					if realResourceRef := service.BackendRef().RealResourceBackendRef(); realResourceRef != nil {
+						if common_api.TargetRefKind(realResourceRef.Resource.ResourceType) == common_api.MeshService {
+							if ms := meshCtx.MeshServiceByIdentifier[pointer.Deref(realResourceRef.Resource).ResourceIdentifier]; ms != nil {
 								tlsReady = ms.Status.TLS.Status == meshservice_api.TLSReady
 							}
 						}
@@ -113,8 +112,8 @@ func GenerateClusters(
 							proxy.SecretsTracker,
 							meshCtx.Resource,
 							tlsReady,
-							SniForBackendRef(service.BackendRef(), meshCtx, systemNamespace),
-							ServiceTagIdentities(service.BackendRef(), meshCtx),
+							SniForBackendRef(realResourceRef, meshCtx, systemNamespace),
+							ServiceTagIdentities(realResourceRef, meshCtx),
 						))
 					} else {
 						edsClusterBuilder.Configure(envoy_clusters.ClientSideMTLS(
@@ -129,11 +128,16 @@ func GenerateClusters(
 				return nil, errors.Wrapf(err, "build CDS for cluster %s failed", clusterName)
 			}
 
+			var resourceOrigin *core_model.TypedResourceIdentifier
+			if service.BackendRef().ReferencesRealResource() {
+				resourceOrigin = service.BackendRef().RealResourceBackendRef().Resource
+			}
+
 			resources = resources.Add(&core_xds.Resource{
 				Name:           clusterName,
 				Origin:         generator.OriginOutbound,
 				Resource:       edsCluster,
-				ResourceOrigin: createResourceOrigin(service.BackendRef(), meshCtx),
+				ResourceOrigin: resourceOrigin,
 				Protocol:       protocol,
 			})
 		}
@@ -142,67 +146,44 @@ func GenerateClusters(
 	return resources, nil
 }
 
-func createResourceOrigin(
-	ref core_model.ResolvedBackendRef,
-	meshCtx xds_context.MeshContext,
-) *core_model.TypedResourceIdentifier {
-	switch {
-	case ref.LegacyBackendRef.Kind == common_api.MeshService && ref.LegacyBackendRef.ReferencesRealObject():
-		ms := meshCtx.MeshServiceByIdentifier[pointer.Deref(ref.Resource).ResourceIdentifier]
-		port, ok := ms.FindPort(pointer.Deref(ref.LegacyBackendRef.Port))
-		if ok {
-			return pointer.To(core_rules.UniqueKey(ms, port.Name))
-		}
-		return pointer.To(core_rules.UniqueKey(ms, ""))
-	case ref.LegacyBackendRef.Kind == common_api.MeshExternalService:
-		mes := meshCtx.MeshExternalServiceByIdentifier[pointer.Deref(ref.Resource).ResourceIdentifier]
-		return pointer.To(core_rules.UniqueKey(mes, ""))
-	case ref.LegacyBackendRef.Kind == common_api.MeshMultiZoneService:
-		mzs := meshCtx.MeshMultiZoneServiceByIdentifier[pointer.Deref(ref.Resource).ResourceIdentifier]
-		port, ok := mzs.FindPort(pointer.Deref(ref.LegacyBackendRef.Port))
-		if ok {
-			return pointer.To(core_rules.UniqueKey(mzs, port.Name))
-		}
-		return pointer.To(core_rules.UniqueKey(mzs, ""))
-	}
-	return nil
-}
-
 func SniForBackendRef(
-	backendRef core_model.ResolvedBackendRef,
+	backendRef *core_model.RealResourceBackendRef,
 	meshCtx xds_context.MeshContext,
 	systemNamespace string,
 ) string {
 	var resource core_model.Resource
 	var name string
-	switch backendRef.LegacyBackendRef.Kind {
+	var port uint32
+	switch common_api.TargetRefKind(backendRef.Resource.ResourceType) {
 	case common_api.MeshService:
 		ms := meshCtx.MeshServiceByIdentifier[pointer.Deref(backendRef.Resource).ResourceIdentifier]
 		resource = ms
 		name = ms.SNIName(systemNamespace)
+		if p, ok := ms.FindPortByName(backendRef.Resource.SectionName); ok {
+			port = p.Port
+		}
 	case common_api.MeshExternalService:
 		mes := meshCtx.MeshExternalServiceByIdentifier[pointer.Deref(backendRef.Resource).ResourceIdentifier]
 		resource = mes
 		name = core_model.GetDisplayName(resource.GetMeta())
+		port = uint32(mes.Spec.Match.Port)
 	case common_api.MeshMultiZoneService:
-		resource = meshCtx.MeshMultiZoneServiceByIdentifier[pointer.Deref(backendRef.Resource).ResourceIdentifier]
+		mzms := meshCtx.MeshMultiZoneServiceByIdentifier[pointer.Deref(backendRef.Resource).ResourceIdentifier]
+		resource = mzms
 		name = core_model.GetDisplayName(resource.GetMeta())
+		if p, ok := mzms.FindPortByName(backendRef.Resource.SectionName); ok {
+			port = p.Port
+		}
 	}
-	return tls.SNIForResource(
-		name,
-		resource.GetMeta().GetMesh(),
-		resource.Descriptor().Name,
-		pointer.Deref(backendRef.LegacyBackendRef.Port),
-		nil,
-	)
+	return tls.SNIForResource(name, resource.GetMeta().GetMesh(), resource.Descriptor().Name, port, nil)
 }
 
 func ServiceTagIdentities(
-	backendRef core_model.ResolvedBackendRef,
+	backendRef *core_model.RealResourceBackendRef,
 	meshCtx xds_context.MeshContext,
 ) []string {
 	var result []string
-	switch backendRef.LegacyBackendRef.Kind {
+	switch common_api.TargetRefKind(backendRef.Resource.ResourceType) {
 	case common_api.MeshService:
 		ms := meshCtx.MeshServiceByIdentifier[pointer.Deref(backendRef.Resource).ResourceIdentifier]
 		for _, identity := range ms.Spec.Identities {

--- a/pkg/plugins/policies/core/xds/meshroute/listeners.go
+++ b/pkg/plugins/policies/core/xds/meshroute/listeners.go
@@ -58,12 +58,27 @@ func MakeHTTPSplit(
 }
 
 type DestinationService struct {
-	OutboundInterface mesh_proto.OutboundInterface
-	Resource          *core_model.TypedResourceIdentifier
-	Tags              envoy_tags.Tags
-	Protocol          core_mesh.Protocol
-	ServiceName       string
-	BackendRef        common_api.BackendRef
+	Outbound    *xds_types.Outbound
+	Protocol    core_mesh.Protocol
+	ServiceName string
+}
+
+func (ds *DestinationService) DefaultBackendRef() *core_model.ResolvedBackendRef {
+	if ds.Outbound.Resource != nil {
+		return core_model.NewResolvedBackendRef(&core_model.RealResourceBackendRef{
+			Resource: ds.Outbound.Resource,
+			Weight:   100,
+		})
+	} else {
+		return core_model.NewResolvedBackendRef(&core_model.LegacyBackendRef{
+			TargetRef: common_api.TargetRef{
+				Kind: common_api.MeshService,
+				Name: ds.Outbound.LegacyOutbound.GetService(),
+				Tags: ds.Outbound.LegacyOutbound.GetTags(),
+			},
+			Weight: pointer.To(uint(100)),
+		})
+	}
 }
 
 func CollectServices(
@@ -111,21 +126,9 @@ func collectMeshService(
 		protocol = port.AppProtocol
 	}
 	return &DestinationService{
-		OutboundInterface: mesh_proto.OutboundInterface{
-			DataplaneIP:   outbound.GetAddress(),
-			DataplanePort: outbound.GetPort(),
-		},
-		Tags:        outbound.LegacyOutbound.GetTags(),
-		Resource:    outbound.Resource,
+		Outbound:    outbound,
 		Protocol:    protocol,
 		ServiceName: ms.DestinationName(port.Port),
-		BackendRef: common_api.BackendRef{
-			TargetRef: common_api.TargetRef{
-				Kind: common_api.MeshService,
-				Name: ms.GetMeta().GetName(),
-			},
-			Port: &port.Port,
-		},
 	}
 }
 
@@ -142,21 +145,9 @@ func collectMeshExternalService(
 		protocol = mes.Spec.Match.Protocol
 	}
 	return &DestinationService{
-		Protocol: protocol,
-		OutboundInterface: mesh_proto.OutboundInterface{
-			DataplaneIP:   outbound.GetAddress(),
-			DataplanePort: outbound.GetPort(),
-		},
-		Tags:        outbound.LegacyOutbound.GetTags(),
-		Resource:    outbound.Resource,
+		Outbound:    outbound,
+		Protocol:    protocol,
 		ServiceName: mes.DestinationName(uint32(mes.Spec.Match.Port)),
-		BackendRef: common_api.BackendRef{
-			TargetRef: common_api.TargetRef{
-				Kind: common_api.MeshExternalService,
-				Name: mes.GetMeta().GetName(),
-			},
-			Port: pointer.To(uint32(mes.Spec.Match.Port)),
-		},
 	}
 }
 
@@ -177,21 +168,9 @@ func collectMeshMultiZoneService(
 		protocol = port.AppProtocol
 	}
 	return &DestinationService{
-		OutboundInterface: mesh_proto.OutboundInterface{
-			DataplaneIP:   outbound.GetAddress(),
-			DataplanePort: outbound.GetPort(),
-		},
-		Tags:        outbound.LegacyOutbound.GetTags(),
-		Resource:    outbound.Resource,
+		Outbound:    outbound,
 		Protocol:    protocol,
 		ServiceName: svc.DestinationName(port.Port),
-		BackendRef: common_api.BackendRef{
-			TargetRef: common_api.TargetRef{
-				Kind: common_api.MeshMultiZoneService,
-				Name: svc.GetMeta().GetName(),
-			},
-			Port: &port.Port,
-		},
 	}
 }
 
@@ -201,70 +180,52 @@ func collectServiceTagService(
 ) *DestinationService {
 	serviceName := outbound.LegacyOutbound.GetService()
 	return &DestinationService{
-		OutboundInterface: mesh_proto.OutboundInterface{
-			DataplaneIP:   outbound.GetAddress(),
-			DataplanePort: outbound.GetPort(),
-		},
-		Tags:        outbound.LegacyOutbound.GetTags(),
-		Resource:    outbound.Resource,
+		Outbound:    outbound,
 		Protocol:    meshCtx.GetServiceProtocol(serviceName),
 		ServiceName: serviceName,
-		BackendRef: common_api.BackendRef{
-			TargetRef: common_api.TargetRef{
-				Kind: common_api.MeshService,
-				Name: serviceName,
-				Tags: outbound.LegacyOutbound.GetTags(),
-			},
-		},
 	}
 }
 
-func GetServiceAndProtocolFromRef(
+func GetServiceProtocolPortFromRef(
 	meshCtx xds_context.MeshContext,
-	ref core_model.ResolvedBackendRef,
-) (string, core_mesh.Protocol, bool) {
-	switch {
-	case ref.LegacyBackendRef.Kind == common_api.MeshExternalService:
+	ref *core_model.RealResourceBackendRef,
+) (string, core_mesh.Protocol, uint32, bool) {
+	switch common_api.TargetRefKind(ref.Resource.ResourceType) {
+	case common_api.MeshExternalService:
 		mes, ok := meshCtx.MeshExternalServiceByIdentifier[pointer.Deref(ref.Resource).ResourceIdentifier]
 		if !ok {
-			return "", "", false
+			return "", "", 0, false
 		}
-		port := pointer.Deref(ref.LegacyBackendRef.Port)
-		// if backendRef has no port, get the one from MeshExternalService since match allows only 1 port
-		if port == 0 {
-			port = uint32(mes.Spec.Match.Port)
-		}
+		port := uint32(mes.Spec.Match.Port)
 		service := mes.DestinationName(port)
 		protocol := meshCtx.GetServiceProtocol(service)
-		return service, protocol, true
-	case ref.LegacyBackendRef.Kind == common_api.MeshMultiZoneService:
+		return service, protocol, port, true
+	case common_api.MeshMultiZoneService:
 		ms, ok := meshCtx.MeshMultiZoneServiceByIdentifier[pointer.Deref(ref.Resource).ResourceIdentifier]
 		if !ok {
-			return "", "", false
+			return "", "", 0, false
 		}
-		port, ok := ms.FindPort(*ref.LegacyBackendRef.Port)
+		port, ok := ms.FindPortByName(ref.Resource.SectionName)
 		if !ok {
-			return "", "", false
+			return "", "", 0, false
 		}
-		service := ms.DestinationName(*ref.LegacyBackendRef.Port)
+		service := ms.DestinationName(port.Port)
 		protocol := port.AppProtocol
-		return service, protocol, true
-	case ref.LegacyBackendRef.Kind == common_api.MeshService && ref.LegacyBackendRef.ReferencesRealObject():
+		return service, protocol, port.Port, true
+	case common_api.MeshService:
 		ms, ok := meshCtx.MeshServiceByIdentifier[pointer.Deref(ref.Resource).ResourceIdentifier]
 		if !ok {
-			return "", "", false
+			return "", "", 0, false
 		}
-		port, ok := ms.FindPort(*ref.LegacyBackendRef.Port)
+		port, ok := ms.FindPortByName(ref.Resource.SectionName)
 		if !ok {
-			return "", "", false
+			return "", "", 0, false
 		}
-		service := ms.DestinationName(*ref.LegacyBackendRef.Port)
+		service := ms.DestinationName(port.Port)
 		protocol := port.AppProtocol // todo(jakubdyszkiewicz): do we need to default to TCP or will this be done by MeshService defaulter?
-		return service, protocol, true
+		return service, protocol, port.Port, true
 	default:
-		service := ref.LegacyBackendRef.Name
-		protocol := meshCtx.GetServiceProtocol(service)
-		return service, protocol, true
+		return "", "", 0, false
 	}
 }
 
@@ -278,86 +239,141 @@ func makeSplit(
 	var split []envoy_common.Split
 
 	for _, ref := range refs {
-		switch ref.LegacyBackendRef.Kind {
-		case common_api.MeshService, common_api.MeshExternalService, common_api.MeshServiceSubset, common_api.MeshMultiZoneService:
-		default:
-			continue
-		}
-
-		var service string
-		var protocol core_mesh.Protocol
-		if pointer.DerefOr(ref.LegacyBackendRef.Weight, 1) == 0 {
-			continue
-		}
-		service, protocol, ok := GetServiceAndProtocolFromRef(meshCtx, ref)
-		if !ok {
-			continue
-		}
-		if _, ok := protocols[protocol]; !ok {
-			return nil
-		}
-
-		var clusterName string
-		switch ref.LegacyBackendRef.Kind {
-		case common_api.MeshExternalService:
-			clusterName = meshCtx.MeshExternalServiceByIdentifier[pointer.Deref(ref.Resource).ResourceIdentifier].DestinationName(pointer.Deref(ref.LegacyBackendRef.Port))
-		case common_api.MeshMultiZoneService:
-			clusterName = meshCtx.MeshMultiZoneServiceByIdentifier[pointer.Deref(ref.Resource).ResourceIdentifier].DestinationName(*ref.LegacyBackendRef.Port)
-		case common_api.MeshService:
-			if ref.LegacyBackendRef.Port != nil {
-				clusterName = meshCtx.MeshServiceByIdentifier[pointer.Deref(ref.Resource).ResourceIdentifier].DestinationName(*ref.LegacyBackendRef.Port)
-				break
+		if ref.ReferencesRealResource() {
+			if s := handleRealResources(protocols, clusterCache, servicesAcc, ref.RealResourceBackendRef(), meshCtx); s != nil {
+				split = append(split, s)
 			}
-			fallthrough
-		default:
-			clusterName, _ = envoy_tags.Tags(ref.LegacyBackendRef.Tags).
-				WithTags(mesh_proto.ServiceTag, service).
-				DestinationClusterName(nil)
+		} else {
+			if s := handleLegacyBackendRef(protocols, clusterCache, servicesAcc, ref.LegacyBackendRef(), meshCtx); s != nil {
+				split = append(split, s)
+			}
 		}
-
-		// The mesh tag is present here if this destination is generated
-		// from a cross-mesh MeshGateway listener virtual outbound.
-		// It is not part of the service tags.
-		if mesh, ok := ref.LegacyBackendRef.Tags[mesh_proto.MeshTag]; ok {
-			// The name should be distinct to the service & mesh combination
-			clusterName = fmt.Sprintf("%s_%s", clusterName, mesh)
-		}
-
-		isExternalService := meshCtx.IsExternalService(service)
-		refHash := ref.LegacyBackendRef.Hash()
-
-		if existingClusterName, ok := clusterCache[refHash]; ok {
-			// cluster already exists, so adding only split
-			split = append(split, plugins_xds.NewSplitBuilder().
-				WithClusterName(existingClusterName).
-				WithWeight(uint32(pointer.DerefOr(ref.LegacyBackendRef.Weight, 1))).
-				WithExternalService(isExternalService).
-				Build())
-			continue
-		}
-
-		clusterCache[refHash] = clusterName
-
-		split = append(split, plugins_xds.NewSplitBuilder().
-			WithClusterName(clusterName).
-			WithWeight(uint32(pointer.DerefOr(ref.LegacyBackendRef.Weight, 1))).
-			WithExternalService(isExternalService).
-			Build())
-
-		clusterBuilder := plugins_xds.NewClusterBuilder().
-			WithService(service).
-			WithName(clusterName).
-			WithTags(envoy_tags.Tags(ref.LegacyBackendRef.Tags).
-				WithTags(mesh_proto.ServiceTag, ref.LegacyBackendRef.Name).
-				WithoutTags(mesh_proto.MeshTag)).
-			WithExternalService(isExternalService)
-
-		if mesh, ok := ref.LegacyBackendRef.Tags[mesh_proto.MeshTag]; ok {
-			clusterBuilder.WithMesh(mesh)
-		}
-
-		servicesAcc.AddBackendRef(ref, clusterBuilder.Build())
 	}
 
+	return split
+}
+
+func handleRealResources(
+	protocols map[core_mesh.Protocol]struct{},
+	clusterCache map[common_api.BackendRefHash]string,
+	servicesAcc envoy_common.ServicesAccumulator,
+	ref *core_model.RealResourceBackendRef,
+	meshCtx xds_context.MeshContext,
+) envoy_common.Split {
+	if ref.Weight == 0 {
+		return nil
+	}
+
+	service, protocol, port, ok := GetServiceProtocolPortFromRef(meshCtx, ref)
+	if !ok {
+		return nil
+	}
+	if _, ok := protocols[protocol]; !ok {
+		return nil
+	}
+
+	var clusterName string
+	var isExternalService bool
+
+	switch common_api.TargetRefKind(ref.Resource.ResourceType) {
+	case common_api.MeshExternalService:
+		clusterName = meshCtx.MeshExternalServiceByIdentifier[pointer.Deref(ref.Resource).ResourceIdentifier].DestinationName(port)
+		isExternalService = true
+	case common_api.MeshMultiZoneService:
+		clusterName = meshCtx.MeshMultiZoneServiceByIdentifier[pointer.Deref(ref.Resource).ResourceIdentifier].DestinationName(port)
+	case common_api.MeshService:
+		clusterName = meshCtx.MeshServiceByIdentifier[pointer.Deref(ref.Resource).ResourceIdentifier].DestinationName(port)
+	}
+
+	// todo(lobkovilya): instead of computing hash we should use ResourceIdentifier as a key in clusterCache (or maybe we don't need clusterCache)
+	refHash := common_api.BackendRefHash(ref.Resource.String())
+
+	splitTo := func(clusterName string) envoy_common.Split {
+		return plugins_xds.NewSplitBuilder().
+			WithClusterName(clusterName).
+			WithWeight(uint32(ref.Weight)).
+			WithExternalService(isExternalService).
+			Build()
+	}
+
+	if existingClusterName, ok := clusterCache[refHash]; ok {
+		// cluster already exists, so adding only split
+		return splitTo(existingClusterName)
+	}
+
+	clusterCache[refHash] = clusterName
+
+	clusterBuilder := plugins_xds.NewClusterBuilder().
+		WithService(service).
+		WithName(clusterName).
+		WithTags(envoy_tags.Tags{}.WithTags(mesh_proto.ServiceTag, service)). // todo(lobkovilya): do we need tags for real resource cluster?
+		WithExternalService(isExternalService)
+
+	servicesAcc.AddBackendRef(core_model.NewResolvedBackendRef(ref), clusterBuilder.Build())
+
+	return splitTo(clusterName)
+}
+
+func handleLegacyBackendRef(
+	protocols map[core_mesh.Protocol]struct{},
+	clusterCache map[common_api.BackendRefHash]string,
+	servicesAcc envoy_common.ServicesAccumulator,
+	ref *core_model.LegacyBackendRef,
+	meshCtx xds_context.MeshContext,
+) envoy_common.Split {
+	if ref.Weight != nil && *ref.Weight == 0 {
+		return nil
+	}
+
+	service := ref.Name
+	protocol := meshCtx.GetServiceProtocol(service)
+	if _, ok := protocols[protocol]; !ok {
+		return nil
+	}
+	clusterName, _ := envoy_tags.Tags(ref.Tags).
+		WithTags(mesh_proto.ServiceTag, service).
+		DestinationClusterName(nil)
+
+	// The mesh tag is present here if this destination is generated
+	// from a cross-mesh MeshGateway listener virtual outbound.
+	// It is not part of the service tags.
+	if mesh, ok := ref.Tags[mesh_proto.MeshTag]; ok {
+		// The name should be distinct to the service & mesh combination
+		clusterName = fmt.Sprintf("%s_%s", clusterName, mesh)
+	}
+
+	isExternalService := meshCtx.IsExternalService(service)
+	refHash := common_api.BackendRef(*ref).Hash()
+
+	if existingClusterName, ok := clusterCache[refHash]; ok {
+		// cluster already exists, so adding only split
+		return plugins_xds.NewSplitBuilder().
+			WithClusterName(existingClusterName).
+			WithWeight(uint32(pointer.DerefOr(ref.Weight, 1))).
+			WithExternalService(isExternalService).
+			Build()
+	}
+
+	clusterCache[refHash] = clusterName
+
+	split := plugins_xds.NewSplitBuilder().
+		WithClusterName(clusterName).
+		WithWeight(uint32(pointer.DerefOr(ref.Weight, 1))).
+		WithExternalService(isExternalService).
+		Build()
+
+	clusterBuilder := plugins_xds.NewClusterBuilder().
+		WithService(service).
+		WithName(clusterName).
+		WithTags(envoy_tags.Tags(ref.Tags).
+			WithTags(mesh_proto.ServiceTag, ref.Name).
+			WithoutTags(mesh_proto.MeshTag)).
+		WithExternalService(isExternalService)
+
+	if mesh, ok := ref.Tags[mesh_proto.MeshTag]; ok {
+		clusterBuilder.WithMesh(mesh)
+	}
+
+	servicesAcc.AddBackendRef(core_model.NewResolvedBackendRef(ref), clusterBuilder.Build())
 	return split
 }

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/compare.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/compare.go
@@ -132,8 +132,6 @@ func SortRules(
 				if resolved := core_model.ResolveBackendRef(origin, br, labelResolver); resolved != nil {
 					backendRefs = append(backendRefs, *resolved)
 				}
-			} else {
-				backendRefs = append(backendRefs, core_model.ResolvedBackendRef{LegacyBackendRef: &br})
 			}
 		}
 		out = append(out, Route{

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
@@ -32,10 +32,13 @@ func generateFromService(
 	rules rules.ToRules,
 	svc meshroute_xds.DestinationService,
 ) (*core_xds.ResourceSet, error) {
-	tags := svc.BackendRef.Tags
-	listenerBuilder := envoy_listeners.NewOutboundListenerBuilder(proxy.APIVersion, svc.OutboundInterface.DataplaneIP, svc.OutboundInterface.DataplanePort, core_xds.SocketAddressProtocolTCP).
+	var tags envoy_tags.Tags
+	if svc.Outbound.LegacyOutbound != nil {
+		tags = svc.Outbound.LegacyOutbound.GetTags()
+	}
+	listenerBuilder := envoy_listeners.NewOutboundListenerBuilder(proxy.APIVersion, svc.Outbound.GetAddress(), svc.Outbound.GetPort(), core_xds.SocketAddressProtocolTCP).
 		Configure(envoy_listeners.TransparentProxying(proxy.Dataplane.Spec.Networking.GetTransparentProxying())).
-		Configure(envoy_listeners.TagsMetadata(envoy_tags.Tags(tags).WithoutTags(mesh_proto.MeshTag)))
+		Configure(envoy_listeners.TagsMetadata(tags.WithoutTags(mesh_proto.MeshTag)))
 
 	resourceName := svc.ServiceName
 
@@ -57,7 +60,7 @@ func generateFromService(
 				// we need to create a split for the mirror backend
 				_ = meshroute_xds.MakeHTTPSplit(
 					clusterCache, servicesAcc,
-					[]core_model.ResolvedBackendRef{{LegacyBackendRef: &filter.RequestMirror.BackendRef}},
+					[]core_model.ResolvedBackendRef{*core_model.NewResolvedBackendRef(pointer.To(core_model.LegacyBackendRef(filter.RequestMirror.BackendRef)))},
 					meshCtx,
 				)
 			}
@@ -76,7 +79,7 @@ func generateFromService(
 	}
 
 	var outboundRouteName string
-	if svc.BackendRef.Kind == common_api.MeshExternalService {
+	if svc.Outbound.Resource != nil && svc.Outbound.Resource.ResourceType == core_model.ResourceType(common_api.MeshExternalService) {
 		outboundRouteName = resourceName
 	}
 	outboundRouteConfigurer := &xds.HttpOutboundRouteConfigurer{
@@ -105,7 +108,7 @@ func generateFromService(
 			Name:           listener.GetName(),
 			Origin:         generator.OriginOutbound,
 			Resource:       listener,
-			ResourceOrigin: svc.Resource,
+			ResourceOrigin: svc.Outbound.Resource,
 			Protocol:       svc.Protocol,
 		})
 
@@ -157,8 +160,8 @@ func ComputeHTTPRouteConf(toRules rules.ToRules, svc meshroute_xds.DestinationSe
 		}
 	}
 	// check if there is configuration for real MeshService and prioritize it
-	if svc.Resource != nil {
-		resourceConf := toRules.ResourceRules.Compute(*svc.Resource, meshCtx.Resources)
+	if svc.Outbound.Resource != nil {
+		resourceConf := toRules.ResourceRules.Compute(*svc.Outbound.Resource, meshCtx.Resources)
 		if resourceConf != nil && len(resourceConf.Conf) != 0 {
 			conf = pointer.To(resourceConf.Conf[0].(api.PolicyDefault))
 			for hash := range resourceConf.BackendRefOriginIndex {
@@ -219,12 +222,9 @@ func prepareRoutes(toRules rules.ToRules, svc meshroute_xds.DestinationService, 
 		}
 
 		if len(route.BackendRefs) == 0 {
-			defaultBackend := svc.BackendRef
-			defaultBackend.Weight = pointer.To(uint(100))
-			route.BackendRefs = []core_model.ResolvedBackendRef{{
-				LegacyBackendRef: &defaultBackend,
-				Resource:         svc.Resource,
-			}}
+			route.BackendRefs = []core_model.ResolvedBackendRef{
+				*svc.DefaultBackendRef(),
+			}
 		}
 	}
 

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
@@ -701,6 +701,15 @@ var _ = Describe("MeshHTTPRoute", func() {
 						xds_builders.MatchedPolicies().
 							WithToPolicy(api.MeshHTTPRouteType, core_rules.ToRules{
 								Rules: core_rules.Rules{{
+									Origin: []core_model.ResourceMeta{&test_model.ResourceMeta{Mesh: "default", Name: "http-route"}},
+									BackendRefOriginIndex: map[core_rules.MatchesHash]int{
+										core_rules.MatchesHash(api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/v1"}}})): 0,
+										core_rules.MatchesHash(api.HashMatches([]api.Match{
+											{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/v2"}},
+											{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/v3"}},
+										})): 0,
+										core_rules.MatchesHash(api.HashMatches([]api.Match{{QueryParams: []api.QueryParamsMatch{{Type: api.ExactQueryMatch, Name: "v1", Value: "true"}}}})): 0,
+									},
 									Conf: api.PolicyDefault{
 										Rules: []api.Rule{{
 											Matches: []api.Match{{

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.clusters.golden.yaml
@@ -31,7 +31,7 @@ resources:
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
-        sni: afce62f771ed74b78.example.0.default.mes
+        sni: afce62f771ed74b78.example.9090.default.mes
     type: EDS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners.go
@@ -5,7 +5,6 @@ import (
 
 	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
 	meshroute_xds "github.com/kumahq/kuma/pkg/plugins/policies/core/xds/meshroute"
@@ -13,6 +12,7 @@ import (
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	envoy_listeners "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
+	envoy_tags "github.com/kumahq/kuma/pkg/xds/envoy/tags"
 	"github.com/kumahq/kuma/pkg/xds/generator"
 )
 
@@ -31,11 +31,7 @@ func generateFromService(
 	serviceName := svc.ServiceName
 	protocol := svc.Protocol
 
-	fallbackBackendRef := model.ResolvedBackendRef{
-		LegacyBackendRef: &svc.BackendRef,
-		Resource:         svc.Resource,
-	}
-	backendRefs := getBackendRefs(toRulesTCP, toRulesHTTP, svc, protocol, fallbackBackendRef, meshCtx)
+	backendRefs := getBackendRefs(toRulesTCP, toRulesHTTP, svc, protocol, meshCtx)
 	if len(backendRefs) == 0 {
 		return nil, nil
 	}
@@ -52,7 +48,7 @@ func generateFromService(
 		Name:           listener.GetName(),
 		Origin:         generator.OriginOutbound,
 		Resource:       listener,
-		ResourceOrigin: svc.Resource,
+		ResourceOrigin: svc.Outbound.Resource,
 		Protocol:       protocol,
 	})
 	return resources, nil
@@ -92,14 +88,17 @@ func buildOutboundListener(
 	svc meshroute_xds.DestinationService,
 	opts ...envoy_listeners.ListenerBuilderOpt,
 ) (envoy_common.NamedResource, error) {
-	tags := svc.Tags
+	var tags envoy_tags.Tags
+	if svc.Outbound.LegacyOutbound != nil {
+		tags = svc.Outbound.LegacyOutbound.Tags
+	}
 
 	// build listener name in format: "outbound:[IP]:[Port]"
 	// i.e. "outbound:240.0.0.0:80"
 	builder := envoy_listeners.NewOutboundListenerBuilder(
 		proxy.APIVersion,
-		svc.OutboundInterface.DataplaneIP,
-		svc.OutboundInterface.DataplanePort,
+		svc.Outbound.GetAddress(),
+		svc.Outbound.GetPort(),
 		core_xds.SocketAddressProtocolTCP,
 	)
 

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners_backendrefs.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners_backendrefs.go
@@ -24,8 +24,8 @@ func computeConf(toRules core_xds.ToRules, svc meshroute_xds.DestinationService,
 		}
 	}
 	// check if there is configuration for real MeshService and prioritize it
-	if svc.Resource != nil {
-		resourceConf := toRules.ResourceRules.Compute(*svc.Resource, meshCtx.Resources)
+	if svc.Outbound.Resource != nil {
+		resourceConf := toRules.ResourceRules.Compute(*svc.Outbound.Resource, meshCtx.Resources)
 		if resourceConf != nil && len(resourceConf.Conf) != 0 {
 			tcpConf = pointer.To(resourceConf.Conf[0].(api.Rule))
 			if o, ok := resourceConf.GetBackendRefOrigin(core_xds.EmptyMatches); ok {
@@ -41,7 +41,6 @@ func getBackendRefs(
 	toRulesHTTP core_xds.ToRules,
 	svc meshroute_xds.DestinationService,
 	protocol core_mesh.Protocol,
-	fallbackBackendRef core_model.ResolvedBackendRef,
 	meshCtx xds_context.MeshContext,
 ) []core_model.ResolvedBackendRef {
 	tcpConf, backendRefOrigin := computeConf(toRulesTCP, svc, meshCtx)
@@ -68,12 +67,10 @@ func getBackendRefs(
 				if resolved := core_model.ResolveBackendRef(backendRefOrigin, br, meshCtx.ResolveResourceIdentifier); resolved != nil {
 					backendRefs = append(backendRefs, *resolved)
 				}
-			} else {
-				backendRefs = append(backendRefs, core_model.ResolvedBackendRef{LegacyBackendRef: &br})
 			}
 		}
 	} else {
-		return []core_model.ResolvedBackendRef{fallbackBackendRef}
+		return []core_model.ResolvedBackendRef{*svc.DefaultBackendRef()}
 	}
 
 	return backendRefs

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
@@ -275,6 +275,12 @@ var _ = Describe("MeshTCPRoute", func() {
 			rules := core_rules.ToRules{
 				Rules: core_rules.Rules{
 					{
+						Origin: []core_model.ResourceMeta{
+							&test_model.ResourceMeta{Mesh: "mesh-1", Name: "tcp-route"},
+						},
+						BackendRefOriginIndex: map[core_rules.MatchesHash]int{
+							core_rules.EmptyMatches: 0,
+						},
 						Subset: core_rules.MeshService("backend"),
 						Conf: api.Rule{
 							Default: api.RuleConf{
@@ -651,6 +657,12 @@ var _ = Describe("MeshTCPRoute", func() {
 			rules := core_rules.ToRules{
 				Rules: core_rules.Rules{
 					{
+						Origin: []core_model.ResourceMeta{
+							&test_model.ResourceMeta{Mesh: "mesh-1", Name: "tcp-route"},
+						},
+						BackendRefOriginIndex: map[core_rules.MatchesHash]int{
+							core_rules.EmptyMatches: 0,
+						},
 						Subset: core_rules.MeshService("backend"),
 						Conf: api.Rule{
 							Default: api.RuleConf{
@@ -830,6 +842,12 @@ var _ = Describe("MeshTCPRoute", func() {
 			tcpRules := core_rules.ToRules{
 				Rules: core_rules.Rules{
 					{
+						Origin: []core_model.ResourceMeta{
+							&test_model.ResourceMeta{Mesh: "mesh-1", Name: "tcp-route"},
+						},
+						BackendRefOriginIndex: map[core_rules.MatchesHash]int{
+							core_rules.EmptyMatches: 0,
+						},
 						Subset: core_rules.MeshService("backend"),
 						Conf: api.Rule{
 							Default: api.RuleConf{
@@ -935,6 +953,12 @@ var _ = Describe("MeshTCPRoute", func() {
 			rules := core_rules.ToRules{
 				Rules: core_rules.Rules{
 					{
+						Origin: []core_model.ResourceMeta{
+							&test_model.ResourceMeta{Mesh: "mesh-1", Name: "tcp-route"},
+						},
+						BackendRefOriginIndex: map[core_rules.MatchesHash]int{
+							core_rules.EmptyMatches: 0,
+						},
 						Subset: core_rules.MeshService("backend"),
 						Conf: api.Rule{
 							Default: api.RuleConf{

--- a/pkg/plugins/runtime/gateway/cluster_generator.go
+++ b/pkg/plugins/runtime/gateway/cluster_generator.go
@@ -45,11 +45,11 @@ func (c *ClusterGenerator) GenerateClusters(ctx context.Context, xdsCtx xds_cont
 		var r *core_xds.Resource
 		var err error
 
-		if dest.BackendRef != nil && dest.BackendRef.Resource != nil {
+		if dest.BackendRef != nil && dest.BackendRef.ReferencesRealResource() {
 			r, service, err = c.generateRealBackendRefCluster(
 				xdsCtx.Mesh,
 				info.Proxy,
-				*dest.BackendRef,
+				dest.BackendRef.RealResourceBackendRef(),
 				dest.RouteProtocol,
 				xdsCtx.ControlPlane.SystemNamespace,
 				hostTags,
@@ -147,12 +147,12 @@ func (c *ClusterGenerator) GenerateClusters(ctx context.Context, xdsCtx xds_cont
 func (c *ClusterGenerator) generateRealBackendRefCluster(
 	meshCtx xds_context.MeshContext,
 	proxy *core_xds.Proxy,
-	backendRef model.ResolvedBackendRef,
+	backendRef *model.RealResourceBackendRef,
 	routeProtocol core_mesh.Protocol,
 	systemNamespace string,
 	identifyingTags map[string]string,
 ) (*core_xds.Resource, string, error) {
-	service, destProtocol, ok := meshroute.GetServiceAndProtocolFromRef(meshCtx, backendRef)
+	service, destProtocol, _, ok := meshroute.GetServiceProtocolPortFromRef(meshCtx, backendRef)
 	if !ok {
 		return nil, "", nil
 	}

--- a/pkg/xds/envoy/types.go
+++ b/pkg/xds/envoy/types.go
@@ -146,7 +146,7 @@ type Service struct {
 	clusters           []Cluster
 	hasExternalService bool
 	tlsReady           bool
-	backendRef         model.ResolvedBackendRef
+	backendRef         *model.ResolvedBackendRef
 }
 
 func (c *Service) Add(cluster Cluster) {
@@ -176,7 +176,7 @@ func (c *Service) TLSReady() bool {
 	return c.tlsReady
 }
 
-func (c *Service) BackendRef() model.ResolvedBackendRef {
+func (c *Service) BackendRef() *model.ResolvedBackendRef {
 	return c.backendRef
 }
 
@@ -219,7 +219,7 @@ func (sa ServicesAccumulator) Add(clusters ...Cluster) {
 	}
 }
 
-func (sa ServicesAccumulator) AddBackendRef(backendRef model.ResolvedBackendRef, cluster Cluster) {
+func (sa ServicesAccumulator) AddBackendRef(backendRef *model.ResolvedBackendRef, cluster Cluster) {
 	if sa.services[cluster.Service()] == nil {
 		sa.services[cluster.Service()] = &Service{
 			tlsReady:   sa.tlsReadiness[cluster.Service()],
@@ -228,7 +228,7 @@ func (sa ServicesAccumulator) AddBackendRef(backendRef model.ResolvedBackendRef,
 		}
 	}
 	// prioritize backendRef pointing to real resource
-	if backendRef.LegacyBackendRef.ReferencesRealObject() && !sa.services[cluster.Service()].backendRef.LegacyBackendRef.ReferencesRealObject() {
+	if backendRef.ReferencesRealResource() && !sa.services[cluster.Service()].backendRef.ReferencesRealResource() {
 		sa.services[cluster.Service()].backendRef = backendRef
 	}
 	sa.services[cluster.Service()].Add(cluster)

--- a/pkg/xds/generator/zoneproxy/generator.go
+++ b/pkg/xds/generator/zoneproxy/generator.go
@@ -5,7 +5,6 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
-	"github.com/kumahq/kuma/pkg/util/pointer"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	envoy_clusters "github.com/kumahq/kuma/pkg/xds/envoy/clusters"
 	envoy_endpoints "github.com/kumahq/kuma/pkg/xds/envoy/endpoints"
@@ -38,7 +37,7 @@ func GenerateCDS(
 			envoy_tags.Without(mesh_proto.ServiceTag),
 		)
 		clusterName := envoy_names.GetMeshClusterName(meshName, service)
-		if clusters.BackendRef().LegacyBackendRef != nil && clusters.BackendRef().LegacyBackendRef.ReferencesRealObject() {
+		if clusters.BackendRef().ReferencesRealResource() {
 			clusterName = service
 		}
 		edsCluster, err := envoy_clusters.NewClusterBuilder(apiVersion, clusterName).
@@ -72,7 +71,7 @@ func GenerateEDS(
 		clusters := services[service]
 		endpoints := endpointMap[service]
 		clusterName := envoy_names.GetMeshClusterName(meshName, service)
-		if clusters.BackendRef().LegacyBackendRef != nil && clusters.BackendRef().LegacyBackendRef.ReferencesRealObject() {
+		if clusters.BackendRef().ReferencesRealResource() {
 			clusterName = service
 		}
 		cla, err := envoy_endpoints.CreateClusterLoadAssignment(clusterName, endpoints, apiVersion)
@@ -208,7 +207,7 @@ func AddFilterChains(
 		)
 
 		listenerBuilder.Configure(filterChain)
-		servicesAcc.AddBackendRef(pointer.Deref(refDest.Resource), cluster)
+		servicesAcc.AddBackendRef(refDest.Resource, cluster)
 	}
 
 	return servicesAcc.Services()


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
