### PR TITLE
test(e2e): avoid name conflict and simplfy logic

### DIFF
--- a/test/e2e_env/kubernetes/externalservices/externalservices.go
+++ b/test/e2e_env/kubernetes/externalservices/externalservices.go
@@ -42,6 +42,7 @@ spec:
 		err := NewClusterSetup().
 			Install(YamlK8s(meshPassthroughEnabled)).
 			Install(Namespace(namespace)).
+			Install(TrafficRouteKubernetes(meshName)).
 			Install(NamespaceWithSidecarInjection(clientNamespace)).
 			Install(democlient.Install(democlient.WithNamespace(clientNamespace), democlient.WithMesh(meshName))).
 			Setup(kubernetes.Cluster)
@@ -177,7 +178,7 @@ apiVersion: kuma.io/v1alpha1
 kind: TrafficPermission
 mesh: external-services
 metadata:
-  name: traffic-to-es
+  name: traffic-to-es-tls
 spec:
   sources:
     - match:


### PR DESCRIPTION
### Checklist prior to review

* rework MeshTCPRoute to check if there are responses from 4 instances
* change resource name

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
