### PR TITLE
test(e2e): improve gateway matchers

### DIFF
--- a/test/e2e_env/universal/gateway/utils.go
+++ b/test/e2e_env/universal/gateway/utils.go
@@ -174,11 +174,10 @@ func echoServerApp(mesh, name, service, instance string) InstallFunc {
 	}
 }
 
-func ProxySimpleRequests(cluster Cluster, instance, gateway, host string, opts ...client.CollectResponsesOptsFn) {
-	targetPath := path.Join("test", GinkgoT().Name())
-
+func ProxySimpleRequests(cluster Cluster, instance, gateway, host string, opts ...client.CollectResponsesOptsFn) func(Gomega) {
 	Logf("expecting 200 response from %q", gateway)
-	Eventually(func(g Gomega) {
+	return func(g Gomega) {
+		targetPath := path.Join("test", GinkgoT().Name())
 		var escaped []string
 		for _, segment := range strings.Split(targetPath, "/") {
 			escaped = append(escaped, url.PathEscape(segment))
@@ -187,18 +186,18 @@ func ProxySimpleRequests(cluster Cluster, instance, gateway, host string, opts .
 		target := fmt.Sprintf("http://%s/%s", gateway, path.Join(escaped...))
 
 		opts = append(opts, client.WithHeader("Host", host))
-		response, err := client.CollectEchoResponse(cluster, "gateway-client", target, opts...)
-
-		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(response.Instance).To(Equal(instance))
-		g.Expect(response.Received.Headers["Host"]).To(ContainElement(host))
-	}, "60s", "1s").Should(Succeed())
+		g.Expect(client.CollectEchoResponse(cluster, "gateway-client", target, opts...)).
+			Should(And(
+				HaveField("Instance", instance),
+				HaveField("Received.Headers", HaveKeyWithValue("Host", []string{host})),
+			))
+	}
 }
 
 // proxySecureRequests tests that basic HTTPS requests are proxied to the echo-server.
-func proxySecureRequests(cluster Cluster, instance string, gateway string, opts ...client.CollectResponsesOptsFn) {
+func proxySecureRequests(cluster Cluster, instance string, gateway string, opts ...client.CollectResponsesOptsFn) func(Gomega) {
 	Logf("expecting 200 response from %q", gateway)
-	Eventually(func(g Gomega) {
+	return func(g Gomega) {
 		target := fmt.Sprintf("https://%s/%s",
 			gateway, path.Join("https", "test", url.PathEscape(GinkgoT().Name())),
 		)
@@ -206,10 +205,10 @@ func proxySecureRequests(cluster Cluster, instance string, gateway string, opts 
 		opts = append(opts,
 			client.Insecure(),
 			client.WithHeader("Host", "example.kuma.io"))
-		response, err := client.CollectEchoResponse(cluster, "gateway-client", target, opts...)
-
-		g.Expect(err).To(Succeed())
-		g.Expect(response.Instance).To(Equal(instance))
-		g.Expect(response.Received.Headers["Host"]).To(ContainElement("example.kuma.io"))
-	}, "60s", "1s").Should(Succeed())
+		g.Expect(client.CollectEchoResponse(cluster, "gateway-client", target, opts...)).
+			Should(And(
+				HaveField("Instance", instance),
+				HaveField("Received.Headers", HaveKeyWithValue("Host", []string{"example.kuma.io"})),
+			))
+	}
 }

--- a/test/e2e_env/universal/meshaccesslog/meshaccesslog.go
+++ b/test/e2e_env/universal/meshaccesslog/meshaccesslog.go
@@ -405,11 +405,8 @@ spec:
 `, trafficLogFormat, tcpSinkDockerName)
 		Expect(YamlUniversal(yaml)(universal.Cluster)).To(Succeed())
 
-		makeRequest := func(g Gomega) {
-			gateway.ProxySimpleRequests(universal.Cluster, "echo-v1",
-				GatewayAddressPort("edge-gateway", 8080), "example.kuma.io")
-		}
-		src, dst := expectTrafficLogged(makeRequest)
+		src, dst := expectTrafficLogged(gateway.ProxySimpleRequests(universal.Cluster, "echo-v1",
+			GatewayAddressPort("edge-gateway", 8080), "example.kuma.io"))
 
 		Expect(src).To(Equal("edge-gateway"))
 		Expect(dst).To(Equal("*"))

--- a/test/e2e_env/universal/observability/meshtrace.go
+++ b/test/e2e_env/universal/observability/meshtrace.go
@@ -95,14 +95,14 @@ func PluginTest() {
 		err := YamlUniversal(traceAll(mesh, obsClient.ZipkinCollectorURL()))(universal.Cluster)
 		Expect(err).ToNot(HaveOccurred())
 
-		Eventually(func() ([]string, error) {
+		Eventually(func(g Gomega) {
 			gateway.ProxySimpleRequests(universal.Cluster, "universal1",
-				GatewayAddressPort("edge-gateway", 8080), "example.kuma.io")
-			return obsClient.TracedServices()
-		}, "30s", "1s").Should(ContainElements([]string{
-			"edge-gateway",
-			"jaeger-query",
-			"test-server",
-		}))
+				GatewayAddressPort("edge-gateway", 8080), "example.kuma.io")(g)
+			g.Expect(obsClient.TracedServices()).Should(ContainElements([]string{
+				"edge-gateway",
+				"jaeger-query",
+				"test-server",
+			}))
+		}, "30s", "1s").Should(Succeed())
 	})
 }


### PR DESCRIPTION
For gateway utils it was using a helper which didn't include good offsets
This resulted in hard to comprehend test failure.

Improved this and rewrote gateway test with externalService to try to fix flakiness

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
