### PR TITLE
chore(codeql): fix minor lint issues

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -141,7 +141,7 @@ jobs:
       - name: "Download all SBOM assets"
         id: collect_sbom
         if: ${{ needs.build_publish.result == 'success' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           path: ${{ env.SECURITY_ASSETS_DOWNLOAD_PATH }}
           pattern: "*sbom.{cyclonedx,spdx}.json"
@@ -151,7 +151,7 @@ jobs:
       - name: "Download binary artifact provenance"
         if: ${{ needs.provenance.result == 'success' && github.ref_type == 'tag' }}
         id: collect_provenance
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           path: ${{ env.SECURITY_ASSETS_DOWNLOAD_PATH }}
           pattern: ${{ github.event.repository.name }}.intoto.jsonl

--- a/app/kumactl/cmd/install/render_helm_files.go
+++ b/app/kumactl/cmd/install/render_helm_files.go
@@ -27,7 +27,7 @@ func labelRegex(label string) *regexp.Regexp {
 var stripLabelsRegexps = []*regexp.Regexp{
 	labelRegex("app\\.kubernetes\\.io/managed-by"),
 	labelRegex("helm\\.sh/chart"),
-	labelRegex("app.kubernetes\\.io/version"),
+	labelRegex("app\\.kubernetes\\.io/version"),
 }
 
 var kumaSystemNamespace = func(namespace string) string {

--- a/test/e2e_env/kubernetes/appprobeproxy/probe_proxy.go
+++ b/test/e2e_env/kubernetes/appprobeproxy/probe_proxy.go
@@ -101,8 +101,8 @@ func ApplicationProbeProxy() {
 			container := getAppContainer(httpPod, httpAppName)
 			g.Expect(container).ToNot(BeNil())
 			g.Expect(container.ReadinessProbe.HTTPGet).ToNot(BeNil())
-			probeProxyPort, _ := strconv.Atoi(probeProxyPortAnno)
-			g.Expect(container.ReadinessProbe.HTTPGet.Port).To(Equal(intstr.FromInt32(int32(probeProxyPort)))) //nolint:gosec  // we never overflow here
+			port := intstr.FromString(probeProxyPortAnno)
+			g.Expect(container.ReadinessProbe.HTTPGet.Port.IntValue()).To(Equal(port.IntValue()))
 			g.Expect(container.ReadinessProbe.HTTPGet.Path).To(Equal("/80/probes?type=readiness"))
 		}, "30s", "1s").Should(Succeed())
 
@@ -194,8 +194,8 @@ func ApplicationProbeProxy() {
 			g.Expect(container).ToNot(BeNil())
 			g.Expect(container.ReadinessProbe.HTTPGet).ToNot(BeNil())
 
-			port, _ := strconv.Atoi(virtualProbesPortAnno)
-			g.Expect(container.ReadinessProbe.HTTPGet.Port).To(Equal(intstr.FromInt32(int32(port)))) //nolint:gosec  // we never overflow here
+			port := intstr.FromString(virtualProbesPortAnno)
+			g.Expect(container.ReadinessProbe.HTTPGet.Port.IntValue()).To(Equal(port.IntValue()))
 			g.Expect(container.ReadinessProbe.HTTPGet.Path).To(Equal("/80/probes?type=readiness"))
 		}, "30s", "1s").Should(Succeed())
 


### PR DESCRIPTION
These were flagged by CodeQL so getting them fixed

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

> Changelog: skip
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
