### PR TITLE
fix(xds): eds deadlock on initial fetch timeout

### DIFF
--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic-gateway.gateway.cluster.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic-gateway.gateway.cluster.golden.yaml
@@ -2,7 +2,6 @@ connectTimeout: 5s
 edsClusterConfig:
   edsConfig:
     ads: {}
-    initialFetchTimeout: 0s
     resourceApiVersion: V3
 name: backend-c58ee0574727fc94
 perConnectionBufferLimitBytes: 32768

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic-gateway.gateway.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic-gateway.gateway.listener.golden.yaml
@@ -56,7 +56,6 @@ filterChains:
       rds:
         configSource:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
         routeConfigName: gateway:HTTP:8080:*
       requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/basic.gateway_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/basic.gateway_cluster.golden.yaml
@@ -13,7 +13,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-26cb64fa4e85e7b7
     perConnectionBufferLimitBytes: 32768

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/real-MeshService-targeted-to-real-MeshService.gateway_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/real-MeshService-targeted-to-real-MeshService.gateway_cluster.golden.yaml
@@ -12,7 +12,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: default_backend___msvc_80-01804e3659fbd290
     perConnectionBufferLimitBytes: 32768

--- a/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/testdata/gateway_basic_listener.golden.yaml
+++ b/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/testdata/gateway_basic_listener.golden.yaml
@@ -56,7 +56,6 @@ filterChains:
       rds:
         configSource:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
         routeConfigName: sample-gateway:HTTP:8080:*
       requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic-meshhttproute.gateway_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic-meshhttproute.gateway_cluster.golden.yaml
@@ -11,7 +11,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     healthChecks:
     - eventLogger:
@@ -68,7 +67,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-945e63bff332f46a
     perConnectionBufferLimitBytes: 32768

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic.gateway_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic.gateway_cluster.golden.yaml
@@ -11,7 +11,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     healthChecks:
     - eventLogger:

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/real-mesh-service-meshhttproute.gateway_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/real-mesh-service-meshhttproute.gateway_cluster.golden.yaml
@@ -10,7 +10,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     healthChecks:
     - eventLogger:

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/real-mesh-service-target-real-mesh-service-meshhttproute.gateway_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/real-mesh-service-target-real-mesh-service-meshhttproute.gateway_cluster.golden.yaml
@@ -10,7 +10,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     healthChecks:
     - eventLogger:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-labels.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-labels.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: default_backend-second___msvc_80
     transportSocket:
@@ -44,7 +43,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: default_backend___msvc_80
     transportSocket:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend
     type: EDS
@@ -20,7 +19,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-c72efb5be46fae6b
     type: EDS
@@ -35,7 +33,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: default_backend___msvc_80
     type: EDS

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend
     type: EDS
@@ -20,7 +19,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-c72efb5be46fae6b
     type: EDS

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: default_example___extsvc_9090
     transportSocket:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: default_multi-backend___mzsvc_80
     transportSocket:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: default_backend___msvc_80
     transportSocket:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-route-outbound-with-tags-with-mtls.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-route-outbound-with-tags-with-mtls.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-c72efb5be46fae6b
     transportSocket:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-route.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-route.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend
     type: EDS

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-default-meshexternalservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-default-meshexternalservice.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: default_example___extsvc_9090
     transportSocket:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.clusters.golden.yaml
@@ -6,7 +6,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-348a834721ead661
     perConnectionBufferLimitBytes: 32768
@@ -25,7 +24,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-6d0a1cf7605e8b1e
     perConnectionBufferLimitBytes: 32768
@@ -44,7 +42,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-a285094d9b0d7032
     perConnectionBufferLimitBytes: 32768
@@ -63,7 +60,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-dda53ef9426194b2
     perConnectionBufferLimitBytes: 32768
@@ -82,7 +78,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-ed49e74a1f66b25c
     perConnectionBufferLimitBytes: 32768
@@ -101,7 +96,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-wild-aac0221a73d6116a
     perConnectionBufferLimitBytes: 32768
@@ -120,7 +114,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-wild-dev-52ee11d917faac3e
     perConnectionBufferLimitBytes: 32768

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-different-hostnames-specific.listeners.golden.yaml
@@ -43,7 +43,6 @@ resources:
           rds:
             configSource:
               ads: {}
-              initialFetchTimeout: 0s
               resourceApiVersion: V3
             routeConfigName: sample-gateway:HTTP:8080:*
           requestHeadersTimeout: 0.500s
@@ -102,7 +101,6 @@ resources:
           rds:
             configSource:
               ads: {}
-              initialFetchTimeout: 0s
               resourceApiVersion: V3
             routeConfigName: sample-gateway:HTTP:8081:*
           requestHeadersTimeout: 0.500s
@@ -161,7 +159,6 @@ resources:
           rds:
             configSource:
               ads: {}
-              initialFetchTimeout: 0s
               resourceApiVersion: V3
             routeConfigName: sample-gateway:HTTP:8082:*
           requestHeadersTimeout: 0.500s
@@ -224,7 +221,6 @@ resources:
           rds:
             configSource:
               ads: {}
-              initialFetchTimeout: 0s
               resourceApiVersion: V3
             routeConfigName: sample-gateway:HTTPS:8083:*.secure.dev
           requestHeadersTimeout: 0.500s
@@ -287,7 +283,6 @@ resources:
           rds:
             configSource:
               ads: {}
-              initialFetchTimeout: 0s
               resourceApiVersion: V3
             routeConfigName: sample-gateway:HTTPS:8083:*.super-secure.dev
           requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-specific.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-specific.clusters.golden.yaml
@@ -6,7 +6,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-26cb64fa4e85e7b7
     perConnectionBufferLimitBytes: 32768

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-specific.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-listener-specific.listeners.golden.yaml
@@ -43,7 +43,6 @@ resources:
           rds:
             configSource:
               ads: {}
-              initialFetchTimeout: 0s
               resourceApiVersion: V3
             routeConfigName: sample-gateway:HTTP:8080:*
           requestHeadersTimeout: 0.500s
@@ -102,7 +101,6 @@ resources:
           rds:
             configSource:
               ads: {}
-              initialFetchTimeout: 0s
               resourceApiVersion: V3
             routeConfigName: sample-gateway:HTTP:8081:*
           requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-real-mesh-service.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-real-mesh-service.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: default_backend___msvc_80-01804e3659fbd290
     perConnectionBufferLimitBytes: 32768

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-real-mesh-service.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-real-mesh-service.listeners.golden.yaml
@@ -43,7 +43,6 @@ resources:
           rds:
             configSource:
               ads: {}
-              initialFetchTimeout: 0s
               resourceApiVersion: V3
             routeConfigName: sample-gateway:HTTP:8080:*
           requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway.clusters.golden.yaml
