### PR TITLE
refactor(MeshGateway): add ResourceRules to GatewayRules, ResourceOrigin and Protocol to clusters

### DIFF
--- a/pkg/core/xds/resource.go
+++ b/pkg/core/xds/resource.go
@@ -178,8 +178,10 @@ func NonMeshExternalService(r *Resource) bool {
 	return r.ResourceOrigin == nil || (r.ResourceOrigin != nil && r.ResourceOrigin.ResourceType != meshexternalservice_api.MeshExternalServiceType)
 }
 
-func (s *ResourceSet) IndexByOrigin(filters ...func(*Resource) bool) map[core_model.TypedResourceIdentifier]map[string][]*Resource {
-	byOwner := map[core_model.TypedResourceIdentifier]map[string][]*Resource{}
+type ResourcesByType map[string][]*Resource
+
+func (s *ResourceSet) IndexByOrigin(filters ...func(*Resource) bool) map[core_model.TypedResourceIdentifier]ResourcesByType {
+	byOwner := map[core_model.TypedResourceIdentifier]ResourcesByType{}
 	for typ, nameToRes := range s.typeToNamesIndex {
 		for _, resource := range nameToRes {
 			add := true

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.golden.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.golden.yaml
@@ -44,137 +44,149 @@ FromRules:
 ToRules:
   ByListener:
     127.0.0.1:8080:
-    - BackendRefOriginIndex: {}
-      Conf:
-        backends:
-        - file:
-            path: /gateway-listener
-          type: File
-      Origin:
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: mesh
-        type: MeshAccessLog
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: gateway
-        type: MeshAccessLog
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: gatewaylistener
-        type: MeshAccessLog
-      Subset: []
+      ResourceRules: {}
+      Rules:
+      - BackendRefOriginIndex: {}
+        Conf:
+          backends:
+          - file:
+              path: /gateway-listener
+            type: File
+        Origin:
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: mesh
+          type: MeshAccessLog
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: gateway
+          type: MeshAccessLog
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: gatewaylistener
+          type: MeshAccessLog
+        Subset: []
     127.0.0.1:8081:
-    - BackendRefOriginIndex: {}
-      Conf:
-        backends:
-        - file:
-            path: /servicesubset
-          type: File
-      Origin:
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: mesh
-        type: MeshAccessLog
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: gateway
-        type: MeshAccessLog
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: servicesubset
-        type: MeshAccessLog
-      Subset: []
+      ResourceRules: {}
+      Rules:
+      - BackendRefOriginIndex: {}
+        Conf:
+          backends:
+          - file:
+              path: /servicesubset
+            type: File
+        Origin:
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: mesh
+          type: MeshAccessLog
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: gateway
+          type: MeshAccessLog
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: servicesubset
+          type: MeshAccessLog
+        Subset: []
     127.0.0.1:8082:
-    - BackendRefOriginIndex: {}
-      Conf:
-        backends:
-        - file:
-            path: /to-gateway
-          type: File
-      Origin:
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: mesh
-        type: MeshAccessLog
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: gateway
-        type: MeshAccessLog
-      Subset: []
+      ResourceRules: {}
+      Rules:
+      - BackendRefOriginIndex: {}
+        Conf:
+          backends:
+          - file:
+              path: /to-gateway
+            type: File
+        Origin:
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: mesh
+          type: MeshAccessLog
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: gateway
+          type: MeshAccessLog
+        Subset: []
   ByListenerAndHostname:
     127.0.0.1:8080:*:
-    - BackendRefOriginIndex: {}
-      Conf:
-        backends:
-        - file:
-            path: /gateway-listener
-          type: File
-      Origin:
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: mesh
-        type: MeshAccessLog
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: gateway
-        type: MeshAccessLog
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: gatewaylistener
-        type: MeshAccessLog
-      Subset: []
+      ResourceRules: {}
+      Rules:
+      - BackendRefOriginIndex: {}
+        Conf:
+          backends:
+          - file:
+              path: /gateway-listener
+            type: File
+        Origin:
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: mesh
+          type: MeshAccessLog
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: gateway
+          type: MeshAccessLog
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: gatewaylistener
+          type: MeshAccessLog
+        Subset: []
     127.0.0.1:8081:*:
-    - BackendRefOriginIndex: {}
-      Conf:
-        backends:
-        - file:
-            path: /to-gateway
-          type: File
-      Origin:
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: mesh
-        type: MeshAccessLog
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: servicesubset
-        type: MeshAccessLog
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: gateway
-        type: MeshAccessLog
-      Subset: []
+      ResourceRules: {}
+      Rules:
+      - BackendRefOriginIndex: {}
+        Conf:
+          backends:
+          - file:
+              path: /to-gateway
+            type: File
+        Origin:
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: mesh
+          type: MeshAccessLog
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: servicesubset
+          type: MeshAccessLog
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: gateway
+          type: MeshAccessLog
+        Subset: []
     127.0.0.1:8082:*:
-    - BackendRefOriginIndex: {}
-      Conf:
-        backends:
-        - file:
-            path: /to-gateway
-          type: File
-      Origin:
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: mesh
-        type: MeshAccessLog
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: gateway
-        type: MeshAccessLog
-      Subset: []
+      ResourceRules: {}
+      Rules:
+      - BackendRefOriginIndex: {}
+        Conf:
+          backends:
+          - file:
+              path: /to-gateway
+            type: File
+        Origin:
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: mesh
+          type: MeshAccessLog
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: gateway
+          type: MeshAccessLog
+        Subset: []

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/02.golden.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/02.golden.yaml
@@ -6,184 +6,202 @@ FromRules:
 ToRules:
   ByListener:
     127.0.0.1:8080:
-    - BackendRefOriginIndex: {}
-      Conf:
-        backends:
-        - file:
-            path: /meshsubset
-          type: File
-      Origin:
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: mesh
-        type: MeshAccessLog
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: meshsubset
-        type: MeshAccessLog
-      Subset: []
+      ResourceRules: {}
+      Rules:
+      - BackendRefOriginIndex: {}
+        Conf:
+          backends:
+          - file:
+              path: /meshsubset
+            type: File
+        Origin:
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: mesh
+          type: MeshAccessLog
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: meshsubset
+          type: MeshAccessLog
+        Subset: []
     127.0.0.1:8081:
-    - BackendRefOriginIndex: {}
-      Conf:
-        backends:
-        - file:
-            path: /meshsubset
-          type: File
-      Origin:
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: mesh
-        type: MeshAccessLog
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: meshsubset
-        type: MeshAccessLog
-      Subset: []
+      ResourceRules: {}
+      Rules:
+      - BackendRefOriginIndex: {}
+        Conf:
+          backends:
+          - file:
+              path: /meshsubset
+            type: File
+        Origin:
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: mesh
+          type: MeshAccessLog
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: meshsubset
+          type: MeshAccessLog
+        Subset: []
     127.0.0.1:8082:
-    - BackendRefOriginIndex: {}
-      Conf:
-        backends:
-        - file:
-            path: /meshsubset
-          type: File
-      Origin:
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: mesh
-        type: MeshAccessLog
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: meshsubset
-        type: MeshAccessLog
-      Subset: []
+      ResourceRules: {}
+      Rules:
+      - BackendRefOriginIndex: {}
+        Conf:
+          backends:
+          - file:
+              path: /meshsubset
+            type: File
+        Origin:
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: mesh
+          type: MeshAccessLog
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: meshsubset
+          type: MeshAccessLog
+        Subset: []
     127.0.0.1:8083:
-    - BackendRefOriginIndex: {}
-      Conf:
-        backends:
-        - file:
-            path: /applied-only-to-hostname
-          type: File
-      Origin:
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: mesh
-        type: MeshAccessLog
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: meshsubset
-        type: MeshAccessLog
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: only-one-hostname-listener
-        type: MeshAccessLog
-      Subset: []
+      ResourceRules: {}
+      Rules:
+      - BackendRefOriginIndex: {}
+        Conf:
+          backends:
+          - file:
+              path: /applied-only-to-hostname
+            type: File
+        Origin:
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: mesh
+          type: MeshAccessLog
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: meshsubset
+          type: MeshAccessLog
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: only-one-hostname-listener
+          type: MeshAccessLog
+        Subset: []
   ByListenerAndHostname:
     127.0.0.1:8080:*:
-    - BackendRefOriginIndex: {}
-      Conf:
-        backends:
-        - file:
-            path: /meshsubset
-          type: File
-      Origin:
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: mesh
-        type: MeshAccessLog
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: meshsubset
-        type: MeshAccessLog
-      Subset: []
+      ResourceRules: {}
+      Rules:
+      - BackendRefOriginIndex: {}
+        Conf:
+          backends:
+          - file:
+              path: /meshsubset
+            type: File
+        Origin:
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: mesh
+          type: MeshAccessLog
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: meshsubset
+          type: MeshAccessLog
+        Subset: []
     127.0.0.1:8081:*:
-    - BackendRefOriginIndex: {}
-      Conf:
-        backends:
-        - file:
-            path: /meshsubset
-          type: File
-      Origin:
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: mesh
-        type: MeshAccessLog
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: meshsubset
-        type: MeshAccessLog
-      Subset: []
+      ResourceRules: {}
+      Rules:
+      - BackendRefOriginIndex: {}
+        Conf:
+          backends:
+          - file:
+              path: /meshsubset
+            type: File
+        Origin:
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: mesh
+          type: MeshAccessLog
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: meshsubset
+          type: MeshAccessLog
+        Subset: []
     127.0.0.1:8082:*:
-    - BackendRefOriginIndex: {}
-      Conf:
-        backends:
-        - file:
-            path: /meshsubset
-          type: File
-      Origin:
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: mesh
-        type: MeshAccessLog
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: meshsubset
-        type: MeshAccessLog
-      Subset: []
+      ResourceRules: {}
+      Rules:
+      - BackendRefOriginIndex: {}
+        Conf:
+          backends:
+          - file:
+              path: /meshsubset
+            type: File
+        Origin:
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: mesh
+          type: MeshAccessLog
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: meshsubset
+          type: MeshAccessLog
+        Subset: []
     127.0.0.1:8083:four-hostname-1:
-    - BackendRefOriginIndex: {}
-      Conf:
-        backends:
-        - file:
-            path: /applied-only-to-hostname
-          type: File
-      Origin:
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: mesh
-        type: MeshAccessLog
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: meshsubset
-        type: MeshAccessLog
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: only-one-hostname-listener
-        type: MeshAccessLog
-      Subset: []
+      ResourceRules: {}
+      Rules:
+      - BackendRefOriginIndex: {}
+        Conf:
+          backends:
+          - file:
+              path: /applied-only-to-hostname
+            type: File
+        Origin:
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: mesh
+          type: MeshAccessLog
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: meshsubset
+          type: MeshAccessLog
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: only-one-hostname-listener
+          type: MeshAccessLog
+        Subset: []
     127.0.0.1:8083:four-hostname-2:
-    - BackendRefOriginIndex: {}
-      Conf:
-        backends:
-        - file:
-            path: /meshsubset
-          type: File
-      Origin:
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: mesh
-        type: MeshAccessLog
-      - creationTime: "0001-01-01T00:00:00Z"
-        mesh: mesh-1
-        modificationTime: "0001-01-01T00:00:00Z"
-        name: meshsubset
-        type: MeshAccessLog
-      Subset: []
+      ResourceRules: {}
+      Rules:
+      - BackendRefOriginIndex: {}
+        Conf:
+          backends:
+          - file:
+              path: /meshsubset
+            type: File
+        Origin:
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: mesh
+          type: MeshAccessLog
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: mesh-1
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: meshsubset
+          type: MeshAccessLog
+        Subset: []

--- a/pkg/plugins/policies/core/rules/rules.go
+++ b/pkg/plugins/policies/core/rules/rules.go
@@ -90,10 +90,10 @@ type GatewayToRules struct {
 	// ByListener contains rules that are not specific to hostnames
 	// If the policy supports `GatewayListenerTagsAllowed: true`
 	// then it likely should use ByListenerAndHostname
-	ByListener map[InboundListener]Rules
+	ByListener map[InboundListener]ToRules
 	// ByListenerAndHostname contains rules for policies that are specific to hostnames
 	// This only relevant if the policy has `GatewayListenerTagsAllowed: true`
-	ByListenerAndHostname map[InboundListenerHostname]Rules
+	ByListenerAndHostname map[InboundListenerHostname]ToRules
 }
 
 type GatewayRules struct {
@@ -375,21 +375,21 @@ func BuildGatewayRules(
 	matchedPoliciesByListener map[InboundListenerHostname][]core_model.Resource,
 	reader ResourceReader,
 ) (GatewayRules, error) {
-	toRulesByInbound := map[InboundListener]Rules{}
-	toRulesByListenerHostname := map[InboundListenerHostname]Rules{}
+	toRulesByInbound := map[InboundListener]ToRules{}
+	toRulesByListenerHostname := map[InboundListenerHostname]ToRules{}
 	for listener, policies := range matchedPoliciesByListener {
 		toRules, err := BuildToRules(policies, reader)
 		if err != nil {
 			return GatewayRules{}, err
 		}
-		toRulesByListenerHostname[listener] = toRules.Rules
+		toRulesByListenerHostname[listener] = toRules
 	}
 	for inbound, policies := range matchedPoliciesByInbound {
 		toRules, err := BuildToRules(policies, reader)
 		if err != nil {
 			return GatewayRules{}, err
 		}
-		toRulesByInbound[inbound] = toRules.Rules
+		toRulesByInbound[inbound] = toRules
 	}
 
 	fromRules, err := BuildFromRules(matchedPoliciesByInbound)

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin.go
@@ -207,7 +207,7 @@ func applyToGateway(
 
 		if toListenerRules, ok := rules.ToRules.ByListener[listenerKey]; ok {
 			if err := configureOutbound(
-				toListenerRules,
+				toListenerRules.Rules,
 				proxy.Dataplane,
 				core_rules.Subset{},
 				mesh_proto.MatchAllTag,

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
@@ -737,9 +737,9 @@ var _ = Describe("MeshAccessLog", func() {
 					},
 				},
 				ToRules: core_rules.GatewayToRules{
-					ByListener: map[core_rules.InboundListener]core_rules.Rules{
+					ByListener: map[core_rules.InboundListener]core_rules.ToRules{
 						{Address: "127.0.0.1", Port: 8080}: {
-							{
+							Rules: core_rules.Rules{{
 								Subset: core_rules.Subset{},
 								Conf: api.Conf{
 									Backends: &[]api.Backend{{
@@ -748,7 +748,7 @@ var _ = Describe("MeshAccessLog", func() {
 										},
 									}},
 								},
-							},
+							}},
 						},
 					},
 				},

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin.go
@@ -155,7 +155,7 @@ func applyToGateways(
 					serviceName := dest.Destination[mesh_proto.ServiceTag]
 
 					if err := configure(
-						rules,
+						rules.Rules,
 						core_rules.MeshService(serviceName),
 						cluster,
 					); err != nil {

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin_test.go
@@ -606,16 +606,18 @@ var _ = Describe("MeshCircuitBreaker", func() {
 			name: "basic",
 			rules: core_rules.GatewayRules{
 				ToRules: core_rules.GatewayToRules{
-					ByListener: map[core_rules.InboundListener]core_rules.Rules{
-						{Address: "192.168.0.1", Port: 8080}: {{
-							Subset: core_rules.Subset{core_rules.Tag{
-								Key:   mesh_proto.ServiceTag,
-								Value: "backend",
+					ByListener: map[core_rules.InboundListener]core_rules.ToRules{
+						{Address: "192.168.0.1", Port: 8080}: {
+							Rules: core_rules.Rules{{
+								Subset: core_rules.Subset{core_rules.Tag{
+									Key:   mesh_proto.ServiceTag,
+									Value: "backend",
+								}},
+								Conf: api.Conf{
+									ConnectionLimits: genConnectionLimits(),
+								},
 							}},
-							Conf: api.Conf{
-								ConnectionLimits: genConnectionLimits(),
-							},
-						}},
+						},
 					},
 				},
 			},

--- a/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin.go
@@ -129,7 +129,7 @@ func applyToGateways(
 			protocol = core_mesh.ProtocolTCP
 		}
 		for _, filterChain := range gatewayListener.FilterChains {
-			if err := configure(rules, filterChain, protocol); err != nil {
+			if err := configure(rules.Rules, filterChain, protocol); err != nil {
 				return err
 			}
 		}

--- a/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin_test.go
@@ -442,9 +442,9 @@ var _ = Describe("MeshFaultInjection", func() {
 		// given
 		rules := core_rules.GatewayRules{
 			ToRules: core_rules.GatewayToRules{
-				ByListener: map[core_rules.InboundListener]core_rules.Rules{
+				ByListener: map[core_rules.InboundListener]core_rules.ToRules{
 					{Address: "192.168.0.1", Port: 8080}: {
-						{
+						Rules: core_rules.Rules{{
 							Subset: core_rules.Subset{},
 							Conf: api.Conf{
 								Http: &[]api.FaultInjectionConf{
@@ -464,7 +464,7 @@ var _ = Describe("MeshFaultInjection", func() {
 									},
 								},
 							},
-						},
+						}},
 					},
 				},
 			},

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin.go
@@ -117,7 +117,7 @@ func applyToGateways(
 
 					if err := configure(
 						proxy.Dataplane,
-						rules,
+						rules.Rules,
 						core_rules.MeshService(serviceName),
 						toProtocol(listenerInfo.Listener.Protocol),
 						cluster,

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
@@ -508,9 +508,9 @@ var _ = Describe("MeshHealthCheck", func() {
 			gatewayRoutes: []*core_mesh.MeshGatewayRouteResource{samples.BackendGatewayRoute()},
 			rules: core_rules.GatewayRules{
 				ToRules: core_rules.GatewayToRules{
-					ByListenerAndHostname: map[core_rules.InboundListenerHostname]core_rules.Rules{
+					ByListenerAndHostname: map[core_rules.InboundListenerHostname]core_rules.ToRules{
 						rules.NewInboundListenerHostname("192.168.0.1", 8080, "*"): {
-							{
+							Rules: core_rules.Rules{{
 								Subset: core_rules.Subset{},
 								Conf: api.Conf{
 									Interval:                     test.ParseDuration("10s"),
@@ -546,7 +546,7 @@ var _ = Describe("MeshHealthCheck", func() {
 									},
 									ReuseConnection: pointer.To(true),
 								},
-							},
+							}},
 						},
 					},
 				},
@@ -584,9 +584,9 @@ var _ = Describe("MeshHealthCheck", func() {
 			},
 			meshhttproutes: core_rules.GatewayRules{
 				ToRules: core_rules.GatewayToRules{
-					ByListenerAndHostname: map[core_rules.InboundListenerHostname]core_rules.Rules{
+					ByListenerAndHostname: map[core_rules.InboundListenerHostname]core_rules.ToRules{
 						rules.NewInboundListenerHostname("192.168.0.1", 8080, "*"): {
-							{
+							Rules: core_rules.Rules{{
 								Subset: core_rules.MeshSubset(),
 								Conf: meshhttproute_api.PolicyDefault{
 									Rules: []meshhttproute_api.Rule{{
@@ -611,16 +611,16 @@ var _ = Describe("MeshHealthCheck", func() {
 								BackendRefOriginIndex: core_rules.BackendRefOriginIndex{
 									meshhttproute_api.HashMatches([]meshhttproute_api.Match{{Path: &meshhttproute_api.PathMatch{Type: meshhttproute_api.Exact, Value: "/"}}}): 0,
 								},
-							},
+							}},
 						},
 					},
 				},
 			},
 			rules: core_rules.GatewayRules{
 				ToRules: core_rules.GatewayToRules{
-					ByListenerAndHostname: map[core_rules.InboundListenerHostname]core_rules.Rules{
+					ByListenerAndHostname: map[core_rules.InboundListenerHostname]core_rules.ToRules{
 						rules.NewInboundListenerHostname("192.168.0.1", 8080, "*"): {
-							{
+							Rules: core_rules.Rules{{
 								Subset: core_rules.Subset{},
 								Conf: api.Conf{
 									Interval:                     test.ParseDuration("10s"),
@@ -656,7 +656,7 @@ var _ = Describe("MeshHealthCheck", func() {
 									},
 									ReuseConnection: pointer.To(true),
 								},
-							},
+							}},
 						},
 					},
 				},
@@ -666,9 +666,9 @@ var _ = Describe("MeshHealthCheck", func() {
 			name: "basic-meshhttproute",
 			meshhttproutes: core_rules.GatewayRules{
 				ToRules: core_rules.GatewayToRules{
-					ByListenerAndHostname: map[core_rules.InboundListenerHostname]core_rules.Rules{
+					ByListenerAndHostname: map[core_rules.InboundListenerHostname]core_rules.ToRules{
 						rules.NewInboundListenerHostname("192.168.0.1", 8080, "*"): {
-							{
+							Rules: core_rules.Rules{{
 								Subset: core_rules.MeshSubset(),
 								Conf: meshhttproute_api.PolicyDefault{
 									Rules: []meshhttproute_api.Rule{{
@@ -686,16 +686,16 @@ var _ = Describe("MeshHealthCheck", func() {
 										},
 									}},
 								},
-							},
+							}},
 						},
 					},
 				},
 			},
 			meshtcproutes: core_rules.GatewayRules{
 				ToRules: core_rules.GatewayToRules{
-					ByListenerAndHostname: map[core_rules.InboundListenerHostname]core_rules.Rules{
+					ByListenerAndHostname: map[core_rules.InboundListenerHostname]core_rules.ToRules{
 						rules.NewInboundListenerHostname("192.168.0.1", 8081, "*"): {
-							{
+							Rules: core_rules.Rules{{
 								Subset: core_rules.MeshSubset(),
 								Conf: meshtcproute_api.Rule{
 									Default: meshtcproute_api.RuleConf{
@@ -705,16 +705,16 @@ var _ = Describe("MeshHealthCheck", func() {
 										}},
 									},
 								},
-							},
+							}},
 						},
 					},
 				},
 			},
 			rules: core_rules.GatewayRules{
 				ToRules: core_rules.GatewayToRules{
-					ByListenerAndHostname: map[core_rules.InboundListenerHostname]core_rules.Rules{
+					ByListenerAndHostname: map[core_rules.InboundListenerHostname]core_rules.ToRules{
 						rules.NewInboundListenerHostname("192.168.0.1", 8080, "*"): {
-							{
+							Rules: core_rules.Rules{{
 								Subset: core_rules.Subset{},
 								Conf: api.Conf{
 									Interval:                     test.ParseDuration("10s"),
@@ -750,10 +750,10 @@ var _ = Describe("MeshHealthCheck", func() {
 									},
 									ReuseConnection: pointer.To(true),
 								},
-							},
+							}},
 						},
 						rules.NewInboundListenerHostname("192.168.0.1", 8081, "*"): {
-							{
+							Rules: core_rules.Rules{{
 								Subset: core_rules.Subset{},
 								Conf: api.Conf{
 									Interval:                     test.ParseDuration("10s"),
@@ -770,7 +770,7 @@ var _ = Describe("MeshHealthCheck", func() {
 									NoTrafficInterval:            test.ParseDuration("16s"),
 									ReuseConnection:              pointer.To(true),
 								},
-							},
+							}},
 						},
 					},
 				},

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/gateway_routes.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/gateway_routes.go
@@ -65,7 +65,9 @@ func sortRulesToHosts(
 		}
 		var ruleHostnames []string
 		rulesByHostname := map[string][]ruleByHostname{}
-		for _, rawRule := range rawRules {
+		// it's ok for us to ignore ResourceRules because MeshGateway routes
+		// target kind: Mesh
+		for _, rawRule := range rawRules.Rules {
 			conf := rawRule.Conf.(api.PolicyDefault)
 
 			backendRefOrigin := map[common_api.MatchesHash]model.ResourceMeta{}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
@@ -1720,84 +1720,86 @@ var _ = Describe("MeshHTTPRoute", func() {
 				WithResources(resources).
 				WithEndpointMap(outboundTargets).Build()
 
-			commonRules := core_rules.Rules{
-				{
-					Subset: core_rules.MeshSubset(),
-					Conf: api.PolicyDefault{
-						Rules: []api.Rule{{
-							Matches: []api.Match{{
-								Path: &api.PathMatch{
-									Type:  api.PathPrefix,
-									Value: "/wild",
+			commonRules := core_rules.ToRules{
+				Rules: core_rules.Rules{
+					{
+						Subset: core_rules.MeshSubset(),
+						Conf: api.PolicyDefault{
+							Rules: []api.Rule{{
+								Matches: []api.Match{{
+									Path: &api.PathMatch{
+										Type:  api.PathPrefix,
+										Value: "/wild",
+									},
+								}},
+								Default: api.RuleConf{
+									BackendRefs: &[]common_api.BackendRef{{
+										TargetRef: builders.TargetRefService("backend"),
+										Weight:    pointer.To(uint(100)),
+									}},
 								},
 							}},
-							Default: api.RuleConf{
-								BackendRefs: &[]common_api.BackendRef{{
-									TargetRef: builders.TargetRefService("backend"),
-									Weight:    pointer.To(uint(100)),
-								}},
-							},
-						}},
+						},
 					},
-				},
-				{
-					Subset: core_rules.MeshSubset(),
-					Conf: api.PolicyDefault{
-						Hostnames: []string{"go.dev"},
-						Rules: []api.Rule{{
-							Matches: []api.Match{{
-								Path: &api.PathMatch{
-									Type:  api.PathPrefix,
-									Value: "/go-dev",
+					{
+						Subset: core_rules.MeshSubset(),
+						Conf: api.PolicyDefault{
+							Hostnames: []string{"go.dev"},
+							Rules: []api.Rule{{
+								Matches: []api.Match{{
+									Path: &api.PathMatch{
+										Type:  api.PathPrefix,
+										Value: "/go-dev",
+									},
+								}},
+								Default: api.RuleConf{
+									BackendRefs: &[]common_api.BackendRef{{
+										TargetRef: builders.TargetRefService("backend"),
+										Weight:    pointer.To(uint(100)),
+									}},
 								},
 							}},
-							Default: api.RuleConf{
-								BackendRefs: &[]common_api.BackendRef{{
-									TargetRef: builders.TargetRefService("backend"),
-									Weight:    pointer.To(uint(100)),
-								}},
-							},
-						}},
+						},
 					},
-				},
-				{
-					Subset: core_rules.MeshSubset(),
-					Conf: api.PolicyDefault{
-						Hostnames: []string{"*.dev"},
-						Rules: []api.Rule{{
-							Matches: []api.Match{{
-								Path: &api.PathMatch{
-									Type:  api.PathPrefix,
-									Value: "/wild-dev",
+					{
+						Subset: core_rules.MeshSubset(),
+						Conf: api.PolicyDefault{
+							Hostnames: []string{"*.dev"},
+							Rules: []api.Rule{{
+								Matches: []api.Match{{
+									Path: &api.PathMatch{
+										Type:  api.PathPrefix,
+										Value: "/wild-dev",
+									},
+								}},
+								Default: api.RuleConf{
+									BackendRefs: &[]common_api.BackendRef{{
+										TargetRef: builders.TargetRefService("backend"),
+										Weight:    pointer.To(uint(100)),
+									}},
 								},
 							}},
-							Default: api.RuleConf{
-								BackendRefs: &[]common_api.BackendRef{{
-									TargetRef: builders.TargetRefService("backend"),
-									Weight:    pointer.To(uint(100)),
-								}},
-							},
-						}},
+						},
 					},
-				},
-				{
-					Subset: core_rules.MeshSubset(),
-					Conf: api.PolicyDefault{
-						Hostnames: []string{"other.dev"},
-						Rules: []api.Rule{{
-							Matches: []api.Match{{
-								Path: &api.PathMatch{
-									Type:  api.PathPrefix,
-									Value: "/other-dev",
+					{
+						Subset: core_rules.MeshSubset(),
+						Conf: api.PolicyDefault{
+							Hostnames: []string{"other.dev"},
+							Rules: []api.Rule{{
+								Matches: []api.Match{{
+									Path: &api.PathMatch{
+										Type:  api.PathPrefix,
+										Value: "/other-dev",
+									},
+								}},
+								Default: api.RuleConf{
+									BackendRefs: &[]common_api.BackendRef{{
+										TargetRef: builders.TargetRefService("backend"),
+										Weight:    pointer.To(uint(100)),
+									}},
 								},
 							}},
-							Default: api.RuleConf{
-								BackendRefs: &[]common_api.BackendRef{{
-									TargetRef: builders.TargetRefService("backend"),
-									Weight:    pointer.To(uint(100)),
-								}},
-							},
-						}},
+						},
 					},
 				},
 			}
@@ -1811,7 +1813,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 						xds_builders.MatchedPolicies().
 							WithGatewayPolicy(api.MeshHTTPRouteType, core_rules.GatewayRules{
 								ToRules: core_rules.GatewayToRules{
-									ByListenerAndHostname: map[rules.InboundListenerHostname]rules.Rules{
+									ByListenerAndHostname: map[rules.InboundListenerHostname]rules.ToRules{
 										core_rules.NewInboundListenerHostname("192.168.0.1", 8080, "*"):      commonRules,
 										core_rules.NewInboundListenerHostname("192.168.0.1", 8081, "go.dev"): commonRules,
 										core_rules.NewInboundListenerHostname("192.168.0.1", 8082, "*.dev"):  commonRules,
@@ -1884,34 +1886,36 @@ var _ = Describe("MeshHTTPRoute", func() {
 				WithResources(resources).
 				WithEndpointMap(outboundTargets).Build()
 
-			commonRules := core_rules.Rules{
-				{
-					Subset: core_rules.MeshSubset(),
-					Origin: []core_model.ResourceMeta{
-						&test_model.ResourceMeta{Mesh: "default", Name: "http-route"},
-					},
-					BackendRefOriginIndex: map[common_api.MatchesHash]int{
-						api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/"}}}): 0,
-					},
-					Conf: api.PolicyDefault{
-						Rules: []api.Rule{{
-							Matches: []api.Match{{
-								Path: &api.PathMatch{
-									Type:  api.PathPrefix,
-									Value: "/",
+			commonRules := core_rules.ToRules{
+				Rules: core_rules.Rules{
+					{
+						Subset: core_rules.MeshSubset(),
+						Origin: []core_model.ResourceMeta{
+							&test_model.ResourceMeta{Mesh: "default", Name: "http-route"},
+						},
+						BackendRefOriginIndex: map[common_api.MatchesHash]int{
+							api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/"}}}): 0,
+						},
+						Conf: api.PolicyDefault{
+							Rules: []api.Rule{{
+								Matches: []api.Match{{
+									Path: &api.PathMatch{
+										Type:  api.PathPrefix,
+										Value: "/",
+									},
+								}},
+								Default: api.RuleConf{
+									BackendRefs: &[]common_api.BackendRef{{
+										TargetRef: common_api.TargetRef{
+											Kind: common_api.MeshService,
+											Name: "backend",
+										},
+										Port:   pointer.To(uint32(80)),
+										Weight: pointer.To(uint(100)),
+									}},
 								},
 							}},
-							Default: api.RuleConf{
-								BackendRefs: &[]common_api.BackendRef{{
-									TargetRef: common_api.TargetRef{
-										Kind: common_api.MeshService,
-										Name: "backend",
-									},
-									Port:   pointer.To(uint32(80)),
-									Weight: pointer.To(uint(100)),
-								}},
-							},
-						}},
+						},
 					},
 				},
 			}
@@ -1925,7 +1929,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 						xds_builders.MatchedPolicies().
 							WithGatewayPolicy(api.MeshHTTPRouteType, core_rules.GatewayRules{
 								ToRules: core_rules.GatewayToRules{
-									ByListenerAndHostname: map[rules.InboundListenerHostname]rules.Rules{
+									ByListenerAndHostname: map[rules.InboundListenerHostname]rules.ToRules{
 										core_rules.NewInboundListenerHostname("192.168.0.1", 8080, "*"): commonRules,
 									},
 								},
@@ -1984,46 +1988,54 @@ var _ = Describe("MeshHTTPRoute", func() {
 						xds_builders.MatchedPolicies().
 							WithGatewayPolicy(api.MeshHTTPRouteType, core_rules.GatewayRules{
 								ToRules: core_rules.GatewayToRules{
-									ByListenerAndHostname: map[rules.InboundListenerHostname]rules.Rules{
-										core_rules.NewInboundListenerHostname("192.168.0.1", 8080, "*"): {{
-											Subset: core_rules.MeshSubset(),
-											Conf: api.PolicyDefault{
-												Rules: []api.Rule{{
-													Matches: []api.Match{{
-														Path: &api.PathMatch{
-															Type:  api.PathPrefix,
-															Value: "/wild",
-														},
-													}},
-													Default: api.RuleConf{
-														BackendRefs: &[]common_api.BackendRef{{
-															TargetRef: builders.TargetRefService("backend"),
-															Weight:    pointer.To(uint(100)),
+									ByListenerAndHostname: map[rules.InboundListenerHostname]rules.ToRules{
+										core_rules.NewInboundListenerHostname("192.168.0.1", 8080, "*"): {
+											Rules: rules.Rules{
+												{
+													Subset: core_rules.MeshSubset(),
+													Conf: api.PolicyDefault{
+														Rules: []api.Rule{{
+															Matches: []api.Match{{
+																Path: &api.PathMatch{
+																	Type:  api.PathPrefix,
+																	Value: "/wild",
+																},
+															}},
+															Default: api.RuleConf{
+																BackendRefs: &[]common_api.BackendRef{{
+																	TargetRef: builders.TargetRefService("backend"),
+																	Weight:    pointer.To(uint(100)),
+																}},
+															},
 														}},
 													},
-												}},
+												},
 											},
-										}},
-										core_rules.NewInboundListenerHostname("192.168.0.1", 8081, "go.dev"): {{
-											Subset: core_rules.MeshSubset(),
-											Conf: api.PolicyDefault{
-												Hostnames: []string{"go.dev"},
-												Rules: []api.Rule{{
-													Matches: []api.Match{{
-														Path: &api.PathMatch{
-															Type:  api.PathPrefix,
-															Value: "/go-dev",
-														},
-													}},
-													Default: api.RuleConf{
-														BackendRefs: &[]common_api.BackendRef{{
-															TargetRef: builders.TargetRefService("backend"),
-															Weight:    pointer.To(uint(100)),
+										},
+										core_rules.NewInboundListenerHostname("192.168.0.1", 8081, "go.dev"): {
+											Rules: rules.Rules{
+												{
+													Subset: core_rules.MeshSubset(),
+													Conf: api.PolicyDefault{
+														Hostnames: []string{"go.dev"},
+														Rules: []api.Rule{{
+															Matches: []api.Match{{
+																Path: &api.PathMatch{
+																	Type:  api.PathPrefix,
+																	Value: "/go-dev",
+																},
+															}},
+															Default: api.RuleConf{
+																BackendRefs: &[]common_api.BackendRef{{
+																	TargetRef: builders.TargetRefService("backend"),
+																	Weight:    pointer.To(uint(100)),
+																}},
+															},
 														}},
 													},
-												}},
+												},
 											},
-										}},
+										},
 									},
 								},
 							}),
@@ -2136,183 +2148,207 @@ var _ = Describe("MeshHTTPRoute", func() {
 						xds_builders.MatchedPolicies().
 							WithGatewayPolicy(api.MeshHTTPRouteType, core_rules.GatewayRules{
 								ToRules: core_rules.GatewayToRules{
-									ByListenerAndHostname: map[rules.InboundListenerHostname]rules.Rules{
-										core_rules.NewInboundListenerHostname("192.168.0.1", 8080, "other.dev"): {{
-											Subset: core_rules.MeshSubset(),
-											Conf: api.PolicyDefault{
-												Hostnames: []string{"*.dev"},
-												Rules: []api.Rule{{
-													Matches: []api.Match{{
-														Path: &api.PathMatch{
-															Type:  api.PathPrefix,
-															Value: "/to-other-dev",
-														},
-													}},
-													Default: api.RuleConf{
-														BackendRefs: &[]common_api.BackendRef{{
-															TargetRef: builders.TargetRefService("backend"),
-															Weight:    pointer.To(uint(100)),
+									ByListenerAndHostname: map[rules.InboundListenerHostname]rules.ToRules{
+										core_rules.NewInboundListenerHostname("192.168.0.1", 8080, "other.dev"): {
+											Rules: rules.Rules{
+												{
+													Subset: core_rules.MeshSubset(),
+													Conf: api.PolicyDefault{
+														Hostnames: []string{"*.dev"},
+														Rules: []api.Rule{{
+															Matches: []api.Match{{
+																Path: &api.PathMatch{
+																	Type:  api.PathPrefix,
+																	Value: "/to-other-dev",
+																},
+															}},
+															Default: api.RuleConf{
+																BackendRefs: &[]common_api.BackendRef{{
+																	TargetRef: builders.TargetRefService("backend"),
+																	Weight:    pointer.To(uint(100)),
+																}},
+															},
 														}},
 													},
-												}},
+												},
 											},
-										}},
-										core_rules.NewInboundListenerHostname("192.168.0.1", 8080, "go.dev"): {{
-											Subset: core_rules.MeshSubset(),
-											Conf: api.PolicyDefault{
-												Hostnames: []string{"*.dev"},
-												Rules: []api.Rule{{
-													Matches: []api.Match{{
-														Path: &api.PathMatch{
-															Type:  api.PathPrefix,
-															Value: "/to-go-dev",
-														},
-													}},
-													Default: api.RuleConf{
-														BackendRefs: &[]common_api.BackendRef{{
-															TargetRef: builders.TargetRefService("backend"),
-															Weight:    pointer.To(uint(100)),
+										},
+										core_rules.NewInboundListenerHostname("192.168.0.1", 8080, "go.dev"): {
+											Rules: rules.Rules{
+												{
+													Subset: core_rules.MeshSubset(),
+													Conf: api.PolicyDefault{
+														Hostnames: []string{"*.dev"},
+														Rules: []api.Rule{{
+															Matches: []api.Match{{
+																Path: &api.PathMatch{
+																	Type:  api.PathPrefix,
+																	Value: "/to-go-dev",
+																},
+															}},
+															Default: api.RuleConf{
+																BackendRefs: &[]common_api.BackendRef{{
+																	TargetRef: builders.TargetRefService("backend"),
+																	Weight:    pointer.To(uint(100)),
+																}},
+															},
 														}},
 													},
-												}},
+												},
 											},
-										}},
-										core_rules.NewInboundListenerHostname("192.168.0.1", 8081, ""): {{
-											Subset: core_rules.MeshSubset(),
-											Conf: api.PolicyDefault{
-												Hostnames: []string{"*.dev"},
-												Rules: []api.Rule{{
-													Matches: []api.Match{{
-														Path: &api.PathMatch{
-															Type:  api.PathPrefix,
-															Value: "/wild-dev",
-														},
-													}},
-													Default: api.RuleConf{
-														BackendRefs: &[]common_api.BackendRef{{
-															TargetRef: builders.TargetRefService("backend"),
-															Weight:    pointer.To(uint(100)),
+										},
+										core_rules.NewInboundListenerHostname("192.168.0.1", 8081, ""): {
+											Rules: rules.Rules{
+												{
+													Subset: core_rules.MeshSubset(),
+													Conf: api.PolicyDefault{
+														Hostnames: []string{"*.dev"},
+														Rules: []api.Rule{{
+															Matches: []api.Match{{
+																Path: &api.PathMatch{
+																	Type:  api.PathPrefix,
+																	Value: "/wild-dev",
+																},
+															}},
+															Default: api.RuleConf{
+																BackendRefs: &[]common_api.BackendRef{{
+																	TargetRef: builders.TargetRefService("backend"),
+																	Weight:    pointer.To(uint(100)),
+																}},
+															},
 														}},
 													},
-												}},
+												},
 											},
-										}},
-										core_rules.NewInboundListenerHostname("192.168.0.1", 8082, ""): {{
-											Subset: core_rules.MeshSubset(),
-											Conf: api.PolicyDefault{
-												Rules: []api.Rule{{
-													Matches: []api.Match{{
-														Path: &api.PathMatch{
-															Type:  api.PathPrefix,
-															Value: "/same-path",
-														},
-													}},
-													Default: api.RuleConf{
-														BackendRefs: &[]common_api.BackendRef{{
-															TargetRef: builders.TargetRefService("backend-wild"),
-															Weight:    pointer.To(uint(100)),
+										},
+										core_rules.NewInboundListenerHostname("192.168.0.1", 8082, ""): {
+											Rules: rules.Rules{
+												{
+													Subset: core_rules.MeshSubset(),
+													Conf: api.PolicyDefault{
+														Rules: []api.Rule{{
+															Matches: []api.Match{{
+																Path: &api.PathMatch{
+																	Type:  api.PathPrefix,
+																	Value: "/same-path",
+																},
+															}},
+															Default: api.RuleConf{
+																BackendRefs: &[]common_api.BackendRef{{
+																	TargetRef: builders.TargetRefService("backend-wild"),
+																	Weight:    pointer.To(uint(100)),
+																}},
+															},
 														}},
 													},
-												}},
-											},
-										}, {
-											Subset: core_rules.MeshSubset(),
-											Conf: api.PolicyDefault{
-												Hostnames: []string{"*.dev"},
-												Rules: []api.Rule{{
-													Matches: []api.Match{{
-														Path: &api.PathMatch{
-															Type:  api.PathPrefix,
-															Value: "/same-path",
-														},
-													}},
-													Default: api.RuleConf{
-														BackendRefs: &[]common_api.BackendRef{{
-															TargetRef: builders.TargetRefService("backend-wild-dev"),
-															Weight:    pointer.To(uint(100)),
+												}, {
+													Subset: core_rules.MeshSubset(),
+													Conf: api.PolicyDefault{
+														Hostnames: []string{"*.dev"},
+														Rules: []api.Rule{{
+															Matches: []api.Match{{
+																Path: &api.PathMatch{
+																	Type:  api.PathPrefix,
+																	Value: "/same-path",
+																},
+															}},
+															Default: api.RuleConf{
+																BackendRefs: &[]common_api.BackendRef{{
+																	TargetRef: builders.TargetRefService("backend-wild-dev"),
+																	Weight:    pointer.To(uint(100)),
+																}},
+															},
 														}},
 													},
-												}},
+												},
 											},
-										}},
-										core_rules.NewInboundListenerHostname("192.168.0.1", 8083, "*.secure.dev"): {{
-											Subset: core_rules.MeshSubset(),
-											Conf: api.PolicyDefault{
-												Hostnames: []string{"first-specific.secure.dev"},
-												Rules: []api.Rule{{
-													Matches: []api.Match{{
-														Path: &api.PathMatch{
-															Type:  api.PathPrefix,
-															Value: "/first-specific-dev",
-														},
-													}},
-													Default: api.RuleConf{
-														BackendRefs: &[]common_api.BackendRef{{
-															TargetRef: builders.TargetRefService("backend"),
-															Weight:    pointer.To(uint(100)),
+										},
+										core_rules.NewInboundListenerHostname("192.168.0.1", 8083, "*.secure.dev"): {
+											Rules: rules.Rules{
+												{
+													Subset: core_rules.MeshSubset(),
+													Conf: api.PolicyDefault{
+														Hostnames: []string{"first-specific.secure.dev"},
+														Rules: []api.Rule{{
+															Matches: []api.Match{{
+																Path: &api.PathMatch{
+																	Type:  api.PathPrefix,
+																	Value: "/first-specific-dev",
+																},
+															}},
+															Default: api.RuleConf{
+																BackendRefs: &[]common_api.BackendRef{{
+																	TargetRef: builders.TargetRefService("backend"),
+																	Weight:    pointer.To(uint(100)),
+																}},
+															},
 														}},
 													},
-												}},
-											},
-										}, {
-											Subset: core_rules.MeshSubset(),
-											Conf: api.PolicyDefault{
-												Hostnames: []string{"second-specific.secure.dev"},
-												Rules: []api.Rule{{
-													Matches: []api.Match{{
-														Path: &api.PathMatch{
-															Type:  api.PathPrefix,
-															Value: "/second-specific-dev",
-														},
-													}},
-													Default: api.RuleConf{
-														BackendRefs: &[]common_api.BackendRef{{
-															TargetRef: builders.TargetRefService("backend"),
-															Weight:    pointer.To(uint(100)),
+												}, {
+													Subset: core_rules.MeshSubset(),
+													Conf: api.PolicyDefault{
+														Hostnames: []string{"second-specific.secure.dev"},
+														Rules: []api.Rule{{
+															Matches: []api.Match{{
+																Path: &api.PathMatch{
+																	Type:  api.PathPrefix,
+																	Value: "/second-specific-dev",
+																},
+															}},
+															Default: api.RuleConf{
+																BackendRefs: &[]common_api.BackendRef{{
+																	TargetRef: builders.TargetRefService("backend"),
+																	Weight:    pointer.To(uint(100)),
+																}},
+															},
 														}},
 													},
-												}},
+												},
 											},
-										}},
-										core_rules.NewInboundListenerHostname("192.168.0.1", 8083, "*.super-secure.dev"): {{
-											Subset: core_rules.MeshSubset(),
-											Conf: api.PolicyDefault{
-												Hostnames: []string{"first-specific.super-secure.dev"},
-												Rules: []api.Rule{{
-													Matches: []api.Match{{
-														Path: &api.PathMatch{
-															Type:  api.PathPrefix,
-															Value: "/first-specific-super-dev",
-														},
-													}},
-													Default: api.RuleConf{
-														BackendRefs: &[]common_api.BackendRef{{
-															TargetRef: builders.TargetRefService("backend"),
-															Weight:    pointer.To(uint(100)),
+										},
+										core_rules.NewInboundListenerHostname("192.168.0.1", 8083, "*.super-secure.dev"): {
+											Rules: rules.Rules{
+												{
+													Subset: core_rules.MeshSubset(),
+													Conf: api.PolicyDefault{
+														Hostnames: []string{"first-specific.super-secure.dev"},
+														Rules: []api.Rule{{
+															Matches: []api.Match{{
+																Path: &api.PathMatch{
+																	Type:  api.PathPrefix,
+																	Value: "/first-specific-super-dev",
+																},
+															}},
+															Default: api.RuleConf{
+																BackendRefs: &[]common_api.BackendRef{{
+																	TargetRef: builders.TargetRefService("backend"),
+																	Weight:    pointer.To(uint(100)),
+																}},
+															},
 														}},
 													},
-												}},
-											},
-										}, {
-											Subset: core_rules.MeshSubset(),
-											Conf: api.PolicyDefault{
-												Hostnames: []string{"second-specific.super-secure.dev"},
-												Rules: []api.Rule{{
-													Matches: []api.Match{{
-														Path: &api.PathMatch{
-															Type:  api.PathPrefix,
-															Value: "/second-specific-super-dev",
-														},
-													}},
-													Default: api.RuleConf{
-														BackendRefs: &[]common_api.BackendRef{{
-															TargetRef: builders.TargetRefService("backend"),
-															Weight:    pointer.To(uint(100)),
+												}, {
+													Subset: core_rules.MeshSubset(),
+													Conf: api.PolicyDefault{
+														Hostnames: []string{"second-specific.super-secure.dev"},
+														Rules: []api.Rule{{
+															Matches: []api.Match{{
+																Path: &api.PathMatch{
+																	Type:  api.PathPrefix,
+																	Value: "/second-specific-super-dev",
+																},
+															}},
+															Default: api.RuleConf{
+																BackendRefs: &[]common_api.BackendRef{{
+																	TargetRef: builders.TargetRefService("backend"),
+																	Weight:    pointer.To(uint(100)),
+																}},
+															},
 														}},
 													},
-												}},
+												},
 											},
-										}},
+										},
 									},
 								},
 							}),

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
@@ -264,7 +264,7 @@ func (p plugin) configureGateway(
 					}
 
 					serviceName := dest.Destination[mesh_proto.ServiceTag]
-					localityConf := core_rules.ComputeConf[api.Conf](rules, core_rules.MeshService(serviceName))
+					localityConf := core_rules.ComputeConf[api.Conf](rules.Rules, core_rules.MeshService(serviceName))
 					if localityConf == nil {
 						continue
 					}

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
@@ -1475,9 +1475,9 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 				),
 			rules: core_rules.GatewayRules{
 				ToRules: core_rules.GatewayToRules{
-					ByListener: map[core_rules.InboundListener]core_rules.Rules{
+					ByListener: map[core_rules.InboundListener]core_rules.ToRules{
 						{Address: "192.168.0.1", Port: 8080}: {
-							{
+							Rules: core_rules.Rules{{
 								Subset: core_rules.Subset{},
 								Conf: v1alpha1.Conf{
 									LoadBalancer: &v1alpha1.LoadBalancer{
@@ -1505,7 +1505,7 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 										},
 									},
 								},
-							},
+							}},
 						},
 					},
 				},
@@ -1526,9 +1526,9 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 				),
 			rules: core_rules.GatewayRules{
 				ToRules: core_rules.GatewayToRules{
-					ByListener: map[core_rules.InboundListener]core_rules.Rules{
+					ByListener: map[core_rules.InboundListener]core_rules.ToRules{
 						{Address: "192.168.0.1", Port: 8080}: {
-							{
+							Rules: core_rules.Rules{{
 								Subset: core_rules.Subset{},
 								Conf: v1alpha1.Conf{
 									LocalityAwareness: &v1alpha1.LocalityAwareness{
@@ -1575,7 +1575,7 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 										},
 									},
 								},
-							},
+							}},
 						},
 					},
 				},
@@ -1596,9 +1596,9 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 				),
 			rules: core_rules.GatewayRules{
 				ToRules: core_rules.GatewayToRules{
-					ByListener: map[core_rules.InboundListener]core_rules.Rules{
+					ByListener: map[core_rules.InboundListener]core_rules.ToRules{
 						{Address: "192.168.0.1", Port: 8080}: {
-							{
+							Rules: core_rules.Rules{{
 								Subset: core_rules.Subset{},
 								Conf: v1alpha1.Conf{
 									LocalityAwareness: &v1alpha1.LocalityAwareness{
@@ -1613,7 +1613,7 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 										},
 									},
 								},
-							},
+							}},
 						},
 					},
 				},

--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin.go
@@ -89,7 +89,7 @@ func applyToGateways(
 				continue
 			}
 
-			if err := configureGateway(rules, gatewayListener, route); err != nil {
+			if err := configureGateway(rules.Rules, gatewayListener, route); err != nil {
 				return err
 			}
 		}

--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin_test.go
@@ -720,27 +720,31 @@ var _ = Describe("MeshRateLimit", func() {
 			gatewayRoutes: []*core_mesh.MeshGatewayRouteResource{samples.BackendGatewayRoute()},
 			rules: core_rules.GatewayRules{
 				ToRules: core_rules.GatewayToRules{
-					ByListener: map[core_rules.InboundListener]core_rules.Rules{
-						{Address: "192.168.0.1", Port: 8080}: {{
-							Subset: core_rules.Subset{},
-							Conf: api.Conf{
-								Local: &api.Local{
-									HTTP: &api.LocalHTTP{
-										RequestRate: &api.Rate{
-											Num:      100,
-											Interval: v1.Duration{Duration: 10 * time.Second},
-										},
-										OnRateLimit: &api.OnRateLimit{
-											Status: pointer.To(uint32(444)),
-											Headers: &api.HeaderModifier{
-												Add: []api.HeaderKeyValue{
-													{
-														Name:  "x-kuma-rate-limit-header",
-														Value: "test-value",
-													},
-													{
-														Name:  "x-kuma-rate-limit",
-														Value: "other-value",
+					ByListener: map[core_rules.InboundListener]core_rules.ToRules{
+						{Address: "192.168.0.1", Port: 8080}: {
+							Rules: core_rules.Rules{
+								{
+									Subset: core_rules.Subset{},
+									Conf: api.Conf{
+										Local: &api.Local{
+											HTTP: &api.LocalHTTP{
+												RequestRate: &api.Rate{
+													Num:      100,
+													Interval: v1.Duration{Duration: 10 * time.Second},
+												},
+												OnRateLimit: &api.OnRateLimit{
+													Status: pointer.To(uint32(444)),
+													Headers: &api.HeaderModifier{
+														Add: []api.HeaderKeyValue{
+															{
+																Name:  "x-kuma-rate-limit-header",
+																Value: "test-value",
+															},
+															{
+																Name:  "x-kuma-rate-limit",
+																Value: "other-value",
+															},
+														},
 													},
 												},
 											},
@@ -748,7 +752,7 @@ var _ = Describe("MeshRateLimit", func() {
 									},
 								},
 							},
-						}},
+						},
 					},
 				},
 			},
@@ -758,9 +762,9 @@ var _ = Describe("MeshRateLimit", func() {
 			gatewayRoutes: []*core_mesh.MeshGatewayRouteResource{samples.BackendGatewayRoute()},
 			meshhttproutes: core_rules.GatewayRules{
 				ToRules: core_rules.GatewayToRules{
-					ByListenerAndHostname: map[core_rules.InboundListenerHostname]core_rules.Rules{
+					ByListenerAndHostname: map[core_rules.InboundListenerHostname]core_rules.ToRules{
 						core_rules.NewInboundListenerHostname("192.168.0.1", 8080, "*"): {
-							{
+							Rules: core_rules.Rules{{
 								Subset: core_rules.MeshSubset(),
 								Conf: meshhttproute_api.PolicyDefault{
 									Rules: []meshhttproute_api.Rule{
@@ -795,16 +799,16 @@ var _ = Describe("MeshRateLimit", func() {
 										},
 									},
 								},
-							},
+							}},
 						},
 					},
 				},
 			},
 			rules: core_rules.GatewayRules{
 				ToRules: core_rules.GatewayToRules{
-					ByListener: map[core_rules.InboundListener]core_rules.Rules{
+					ByListener: map[core_rules.InboundListener]core_rules.ToRules{
 						{Address: "192.168.0.1", Port: 8080}: {
-							{
+							Rules: core_rules.Rules{{
 								Subset: core_rules.Subset{
 									{
 										Key:   core_rules.RuleMatchesHashTag,
@@ -836,7 +840,7 @@ var _ = Describe("MeshRateLimit", func() {
 										},
 									},
 								},
-							},
+							}},
 						},
 					},
 				},

--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin.go
@@ -115,7 +115,7 @@ func applyToGateway(
 			protocol = core_mesh.ProtocolTCP
 		}
 		configurer := plugin_xds.DeprecatedConfigurer{
-			Rules:    toRules,
+			Rules:    toRules.Rules,
 			Protocol: protocol,
 			Subset:   core_rules.MeshSubset(),
 		}

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin.go
@@ -185,7 +185,9 @@ func sortRulesToHosts(
 		if !ok {
 			continue
 		}
-		hostInfo.AppendEntries(generateEnvoyRouteEntries(meshCtx, host, rulesForListener, resolver))
+		// it's ok for us to ignore ResourceRules because MeshGateway routes
+		// target kind: Mesh
+		hostInfo.AppendEntries(generateEnvoyRouteEntries(meshCtx, host, rulesForListener.Rules, resolver))
 		meshroute_gateway.AddToListenerByHostname(
 			hostInfosByHostname,
 			protocol,

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
@@ -1128,10 +1128,10 @@ var _ = Describe("MeshTCPRoute", func() {
 						xds_builders.MatchedPolicies().
 							WithGatewayPolicy(api.MeshTCPRouteType, core_rules.GatewayRules{
 								ToRules: core_rules.GatewayToRules{
-									ByListenerAndHostname: map[core_rules.InboundListenerHostname]core_rules.Rules{
-										core_rules.NewInboundListenerHostname("192.168.0.1", 9080, "*"):         {&rules, &tlsOtherRules},
-										core_rules.NewInboundListenerHostname("192.168.0.1", 9081, "other.dev"): {&tlsOtherRules},
-										core_rules.NewInboundListenerHostname("192.168.0.1", 9081, "go.dev"):    {&tlsGoRules},
+									ByListenerAndHostname: map[core_rules.InboundListenerHostname]core_rules.ToRules{
+										core_rules.NewInboundListenerHostname("192.168.0.1", 9080, "*"):         {Rules: core_rules.Rules{&rules, &tlsOtherRules}},
+										core_rules.NewInboundListenerHostname("192.168.0.1", 9081, "other.dev"): {Rules: core_rules.Rules{&tlsOtherRules}},
+										core_rules.NewInboundListenerHostname("192.168.0.1", 9081, "go.dev"):    {Rules: core_rules.Rules{&tlsGoRules}},
 									},
 								},
 							}),

--- a/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
@@ -196,14 +196,14 @@ func applyToGateway(
 			continue
 		}
 
-		conf = getConf(toRules, core_rules.MeshSubset())
+		conf = getConf(toRules.Rules, core_rules.MeshSubset())
 		for _, listenerHostname := range listenerInfo.ListenerHostnames {
 			route, ok := gatewayRoutes[listenerHostname.EnvoyRouteName(listenerInfo.Listener.EnvoyListenerName)]
 
 			if ok {
 				for _, vh := range route.VirtualHosts {
 					for _, r := range vh.Routes {
-						routeConf := getConf(toRules, core_rules.MeshSubset().WithTag(core_rules.RuleMatchesHashTag, r.Name, false))
+						routeConf := getConf(toRules.Rules, core_rules.MeshSubset().WithTag(core_rules.RuleMatchesHashTag, r.Name, false))
 						if routeConf == nil {
 							if conf == nil {
 								continue
@@ -236,13 +236,13 @@ func applyToGateway(
 
 					serviceName := dest.Destination[mesh_proto.ServiceTag]
 
-					conf := getConf(toRules, core_rules.MeshService(serviceName))
+					conf := getConf(toRules.Rules, core_rules.MeshService(serviceName))
 					if conf == nil {
 						continue
 					}
 
 					if err := applyToClusters(
-						toRules,
+						toRules.Rules,
 						serviceName,
 						meshCtx.GetServiceProtocol(serviceName),
 						cluster,

--- a/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin_test.go
@@ -596,9 +596,9 @@ var _ = Describe("MeshTimeout", func() {
 				},
 			},
 			ToRules: core_rules.GatewayToRules{
-				ByListener: map[core_rules.InboundListener]core_rules.Rules{
+				ByListener: map[core_rules.InboundListener]core_rules.ToRules{
 					{Address: "192.168.0.1", Port: 8080}: {
-						{
+						Rules: core_rules.Rules{{
 							Subset: core_rules.MeshSubset(),
 							Conf: api.Conf{
 								ConnectionTimeout: test.ParseDuration("10s"),
@@ -610,7 +610,7 @@ var _ = Describe("MeshTimeout", func() {
 									MaxConnectionDuration: test.ParseDuration("10m"),
 								},
 							},
-						},
+						}},
 					},
 				},
 			},
@@ -618,9 +618,9 @@ var _ = Describe("MeshTimeout", func() {
 	}), Entry("no-default-idle-timeout", gatewayTestCase{
 		rules: core_rules.GatewayRules{
 			ToRules: core_rules.GatewayToRules{
-				ByListener: map[core_rules.InboundListener]core_rules.Rules{
+				ByListener: map[core_rules.InboundListener]core_rules.ToRules{
 					{Address: "192.168.0.1", Port: 8080}: {
-						{
+						Rules: core_rules.Rules{{
 							Subset: core_rules.MeshSubset(),
 							Conf: api.Conf{
 								ConnectionTimeout: test.ParseDuration("10s"),
@@ -631,7 +631,7 @@ var _ = Describe("MeshTimeout", func() {
 									MaxConnectionDuration: test.ParseDuration("10m"),
 								},
 							},
-						},
+						}},
 					},
 				},
 			},
@@ -646,16 +646,16 @@ var _ = Describe("MeshTimeout", func() {
 		},
 		rules: core_rules.GatewayRules{
 			ToRules: core_rules.GatewayToRules{
-				ByListener: map[core_rules.InboundListener]core_rules.Rules{
+				ByListener: map[core_rules.InboundListener]core_rules.ToRules{
 					{Address: "192.168.0.1", Port: 8080}: {
-						{
+						Rules: core_rules.Rules{{
 							Subset: core_rules.MeshService("backend"),
 							Conf: api.Conf{
 								Http: &api.Http{
 									RequestTimeout: test.ParseDuration("24s"),
 								},
 							},
-						},
+						}},
 					},
 				},
 			},
@@ -663,9 +663,9 @@ var _ = Describe("MeshTimeout", func() {
 	}), Entry("route-level-timeouts", gatewayTestCase{
 		meshhttproutes: core_rules.GatewayRules{
 			ToRules: core_rules.GatewayToRules{
-				ByListenerAndHostname: map[core_rules.InboundListenerHostname]core_rules.Rules{
+				ByListenerAndHostname: map[core_rules.InboundListenerHostname]core_rules.ToRules{
 					core_rules.NewInboundListenerHostname("192.168.0.1", 8080, "*"): {
-						{
+						Rules: core_rules.Rules{{
 							Subset: core_rules.MeshSubset(),
 							Conf: meshhttproute_api.PolicyDefault{
 								Rules: []meshhttproute_api.Rule{
@@ -700,16 +700,16 @@ var _ = Describe("MeshTimeout", func() {
 									},
 								},
 							},
-						},
+						}},
 					},
 				},
 			},
 		},
 		rules: core_rules.GatewayRules{
 			ToRules: core_rules.GatewayToRules{
-				ByListener: map[core_rules.InboundListener]core_rules.Rules{
+				ByListener: map[core_rules.InboundListener]core_rules.ToRules{
 					{Address: "192.168.0.1", Port: 8080}: {
-						{
+						Rules: core_rules.Rules{{
 							Subset: core_rules.Subset{
 								{
 									Key:   core_rules.RuleMatchesHashTag,
@@ -722,7 +722,7 @@ var _ = Describe("MeshTimeout", func() {
 									StreamIdleTimeout: test.ParseDuration("99s"),
 								},
 							},
-						},
+						}},
 					},
 				},
 			},

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin_test.go
@@ -210,25 +210,27 @@ var _ = Describe("MeshTLS", func() {
 					WithGatewayPolicy(api.MeshTLSType, getGatewayRules(policy.Spec.From)).
 					WithGatewayPolicy(meshhttproute_api.MeshHTTPRouteType, core_rules.GatewayRules{
 						ToRules: core_rules.GatewayToRules{
-							ByListenerAndHostname: map[core_rules.InboundListenerHostname]core_rules.Rules{
+							ByListenerAndHostname: map[core_rules.InboundListenerHostname]core_rules.ToRules{
 								core_rules.NewInboundListenerHostname("192.168.0.1", 8080, "*"): {
-									{
-										BackendRefOriginIndex: backendRefOriginIndex,
-										Origin: []core_model.ResourceMeta{
-											&test_model.ResourceMeta{Mesh: "default", Name: "http-route"},
-										},
-										Subset: core_rules.MeshSubset(),
-										Conf: meshhttproute_api.PolicyDefault{
-											Rules: []meshhttproute_api.Rule{
-												{
-													Matches: []meshhttproute_api.Match{{
-														Path: &meshhttproute_api.PathMatch{
-															Type:  meshhttproute_api.Exact,
-															Value: "/",
+									Rules: core_rules.Rules{
+										{
+											BackendRefOriginIndex: backendRefOriginIndex,
+											Origin: []core_model.ResourceMeta{
+												&test_model.ResourceMeta{Mesh: "default", Name: "http-route"},
+											},
+											Subset: core_rules.MeshSubset(),
+											Conf: meshhttproute_api.PolicyDefault{
+												Rules: []meshhttproute_api.Rule{
+													{
+														Matches: []meshhttproute_api.Match{{
+															Path: &meshhttproute_api.PathMatch{
+																Type:  meshhttproute_api.Exact,
+																Value: "/",
+															},
+														}},
+														Default: meshhttproute_api.RuleConf{
+															BackendRefs: &[]common_api.BackendRef{backendRef},
 														},
-													}},
-													Default: meshhttproute_api.RuleConf{
-														BackendRefs: &[]common_api.BackendRef{backendRef},
 													},
 												},
 											},

--- a/pkg/plugins/runtime/gateway/cluster_generator.go
+++ b/pkg/plugins/runtime/gateway/cluster_generator.go
@@ -184,6 +184,7 @@ func (c *ClusterGenerator) generateRealBackendRefCluster(
 		mesh_proto.ServiceTag: service,
 	}
 	cluster, err := buildClusterResource(tags, edsClusterBuilder, identifyingTags)
+	cluster.ResourceOrigin = backendRef.Resource
 	return cluster, service, err
 }
 

--- a/pkg/plugins/runtime/gateway/cluster_generator.go
+++ b/pkg/plugins/runtime/gateway/cluster_generator.go
@@ -185,6 +185,7 @@ func (c *ClusterGenerator) generateRealBackendRefCluster(
 	}
 	cluster, err := buildClusterResource(tags, edsClusterBuilder, identifyingTags)
 	cluster.ResourceOrigin = backendRef.Resource
+	cluster.Protocol = routeProtocol
 	return cluster, service, err
 }
 


### PR DESCRIPTION
Follow up PRs will introduce support for individual policies

Almost all the changes are because of reformatting in tests and golden files, go commit by commit

See final 3 commits of https://github.com/kumahq/kuma/pull/11541 for how it will look in policies

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- https://github.com/kumahq/kuma/issues/11534
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
