### PR TITLE
feat(observability): default installation with exclusive mesh services

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-observability.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.defaults.golden.yaml
@@ -11909,6 +11909,7 @@ metadata:
   namespace: mesh-observability
   labels:
     app: grafana
+    kuma.io/mesh: default
 spec:
   type: ClusterIP
   ports:
@@ -11951,6 +11952,7 @@ metadata:
   labels:
     component: "server"
     app: prometheus
+    kuma.io/mesh: default
   name: prometheus-server
   namespace: mesh-observability
 spec:

--- a/app/kumactl/cmd/install/testdata/install-observability.no-grafana.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-grafana.golden.yaml
@@ -518,6 +518,7 @@ metadata:
   labels:
     component: "server"
     app: prometheus
+    kuma.io/mesh: default
   name: prometheus-server
   namespace: mesh-observability
 spec:

--- a/app/kumactl/cmd/install/testdata/install-observability.no-jaeger.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-jaeger.golden.yaml
@@ -11909,6 +11909,7 @@ metadata:
   namespace: mesh-observability
   labels:
     app: grafana
+    kuma.io/mesh: default
 spec:
   type: ClusterIP
   ports:
@@ -11951,6 +11952,7 @@ metadata:
   labels:
     component: "server"
     app: prometheus
+    kuma.io/mesh: default
   name: prometheus-server
   namespace: mesh-observability
 spec:

--- a/app/kumactl/cmd/install/testdata/install-observability.no-loki.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-loki.golden.yaml
@@ -11909,6 +11909,7 @@ metadata:
   namespace: mesh-observability
   labels:
     app: grafana
+    kuma.io/mesh: default
 spec:
   type: ClusterIP
   ports:
@@ -11951,6 +11952,7 @@ metadata:
   labels:
     component: "server"
     app: prometheus
+    kuma.io/mesh: default
   name: prometheus-server
   namespace: mesh-observability
 spec:

--- a/app/kumactl/cmd/install/testdata/install-observability.no-prometheus.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-prometheus.golden.yaml
@@ -11406,6 +11406,7 @@ metadata:
   namespace: mesh-observability
   labels:
     app: grafana
+    kuma.io/mesh: default
 spec:
   type: ClusterIP
   ports:

--- a/app/kumactl/cmd/install/testdata/install-observability.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.overrides.golden.yaml
@@ -11909,6 +11909,7 @@ metadata:
   namespace: kuma
   labels:
     app: grafana
+    kuma.io/mesh: mesh-1
 spec:
   type: ClusterIP
   ports:
@@ -11951,6 +11952,7 @@ metadata:
   labels:
     component: "server"
     app: prometheus
+    kuma.io/mesh: mesh-1
   name: prometheus-server
   namespace: kuma
 spec:

--- a/app/kumactl/data/install/k8s/metrics/grafana/grafana.yaml
+++ b/app/kumactl/data/install/k8s/metrics/grafana/grafana.yaml
@@ -215,6 +215,7 @@ metadata:
   namespace: {{ .Namespace }}
   labels:
     app: grafana
+    kuma.io/mesh: {{ .Mesh }}
 spec:
   type: ClusterIP
   ports:

--- a/app/kumactl/data/install/k8s/metrics/prometheus/server.yaml
+++ b/app/kumactl/data/install/k8s/metrics/prometheus/server.yaml
@@ -382,6 +382,7 @@ metadata:
   labels:
     component: "server"
     app: prometheus
+    kuma.io/mesh: {{ .Mesh }}
   name: prometheus-server
   namespace: {{ .Namespace }}
 spec:


### PR DESCRIPTION
### Checklist prior to review

Prometheus is broken by default with Exclusive MeshService.
It's because we install prometheus and grafana in the mesh by default.
The `mesh-observability` namespace has disabled sidecar injection. We enable this for a couple of services. In this case, we had to annotate those services with `kuma.io/mesh` for CP to know that it should convert those for MeshSerivce

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
