### PR TITLE
fix(MeshGateway): apply policies to clusters from real backendRefs

### DIFF
--- a/pkg/plugins/policies/core/xds/meshroute/gateway/gateway.go
+++ b/pkg/plugins/policies/core/xds/meshroute/gateway/gateway.go
@@ -30,7 +30,7 @@ type listenersHostnames struct {
 }
 
 type MapGatewayRulesToHosts func(
-	meshLocalResources xds_context.ResourceMap,
+	meshCtx xds_context.MeshContext,
 	rules rules.GatewayRules,
 	address string,
 	port uint32,
@@ -99,7 +99,7 @@ func CollectListenerInfos(
 		}
 
 		hostInfos := mapRules(
-			meshCtx.Resources.MeshLocalResources,
+			meshCtx,
 			rawRules,
 			networking.Address,
 			listener.listener.GetPort(),

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
@@ -16,6 +16,7 @@ import (
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	meshexternalservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
+	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
@@ -408,6 +409,7 @@ var _ = Describe("MeshHealthCheck", func() {
 		gatewayRoutes  []*core_mesh.MeshGatewayRouteResource
 		meshhttproutes core_rules.GatewayRules
 		meshtcproutes  core_rules.GatewayRules
+		meshservices   []*meshservice_api.MeshServiceResource
 		rules          core_rules.GatewayRules
 	}
 	DescribeTable("should generate proper Envoy config for MeshGateways",
@@ -451,6 +453,11 @@ var _ = Describe("MeshHealthCheck", func() {
 			if len(given.gatewayRoutes) > 0 {
 				resources.MeshLocalResources[core_mesh.MeshGatewayRouteType] = &core_mesh.MeshGatewayRouteResourceList{
 					Items: given.gatewayRoutes,
+				}
+			}
+			if len(given.meshservices) > 0 {
+				resources.MeshLocalResources[meshservice_api.MeshServiceType] = &meshservice_api.MeshServiceResourceList{
+					Items: given.meshservices,
 				}
 			}
 
@@ -499,6 +506,116 @@ var _ = Describe("MeshHealthCheck", func() {
 		Entry("basic outbound cluster with HTTP health check", gatewayTestCase{
 			name:          "basic",
 			gatewayRoutes: []*core_mesh.MeshGatewayRouteResource{samples.BackendGatewayRoute()},
+			rules: core_rules.GatewayRules{
+				ToRules: core_rules.GatewayToRules{
+					ByListenerAndHostname: map[core_rules.InboundListenerHostname]core_rules.Rules{
+						rules.NewInboundListenerHostname("192.168.0.1", 8080, "*"): {
+							{
+								Subset: core_rules.Subset{},
+								Conf: api.Conf{
+									Interval:                     test.ParseDuration("10s"),
+									Timeout:                      test.ParseDuration("2s"),
+									UnhealthyThreshold:           pointer.To[int32](3),
+									HealthyThreshold:             pointer.To[int32](1),
+									InitialJitter:                test.ParseDuration("13s"),
+									IntervalJitter:               test.ParseDuration("15s"),
+									IntervalJitterPercent:        pointer.To[int32](10),
+									HealthyPanicThreshold:        pointer.To(intstr.FromString("62.9")),
+									FailTrafficOnPanic:           pointer.To(true),
+									EventLogPath:                 pointer.To("/tmp/log.txt"),
+									AlwaysLogHealthCheckFailures: pointer.To(false),
+									NoTrafficInterval:            test.ParseDuration("16s"),
+									Http: &api.HttpHealthCheck{
+										Disabled: pointer.To(false),
+										Path:     pointer.To("/health"),
+										RequestHeadersToAdd: &api.HeaderModifier{
+											Add: []api.HeaderKeyValue{
+												{
+													Name:  "x-some-header",
+													Value: "value",
+												},
+											},
+											Set: []api.HeaderKeyValue{
+												{
+													Name:  "x-some-other-header",
+													Value: "value",
+												},
+											},
+										},
+										ExpectedStatuses: &[]int32{200, 201},
+									},
+									ReuseConnection: pointer.To(true),
+								},
+							},
+						},
+					},
+				},
+			},
+		}),
+		Entry("HTTP HealthCheck to real MeshService", gatewayTestCase{
+			name: "real-mesh-service-meshhttproute",
+			meshservices: []*meshservice_api.MeshServiceResource{
+				{
+					Meta: &test_model.ResourceMeta{Name: "backend", Mesh: "default"},
+					Spec: &meshservice_api.MeshService{
+						Selector: meshservice_api.Selector{},
+						Ports: []meshservice_api.Port{{
+							Port:        80,
+							TargetPort:  intstr.FromInt(8084),
+							AppProtocol: core_mesh.ProtocolHTTP,
+						}},
+						Identities: []meshservice_api.MeshServiceIdentity{
+							{
+								Type:  meshservice_api.MeshServiceIdentityServiceTagType,
+								Value: "backend",
+							},
+							{
+								Type:  meshservice_api.MeshServiceIdentityServiceTagType,
+								Value: "other-backend",
+							},
+						},
+					},
+					Status: &meshservice_api.MeshServiceStatus{
+						VIPs: []meshservice_api.VIP{{
+							IP: "10.0.0.1",
+						}},
+					},
+				},
+			},
+			meshhttproutes: core_rules.GatewayRules{
+				ToRules: core_rules.GatewayToRules{
+					ByListenerAndHostname: map[core_rules.InboundListenerHostname]core_rules.Rules{
+						rules.NewInboundListenerHostname("192.168.0.1", 8080, "*"): {
+							{
+								Subset: core_rules.MeshSubset(),
+								Conf: meshhttproute_api.PolicyDefault{
+									Rules: []meshhttproute_api.Rule{{
+										Matches: []meshhttproute_api.Match{{
+											Path: &meshhttproute_api.PathMatch{
+												Type:  meshhttproute_api.Exact,
+												Value: "/",
+											},
+										}},
+										Default: meshhttproute_api.RuleConf{
+											BackendRefs: &[]common_api.BackendRef{{
+												TargetRef: builders.TargetRefService("backend"),
+												Port:      pointer.To(uint32(80)),
+												Weight:    pointer.To(uint(100)),
+											}},
+										},
+									}},
+								},
+								Origin: []core_model.ResourceMeta{
+									&test_model.ResourceMeta{Mesh: "default", Name: "http-route"},
+								},
+								BackendRefOriginIndex: core_rules.BackendRefOriginIndex{
+									meshhttproute_api.HashMatches([]meshhttproute_api.Match{{Path: &meshhttproute_api.PathMatch{Type: meshhttproute_api.Exact, Value: "/"}}}): 0,
+								},
+							},
+						},
+					},
+				},
+			},
 			rules: core_rules.GatewayRules{
 				ToRules: core_rules.GatewayToRules{
 					ByListenerAndHostname: map[core_rules.InboundListenerHostname]core_rules.Rules{

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/real-mesh-service-meshhttproute.gateway_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/real-mesh-service-meshhttproute.gateway_cluster.golden.yaml
@@ -2,11 +2,49 @@ resources:
 - name: default_backend___msvc_80-e3a0069bda479bd1
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    commonLbConfig:
+      healthyPanicThreshold:
+        value: 62.9
+      zoneAwareLbConfig:
+        failTrafficOnPanic: true
     edsClusterConfig:
       edsConfig:
         ads: {}
         initialFetchTimeout: 0s
         resourceApiVersion: V3
+    healthChecks:
+    - eventLogger:
+      - name: envoy.health_check.event_sinks.file
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.health_check.event_sinks.file.v3.HealthCheckEventFileSink
+          eventLogPath: /tmp/log.txt
+      healthyThreshold: 1
+      httpHealthCheck:
+        expectedStatuses:
+        - end: "201"
+          start: "200"
+        - end: "202"
+          start: "201"
+        path: /health
+        requestHeadersToAdd:
+        - header:
+            key: x-kuma-tags
+            value: '&kuma.io/service=sample-gateway&'
+        - header:
+            key: x-some-header
+            value: value
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
+          header:
+            key: x-some-other-header
+            value: value
+      initialJitter: 13s
+      interval: 10s
+      intervalJitter: 15s
+      intervalJitterPercent: 10
+      noTrafficInterval: 16s
+      reuseConnection: true
+      timeout: 2s
+      unhealthyThreshold: 3
     name: default_backend___msvc_80-e3a0069bda479bd1
     perConnectionBufferLimitBytes: 32768
     type: EDS

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/real-mesh-service-meshhttproute.gateway_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/real-mesh-service-meshhttproute.gateway_cluster.golden.yaml
@@ -1,0 +1,17 @@
+resources:
+- name: default_backend___msvc_80-e3a0069bda479bd1
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+        initialFetchTimeout: 0s
+        resourceApiVersion: V3
+    name: default_backend___msvc_80-e3a0069bda479bd1
+    perConnectionBufferLimitBytes: 32768
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          httpProtocolOptions: {}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/gateway_routes.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/gateway_routes.go
@@ -12,6 +12,7 @@ import (
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
+	"github.com/kumahq/kuma/pkg/plugins/policies/core/xds/meshroute"
 	meshroute_gateway "github.com/kumahq/kuma/pkg/plugins/policies/core/xds/meshroute/gateway"
 	api "github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
 	plugin_gateway "github.com/kumahq/kuma/pkg/plugins/runtime/gateway"
@@ -29,7 +30,7 @@ type ruleByHostname struct {
 }
 
 func sortRulesToHosts(
-	meshLocalResources xds_context.ResourceMap,
+	meshCtx xds_context.MeshContext,
 	rawRules rules.GatewayRules,
 	address string,
 	port uint32,
@@ -148,13 +149,13 @@ func sortRulesToHosts(
 			for _, t := range plugin_gateway.ConnectionPolicyTypes {
 				matches := match.ConnectionPoliciesBySource(
 					host.Tags,
-					match.ToConnectionPolicies(meshLocalResources[t]))
+					match.ToConnectionPolicies(meshCtx.Resources.MeshLocalResources[t]))
 				host.Policies[t] = matches
 			}
 			hostInfo := plugin_gateway.GatewayHostInfo{
 				Host: host,
 			}
-			hostInfo.AppendEntries(generateEnvoyRouteEntries(host, rules, resolver))
+			hostInfo.AppendEntries(generateEnvoyRouteEntries(meshCtx, host, rules, resolver))
 
 			meshroute_gateway.AddToListenerByHostname(
 				hostInfosByHostname,
@@ -171,6 +172,7 @@ func sortRulesToHosts(
 }
 
 func generateEnvoyRouteEntries(
+	meshCtx xds_context.MeshContext,
 	host plugin_gateway.GatewayHost,
 	toRules []ruleByHostname,
 	resolver model.LabelResourceIdentifierResolver,
@@ -192,7 +194,7 @@ func generateEnvoyRouteEntries(
 			}
 			slices.Sort(names)
 
-			entry := makeHttpRouteEntry(strings.Join(names, "_"), rule, rules.Rule.BackendRefOrigin, resolver)
+			entry := makeHttpRouteEntry(meshCtx, strings.Join(names, "_"), rule, rules.Rule.BackendRefOrigin, resolver)
 
 			hashedMatches := api.HashMatches(rule.Matches)
 			// The rule matches if any of the matches is successful (it has OR
@@ -220,6 +222,7 @@ func generateEnvoyRouteEntries(
 }
 
 func makeHttpRouteEntry(
+	meshCtx xds_context.MeshContext,
 	name string,
 	rule api.Rule,
 	backendRefToOrigin map[common_api.MatchesHash]model.ResourceMeta,
@@ -230,11 +233,19 @@ func makeHttpRouteEntry(
 	}
 
 	for _, b := range pointer.Deref(rule.Default.BackendRefs) {
+		var dest map[string]string
 		var ref *model.ResolvedBackendRef
 		if origin, ok := backendRefToOrigin[api.HashMatches(rule.Matches)]; ok {
 			ref = model.ResolveBackendRef(origin, b, resolver)
+			if ref.ReferencesRealResource() {
+				service, _, _, ok := meshroute.GetServiceProtocolPortFromRef(meshCtx, ref.RealResourceBackendRef())
+				if ok {
+					dest = map[string]string{
+						mesh_proto.ServiceTag: service,
+					}
+				}
+			}
 		}
-		var dest map[string]string
 		if ref == nil || ref.ResourceOrNil() == nil {
 			// We have a legacy backendRef
 			if !b.ReferencesRealObject() {

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin.go
@@ -157,7 +157,7 @@ func ApplyToGateway(
 }
 
 func sortRulesToHosts(
-	_ xds_context.ResourceMap,
+	meshCtx xds_context.MeshContext,
 	rawRules rules.GatewayRules,
 	address string,
 	port uint32,
@@ -185,7 +185,7 @@ func sortRulesToHosts(
 		if !ok {
 			continue
 		}
-		hostInfo.AppendEntries(generateEnvoyRouteEntries(host, rulesForListener, resolver))
+		hostInfo.AppendEntries(generateEnvoyRouteEntries(meshCtx, host, rulesForListener, resolver))
 		meshroute_gateway.AddToListenerByHostname(
 			hostInfosByHostname,
 			protocol,


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- Fixes https://github.com/kumahq/kuma/issues/11529
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
