### PR TITLE
test(e2e): improve meshtimeout kubernetes tests

### DIFF
--- a/pkg/test/resources/builders/mesh_builder.go
+++ b/pkg/test/resources/builders/mesh_builder.go
@@ -131,6 +131,16 @@ func (m *MeshBuilder) WithMeshServicesEnabled(enabled mesh_proto.Mesh_MeshServic
 	return m
 }
 
+func (m *MeshBuilder) WithoutInitialPolicies() *MeshBuilder {
+	m.res.Spec.SkipCreatingInitialPolicies = []string{"*"}
+	return m
+}
+
+func (m *MeshBuilder) WithSkipCreatingInitialPolicies(policies []string) *MeshBuilder {
+	m.res.Spec.SkipCreatingInitialPolicies = policies
+	return m
+}
+
 func (m *MeshBuilder) With(fn func(resource *core_mesh.MeshResource)) *MeshBuilder {
 	fn(m.res)
 	return m

--- a/test/e2e_env/kubernetes/meshtimeout/meshtimeout.go
+++ b/test/e2e_env/kubernetes/meshtimeout/meshtimeout.go
@@ -2,13 +2,16 @@ package meshtimeout
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	meshretry_api "github.com/kumahq/kuma/pkg/plugins/policies/meshretry/api/v1alpha1"
-	"github.com/kumahq/kuma/pkg/plugins/policies/meshtimeout/api/v1alpha1"
+	meshtimeout_api "github.com/kumahq/kuma/pkg/plugins/policies/meshtimeout/api/v1alpha1"
+	"github.com/kumahq/kuma/pkg/test/resources/builders"
 	. "github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/framework/client"
 	"github.com/kumahq/kuma/test/framework/deployments/democlient"
@@ -17,94 +20,66 @@ import (
 )
 
 func MeshTimeout() {
-	Context("meshServices disabled", func() {
-		MeshTimeoutWithMesh(MeshKubernetes, "meshtimeout")
-	})
-	Context("meshServices enabled", func() {
-		MeshTimeoutWithMesh(func(s string) InstallFunc {
-			return MeshWithMeshServicesKubernetes(s, "Exclusive")
-		}, "meshtimeout-ms-enabled")
-	})
-}
+	DescribeTableSubtree("with meshServices mode", func(mode mesh_proto.Mesh_MeshServices_Enabled) {
+		mesh := fmt.Sprintf("meshtimeout-ms-%s", strings.ToLower(mode.String()))
+		namespace := fmt.Sprintf("%s-namespace", mesh)
+		testServerURL := fmt.Sprintf("test-server.%s.svc:80", namespace)
 
-func MeshTimeoutWithMesh(meshInstaller func(string) InstallFunc, mesh string) {
-	namespace := fmt.Sprintf("%s-namespace", mesh)
-	testServerURL := fmt.Sprintf("test-server.%s.svc:80", namespace)
+		BeforeAll(func() {
+			err := NewClusterSetup().
+				Install(YamlK8s(builders.Mesh().
+					WithName(mesh).
+					WithoutInitialPolicies().
+					WithMeshServicesEnabled(mode).
+					KubeYaml())).
+				Install(NamespaceWithSidecarInjection(namespace)).
+				Install(democlient.Install(democlient.WithNamespace(namespace), democlient.WithMesh(mesh))).
+				Install(testserver.Install(testserver.WithMesh(mesh), testserver.WithNamespace(namespace))).
+				Setup(kubernetes.Cluster)
+			Expect(err).ToNot(HaveOccurred())
+		})
 
-	BeforeAll(func() {
-		err := NewClusterSetup().
-			Install(meshInstaller(mesh)).
-			Install(NamespaceWithSidecarInjection(namespace)).
-			Install(democlient.Install(democlient.WithNamespace(namespace), democlient.WithMesh(mesh))).
-			Install(testserver.Install(testserver.WithMesh(mesh), testserver.WithNamespace(namespace))).
-			Setup(kubernetes.Cluster)
-		Expect(err).ToNot(HaveOccurred())
+		AfterEachFailure(func() {
+			DebugKube(kubernetes.Cluster, mesh, namespace)
+		})
 
-		// Delete the default meshtimeout policy
-		Expect(DeleteMeshPolicyOrError(
-			kubernetes.Cluster,
-			v1alpha1.MeshTimeoutResourceTypeDescriptor,
-			fmt.Sprintf("mesh-timeout-all-%s", mesh),
-		)).To(Succeed())
+		E2EAfterAll(func() {
+			Expect(kubernetes.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
+			Expect(kubernetes.Cluster.DeleteMesh(mesh)).To(Succeed())
+		})
 
-		// Delete the default meshretry policy
-		Expect(DeleteMeshPolicyOrError(
-			kubernetes.Cluster,
-			meshretry_api.MeshRetryResourceTypeDescriptor,
-			fmt.Sprintf("mesh-retry-all-%s", mesh),
-		)).To(Succeed())
-	})
+		DescribeTable("should add timeouts", FlakeAttempts(3), func(timeoutConfig string) {
+			// Delete all retries and timeouts policy
+			Expect(DeleteMeshResources(kubernetes.Cluster, mesh,
+				meshtimeout_api.MeshTimeoutResourceTypeDescriptor,
+				meshretry_api.MeshRetryResourceTypeDescriptor,
+			)).To(Succeed())
 
-	AfterEachFailure(func() {
-		DebugKube(kubernetes.Cluster, mesh, namespace)
-	})
+			Eventually(func(g Gomega) {
+				start := time.Now()
+				g.Expect(client.CollectEchoResponse(
+					kubernetes.Cluster, "demo-client", testServerURL,
+					client.FromKubernetesPod(namespace, "demo-client"),
+					client.WithHeader("x-set-response-delay-ms", "5000"),
+					client.WithMaxTime(10),
+				)).Should(HaveField("Instance", ContainSubstring("test-server")))
+				g.Expect(time.Since(start)).To(BeNumerically(">", time.Second*5))
+			}, "30s", "1s").Should(Succeed())
 
-	E2EAfterAll(func() {
-		Expect(kubernetes.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
-		Expect(kubernetes.Cluster.DeleteMesh(mesh)).To(Succeed())
-	})
+			// when
+			Expect(YamlK8s(timeoutConfig)(kubernetes.Cluster)).To(Succeed())
 
-	DescribeTable("should add timeouts", FlakeAttempts(3), func(timeoutConfig string) {
-		// given no MeshTimeout
-		mts, err := kubernetes.Cluster.GetKumactlOptions().KumactlList("meshtimeouts", mesh)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(mts).To(
-			Or(
-				HaveExactElements(Equal(fmt.Sprintf("mesh-gateways-timeout-all-%s.kuma-system", mesh))),
-				BeEmpty(),
-			),
-		)
-
-		Eventually(func(g Gomega) {
-			start := time.Now()
-			_, err := client.CollectEchoResponse(
-				kubernetes.Cluster, "demo-client", testServerURL,
-				client.FromKubernetesPod(namespace, "demo-client"),
-				client.WithHeader("x-set-response-delay-ms", "5000"),
-				client.WithMaxTime(10),
-			)
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(time.Since(start)).To(BeNumerically(">", time.Second*5))
-		}, "30s", "1s").Should(Succeed())
-
-		// when
-		Expect(YamlK8s(timeoutConfig)(kubernetes.Cluster)).To(Succeed())
-
-		// then
-		Eventually(func(g Gomega) {
-			response, err := client.CollectFailure(
-				kubernetes.Cluster, "demo-client", testServerURL,
-				client.FromKubernetesPod(namespace, "demo-client"),
-				client.WithHeader("x-set-response-delay-ms", "5000"),
-				client.WithMaxTime(10), // we don't want 'curl' to return early
-			)
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(response.ResponseCode).To(Equal(504))
-		}, "1m", "1s", MustPassRepeatedly(5)).Should(Succeed())
-
-		Expect(DeleteYamlK8s(timeoutConfig)(kubernetes.Cluster)).To(Succeed())
-	},
-		Entry("outbound timeout", fmt.Sprintf(`
+			// then
+			Eventually(func(g Gomega) {
+				g.Expect(client.CollectFailure(
+					kubernetes.Cluster, "demo-client", testServerURL,
+					client.FromKubernetesPod(namespace, "demo-client"),
+					client.WithHeader("x-set-response-delay-ms", "5000"),
+					client.WithMaxTime(10), // we don't want 'curl' to return early
+				)).Should(HaveField("ResponseCode", 504))
+			}, "1m", "1s", MustPassRepeatedly(5)).Should(Succeed())
+		},
+			Entry("outbound", fmt.Sprintf(`
 apiVersion: kuma.io/v1alpha1
 kind: MeshTimeout
 metadata:
@@ -123,7 +98,7 @@ spec:
         http:
           requestTimeout: 2s
           maxStreamDuration: 20s`, Config.KumaNamespace, mesh)),
-		Entry("inbound timeout", fmt.Sprintf(`
+			Entry("inbound", fmt.Sprintf(`
 apiVersion: kuma.io/v1alpha1
 kind: MeshTimeout
 metadata:
@@ -142,7 +117,7 @@ spec:
         http:
           requestTimeout: 2s
           maxStreamDuration: 20s`, Config.KumaNamespace, mesh)),
-		Entry("consumer MeshTimeout policy", fmt.Sprintf(`
+			Entry("consumer policy", fmt.Sprintf(`
 apiVersion: kuma.io/v1alpha1
 kind: MeshTimeout
 metadata:
@@ -161,32 +136,10 @@ spec:
         http:
           requestTimeout: 2s
           maxStreamDuration: 20s`, namespace, mesh)),
-	)
-
-	It("should target real MeshService resource", func() {
-		// given no MeshTimeout
-		mts, err := kubernetes.Cluster.GetKumactlOptions().KumactlList("meshtimeouts", mesh)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(mts).To(
-			Or(
-				HaveExactElements(Equal(fmt.Sprintf("mesh-gateways-timeout-all-%s.kuma-system", mesh))),
-				BeEmpty(),
-			),
-		)
-
-		Eventually(func(g Gomega) {
-			start := time.Now()
-			_, err := client.CollectEchoResponse(
-				kubernetes.Cluster, "demo-client", testServerURL,
-				client.FromKubernetesPod(namespace, "demo-client"),
-				client.WithHeader("x-set-response-delay-ms", "5000"),
-				client.WithMaxTime(10),
-			)
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(time.Since(start)).To(BeNumerically(">", time.Second*5))
-		}, "30s", "1s").Should(Succeed())
-
-		timeoutConfig := fmt.Sprintf(`
+			func() []TableEntry { // Some tests don't run with all modes
+				out := []TableEntry{}
+				if mode == mesh_proto.Mesh_MeshServices_Exclusive { // These tests are only valid when using MeshService
+					out = append(out, Entry("producer policy", fmt.Sprintf(`
 apiVersion: kuma.io/v1alpha1
 kind: MeshTimeout
 metadata:
@@ -204,23 +157,13 @@ spec:
         idleTimeout: 20s
         http:
           requestTimeout: 2s
-          maxStreamDuration: 20s`, namespace, mesh, namespace)
-
-		// when
-		Expect(YamlK8s(timeoutConfig)(kubernetes.Cluster)).To(Succeed())
-
-		// then
-		Eventually(func(g Gomega) {
-			response, err := client.CollectFailure(
-				kubernetes.Cluster, "demo-client", testServerURL,
-				client.FromKubernetesPod(namespace, "demo-client"),
-				client.WithHeader("x-set-response-delay-ms", "5000"),
-				client.WithMaxTime(10), // we don't want 'curl' to return early
-			)
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(response.ResponseCode).To(Equal(504))
-		}, "1m", "1s", MustPassRepeatedly(5)).Should(Succeed())
-
-		Expect(DeleteYamlK8s(timeoutConfig)(kubernetes.Cluster)).To(Succeed())
-	})
+          maxStreamDuration: 20s`, namespace, mesh, namespace)))
+				}
+				return out
+			}(),
+		)
+	},
+		Entry("Disabled", mesh_proto.Mesh_MeshServices_Disabled),
+		Entry("Exclusive", mesh_proto.Mesh_MeshServices_Exclusive),
+	)
 }


### PR DESCRIPTION
Improve general tests by removing repetition and systematically delete all policies at the start.

Run some tests that work only on Exclusive and not with other modes

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
