### PR TITLE
chore(debug): get envoy logs in docker logs on universal tests

### DIFF
--- a/test/framework/universal_app.go
+++ b/test/framework/universal_app.go
@@ -444,42 +444,43 @@ func (s *UniversalApp) CreateDP(
 	// run the DP as user `envoy` so iptables can distinguish its traffic if needed
 	args := []string{
 		"runuser", "-u", "kuma-dp", "--",
-		"/usr/bin/kuma-dp", "run",
-		"--cp-address=" + cpAddress,
-		"--dataplane-token-file=/kuma/token-" + name,
-		"--binary-path", "/usr/local/bin/envoy",
+		"/bin/bash", "-c",
 	}
+
+	dpRun := "'/usr/bin/kuma-dp run " +
+			"--cp-address=" + cpAddress + " " +
+			"--dataplane-token-file=/kuma/token-" + name + " " +
+			"--binary-path /usr/local/bin/envoy "
 
 	if dpyaml != "" {
 		err = ssh.NewApp(s.containerName, "", s.verbose, s.ports[sshPort], nil, []string{"printf ", "\"" + dpyaml + "\"", ">", "/kuma/dpyaml-" + name}).Run()
 		if err != nil {
 			panic(err)
 		}
-		args = append(args,
-			"--dataplane-file=/kuma/dpyaml-"+name,
-			"--dataplane-var", "name="+name,
-			"--dataplane-var", "address="+ip)
+		dpRun += " --dataplane-file=/kuma/dpyaml-" + name + " --dataplane-var name=" + name + " --dataplane-var address="+ip
 	} else {
-		args = append(args,
-			"--name="+name,
-			"--mesh="+mesh)
+		dpRun += " --name="+ name + " --mesh=" + mesh
 	}
 
 	if concurrency > 0 {
-		args = append(args, "--concurrency", strconv.Itoa(concurrency))
+		dpRun += " --concurrency " + strconv.Itoa(concurrency)
 	}
 
 	if builtindns {
-		args = append(args, "--dns-enabled")
+		dpRun += " --dns-enabled "
 	}
 
 	if proxyType != "" {
-		args = append(args, "--proxy-type", proxyType)
+		dpRun += " --proxy-type " + proxyType
 	}
 
 	if Config.Debug {
-		args = append(args, "--log-level", "debug")
+		dpRun += "--log-level debug "
 	}
+
+	// we put the logs in the init process, so they are also available in 'docker logs...' command
+	dpRun += "' >> /proc/1/fd/1"
+	args = append(args, dpRun)
 
 	s.dpApp = ssh.NewApp(s.containerName, s.logsPath, s.verbose, s.ports[sshPort], envsMap, args)
 }

--- a/test/framework/universal_app.go
+++ b/test/framework/universal_app.go
@@ -448,18 +448,18 @@ func (s *UniversalApp) CreateDP(
 	}
 
 	dpRun := "'/usr/bin/kuma-dp run " +
