### PR TITLE
test(framework): dont print CP logs to stdout on Universal as they can be too long

### DIFF
--- a/test/framework/envs/universal/env.go
+++ b/test/framework/envs/universal/env.go
@@ -58,18 +58,6 @@ func RestoreState(bytes []byte) {
 	Cluster.SetCp(cp)
 }
 
-func PrintCPLogsOnFailure(report ginkgo.Report) {
-	if !report.SuiteSucceeded {
-		logs, err := Cluster.GetKumaCPLogs()
-		if err != nil {
-			framework.Logf("could not retrieve cp logs")
-		} else {
-			framework.DebugUniversalCPLogs(Cluster)
-			framework.Logf(logs)
-		}
-	}
-}
-
 func ExpectCpToNotPanic() {
 	logs, err := Cluster.GetKumaCPLogs()
 	if err != nil {
@@ -89,5 +77,8 @@ func AfterSuite(report ginkgo.Report) {
 	if framework.Config.CleanupLogsOnSuccess {
 		universal_logs.CleanupIfSuccess(framework.Config.UniversalE2ELogsPath, report)
 	}
-	PrintCPLogsOnFailure(report)
+	if !report.SuiteSucceeded {
+		framework.Logf("Please see full CP logs by downloading the debug artifacts")
+		framework.DebugUniversalCPLogs(Cluster)
+	}
 }


### PR DESCRIPTION
When the debug level logs are enbled,too many log entries make the GitHub log view truncate.
We now export the CP logs into artifacts, so don't need to print to stdout any more.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues 
  - N/A
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS 
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) 
  - Manually tested
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? 
  - No
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) 
  - No


> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
