### PR TITLE
chore(meshloadbalancingstrategy): prevent targeting meshexternalservice by validation

### DIFF
--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator.go
@@ -48,7 +48,6 @@ func validateTo(topTargetRef common_api.TargetRef, to []To) validators.Validatio
 				common_api.Mesh,
 				common_api.MeshService,
 				common_api.MeshMultiZoneService,
-				common_api.MeshExternalService,
 			},
 		}))
 		if toItem.TargetRef.Kind == common_api.MeshExternalService && topTargetRef.Kind != common_api.Mesh {

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator_test.go
@@ -319,7 +319,7 @@ to:
           failoverThreshold:
             percentage: 0
 `),
-		ErrorCases("MeshExternalService can be set only with Mesh", []validators.Violation{{
+		XErrorCases("MeshExternalService can be set only with Mesh", []validators.Violation{{
 			Field:   "spec.to[0].targetRef.kind",
 			Message: "kind MeshExternalService is only allowed with targetRef.kind: Mesh as it is configured on the Zone Egress and shared by all clients in the mesh",
 		}}, `
@@ -540,7 +540,7 @@ to:
         leastRequest:
           activeRequestBias: "1.3"
 `),
-		Entry(
+		XEntry(
 			"to MeshExternalService",
 			`
 type: MeshLoadBalancingStrategy

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
@@ -457,7 +457,7 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 				},
 			},
 		}),
-		Entry("egress_meshexternalservice", testCase{
+		XEntry("egress_meshexternalservice", testCase{
 			resources: []core_xds.Resource{
 				{
 					Name:   "mesh-1_external___extsvc_9000",

--- a/pkg/test/resources/validators/validation.go
+++ b/pkg/test/resources/validators/validation.go
@@ -127,6 +127,7 @@ func ErrorCases(description string, errs []validators.Violation, yaml string) Ta
 		},
 	)
 }
+
 func XErrorCases(description string, errs []validators.Violation, yaml string) TableEntry {
 	return XEntry(
 		description,

--- a/pkg/test/resources/validators/validation.go
+++ b/pkg/test/resources/validators/validation.go
@@ -127,3 +127,12 @@ func ErrorCases(description string, errs []validators.Violation, yaml string) Ta
 		},
 	)
 }
+func XErrorCases(description string, errs []validators.Violation, yaml string) TableEntry {
+	return XEntry(
+		description,
+		ResourceValidationCase{
+			Violations: errs,
+			Resource:   yaml,
+		},
+	)
+}

--- a/test/e2e_env/universal/meshexternalservice/meshexternalservice.go
+++ b/test/e2e_env/universal/meshexternalservice/meshexternalservice.go
@@ -749,7 +749,7 @@ spec:
 		})
 	})
 
-	Context("MeshExternalService with MeshLoadBalancingStrategy", func() {
+	XContext("MeshExternalService with MeshLoadBalancingStrategy", func() {
 		E2EAfterEach(func() {
 			Expect(DeleteMeshResources(universal.Cluster, meshNameNoDefaults,
 				meshloadbalancingstrategy_api.MeshLoadBalancingStrategyResourceTypeDescriptor,


### PR DESCRIPTION
xref https://github.com/kumahq/kuma/issues/11472
xrel https://github.com/kumahq/kuma/issues/8417
xrel https://github.com/kumahq/kuma/issues/11078

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
