### PR TITLE
test(e2e): retry when there is no port

### DIFF
--- a/test/framework/docker.go
+++ b/test/framework/docker.go
@@ -12,8 +12,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-const(
-	retries = 5
+const (
+	retries      = 5
 	retryTimeout = 500 * time.Millisecond
 )
 
@@ -32,7 +32,7 @@ func GetPublishedDockerPorts(
 		var err error
 		// Sometimes the port may not be available immediately, and it can take some time.
 		// Since we didn't retry, tests were failing with and an error
-		// `missing port in addres` on OSX.
+		// `missing port in address` on OSX.
 		retry.DoWithRetry(t, "get port", retries, retryTimeout, func() (string, error) {
 			out, err = shell.RunCommandAndGetStdOutE(t, cmd)
 			if err != nil {

--- a/test/framework/docker.go
+++ b/test/framework/docker.go
@@ -4,10 +4,17 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/pkg/errors"
+)
+
+const(
+	retries = 5
+	retryTimeout = 500 * time.Millisecond
 )
 
 func GetPublishedDockerPorts(
@@ -21,7 +28,21 @@ func GetPublishedDockerPorts(
 			Command: "docker",
 			Args:    []string{"port", container, strconv.Itoa(int(port))},
 		}
-		out, err := shell.RunCommandAndGetStdOutE(t, cmd)
+		var out string
+		var err error
+		// Sometimes the port may not be available immediately, and it can take some time.
+		// Since we didn't retry, tests were failing with and an error
+		// `missing port in addres` on OSX.
+		retry.DoWithRetry(t, "get port", retries, retryTimeout, func() (string, error) {
+			out, err = shell.RunCommandAndGetStdOutE(t, cmd)
+			if err != nil {
+				return "", err
+			}
+			if out == "" {
+				return "", errors.New("there is no port available")
+			}
+			return out, nil
+		})
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
### Checklist prior to review

While running universal tests on macOS, you might notice that tests randomly fail with the following error message
```
      <*net.AddrError | 0x14000d97280>:
      missing port in address
      {
          Err: "missing port in address",
          Addr: "",
```
During debugging, I discovered that sometimes the port is not available immediately, but no error is thrown. To handle this, I introduced a method that retries the call up to 5 times to check if the port becomes available.

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
