### PR TITLE
fix(inspect-api): add missing resources to BaseMeshContext

### DIFF
--- a/pkg/core/resources/apis/donothingresource/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/donothingresource/api/v1alpha1/zz_generated.resource.go
@@ -151,4 +151,5 @@ var DoNothingResourceResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasFromTargetRef:             false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
+	IsReferenceableInTo:          false,
 }

--- a/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/zz_generated.resource.go
@@ -152,4 +152,5 @@ var HostnameGeneratorResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasFromTargetRef:             false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: true,
+	IsReferenceableInTo:          false,
 }

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/meshexternalservice.go
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/meshexternalservice.go
@@ -14,6 +14,7 @@ import (
 // +kuma:policy:is_policy=false
 // +kuma:policy:allowed_on_system_namespace_only=true
 // +kuma:policy:has_status=true
+// +kuma:policy:is_referenceable_in_to=true
 type MeshExternalService struct {
 	// Match defines traffic that should be routed through the sidecar.
 	Match Match `json:"match"`

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/zz_generated.resource.go
@@ -163,4 +163,5 @@ var MeshExternalServiceResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasFromTargetRef:             false,
 	HasStatus:                    true,
 	AllowedOnSystemNamespaceOnly: true,
+	IsReferenceableInTo:          true,
 }

--- a/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/meshmultizoneservice.go
+++ b/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/meshmultizoneservice.go
@@ -13,6 +13,7 @@ import (
 // It aggregates existing MeshServices by labels.
 // +kuma:policy:is_policy=false
 // +kuma:policy:has_status=true
+// +kuma:policy:is_referenceable_in_to=true
 type MeshMultiZoneService struct {
 	// Selector is a way to select multiple MeshServices
 	Selector Selector `json:"selector"`

--- a/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/zz_generated.resource.go
@@ -163,4 +163,5 @@ var MeshMultiZoneServiceResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasFromTargetRef:             false,
 	HasStatus:                    true,
 	AllowedOnSystemNamespaceOnly: false,
+	IsReferenceableInTo:          true,
 }

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/meshservice.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/meshservice.go
@@ -33,6 +33,7 @@ const maxNameLength = 63
 // +kuma:policy:is_policy=false
 // +kuma:policy:has_status=true
 // +kuma:policy:kds_flags=model.ZoneToGlobalFlag | model.GlobalToAllButOriginalZoneFlag
+// +kuma:policy:is_referenceable_in_to=true
 type MeshService struct {
 	// State of MeshService. Available if there is at least one healthy endpoint. Otherwise, Unavailable.
 	// It's used for cross zone communication to check if we should send traffic to it, when MeshService is aggregated into MeshMultiZoneService.

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/zz_generated.resource.go
@@ -163,4 +163,5 @@ var MeshServiceResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasFromTargetRef:             false,
 	HasStatus:                    true,
 	AllowedOnSystemNamespaceOnly: false,
+	IsReferenceableInTo:          true,
 }

--- a/pkg/core/resources/model/resource.go
+++ b/pkg/core/resources/model/resource.go
@@ -196,6 +196,8 @@ type ResourceTypeDescriptor struct {
 	DumpForGlobal bool
 	// AllowedOnSystemNamespaceOnly whether this resource type can be created only in the system namespace
 	AllowedOnSystemNamespaceOnly bool
+	// IsReferenceableInTo whether this resource type can be used in spec.to[].targetRef
+	IsReferenceableInTo bool
 }
 
 func newObject(baseResource Resource) Resource {

--- a/pkg/plugins/policies/donothingpolicy/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/donothingpolicy/api/v1alpha1/zz_generated.resource.go
@@ -151,4 +151,5 @@ var DoNothingPolicyResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasFromTargetRef:             true,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
+	IsReferenceableInTo:          false,
 }

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/zz_generated.resource.go
@@ -152,4 +152,5 @@ var MeshAccessLogResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasFromTargetRef:             true,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
+	IsReferenceableInTo:          false,
 }

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/zz_generated.resource.go
@@ -152,4 +152,5 @@ var MeshCircuitBreakerResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasFromTargetRef:             true,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
+	IsReferenceableInTo:          false,
 }

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/zz_generated.resource.go
@@ -152,4 +152,5 @@ var MeshFaultInjectionResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasFromTargetRef:             true,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
+	IsReferenceableInTo:          false,
 }

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/zz_generated.resource.go
@@ -152,4 +152,5 @@ var MeshHealthCheckResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasFromTargetRef:             false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
+	IsReferenceableInTo:          false,
 }

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/zz_generated.resource.go
@@ -152,4 +152,5 @@ var MeshHTTPRouteResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasFromTargetRef:             false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
+	IsReferenceableInTo:          false,
 }

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/zz_generated.resource.go
@@ -152,4 +152,5 @@ var MeshLoadBalancingStrategyResourceTypeDescriptor = model.ResourceTypeDescript
 	HasFromTargetRef:             false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
