### PR TITLE
fix(xds): preserve deleted resources

### DIFF
--- a/pkg/plugins/runtime/gateway/gateway_route_generator_test.go
+++ b/pkg/plugins/runtime/gateway/gateway_route_generator_test.go
@@ -3,6 +3,7 @@ package gateway_test
 import (
 	"context"
 	"path"
+	"sync"
 
 	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	. "github.com/onsi/ginkgo/v2"
@@ -41,7 +42,7 @@ var _ = Describe("Gateway Route", func() {
 		if err != nil {
 			return nil, err
 		}
-		reconciler := xds_server.DefaultReconciler(rt, serverCtx, statsCallbacks)
+		reconciler := xds_server.DefaultReconciler(rt, serverCtx, statsCallbacks, &sync.Mutex{})
 
 		// We expect there to be a Dataplane fixture named
 		// "default" in the current mesh.

--- a/pkg/plugins/runtime/gateway/listener_generator_test.go
+++ b/pkg/plugins/runtime/gateway/listener_generator_test.go
@@ -3,6 +3,7 @@ package gateway_test
 import (
 	"context"
 	"path"
+	"sync"
 
 	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	. "github.com/onsi/ginkgo/v2"
@@ -26,7 +27,7 @@ var _ = Describe("Gateway Listener", func() {
 		if err != nil {
 			return nil, err
 		}
-		reconciler := xds_server.DefaultReconciler(rt, serverCtx, statsCallbacks)
+		reconciler := xds_server.DefaultReconciler(rt, serverCtx, statsCallbacks, &sync.Mutex{})
 
 		Expect(StoreInlineFixture(rt, []byte(gateway))).To(Succeed())
 

--- a/pkg/xds/server/v3/components.go
+++ b/pkg/xds/server/v3/components.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	envoy_service_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
@@ -39,9 +40,10 @@ func RegisterXDS(
 	authCallbacks := auth.NewCallbacks(rt.ReadOnlyResourceManager(), authenticator, auth.DPNotFoundRetry{}) // no need to retry on DP Not Found because we are creating DP in DataplaneLifecycle callback
 
 	metadataTracker := xds_callbacks.NewDataplaneMetadataTracker()
-	reconciler := DefaultReconciler(rt, xdsContext, statsCallbacks)
-	ingressReconciler := DefaultIngressReconciler(rt, xdsContext, statsCallbacks)
-	egressReconciler := DefaultEgressReconciler(rt, xdsContext, statsCallbacks)
+	snapshotCacheMux := &sync.Mutex{}
+	reconciler := DefaultReconciler(rt, xdsContext, statsCallbacks, snapshotCacheMux)
+	ingressReconciler := DefaultIngressReconciler(rt, xdsContext, statsCallbacks, snapshotCacheMux)
+	egressReconciler := DefaultEgressReconciler(rt, xdsContext, statsCallbacks, snapshotCacheMux)
 	watchdogFactory, err := xds_sync.DefaultDataplaneWatchdogFactory(rt, metadataTracker, reconciler, ingressReconciler, egressReconciler, xdsMetrics, envoyCpCtx, envoy_common.APIV3)
 	if err != nil {
 		return err
@@ -58,7 +60,7 @@ func RegisterXDS(
 		util_xds_v3.AdaptCallbacks(xds_callbacks.DataplaneCallbacksToXdsCallbacks(xds_callbacks.NewDataplaneSyncTracker(watchdogFactory.New))),
 		util_xds_v3.AdaptCallbacks(DefaultDataplaneStatusTracker(rt, envoyCpCtx.Secrets)),
 		util_xds_v3.AdaptCallbacks(xds_callbacks.NewNackBackoff(rt.Config().XdsServer.NACKBackoff.Duration)),
-		newResourceWarmingForcer(xdsContext.Cache(), xdsContext.Hasher()),
+		newResourceWarmingForcer(xdsContext.Cache(), xdsContext.Hasher(), snapshotCacheMux),
 	}
 
 	if cb := rt.XDS().ServerCallbacks; cb != nil {
@@ -76,6 +78,7 @@ func DefaultReconciler(
 	rt core_runtime.Runtime,
 	xdsContext XdsContext,
 	statsCallbacks util_xds.StatsCallbacks,
+	snapshotCacheMux *sync.Mutex,
 ) xds_sync.SnapshotReconciler {
 	resolver := xds_template.SequentialResolver(
 		&xds_template.SimpleProxyTemplateResolver{
@@ -89,8 +92,9 @@ func DefaultReconciler(
 			ResourceSetHooks:      rt.XDS().Hooks.ResourceSetHooks(),
 			ProxyTemplateResolver: resolver,
 		},
-		cacher:         &simpleSnapshotCacher{xdsContext.Hasher(), xdsContext.Cache()},
-		statsCallbacks: statsCallbacks,
+		cacher:           &simpleSnapshotCacher{xdsContext.Hasher(), xdsContext.Cache()},
+		statsCallbacks:   statsCallbacks,
+		snapshotCacheMux: snapshotCacheMux,
 	}
 }
 
@@ -98,6 +102,7 @@ func DefaultIngressReconciler(
 	rt core_runtime.Runtime,
 	xdsContext XdsContext,
 	statsCallbacks util_xds.StatsCallbacks,
+	snapshotCacheMux *sync.Mutex,
 ) xds_sync.SnapshotReconciler {
 	resolver := &xds_template.StaticProxyTemplateResolver{
 		Template: &mesh_proto.ProxyTemplate{
@@ -114,8 +119,9 @@ func DefaultIngressReconciler(
 			ResourceSetHooks:      rt.XDS().Hooks.ResourceSetHooks(),
 			ProxyTemplateResolver: resolver,
 		},
-		cacher:         &simpleSnapshotCacher{xdsContext.Hasher(), xdsContext.Cache()},
-		statsCallbacks: statsCallbacks,
+		cacher:           &simpleSnapshotCacher{xdsContext.Hasher(), xdsContext.Cache()},
+		statsCallbacks:   statsCallbacks,
+		snapshotCacheMux: snapshotCacheMux,
 	}
 }
 
@@ -123,6 +129,7 @@ func DefaultEgressReconciler(
 	rt core_runtime.Runtime,
 	xdsContext XdsContext,
 	statsCallbacks util_xds.StatsCallbacks,
+	snapshotCacheMux *sync.Mutex,
 ) xds_sync.SnapshotReconciler {
 	resolver := &xds_template.StaticProxyTemplateResolver{
 		Template: &mesh_proto.ProxyTemplate{
@@ -139,8 +146,9 @@ func DefaultEgressReconciler(
 			ResourceSetHooks:      rt.XDS().Hooks.ResourceSetHooks(),
 			ProxyTemplateResolver: resolver,
 		},
-		cacher:         &simpleSnapshotCacher{xdsContext.Hasher(), xdsContext.Cache()},
-		statsCallbacks: statsCallbacks,
+		cacher:           &simpleSnapshotCacher{xdsContext.Hasher(), xdsContext.Cache()},
+		statsCallbacks:   statsCallbacks,
+		snapshotCacheMux: snapshotCacheMux,
 	}
 }
 

--- a/pkg/xds/server/v3/reconcile.go
+++ b/pkg/xds/server/v3/reconcile.go
@@ -81,7 +81,7 @@ func (r *reconciler) Reconcile(ctx context.Context, xdsCtx xds_context.Context, 
 
 	preserveDeletedResources(snapshot, previous)
 
-	//if err := snapshot.Consistent(); err != nil {
+	// if err := snapshot.Consistent(); err != nil {
 	//	return false, errors.Wrap(err, "inconsistent snapshot")
 	//}
 
@@ -141,7 +141,6 @@ func preserveDeletedResources(snapshot *envoy_cache.Snapshot, previous *envoy_ca
 					}
 				}
 			}
-
 		}
 	}
 }

--- a/pkg/xds/server/v3/reconcile_test.go
+++ b/pkg/xds/server/v3/reconcile_test.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"context"
+	"sync"
 
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -140,6 +141,7 @@ var _ = Describe("Reconcile", func() {
 				}),
 				&simpleSnapshotCacher{xdsContext.Hasher(), xdsContext.Cache()},
 				statsCallbacks,
+				&sync.Mutex{},
 			}
 
 			// given
@@ -227,14 +229,8 @@ var _ = Describe("Reconcile", func() {
 				Not(Equal(routeV1)),
 				Not(BeEmpty()),
 			))
-			Expect(snapshot.GetVersion(resource.ClusterType)).To(SatisfyAll(
-				Not(Equal(clusterV1)),
-				Not(BeEmpty()),
-			))
-			Expect(snapshot.GetVersion(resource.EndpointType)).To(SatisfyAll(
-				Not(Equal(endpointV1)),
-				Not(BeEmpty()),
-			))
+			Expect(snapshot.GetVersion(resource.ClusterType)).To(Equal(clusterV1))
+			Expect(snapshot.GetVersion(resource.EndpointType)).To(Equal(endpointV1))
 			Expect(snapshot.GetVersion(resource.SecretType)).To(SatisfyAll(
 				Not(Equal(secretV1)),
 				Not(BeEmpty()),


### PR DESCRIPTION
### Checklist prior to review

WIP: Test CI

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
