### PR TITLE
fix(inspect-api): don't set 'toRules' when `meshServices.mode: Exclusive`

### DIFF
--- a/api/openapi/specs/common/resource.yaml
+++ b/api/openapi/specs/common/resource.yaml
@@ -78,7 +78,7 @@ components:
           $ref: '#/components/schemas/ProxyRule'
         toRules:
           type: array
-          description: a set of rules for the outbounds of this proxy. The field is not set when 'meshService.mode' is 'Exclusive'.
+          description: a set of rules for the outbounds of this proxy. The field is not set when 'meshService.mode' on Mesh is set to 'Exclusive'.
           items:
             $ref: '#/components/schemas/Rule'
         toResourceRules:

--- a/api/openapi/specs/common/resource.yaml
+++ b/api/openapi/specs/common/resource.yaml
@@ -78,12 +78,12 @@ components:
           $ref: '#/components/schemas/ProxyRule'
         toRules:
           type: array
-          description: a set of rules for the outbounds of this proxy
+          description: a set of rules for the outbounds of this proxy. The field is not set when 'meshService.mode' is 'Exclusive'.
           items:
             $ref: '#/components/schemas/Rule'
         toResourceRules:
           type: array
-          description: a set of rules for the resources targeted by this proxy
+          description: a set of rules for the outbounds produced by real resources (i.e MeshService, MeshExternalService, MeshMultiZoneService).
           items:
             $ref: '#/components/schemas/ResourceRule'
         fromRules:

