### PR TITLE
fix(api-server): skip display-name label for service insight

### DIFF
--- a/pkg/api-server/service_insight_endpoints.go
+++ b/pkg/api-server/service_insight_endpoints.go
@@ -108,7 +108,6 @@ func (s *serviceInsightEndpoints) listResources(request *restful.Request, respon
 		_, exists := filterMap[service.ServiceType]
 		return exists
 	})
-
 	restList := rest.ResourceList{
 		Total: uint32(len(items)),
 		Items: items,

--- a/pkg/api-server/service_insight_endpoints.go
+++ b/pkg/api-server/service_insight_endpoints.go
@@ -2,6 +2,7 @@ package api_server
 
 import (
 	"fmt"
+	"maps"
 	"sort"
 	"strconv"
 	"strings"
@@ -55,6 +56,10 @@ func (s *serviceInsightEndpoints) findResource(request *restful.Request, respons
 		res := out.(*rest_unversioned.Resource)
 		res.Meta.Name = service
 		res.Spec = stat
+
+		mapperFn := removeDisplayNameLabel()
+		mapperFn(res)
+
 		if err := response.WriteAsJson(res); err != nil {
 			core.Log.Error(err, "Could not write the response")
 		}
@@ -99,13 +104,17 @@ func (s *serviceInsightEndpoints) listResources(request *restful.Request, respon
 		}
 	}
 
-	items := s.expandInsights(serviceInsightList, nameContains, func(service *v1alpha1.ServiceInsight_Service) bool {
-		if len(filterMap) == 0 {
-			return true
-		}
-		_, exists := filterMap[service.ServiceType]
-		return exists
-	})
+	items := s.expandInsights(serviceInsightList, nameContains,
+		func(service *v1alpha1.ServiceInsight_Service) bool {
+			if len(filterMap) == 0 {
+				return true
+			}
+			_, exists := filterMap[service.ServiceType]
+			return exists
+		},
+		removeDisplayNameLabel(),
+	)
+
 	restList := rest.ResourceList{
 		Total: uint32(len(items)),
 		Items: items,
@@ -135,7 +144,12 @@ func (s *serviceInsightEndpoints) fillStaticInfo(name string, stat *v1alpha1.Ser
 // 2) Mesh+Name is a key on Universal, but not on Kubernetes, so if there are two services of the same name in different Meshes we would have problems with naming.
 // From the API perspective it's better to provide ServiceInsight per Service, not per Mesh.
 // For this reason, this method expand the one ServiceInsight resource for the mesh to resource per service
-func (s *serviceInsightEndpoints) expandInsights(serviceInsightList *mesh.ServiceInsightResourceList, nameContains string, filterFn func(service *v1alpha1.ServiceInsight_Service) bool) []rest.Resource {
+func (s *serviceInsightEndpoints) expandInsights(
+	serviceInsightList *mesh.ServiceInsightResourceList,
+	nameContains string,
+	filterFn func(service *v1alpha1.ServiceInsight_Service) bool,
+	mapperFn unversionedResourceMapper,
+) []rest.Resource {
 	restItems := []rest.Resource{} // Needs to be set to avoid returning nil and have the api return []
 	for _, insight := range serviceInsightList.Items {
 		for serviceName, service := range insight.Spec.Services {
@@ -145,6 +159,7 @@ func (s *serviceInsightEndpoints) expandInsights(serviceInsightList *mesh.Servic
 				res := out.(*rest_unversioned.Resource)
 				res.Meta.Name = serviceName
 				res.Spec = service
+				mapperFn(res)
 				restItems = append(restItems, out)
 			}
 		}
@@ -195,4 +210,18 @@ func (s *serviceInsightEndpoints) paginateResources(request *restful.Request, re
 
 	restList.Next = nextLink(request, nextOffset)
 	return nil
+}
+
+type unversionedResourceMapper func(resource *rest_unversioned.Resource)
+
+// Since the value of label "kuma.io/display-name" is same with the ServiceInsight resource name,
+// in which it looks weird for the API to each service. Ref: https://github.com/kumahq/kuma/issues/9729
+func removeDisplayNameLabel() unversionedResourceMapper {
+	return func(resource *rest_unversioned.Resource) {
+		tmpMeta := resource.GetMeta()
+		maps.DeleteFunc(tmpMeta.Labels, func(key string, val string) bool {
+			return key == v1alpha1.DisplayName
+		})
+		resource.Meta = tmpMeta
+	}
 }

--- a/pkg/api-server/testdata/service-insights/get.input.yaml
+++ b/pkg/api-server/testdata/service-insights/get.input.yaml
@@ -5,6 +5,8 @@ name: mesh-1
 type: ServiceInsight
 mesh: mesh-1
 name: all-services-mesh-1
+labels:
+  kuma.io/display-name: all-services-mesh-1 # refer to https://github.com/kumahq/kuma/issues/9729
 services:
   backend:
     status: partially_degraded

--- a/pkg/api-server/testdata/service-insights/get.input.yaml
+++ b/pkg/api-server/testdata/service-insights/get.input.yaml
@@ -6,7 +6,7 @@ type: ServiceInsight
 mesh: mesh-1
 name: all-services-mesh-1
 labels:
-  kuma.io/display-name: all-services-mesh-1 # refer to https://github.com/kumahq/kuma/issues/9729
+  kuma.io/display-name: all-services-mesh-1 # add display name manually to test if it's removed in the response
 services:
   backend:
     status: partially_degraded

--- a/pkg/api-server/testdata/service-insights/list-simple.input.yaml
+++ b/pkg/api-server/testdata/service-insights/list-simple.input.yaml
@@ -6,7 +6,7 @@ type: ServiceInsight
 mesh: mesh-1
 name: all-services-mesh-1
 labels:
-  kuma.io/display-name: all-services-mesh-1 # refer to https://github.com/kumahq/kuma/issues/9729
+  kuma.io/display-name: all-services-mesh-1 # add display name manually to test if it's removed in the response
 services:
   frontend:
     status: partially_degraded

--- a/pkg/api-server/testdata/service-insights/list-simple.input.yaml
+++ b/pkg/api-server/testdata/service-insights/list-simple.input.yaml
@@ -5,6 +5,8 @@ name: mesh-1
 type: ServiceInsight
 mesh: mesh-1
 name: all-services-mesh-1
+labels:
+  kuma.io/display-name: all-services-mesh-1 # refer to https://github.com/kumahq/kuma/issues/9729
 services:
   frontend:
     status: partially_degraded

--- a/pkg/api-server/testdata/service-insights/pagination.input.yaml
+++ b/pkg/api-server/testdata/service-insights/pagination.input.yaml
@@ -7,7 +7,7 @@ type: ServiceInsight
 mesh: mesh-1
 name: all-services-mesh-1
 labels:
-  kuma.io/display-name: all-services-mesh-1 # refer to https://github.com/kumahq/kuma/issues/9729
+  kuma.io/display-name: all-services-mesh-1 # add display name manually to test if it's removed in the response
 services:
   frontend:
     status: partially_degraded

--- a/pkg/api-server/testdata/service-insights/pagination.input.yaml
+++ b/pkg/api-server/testdata/service-insights/pagination.input.yaml
@@ -6,6 +6,8 @@ name: mesh-1
 type: ServiceInsight
 mesh: mesh-1
 name: all-services-mesh-1
+labels:
+  kuma.io/display-name: all-services-mesh-1 # refer to https://github.com/kumahq/kuma/issues/9729
 services:
   frontend:
     status: partially_degraded


### PR DESCRIPTION
This API would list the SeviceInsight resources with k8s mode, in which the common method [GetLabels](https://github.com/kumahq/kuma/blob/e21c751d782bc06eb7e8c779dacf71097bfe5732/pkg/plugins/resources/k8s/store.go#L299) would be called and supplement the `display-name` for the `Meta`.

So, let's just add a mapper function to remove that label in the API-Server component.


### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.


If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- close #9729 
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
