### PR TITLE
test(meshservice): fix flaky tests on resource grace period

### DIFF
--- a/pkg/core/resources/apis/meshservice/generate/generator_test.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator_test.go
@@ -274,8 +274,8 @@ var _ = Describe("MeshService generator", func() {
 			labelGracePeriodStartedAt = ms.GetMeta().GetLabels()[mesh_proto.DeletionGracePeriodStartedLabel]
 		}, "2s", "100ms").Should(Succeed())
 
-		gracePeriodStartedAt := time.Now()
-		err = gracePeriodStartedAt.UnmarshalText([]byte(labelGracePeriodStartedAt))
+		gracePeriodStartedAt := time.Time{}
+		err := gracePeriodStartedAt.UnmarshalText([]byte(labelGracePeriodStartedAt))
 		Expect(err).ToNot(HaveOccurred())
 
 		// Before the grace period it still exists and afterwards it eventually

--- a/pkg/core/resources/apis/meshservice/generate/generator_test.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator_test.go
@@ -285,7 +285,7 @@ var _ = Describe("MeshService generator", func() {
 			if time.Now().Before(gracePeriodEndsAt) {
 				g.Expect(err).To(Succeed())
 			}
-		}, gracePeriodEndsAt.Add(-50*time.Millisecond).Sub(time.Now()).String(), "50ms").Should(Succeed())
+		}, time.Until(gracePeriodEndsAt.Add(-50*time.Millisecond)).String(), "50ms").Should(Succeed())
 		Eventually(func(g Gomega) {
 			g.Expect(resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))).ToNot(Succeed())
 		}, "2s", "100ms").Should(Succeed())

--- a/pkg/core/resources/apis/meshservice/generate/generator_test.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator_test.go
@@ -275,8 +275,7 @@ var _ = Describe("MeshService generator", func() {
 		}, "2s", "100ms").Should(Succeed())
 
 		gracePeriodStartedAt := time.Time{}
-		err := gracePeriodStartedAt.UnmarshalText([]byte(labelGracePeriodStartedAt))
-		Expect(err).ToNot(HaveOccurred())
+		Expect(gracePeriodStartedAt.UnmarshalText([]byte(labelGracePeriodStartedAt))).To(Succeed())
 
 		// Before the grace period it still exists and afterwards it eventually
 		// disappears


### PR DESCRIPTION
Fixes flaky test at:
https://github.com/kumahq/kuma/actions/runs/10946133312/job/30392313021#step:6:183

The original asserion can overflow the grace period on resouces, now we strictly read the start time from the resource label to prevent the overflow.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues 
  - N/A
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS 
  - Confirmed
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) 
  - Manual tested
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? 
  - No
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) 
  - No


> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