+	IsReferenceableInTo:          false,
 }

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/zz_generated.resource.go
@@ -152,4 +152,5 @@ var MeshMetricResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasFromTargetRef:             false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
+	IsReferenceableInTo:          false,
 }

--- a/pkg/plugins/policies/meshpassthrough/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshpassthrough/api/v1alpha1/zz_generated.resource.go
@@ -152,4 +152,5 @@ var MeshPassthroughResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasFromTargetRef:             false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
+	IsReferenceableInTo:          false,
 }

--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/zz_generated.resource.go
@@ -152,4 +152,5 @@ var MeshProxyPatchResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasFromTargetRef:             false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
+	IsReferenceableInTo:          false,
 }

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/zz_generated.resource.go
@@ -152,4 +152,5 @@ var MeshRateLimitResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasFromTargetRef:             true,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
+	IsReferenceableInTo:          false,
 }

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/zz_generated.resource.go
@@ -152,4 +152,5 @@ var MeshRetryResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasFromTargetRef:             false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
+	IsReferenceableInTo:          false,
 }

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/zz_generated.resource.go
@@ -152,4 +152,5 @@ var MeshTCPRouteResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasFromTargetRef:             false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
+	IsReferenceableInTo:          false,
 }

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/zz_generated.resource.go
@@ -152,4 +152,5 @@ var MeshTimeoutResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasFromTargetRef:             true,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
+	IsReferenceableInTo:          false,
 }

--- a/pkg/plugins/policies/meshtls/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshtls/api/v1alpha1/zz_generated.resource.go
@@ -152,4 +152,5 @@ var MeshTLSResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasFromTargetRef:             true,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
+	IsReferenceableInTo:          false,
 }

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/zz_generated.resource.go
@@ -152,4 +152,5 @@ var MeshTraceResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasFromTargetRef:             false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
+	IsReferenceableInTo:          false,
 }

--- a/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/zz_generated.resource.go
@@ -152,4 +152,5 @@ var MeshTrafficPermissionResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasFromTargetRef:             true,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
+	IsReferenceableInTo:          false,
 }

--- a/pkg/xds/context/mesh_context_builder.go
+++ b/pkg/xds/context/mesh_context_builder.go
@@ -17,7 +17,6 @@ import (
 	meshextenralservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
 	meshmzservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
-	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
@@ -294,7 +293,7 @@ func (m *meshContextBuilder) BuildBaseMeshContextIfChanged(ctx context.Context, 
 		}
 		// Only pick the policies, gateways, external services and the vip config map
 		switch {
-		case desc.IsPolicy || desc.Name == core_mesh.MeshGatewayType || desc.Name == core_mesh.ExternalServiceType || desc.Name == meshservice_api.MeshServiceType:
+		case desc.IsPolicy || desc.IsReferenceableInTo || desc.Name == core_mesh.MeshGatewayType || desc.Name == core_mesh.ExternalServiceType:
 			rmap[t], err = m.fetchResourceList(ctx, t, mesh, nil)
 		case desc.Name == system.ConfigType:
 			rmap[t], err = m.fetchResourceList(ctx, t, mesh, func(rs core_model.Resource) bool {

--- a/tools/policy-gen/generator/cmd/core_resource.go
+++ b/tools/policy-gen/generator/cmd/core_resource.go
@@ -222,5 +222,6 @@ var {{.Name}}ResourceTypeDescriptor = model.ResourceTypeDescriptor{
 		HasFromTargetRef: {{.HasFrom}},
 		HasStatus: {{.HasStatus}},
 		AllowedOnSystemNamespaceOnly: {{.AllowedOnSystemNamespaceOnly}},
+		IsReferenceableInTo: {{.IsReferenceableInTo}},
 	}
 `))

--- a/tools/policy-gen/generator/pkg/parse/policyconfig.go
+++ b/tools/policy-gen/generator/pkg/parse/policyconfig.go
@@ -40,6 +40,7 @@ type PolicyConfig struct {
 	KDSFlags                     string
 	Scope                        ResourceScope
 	AllowedOnSystemNamespaceOnly bool
+	IsReferenceableInTo          bool
 }
 
 func Policy(path string) (PolicyConfig, error) {
@@ -147,6 +148,9 @@ func newPolicyConfig(pkg, name string, markers map[string]string, fields map[str
 	}
 	if v, ok := parseBool(markers, "kuma:policy:allowed_on_system_namespace_only"); ok {
 		res.AllowedOnSystemNamespaceOnly = v
+	}
+	if v, ok := parseBool(markers, "kuma:policy:is_referenceable_in_to"); ok {
+		res.IsReferenceableInTo = v
 	}
 	if v, ok := markers["kuma:policy:kds_flags"]; ok {
 		res.KDSFlags = v


### PR DESCRIPTION
* add Descriptor field to identify resources that can be referenced in 'to'

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