@@ -6,7 +6,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-26cb64fa4e85e7b7
     perConnectionBufferLimitBytes: 32768

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway.listeners.golden.yaml
@@ -43,7 +43,6 @@ resources:
           rds:
             configSource:
               ads: {}
-              initialFetchTimeout: 0s
               resourceApiVersion: V3
             routeConfigName: sample-gateway:HTTP:8080:*
           requestHeadersTimeout: 0.500s
@@ -102,7 +101,6 @@ resources:
           rds:
             configSource:
               ads: {}
-              initialFetchTimeout: 0s
               resourceApiVersion: V3
             routeConfigName: sample-gateway:HTTP:8081:*
           requestHeadersTimeout: 0.500s
@@ -161,7 +159,6 @@ resources:
           rds:
             configSource:
               ads: {}
-              initialFetchTimeout: 0s
               resourceApiVersion: V3
             routeConfigName: sample-gateway:HTTP:8082:*
           requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/grpc-service.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/grpc-service.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend
     type: EDS

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/headers-match.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/headers-match.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend
     type: EDS

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: default_example___extsvc_9090
     transportSocket:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/match-priority.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/match-priority.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend
     type: EDS

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: default_example___extsvc_9090
     transportSocket:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: default_example___extsvc_9090
     transportSocket:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: default_example___extsvc_9090
     transportSocket:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/mixed-tcp-and-http-outbounds.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/mixed-tcp-and-http-outbounds.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend
     type: EDS

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/request-header-modifiers.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/request-header-modifiers.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend
     type: EDS

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/request-mirror.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/request-mirror.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend
     type: EDS
@@ -20,7 +19,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: payments-9f43ffb3c22f8c19
     type: EDS

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/request-redirect.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/request-redirect.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend
     type: EDS

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/response-header-modifiers.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/response-header-modifiers.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend
     type: EDS

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/url-rewrite.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/url-rewrite.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend
     type: EDS

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/basic.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/basic.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbPolicy: RANDOM
     name: backend

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/basic.gateway.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/basic.gateway.clusters.golden.yaml
@@ -6,7 +6,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbPolicy: RING_HASH
     name: backend-d230d75c0fcb71dc

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/basic.gateway.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/basic.gateway.listeners.golden.yaml
@@ -43,7 +43,6 @@ resources:
           rds:
             configSource:
               ads: {}
-              initialFetchTimeout: 0s
               resourceApiVersion: V3
             routeConfigName: sample-gateway:HTTP:8080:*
           requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/egress.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/egress.clusters.golden.yaml
@@ -6,7 +6,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh-1:eds-cluster
     type: EDS

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/egress_basic.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/egress_basic.clusters.golden.yaml
@@ -6,7 +6,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh-1:eds-cluster
     type: EDS

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware.gateway.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware.gateway.clusters.golden.yaml
@@ -8,7 +8,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-d230d75c0fcb71dc
     perConnectionBufferLimitBytes: 32768

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware.gateway.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware.gateway.listeners.golden.yaml
@@ -43,7 +43,6 @@ resources:
           rds:
             configSource:
               ads: {}
-              initialFetchTimeout: 0s
               resourceApiVersion: V3
             routeConfigName: sample-gateway:HTTP:8080:*
           requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware_basic.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware_basic.clusters.golden.yaml
@@ -7,7 +7,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbPolicy: RANDOM
     name: backend

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware_basic_egress_enabled.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware_basic_egress_enabled.clusters.golden.yaml
@@ -7,7 +7,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbPolicy: RANDOM
     name: backend

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware_cross_zone.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware_cross_zone.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbPolicy: RANDOM
     name: backend

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware_no_cross_zone.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware_no_cross_zone.clusters.golden.yaml
@@ -7,7 +7,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbPolicy: RANDOM
     name: backend

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware_split.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware_split.clusters.golden.yaml
@@ -7,7 +7,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbPolicy: RANDOM
     name: backend-bb38a94289f18fb9
@@ -20,7 +19,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbPolicy: RANDOM
     name: backend-c72efb5be46fae6b

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/no-cross-zone.gateway.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/no-cross-zone.gateway.clusters.golden.yaml
@@ -6,7 +6,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-d230d75c0fcb71dc
     perConnectionBufferLimitBytes: 32768

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/no-cross-zone.gateway.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/no-cross-zone.gateway.listeners.golden.yaml
@@ -43,7 +43,6 @@ resources:
           rds:
             configSource:
               ads: {}
-              initialFetchTimeout: 0s
               resourceApiVersion: V3
             routeConfigName: sample-gateway:HTTP:8080:*
           requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/real-MeshService-targeted-to-real-MeshService.gateway.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/real-MeshService-targeted-to-real-MeshService.gateway.clusters.golden.yaml
@@ -7,7 +7,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: default_backend___msvc_80-65ee15ea276ba345
     perConnectionBufferLimitBytes: 32768

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/real-MeshService-targeted-to-real-MeshService.gateway.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/real-MeshService-targeted-to-real-MeshService.gateway.listeners.golden.yaml
@@ -43,7 +43,6 @@ resources:
           rds:
             configSource:
               ads: {}
-              initialFetchTimeout: 0s
               resourceApiVersion: V3
             routeConfigName: sample-gateway:HTTP:8080:*
           requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/testdata/basic.gateway.listener.golden.yaml
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/testdata/basic.gateway.listener.golden.yaml
@@ -39,7 +39,6 @@ filterChains:
       rds:
         configSource:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
         routeConfigName: sample-gateway:HTTP:8080:*
       requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/testdata/http-route.gateway.listener.golden.yaml
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/testdata/http-route.gateway.listener.golden.yaml
@@ -39,7 +39,6 @@ filterChains:
       rds:
         configSource:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
         routeConfigName: sample-gateway:HTTP:8080:*
       requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/testdata/gateway.http.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/testdata/gateway.http.listeners.golden.yaml
@@ -39,7 +39,6 @@ filterChains:
       rds:
         configSource:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
         routeConfigName: sample-gateway:HTTP:8080:*
       requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/testdata/per-route-configuration.gateway.http.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/testdata/per-route-configuration.gateway.http.listeners.golden.yaml
@@ -39,7 +39,6 @@ filterChains:
       rds:
         configSource:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
         routeConfigName: sample-gateway:HTTP:8080:*
       requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-no-policies.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-no-policies.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend
     type: EDS

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-real-meshservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-real-meshservice.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: default_backend___msvc_80
     type: EDS

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend
     transportSocket:
@@ -44,7 +43,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: default_example___extsvc_9090
     transportSocket:

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/gateway.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/gateway.clusters.golden.yaml
@@ -6,7 +6,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-26cb64fa4e85e7b7
     perConnectionBufferLimitBytes: 32768