-			"--cp-address=" + cpAddress + " " +
-			"--dataplane-token-file=/kuma/token-" + name + " " +
-			"--binary-path /usr/local/bin/envoy "
+		"--cp-address=" + cpAddress + " " +
+		"--dataplane-token-file=/kuma/token-" + name + " " +
+		"--binary-path /usr/local/bin/envoy "
 
 	if dpyaml != "" {
 		err = ssh.NewApp(s.containerName, "", s.verbose, s.ports[sshPort], nil, []string{"printf ", "\"" + dpyaml + "\"", ">", "/kuma/dpyaml-" + name}).Run()
 		if err != nil {
 			panic(err)
 		}
-		dpRun += " --dataplane-file=/kuma/dpyaml-" + name + " --dataplane-var name=" + name + " --dataplane-var address="+ip
+		dpRun += " --dataplane-file=/kuma/dpyaml-" + name + " --dataplane-var name=" + name + " --dataplane-var address=" + ip
 	} else {
-		dpRun += " --name="+ name + " --mesh=" + mesh
+		dpRun += " --name=" + name + " --mesh=" + mesh
 	}
 
 	if concurrency > 0 {


### PR DESCRIPTION
this is a bit hacky but works:

```
docker logs kuma-3_test-server_WP7yST | head -n 30

Server listening on 0.0.0.0 port 22.
Server listening on :: port 22.
Accepted none for root from 172.18.0.1 port 55380 ssh2
syslogin_perform_logout: logout() returned an error
Received disconnect from 172.18.0.1 port 55380:11: disconnected by user
Disconnected from user root 172.18.0.1 port 55380
Accepted none for root from 172.18.0.1 port 55384 ssh2
syslogin_perform_logout: logout() returned an error
Received disconnect from 172.18.0.1 port 55384:11: disconnected by user
Disconnected from user root 172.18.0.1 port 55384
Accepted none for root from 172.18.0.1 port 55386 ssh2
syslogin_perform_logout: logout() returned an error
Received disconnect from 172.18.0.1 port 55386:11: disconnected by user
Disconnected from user root 172.18.0.1 port 55386
Accepted none for root from 172.18.0.1 port 55396 ssh2
syslogin_perform_logout: logout() returned an error
Received disconnect from 172.18.0.1 port 55396:11: disconnected by user
Disconnected from user root 172.18.0.1 port 55396
Accepted none for root from 172.18.0.1 port 55408 ssh2
Accepted none for root from 172.18.0.1 port 55422 ssh2
[2024-09-25 17:01:20.706][139][info][main] [source/server/server.cc:428] initializing epoch 0 (base id=0, hot restart version=disabled)
[2024-09-25 17:01:20.706][139][info][main] [source/server/server.cc:430] statically linked extensions:
[2024-09-25 17:01:20.706][139][info][main] [source/server/server.cc:432]   envoy.health_check.event_sinks: envoy.health_check.event_sink.file
[2024-09-25 17:01:20.706][139][info][main] [source/server/server.cc:432]   envoy.formatter: envoy.formatter.cel, envoy.formatter.metadata, envoy.formatter.req_without_query
[2024-09-25 17:01:20.706][139][info][main] [source/server/server.cc:432]   envoy.network.dns_resolver: envoy.network.dns_resolver.cares, envoy.network.dns_resolver.getaddrinfo
[2024-09-25 17:01:20.706][139][info][main] [source/server/server.cc:432]   envoy.http.stateful_session: envoy.http.stateful_session.cookie, envoy.http.stateful_session.header
[2024-09-25 17:01:20.706][139][info][main] [source/server/server.cc:432]   envoy.request_id: envoy.request_id.uuid
[2024-09-25 17:01:20.706][139][info][main] [source/server/server.cc:432]   envoy.filters.listener: envoy.filters.listener.http_inspector, envoy.filters.listener.local_ratelimit, envoy.filters.listener.original_dst, envoy.filters.listener.original_src, envoy.filters.listener.proxy_protocol, envoy.filters.listener.tls_inspector, envoy.listener.http_inspector, envoy.listener.original_dst, envoy.listener.original_src, envoy.listener.proxy_protocol, envoy.listener.tls_inspector
[2024-09-25 17:01:20.706][139][info][main] [source/server/server.cc:432]   envoy.tracers: envoy.dynamic.ot, envoy.tracers.datadog, envoy.tracers.dynamic_ot, envoy.tracers.opencensus, envoy.tracers.opentelemetry, envoy.tracers.skywalking, envoy.tracers.xray, envoy.tracers.zipkin, envoy.zipkin
[2024-09-25 17:01:20.706][139][info][main] [source/server/server.cc:432]   envoy.transport_sockets.upstream: envoy.transport_sockets.alts, envoy.transport_sockets.http_11_proxy, envoy.transport_sockets.internal_upstream, envoy.transport_sockets.quic, envoy.transport_sockets.raw_buffer, envoy.transport_sockets.starttls, envoy.transport_sockets.tap, envoy.transport_sockets.tcp_stats, envoy.transport_sockets.tls, envoy.transport_sockets.upstream_proxy_protocol, raw_buffer, starttls, tls
[2024-09-25 17:01:20.706][139][info][main] [source/server/server.cc:432]   envoy.rate_limit_descriptors: envoy.rate_limit_descriptors.expr
[2024-09-25 17:01:20.706][139][info][main] [source/server/server.cc:432]   envoy.quic.connection_id_generator: envoy.quic.deterministic_connection_id_generator
[2024-09-25 17:01:20.706][139][info][main] [source/server/server.cc:432]   envoy.resolvers: envoy.ip
[2024-09-25 17:01:20.706][139][info][main] [source/server/server.cc:432]   envoy.rbac.matchers: envoy.rbac.matchers.upstream_ip_port
[2024-09-25 17:01:20.706][139][info][main] [source/server/server.cc:432]   envoy.matching.http.input: envoy.matching.inputs.cel_data_input, envoy.matching.inputs.destination_ip, envoy.matching.inputs.destination_port, envoy.matching.inputs.direct_source_ip, envoy.matching.inputs.dns_san, envoy.matching.inputs.request_headers, envoy.matching.inputs.request_trailers, envoy.matching.inputs.response_headers, envoy.matching.inputs.response_trailers, envoy.matching.inputs.server_name, envoy.matching.inputs.source_ip, envoy.matching.inputs.source_port, envoy.matching.inputs.source_type, envoy.matching.inputs.status_code_class_input, envoy.matching.inputs.status_code_input, envoy.matching.inputs.subject, envoy.matching.inputs.uri_san, query_params
[2024-09-25 17:01:20.706][139][info][main] [source/server/server.cc:432]   envoy.transport_sockets.downstream: envoy.transport_sockets.alts, envoy.transport_sockets.quic, envoy.transport_sockets.raw_buffer, envoy.transport_sockets.starttls, envoy.transport_sockets.tap, envoy.transport_sockets.tcp_stats, envoy.transport_sockets.tls, raw_buffer, starttls, tls
[2024-09-25 17:01:20.706][139][info][main] [source/server/server.cc:432]   envoy.http.header_validators: envoy.http.header_validators.envoy_default
[2024-09-25 17:01:20.706][139][info][main] [source/server/server.cc:432]   envoy.dubbo_proxy.serializers: dubbo.hessian2
[2024-09-25 17:01:20.706][139][info][main] [source/server/server.cc:432]   envoy.grpc_credentials: envoy.grpc_credentials.aws_iam, envoy.grpc_credentials.default, envoy.grpc_credentials.file_based_metadata
[2024-09-25 17:01:20.706][139][info][main] [source/server/server.cc:432]   envoy.filters.network: envoy.echo, envoy.ext_authz, envoy.filters.network.connection_limit, envoy.filters.network.direct_response, envoy.filters.network.dubbo_proxy, envoy.filters.network.echo, envoy.filters.network.ext_authz, envoy.filters.network.http_connection_manager, envoy.filters.network.kafka_broker, envoy.filters.network.local_ratelimit, envoy.filters.network.mongo_proxy, envoy.filters.network.ratelimit, envoy.filters.network.rbac, envoy.filters.network.redis_proxy, envoy.filters.network.set_filter_state, envoy.filters.network.sni_cluster, envoy.filters.network.sni_dynamic_forward_proxy, envoy.filters.network.tcp_proxy, envoy.filters.network.thrift_proxy, envoy.filters.network.wasm, envoy.filters.network.zookeeper_proxy, envoy.http_connection_manager, envoy.mongo_proxy, envoy.ratelimit, envoy.redis_proxy, envoy.tcp_proxy
[2024-09-25 17:01:20.706][139][info][main] [source/server/server.cc:432]   envoy.tls.cert_validator: envoy.tls.cert_validator.default, envoy.tls.cert_validator.spiffe
[2024-09-25 17:01:20.706][139][info][main] [source/server/server.cc:432]   envoy.filters.udp.session: envoy.filters.udp.session.dynamic_forward_proxy, envoy.filters.udp.session.http_capsule
[2024-09-25 17:01:20.706][139][info][main] [source/server/server.cc:432]   envoy.filters.udp_listener: envoy.filters.udp.dns_filter, envoy.filters.udp_listener.udp_proxy
[2024-09-25 17:01:20.706][139][info][main] [source/server/server.cc:432]   envoy.matching.common_inputs: envoy.matching.common_inputs.environment_variable
[2024-09-25 17:01:20.706][139][info][main] [source/server/server.cc:432]   envoy.tracers.opentelemetry.samplers: envoy.tracers.opentelemetry.samplers.always_on, envoy.tracers.opentelemetry.samplers.dynatrace
[2024-09-25 17:01:20.706][139][info][main] [source/server/server.cc:432]   envoy.http.injected_credentials: envoy.http.injected_credentials.generic
[2024-09-25 17:01:20.706][139][info][main] [source/server/server.cc:432]   envoy.upstreams: envoy.filters.connection_pools.tcp.generic
[2024-09-25 17:01:20.706][139][info][main] [source/server/server.cc:432]   envoy.regex_engines: envoy.regex_engines.google_re2
[2024-09-25 17:01:20.706][139][info][main] [source/server/server.cc:432]   envoy.listener_manager_impl: envoy.listener_manager_impl.default, envoy.listener_manager_impl.validation
[2024-09-25 17:01:20.706][139][info][main] [source/server/server.cc:432]   quic.http_server_connection: quic.http_server_connection.default
Received disconnect from 172.18.0.1 port 55408:11: disconnected by user
Disconnected from user root 172.18.0.1 port 55408
Received disconnect from 172.18.0.1 port 55422:11: disconnected by user
syslogin_perform_logout: logout() returned an error
Disconnected from user root 172.18.0.1 port 55422
syslogin_perform_logout: logout() returned an error
```

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
