### PR TITLE
fix(MeshGateway): handle unresolved real backendRefs

### DIFF
--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/gateway_routes.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/gateway_routes.go
@@ -16,6 +16,7 @@ import (
 	api "github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
 	plugin_gateway "github.com/kumahq/kuma/pkg/plugins/runtime/gateway"
 	"github.com/kumahq/kuma/pkg/plugins/runtime/gateway/match"
+	"github.com/kumahq/kuma/pkg/plugins/runtime/gateway/metadata"
 	"github.com/kumahq/kuma/pkg/plugins/runtime/gateway/route"
 	"github.com/kumahq/kuma/pkg/util/pointer"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
@@ -235,11 +236,19 @@ func makeHttpRouteEntry(
 		}
 		var dest map[string]string
 		if ref == nil || ref.ResourceOrNil() == nil {
-			var ok bool
-			dest, ok = tags.FromLegacyTargetRef(b.TargetRef)
-			if !ok {
-				// This should be caught by validation
-				continue
+			// We have a legacy backendRef
+			if !b.ReferencesRealObject() {
+				var ok bool
+				dest, ok = tags.FromLegacyTargetRef(b.TargetRef)
+				if !ok {
+					// This should be caught by validation
+					continue
+				}
+			} else {
+				// We have a real backendRef but it's not valid
+				dest = map[string]string{
+					mesh_proto.ServiceTag: metadata.UnresolvedBackendServiceTag,
+				}
 			}
 		}
 		target := route.Destination{

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin_test.go
@@ -152,6 +152,7 @@ var _ = Describe("MeshTLS", func() {
 				Items: []*core_mesh.MeshGatewayResource{samples.GatewayResource()},
 			}
 			backendRefOriginIndex := map[common_api.MatchesHash]int{}
+			var backendRef common_api.BackendRef
 			if given.meshService {
 				backendRefOriginIndex = map[common_api.MatchesHash]int{
 					meshhttproute_api.HashMatches([]meshhttproute_api.Match{
@@ -183,6 +184,16 @@ var _ = Describe("MeshTLS", func() {
 				}
 				resources.MeshLocalResources[meshservice_api.MeshServiceType] = &meshservice_api.MeshServiceResourceList{
 					Items: []*meshservice_api.MeshServiceResource{&meshSvc},
+				}
+				backendRef = common_api.BackendRef{
+					TargetRef: builders.TargetRefMeshService("backend", "", ""),
+					Port:      pointer.To[uint32](80),
+					Weight:    pointer.To(uint(100)),
+				}
+			} else {
+				backendRef = common_api.BackendRef{
+					TargetRef: builders.TargetRefMeshService("backend", "", ""),
+					Weight:    pointer.To(uint(100)),
 				}
 			}
 
@@ -217,11 +228,7 @@ var _ = Describe("MeshTLS", func() {
 														},
 													}},
 													Default: meshhttproute_api.RuleConf{
-														BackendRefs: &[]common_api.BackendRef{{
-															TargetRef: builders.TargetRefMeshService("backend", "", "test-port"),
-															Port:      pointer.To[uint32](80),
-															Weight:    pointer.To(uint(100)),
-														}},
+														BackendRefs: &[]common_api.BackendRef{backendRef},
 													},
 												},
 											},


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- #11456 
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
