### PR TITLE
fix(meshexternalservice): allow defining only name or labels

### DIFF
--- a/pkg/core/resources/apis/mesh/validators.go
+++ b/pkg/core/resources/apis/mesh/validators.go
@@ -405,15 +405,16 @@ func ValidateTargetRef(
 		err.Add(disallowedField("namespace", ref.Namespace, ref.Kind))
 		err.Add(disallowedField("sectionName", ref.SectionName, ref.Kind))
 	case common_api.MeshExternalService:
-		err.Add(requiredField("name", ref.Name, ref.Kind))
 		err.Add(validateName(ref.Name, opts.AllowedInvalidNames))
 		err.Add(disallowedField("mesh", ref.Mesh, ref.Kind))
+		err.Add(disallowedField("tags", ref.Tags, ref.Kind))
 		err.Add(disallowedField("proxyTypes", ref.ProxyTypes, ref.Kind))
-		err.Add(ValidateTags(validators.RootedAt("tags"), ref.Tags, ValidateTagsOpts{}))
-		if ref.Kind == common_api.MeshGateway && len(ref.Tags) > 0 && !opts.GatewayListenerTagsAllowed {
-			err.Add(disallowedField("tags", ref.Tags, ref.Kind))
+		if len(ref.Labels) == 0 {
+			err.Add(requiredField("name", ref.Name, ref.Kind))
 		}
-		err.Add(disallowedField("labels", ref.Labels, ref.Kind))
+		if len(ref.Labels) > 0 && (ref.Name != "" || ref.Namespace != "") {
+			err.AddViolation("labels", "either labels or name must be specified")
+		}
 		err.Add(disallowedField("sectionName", ref.SectionName, ref.Kind))
 	}
 

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/validator_test.go
@@ -90,6 +90,25 @@ to:
         requestTimeout: 1s
         streamIdleTimeout: 2s
 `),
+			Entry("example MeshExternalService", `
+targetRef:
+  kind: MeshSubset
+  tags:
+    kuma.io/service: web-frontend
+to:
+  - targetRef:
+      kind: MeshExternalService
+      name: web-backend
+    default:
+      http:
+        requestTimeout: 1s
+  - targetRef:
+      kind: MeshExternalService
+      labels:
+        kuma.io/display-name: web-backend
+    default:
+      http:
+        requestTimeout: 1s`),
 		)
 
 		type testCase struct {
@@ -286,6 +305,24 @@ violations:
     message: must not be defined
   - field: spec.to[0].targetRef.kind
     message: value is not supported`,
+			}),
+			Entry("to TargetRef using labels and name for MeshExternalService", testCase{
+				inputYaml: `
+targetRef:
+  kind: Mesh
+to:
+  - targetRef:
+      kind: MeshExternalService
+      name: web-backend
+      labels:
+        kuma.io/display-name: web-backend
+    default:
+      connectionTimeout: 10s
+      idleTimeout: 1h`,
+				expected: `
+violations:
+  - field: spec.to[0].targetRef.labels
+    message: either labels or name must be specified`,
 			}),
 		)
 	})


### PR DESCRIPTION
### Checklist prior to review

fix: https://github.com/kumahq/kuma/issues/11499

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
