### PR TITLE
test(e2e): use different name for gateway resource

### DIFF
--- a/test/e2e_env/multizone/meshmultizoneservice/connectivity.go
+++ b/test/e2e_env/multizone/meshmultizoneservice/connectivity.go
@@ -46,14 +46,14 @@ spec:
 apiVersion: kuma.io/v1alpha1
 kind: MeshGateway
 metadata:
-  name: edge-gateway
+  name: edge-gateway-mmzs
   labels:
     kuma.io/origin: zone
 mesh: %s
 spec:
   selectors:
   - match:
-      kuma.io/service: edge-gateway_%s_svc
+      kuma.io/service: edge-gateway-mmzs_%s_svc
   conf:
     listeners:
     - port: 8080
@@ -63,7 +63,7 @@ spec:
 apiVersion: kuma.io/v1alpha1
 kind: MeshHTTPRoute
 metadata:
-  name: route
+  name: route-mzms
   namespace: %s
   labels:
     kuma.io/mesh: %s
@@ -71,7 +71,7 @@ metadata:
 spec:
   targetRef:
     kind: MeshGateway
-    name: edge-gateway
+    name: edge-gateway-mmzs
   to:
     - targetRef:
         kind: Mesh
@@ -103,7 +103,7 @@ spec:
 			Install(democlient.Install(democlient.WithNamespace(namespace), democlient.WithMesh(meshName))).
 			Install(YamlK8s(meshGateway)).
 			Install(YamlK8s(gatewayRoute)).
-			Install(YamlK8s(gateway.MkGatewayInstance("edge-gateway", namespace, meshName))).
+			Install(YamlK8s(gateway.MkGatewayInstance("edge-gateway-mmzs", namespace, meshName))).
 			Setup(multizone.KubeZone1)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -134,6 +134,7 @@ spec:
 
 	E2EAfterAll(func() {
 		Expect(multizone.KubeZone1.TriggerDeleteNamespace(namespace)).To(Succeed())
+		Expect(multizone.KubeZone1.TriggerDeleteNamespace(clientNamespace)).To(Succeed())
 		Expect(multizone.KubeZone2.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(multizone.UniZone1.DeleteMeshApps(meshName)).To(Succeed())
 		Expect(multizone.UniZone2.DeleteMeshApps(meshName)).To(Succeed())
@@ -164,7 +165,7 @@ spec:
 			Eventually(func(g Gomega) {
 				response, err := client.CollectEchoResponse(
 					multizone.KubeZone1, "demo-client",
-					fmt.Sprintf("http://edge-gateway.%s:8080/%s", namespace, given.address),
+					fmt.Sprintf("http://edge-gateway-mmzs.%s:8080/%s", namespace, given.address),
 					client.FromKubernetesPod(clientNamespace, "demo-client"),
 				)
 
@@ -173,7 +174,7 @@ spec:
 			}, "30s", "1s").Should(Succeed())
 		},
 		Entry("should access MeshMultiZoneService", testCase{
-			address:       "/mmzs",
+			address:       "mmzs",
 			instanceMatch: Equal("kube-test-server-1"),
 		}),
 	)

--- a/test/e2e_env/universal/meshaccesslog/meshaccesslog.go
+++ b/test/e2e_env/universal/meshaccesslog/meshaccesslog.go
@@ -56,7 +56,7 @@ spec:
 			Install(YamlUniversal(uniServiceYAML)).
 			Install(YamlUniversal(`
 type: HostnameGenerator
-name: uni-ms
+name: uni-ms-mal
 spec:
   template: '{{ .DisplayName }}.universal.ms'
   selector:

--- a/test/e2e_env/universal/meshhealthcheck/policy.go
+++ b/test/e2e_env/universal/meshhealthcheck/policy.go
@@ -150,7 +150,7 @@ spec:
 				Install(YamlUniversal(uniServiceYAML)).
 				Install(YamlUniversal(`
 type: HostnameGenerator
-name: uni-ms
+name: uni-ms-mhc
 spec:
   template: '{{ .DisplayName }}.universal.ms'
   selector:

--- a/test/e2e_env/universal/meshretry/http.go
+++ b/test/e2e_env/universal/meshretry/http.go
@@ -42,7 +42,7 @@ spec:
 			Install(YamlUniversal(uniServiceYAML)).
 			Install(YamlUniversal(`
 type: HostnameGenerator
-name: uni-ms
+name: uni-ms-retry
 spec:
   template: '{{ .DisplayName }}.universal.ms'
   selector:


### PR DESCRIPTION
### Checklist prior to review

It appears that we have two `MeshGateway` resources with the name `edge-gateway`. Each one can override the other's selector, potentially causing other tests to fail. Since `MeshGateway` is not [namespace-scoped](https://github.com/kumahq/kuma/blob/master/docs/generated/raw/crds/kuma.io_meshgateways.yaml#L17), I have renamed the resources to avoid conflicts. I also changed the route name to avoid conflicts. 

On Universal, I renamed the resources because there were already resources with the same name.

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
