### PR TITLE
feat(inspect-api): return the list of outbounds

### DIFF
--- a/api/openapi/specs/api.yaml
+++ b/api/openapi/specs/api.yaml
@@ -244,7 +244,7 @@ components:
       type: object
       title: InspectRules
       description: A list of rules for a dataplane
-      required: [rules, resource, httpMatches]
+      required: [rules, resource, httpMatches, outbounds]
       properties:
         resource:
           $ref: './common/resource.yaml#/components/schemas/Meta'
@@ -256,6 +256,10 @@ components:
           type: array
           items:
             $ref: './common/resource.yaml#/components/schemas/HttpMatch'
+        outbounds:
+          type: array
+          items:
+            $ref: './common/resource.yaml#/components/schemas/Outbound'
     BaseStatus:
       type: object
       title: Status

--- a/api/openapi/specs/common/resource.yaml
+++ b/api/openapi/specs/common/resource.yaml
@@ -201,3 +201,46 @@ components:
         match:
           type: object
           x-go-type: interface{}
+    ResourceIdentifier:
+      type: object
+      description: ResourceIdentifier uniquely identifies resources across all clusters (zones and global). Regardless of the origin and where it was synced to, the combination of (mesh, zone, namespace, name) is unique.
+      required: [type, mesh, displayName, zone, namespace, sectionName]
+      properties:
+        type:
+          type: string
+          example: MeshService
+          description: The type of the resource.
+        mesh:
+          type: string
+          example: default
+          description: The mesh the resource is part of.
+        displayName:
+          type: string
+          example: my-service
+          description: The original name of the resource. The real field 'name' will be different after the resource is synced from the source cluster.
+        zone:
+          type: string
+          example: zone-1
+          description: The zone the resource is part of.
+        namespace:
+          type: string
+          example: default
+          description: The namespace the resource is part of.
+        sectionName:
+          type: string
+          example: http-port
+          description: The section name allows to address a specific section of a resource (i.e. a port of a MeshService).
+    Outbound:
+      type: object
+      required: [name, resourceIdentifier, envoy]
+      properties:
+        name:
+          type: string
+          example: my-service-xv68564xbv2xwwfw
+          description: The name of the resource, contains hash-suffix when resource is synced from zone to global or global to zone.
+        envoy:
+          type: string
+          example: mesh-1_my-service_default_zone-1_msvc_5000
+          description: The name of envoy resources that are generated from this resource.
+        resourceIdentifier:
+          $ref: '#/components/schemas/ResourceIdentifier'

--- a/api/openapi/types/common/zz_generated.resource.go
+++ b/api/openapi/types/common/zz_generated.resource.go
@@ -61,6 +61,18 @@ type Meta struct {
 	Type string `json:"type"`
 }
 
