### PR TITLE
fix(meshmultizoneservice): order of matched mesh services

### DIFF
--- a/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/meshmultizoneservice.go
+++ b/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/meshmultizoneservice.go
@@ -63,3 +63,7 @@ type MatchedMeshService struct {
 	Zone      string `json:"zone"`
 	Mesh      string `json:"mesh"`
 }
+
+func (m MatchedMeshService) Hash() string {
+	return fmt.Sprintf("%s/%s/%s/%s", m.Name, m.Namespace, m.Zone, m.Mesh)
+}

--- a/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/meshmultizoneservice.go
+++ b/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/meshmultizoneservice.go
@@ -64,6 +64,6 @@ type MatchedMeshService struct {
 	Mesh      string `json:"mesh"`
 }
 
-func (m MatchedMeshService) Hash() string {
+func (m *MatchedMeshService) FullyQualifiedName() string {
 	return fmt.Sprintf("%s/%s/%s/%s", m.Name, m.Namespace, m.Zone, m.Mesh)
 }

--- a/pkg/core/resources/apis/meshmultizoneservice/status_updater.go
+++ b/pkg/core/resources/apis/meshmultizoneservice/status_updater.go
@@ -111,7 +111,7 @@ func (s *StatusUpdater) updateStatus(ctx context.Context) error {
 		}
 
 		sort.Slice(matched, func(i, j int) bool {
-			return matched[i].Name < matched[j].Name
+			return matched[i].Hash() < matched[j].Hash()
 		})
 
 		if !reflect.DeepEqual(mzSvc.Status.MeshServices, matched) {

--- a/pkg/core/resources/apis/meshmultizoneservice/status_updater.go
+++ b/pkg/core/resources/apis/meshmultizoneservice/status_updater.go
@@ -111,7 +111,7 @@ func (s *StatusUpdater) updateStatus(ctx context.Context) error {
 		}
 
 		sort.Slice(matched, func(i, j int) bool {
-			return matched[i].Hash() < matched[j].Hash()
+			return matched[i].FullyQualifiedName() < matched[j].FullyQualifiedName()
 		})
 
 		if !reflect.DeepEqual(mzSvc.Status.MeshServices, matched) {

--- a/pkg/core/resources/apis/meshmultizoneservice/status_updater_test.go
+++ b/pkg/core/resources/apis/meshmultizoneservice/status_updater_test.go
@@ -46,57 +46,63 @@ var _ = Describe("Updater", func() {
 		close(stopCh)
 	})
 
+	matchedMeshServices := func() ([]meshmzservice_api.MatchedMeshService, error) {
+		mzsvc := meshmzservice_api.NewMeshMultiZoneServiceResource()
+		err := resManager.Get(context.Background(), mzsvc, store.GetByKey("backend", model.DefaultMesh))
+		if err != nil {
+			return nil, err
+		}
+		return mzsvc.Status.MeshServices, nil
+	}
+
+	ms1Builder := samples.MeshServiceBackendBuilder().
+		WithName("backend").
+		WithDataplaneTagsSelectorKV("app", "backend").
+		WithLabels(map[string]string{
+			mesh_proto.DisplayName: "backend",
+			mesh_proto.ZoneTag:     "east",
+		})
+
+	ms2Builder := samples.MeshServiceBackendBuilder().
+		WithName("backend-syncedhash").
+		WithDataplaneTagsSelectorKV("app", "backend").
+		WithLabels(map[string]string{
+			mesh_proto.DisplayName: "backend",
+			mesh_proto.ZoneTag:     "west",
+		})
+
 	It("should add mesh services to the status of multizone service", func() {
 		// when
-		ms1Builder := samples.MeshServiceBackendBuilder().
-			WithName("backend").
-			WithDataplaneTagsSelector(map[string]string{
-				"app": "backend",
-			}).
-			WithLabels(map[string]string{
-				mesh_proto.DisplayName: "backend",
-				mesh_proto.ZoneTag:     "east",
-			})
 		Expect(ms1Builder.Create(resManager)).To(Succeed())
 		Expect(samples.MeshServiceWebBuilder().Create(resManager)).To(Succeed()) // to check if we ignore it
 		Expect(samples.MeshMultiZoneServiceBackendBuilder().Create(resManager)).To(Succeed())
 
 		// then
-		Eventually(func(g Gomega) {
-			mzsvc := meshmzservice_api.NewMeshMultiZoneServiceResource()
-
-			err := resManager.Get(context.Background(), mzsvc, store.GetByKey("backend", model.DefaultMesh))
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(mzsvc.Status.MeshServices).To(Equal([]meshmzservice_api.MatchedMeshService{{
-				Name: "backend",
-				Zone: "east",
-				Mesh: "default",
-			}}))
-		}, "10s", "100ms").Should(Succeed())
+		Eventually(matchedMeshServices, "10s", "100ms").Should(Equal([]meshmzservice_api.MatchedMeshService{
+			{Name: "backend", Zone: "east", Mesh: "default"},
+		}))
 
 		// when new service is added
-		ms2Builder := samples.MeshServiceBackendBuilder().
-			WithName("backend-syncedhash").
-			WithDataplaneTagsSelector(map[string]string{
-				"app": "backend",
-			}).
-			WithLabels(map[string]string{
-				mesh_proto.DisplayName: "backend",
-				mesh_proto.ZoneTag:     "west",
-			})
 		Expect(ms2Builder.Create(resManager)).To(Succeed())
 
 		// then
-		Eventually(func(g Gomega) {
-			mzsvc := meshmzservice_api.NewMeshMultiZoneServiceResource()
+		Eventually(matchedMeshServices, "10s", "100ms").Should(Equal([]meshmzservice_api.MatchedMeshService{
+			{Name: "backend", Zone: "east", Mesh: "default"},
+			{Name: "backend", Zone: "west", Mesh: "default"},
+		}))
+	})
 
-			err := resManager.Get(context.Background(), mzsvc, store.GetByKey("backend", model.DefaultMesh))
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(mzsvc.Status.MeshServices).To(Equal([]meshmzservice_api.MatchedMeshService{
-				{Name: "backend", Zone: "east", Mesh: "default"},
-				{Name: "backend", Zone: "west", Mesh: "default"},
-			}))
-		}, "10s", "100ms").Should(Succeed())
+	It("should result in the same list when services are added in a different order", func() {
+		// when
+		Expect(ms2Builder.Create(resManager)).To(Succeed())
+		Expect(ms1Builder.Create(resManager)).To(Succeed())
+		Expect(samples.MeshMultiZoneServiceBackendBuilder().Create(resManager)).To(Succeed())
+
+		// then
+		Eventually(matchedMeshServices, "10s", "100ms").Should(Equal([]meshmzservice_api.MatchedMeshService{
+			{Name: "backend", Zone: "east", Mesh: "default"},
+			{Name: "backend", Zone: "west", Mesh: "default"},
+		}))
 	})
 
 	It("should emit metric", func() {


### PR DESCRIPTION
### Checklist prior to review

Fix #11470

It was right when we added it, because it was just name which was a hashed name. It was then modified to also add namespace, zone and mesh here, so just sorting by name is not enough

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
