### PR TITLE
ci(github): move checklist to a PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,16 @@
-### Checklist prior to review
+## Motivation
 
-<!--
-Each of these sections need to be filled by the author when opening the PR.
+<!-- Why are we doing this change -->
 
-If something doesn't apply please check the box and add a justification after the `--`
--->
+## Implementation information
 
-- [ ] [Link to relevant issue][1] as well as docs and UI issues --
-- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
-- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
-  - Don't forget `ci/` labels to run additional/fewer tests
-- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
-- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
+<!-- Explain how this was done and potentially alternatives considered and discarded -->
+
+## Supporting documentation
+
+<!-- Is there a MADR? An Issue? A related PR? -->
+
+Fix #XX
 
 <!--
 > Changelog: skip
@@ -19,5 +18,3 @@ If something doesn't apply please check the box and add a justification after th
 <!--
 Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
 -->
-
-[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -61,4 +61,4 @@ jobs:
             - [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
             [1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
 
-        run: gh pr comment -R "${{ github.repository }}" "${{ github.event.pull_request.number }}" -f ${{ env.CHECKLIST_MESSAGE}}
+        run: gh pr comment -R "${{ github.repository }}" "${{ github.event.pull_request.number }}" -b ${{ env.CHECKLIST_MESSAGE}}

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -42,3 +42,23 @@ jobs:
           NO_BACKPORT_AUTOLABEL: no-backport-autolabel
         run: |
           tools/ci/needs_backporting.sh "${{ github.repository }}" "${{ github.event.pull_request.number }}" "origin/${{ github.base_ref }}" "HEAD" "$PREDEFINED_GLOBS" "$LABEL_TO_ADD" "$NO_BACKPORT_AUTOLABEL"
+      - name: Add checklist comment
+        if: github.event.action == 'opened' && github.event.pull_request.author != 'dependabot'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          CHECKLIST_MESSAGE: |
+            :mag: Each of these sections need to be checked by the reviewer of the PR :mag::
+            
+            If something doesn't apply please check the box and add a justification if the reason is non obvious.
+            
+            - [ ] Is the PR title satisfactory? Is this part of a larger feature and should be grouped using `> Changelog`?
+            - [ ] PR description is clear and complete. It [Link to relevant issue][1] as well as docs and UI issues
+            - [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) 
+            - [ ] IPv6 is taken into account (.e.g: no concatenation of host port)
+            - [ ] Tests (Unit test, E2E tests, manual test on universal and k8s)
+                - Don't forget `ci/` labels to run additional/fewer tests
+            - [ ] Does this contain a change that needs to be notified to users? In this case it [`UPGRADE.md`](../blob/master/UPGRADE.md) should be updated.
+            - [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
+            [1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
+
+        run: gh pr comment -R "${{ github.repository }}" "${{ github.event.pull_request.number }}" -f ${{ env.CHECKLIST_MESSAGE}}


### PR DESCRIPTION
This is so that we can use the PR description as a commit message. Also the checklist should be checked by the reviewer.

xrel https://github.com/Kong/team-mesh/issues/302

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
