### PR TITLE
fix(kuma-cp): do not sync policies with empty topLevel targetRef to zones that does not support it

### DIFF
--- a/api/common/v1alpha1/ref.go
+++ b/api/common/v1alpha1/ref.go
@@ -80,6 +80,10 @@ func (x TargetRefKindSlice) Swap(i, j int)      { x[i], x[j] = x[j], x[i] }
 
 // TargetRef defines structure that allows attaching policy to various objects
 type TargetRef struct {
+	// This is needed to not sync policies with empty topLevelTarget ref to old zones that does not support it
+	// This can be removed in 2.11.x
+	UsesSyntacticSugar bool `json:"-"`
+
 	// Kind of the referenced resource
 	// +kubebuilder:validation:Enum=Mesh;MeshSubset;MeshGateway;MeshService;MeshExternalService;MeshMultiZoneService;MeshServiceSubset;MeshHTTPRoute
 	Kind TargetRefKind `json:"kind,omitempty"`

--- a/pkg/kds/context/context.go
+++ b/pkg/kds/context/context.go
@@ -273,6 +273,12 @@ func GlobalProvidedFilter(rm manager.ResourceManager, configs map[string]bool) r
 
 		switch {
 		case isGlobal && r.Descriptor().KDSFlags.Has(core_model.GlobalToAllZonesFlag):
+			if r.Descriptor().IsPluginOriginated && r.Descriptor().IsPolicy {
+				policy := r.GetSpec().(core_model.Policy)
+				if policy.GetTargetRef().UsesSyntacticSugar && !features.HasFeature(kds.FeatureOptionalTopLevelTargetRef) {
+					return false
+				}
+			}
 			return true
 		case !isGlobal && r.Descriptor().KDSFlags.Has(core_model.GlobalToAllButOriginalZoneFlag):
 			if r.Descriptor().IsPluginOriginated && r.Descriptor().IsPolicy {
@@ -280,6 +286,9 @@ func GlobalProvidedFilter(rm manager.ResourceManager, configs map[string]bool) r
 					return false
 				}
 				policy := r.GetSpec().(core_model.Policy)
+				if policy.GetTargetRef().UsesSyntacticSugar && !features.HasFeature(kds.FeatureOptionalTopLevelTargetRef) {
+					return false
+				}
 				role, err := core_model.ComputePolicyRole(policy, r.GetMeta().GetLabels()[mesh_proto.KubeNamespaceTag])
 				if err != nil {
 					ri := core_model.NewResourceIdentifier(r)

--- a/pkg/kds/context/context_test.go
+++ b/pkg/kds/context/context_test.go
@@ -438,7 +438,7 @@ var _ = Describe("Context", func() {
 				func(given testCase) {
 					ctx := stdcontext.Background()
 					// when
-					ok := predicate(ctx, clusterID, kds.Features{}, given.resource)
+					ok := predicate(ctx, clusterID, kds.Features{kds.FeatureOptionalTopLevelTargetRef: true}, given.resource)
 
 					// then
 					Expect(ok).To(BeTrue())

--- a/pkg/kds/features.go
+++ b/pkg/kds/features.go
@@ -37,6 +37,8 @@ const FeatureHostnameGeneratorMzSelector string = "hg-mz-selector"
 // FeatureProducerPolicyFlow means that the zone control plane supports the producer policy flow.
 const FeatureProducerPolicyFlow string = "producer-policy-flow"
 
+const FeatureOptionalTopLevelTargetRef string = "optional-top-level-target-ref"
+
 func ContextHasFeature(ctx context.Context, feature string) bool {
 	md, _ := metadata.FromIncomingContext(ctx)
 	features := md.Get(FeaturesMetadataKey)

--- a/pkg/kds/v2/client/stream.go
+++ b/pkg/kds/v2/client/stream.go
@@ -79,6 +79,7 @@ func (s *stream) DeltaDiscoveryRequest(resourceType core_model.ResourceType) err
 							{Kind: &structpb.Value_StringValue{StringValue: kds.FeatureHashSuffix}},
 							{Kind: &structpb.Value_StringValue{StringValue: kds.FeatureHostnameGeneratorMzSelector}},
 							{Kind: &structpb.Value_StringValue{StringValue: kds.FeatureProducerPolicyFlow}},
+							{Kind: &structpb.Value_StringValue{StringValue: kds.FeatureOptionalTopLevelTargetRef}},
 						},
 					}}},
 				},

--- a/pkg/plugins/policies/donothingpolicy/api/v1alpha1/zz_generated.helpers.go
+++ b/pkg/plugins/policies/donothingpolicy/api/v1alpha1/zz_generated.helpers.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (x *DoNothingPolicy) GetTargetRef() common_api.TargetRef {
-	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh})
+	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh, UsesSyntacticSugar: true})
 }
 
 func (x *From) GetTargetRef() common_api.TargetRef {

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/zz_generated.helpers.go
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/zz_generated.helpers.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (x *MeshAccessLog) GetTargetRef() common_api.TargetRef {
-	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh})
+	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh, UsesSyntacticSugar: true})
 }
 
 func (x *From) GetTargetRef() common_api.TargetRef {

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/zz_generated.helpers.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/zz_generated.helpers.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (x *MeshCircuitBreaker) GetTargetRef() common_api.TargetRef {
-	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh})
+	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh, UsesSyntacticSugar: true})
 }
 
 func (x *From) GetTargetRef() common_api.TargetRef {

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/zz_generated.helpers.go
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/zz_generated.helpers.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (x *MeshFaultInjection) GetTargetRef() common_api.TargetRef {
-	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh})
+	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh, UsesSyntacticSugar: true})
 }
 
 func (x *From) GetTargetRef() common_api.TargetRef {

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/zz_generated.helpers.go
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/zz_generated.helpers.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (x *MeshHealthCheck) GetTargetRef() common_api.TargetRef {
-	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh})
+	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh, UsesSyntacticSugar: true})
 }
 
 func (x *To) GetTargetRef() common_api.TargetRef {

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/zz_generated.helpers.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/zz_generated.helpers.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (x *MeshHTTPRoute) GetTargetRef() common_api.TargetRef {
-	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh})
+	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh, UsesSyntacticSugar: true})
 }
 
 func (x *To) GetTargetRef() common_api.TargetRef {

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/zz_generated.helpers.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/zz_generated.helpers.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (x *MeshLoadBalancingStrategy) GetTargetRef() common_api.TargetRef {
-	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh})
+	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh, UsesSyntacticSugar: true})
 }
 
 func (x *To) GetTargetRef() common_api.TargetRef {

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/zz_generated.helpers.go
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/zz_generated.helpers.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (x *MeshMetric) GetTargetRef() common_api.TargetRef {
-	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh})
+	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh, UsesSyntacticSugar: true})
 }
 
 func (x *MeshMetric) GetDefault() interface{} {

--- a/pkg/plugins/policies/meshpassthrough/api/v1alpha1/zz_generated.helpers.go
+++ b/pkg/plugins/policies/meshpassthrough/api/v1alpha1/zz_generated.helpers.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (x *MeshPassthrough) GetTargetRef() common_api.TargetRef {
-	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh})
+	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh, UsesSyntacticSugar: true})
 }
 
 func (x *MeshPassthrough) GetDefault() interface{} {

--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/zz_generated.helpers.go
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/zz_generated.helpers.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (x *MeshProxyPatch) GetTargetRef() common_api.TargetRef {
-	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh})
+	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh, UsesSyntacticSugar: true})
 }
 
 func (x *MeshProxyPatch) GetDefault() interface{} {

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/zz_generated.helpers.go
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/zz_generated.helpers.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (x *MeshRateLimit) GetTargetRef() common_api.TargetRef {
-	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh})
+	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh, UsesSyntacticSugar: true})
 }
 
 func (x *From) GetTargetRef() common_api.TargetRef {

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/zz_generated.helpers.go
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/zz_generated.helpers.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (x *MeshRetry) GetTargetRef() common_api.TargetRef {
-	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh})
+	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh, UsesSyntacticSugar: true})
 }
 
 func (x *To) GetTargetRef() common_api.TargetRef {

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/zz_generated.helpers.go
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/zz_generated.helpers.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (x *MeshTCPRoute) GetTargetRef() common_api.TargetRef {
-	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh})
+	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh, UsesSyntacticSugar: true})
 }
 
 func (x *To) GetTargetRef() common_api.TargetRef {

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/zz_generated.helpers.go
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/zz_generated.helpers.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (x *MeshTimeout) GetTargetRef() common_api.TargetRef {
-	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh})
+	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh, UsesSyntacticSugar: true})
 }
 
 func (x *From) GetTargetRef() common_api.TargetRef {

--- a/pkg/plugins/policies/meshtls/api/v1alpha1/zz_generated.helpers.go
+++ b/pkg/plugins/policies/meshtls/api/v1alpha1/zz_generated.helpers.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (x *MeshTLS) GetTargetRef() common_api.TargetRef {
-	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh})
+	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh, UsesSyntacticSugar: true})
 }
 
 func (x *From) GetTargetRef() common_api.TargetRef {

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/zz_generated.helpers.go
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/zz_generated.helpers.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (x *MeshTrace) GetTargetRef() common_api.TargetRef {
-	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh})
+	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh, UsesSyntacticSugar: true})
 }
 
 func (x *MeshTrace) GetDefault() interface{} {

--- a/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/zz_generated.helpers.go
+++ b/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/zz_generated.helpers.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (x *MeshTrafficPermission) GetTargetRef() common_api.TargetRef {
-	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh})
+	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh, UsesSyntacticSugar: true})
 }
 
 func (x *From) GetTargetRef() common_api.TargetRef {

--- a/tools/policy-gen/generator/cmd/helpers.go
+++ b/tools/policy-gen/generator/cmd/helpers.go
@@ -62,7 +62,7 @@ import (
 )
 
 func (x *{{.name}}) GetTargetRef() common_api.TargetRef {
-	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh})
+	return pointer.DerefOr(x.TargetRef, common_api.TargetRef{Kind: common_api.Mesh, UsesSyntacticSugar: true})
 }
 
 {{ if .generateFrom }}


### PR DESCRIPTION
Fixes: #11426

Since `Policy` interface exposes only function `GetTargetRef` which returns default targetRef, we don't have an easy way of checking if policy had targetRef set. To deal with this, we can introduce `UsesSyntacticSugar` to make sure we are not syncing policies not supported by older version. This can be easily removed in two versions

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
