### PR TITLE
feat(Mesh*Route): require port with MeshMultiZoneService backends

### DIFF
--- a/pkg/core/validators/common_validators.go
+++ b/pkg/core/validators/common_validators.go
@@ -262,3 +262,14 @@ func ValidateLength(path PathBuilder, maxLength int, v string) ValidationError {
 
 	return err
 }
+
+func ValidateBackendRef(b common_api.BackendRef) ValidationError {
+	verr := OK()
+	switch b.Kind {
+	case common_api.MeshMultiZoneService:
+		if b.Port == nil {
+			verr.AddViolationAt(RootedAt("port"), MustBeDefined+" with kind MeshMultiZoneService")
+		}
+	}
+	return verr
+}

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation.go
@@ -380,6 +380,10 @@ func validateBackendRefs(
 				AllowedInvalidNames: []string{metadata.UnresolvedBackendServiceTag},
 			}),
 		)
+		errs.AddErrorAt(
+			validators.Root().Index(i),
+			validators.ValidateBackendRef(backendRef),
+		)
 	}
 
 	return errs

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation_test.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation_test.go
@@ -305,6 +305,31 @@ to:
               version: v1
 
 `),
+		ErrorCases("missing port in backendRefs",
+			[]validators.Violation{{
+				Field:   `spec.to[0].rules[0].default.backendRefs[0].port`,
+				Message: "must be defined with kind MeshMultiZoneService",
+			}}, `
+type: MeshHTTPRoute
+mesh: mesh-1
+name: route-1
+targetRef:
+  kind: MeshService
+  name: frontend
+to:
+- targetRef:
+    kind: MeshService
+    name: frontend
+  rules:
+    - matches:
+      - path:
+          type: PathPrefix
+          value: /
+      default:
+        backendRefs:
+          - kind: MeshMultiZoneService
+            name: test-server
+`),
 		ErrorCases("hostnames and hostname to backend rewrite not allowed with services",
 			[]validators.Violation{{
 				Field:   `spec.to[0].hostnames`,

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/validator.go
@@ -116,6 +116,10 @@ func validateBackendRefs(backendRefs []common_api.BackendRef) validators.Validat
 				},
 			),
 		)
+		verr.AddErrorAt(
+			validators.Root().Index(i),
+			validators.ValidateBackendRef(backendRef),
+		)
 	}
 
 	return verr

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/validator_test.go
@@ -80,6 +80,27 @@ to:
         tags:
           version: v1
 `),
+		ErrorCase("missing port in backendRefs",
+			validators.Violation{
+				Field:   "spec.to[0].rules[0].default.backendRefs[0].port",
+				Message: "must be defined with kind MeshMultiZoneService",
+			}, `
+type: MeshTCPRoute
+mesh: mesh-1
+name: route-1
+targetRef:
+  kind: MeshService
+  name: frontend
+to:
+- targetRef:
+    kind: MeshService
+    name: backend
+  rules:
+  - default:
+      backendRefs:
+      - kind: MeshMultiZoneService
+        name: test-server
+`),
 	)
 	DescribeValidCases(
 		api.NewMeshTCPRouteResource,


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- #11465
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
