### PR TITLE
test(e2e): speed up namespace termination

### DIFF
--- a/test/e2e/helm/kuma_helm_upgrade_multizone.go
+++ b/test/e2e/helm/kuma_helm_upgrade_multizone.go
@@ -43,9 +43,9 @@ func UpgradingWithHelmChartMultizone() {
 		}()
 		go func() {
 			defer grp.Done()
-			Expect(zoneK8s.DeleteNamespace(namespace)).To(Succeed())
 			Expect(zoneK8s.DeleteKuma()).To(Succeed())
 			Expect(zoneK8s.DismissCluster()).To(Succeed())
+			Expect(zoneK8s.DeleteNamespace(namespace)).To(Succeed())
 		}()
 		go func() {
 			defer grp.Done()

--- a/test/e2e/helm/kuma_helm_upgrade_multizone.go
+++ b/test/e2e/helm/kuma_helm_upgrade_multizone.go
@@ -43,9 +43,9 @@ func UpgradingWithHelmChartMultizone() {
 		}()
 		go func() {
 			defer grp.Done()
+			Expect(zoneK8s.DeleteNamespace(namespace)).To(Succeed())
 			Expect(zoneK8s.DeleteKuma()).To(Succeed())
 			Expect(zoneK8s.DismissCluster()).To(Succeed())
-			Expect(zoneK8s.DeleteNamespace(namespace)).To(Succeed())
 		}()
 		go func() {
 			defer grp.Done()

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -1033,6 +1033,13 @@ func (c *K8sCluster) DeleteNamespace(namespace string) error {
 		return err
 	}
 
+	// speed up namespace termination by terminating pods without grace period.
+	// Namespace is then deleted in ~6s instead of ~43s.
+	err := k8s.RunKubectlE(c.GetTesting(), c.GetKubectlOptions(namespace), "delete", "pods", "--all", "--grace-period=0")
+	if err != nil {
+		return err
+	}
+
 	c.WaitNamespaceDelete(namespace)
 
 	return nil
@@ -1045,6 +1052,7 @@ func (c *K8sCluster) TriggerDeleteNamespace(namespace string) error {
 		}
 		return err
 	}
+
 	// speed up namespace termination by terminating pods without grace period.
 	// Namespace is then deleted in ~6s instead of ~43s.
 	return k8s.RunKubectlE(c.GetTesting(), c.GetKubectlOptions(namespace), "delete", "pods", "--all", "--grace-period=0")


### PR DESCRIPTION
We've tested this mechanism in `TriggerDeleteNamespace` so it can be safely used in sync version of this method

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
