### PR TITLE
test(framework): smarter logs on universal, multizone and gatewayapi

### DIFF
--- a/test/e2e_env/gatewayapi/conformance_test.go
+++ b/test/e2e_env/gatewayapi/conformance_test.go
@@ -106,8 +106,8 @@ func TestConformance(t *testing.T) {
 		RestConfig:           clientConfig,
 		Clientset:            clientset,
 		GatewayClassName:     "kuma",
-		CleanupBaseResources: !Config.Debug,
-		Debug:                Config.Debug,
+		CleanupBaseResources: !Config.Debug, // we need to keep the resources to collect logs when Debug is enabled
+		Debug:                Config.Debug,  // controls if request details should be printed to stdout
 		NamespaceLabels: map[string]string{
 			metadata.KumaSidecarInjectionAnnotation: metadata.AnnotationEnabled,
 		},

--- a/test/e2e_env/gatewayapi/conformance_test.go
+++ b/test/e2e_env/gatewayapi/conformance_test.go
@@ -51,7 +51,7 @@ func TestConformance(t *testing.T) {
 	opts := cluster.GetKubectlOptions()
 
 	t.Cleanup(func() {
-		if t.Failed() || Config.Debug {
+		if t.Failed() {
 			var namespaces []string
 			clientset, err := k8s.GetKubernetesClientFromOptionsE(t, opts)
 			if err == nil {
@@ -106,7 +106,7 @@ func TestConformance(t *testing.T) {
 		RestConfig:           clientConfig,
 		Clientset:            clientset,
 		GatewayClassName:     "kuma",
-		CleanupBaseResources: true,
+		CleanupBaseResources: !Config.Debug,
 		Debug:                Config.Debug,
 		NamespaceLabels: map[string]string{
 			metadata.KumaSidecarInjectionAnnotation: metadata.AnnotationEnabled,

--- a/test/framework/envs/multizone/env.go
+++ b/test/framework/envs/multizone/env.go
@@ -261,14 +261,9 @@ func AfterSuite(report ginkgo.Report) {
 
 func PrintCPLogsOnFailure(report ginkgo.Report) {
 	if !report.SuiteSucceeded {
+		framework.Logf("Please see full CP logs by downloading the debug artifacts")
 		for _, cluster := range append(Zones(), Global) {
-			Logf("\n\n\n\n\nCP logs of: " + cluster.Name())
-			logs, err := cluster.GetKumaCPLogs()
-			if err != nil {
-				Logf("could not retrieve cp logs")
-			} else {
-				Logf(logs)
-			}
+			framework.DebugUniversalCPLogs(cluster)
 		}
 	}
 }

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -158,7 +158,7 @@ func (c *UniversalCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOpt
 	verboseOutToStd := true
 	cmd := []string{"kuma-cp", "run", "--config-file", "/kuma/kuma-cp.conf"}
 	if Config.Debug {
-		// in debug mode, we will CP debug level logs wil be enabled and will be dump logs into files
+		// in debug mode, we will enable debug level logs on CP, and they'll be dump logs into files
 		// so don't need to print onto stdout/stderr, otherwise the test output will be too verbose
 		verboseOutToStd = false
 		cmd = append(cmd, "--log-level", "debug")

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -155,8 +155,12 @@ func (c *UniversalCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOpt
 		dockerVolumes = append(dockerVolumes, path+":/kuma/kuma-cp.conf")
 	}
 
+	verboseOutToStd := true
 	cmd := []string{"kuma-cp", "run", "--config-file", "/kuma/kuma-cp.conf"}
 	if Config.Debug {
+		// in debug mode, we will CP debug level logs wil be enabled and will be dump logs into files
+		// so don't need to print onto stdout/stderr, otherwise the test output will be too verbose
+		verboseOutToStd = false
 		cmd = append(cmd, "--log-level", "debug")
 	}
 	if mode == core.Zone {
@@ -164,7 +168,7 @@ func (c *UniversalCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOpt
 		env["KUMA_MULTIZONE_ZONE_KDS_TLS_SKIP_VERIFY"] = "true"
 	}
 
-	app, err := NewUniversalApp(c.t, c.name, AppModeCP, "", AppModeCP, c.opts.isipv6, true, []string{}, dockerVolumes, "", 0)
+	app, err := NewUniversalApp(c.t, c.name, AppModeCP, "", AppModeCP, c.opts.isipv6, verboseOutToStd, []string{}, dockerVolumes, "", 0)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Solving two issues:
1. When `ENABLE_E2E_DEBUG_GLOBALLY` is turned on, there is too much logs flooding the GHA output view and it's truncated (fixing again, a further step following [a previous PR](https://github.com/kumahq/kuma/pull/11506))
2. We can't collect logs from pods from GatewayAPI conformance for the moment as they are cleaned up after running. So turn off cleaning up when debug is enabled.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues 
  - A helper effort when fixing flakiness: https://github.com/kumahq/kuma/actions/runs/10986369217/job/30500941118
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS 
  - Confirmed
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) 
  - Tested
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? 
  - No need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) 
  - No


> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
