### PR TITLE
fix(federation): set skipCreatingInitialPolicies on exported Meshes

### DIFF
--- a/app/kumactl/cmd/export/export.go
+++ b/app/kumactl/cmd/export/export.go
@@ -97,7 +97,13 @@ $ kumactl export --profile federation --format universal > policies.yaml
 					if err := rs.List(cmd.Context(), list); err != nil {
 						return errors.Wrapf(err, "could not list %q", resDesc.Name)
 					}
-					allResources = append(allResources, list.GetItems()...)
+					for _, res := range list.GetItems() {
+						if res.Descriptor().Name == core_mesh.MeshType {
+							mesh := res.(*core_mesh.MeshResource)
+							mesh.Spec.SkipCreatingInitialPolicies = []string{"*"}
+						}
+						allResources = append(allResources, res)
+					}
 				} else {
 					for _, mesh := range meshes.Items {
 						list := resDesc.NewList()

--- a/app/kumactl/cmd/export/testdata/export-no-dp.golden.yaml
+++ b/app/kumactl/cmd/export/testdata/export-no-dp.golden.yaml
@@ -4,6 +4,8 @@ creationTime: "0001-01-01T00:00:00Z"
 modificationTime: "0001-01-01T00:00:00Z"
 name: default
 type: Mesh
+skipCreatingInitialPolicies:
+- '*'
 ---
 creationTime: "0001-01-01T00:00:00Z"
 mesh: default

--- a/app/kumactl/cmd/export/testdata/export.golden.yaml
+++ b/app/kumactl/cmd/export/testdata/export.golden.yaml
@@ -4,11 +4,15 @@ creationTime: "0001-01-01T00:00:00Z"
 modificationTime: "0001-01-01T00:00:00Z"
 name: default
 type: Mesh
+skipCreatingInitialPolicies:
+- '*'
 ---
 creationTime: "0001-01-01T00:00:00Z"
 modificationTime: "0001-01-01T00:00:00Z"
 name: another-mesh
 type: Mesh
+skipCreatingInitialPolicies:
+- '*'
 ---
 creationTime: "0001-01-01T00:00:00Z"
 mesh: default


### PR DESCRIPTION
This way users have the opportunity to manage all policies themselves at the global level.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --


> Changelog: fix(federation): set skipCreatingInitialPolicies on exported Meshes
> This way users have the opportunity to manage all policies themselves at the global level.

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
