### PR TITLE
fix(policy): verify zone if dpp origin is zone and metadata exists

### DIFF
--- a/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/meshtimeout_consumer_dataplanes.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/meshtimeout_consumer_dataplanes.golden.json
@@ -9,7 +9,26 @@
    "mesh": "default",
    "name": "dp-1",
    "type": "Dataplane"
+  },
+  {
+   "labels": {
+    "k8s.kuma.io/namespace": "kuma-demo",
+    "kuma.io/display-name": "dp-2",
+    "kuma.io/zone": "zone-2"
+   },
+   "mesh": "default",
+   "name": "dp-2",
+   "type": "Dataplane"
+  },
+  {
+   "labels": {
+    "k8s.kuma.io/namespace": "kuma-demo",
+    "kuma.io/display-name": "dp-3"
+   },
+   "mesh": "default",
+   "name": "dp-3",
+   "type": "Dataplane"
   }
  ],
- "total": 1
+ "total": 3
 }

--- a/pkg/plugins/policies/core/matchers/dataplane.go
+++ b/pkg/plugins/policies/core/matchers/dataplane.go
@@ -193,7 +193,15 @@ func dppSelectedByZone(meta core_model.ResourceMeta, dpp *core_mesh.DataplaneRes
 	case mesh_proto.ProducerPolicyRole:
 		return true
 	default:
-		origin, ok := meta.GetLabels()[string(mesh_proto.ResourceOriginLabel)]
+		if dpp.GetMeta() == nil {
+			return true
+		}
+		// we should return true once dpp has no origin.
+		// Resource that cannot be created on zone(global one) doesn't have it
+		if _, ok := dpp.GetMeta().GetLabels()[mesh_proto.ResourceOriginLabel]; !ok {
+			return true
+		}
+		origin, ok := meta.GetLabels()[mesh_proto.ResourceOriginLabel]
 		if ok && origin == string(mesh_proto.ZoneResourceOrigin) {
 			zone, ok := meta.GetLabels()[string(mesh_proto.ZoneTag)]
 			return ok && dpp.GetMeta().GetLabels()[mesh_proto.ZoneTag] == zone


### PR DESCRIPTION
### Checklist prior to review

[This PR](https://github.com/kumahq/kuma/pull/11425) introduced an error that caused ExternalServices to not be properly matched. Autoreachable services build a graph of relationships based on a fake Dataplane, which lacks labels, leading to a nil pointer issue. Additionally, the zone tag is not supported for autoreachable services, making its introduction unnecessary. Finally, since ExternalService is a global resource, the origin label will not be added.

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