--- a/api/openapi/types/common/zz_generated.resource.go
+++ b/api/openapi/types/common/zz_generated.resource.go
@@ -36,7 +36,7 @@ type InspectRule struct {
 	// ToResourceRules a set of rules for the outbounds produced by real resources (i.e MeshService, MeshExternalService, MeshMultiZoneService).
 	ToResourceRules *[]ResourceRule `json:"toResourceRules,omitempty"`
 
-	// ToRules a set of rules for the outbounds of this proxy. The field is not set when 'meshService.mode' is 'Exclusive'.
+	// ToRules a set of rules for the outbounds of this proxy. The field is not set when 'meshService.mode' on Mesh is set to 'Exclusive'.
 	ToRules *[]Rule `json:"toRules,omitempty"`
 
 	// Type the type of the policy

--- a/api/openapi/types/common/zz_generated.resource.go
+++ b/api/openapi/types/common/zz_generated.resource.go
@@ -33,10 +33,10 @@ type InspectRule struct {
 	FromRules *[]FromRule `json:"fromRules,omitempty"`
 	ProxyRule *ProxyRule  `json:"proxyRule,omitempty"`
 
-	// ToResourceRules a set of rules for the resources targeted by this proxy
+	// ToResourceRules a set of rules for the outbounds produced by real resources (i.e MeshService, MeshExternalService, MeshMultiZoneService).
 	ToResourceRules *[]ResourceRule `json:"toResourceRules,omitempty"`
 
-	// ToRules a set of rules for the outbounds of this proxy
+	// ToRules a set of rules for the outbounds of this proxy. The field is not set when 'meshService.mode' is 'Exclusive'.
 	ToRules *[]Rule `json:"toRules,omitempty"`
 
 	// Type the type of the policy

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -2601,12 +2601,16 @@ components:
           $ref: '#/components/schemas/ProxyRule'
         toRules:
           type: array
-          description: a set of rules for the outbounds of this proxy
+          description: >-
+            a set of rules for the outbounds of this proxy. The field is not set
+            when 'meshService.mode' is 'Exclusive'.
           items:
             $ref: '#/components/schemas/Rule'
         toResourceRules:
           type: array
-          description: a set of rules for the resources targeted by this proxy
+          description: >-
+            a set of rules for the outbounds produced by real resources (i.e
+            MeshService, MeshExternalService, MeshMultiZoneService).
           items:
             $ref: '#/components/schemas/ResourceRule'
         fromRules:

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -2603,7 +2603,7 @@ components:
           type: array
           description: >-
             a set of rules for the outbounds of this proxy. The field is not set
-            when 'meshService.mode' is 'Exclusive'.
+            when 'meshService.mode' on Mesh is set to 'Exclusive'.
           items:
             $ref: '#/components/schemas/Rule'
         toResourceRules:

--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -898,12 +898,14 @@ func (r *resourceEndpoints) rulesForResource() restful.RouteFunction {
 				continue
 			}
 			toRules := []api_common.Rule{}
-			for _, ruleItem := range res.ToRules.Rules {
-				toRules = append(toRules, api_common.Rule{
-					Conf:     ruleItem.Conf,
-					Matchers: oapi_helpers.SubsetToRuleMatcher(ruleItem.Subset),
-					Origin:   oapi_helpers.ResourceMetaListToMetaList(res.Type, ruleItem.Origin),
-				})
+			if baseMeshContext.Mesh.Spec.MeshServicesMode() != mesh_proto.Mesh_MeshServices_Exclusive {
+				for _, ruleItem := range res.ToRules.Rules {
+					toRules = append(toRules, api_common.Rule{
+						Conf:     ruleItem.Conf,
+						Matchers: oapi_helpers.SubsetToRuleMatcher(ruleItem.Subset),
+						Origin:   oapi_helpers.ResourceMetaListToMetaList(res.Type, ruleItem.Origin),
+					})
+				}
 			}
 			var proxyRule *api_common.ProxyRule
 			if len(res.SingleItemRules.Rules) > 0 {

--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -899,6 +899,8 @@ func (r *resourceEndpoints) rulesForResource() restful.RouteFunction {
 			}
 			toRules := []api_common.Rule{}
 			if baseMeshContext.Mesh.Spec.MeshServicesMode() != mesh_proto.Mesh_MeshServices_Exclusive {
+				// Old 'ToRules' don't affect outbounds that were produced by real resources.
+				// That's why we don't have to set them when the mode is Exclusive
 				for _, ruleItem := range res.ToRules.Rules {
 					toRules = append(toRules, api_common.Rule{
 						Conf:     ruleItem.Conf,

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/resource_rule_meshtimeout_exclusive.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/resource_rule_meshtimeout_exclusive.golden.json
@@ -1,0 +1,81 @@
+{
+ "httpMatches": [],
+ "resource": {
+  "labels": {},
+  "mesh": "mesh-1",
+  "name": "dp-1",
+  "type": "Dataplane"
+ },
+ "rules": [
+  {
+   "fromRules": [],
+   "toResourceRules": [
+    {
+     "conf": [
+      {
+       "connectionTimeout": "11s",
+       "idleTimeout": "10s",
+       "http": {
+        "requestTimeout": "12s"
+       }
+      }
+     ],
+     "origin": [
+      {
+       "resourceMeta": {
+        "labels": {},
+        "mesh": "mesh-1",
+        "name": "matched-for-rules-mt-1",
+        "type": "MeshTimeout"
+       },
+       "ruleIndex": 0
+      }
+     ],
+     "resourceMeta": {
+      "labels": {
+       "env": "dev"
+      },
+      "mesh": "mesh-1",
+      "name": "backend-1",
+      "type": "MeshService"
+     },
+     "resourceSectionName": ""
+    },
+    {
+     "conf": [
+      {
+       "connectionTimeout": "11s",
+       "idleTimeout": "10s",
+       "http": {
+        "requestTimeout": "12s"
+       }
+      }
+     ],
+     "origin": [
+      {
+       "resourceMeta": {
+        "labels": {},
+        "mesh": "mesh-1",
+        "name": "matched-for-rules-mt-1",
+        "type": "MeshTimeout"
+       },
+       "ruleIndex": 0
+      }
+     ],
+     "resourceMeta": {
+      "labels": {
+       "env": "dev"
+      },
+      "mesh": "mesh-1",
+      "name": "backend-2",
+      "type": "MeshService"
+     },
+     "resourceSectionName": ""
+    }
+   ],
+   "toRules": [],
+   "type": "MeshTimeout",
+   "warnings": []
+  }
+ ]
+}

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/resource_rule_meshtimeout_exclusive.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/resource_rule_meshtimeout_exclusive.input.yaml
@@ -1,0 +1,75 @@
+#/meshes/mesh-1/dataplanes/dp-1/_rules 200
+type: Mesh
+name: mesh-1
+meshServices:
+  mode: Exclusive
+---
+type: Dataplane
+name: dp-1
+mesh: mesh-1
+networking:
+  address: 127.0.0.1
+  inbound:
+    - port: 8080
+      tags:
+        app: backend
+        kuma.io/service: foo
+---
+type: MeshTimeout
+name: matched-for-rules-mt-1
+mesh: mesh-1
+spec:
+  targetRef:
+    kind: Mesh
+  to:
+    - targetRef:
+        kind: MeshService
+        labels:
+          env: dev
+      default:
+        idleTimeout: 10s
+        connectionTimeout: 11s
+        http:
+          requestTimeout: 12s
+---
+type: MeshService
+name: backend-1
+mesh: mesh-1
+labels:
+  env: dev
+spec:
+  selector:
+    dataplaneTags:
+      app: backend
+  ports:
+    - port: 80
+      targetPort: 80
+      appProtocol: http
+---
+type: MeshService
+name: backend-2
+mesh: mesh-1
+labels:
+  env: dev
+spec:
+  selector:
+    dataplaneTags:
+      app: backend
+  ports:
+    - port: 80
+      targetPort: 80
+      appProtocol: http
+---
+type: MeshService
+name: backend-3
+mesh: mesh-1
+labels:
+  env: prod
+spec:
+  selector:
+    dataplaneTags:
+      app: backend
+  ports:
+    - port: 80
+      targetPort: 80
+      appProtocol: http


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues -- Fix https://github.com/kumahq/kuma/issues/11473
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