@@ -18,7 +17,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: go-backend-1-a3e0f78d6b8a9607
     perConnectionBufferLimitBytes: 32768
@@ -30,7 +28,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: go-backend-2-3568c8790af04ca0
     perConnectionBufferLimitBytes: 32768
@@ -42,7 +39,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: other-backend-d14e06e801b3b5d6
     perConnectionBufferLimitBytes: 32768

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/kafka.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/kafka.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-bb38a94289f18fb9
     type: EDS
@@ -20,7 +19,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-c72efb5be46fae6b
     type: EDS

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/meshhttproute-clash-http-destination.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/meshhttproute-clash-http-destination.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: tcp-backend
     type: EDS

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/meshhttproute-clash-tcp-destination.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/meshhttproute-clash-tcp-destination.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: tcp-backend
     type: EDS

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/redirect-traffic.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/redirect-traffic.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: tcp-backend
     type: EDS

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/split-traffic.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/split-traffic.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-bb38a94289f18fb9
     type: EDS
@@ -20,7 +19,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-c72efb5be46fae6b
     type: EDS
@@ -61,7 +59,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: other-backend
     type: EDS

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend
     transportSocket:
@@ -44,7 +43,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: default_example2___extsvc_9090
     transportSocket:

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/basic.gateway.cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/basic.gateway.cluster.golden.yaml
@@ -2,7 +2,6 @@ connectTimeout: 10s
 edsClusterConfig:
   edsConfig:
     ads: {}
-    initialFetchTimeout: 0s
     resourceApiVersion: V3
 name: backend-26cb64fa4e85e7b7
 perConnectionBufferLimitBytes: 32768

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/basic.gateway.listener.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/basic.gateway.listener.golden.yaml
@@ -39,7 +39,6 @@ filterChains:
       rds:
         configSource:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
         routeConfigName: sample-gateway:HTTP:8080:*
       requestHeadersTimeout: 99s

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/no-default-idle-timeout.gateway.cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/no-default-idle-timeout.gateway.cluster.golden.yaml
@@ -2,7 +2,6 @@ connectTimeout: 10s
 edsClusterConfig:
   edsConfig:
     ads: {}
-    initialFetchTimeout: 0s
     resourceApiVersion: V3
 name: backend-26cb64fa4e85e7b7
 perConnectionBufferLimitBytes: 32768

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/no-default-idle-timeout.gateway.listener.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/no-default-idle-timeout.gateway.listener.golden.yaml
@@ -39,7 +39,6 @@ filterChains:
       rds:
         configSource:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
         routeConfigName: sample-gateway:HTTP:8080:*
       requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/no-route-level-timeouts.gateway.cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/no-route-level-timeouts.gateway.cluster.golden.yaml
@@ -2,7 +2,6 @@ connectTimeout: 5s
 edsClusterConfig:
   edsConfig:
     ads: {}
-    initialFetchTimeout: 0s
     resourceApiVersion: V3
 name: backend-26cb64fa4e85e7b7
 perConnectionBufferLimitBytes: 32768

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/no-route-level-timeouts.gateway.listener.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/no-route-level-timeouts.gateway.listener.golden.yaml
@@ -39,7 +39,6 @@ filterChains:
       rds:
         configSource:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
         routeConfigName: sample-gateway:HTTP:8080:*
       requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/route-level-timeouts.gateway.cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/route-level-timeouts.gateway.cluster.golden.yaml
@@ -2,7 +2,6 @@ connectTimeout: 5s
 edsClusterConfig:
   edsConfig:
     ads: {}
-    initialFetchTimeout: 0s
     resourceApiVersion: V3
 name: backend-26cb64fa4e85e7b7
 perConnectionBufferLimitBytes: 32768

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/route-level-timeouts.gateway.listener.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/route-level-timeouts.gateway.listener.golden.yaml
@@ -39,7 +39,6 @@ filterChains:
       rds:
         configSource:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
         routeConfigName: sample-gateway:HTTP:8080:*
       requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/gateway-tls-version-and-cipher-meshservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/gateway-tls-version-and-cipher-meshservice.clusters.golden.yaml
@@ -5,7 +5,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: default_backend___msvc_80-01804e3659fbd290
     perConnectionBufferLimitBytes: 32768

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/gateway-tls-version-and-cipher-meshservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/gateway-tls-version-and-cipher-meshservice.listeners.golden.yaml
@@ -43,7 +43,6 @@ resources:
           rds:
             configSource:
               ads: {}
-              initialFetchTimeout: 0s
               resourceApiVersion: V3
             routeConfigName: sample-gateway:HTTP:8080:*
           requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/gateway-tls-version-and-cipher.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/gateway-tls-version-and-cipher.clusters.golden.yaml
@@ -6,7 +6,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend-26cb64fa4e85e7b7
     perConnectionBufferLimitBytes: 32768

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/gateway-tls-version-and-cipher.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/gateway-tls-version-and-cipher.listeners.golden.yaml
@@ -43,7 +43,6 @@ resources:
           rds:
             configSource:
               ads: {}
-              initialFetchTimeout: 0s
               resourceApiVersion: V3
             routeConfigName: sample-gateway:HTTP:8080:*
           requestHeadersTimeout: 0.500s

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/simple-gateway.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/simple-gateway.listeners.golden.yaml
@@ -39,7 +39,6 @@ filterChains:
       rds:
         configSource:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
         routeConfigName: sample-gateway:HTTP:8080:*
       requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/01-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/01-gateway-listener.yaml
@@ -46,7 +46,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/02-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/02-gateway-listener.yaml
@@ -46,7 +46,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s
@@ -103,7 +102,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:9090:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/03-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/03-gateway-listener.yaml
@@ -61,7 +61,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: tracing-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/04-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/04-gateway-listener.yaml
@@ -55,7 +55,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: logging-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/05-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/05-gateway-listener.yaml
@@ -50,7 +50,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: default-gateway:HTTPS:443:bar.example.com
             requestHeadersTimeout: 0.500s
@@ -113,7 +112,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: default-gateway:HTTPS:443:foo.example.com
             requestHeadersTimeout: 0.500s
@@ -176,7 +174,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: default-gateway:HTTPS:443:*.example.com
             requestHeadersTimeout: 0.500s
@@ -237,7 +234,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: default-gateway:HTTPS:443:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -87,7 +86,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -87,7 +86,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -87,7 +86,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-mirror-90205ae37cc0294e
       perConnectionBufferLimitBytes: 32768
@@ -36,7 +35,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -114,7 +112,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/05-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/05-gateway-route.yaml
@@ -46,7 +46,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-mirror-90205ae37cc0294e
       perConnectionBufferLimitBytes: 32768
