### PR TITLE
fix(inspect-api): `conf` should be an array of unknown structs

### DIFF
--- a/api/openapi/specs/common/resource.yaml
+++ b/api/openapi/specs/common/resource.yaml
@@ -174,9 +174,11 @@ components:
           type: string
         conf:
           description: The actual conf generated
-          type: object
-          additionalProperties: true
-          x-go-type: 'interface{}'
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+            x-go-type: 'interface{}'
         origin:
           type: array
           description: The list of policies that contributed to the 'conf'. The order is important as it reflects in what order confs were merged to get the resulting 'conf'.

--- a/api/openapi/types/common/zz_generated.resource.go
+++ b/api/openapi/types/common/zz_generated.resource.go
@@ -83,7 +83,7 @@ type ProxyRule struct {
 // ResourceRule defines model for ResourceRule.
 type ResourceRule struct {
 	// Conf The actual conf generated
-	Conf interface{} `json:"conf"`
+	Conf []interface{} `json:"conf"`
 
 	// Origin The list of policies that contributed to the 'conf'. The order is important as it reflects in what order confs were merged to get the resulting 'conf'.
 	Origin              []ResourceRuleOrigin `json:"origin"`

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -2549,9 +2549,11 @@ components:
           type: string
         conf:
           description: The actual conf generated
-          type: object
-          additionalProperties: true
-          x-go-type: interface{}
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+            x-go-type: interface{}
         origin:
           type: array
           description: >-

--- a/mk/generate.mk
+++ b/mk/generate.mk
@@ -109,6 +109,10 @@ generate/oas: $(GENERATE_OAS_PREREQUISITES)
 		PATH=$(CI_TOOLS_BIN_DIR):$$PATH oapi-codegen -config api/openapi/openapi.cfg.yaml -o api/openapi/types/$$(dirname $${DEST}})/zz_generated.$$(basename $${DEST}).go $${endpoint}.yaml; \
 	done
 
+.PHONY: generate/oas-for-ts
+generate/oas-for-ts: generate/oas docs/generated/openapi.yaml ## Regenerate OpenAPI spec from `/api/openapi/specs` ready for typescript type generation
+
+
 .PHONY: generate/builtin-crds
 generate/builtin-crds: $(RESOURCE_GEN)
 	$(RESOURCE_GEN) -package mesh -generator crd > ./pkg/plugins/resources/k8s/native/api/v1alpha1/zz_generated.mesh.go


### PR DESCRIPTION
1. Amends `toResourceRules[].conf` to be an array of structs rather than a struct
2. Adds a makefile target for easier full generation of all OpenAPI related code (i.e. _both_ the golang and the `docs` YAMLs which typescript uses)


### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
