### PR TITLE
fix(inspect-api): don't panic when outbound doesn't have 'kuma.io/service' tag

### DIFF
--- a/pkg/core/xds/inspect/rules.go
+++ b/pkg/core/xds/inspect/rules.go
@@ -106,6 +106,12 @@ func getOutboundRuleAttachments(rules core_rules.Rules, networking *mesh_proto.D
 	byUniqueClusterName := map[string]*RuleAttachment{}
 	for _, outbound := range networking.Outbound {
 		outboundTags := outbound.GetTags()
+		if _, ok := outboundTags[mesh_proto.ServiceTag]; !ok {
+			// RuleAttachment is part of the old '/rules' API that doesn't support referencing real resources.
+			// That's why we're skipping outbounds with 'backendRef' (they don't have 'kuma.io/service' tag).
+			// For the real resource referencing check '/_rules' endpoint.
+			continue
+		}
 		name, err := tags.Tags(outboundTags).DestinationClusterName(nil)
 		if err != nil {
 			// Error is impossible here (there's always a service on Outbound)


### PR DESCRIPTION
Since '/rules' is an old endpoint, this PR doesn't try to compute RuleAttachment for new outbounds with backendRef. It skips such outbounds to avoid panic. 

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues -- Fix https://github.com/kumahq/kuma/issues/11194
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
