### PR TITLE
test(e2e): output namespace last condition once met deletion timeout

### DIFF
--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -200,13 +200,21 @@ func (c *K8sCluster) WaitNamespaceDelete(namespace string) {
 		c.defaultRetries,
 		c.defaultTimeout,
 		func() (string, error) {
-			_, err := k8s.GetNamespaceE(c.t,
+			nsObject, err := k8s.GetNamespaceE(c.t,
 				c.GetKubectlOptions(),
 				namespace)
 			if err != nil {
-				return "Namespace " + namespace + " deleted", nil
+				if k8s_errors.IsNotFound(err) {
+					return "Namespace " + namespace + " deleted", nil
+				}
+				return "Failed to get Namespace " + namespace, err
 			}
-			return "Namespace available " + namespace, fmt.Errorf("Namespace %s still active", namespace)
+
+			nsLastCondition := ""
+			if len(nsObject.Status.Conditions) != 0 {
+				nsLastCondition = nsObject.Status.Conditions[len(nsObject.Status.Conditions)-1].String()
+			}
+			return "Namespace available " + namespace, fmt.Errorf("Namespace %s still active, last condition: %s", namespace, nsLastCondition)
 		})
 }
 

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -210,7 +210,7 @@ func (c *K8sCluster) WaitNamespaceDelete(namespace string) {
 				return "Failed to get Namespace " + namespace, err
 			}
 
-			nsLastCondition := ""
+			nsLastCondition := "unknown"
 			if len(nsObject.Status.Conditions) != 0 {
 				nsLastCondition = nsObject.Status.Conditions[len(nsObject.Status.Conditions)-1].String()
 			}


### PR DESCRIPTION
We met the `Namespace` deletion timeout but got no obvious messages, let's output the `Namespace.Status.Condition` to see the usefull messages.

Here's a error that we hit in one CI, we spent 360s to delete that namespace and hit the timeout

```text
Zone and Global with Helm chart should deploy Zone and Global on 2 clusters 2024-09-27T14:16:22Z retry.go:91: Wait for kuma-test Namespace to terminate.
Zone and Global with Helm chart should deploy Zone and Global on 2 clusters 2024-09-27T14:16:22Z client.go:45: Configuring Kubernetes client using config file /home/ubuntu/.kube/kind-kuma-2-config with context 
Zone and Global with Helm chart should deploy Zone and Global on 2 clusters 2024-09-27T14:16:22Z retry.go:103: Wait for kuma-test Namespace to terminate. returned an error: Namespace kuma-test still active. Sleeping for 6s and will try again.
  [FAILED] in [AfterAll] - github.com/gruntwork-io/terratest@v0.47.1/modules/retry/retry.go:59 @ 09/27/24 14:16:28.145
• [FAILED] [366.537 seconds]
Zone and Global with Helm chart [AfterAll] should execute admin operations on Global CP [job-2]
  [AfterAll] github.com/kumahq/kuma/test/framework/ginkgo.go:44
  [It] github.com/kumahq/kuma/test/e2e/helm/kuma_helm_deploy_global_zone.go:172

  [FAILED] 'Wait for kuma-test Namespace to terminate.' unsuccessful after 60 retries
```

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
