### PR TITLE
chore(mads): supplement debug log for snapshot reconcile

### DIFF
--- a/pkg/mads/v1/reconcile/interfaces.go
+++ b/pkg/mads/v1/reconcile/interfaces.go
@@ -4,11 +4,12 @@ import (
 	"context"
 
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"github.com/go-logr/logr"
 )
 
 // Reconciler re-computes configuration for a given node.
 type Reconciler interface {
-	Reconcile(context.Context) error
+	Reconcile(context.Context, logr.Logger) error
 	// NeedsReconciliation checks if there is a valid configuration snapshot already present
 	// for a given node
 	NeedsReconciliation(node *envoy_core.Node) bool

--- a/pkg/mads/v1/reconcile/reconciler.go
+++ b/pkg/mads/v1/reconcile/reconciler.go
@@ -51,7 +51,7 @@ func (r *reconciler) Reconcile(ctx context.Context, log logr.Logger) error {
 		oldSnapshot, _ := r.cache.GetSnapshot(clientId)
 		switch {
 		case oldSnapshot == nil:
-			log.V(2).Info("no snapshot found", "clientId", clientId)
+			log.V(2).Info("no snapshot found", "clientId", clientId, "newSnapshot", newSnapshot)
 			snap = newSnapshot
 		case !util_xds_v3.SingleTypeSnapshotEqual(oldSnapshot, newSnapshot):
 			log.V(2).Info("detected changes in the snapshots", "oldSnapshot", oldSnapshot, "newSnapshot", newSnapshot)

--- a/pkg/mads/v1/service/service.go
+++ b/pkg/mads/v1/service/service.go
@@ -34,7 +34,7 @@ func NewService(config *mads.MonitoringAssignmentServerConfig, rm core_manager.R
 		// issue: https://github.com/kumahq/kuma/issues/8764
 		NewSyncTracker(reconciler, config.AssignmentRefreshInterval.Duration, log),
 		// For on-demand reconciliation
-		util_xds_v3.AdaptRestCallbacks(NewReconcilerRestCallbacks(reconciler)),
+		util_xds_v3.AdaptRestCallbacks(NewReconcilerRestCallbacks(reconciler, log)),
 	}
 	srv := NewServer(cache, callbacks)
 

--- a/pkg/mads/v1/service_test.go
+++ b/pkg/mads/v1/service_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/emicklei/go-restful/v3"
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	"github.com/go-logr/logr"
 	"github.com/golang/protobuf/jsonpb"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -22,11 +21,13 @@ import (
 	observability_v1 "github.com/kumahq/kuma/api/observability/v1"
 	mads_config "github.com/kumahq/kuma/pkg/config/mads"
 	config_types "github.com/kumahq/kuma/pkg/config/types"
+	"github.com/kumahq/kuma/pkg/core"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	rest_error_types "github.com/kumahq/kuma/pkg/core/rest/errors/types"
+	"github.com/kumahq/kuma/pkg/log"
 	mads_v1 "github.com/kumahq/kuma/pkg/mads/v1"
 	"github.com/kumahq/kuma/pkg/mads/v1/service"
 	"github.com/kumahq/kuma/pkg/plugins/resources/memory"
@@ -57,7 +58,7 @@ var _ = Describe("MADS http service", func() {
 		cfg.AssignmentRefreshInterval = config_types.Duration{Duration: refreshInterval}
 		cfg.DefaultFetchTimeout = config_types.Duration{Duration: defaultFetchTimeout}
 
-		svc := service.NewService(cfg, resManager, logr.Discard(), nil)
+		svc := service.NewService(cfg, resManager, core.NewLogger(log.DebugLevel), nil)
 
 		ws := new(restful.WebService)
 		svc.RegisterRoutes(ws)


### PR DESCRIPTION
Refer to the [CI](https://github.com/kumahq/kuma/actions/runs/11012801647/job/30580231456#step:6:264), we met the mads unit test failure again.

It shows the `snapshot` version changed again. However, I can't reproduce it locally.
So, I wanna add some debug logs to track the snapshot changes.

```text
• [FAILED] [0.013 seconds]
MADS http service with resources [It] should return the monitoring assignments
github.com/kumahq/kuma/pkg/mads/v1/service_test.go:218

  Timeline >>
  "level"=0 "msg"="Got response" "response"="{\"version_info\":\"5fbf6d1f-3ea4-416f-847b-ad18f787e641\",\"resources\":[{\"@type\":\"type.googleapis.com/kuma.observability.v1.MonitoringAssignment\",\"mesh\":\"test\",\"service\":\"gateway\",\"targets\":[{\"name\":\"dp-1\",\"scheme\":\"http\",\"address\":\"192.168.0.1:5670\",\"metrics_path\":\"/metrics\",\"labels\":{\"kuma_io_service\":\"gateway\",\"kuma_io_services\":\",gateway,\",\"region\":\"eu\",\"regions\":\",eu,\"}}]}],\"type_url\":\"type.googleapis.com/kuma.observability.v1.MonitoringAssignment\"}"
  STEP: Doing other discovery request with clientId "test" and version "5fbf6d1f-3ea4-416f-847b-ad18f787e641" @ 09/24/24 11:46:47.079
  [FAILED] in [It] - github.com/kumahq/kuma/pkg/mads/v1/service_test.go:279 @ 09/24/24 11:46:47.081
  << Timeline

  [FAILED] Expected
      <*http.Response>: {
          Status:     <string>: "200 OK"
          StatusCode: <int>: 200
          Body:       <string>: "{\"version_info\":\"9e2f4d26-45b3-4e92-87b0-987d1094de29\",\"resources\":[{\"@type\":\"type.googleapis.com/kuma.observability.v1.MonitoringAssignment\",\"mesh\":\"test\",\"service\":\"gateway\",\"targets\":[{\"name\":\"dp-1\",\"scheme\":\"http\",\"address\":\"192.168.0.1:5670\",\"metrics_path\":\"/metrics\",\"labels\":{\"kuma_io_service\":\"gateway\",\"kuma_io_services\":\",gateway,\",\"region\":\"eu\",\"regions\":\",eu,\"}}]}],\"type_url\":\"type.googleapis.com/kuma.observability.v1.MonitoringAssignment\"}"
      }
  to have HTTP status
      <int>: 304
  In [It] at: github.com/kumahq/kuma/pkg/mads/v1/service_test.go:279 @ 09/24/24 11:46:47.081
```

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
