### PR TITLE
test(e2e): add function mapping Mesh resource to KubeYaml

### DIFF
--- a/pkg/test/resources/builders/mesh_builder.go
+++ b/pkg/test/resources/builders/mesh_builder.go
@@ -105,6 +105,14 @@ func (m *MeshBuilder) WithEgressRoutingEnabled() *MeshBuilder {
 	return m
 }
 
+func (m *MeshBuilder) WithMeshExternalServiceTrafficForbidden() *MeshBuilder {
+	if m.res.Spec.Routing == nil {
+		m.res.Spec.Routing = &mesh_proto.Routing{}
+	}
+	m.res.Spec.Routing.DefaultForbidMeshExternalServiceAccess = true
+	return m
+}
+
 func (m *MeshBuilder) WithoutPassthrough() *MeshBuilder {
 	if m.res.Spec.Networking == nil {
 		m.res.Spec.Networking = &mesh_proto.Networking{}

--- a/test/e2e_env/kubernetes/gateway/delegated.go
+++ b/test/e2e_env/kubernetes/gateway/delegated.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/kumahq/kuma/pkg/test/resources/samples"
 	"github.com/kumahq/kuma/test/e2e_env/kubernetes/gateway/delegated"
 	. "github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/framework/deployments/democlient"
@@ -40,7 +41,7 @@ spec:
 
 	BeforeAll(func() {
 		err := NewClusterSetup().
-			Install(MTLSMeshKubernetes(config.Mesh)).
+			Install(YamlK8s(samples.MeshMTLSBuilder().WithName(config.Mesh).KubeYaml())).
 			Install(MeshTrafficPermissionAllowAllKubernetes(config.Mesh)).
 			Install(NamespaceWithSidecarInjection(config.Namespace)).
 			Install(Namespace(config.NamespaceOutsideMesh)).


### PR DESCRIPTION
### Checklist prior to review

Added option to map resource into kube yaml and changed 2 tests to show it.

- [ ] [Link to relevant issue][1] as well as docs and UI issues -- xref: https://github.com/kumahq/kuma/issues/11294
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
