### PR TITLE
fix(e2e): don't reuse namespace for helm upgrade test

### DIFF
--- a/test/e2e/helm/kuma_helm_upgrade_multizone.go
+++ b/test/e2e/helm/kuma_helm_upgrade_multizone.go
@@ -20,6 +20,7 @@ import (
 )
 
 func UpgradingWithHelmChartMultizone() {
+	namespace := "helm-upgrade-ns"
 	var global, zoneK8s, zoneUniversal Cluster
 	var globalCP ControlPlane
 
@@ -42,7 +43,7 @@ func UpgradingWithHelmChartMultizone() {
 		}()
 		go func() {
 			defer grp.Done()
-			Expect(zoneK8s.DeleteNamespace(TestNamespace)).To(Succeed())
+			Expect(zoneK8s.DeleteNamespace(namespace)).To(Succeed())
 			Expect(zoneK8s.DeleteKuma()).To(Succeed())
 			Expect(zoneK8s.DismissCluster()).To(Succeed())
 		}()
@@ -114,7 +115,7 @@ spec:
 			By("Sync DPPs from Zone to Global")
 			// when start test server on Zone
 			err = NewClusterSetup().
-				Install(NamespaceWithSidecarInjection(TestNamespace)).
+				Install(NamespaceWithSidecarInjection(namespace)).
 				Install(testserver.Install()).Setup(zoneK8s)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/helm/kuma_helm_upgrade_multizone.go
+++ b/test/e2e/helm/kuma_helm_upgrade_multizone.go
@@ -116,7 +116,7 @@ spec:
 			// when start test server on Zone
 			err = NewClusterSetup().
 				Install(NamespaceWithSidecarInjection(namespace)).
-				Install(testserver.Install()).Setup(zoneK8s)
+				Install(testserver.Install(testserver.WithNamespace(namespace))).Setup(zoneK8s)
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(func(g Gomega) (int, error) {


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
