### PR TITLE
test(framework): enable debug log for both CP and DP on universal

### DIFF
--- a/test/framework/debug.go
+++ b/test/framework/debug.go
@@ -48,7 +48,7 @@ func debugUniversalCopyLogs(debugPath string) []error {
 	srcPath := universal_logs.GetLogsPath(
 		ginkgo.CurrentSpecReport(),
 		Config.UniversalE2ELogsPath,
-	).Describe
+	).Root
 	destPath := filepath.Join(debugPath, "logs")
 
 	Logf("copying logs from %q to %q", srcPath, destPath)

--- a/test/framework/debug.go
+++ b/test/framework/debug.go
@@ -44,11 +44,26 @@ func DebugUniversal(cluster Cluster, mesh string) {
 	}
 }
 
+func DebugUniversalCPLogs(cluster Cluster) {
+	ginkgo.GinkgoHelper()
+
+	debugDir := prepareDebugDir()
+
+	logs, err := cluster.GetKumaCPLogs()
+	if err != nil {
+		Logf("[WARNING]: could not retrieve cp logs, error: %s", err.Error())
+	} else {
+		cpLogsExportPath := filepath.Join(debugDir, fmt.Sprintf("cp-log-%s.log", cluster.Name()))
+		Logf("saving CP logs of cluster %q to %q", cluster.Name(), cpLogsExportPath)
+		Expect(os.WriteFile(cpLogsExportPath, []byte(logs), 0o600)).To(Succeed())
+	}
+}
+
 func debugUniversalCopyLogs(debugPath string) []error {
 	srcPath := universal_logs.GetLogsPath(
 		ginkgo.CurrentSpecReport(),
 		Config.UniversalE2ELogsPath,
-	).Root
+	).Describe
 	destPath := filepath.Join(debugPath, "logs")
 
 	Logf("copying logs from %q to %q", srcPath, destPath)

--- a/test/framework/envs/universal/env.go
+++ b/test/framework/envs/universal/env.go
@@ -64,6 +64,7 @@ func PrintCPLogsOnFailure(report ginkgo.Report) {
 		if err != nil {
 			framework.Logf("could not retrieve cp logs")
 		} else {
+			framework.DebugUniversalCPLogs(Cluster)
 			framework.Logf(logs)
 		}
 	}

--- a/test/framework/universal_app.go
+++ b/test/framework/universal_app.go
@@ -477,6 +477,10 @@ func (s *UniversalApp) CreateDP(
 		args = append(args, "--proxy-type", proxyType)
 	}
 
+	if Config.Debug {
+		args = append(args, "--log-level", "debug")
+	}
+
 	s.dpApp = ssh.NewApp(s.containerName, s.logsPath, s.verbose, s.ports[sshPort], envsMap, args)
 }
 

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -156,6 +156,9 @@ func (c *UniversalCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOpt
 	}
 
 	cmd := []string{"kuma-cp", "run", "--config-file", "/kuma/kuma-cp.conf"}
+	if Config.Debug {
+		cmd = append(cmd, "--log-level", "debug")
+	}
 	if mode == core.Zone {
 		env["KUMA_MULTIZONE_ZONE_NAME"] = c.ZoneName()
 		env["KUMA_MULTIZONE_ZONE_KDS_TLS_SKIP_VERIFY"] = "true"


### PR DESCRIPTION
Similar to the kube debuggability PR: https://github.com/kumahq/kuma/pull/11466 , This PR tries to enable `debug` log level on both CP and DP when `Config.Debug` switch is enabled.
To export CP logs, the PR also copies all logs generated in the E2E running instead of just generated from `Describe`. 


### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues 
  - N/A
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS 
  - Confirmed
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) 
  - Manually tested
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? 
  - No
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) 
  - No


> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
