### PR TITLE
fix(kumactl): declare meshes before secrets when exporting

### DIFF
--- a/app/kumactl/cmd/export/export.go
+++ b/app/kumactl/cmd/export/export.go
@@ -16,6 +16,7 @@ import (
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_system "github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/core/resources/model/rest/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	admin_tls "github.com/kumahq/kuma/pkg/envoy/admin/tls"
 	intercp_tls "github.com/kumahq/kuma/pkg/intercp/tls"
@@ -91,6 +92,7 @@ $ kumactl export --profile federation --format universal > policies.yaml
 				return errors.Wrap(err, "could not list meshes")
 			}
 
+			var meshDeclarations []model.Resource
 			var meshSecrets []model.Resource
 			var otherResources []model.Resource
 			for _, resDesc := range resTypes {
@@ -103,6 +105,14 @@ $ kumactl export --profile federation --format universal > policies.yaml
 						if res.Descriptor().Name == core_mesh.MeshType {
 							mesh := res.(*core_mesh.MeshResource)
 							mesh.Spec.SkipCreatingInitialPolicies = []string{"*"}
+							meshDeclaration := core_mesh.NewMeshResource()
+							meshDeclaration.SetMeta(
+								v1alpha1.ResourceMeta{
+									Type: string(core_mesh.MeshType),
+									Name: res.GetMeta().GetName(),
+								},
+							)
+							meshDeclarations = append(meshDeclarations, meshDeclaration)
 						}
 						otherResources = append(otherResources, res)
 					}
@@ -123,7 +133,7 @@ $ kumactl export --profile federation --format universal > policies.yaml
 				}
 			}
 
-			allResources := append(meshSecrets, otherResources...)
+			allResources := append(meshDeclarations, append(meshSecrets, otherResources...)...)
 			var resources []model.Resource
 			var userTokenSigningKeys []model.Resource
 			// filter out envoy-admin-ca and inter-cp-ca otherwise it will cause TLS handshake errors

--- a/app/kumactl/cmd/export/testdata/export-kube.golden.yaml
+++ b/app/kumactl/cmd/export/testdata/export-kube.golden.yaml
@@ -9,6 +9,15 @@ metadata:
 spec: {}
 ---
 apiVersion: kuma.io/v1alpha1
+kind: Mesh
+metadata:
+  annotations:
+    k8s.kuma.io/mesh-defaults-generated: "true"
+  creationTimestamp: "2024-01-08T17:25:45Z"
+  name: default
+spec: {}
+---
+apiVersion: kuma.io/v1alpha1
 kind: MeshAccessLog
 metadata:
   annotations:

--- a/app/kumactl/cmd/export/testdata/export-no-dp.golden.yaml
+++ b/app/kumactl/cmd/export/testdata/export-no-dp.golden.yaml
@@ -4,6 +4,11 @@ creationTime: "0001-01-01T00:00:00Z"
 modificationTime: "0001-01-01T00:00:00Z"
 name: default
 type: Mesh
+---
+creationTime: "0001-01-01T00:00:00Z"
+modificationTime: "0001-01-01T00:00:00Z"
+name: default
+type: Mesh
 skipCreatingInitialPolicies:
 - '*'
 ---

--- a/app/kumactl/cmd/export/testdata/export.golden.yaml
+++ b/app/kumactl/cmd/export/testdata/export.golden.yaml
@@ -1,6 +1,16 @@
 # Product: Kuma, Version: 0.0.0-testversion, Hostname: localhost, ClusterId: test-cluster, InstanceId: test-instance
 ---
 creationTime: "0001-01-01T00:00:00Z"
+modificationTime: "0001-01-01T00:00:00Z"
+name: default
+type: Mesh
+---
+creationTime: "0001-01-01T00:00:00Z"
+modificationTime: "0001-01-01T00:00:00Z"
+name: another-mesh
+type: Mesh
+---
+creationTime: "0001-01-01T00:00:00Z"
 mesh: default
 modificationTime: "0001-01-01T00:00:00Z"
 name: dataplane-token-signing-key-1


### PR DESCRIPTION
This fixes changes introduced by #11497. Universal checks whether a mesh exists before allowing a secret to be created.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- #11420 
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
