### PR TITLE
fix(kuma-cp): add labels to dataplane object on universal

### DIFF
--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -70,6 +70,7 @@ type resourceEndpoints struct {
 	meshContextBuilder xds_context.MeshContextBuilder
 	xdsHooks           []xds_hooks.ResourceSetHook
 	systemNamespace    string
+	isK8s              bool
 
 	disableOriginLabelValidation bool
 }
@@ -398,7 +399,17 @@ func (r *resourceEndpoints) createResource(
 		_ = res.SetStatus(resRest.GetStatus())
 	}
 
-	labels, err := model.ComputeLabels(res, r.mode, false, r.systemNamespace, r.zoneName)
+	labels, err := model.ComputeLabels(
+		res.Descriptor(),
+		res.GetSpec(),
+		res.GetMeta().GetLabels(),
+		res.GetMeta().GetNameExtensions(),
+		meshName,
+		r.mode,
+		r.isK8s,
+		r.systemNamespace,
+		r.zoneName,
+	)
 	if err != nil {
 		rest_errors.HandleError(ctx, response, err, "Could not compute labels for a resource")
 		return

--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -290,6 +290,7 @@ func addResourcesEndpoints(
 			disableOriginLabelValidation: cfg.Multizone.Zone.DisableOriginLabelValidation,
 			xdsHooks:                     xdsHooks,
 			systemNamespace:              cfg.Store.Kubernetes.SystemNamespace,
+			isK8s:                        cfg.Environment == config_core.KubernetesEnvironment,
 		}
 		if cfg.Mode == config_core.Zone && cfg.Multizone != nil && cfg.Multizone.Zone != nil {
 			endpoints.zoneName = cfg.Multizone.Zone.Name

--- a/pkg/core/bootstrap/bootstrap.go
+++ b/pkg/core/bootstrap/bootstrap.go
@@ -421,7 +421,14 @@ func initializeResourceManager(cfg kuma_cp.Config, builder *core_runtime.Builder
 
 	customizableManager.Customize(
 		mesh.DataplaneType,
-		dataplane.NewDataplaneManager(builder.ResourceStore(), builder.Config().Multizone.Zone.Name, builder.ResourceValidators().Dataplane),
+		dataplane.NewDataplaneManager(
+			builder.ResourceStore(),
+			builder.Config().Multizone.Zone.Name,
+			builder.Config().Mode,
+			builder.Config().Environment == config_core.KubernetesEnvironment,
+			builder.Config().Store.Kubernetes.SystemNamespace,
+			builder.ResourceValidators().Dataplane,
+		),
 	)
 
 	customizableManager.Customize(

--- a/pkg/core/managers/apis/dataplane/dataplane_manager.go
+++ b/pkg/core/managers/apis/dataplane/dataplane_manager.go
@@ -59,7 +59,7 @@ func (m *dataplaneManager) Create(ctx context.Context, resource core_model.Resou
 	labels, err := core_model.ComputeLabels(
 		resource.Descriptor(),
 		resource.GetSpec(),
-		map[string]string{},
+		opts.Labels,
 		model.ResourceNameExtensions{},
 		opts.Mesh,
 		m.mode,

--- a/pkg/core/managers/apis/dataplane/dataplane_manager_test.go
+++ b/pkg/core/managers/apis/dataplane/dataplane_manager_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	config_core "github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/pkg/core/managers/apis/dataplane"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
@@ -18,7 +19,7 @@ var _ = Describe("Dataplane Manager", func() {
 	It("should create a new dataplane with inbound zone tag", func() {
 		// setup
 		s := memory.NewStore()
-		manager := dataplane.NewDataplaneManager(s, "zone-1", dataplane.NewMembershipValidator())
+		manager := dataplane.NewDataplaneManager(s, "zone-1", config_core.Zone, false, "", dataplane.NewMembershipValidator())
 		err := s.Create(context.Background(), core_mesh.NewMeshResource(), store.CreateByKey(model.DefaultMesh, model.NoMesh))
 		Expect(err).ToNot(HaveOccurred())
 
@@ -51,12 +52,18 @@ var _ = Describe("Dataplane Manager", func() {
 		// then
 		Expect(actual.Spec.Networking.Inbound).To(HaveLen(1))
 		Expect(actual.Spec.Networking.Inbound[0].Tags[mesh_proto.ZoneTag]).To(Equal("zone-1"))
+
+		Expect(actual.Meta.GetLabels()).To(And(
+			HaveKeyWithValue(mesh_proto.ZoneTag, "zone-1"),
+			HaveKeyWithValue(mesh_proto.ResourceOriginLabel, "zone"),
+			HaveKeyWithValue(mesh_proto.EnvTag, "universal"),
+			HaveKeyWithValue(mesh_proto.MeshTag, "default")))
 	})
 
 	It("should update a dataplane with inbound zone tag", func() {
 		// setup
 		s := memory.NewStore()
-		manager := dataplane.NewDataplaneManager(s, "zone-1", dataplane.NewMembershipValidator())
+		manager := dataplane.NewDataplaneManager(s, "zone-1", config_core.Zone, false, "", dataplane.NewMembershipValidator())
 		err := s.Create(context.Background(), core_mesh.NewMeshResource(), store.CreateByKey(model.DefaultMesh, model.NoMesh))
 		Expect(err).ToNot(HaveOccurred())
 
@@ -99,12 +106,18 @@ var _ = Describe("Dataplane Manager", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(actual.Spec.Networking.Inbound).To(HaveLen(1))
 		Expect(actual.Spec.Networking.Inbound[0].Tags[mesh_proto.ZoneTag]).To(Equal("zone-1"))
+
+		Expect(actual.Meta.GetLabels()).To(And(
+			HaveKeyWithValue(mesh_proto.ZoneTag, "zone-1"),
+			HaveKeyWithValue(mesh_proto.ResourceOriginLabel, "zone"),
+			HaveKeyWithValue(mesh_proto.EnvTag, "universal"),
+			HaveKeyWithValue(mesh_proto.MeshTag, "default")))
 	})
 
 	It("should create a new gateway with zone tag", func() {
 		// setup
 		s := memory.NewStore()
-		manager := dataplane.NewDataplaneManager(s, "zone-1", dataplane.NewMembershipValidator())
+		manager := dataplane.NewDataplaneManager(s, "zone-1", config_core.Zone, false, "", dataplane.NewMembershipValidator())
 		err := s.Create(context.Background(), core_mesh.NewMeshResource(), store.CreateByKey(model.DefaultMesh, model.NoMesh))
 		Expect(err).ToNot(HaveOccurred())
 
@@ -138,7 +151,7 @@ var _ = Describe("Dataplane Manager", func() {
 	It("should update a dataplane with gateway zone tag", func() {
 		// setup
 		s := memory.NewStore()
-		manager := dataplane.NewDataplaneManager(s, "zone-1", dataplane.NewMembershipValidator())
+		manager := dataplane.NewDataplaneManager(s, "zone-1", config_core.Zone, false, "", dataplane.NewMembershipValidator())
 		err := s.Create(context.Background(), core_mesh.NewMeshResource(), store.CreateByKey(model.DefaultMesh, model.NoMesh))
 		Expect(err).ToNot(HaveOccurred())
 
@@ -183,7 +196,7 @@ var _ = Describe("Dataplane Manager", func() {
 	It("should set health.ready to false if serviceProbe is provided and health is nil", func() {
 		// setup
 		s := memory.NewStore()
-		manager := dataplane.NewDataplaneManager(s, "zone-1", dataplane.NewMembershipValidator())
+		manager := dataplane.NewDataplaneManager(s, "zone-1", config_core.Zone, false, "", dataplane.NewMembershipValidator())
 		err := s.Create(context.Background(), core_mesh.NewMeshResource(), store.CreateByKey(model.DefaultMesh, model.NoMesh))
 		Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/core/resources/model/resource.go
+++ b/pkg/core/resources/model/resource.go
@@ -456,10 +456,20 @@ func resourceOrigin(labels map[string]string) (mesh_proto.ResourceOrigin, bool) 
 	return "", false
 }
 
-func ComputeLabels(r Resource, mode config_core.CpMode, isK8s bool, systemNamespace string, localZone string) (map[string]string, error) {
+func ComputeLabels(
+	rd ResourceTypeDescriptor,
+	spec ResourceSpec,
+	existingLabels map[string]string,
+	resourceNameExtensions ResourceNameExtensions,
+	mesh string,
+	mode config_core.CpMode,
+	isK8s bool,
+	systemNamespace string,
+	localZone string,
+) (map[string]string, error) {
 	labels := map[string]string{}
-	if r.GetMeta() != nil && len(r.GetMeta().GetLabels()) > 0 {
-		labels = r.GetMeta().GetLabels()
+	if len(existingLabels) > 0 {
+		labels = existingLabels
 	}
 
 	setIfNotExist := func(k, v string) {
@@ -469,22 +479,20 @@ func ComputeLabels(r Resource, mode config_core.CpMode, isK8s bool, systemNamesp
 	}
 
 	getMeshOrDefault := func() string {
-		if r.GetMeta() != nil {
-			if mesh := r.GetMeta().GetMesh(); mesh != "" {
-				return mesh
-			}
+		if mesh != "" {
+			return mesh
 		}
 		return DefaultMesh
 	}
 
-	if r.Descriptor().Scope == ScopeMesh {
+	if rd.Scope == ScopeMesh {
 		setIfNotExist(metadata.KumaMeshLabel, getMeshOrDefault())
 	}
 
 	if mode == config_core.Zone {
 		// If resource can't be created on Zone (like Mesh), there is no point in adding
 		// 'kuma.io/zone', 'kuma.io/origin' and 'kuma.io/env' labels even if the zone is non-federated
-		if r.Descriptor().KDSFlags.Has(AllowedOnZoneSelector) {
+		if rd.KDSFlags.Has(AllowedOnZoneSelector) {
 			setIfNotExist(mesh_proto.ResourceOriginLabel, string(mesh_proto.ZoneResourceOrigin))
 			if labels[mesh_proto.ResourceOriginLabel] != string(mesh_proto.GlobalResourceOrigin) {
 				setIfNotExist(mesh_proto.ZoneTag, localZone)
@@ -498,29 +506,25 @@ func ComputeLabels(r Resource, mode config_core.CpMode, isK8s bool, systemNamesp
 	}
 
 	if isK8s && IsLocallyOriginated(mode, labels) {
-		if r.GetMeta() != nil {
-			ns, ok := r.GetMeta().GetNameExtensions()[mesh_proto.KubeNamespaceTag]
-			if ok && ns != "" {
-				setIfNotExist(mesh_proto.KubeNamespaceTag, ns)
-			}
+		ns, ok := resourceNameExtensions[mesh_proto.KubeNamespaceTag]
+		if ok && ns != "" {
+			setIfNotExist(mesh_proto.KubeNamespaceTag, ns)
 		}
 	}
 
-	if r.GetMeta() != nil {
-		if ns, ok := r.GetMeta().GetNameExtensions()[mesh_proto.KubeNamespaceTag]; ok && r.Descriptor().IsPolicy && r.Descriptor().IsPluginOriginated && IsLocallyOriginated(mode, labels) {
-			var role mesh_proto.PolicyRole
-			switch ns {
-			case systemNamespace:
-				role = mesh_proto.SystemPolicyRole
-			default:
-				var err error
-				role, err = ComputePolicyRole(r.GetSpec().(Policy), ns)
-				if err != nil {
-					return nil, err
-				}
+	if ns, ok := resourceNameExtensions[mesh_proto.KubeNamespaceTag]; ok && rd.IsPolicy && rd.IsPluginOriginated && IsLocallyOriginated(mode, labels) {
+		var role mesh_proto.PolicyRole
+		switch ns {
+		case systemNamespace:
+			role = mesh_proto.SystemPolicyRole
+		default:
+			var err error
+			role, err = ComputePolicyRole(spec.(Policy), ns)
+			if err != nil {
+				return nil, err
 			}
-			labels[mesh_proto.PolicyRoleLabel] = string(role)
 		}
+		labels[mesh_proto.PolicyRoleLabel] = string(role)
 	}
 
 	return labels, nil

--- a/pkg/core/resources/model/resource_test.go
+++ b/pkg/core/resources/model/resource_test.go
@@ -276,7 +276,17 @@ var _ = Describe("ComputeLabels", func() {
 
 	DescribeTable("should return correct label map",
 		func(given testCase) {
-			labels, err := core_model.ComputeLabels(given.r, given.mode, given.isK8s, "kuma-system", given.localZone)
+			labels, err := core_model.ComputeLabels(
+				given.r.Descriptor(),
+				given.r.GetSpec(),
+				given.r.GetMeta().GetLabels(),
+				given.r.GetMeta().GetNameExtensions(),
+				given.r.GetMeta().GetMesh(),
+				given.mode,
+				given.isK8s,
+				"kuma-system",
+				given.localZone,
+			)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(labels).To(Equal(given.expectedLabels))
 		},

--- a/pkg/plugins/runtime/k8s/webhooks/defaulter.go
+++ b/pkg/plugins/runtime/k8s/webhooks/defaulter.go
@@ -66,7 +66,17 @@ func (h *defaultingHandler) Handle(_ context.Context, req admission.Request) adm
 		return resp
 	}
 
-	computed, err := core_model.ComputeLabels(resource, h.Mode, true, h.SystemNamespace, h.ZoneName)
+	computed, err := core_model.ComputeLabels(
+		resource.Descriptor(),
+		resource.GetSpec(),
+		resource.GetMeta().GetLabels(),
+		resource.GetMeta().GetNameExtensions(),
+		resource.GetMeta().GetMesh(),
+		h.Mode,
+		true,
+		h.SystemNamespace,
+		h.ZoneName,
+	)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
 	}


### PR DESCRIPTION
### Checklist prior to review

While investigating the failure of the universal test (https://github.com/kumahq/kuma/pull/11425), I discovered that labels were not being set for dataplanes on the universal environment. In the universal setup, users can send the Dataplane object in the metadata, which is later processed by the control plane. On Kubernetes, we call ComputeLabels in the defaulter, which sets the labels, but this was not happening for the universal environment. In the universal setup, tags were only being set on the inbounds and not on the entire dataplane object. I've added a flow to apply tags to the whole dataplane.

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