@@ -36,7 +35,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -114,7 +112,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -87,7 +86,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: exact-service-6c25eaca226749f3
       perConnectionBufferLimitBytes: 32768
@@ -36,7 +35,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: prefix-service-bfa07e23a84b267b
       perConnectionBufferLimitBytes: 32768
@@ -128,7 +126,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -87,7 +86,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: absent-header-match-327fbb6df03159bd
       perConnectionBufferLimitBytes: 32768
@@ -36,7 +35,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: exact-header-match-d7c910a2e5559eda
       perConnectionBufferLimitBytes: 32768
@@ -61,7 +59,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: present-header-match-b3e34381a1779ec6
       perConnectionBufferLimitBytes: 32768
@@ -86,7 +83,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: regex-header-match-70561bb2da83c870
       perConnectionBufferLimitBytes: 32768
@@ -210,7 +206,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: exact-query-match-36212e4e8ec491f1
       perConnectionBufferLimitBytes: 32768
@@ -36,7 +35,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: regex-query-match-2c070f45017d23a5
       perConnectionBufferLimitBytes: 32768
@@ -128,7 +126,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -87,7 +86,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-exact-0c6c646106bd51f3
       perConnectionBufferLimitBytes: 32768
@@ -36,7 +35,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-prefix-1d3cd70bb04bf6e2
       perConnectionBufferLimitBytes: 32768
@@ -61,7 +59,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-regex-197ed2f99640f307
       perConnectionBufferLimitBytes: 32768
@@ -169,7 +166,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -87,7 +86,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: api-service-4508437668c35ed8
       perConnectionBufferLimitBytes: 32768
@@ -34,7 +33,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-mirror-3dd740a2de879d4c
       perConnectionBufferLimitBytes: 32768
@@ -57,7 +55,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -163,7 +160,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/16-gateway-route.yaml
@@ -8,7 +8,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: api-service-4508437668c35ed8
       outlierDetection:
@@ -38,7 +37,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-mirror-3dd740a2de879d4c
       outlierDetection:
@@ -68,7 +66,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       outlierDetection:
@@ -184,7 +181,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       healthChecks:
       - healthyThreshold: 2
@@ -42,7 +41,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       healthChecks:
       - healthyThreshold: 3
@@ -73,7 +71,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       healthChecks:
       - healthyThreshold: 1
@@ -187,7 +184,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/18-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/18-gateway-route.yaml
@@ -83,7 +83,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/19-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/19-gateway-route.yaml
@@ -97,7 +97,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-4d89cd662308223d
       perConnectionBufferLimitBytes: 32768
@@ -34,7 +33,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-11405a82852416ac
       perConnectionBufferLimitBytes: 32768
@@ -57,7 +55,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-ff1f8bb571f3bfa4
       perConnectionBufferLimitBytes: 32768
@@ -163,7 +160,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: gateway-multihost:HTTP:9080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/21-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/21-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: api-service-4508437668c35ed8
       perConnectionBufferLimitBytes: 32768
@@ -36,7 +35,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-mirror-3dd740a2de879d4c
       perConnectionBufferLimitBytes: 32768
@@ -61,7 +59,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -169,7 +166,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/22-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/22-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: api-service-ebbb1519109a5d70
       perConnectionBufferLimitBytes: 32768
@@ -36,7 +35,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-b70526a3f546ce4f
       perConnectionBufferLimitBytes: 32768
@@ -128,7 +126,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/23-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/23-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: api-service-ebbb1519109a5d70
       perConnectionBufferLimitBytes: 32768
@@ -36,7 +35,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-86192ff3ecc578b7
       perConnectionBufferLimitBytes: 32768
@@ -61,7 +59,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-b70526a3f546ce4f
       perConnectionBufferLimitBytes: 32768
@@ -169,7 +166,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/24-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/24-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: api-service-4508437668c35ed8
       perConnectionBufferLimitBytes: 32768
@@ -36,7 +35,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -128,7 +126,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/25-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/25-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: external-http2-httpbin-b70cd456b09f96ac
       perConnectionBufferLimitBytes: 32768
@@ -111,7 +110,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/26-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/26-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: external-http2-httpbin-b70cd456b09f96ac
       perConnectionBufferLimitBytes: 32768
@@ -95,7 +94,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/cross-mesh-gateway.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/cross-mesh-gateway.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-0ec9724567ed6087
       perConnectionBufferLimitBytes: 32768
@@ -60,7 +59,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-8acee1c4ccf209c2
       perConnectionBufferLimitBytes: 32768
@@ -109,7 +107,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-bfae5b64a0fe8b74
       perConnectionBufferLimitBytes: 32768
@@ -398,7 +395,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s
@@ -477,7 +473,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8081:*
             requestHeadersTimeout: 0.500s
@@ -556,7 +551,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8082:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/drop-prefix-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/drop-prefix-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -87,7 +86,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/external-service-with-timeout-no-egress.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/external-service-with-timeout-no-egress.yaml
@@ -96,7 +96,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/external-service-without-default-traffic-permission.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/external-service-without-default-traffic-permission.yaml
@@ -83,7 +83,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/http-tcp-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/http-tcp-route.yaml
@@ -46,7 +46,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/no-timeout.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/no-timeout.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -85,7 +84,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/response-header-set-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/response-header-set-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -87,7 +86,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/retry-policy.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/retry-policy.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: api-service-4508437668c35ed8
       perConnectionBufferLimitBytes: 32768
@@ -36,7 +35,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-mirror-3dd740a2de879d4c
       perConnectionBufferLimitBytes: 32768
@@ -61,7 +59,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -169,7 +166,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -87,7 +86,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-root-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-root-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -87,7 +86,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-trailing-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-trailing-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -87,7 +86,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/sni-isolation-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/sni-isolation-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-4d89cd662308223d
       perConnectionBufferLimitBytes: 32768
@@ -36,7 +35,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-ff1f8bb571f3bfa4
       perConnectionBufferLimitBytes: 32768
@@ -128,7 +126,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: gateway-multihost:HTTP:9080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/http/unresolved-backend.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/unresolved-backend.yaml
@@ -46,7 +46,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -87,7 +86,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -87,7 +86,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -91,7 +90,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-mirror-90205ae37cc0294e
       perConnectionBufferLimitBytes: 32768
@@ -36,7 +35,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -118,7 +116,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/05-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/05-gateway-route.yaml
@@ -50,7 +50,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-mirror-90205ae37cc0294e
       perConnectionBufferLimitBytes: 32768
@@ -36,7 +35,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -118,7 +116,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -91,7 +90,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: exact-service-6c25eaca226749f3
       perConnectionBufferLimitBytes: 32768
@@ -36,7 +35,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: prefix-service-bfa07e23a84b267b
       perConnectionBufferLimitBytes: 32768
