### PR TITLE
fix(inspect-api): amend openapi types for arbitrary objects

### DIFF
--- a/api/openapi/specs/common/resource.yaml
+++ b/api/openapi/specs/common/resource.yaml
@@ -113,6 +113,8 @@ components:
       properties:
         tags:
           type: object
+          additionalProperties: 
+            type: string
           x-go-type: 'map[string]string'
         port:
           type: integer
@@ -123,7 +125,7 @@ components:
         conf:
           description: The actual conf generated
           type: object
-          x-go-type: 'interface{}'
+          additionalProperties: true
         origin:
           type: array
           items:

--- a/api/openapi/specs/common/resource.yaml
+++ b/api/openapi/specs/common/resource.yaml
@@ -142,6 +142,7 @@ components:
         conf:
           description: The actual conf generated
           type: object
+          additionalProperties: true
           x-go-type: 'interface{}'
         origin:
           type: array
@@ -174,6 +175,7 @@ components:
         conf:
           description: The actual conf generated
           type: object
+          additionalProperties: true
           x-go-type: 'interface{}'
         origin:
           type: array

--- a/api/openapi/specs/common/resource.yaml
+++ b/api/openapi/specs/common/resource.yaml
@@ -126,6 +126,7 @@ components:
           description: The actual conf generated
           type: object
           additionalProperties: true
+          x-go-type: 'interface{}'
         origin:
           type: array
           items:

--- a/api/openapi/types/common/zz_generated.resource.go
+++ b/api/openapi/types/common/zz_generated.resource.go
@@ -76,8 +76,8 @@ type PolicyDescription struct {
 // ProxyRule defines model for ProxyRule.
 type ProxyRule struct {
 	// Conf The actual conf generated
-	Conf   interface{} `json:"conf"`
-	Origin []Meta      `json:"origin"`
+	Conf   map[string]interface{} `json:"conf"`
+	Origin []Meta                 `json:"origin"`
 }
 
 // ResourceRule defines model for ResourceRule.

--- a/api/openapi/types/common/zz_generated.resource.go
+++ b/api/openapi/types/common/zz_generated.resource.go
@@ -76,8 +76,8 @@ type PolicyDescription struct {
 // ProxyRule defines model for ProxyRule.
 type ProxyRule struct {
 	// Conf The actual conf generated
-	Conf   map[string]interface{} `json:"conf"`
-	Origin []Meta                 `json:"origin"`
+	Conf   interface{} `json:"conf"`
+	Origin []Meta      `json:"origin"`
 }
 
 // ResourceRule defines model for ResourceRule.

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -2522,6 +2522,7 @@ components:
         conf:
           description: The actual conf generated
           type: object
+          additionalProperties: true
           x-go-type: interface{}
         origin:
           type: array
@@ -2549,6 +2550,7 @@ components:
         conf:
           description: The actual conf generated
           type: object
+          additionalProperties: true
           x-go-type: interface{}
         origin:
           type: array
@@ -2568,7 +2570,6 @@ components:
           type: object
           additionalProperties:
             type: string
-
           x-go-type: map[string]string
         port:
           type: integer

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -2483,6 +2483,7 @@ components:
         conf:
           description: The actual conf generated
           type: object
+          additionalProperties: true
           x-go-type: interface{}
         origin:
           type: array
@@ -2565,6 +2566,9 @@ components:
       properties:
         tags:
           type: object
+          additionalProperties:
+            type: string
+
           x-go-type: map[string]string
         port:
           type: integer


### PR DESCRIPTION
This PR alters instances of `type: object` (with no additional information) to use:

1.  `additionalProperties: true` in the case where we are saying an arbitrary object/`interface {}` (i.e. TS `Record<string, unknown>`)
2. `additionalProperties.type: string` where we are saying a `map[string]string` (i.e. TS `Record<string, string>`)

Generated files generated using `make generate/oas`.

Previous to this PR these properties were using `never` in the produced frontend TS which was causing issues.

---

**Please note:** I will probably add more amends to this PR once I've had an initial review, so initially I'm looking for comment so I know I'm doing things correctly so I can go ahead and do more before getting a final review ~(see inline question)~

---

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
