### PR TITLE
fix(resourcerules): add own mesh to the MeshContext, so it could be successfully resolved

### DIFF
--- a/pkg/plugins/policies/core/xds/meshroute/clusters.go
+++ b/pkg/plugins/policies/core/xds/meshroute/clusters.go
@@ -84,7 +84,7 @@ func GenerateClusters(
 					Configure(envoy_clusters.Http2())
 
 				if upstreamMeshName := cluster.Mesh(); upstreamMeshName != "" {
-					for _, otherMesh := range append(meshCtx.Resources.OtherMeshes().Items, meshCtx.Resource) {
+					for _, otherMesh := range meshCtx.Resources.Meshes().Items {
 						if otherMesh.GetMeta().GetName() == upstreamMeshName {
 							edsClusterBuilder.Configure(
 								envoy_clusters.CrossMeshClientSideMTLS(

--- a/pkg/xds/context/mesh_context_builder.go
+++ b/pkg/xds/context/mesh_context_builder.go
@@ -468,13 +468,10 @@ func (m *meshContextBuilder) resolveTLSReadiness(
 	}
 }
 
-func (m *meshContextBuilder) decorateWithCrossMeshResources(ctx context.Context, meshName string, resources Resources) error {
+func (m *meshContextBuilder) decorateWithCrossMeshResources(ctx context.Context, localMesh string, resources Resources) error {
 	// Expand with crossMesh info
 	otherMeshesByName := map[string]*core_mesh.MeshResource{}
-	for _, m := range resources.Meshes().GetItems() {
-		if m.GetMeta().GetName() == meshName {
-			continue
-		}
+	for _, m := range resources.OtherMeshes(localMesh).GetItems() {
 		otherMeshesByName[m.GetMeta().GetName()] = m.(*core_mesh.MeshResource)
 		resources.CrossMeshResources[m.GetMeta().GetName()] = map[core_model.ResourceType]core_model.ResourceList{
 			core_mesh.DataplaneType:   &core_mesh.DataplaneResourceList{},

--- a/pkg/xds/context/resources.go
+++ b/pkg/xds/context/resources.go
@@ -150,6 +150,16 @@ func (r Resources) Meshes() *core_mesh.MeshResourceList {
 	return r.ListOrEmpty(core_mesh.MeshType).(*core_mesh.MeshResourceList)
 }
 
+func (r Resources) OtherMeshes(localMesh string) *core_mesh.MeshResourceList {
+	otherMeshes := core_mesh.MeshResourceList{}
+	for _, m := range r.Meshes().Items {
+		if m.GetMeta().GetName() != localMesh {
+			otherMeshes.Items = append(otherMeshes.Items, m)
+		}
+	}
+	return &otherMeshes
+}
+
 func (r Resources) MeshServices() *meshsvc.MeshServiceResourceList {
 	list, ok := r.MeshLocalResources[meshsvc.MeshServiceType]
 	if !ok {

--- a/pkg/xds/context/resources.go
+++ b/pkg/xds/context/resources.go
@@ -146,7 +146,7 @@ func (r Resources) VirtualOutbounds() *core_mesh.VirtualOutboundResourceList {
 	return r.ListOrEmpty(core_mesh.VirtualOutboundType).(*core_mesh.VirtualOutboundResourceList)
 }
 
-func (r Resources) OtherMeshes() *core_mesh.MeshResourceList {
+func (r Resources) Meshes() *core_mesh.MeshResourceList {
 	return r.ListOrEmpty(core_mesh.MeshType).(*core_mesh.MeshResourceList)
 }
 
@@ -199,16 +199,19 @@ func (r Resources) gatewaysAndDataplanesForMesh(localMesh *core_mesh.MeshResourc
 		mesh      *core_mesh.MeshResource
 		resources ResourceMap
 	}
-	meshResourcesTuples := []meshResourcesTuple{{
-		mesh:      localMesh,
-		resources: r.MeshLocalResources,
-	}}
 
-	for _, mesh := range r.OtherMeshes().Items {
-		meshName := mesh.GetMeta().GetName()
+	var meshResourcesTuples []meshResourcesTuple
+	for _, mesh := range r.Meshes().Items {
+		var resources ResourceMap
+		switch {
+		case mesh.GetMeta().GetName() == localMesh.GetMeta().GetName():
+			resources = r.MeshLocalResources
+		default:
+			resources = r.CrossMeshResources[mesh.GetMeta().GetName()]
+		}
 		meshResourcesTuples = append(meshResourcesTuples, meshResourcesTuple{
 			mesh:      mesh,
-			resources: r.CrossMeshResources[meshName],
+			resources: resources,
 		})
 	}
 

--- a/pkg/xds/generator/outbound_proxy_generator.go
+++ b/pkg/xds/generator/outbound_proxy_generator.go
@@ -249,7 +249,7 @@ func (g OutboundProxyGenerator) generateCDS(ctx xds_context.Context, services en
 					Configure(envoy_clusters.Http2())
 
 				if upstreamMeshName := cluster.Mesh(); upstreamMeshName != "" {
-					for _, otherMesh := range append(ctx.Mesh.Resources.OtherMeshes().Items, ctx.Mesh.Resource) {
+					for _, otherMesh := range ctx.Mesh.Resources.Meshes().Items {
 						if otherMesh.GetMeta().GetName() == upstreamMeshName {
 							edsClusterBuilder.Configure(
 								envoy_clusters.CrossMeshClientSideMTLS(

--- a/pkg/xds/generator/secrets/generator.go
+++ b/pkg/xds/generator/secrets/generator.go
@@ -100,12 +100,7 @@ func (g Generator) Generate(
 	usedCAs := proxy.SecretsTracker.UsedCas()
 	usedAllInOne := proxy.SecretsTracker.UsedAllInOne()
 
-	var otherMeshes []*core_mesh.MeshResource
-	for _, m := range xdsCtx.Mesh.Resources.Meshes().Items {
-		if xdsCtx.Mesh.Resource.GetMeta().GetName() != m.GetMeta().GetName() {
-			otherMeshes = append(otherMeshes, m)
-		}
-	}
+	otherMeshes := xdsCtx.Mesh.Resources.OtherMeshes(xdsCtx.Mesh.Resource.GetMeta().GetName()).Items
 
 	if usedAllInOne {
 		identity, allInOneCa, err := xdsCtx.ControlPlane.Secrets.GetAllInOne(ctx, xdsCtx.Mesh.Resource, proxy.Dataplane, otherMeshes)

--- a/pkg/xds/generator/secrets/generator.go
+++ b/pkg/xds/generator/secrets/generator.go
@@ -97,7 +97,7 @@ func (g Generator) Generate(
 	}
 
 	usedIdentity := proxy.SecretsTracker.UsedIdentity()
-	usedCas := proxy.SecretsTracker.UsedCas()
+	usedCAs := proxy.SecretsTracker.UsedCas()
 	usedAllInOne := proxy.SecretsTracker.UsedAllInOne()
 
 	var otherMeshes []*core_mesh.MeshResource
@@ -118,14 +118,14 @@ func (g Generator) Generate(
 		log.V(1).Info("added all in one CA resources")
 	}
 
-	if usedIdentity || len(usedCas) > 0 {
-		var usedCasMeshes []*core_mesh.MeshResource
+	if usedIdentity || len(usedCAs) > 0 {
+		var usedCAsMeshes []*core_mesh.MeshResource
 		for _, otherMesh := range otherMeshes {
-			if _, ok := usedCas[otherMesh.GetMeta().GetName()]; ok {
-				usedCasMeshes = append(usedCasMeshes, otherMesh)
+			if _, ok := usedCAs[otherMesh.GetMeta().GetName()]; ok {
+				usedCAsMeshes = append(usedCAsMeshes, otherMesh)
 			}
 		}
-		identity, generatedMeshCAs, err := xdsCtx.ControlPlane.Secrets.GetForDataPlane(ctx, proxy.Dataplane, xdsCtx.Mesh.Resource, usedCasMeshes)
+		identity, generatedMeshCAs, err := xdsCtx.ControlPlane.Secrets.GetForDataPlane(ctx, proxy.Dataplane, xdsCtx.Mesh.Resource, usedCAsMeshes)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to generate dataplane identity cert and CAs")
 		}
@@ -133,7 +133,7 @@ func (g Generator) Generate(
 		resources.Add(createIdentitySecretResource(proxy.SecretsTracker.RequestIdentityCert().Name(), identity))
 
 		var addedCas []string
-		for mesh := range usedCas {
+		for mesh := range usedCAs {
 			if ca, ok := generatedMeshCAs[mesh]; ok {
 				resources.Add(createCaSecretResource(proxy.SecretsTracker.RequestCa(mesh).Name(), ca))
 			} else {

--- a/pkg/xds/generator/secrets/generator_test.go
+++ b/pkg/xds/generator/secrets/generator_test.go
@@ -67,7 +67,11 @@ var _ = Describe("SecretsGenerator", func() {
 		Entry("zone egress, Mesh has no mTLS configuration", testCase{
 			ctx: xds_context.Context{
 				Mesh: xds_context.MeshContext{
-					Resource: &core_mesh.MeshResource{},
+					Resource: &core_mesh.MeshResource{
+						Meta: &test_model.ResourceMeta{
+							Name: "default",
+						},
+					},
 				},
 				ControlPlane: &xds_context.ControlPlaneContext{
 					Secrets: &xds.TestSecrets{},

--- a/pkg/xds/sync/dataplane_proxy_builder.go
+++ b/pkg/xds/sync/dataplane_proxy_builder.go
@@ -50,8 +50,8 @@ func (p *DataplaneProxyBuilder) Build(ctx context.Context, key core_model.Resour
 
 	meshName := meshContext.Resource.GetMeta().GetName()
 
-	allMeshNames := []string{meshName}
-	for _, mesh := range meshContext.Resources.OtherMeshes().Items {
+	allMeshNames := []string{}
+	for _, mesh := range meshContext.Resources.Meshes().Items {
 		allMeshNames = append(allMeshNames, mesh.GetMeta().GetName())
 	}
 

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -128,6 +128,19 @@ metadata:
 	return YamlK8s(mesh)
 }
 
+func MeshWithMeshServicesKubernetes(name string, meshServicesEnabled string) InstallFunc {
+	mesh := fmt.Sprintf(`
+apiVersion: kuma.io/v1alpha1
+kind: Mesh
+metadata:
+  name: %s
+spec:
+  meshServices:
+    enabled: %s
+`, name, meshServicesEnabled)
+	return YamlK8s(mesh)
+}
+
 func MTLSMeshKubernetes(name string) InstallFunc {
 	mesh := fmt.Sprintf(`
 apiVersion: kuma.io/v1alpha1


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues -- https://github.com/kumahq/kuma/issues/11512
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
