### PR TITLE
test(gatewayapi): cleanup resources manually after dumping debug info

### DIFF
--- a/test/e2e_env/gatewayapi/conformance_test.go
+++ b/test/e2e_env/gatewayapi/conformance_test.go
@@ -51,29 +51,32 @@ func TestConformance(t *testing.T) {
 	opts := cluster.GetKubectlOptions()
 
 	t.Cleanup(func() {
-		if t.Failed() {
-			var namespaces []string
-			clientset, err := k8s.GetKubernetesClientFromOptionsE(t, opts)
-			if err == nil {
-				if nsList, err := clientset.CoreV1().Namespaces().List(context.Background(),
-					metav1.ListOptions{
-						LabelSelector: fmt.Sprintf("%s=%s", metadata.KumaSidecarInjectionAnnotation, metadata.AnnotationEnabled),
-					}); err == nil {
-					for _, ns := range nsList.Items {
-						namespaces = append(namespaces, ns.Name)
-					}
+		var meshNamespaces []string
+		clientset, err := k8s.GetKubernetesClientFromOptionsE(t, opts)
+		if err == nil {
+			if nsList, err := clientset.CoreV1().Namespaces().List(context.Background(),
+				metav1.ListOptions{
+					LabelSelector: fmt.Sprintf("%s=%s", metadata.KumaSidecarInjectionAnnotation, metadata.AnnotationEnabled),
+				}); err == nil {
+				for _, ns := range nsList.Items {
+					meshNamespaces = append(meshNamespaces, ns.Name)
 				}
 			}
+		}
 
-			if len(namespaces) > 0 {
+		if t.Failed() {
+			if len(meshNamespaces) > 0 {
 				g.Expect(func() error { //nolint:unparam  // we need this return type to be included in the Expect block
 					RegisterFailHandler(g.Fail)
-					DebugKube(cluster, "default", namespaces...)
+					DebugKube(cluster, "default", meshNamespaces...)
 					return nil
 				}()).To(Succeed())
 			}
 		}
 
+		for _, ns := range meshNamespaces {
+			g.Expect(cluster.DeleteNamespace(ns)).To(Succeed())
+		}
 		g.Expect(cluster.DeleteKuma()).To(Succeed())
 		g.Expect(cluster.DismissCluster()).To(Succeed())
 	})
@@ -106,7 +109,7 @@ func TestConformance(t *testing.T) {
 		RestConfig:           clientConfig,
 		Clientset:            clientset,
 		GatewayClassName:     "kuma",
-		CleanupBaseResources: true,
+		CleanupBaseResources: false,        // we want to collect details when test fails, so don't clean up here, we'll clean up resources by ourselves.
 		Debug:                Config.Debug, // controls if request details should be printed to stdout
 		NamespaceLabels: map[string]string{
 			metadata.KumaSidecarInjectionAnnotation: metadata.AnnotationEnabled,


### PR DESCRIPTION
GatewayAPI resoruces are cleaned up even when test fails. This prevents us from collecting debug info from the cluster.

When simply set `CleanupBaseResources` to `false`, it will hang because that the next statement `g.Expect(cluster.DeleteKuma()).To(Succeed())` tries to remove the `gatewayclass/kuma` when it's still being referenced in some namespace that is not cleaned up.

This resolves the issues introduced by [the PR of trying to diable cleanup](https://github.com/kumahq/kuma/pull/11510) and replaces the temporary solution in the [previous PR](https://github.com/kumahq/kuma/pull/11527).

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues 
  - N/A
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS 
  - Confirmed
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) 
  - Manual tested
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? 
  - No
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) 
  - No

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
