### PR TITLE
ci(gha): verify CI stability action

### DIFF
--- a/.github/workflows/ci-stability.yaml
+++ b/.github/workflows/ci-stability.yaml
@@ -1,0 +1,68 @@
+name: Check CI stability for PRs with "ci/verify-stability" or "ci/verify-stability-merge-master" label
+
+on:
+  schedule:
+    - cron: "0 */2 19-23 * * 1-5"  # From 7 PM to 11 PM Monday to Friday
+    - cron: "0 */2 0-7 * * 2-6"    # From 12 AM to 7 AM Tuesday to Saturday
+    - cron: "0 */2 * * 6,0"        # Every 2 hours on Saturday and Sunday
+  workflow_dispatch:  # Allows manual trigger from GitHub Actions UI
+env:
+  GH_USER: "github-actions[bot]"
+  GH_EMAIL: "<41898282+github-actions[bot]@users.noreply.github.com>"
+jobs:
+  trigger-ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Get open pull requests
+        uses: octokit/request-action@v2.x
+        id: get_prs
+        with:
+          route: GET /repos/${{ github.repository }}/pulls
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Process PRs
+        id: process_prs
+        run: |
+          pr_numbers_with_verify_stability=$(echo '${{ steps.get_prs.outputs.data }}' | jq -r '.[] | select(.labels[].name == "ci/verify-stability") | .number')
+          pr_numbers_with_verify_stability_merge_master=$(echo '${{ steps.get_prs.outputs.data }}' | jq -r '.[] | select(.labels[].name == "ci/verify-stability-merge-master") | .number')
+          echo "PRs with 'ci/verify-stability' label: $pr_numbers_with_verify_stability"
+          echo "PRs with 'ci/verify-stability-merge-master' label: $pr_numbers_with_verify_stability_merge_master"
+          echo "::set-output name=pr_numbers_with_verify_stability::$pr_numbers_with_verify_stability"
+          echo "::set-output name=pr_numbers_with_verify_stability_merge_master::$pr_numbers_with_verify_stability_merge_master"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Merge master branch (if applicable) and push a single commit
+        if: steps.process_prs.outputs.pr_numbers_with_verify_stability != ''
+        run: |
+          for pr_number in ${{ steps.process_prs.outputs.pr_numbers_with_verify_stability }}; do
+            current_datetime=$(date +"%Y-%m-%d %H:%M:%S")
+            echo "Processing PR #$pr_number"
+
+            # Fetch PR details to get the base branch (original branch name)
+            pr_branch=$(gh pr view $pr_number --json headRefName --jq '.headRefName')
+            echo "The original branch for PR #$pr_number is $pr_branch"
+            git fetch origin pull/$pr_number/head:$pr_branch
+            git checkout $pr_branch
+
+            git config user.name "${GH_USER}"
+            git config user.email "${GH_EMAIL}"
+          
+            # Check if the PR needs to merge with master
+            if echo "${{ steps.process_prs.outputs.pr_numbers_with_verify_stability_merge_master }}" | grep -wq "$pr_number"; then
+              echo "Merging master into PR #$pr_number"
+              git fetch origin master
+              git merge origin/master --no-ff --no-commit
+              git commit --allow-empty -m "Merge master into PR #$pr_number"
+            fi
+          
+            # Commit an empty commit to trigger the CI
+            echo "Pushing empty commit to trigger CI for PR #$pr_number on $current_datetime"
+            git commit --allow-empty -m "Trigger CI for PR #$pr_number on $current_datetime"
+            git push origin $pr_branch
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Checklist prior to review

Introduce GHA action to check CI stability.
It's this https://github.com/kumahq/kuma/pull/11589 but without me leaving the laptop running the script.

The action runs every 2h outside of working hours during weekdays (feel free to suggest better hours) and every 2h on the weekends. It adds a commit to PRs with `ci/verify-stability` label. Additionally, if there is `ci/verify-stability-merge-master` we merge master.

The use case is that we can have a "long-running" PR with both labels so it checks the stability of the current master branch.

You can also do the same but on a PR. Let's say we introduce a risky change. We can remove a label on our long-running PR and instead put `ci/verify-stability` on the PR with a risky change.

Potential improvements:
* Instead of every 2h, we could track if the CI run finished and then push another commit to have more runs.
* It does not work with forks. Not sure if it's even possible, because we push commits to the branch we may not have an access to

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
