### PR TITLE
fix(MeshAccessLog): strengthen validation for MeshAccessLog and MeshGateway

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -11,7 +11,7 @@ does not have any particular instructions.
 ### MeshAccessLog
 
 Policies targeting `spec.targetRef.kind: MeshGateway` can now only target `kind: Mesh` in
-`to[].targetRef`. Previously this was allowed but the resulting configuration
+`to[].targetRef`. Previously MeshService, MeshExternalService, MeshMultiZoneService were allowed but the resulting configuration
 was ambiguous and nondeterministic.
 
 ### MeshExternalService

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,12 @@ does not have any particular instructions.
 
 ## Upgrade to `2.9.x`
 
+### MeshAccessLog
+
+Policies targeting `spec.targetRef.kind: MeshGateway` can now only target `kind: Mesh` in
+`to[].targetRef`. Previously this was allowed but the resulting configuration
+was ambiguous and nondeterministic.
+
 ### MeshExternalService
 
 #### Removal of unix sockets support

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/validator_test.go
@@ -398,6 +398,29 @@ violations:
 - field: spec.from[0].default.backends[1].tcp.format.json
   message: must be defined`,
 			}),
+			Entry("MeshGateway and invalid to kind", testCase{
+				inputYaml: `
+targetRef:
+  kind: MeshGateway
+  name: edge-gateway
+to:
+  - targetRef:
+      kind: MeshService
+      name: web-backend
+    default:
+      backends:
+        - type: File
+          file:
+           format:
+             type: Plain
+             plain: '{"start_time": "%START_TIME%"}'
+           path: '/tmp/logs.txt'
+`,
+				expected: `
+violations:
+- field: spec.to[0].targetRef.kind
+  message: value is not supported`,
+			}),
 		)
 	})
 })

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin.go
@@ -67,8 +67,8 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 		return err
 	}
 
-	if err := plugin_xds.HandleClusters(*endpoints, rs, proxy); err != nil {
-		return errors.Wrap(err, "unable to handle clusters for policy")
+	if err := plugin_xds.AddLogBackendConf(*endpoints, rs, proxy); err != nil {
+		return errors.Wrap(err, "unable to add configuration for MeshAccessLog backends")
 	}
 
 	return nil

--- a/pkg/plugins/policies/meshaccesslog/plugin/xds/clusters.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/xds/clusters.go
@@ -19,7 +19,7 @@ func xdsEndpoint(endpoint LoggingEndpoint) core_xds.Endpoint {
 	}
 }
 
-func HandleClusters(backendEndpoints EndpointAccumulator, rs *core_xds.ResourceSet, proxy *core_xds.Proxy) error {
+func AddLogBackendConf(backendEndpoints EndpointAccumulator, rs *core_xds.ResourceSet, proxy *core_xds.Proxy) error {
 	for backendEndpoint := range backendEndpoints.endpoints {
 		endpoint := xdsEndpoint(backendEndpoint)
 


### PR DESCRIPTION
This is a breaking change. The access logging is configured at the gateway listener level, which makes it impossible to configure depending on the traffic destination.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