+// Outbound defines model for Outbound.
+type Outbound struct {
+	// Envoy The name of envoy resources that are generated from this resource.
+	Envoy string `json:"envoy"`
+
+	// Name The name of the resource, contains hash-suffix when resource is synced from zone to global or global to zone.
+	Name string `json:"name"`
+
+	// ResourceIdentifier ResourceIdentifier uniquely identifies resources across all clusters (zones and global). Regardless of the origin and where it was synced to, the combination of (mesh, zone, namespace, name) is unique.
+	ResourceIdentifier ResourceIdentifier `json:"resourceIdentifier"`
+}
+
 // PolicyDescription information about a policy
 type PolicyDescription struct {
 	// HasFromTargetRef indicates that this policy can be used as an inbound policy
@@ -78,6 +90,27 @@ type ProxyRule struct {
 	// Conf The actual conf generated
 	Conf   interface{} `json:"conf"`
 	Origin []Meta      `json:"origin"`
+}
+
+// ResourceIdentifier ResourceIdentifier uniquely identifies resources across all clusters (zones and global). Regardless of the origin and where it was synced to, the combination of (mesh, zone, namespace, name) is unique.
+type ResourceIdentifier struct {
+	// DisplayName The original name of the resource. The real field 'name' will be different after the resource is synced from the source cluster.
+	DisplayName string `json:"displayName"`
+
+	// Mesh The mesh the resource is part of.
+	Mesh string `json:"mesh"`
+
+	// Namespace The namespace the resource is part of.
+	Namespace string `json:"namespace"`
+
+	// SectionName The section name allows to address a specific section of a resource (i.e. a port of a MeshService).
+	SectionName string `json:"sectionName"`
+
+	// Type The type of the resource.
+	Type string `json:"type"`
+
+	// Zone The zone the resource is part of.
+	Zone string `json:"zone"`
 }
 
 // ResourceRule defines model for ResourceRule.

--- a/api/openapi/types/zz_generated.api.go
+++ b/api/openapi/types/zz_generated.api.go
@@ -112,6 +112,7 @@ type InspectDataplanesForPolicy struct {
 // InspectRules A list of rules for a dataplane
 type InspectRules struct {
 	HttpMatches []externalRef0.HttpMatch   `json:"httpMatches"`
+	Outbounds   []externalRef0.Outbound    `json:"outbounds"`
 	Resource    externalRef0.Meta          `json:"resource"`
 	Rules       []externalRef0.InspectRule `json:"rules"`
 }

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -2142,6 +2142,7 @@ components:
         - rules
         - resource
         - httpMatches
+        - outbounds
       properties:
         resource:
           $ref: '#/components/schemas/Meta'
@@ -2153,6 +2154,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/HttpMatch'
+        outbounds:
+          type: array
+          items:
+            $ref: '#/components/schemas/Outbound'
     BaseStatus:
       type: object
       title: Status
@@ -2632,6 +2637,67 @@ components:
         match:
           type: object
           x-go-type: interface{}
+    ResourceIdentifier:
+      type: object
+      description: >-
+        ResourceIdentifier uniquely identifies resources across all clusters
+        (zones and global). Regardless of the origin and where it was synced to,
+        the combination of (mesh, zone, namespace, name) is unique.
+      required:
+        - type
+        - mesh
+        - displayName
+        - zone
+        - namespace
+        - sectionName
+      properties:
+        type:
+          type: string
+          example: MeshService
+          description: The type of the resource.
+        mesh:
+          type: string
+          example: default
+          description: The mesh the resource is part of.
+        displayName:
+          type: string
+          example: my-service
+          description: >-
+            The original name of the resource. The real field 'name' will be
+            different after the resource is synced from the source cluster.
+        zone:
+          type: string
+          example: zone-1
+          description: The zone the resource is part of.
+        namespace:
+          type: string
+          example: default
+          description: The namespace the resource is part of.
+        sectionName:
+          type: string
+          example: http-port
+          description: >-
+            The section name allows to address a specific section of a resource
+            (i.e. a port of a MeshService).
+    Outbound:
+      type: object
+      required:
+        - name
+        - resourceIdentifier
+        - envoy
+      properties:
+        name:
+          type: string
+          example: my-service-xv68564xbv2xwwfw
+          description: >-
+            The name of the resource, contains hash-suffix when resource is
+            synced from zone to global or global to zone.
+        envoy:
+          type: string
+          example: mesh-1_my-service_default_zone-1_msvc_5000
+          description: The name of envoy resources that are generated from this resource.
+        resourceIdentifier:
+          $ref: '#/components/schemas/ResourceIdentifier'
     JsonPatchItem:
       type: object
       required:

--- a/pkg/api-server/oapi-helpers/helpers.go
+++ b/pkg/api-server/oapi-helpers/helpers.go
@@ -52,3 +52,14 @@ func OriginListToResourceRuleOrigin(resType core_model.ResourceType, origins []c
 	}
 	return out
 }
+
+func TypedResourceIdentifierToResourceIdentifier(tri *core_model.TypedResourceIdentifier) api_common.ResourceIdentifier {
+	return api_common.ResourceIdentifier{
+		Type:        string(tri.ResourceType),
+		DisplayName: tri.Name,
+		Mesh:        tri.Mesh,
+		Namespace:   tri.Namespace,
+		Zone:        tri.Zone,
+		SectionName: tri.SectionName,
+	}
+}

--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -148,7 +148,7 @@ func NewApiServer(
 		xdsHooks,
 	)
 	addPoliciesWsEndpoints(ws, cfg.IsFederatedZoneCP(), cfg.ApiServer.ReadOnly, defs)
-	addInspectEndpoints(ws, cfg, meshContextBuilder, rt.ResourceManager())
+	addInspectEndpoints(ws, cfg.Multizone.Zone.Name, meshContextBuilder, rt.ResourceManager())
 	addInspectEnvoyAdminEndpoints(ws, cfg, rt.ResourceManager(), rt.Access().EnvoyAdminAccess, rt.EnvoyAdminClient())
 	addZoneEndpoints(ws, rt.ResourceManager())
 	guiUrl := ""

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/empty.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/empty.golden.json
@@ -1,5 +1,6 @@
 {
  "httpMatches": [],
+ "outbounds": [],
  "resource": {
   "labels": {},
   "mesh": "default",

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/meshgateway.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/meshgateway.golden.json
@@ -1,5 +1,6 @@
 {
  "httpMatches": [],
+ "outbounds": [],
  "resource": {
   "labels": {
    "k8s.kuma.io/namespace": "kuma-demo",

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/meshhttproute.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/meshhttproute.golden.json
@@ -12,6 +12,7 @@
    ]
   }
  ],
+ "outbounds": [],
  "resource": {
   "labels": {},
   "mesh": "default",

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/meshhttprouteabsent.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/meshhttprouteabsent.golden.json
@@ -1,5 +1,6 @@
 {
  "httpMatches": [],
+ "outbounds": [],
  "resource": {
   "labels": {},
   "mesh": "default",

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/overriding_meshtimeout.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/overriding_meshtimeout.golden.json
@@ -1,5 +1,6 @@
 {
  "httpMatches": [],
+ "outbounds": [],
  "resource": {
   "labels": {},
   "mesh": "default",

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/overriding_meshtrace.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/overriding_meshtrace.golden.json
@@ -1,5 +1,6 @@
 {
  "httpMatches": [],
+ "outbounds": [],
  "resource": {
   "labels": {},
   "mesh": "default",

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/resource_rule_meshtimeout.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/resource_rule_meshtimeout.golden.json
@@ -1,5 +1,43 @@
 {
  "httpMatches": [],
+ "outbounds": [
+  {
+   "envoy": "mesh-1_backend-1___msvc_80",
+   "name": "backend-1",
+   "resourceIdentifier": {
+    "displayName": "backend-1",
+    "mesh": "mesh-1",
+    "namespace": "",
+    "sectionName": "80",
+    "type": "MeshService",
+    "zone": ""
+   }
+  },
+  {
+   "envoy": "mesh-1_backend-2___msvc_80",
+   "name": "backend-2",
+   "resourceIdentifier": {
+    "displayName": "backend-2",
+    "mesh": "mesh-1",
+    "namespace": "",
+    "sectionName": "80",
+    "type": "MeshService",
+    "zone": ""
+   }
+  },
+  {
+   "envoy": "mesh-1_backend-3___msvc_80",
+   "name": "backend-3",
+   "resourceIdentifier": {
+    "displayName": "backend-3",
+    "mesh": "mesh-1",
+    "namespace": "",
+    "sectionName": "80",
+    "type": "MeshService",
+    "zone": ""
+   }
+  }
+ ],
  "resource": {
   "labels": {},
   "mesh": "mesh-1",

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/resource_rule_meshtimeout.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/resource_rule_meshtimeout.input.yaml
@@ -12,6 +12,8 @@ networking:
       tags:
         app: backend
         kuma.io/service: foo
+  transparentProxying:
+    redirectPort: 15001
 ---
 type: MeshTimeout
 name: matched-for-rules-mt-1
@@ -43,6 +45,9 @@ spec:
     - port: 80
       targetPort: 80
       appProtocol: http
+status:
+  vips:
+    - ip: 240.0.0.0
 ---
 type: MeshService
 name: backend-2
@@ -57,6 +62,9 @@ spec:
     - port: 80
       targetPort: 80
       appProtocol: http
+status:
+  vips:
+    - ip: 240.0.0.1
 ---
 type: MeshService
 name: backend-3
@@ -71,3 +79,6 @@ spec:
     - port: 80
       targetPort: 80
       appProtocol: http
+status:
+  vips:
+    - ip: 240.0.0.2

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/resource_rule_meshtimeout_index.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/resource_rule_meshtimeout_index.golden.json
@@ -1,5 +1,19 @@
 {
  "httpMatches": [],
+ "outbounds": [
+  {
+   "envoy": "mesh-1_backend-3___msvc_80",
+   "name": "backend-3",
+   "resourceIdentifier": {
+    "displayName": "backend-3",
+    "mesh": "mesh-1",
+    "namespace": "",
+    "sectionName": "80",
+    "type": "MeshService",
+    "zone": ""
+   }
+  }
+ ],
  "resource": {
   "labels": {},
   "mesh": "mesh-1",

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/resource_rule_meshtimeout_index.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/resource_rule_meshtimeout_index.input.yaml
@@ -1,6 +1,8 @@
 #/meshes/mesh-1/dataplanes/dp-1/_rules 200
 type: Mesh
 name: mesh-1
+meshServices:
+  enabled: Exclusive
 ---
 type: Dataplane
 name: dp-1
@@ -12,6 +14,8 @@ networking:
       tags:
         app: backend
         kuma.io/service: foo
+  transparentProxying:
+    redirectPort: 15001
 ---
 type: MeshTimeout
 name: matched-for-rules-mt-1
@@ -61,3 +65,6 @@ spec:
     - port: 80
       targetPort: 80
       appProtocol: http
+status:
+  vips:
+    - ip: 241.0.0.0

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/resource_rule_meshtimeout_section.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/resource_rule_meshtimeout_section.golden.json
@@ -1,5 +1,19 @@
 {
  "httpMatches": [],
+ "outbounds": [
+  {
+   "envoy": "mesh-1_backend-4___msvc_80",
+   "name": "backend-4",
+   "resourceIdentifier": {
+    "displayName": "backend-4",
+    "mesh": "mesh-1",
+    "namespace": "",
+    "sectionName": "super-port",
+    "type": "MeshService",
+    "zone": ""
+   }
+  }
+ ],
  "resource": {
   "labels": {},
   "mesh": "mesh-1",

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/resource_rule_meshtimeout_section.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/resource_rule_meshtimeout_section.input.yaml
@@ -12,6 +12,8 @@ networking:
       tags:
         app: backend
         kuma.io/service: foo
+  transparentProxying:
+    redirectPort: 15001
 ---
 type: MeshTimeout
 name: matched-for-rules-mt-1
@@ -44,3 +46,6 @@ spec:
       port: 80
       targetPort: 80
       appProtocol: http
+status:
+  vips:
+    - ip: 240.0.0.0

--- a/pkg/xds/server/v3/snapshot_generator_test.go
+++ b/pkg/xds/server/v3/snapshot_generator_test.go
@@ -120,7 +120,7 @@ var _ = Describe("GenerateSnapshot", func() {
 			xds_context.AnyToAnyReachableServicesGraphBuilder,
 		)
 
-		proxyBuilder = sync.DefaultDataplaneProxyBuilder(cfg, envoy_common.APIV3)
+		proxyBuilder = sync.DefaultDataplaneProxyBuilder(cfg.Multizone.Zone.Name, envoy_common.APIV3)
 	})
 
 	create := func(r core_model.Resource) {

--- a/pkg/xds/sync/components.go
+++ b/pkg/xds/sync/components.go
@@ -1,7 +1,6 @@
 package sync
 
 import (
-	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
 	"github.com/kumahq/kuma/pkg/core"
 	core_runtime "github.com/kumahq/kuma/pkg/core/runtime"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
@@ -12,11 +11,11 @@ import (
 var xdsServerLog = core.Log.WithName("xds").WithName("server")
 
 func DefaultDataplaneProxyBuilder(
-	config kuma_cp.Config,
+	zoneName string,
 	apiVersion core_xds.APIVersion,
 ) *DataplaneProxyBuilder {
 	return &DataplaneProxyBuilder{
-		Zone:       config.Multizone.Zone.Name,
+		Zone:       zoneName,
 		APIVersion: apiVersion,
 	}
 }
@@ -54,7 +53,7 @@ func DefaultDataplaneWatchdogFactory(
 	config := rt.Config()
 
 	dataplaneProxyBuilder := DefaultDataplaneProxyBuilder(
-		config,
+		config.Multizone.Zone.Name,
 		apiVersion,
 	)
 


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues -- Fix https://github.com/kumahq/kuma/issues/11500
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