@@ -132,7 +130,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -91,7 +90,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: absent-header-match-327fbb6df03159bd
       perConnectionBufferLimitBytes: 32768
@@ -36,7 +35,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: exact-header-match-d7c910a2e5559eda
       perConnectionBufferLimitBytes: 32768
@@ -61,7 +59,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: present-header-match-b3e34381a1779ec6
       perConnectionBufferLimitBytes: 32768
@@ -86,7 +83,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: regex-header-match-70561bb2da83c870
       perConnectionBufferLimitBytes: 32768
@@ -214,7 +210,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: exact-query-match-36212e4e8ec491f1
       perConnectionBufferLimitBytes: 32768
@@ -36,7 +35,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: regex-query-match-2c070f45017d23a5
       perConnectionBufferLimitBytes: 32768
@@ -132,7 +130,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -91,7 +90,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-exact-0c6c646106bd51f3
       perConnectionBufferLimitBytes: 32768
@@ -36,7 +35,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-prefix-1d3cd70bb04bf6e2
       perConnectionBufferLimitBytes: 32768
@@ -61,7 +59,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-regex-197ed2f99640f307
       perConnectionBufferLimitBytes: 32768
@@ -173,7 +170,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -91,7 +90,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: api-service-4508437668c35ed8
       perConnectionBufferLimitBytes: 32768
@@ -34,7 +33,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-mirror-3dd740a2de879d4c
       perConnectionBufferLimitBytes: 32768
@@ -57,7 +55,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -167,7 +164,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
@@ -8,7 +8,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: api-service-4508437668c35ed8
       outlierDetection:
@@ -38,7 +37,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-mirror-3dd740a2de879d4c
       outlierDetection:
@@ -68,7 +66,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       outlierDetection:
@@ -188,7 +185,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       healthChecks:
       - healthyThreshold: 2
@@ -42,7 +41,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       healthChecks:
       - healthyThreshold: 3
@@ -73,7 +71,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       healthChecks:
       - healthyThreshold: 1
@@ -191,7 +188,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
@@ -87,7 +87,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
@@ -101,7 +101,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-4d89cd662308223d
       perConnectionBufferLimitBytes: 32768
@@ -34,7 +33,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-11405a82852416ac
       perConnectionBufferLimitBytes: 32768
@@ -57,7 +55,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-ff1f8bb571f3bfa4
       perConnectionBufferLimitBytes: 32768
@@ -167,7 +164,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: gateway-multihost:HTTPS:9443:one.example.com
             requestHeadersTimeout: 0.500s
@@ -230,7 +226,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: gateway-multihost:HTTPS:9443:three.example.com
             requestHeadersTimeout: 0.500s
@@ -293,7 +288,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: gateway-multihost:HTTPS:9443:two.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/21-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/21-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: api-service-4508437668c35ed8
       perConnectionBufferLimitBytes: 32768
@@ -36,7 +35,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-mirror-3dd740a2de879d4c
       perConnectionBufferLimitBytes: 32768
@@ -61,7 +59,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -173,7 +170,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/22-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/22-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: api-service-ebbb1519109a5d70
       perConnectionBufferLimitBytes: 32768
@@ -36,7 +35,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-b70526a3f546ce4f
       perConnectionBufferLimitBytes: 32768
@@ -128,7 +126,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/23-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/23-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: api-service-ebbb1519109a5d70
       perConnectionBufferLimitBytes: 32768
@@ -36,7 +35,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-86192ff3ecc578b7
       perConnectionBufferLimitBytes: 32768
@@ -61,7 +59,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-b70526a3f546ce4f
       perConnectionBufferLimitBytes: 32768
@@ -169,7 +166,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/24-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/24-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: api-service-4508437668c35ed8
       perConnectionBufferLimitBytes: 32768
@@ -36,7 +35,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -128,7 +126,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/25-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/25-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: external-http2-httpbin-b70cd456b09f96ac
       perConnectionBufferLimitBytes: 32768
@@ -115,7 +114,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/26-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/26-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: external-http2-httpbin-b70cd456b09f96ac
       perConnectionBufferLimitBytes: 32768
@@ -99,7 +98,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/cross-mesh-gateway.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/cross-mesh-gateway.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-0ec9724567ed6087
       perConnectionBufferLimitBytes: 32768
@@ -60,7 +59,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-8acee1c4ccf209c2
       perConnectionBufferLimitBytes: 32768
@@ -109,7 +107,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-bfae5b64a0fe8b74
       perConnectionBufferLimitBytes: 32768
@@ -398,7 +395,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s
@@ -477,7 +473,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8081:*
             requestHeadersTimeout: 0.500s
@@ -556,7 +551,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8082:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/drop-prefix-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/drop-prefix-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -91,7 +90,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/external-service-with-timeout-no-egress.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/external-service-with-timeout-no-egress.yaml
@@ -96,7 +96,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTP:8080:*
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/external-service-without-default-traffic-permission.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/external-service-without-default-traffic-permission.yaml
@@ -87,7 +87,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/http-tcp-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/http-tcp-route.yaml
@@ -50,7 +50,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/no-timeout.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/no-timeout.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -89,7 +88,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/response-header-set-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/response-header-set-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -91,7 +90,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/retry-policy.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/retry-policy.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: api-service-4508437668c35ed8
       perConnectionBufferLimitBytes: 32768
@@ -36,7 +35,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-mirror-3dd740a2de879d4c
       perConnectionBufferLimitBytes: 32768
@@ -61,7 +59,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -173,7 +170,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -91,7 +90,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-root-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-root-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -91,7 +90,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-trailing-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-trailing-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -91,7 +90,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/sni-isolation-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/sni-isolation-gateway-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-4d89cd662308223d
       perConnectionBufferLimitBytes: 32768
@@ -36,7 +35,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-ff1f8bb571f3bfa4
       perConnectionBufferLimitBytes: 32768
@@ -132,7 +130,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: gateway-multihost:HTTPS:9443:one.example.com
             requestHeadersTimeout: 0.500s
@@ -195,7 +192,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: gateway-multihost:HTTPS:9443:three.example.com
             requestHeadersTimeout: 0.500s
@@ -258,7 +254,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: gateway-multihost:HTTPS:9443:two.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/https/unresolved-backend.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/unresolved-backend.yaml
@@ -50,7 +50,6 @@ Listeners:
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: edge-gateway:HTTPS:8080:echo.example.com
             requestHeadersTimeout: 0.500s

--- a/pkg/plugins/runtime/gateway/testdata/tcp/tcp-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/tcp/tcp-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: api-service-4508437668c35ed8
       perConnectionBufferLimitBytes: 32768
@@ -51,7 +50,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-9f149ed9e14091ca
       perConnectionBufferLimitBytes: 32768
