### PR TITLE
fix(meshtls): don't configure listener when mesh mtls disabled

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -6589,9 +6589,8 @@ spec:
                         'targetRef'
                       properties:
                         mode:
-                          description: |-
-                            Mode defines the behavior of inbound listeners with regard to traffic encryption.
-                            Default: Strict.
+                          description: Mode defines the behavior of inbound listeners
+                            with regard to traffic encryption.
                           enum:
                           - Permissive
                           - Strict

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -6589,9 +6589,8 @@ spec:
                         'targetRef'
                       properties:
                         mode:
-                          description: |-
-                            Mode defines the behavior of inbound listeners with regard to traffic encryption.
-                            Default: Strict.
+                          description: Mode defines the behavior of inbound listeners
+                            with regard to traffic encryption.
                           enum:
                           - Permissive
                           - Strict

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -6609,9 +6609,8 @@ spec:
                         'targetRef'
                       properties:
                         mode:
-                          description: |-
-                            Mode defines the behavior of inbound listeners with regard to traffic encryption.
-                            Default: Strict.
+                          description: Mode defines the behavior of inbound listeners
+                            with regard to traffic encryption.
                           enum:
                           - Permissive
                           - Strict

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -8075,9 +8075,8 @@ spec:
                         'targetRef'
                       properties:
                         mode:
-                          description: |-
-                            Mode defines the behavior of inbound listeners with regard to traffic encryption.
-                            Default: Strict.
+                          description: Mode defines the behavior of inbound listeners
+                            with regard to traffic encryption.
                           enum:
                           - Permissive
                           - Strict

--- a/deployments/charts/kuma/crds/kuma.io_meshtlses.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtlses.yaml
@@ -58,9 +58,8 @@ spec:
                         'targetRef'
                       properties:
                         mode:
-                          description: |-
-                            Mode defines the behavior of inbound listeners with regard to traffic encryption.
-                            Default: Strict.
+                          description: Mode defines the behavior of inbound listeners
+                            with regard to traffic encryption.
                           enum:
                           - Permissive
                           - Strict

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -10275,8 +10275,6 @@ components:
                         description: >-
                           Mode defines the behavior of inbound listeners with
                           regard to traffic encryption.
-
-                          Default: Strict.
                         enum:
                           - Permissive
                           - Strict

--- a/docs/generated/raw/crds/kuma.io_meshtlses.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshtlses.yaml
@@ -58,9 +58,8 @@ spec:
                         'targetRef'
                       properties:
                         mode:
-                          description: |-
-                            Mode defines the behavior of inbound listeners with regard to traffic encryption.
-                            Default: Strict.
+                          description: Mode defines the behavior of inbound listeners
+                            with regard to traffic encryption.
                           enum:
                           - Permissive
                           - Strict

--- a/pkg/plugins/policies/meshtls/api/v1alpha1/meshtls.go
+++ b/pkg/plugins/policies/meshtls/api/v1alpha1/meshtls.go
@@ -44,6 +44,5 @@ type Conf struct {
 	TlsCiphers common_tls.TlsCiphers `json:"tlsCiphers,omitempty"`
 
 	// Mode defines the behavior of inbound listeners with regard to traffic encryption.
-	// Default: Strict.
 	Mode *Mode `json:"mode,omitempty"`
 }

--- a/pkg/plugins/policies/meshtls/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtls/api/v1alpha1/schema.yaml
@@ -31,9 +31,7 @@ properties:
                 'targetRef'
               properties:
                 mode:
-                  description: |-
-                    Mode defines the behavior of inbound listeners with regard to traffic encryption.
-                    Default: Strict.
+                  description: Mode defines the behavior of inbound listeners with regard to traffic encryption.
                   enum:
                     - Permissive
                     - Strict

--- a/pkg/plugins/policies/meshtls/k8s/crd/kuma.io_meshtlses.yaml
+++ b/pkg/plugins/policies/meshtls/k8s/crd/kuma.io_meshtlses.yaml
@@ -58,9 +58,8 @@ spec:
                         'targetRef'
                       properties:
                         mode:
-                          description: |-
-                            Mode defines the behavior of inbound listeners with regard to traffic encryption.
-                            Default: Strict.
+                          description: Mode defines the behavior of inbound listeners
+                            with regard to traffic encryption.
                           enum:
                           - Permissive
                           - Strict

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/permissive-no-mtls.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/permissive-no-mtls.listeners.golden.yaml
@@ -6,46 +6,32 @@ resources:
       socketAddress:
         address: 127.0.0.1
         portValue: 17777
-    bindToPort: false
     enableReusePort: false
     filterChains:
-    - filterChainMatch:
-        transportProtocol: raw_buffer
-      filters:
-      - name: envoy.filters.network.tcp_proxy
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
         typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: localhost:17777
-          idleTimeout: 7200s
-          statPrefix: localhost_17777
-    - filterChainMatch:
-        transportProtocol: tls
-      filters:
-      - name: envoy.filters.network.tcp_proxy
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: localhost:17777
-          idleTimeout: 7200s
-          statPrefix: localhost_17777
-    - filterChainMatch:
-        applicationProtocols:
-        - kuma
-        transportProtocol: tls
-      filters:
-      - name: envoy.filters.network.tcp_proxy
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: localhost:17777
-          idleTimeout: 7200s
-          statPrefix: localhost_17777
-    listenerFilters:
-    - name: envoy.filters.listener.tls_inspector
-      typedConfig:
-        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
-    metadata:
-      filterMetadata:
-        io.kuma.tags:
-          kuma.io/service: backend
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          httpFilters:
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          routeConfig:
+            name: inbound:backend
+            requestHeadersToRemove:
+            - x-kuma-tags
+            validateClusters: false
+            virtualHosts:
+            - domains:
+              - '*'
+              name: backend
+              routes:
+              - match:
+                  prefix: /
+                route:
+                  cluster: backend
+                  timeout: 0s
+          statPrefix: "127_0_0_1_17777"
     name: inbound:127.0.0.1:17777
     trafficDirection: INBOUND
 - name: inbound:127.0.0.1:17778
@@ -55,45 +41,13 @@ resources:
       socketAddress:
         address: 127.0.0.1
         portValue: 17778
-    bindToPort: false
     enableReusePort: false
     filterChains:
-    - filterChainMatch:
-        transportProtocol: raw_buffer
-      filters:
+    - filters:
       - name: envoy.filters.network.tcp_proxy
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: localhost:17778
-          idleTimeout: 7200s
-          statPrefix: localhost_17778
-    - filterChainMatch:
-        transportProtocol: tls
-      filters:
-      - name: envoy.filters.network.tcp_proxy
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: localhost:17778
-          idleTimeout: 7200s
-          statPrefix: localhost_17778
-    - filterChainMatch:
-        applicationProtocols:
-        - kuma
-        transportProtocol: tls
-      filters:
-      - name: envoy.filters.network.tcp_proxy
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: localhost:17778
-          idleTimeout: 7200s
-          statPrefix: localhost_17778
-    listenerFilters:
-    - name: envoy.filters.listener.tls_inspector
-      typedConfig:
-        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
-    metadata:
-      filterMetadata:
-        io.kuma.tags:
-          kuma.io/service: frontend
+          cluster: frontend
+          statPrefix: "127_0_0_1_17778"
     name: inbound:127.0.0.1:17778
     trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-no-mtls.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-no-mtls.listeners.golden.yaml
@@ -6,20 +6,32 @@ resources:
       socketAddress:
         address: 127.0.0.1
         portValue: 17777
-    bindToPort: false
     enableReusePort: false
     filterChains:
     - filters:
-      - name: envoy.filters.network.tcp_proxy
+      - name: envoy.filters.network.http_connection_manager
         typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: localhost:17777
-          idleTimeout: 7200s
-          statPrefix: localhost_17777
-    metadata:
-      filterMetadata:
-        io.kuma.tags:
-          kuma.io/service: backend
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          httpFilters:
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          routeConfig:
+            name: inbound:backend
+            requestHeadersToRemove:
+            - x-kuma-tags
+            validateClusters: false
+            virtualHosts:
+            - domains:
+              - '*'
+              name: backend
+              routes:
+              - match:
+                  prefix: /
+                route:
+                  cluster: backend
+                  timeout: 0s
+          statPrefix: "127_0_0_1_17777"
     name: inbound:127.0.0.1:17777
     trafficDirection: INBOUND
 - name: inbound:127.0.0.1:17778
@@ -29,19 +41,13 @@ resources:
       socketAddress:
         address: 127.0.0.1
         portValue: 17778
-    bindToPort: false
     enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: localhost:17778
-          idleTimeout: 7200s
-          statPrefix: localhost_17778
-    metadata:
-      filterMetadata:
-        io.kuma.tags:
-          kuma.io/service: frontend
+          cluster: frontend
+          statPrefix: "127_0_0_1_17778"
     name: inbound:127.0.0.1:17778
     trafficDirection: INBOUND


### PR DESCRIPTION
### Checklist prior to review

We were incorrectly configuring tls inbound even when mtls was enabled. Added a check and used default mesh mode in the next steps.

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
