### PR TITLE
fix(MeshLoadBalancingStrategy): apply to real resource targeted policies with MeshGateway

### DIFF
--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
@@ -87,6 +87,9 @@ func (p plugin) configureDPP(
 	rs *core_xds.ResourceSet,
 	meshCtx xds_context.MeshContext,
 ) error {
+	if proxy.Dataplane.Spec.IsBuiltinGateway() {
+		return nil
+	}
 	serviceConfs := map[string]api.Conf{}
 
 	for _, outbound := range proxy.Outbounds.Filter(xds_types.NonBackendRefFilter) {

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
@@ -14,6 +14,7 @@ import (
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	meshexternalservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/matchers"
@@ -62,7 +63,7 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 	endpoints := policies_xds.GatherOutboundEndpoints(rs)
 	routes := policies_xds.GatherRoutes(rs)
 
-	if err := p.configureGateway(proxy, policies.GatewayRules, listeners.Gateway, clusters.Gateway, routes.Gateway, rs, ctx.Mesh.Resource.ZoneEgressEnabled()); err != nil {
+	if err := p.configureGateway(ctx.Mesh, proxy, policies.GatewayRules, listeners.Gateway, clusters.Gateway, routes.Gateway, rs, ctx.Mesh.Resource.ZoneEgressEnabled()); err != nil {
 		return err
 	}
 
@@ -129,7 +130,7 @@ func (p plugin) configureDPP(
 		}
 	}
 
-	if err := p.applyToRealResources(proxy, endpoints, rs, toRules.ResourceRules, meshCtx); err != nil {
+	if err := p.applyToRealResources(meshCtx, rs, proxy, toRules.ResourceRules, endpoints); err != nil {
 		return err
 	}
 
@@ -137,42 +138,57 @@ func (p plugin) configureDPP(
 }
 
 func (p plugin) applyToRealResources(
-	proxy *core_xds.Proxy,
-	endpoints policies_xds.EndpointMap,
-	rs *core_xds.ResourceSet,
-	rules core_rules.ResourceRules,
 	meshCtx xds_context.MeshContext,
+	rs *core_xds.ResourceSet,
+	proxy *core_xds.Proxy,
+	rules core_rules.ResourceRules,
+	endpoints policies_xds.EndpointMap,
 ) error {
 	for uri, resType := range rs.IndexByOrigin(core_xds.NonMeshExternalService) {
-		conf := rules.Compute(uri, meshCtx.Resources)
-		if conf == nil {
-			continue
+		if err := p.applyToRealResource(meshCtx, proxy, rules, uri, rs, resType, endpoints); err != nil {
+			return err
 		}
-		apiConf := conf.Conf[0].(api.Conf)
+	}
+	return nil
+}
 
-		for typ, resources := range resType {
-			switch typ {
-			case envoy_resource.ListenerType:
-				for _, resource := range resources {
-					if resource.Origin != generator.OriginOutbound {
-						continue
-					}
-					if err := p.configureListener(resource.Resource.(*envoy_listener.Listener), nil, &apiConf); err != nil {
-						return err
-					}
+func (p plugin) applyToRealResource(
+	meshCtx xds_context.MeshContext,
+	proxy *core_xds.Proxy,
+	rules core_rules.ResourceRules,
+	uri core_model.TypedResourceIdentifier,
+	rs *core_xds.ResourceSet,
+	resourcesByType core_xds.ResourcesByType,
+	endpoints policies_xds.EndpointMap,
+) error {
+	conf := rules.Compute(uri, meshCtx.Resources)
+	if conf == nil {
+		return nil
+	}
+	apiConf := conf.Conf[0].(api.Conf)
+
+	for typ, resources := range resourcesByType {
+		switch typ {
+		case envoy_resource.ListenerType:
+			for _, resource := range resources {
+				if resource.Origin != generator.OriginOutbound {
+					continue
 				}
-			case envoy_resource.ClusterType:
-				for _, resource := range resources {
-					if resource.Origin != generator.OriginOutbound {
-						continue
-					}
-					cluster := resource.Resource.(*envoy_cluster.Cluster)
-					if err := p.configureCluster(cluster, apiConf); err != nil {
-						return err
-					}
-					if err := configureEndpoints(proxy.Dataplane.Spec.TagSet(), cluster, endpoints[cluster.Name], cluster.Name, apiConf, rs, proxy.Zone, proxy.APIVersion, false, generator.OriginOutbound); err != nil {
-						return errors.Wrapf(err, "failed to configure ClusterLoadAssignment for %s", cluster.Name)
-					}
+				if err := p.configureListener(resource.Resource.(*envoy_listener.Listener), nil, &apiConf); err != nil {
+					return err
+				}
+			}
+		case envoy_resource.ClusterType:
+			for _, resource := range resources {
+				if resource.Origin != generator.OriginOutbound {
+					continue
+				}
+				cluster := resource.Resource.(*envoy_cluster.Cluster)
+				if err := p.configureCluster(cluster, apiConf); err != nil {
+					return err
+				}
+				if err := configureEndpoints(proxy.Dataplane.Spec.TagSet(), cluster, endpoints[cluster.Name], cluster.Name, apiConf, rs, proxy.Zone, proxy.APIVersion, false, generator.OriginOutbound); err != nil {
+					return errors.Wrapf(err, "failed to configure ClusterLoadAssignment for %s", cluster.Name)
 				}
 			}
 		}
@@ -218,6 +234,7 @@ func configureEndpoints(
 }
 
 func (p plugin) configureGateway(
+	meshCtx xds_context.MeshContext,
 	proxy *core_xds.Proxy,
 	rules core_rules.GatewayRules,
 	gatewayListeners map[core_rules.InboundListener]*envoy_listener.Listener,
@@ -230,6 +247,7 @@ func (p plugin) configureGateway(
 	if len(gatewayListenerInfos) == 0 {
 		return nil
 	}
+	resourcesByOrigin := rs.IndexByOrigin(core_xds.NonMeshExternalService)
 
 	endpoints := policies_xds.GatherGatewayEndpoints(rs)
 
@@ -264,18 +282,34 @@ func (p plugin) configureGateway(
 					}
 
 					serviceName := dest.Destination[mesh_proto.ServiceTag]
-					localityConf := core_rules.ComputeConf[api.Conf](rules.Rules, core_rules.MeshService(serviceName))
-					if localityConf == nil {
+					if localityConf := core_rules.ComputeConf[api.Conf](rules.Rules, core_rules.MeshService(serviceName)); localityConf != nil {
+						perServiceConfiguration[serviceName] = localityConf
+
+						if err := p.configureCluster(cluster, *localityConf); err != nil {
+							return err
+						}
+
+						if err := configureEndpoints(proxy.Dataplane.Spec.TagSet(), cluster, endpoints[serviceName], clusterName, *localityConf, rs, proxy.Zone, proxy.APIVersion, egressEnabled, metadata.OriginGateway); err != nil {
+							return err
+						}
+					}
+
+					if dest.BackendRef == nil {
 						continue
 					}
-					perServiceConfiguration[serviceName] = localityConf
-
-					if err := p.configureCluster(cluster, *localityConf); err != nil {
-						return err
-					}
-
-					if err := configureEndpoints(proxy.Dataplane.Spec.TagSet(), cluster, endpoints[serviceName], clusterName, *localityConf, rs, proxy.Zone, proxy.APIVersion, egressEnabled, metadata.OriginGateway); err != nil {
-						return err
+					if realRef := dest.BackendRef.ResourceOrNil(); realRef != nil {
+						resources := resourcesByOrigin[*realRef]
+						if err := p.applyToRealResource(
+							meshCtx,
+							proxy,
+							rules.ResourceRules,
+							*realRef,
+							rs,
+							resources,
+							endpoints,
+						); err != nil {
+							return err
+						}
 					}
 				}
 			}

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
@@ -183,7 +183,7 @@ func (p plugin) applyToRealResource(
 			}
 		case envoy_resource.ClusterType:
 			for _, resource := range resources {
-				if resource.Origin != generator.OriginOutbound {
+				if resource.Origin != generator.OriginOutbound && resource.Origin != metadata.OriginGateway {
 					continue
 				}
 				cluster := resource.Resource.(*envoy_cluster.Cluster)

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/real-MeshService-targeted-to-real-MeshService.gateway.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/real-MeshService-targeted-to-real-MeshService.gateway.clusters.golden.yaml
@@ -2,6 +2,8 @@ resources:
 - name: default_backend___msvc_80-65ee15ea276ba345
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    commonLbConfig:
+      localityWeightedLbConfig: {}
     edsClusterConfig:
       edsConfig:
         ads: {}

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/real-MeshService-targeted-to-real-MeshService.gateway.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/real-MeshService-targeted-to-real-MeshService.gateway.clusters.golden.yaml
@@ -1,0 +1,17 @@
+resources:
+- name: default_backend___msvc_80-65ee15ea276ba345
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+        initialFetchTimeout: 0s
+        resourceApiVersion: V3
+    name: default_backend___msvc_80-65ee15ea276ba345
+    perConnectionBufferLimitBytes: 32768
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          httpProtocolOptions: {}

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/real-MeshService-targeted-to-real-MeshService.gateway.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/real-MeshService-targeted-to-real-MeshService.gateway.endpoints.golden.yaml
@@ -1,0 +1,5 @@
+resources:
+- name: default_backend___msvc_80-65ee15ea276ba345
+  resource:
+    '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
+    clusterName: default_backend___msvc_80-65ee15ea276ba345

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/real-MeshService-targeted-to-real-MeshService.gateway.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/real-MeshService-targeted-to-real-MeshService.gateway.listeners.golden.yaml
@@ -1,0 +1,60 @@
+resources:
+- name: sample-gateway:HTTP:8080
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.1
+        portValue: 8080
+    enableReusePort: true
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          commonHttpProtocolOptions:
+            headersWithUnderscoresAction: REJECT_REQUEST
+            idleTimeout: 300s
+          http2ProtocolOptions:
+            allowConnect: true
+            initialConnectionWindowSize: 1048576
+            initialStreamWindowSize: 65536
+            maxConcurrentStreams: 100
+          httpFilters:
+          - name: envoy.filters.http.local_ratelimit
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              statPrefix: rate_limit
+          - name: gzip-compress
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+              compressorLibrary:
+                name: gzip
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+              responseDirectionConfig:
+                disableOnEtagHeader: true
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          mergeSlashes: true
+          normalizePath: true
+          pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
+          rds:
+            configSource:
+              ads: {}
+              initialFetchTimeout: 0s
+              resourceApiVersion: V3
+            routeConfigName: sample-gateway:HTTP:8080:*
+          requestHeadersTimeout: 0.500s
+          serverName: Kuma Gateway
+          statPrefix: sample-gateway
+          streamIdleTimeout: 5s
+          useRemoteAddress: true
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: sample-gateway:HTTP:8080
+    perConnectionBufferLimitBytes: 32768
+    trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/real-MeshService-targeted-to-real-MeshService.gateway.routes.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/real-MeshService-targeted-to-real-MeshService.gateway.routes.golden.yaml
@@ -1,0 +1,28 @@
+resources:
+- name: sample-gateway:HTTP:8080:*
+  resource:
+    '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+    ignorePortInHostMatching: true
+    name: sample-gateway:HTTP:8080:*
+    requestHeadersToRemove:
+    - x-kuma-tags
+    validateClusters: false
+    virtualHosts:
+    - domains:
+      - '*'
+      name: '*'
+      routes:
+      - match:
+          path: /
+        name: JNNc6//C3P17nUsOJm5f4kqG+U3v8pXhS0od9C3+oss=
+        route:
+          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+          idleTimeout: 5s
+          weightedClusters:
+            clusters:
+            - name: default_backend___msvc_80-65ee15ea276ba345
+              requestHeadersToAdd:
+              - header:
+                  key: x-kuma-tags
+                  value: '&k8s.io/az=test&&k8s.io/node=node1&&k8s.io/region=test&&kuma.io/service=sample-gateway&'
+              weight: 100


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- #11534  
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
