### PR TITLE
fix(meshtls): do not panic when no topLevel targetRef

### DIFF
--- a/pkg/plugins/policies/meshtls/api/v1alpha1/testdata/full-valid-no-top-target.input.yaml
+++ b/pkg/plugins/policies/meshtls/api/v1alpha1/testdata/full-valid-no-top-target.input.yaml
@@ -1,0 +1,15 @@
+from:
+  - targetRef:
+      kind: Mesh
+    default:
+      tlsVersion:
+        min: TLS11
+        max: TLS12
+      tlsCiphers:
+        - "ECDHE-ECDSA-AES128-GCM-SHA256"
+        - "ECDHE-ECDSA-AES256-GCM-SHA384"
+        - "ECDHE-ECDSA-CHACHA20-POLY1305"
+        - "ECDHE-RSA-AES128-GCM-SHA256"
+        - "ECDHE-RSA-AES256-GCM-SHA384"
+        - "ECDHE-RSA-CHACHA20-POLY1305"
+      mode: Strict

--- a/pkg/plugins/policies/meshtls/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshtls/api/v1alpha1/validator.go
@@ -7,13 +7,15 @@ import (
 	common_tls "github.com/kumahq/kuma/api/common/v1alpha1/tls"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/validators"
+	"github.com/kumahq/kuma/pkg/util/pointer"
 )
 
 func (r *MeshTLSResource) validate() error {
 	var verr validators.ValidationError
 	path := validators.RootedAt("spec")
 	verr.AddErrorAt(path.Field("targetRef"), validateTop(r.Spec.TargetRef))
-	verr.AddErrorAt(path.Field("from"), validateFrom(r.Spec.From, r.Spec.TargetRef.Kind))
+	topLevel := pointer.DerefOr(r.Spec.TargetRef, common_api.TargetRef{Kind: common_api.Mesh, UsesSyntacticSugar: true})
+	verr.AddErrorAt(path.Field("from"), validateFrom(r.Spec.From, topLevel.Kind))
 	return verr.OrNil()
 }
 

--- a/pkg/plugins/policies/meshtls/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshtls/api/v1alpha1/validator_test.go
@@ -60,6 +60,10 @@ var _ = Describe("MeshTLS", func() {
 				name: "meshtls-3",
 				file: "invalid-top-level",
 			}),
+			Entry("full passing without top level", testCase{
+				name: "meshtls-4",
+				file: "full-valid-no-top-target",
+			}),
 		)
 	})
 })


### PR DESCRIPTION
### Checklist prior to review

We had no default to Mesh top level target ref.

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
