### PR TITLE
chore(meshhealthcheck): prevent targeting meshexternalservice by validation

### DIFF
--- a/pkg/plugins/policies/core/matchers/egress_test.go
+++ b/pkg/plugins/policies/core/matchers/egress_test.go
@@ -128,7 +128,7 @@ var _ = Describe("EgressMatchedPolicies", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(bytes).To(test_matchers.MatchGoldenYAML(strings.Replace(inputFile, ".input.", ".golden.", 1)))
 				},
-				Entry("should generate to resource rules for egress and mesh externalservice"),
+				XEntry("should generate to resource rules for egress and mesh externalservice"),
 			)
 		},
 		test.EntriesForFolder(filepath.Join("egressmatchedpolicies", "meshexternalservice", "torules")),
@@ -151,7 +151,7 @@ var _ = Describe("EgressMatchedPolicies", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(bytes).To(test_matchers.MatchGoldenYAML(strings.Replace(inputFile, ".input.", ".golden.", 1)))
 				},
-				Entry("should generate to resource rules for egress and mesh externalservice"),
+				XEntry("should generate to resource rules for egress and mesh externalservice"),
 			)
 		},
 		test.EntriesForFolder(filepath.Join("egressmatchedpolicies", "meshexternalservice", "fromtorules")),

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/validator.go
@@ -40,7 +40,6 @@ func validateTo(topTargetRef common_api.TargetRef, to []To) validators.Validatio
 			SupportedKinds: []common_api.TargetRefKind{
 				common_api.Mesh,
 				common_api.MeshService,
-				common_api.MeshExternalService,
 				common_api.MeshMultiZoneService,
 			},
 		}))

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/validator_test.go
@@ -82,7 +82,7 @@ to:
       tcp: # it will pick the protocol as described in 'protocol selection' section
         disabled: true # new, default false, can be disabled for override
 `),
-			Entry("to level MeshExternalService", `
+			XEntry("to level MeshExternalService", `
 targetRef:
   kind: Mesh
 to:
@@ -295,7 +295,7 @@ violations:
   - field: spec.to[0].default.http.expectedStatuses[1]
     message: must be in inclusive range [100, 599]`,
 			}),
-			Entry("cannot use MeshExternalService with other type than Mesh", testCase{
+			XEntry("cannot use MeshExternalService with other type than Mesh", testCase{
 				inputYaml: `
 targetRef:
   kind: MeshSubset

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
@@ -287,7 +287,7 @@ var _ = Describe("MeshHealthCheck", func() {
 		}),
 	)
 
-	It("should generate correct configuration for MeshExternalService with ZoneEgress", func() {
+	XIt("should generate correct configuration for MeshExternalService with ZoneEgress", func() {
 		// given
 		rs := core_xds.NewResourceSet()
 		rs.Add(&core_xds.Resource{

--- a/test/e2e_env/universal/meshexternalservice/meshexternalservice.go
+++ b/test/e2e_env/universal/meshexternalservice/meshexternalservice.go
@@ -591,7 +591,7 @@ spec:
 		})
 	})
 
-	Context("MeshExternalService with MeshHealthCheck", func() {
+	XContext("MeshExternalService with MeshHealthCheck", func() {
 		E2EAfterEach(func() {
 			Expect(DeleteMeshResources(universal.Cluster, meshNameNoDefaults,
 				meshhealthcheck_api.MeshHealthCheckResourceTypeDescriptor,


### PR DESCRIPTION
xref https://github.com/kumahq/kuma/issues/11472
xrel https://github.com/kumahq/kuma/issues/8417
xrel https://github.com/kumahq/kuma/issues/11078

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