@@ -91,7 +89,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: external-no-protocol-httpbin-6a3325e78573377c
       perConnectionBufferLimitBytes: 32768

--- a/pkg/plugins/runtime/gateway/testdata/tls/tcp-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/tls/tcp-route.yaml
@@ -11,7 +11,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: api-service-ec4b46e15b91ec0d
       perConnectionBufferLimitBytes: 32768
@@ -51,7 +50,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: echo-service-6376c7d971a22370
       perConnectionBufferLimitBytes: 32768
@@ -91,7 +89,6 @@ Clusters:
       edsClusterConfig:
         edsConfig:
           ads: {}
-          initialFetchTimeout: 0s
           resourceApiVersion: V3
       name: external-tcp-httpbin-bcf553986bd60283
       perConnectionBufferLimitBytes: 32768

--- a/pkg/xds/envoy/clusters/v3/circuit_breaker_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/circuit_breaker_configurer_test.go
@@ -59,7 +59,6 @@ var _ = Describe("CircuitBreakerConfigurer", func() {
         edsClusterConfig:
           edsConfig:
             ads: {}
-            initialFetchTimeout: 0s
             resourceApiVersion: V3
         name: backend
         type: EDS`,

--- a/pkg/xds/envoy/clusters/v3/client_side_mtls_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/client_side_mtls_configurer_test.go
@@ -64,7 +64,6 @@ var _ = Describe("EdsClusterConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             name: testCluster
             transportSocket:
@@ -126,7 +125,6 @@ var _ = Describe("EdsClusterConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             name: testCluster
             transportSocketMatches:
@@ -216,7 +214,6 @@ var _ = Describe("EdsClusterConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             name: testCluster
             transportSocket:

--- a/pkg/xds/envoy/clusters/v3/client_side_tls_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/client_side_tls_configurer_test.go
@@ -66,7 +66,6 @@ var _ = Describe("ClientSideTLSConfigurer", func() {
         edsClusterConfig:
           edsConfig:
             ads: {}
-            initialFetchTimeout: 0s
             resourceApiVersion: V3
         name: testCluster
         transportSocketMatches:
@@ -99,7 +98,6 @@ var _ = Describe("ClientSideTLSConfigurer", func() {
         edsClusterConfig:
           edsConfig:
             ads: {}
-            initialFetchTimeout: 0s
             resourceApiVersion: V3
         name: testCluster
         transportSocketMatches:
@@ -138,7 +136,6 @@ var _ = Describe("ClientSideTLSConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             name: testCluster
             transportSocketMatches:
@@ -197,7 +194,6 @@ var _ = Describe("ClientSideTLSConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             name: testCluster
             transportSocketMatches:
@@ -259,7 +255,6 @@ var _ = Describe("ClientSideTLSConfigurer", func() {
               connectTimeout: 5s
               edsClusterConfig:
                   edsConfig:
-                      initialFetchTimeout: 0s
                       ads: {}
                       resourceApiVersion: V3
               name: testCluster

--- a/pkg/xds/envoy/clusters/v3/eds_cluster_configurer.go
+++ b/pkg/xds/envoy/clusters/v3/eds_cluster_configurer.go
@@ -3,7 +3,6 @@ package clusters
 import (
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 type EdsClusterConfigurer struct{}
@@ -18,7 +17,6 @@ func (e *EdsClusterConfigurer) Configure(c *envoy_cluster.Cluster) error {
 			ConfigSourceSpecifier: &envoy_core.ConfigSource_Ads{
 				Ads: &envoy_core.AggregatedConfigSource{},
 			},
-			InitialFetchTimeout: durationpb.New(0),
 		},
 	}
 	return nil

--- a/pkg/xds/envoy/clusters/v3/eds_cluster_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/eds_cluster_configurer_test.go
@@ -20,7 +20,6 @@ var _ = Describe("EdsClusterConfigurer", func() {
         edsClusterConfig:
           edsConfig:
             ads: {}
-            initialFetchTimeout: 0s
             resourceApiVersion: V3
         name: test:cluster
         type: EDS`

--- a/pkg/xds/envoy/clusters/v3/health_check_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/health_check_configurer_test.go
@@ -45,7 +45,6 @@ var _ = Describe("HealthCheckConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             name: testCluster
             type: EDS`,
@@ -74,7 +73,6 @@ var _ = Describe("HealthCheckConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             healthChecks:
             - healthyThreshold: 2
@@ -118,7 +116,6 @@ var _ = Describe("HealthCheckConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             healthChecks:
             - healthyThreshold: 2
@@ -161,7 +158,6 @@ var _ = Describe("HealthCheckConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             healthChecks:
             - healthyThreshold: 2
@@ -214,7 +210,6 @@ var _ = Describe("HealthCheckConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             healthChecks:
             - healthyThreshold: 2
@@ -283,7 +278,6 @@ var _ = Describe("HealthCheckConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             healthChecks:
             - healthyThreshold: 2
@@ -341,7 +335,6 @@ var _ = Describe("HealthCheckConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             healthChecks:
             - healthyThreshold: 2
@@ -382,7 +375,6 @@ var _ = Describe("HealthCheckConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             healthChecks:
             - healthyThreshold: 2
@@ -423,7 +415,6 @@ var _ = Describe("HealthCheckConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             healthChecks:
             - healthyThreshold: 2
@@ -460,7 +451,6 @@ var _ = Describe("HealthCheckConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             healthChecks:
             - alwaysLogHealthCheckFailures: true

--- a/pkg/xds/envoy/clusters/v3/lb_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/lb_configurer_test.go
@@ -44,7 +44,6 @@ var _ = Describe("Lb", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             name: backend
             type: EDS`,
@@ -63,7 +62,6 @@ var _ = Describe("Lb", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             lbPolicy: LEAST_REQUEST
             leastRequestLbConfig:
@@ -81,7 +79,6 @@ var _ = Describe("Lb", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             lbPolicy: LEAST_REQUEST
             leastRequestLbConfig:
@@ -105,7 +102,6 @@ var _ = Describe("Lb", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             lbPolicy: RING_HASH
             name: backend
@@ -125,7 +121,6 @@ var _ = Describe("Lb", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             lbPolicy: RANDOM
             name: backend
@@ -141,7 +136,6 @@ var _ = Describe("Lb", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             lbPolicy: MAGLEV
             name: backend

--- a/pkg/xds/envoy/clusters/v3/lb_subset_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/lb_subset_configurer_test.go
@@ -42,7 +42,6 @@ var _ = Describe("LbSubset", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             name: backend
             type: EDS`,
@@ -58,7 +57,6 @@ var _ = Describe("LbSubset", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             lbSubsetConfig:
               fallbackPolicy: ANY_ENDPOINT

--- a/pkg/xds/envoy/clusters/v3/outlier_detection_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/outlier_detection_configurer_test.go
@@ -50,7 +50,6 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             name: backend
             outlierDetection:
@@ -77,7 +76,6 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             name: backend
             outlierDetection:
@@ -104,7 +102,6 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             name: backend
             outlierDetection:
@@ -133,7 +130,6 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             name: backend
             outlierDetection:
@@ -163,7 +159,6 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             name: backend
             outlierDetection:
@@ -195,7 +190,6 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             name: backend
             outlierDetection:
@@ -226,7 +220,6 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             name: backend
             outlierDetection:
@@ -258,7 +251,6 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
             edsClusterConfig:
               edsConfig:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
             name: backend
             outlierDetection:

--- a/pkg/xds/envoy/clusters/v3/timeout_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/timeout_configurer_test.go
@@ -95,7 +95,6 @@ connectTimeout: 100s
 edsClusterConfig:
   edsConfig:
     ads: {}
-    initialFetchTimeout: 0s
     resourceApiVersion: V3
 name: backend
 type: EDS
@@ -113,7 +112,6 @@ connectTimeout: 5s
 edsClusterConfig:
   edsConfig:
     ads: {}
-    initialFetchTimeout: 0s
     resourceApiVersion: V3
 name: backend
 type: EDS
@@ -130,7 +128,6 @@ connectTimeout: 100s
 edsClusterConfig:
   edsConfig:
     ads: {}
-    initialFetchTimeout: 0s
     resourceApiVersion: V3
 name: backend
 type: EDS
@@ -165,7 +162,6 @@ connectTimeout: 100s
 edsClusterConfig:
   edsConfig:
     ads: {}
-    initialFetchTimeout: 0s
     resourceApiVersion: V3
 name: backend
 type: EDS
@@ -183,7 +179,6 @@ connectTimeout: 5s
 edsClusterConfig:
   edsConfig:
     ads: {}
-    initialFetchTimeout: 0s
     resourceApiVersion: V3
 name: backend
 type: EDS
@@ -200,7 +195,6 @@ connectTimeout: 100s
 edsClusterConfig:
   edsConfig:
     ads: {}
-    initialFetchTimeout: 0s
     resourceApiVersion: V3
 name: backend
 type: EDS

--- a/pkg/xds/envoy/listeners/v3/http_route_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/http_route_configurer.go
@@ -6,7 +6,6 @@ import (
 	envoy_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/pkg/errors"
-	"google.golang.org/protobuf/types/known/durationpb"
 
 	envoy_routes "github.com/kumahq/kuma/pkg/xds/envoy/routes"
 )
@@ -53,7 +52,6 @@ func (c *HttpDynamicRouteConfigurer) Configure(filterChain *envoy_listener.Filte
 					ConfigSourceSpecifier: &envoy_core.ConfigSource_Ads{
 						Ads: &envoy_core.AggregatedConfigSource{},
 					},
-					InitialFetchTimeout: durationpb.New(0),
 				},
 			},
 		}

--- a/pkg/xds/envoy/listeners/v3/http_route_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_route_configurer_test.go
@@ -44,7 +44,6 @@ var _ = Describe("HttpDynamicRouteConfigurer", func() {
             rds:
               configSource:
                 ads: {}
-                initialFetchTimeout: 0s
                 resourceApiVersion: V3
               routeConfigName: routes/inbound
             statPrefix: inbound

--- a/pkg/xds/generator/egress/testdata/02.internalservice-only.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/02.internalservice-only.golden.yaml
@@ -7,7 +7,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh-1:service-in-zone-2
     type: EDS

--- a/pkg/xds/generator/egress/testdata/03.mixed-services.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/03.mixed-services.golden.yaml
@@ -93,7 +93,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh-1:service-1-zone-2
     type: EDS
@@ -105,7 +104,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh-1:service-2-zone-2
     type: EDS

--- a/pkg/xds/generator/egress/testdata/05.mixed-services-with-custom-trafficpermissions.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/05.mixed-services-with-custom-trafficpermissions.golden.yaml
@@ -93,7 +93,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh-1:service-1-zone-2
     type: EDS
@@ -105,7 +104,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh-1:service-2-zone-2
     type: EDS

--- a/pkg/xds/generator/egress/testdata/06.mixed-services-with-external-in-other-zone.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/06.mixed-services-with-external-in-other-zone.golden.yaml
@@ -38,7 +38,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh-1:externalservice-2
     type: EDS
@@ -50,7 +49,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh-1:service-1-zone-2
     type: EDS
@@ -62,7 +60,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh-1:service-2-zone-2
     type: EDS

--- a/pkg/xds/generator/egress/testdata/subsets-with-meshhttproute.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/subsets-with-meshhttproute.golden.yaml
@@ -7,7 +7,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbSubsetConfig:
       fallbackPolicy: ANY_ENDPOINT

--- a/pkg/xds/generator/egress/testdata/traffic-by-default-meshhttproute.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/traffic-by-default-meshhttproute.golden.yaml
@@ -7,7 +7,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh-1:service-in-zone-2
     type: EDS

--- a/pkg/xds/generator/testdata/ingress/01.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/01.envoy.golden.yaml
@@ -7,7 +7,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh1:backend
     type: EDS

--- a/pkg/xds/generator/testdata/ingress/03.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/03.envoy.golden.yaml
@@ -7,7 +7,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbSubsetConfig:
       fallbackPolicy: ANY_ENDPOINT

--- a/pkg/xds/generator/testdata/ingress/04.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/04.envoy.golden.yaml
@@ -7,7 +7,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbSubsetConfig:
       fallbackPolicy: ANY_ENDPOINT
@@ -28,7 +27,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh2:backend
     type: EDS
@@ -40,7 +38,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbSubsetConfig:
       fallbackPolicy: ANY_ENDPOINT

--- a/pkg/xds/generator/testdata/ingress/05.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/05.envoy.golden.yaml
@@ -7,7 +7,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh1:backend
     type: EDS

--- a/pkg/xds/generator/testdata/ingress/mesh-service.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/mesh-service.envoy.golden.yaml
@@ -6,7 +6,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: default_backend___msvc_80
     type: EDS
@@ -17,7 +16,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: default_backend__east_msvc_80
     type: EDS

--- a/pkg/xds/generator/testdata/ingress/meshgateway.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/meshgateway.envoy.golden.yaml
@@ -7,7 +7,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh1:backend
     type: EDS
@@ -19,7 +18,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: mesh2:mesh-gateway
     type: EDS

--- a/pkg/xds/generator/testdata/ingress/virtual-outbound.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/virtual-outbound.envoy.golden.yaml
@@ -7,7 +7,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbSubsetConfig:
       fallbackPolicy: ANY_ENDPOINT

--- a/pkg/xds/generator/testdata/ingress/with-meshhttproute-subset.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/with-meshhttproute-subset.envoy.golden.yaml
@@ -7,7 +7,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbSubsetConfig:
       fallbackPolicy: ANY_ENDPOINT

--- a/pkg/xds/generator/testdata/ingress/with-meshhttproute.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/with-meshhttproute.envoy.golden.yaml
@@ -7,7 +7,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbSubsetConfig:
       fallbackPolicy: ANY_ENDPOINT

--- a/pkg/xds/generator/testdata/ingress/with-meshtcproute-subset.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/with-meshtcproute-subset.envoy.golden.yaml
@@ -7,7 +7,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbSubsetConfig:
       fallbackPolicy: ANY_ENDPOINT

--- a/pkg/xds/generator/testdata/outbound-proxy/03.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/03.envoy.golden.yaml
@@ -6,7 +6,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbPolicy: RANDOM
     name: api-grpc
@@ -26,7 +25,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: api-http
     outlierDetection:
@@ -50,7 +48,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbPolicy: RING_HASH
     name: api-http2
@@ -73,7 +70,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbPolicy: LEAST_REQUEST
     leastRequestLbConfig:
@@ -92,7 +88,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbPolicy: MAGLEV
     name: backend
@@ -109,7 +104,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: db-c182dd9f4bf584d7
     type: EDS
@@ -125,7 +119,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: db-f7d9086d4169338b
     type: EDS

--- a/pkg/xds/generator/testdata/outbound-proxy/04.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/04.envoy.golden.yaml
@@ -6,7 +6,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: api-http
     outlierDetection:
@@ -54,7 +53,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbPolicy: LEAST_REQUEST
     leastRequestLbConfig:
@@ -97,7 +95,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbPolicy: MAGLEV
     name: backend
@@ -138,7 +135,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: db-c182dd9f4bf584d7
     transportSocket:
@@ -178,7 +174,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: db-f7d9086d4169338b
     transportSocket:

--- a/pkg/xds/generator/testdata/outbound-proxy/09.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/09.envoy.golden.yaml
@@ -6,7 +6,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: api-http-5637c619d2781fec_mesh2
     outlierDetection:

--- a/pkg/xds/generator/testdata/outbound-proxy/10.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/10.envoy.golden.yaml
@@ -6,7 +6,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     lbPolicy: MAGLEV
     name: backend

--- a/pkg/xds/generator/testdata/outbound-proxy/cluster-dots.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/cluster-dots.envoy.golden.yaml
@@ -7,7 +7,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: backend.kuma-system
     type: EDS
@@ -23,7 +22,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: db-104dbb63d60dfdfa
     type: EDS

--- a/pkg/xds/generator/testdata/profile-source/1-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/1-envoy-config.golden.yaml
@@ -6,7 +6,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: db
     transportSocket:
@@ -46,7 +45,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     healthChecks:
     - healthyThreshold: 2

--- a/pkg/xds/generator/testdata/profile-source/2-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/2-envoy-config.golden.yaml
@@ -6,7 +6,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: db
     transportSocket:
@@ -46,7 +45,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     healthChecks:
     - healthyThreshold: 2

--- a/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
@@ -6,7 +6,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: db
     transportSocket:
@@ -46,7 +45,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     healthChecks:
     - healthyThreshold: 2

--- a/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
@@ -6,7 +6,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     name: db
     transportSocket:
@@ -46,7 +45,6 @@ resources:
     edsClusterConfig:
       edsConfig:
         ads: {}
-        initialFetchTimeout: 0s
         resourceApiVersion: V3
     healthChecks:
     - healthyThreshold: 2


### PR DESCRIPTION
### Checklist prior to review

In the recent Kuma patch version (2.8.3, 2.7.7, 2.6.11, 2.5.10) we shipped initial fetch timeout set to 0s.
https://github.com/kumahq/kuma/pull/11024
The reason for this change was to have a better consistency for the xds config. To be specific - to not make Envoy ready unless we have the initial config.
However, we did not anticipate one edge case.

We have “superset” logic in go-control-plane
https://github.com/envoyproxy/go-control-plane/blob/main/pkg/cache/v3/simple.go#L483
If Envoy sends a request `EDS[resourceNames=“X”]`, but in the `SnapshotCache` we have EDS for cluster X and Y we just ignore responding, because “it is expected that envoy makes another request”. How so and why can we expect it?

Before we set snapshot to SnapshotCache we validate it with `Consistent()` that every EDS is referenced by the EDS Cluster, so it’s 1:1 from the CP side.

If by any chance we’ve received `EDS[X]` with `EDS[X,Y]` in SnapshotCache it means that
* We first set `Snapshot(EDS[X], CDS[X])` to cache, sent CDS to Envoy
* We then very quickly set `Snapshot(EDS[X,Y], CDS[X,Y])` to the cache
* Then we received `EDS[X]` from Envoy to warm the X cluster.
* We drop responding while waiting for “expected” EDS

So… why can’t we respond with `EDS[X,Y]` for `EDS[X]`? It’s because of versioning. Let’s see what would happen if we do
* CP responds with `EDS[resources=<X,Y>, version=1]`
* Envoy will discard endpoints for Y, because it does not know about Y yet and sent EDS ACK for version 1
* Envoy then sends CDS to learn about other cluster and gets cluster Y
* Envoy sends `EDS[X,Y]` request with last known version = 1
* Here we expect that CP responds with `EDS[X,Y]`, but it won’t because the version of it is the same as last ACK from Envoy

Why can we expect Envoy to make “another request”? It’s initial fetch timeout. Whenever Envoy receives a new cluster, it sends EDS to warm it. It then waits for 15s by default to receive EDS response. If it does not receive it, it gives up, starts the cluster with empty EDS.
If we set initial fetch timeout to 0s, it waits forever for EDS response.
The real problem here is that while it’s waiting for EDS for cluster X it seems to stop CDS, so we can never push cluster Y, so we never send EDS[X,Y] to warm both cluster. We have a deadlock.

If you are reading this issue and want to apply fix without update, you can use MeshProxyPatch
```
kind: MeshProxyPatch
apiVersion: kuma.io/v1alpha1
metadata:
  name: initial-fetch-timeout
  namespace: kuma-system
spec:
  targetRef:
    kind: Mesh
  default:
    appendModifications:
      - cluster:
          match:
            origin: outbound
          operation: Patch
          value: |-
            edsClusterConfig:
              edsConfig:
                ads: {}
                initialFetchTimeout: 15s
                resourceApiVersion: V3
```

This PR get rids of initial fetch timeout on EDS.
One potential solution to have a consistency of config is to deliver `kuma:readiness` Cluster as EDS cluster, so that Envoy will be ready when first EDS for all clusters is delivered. However, it's better to test it out first for a while on master branch.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
