### PR TITLE
test(e2e): disable metrics server in k3d

### DIFF
--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -43,6 +43,7 @@ K3D_NETWORK_CNI ?= flannel
 K3D_REGISTRY_FILE ?=
 K3D_CLUSTER_CREATE_OPTS ?= -i rancher/k3s:$(CI_K3S_VERSION) \
 	--k3s-arg '--disable=traefik@server:0' \
+	--k3s-arg '--disable=metrics-server@server:0' \
 	--k3s-arg '--kubelet-arg=image-gc-high-threshold=100@server:0' \
 	--k3s-arg '--disable=servicelb@server:0' \
     --volume '$(subst @,\@,$(TOP)/$(KUMA_DIR))/test/framework/deployments:/tmp/deployments@server:0' \


### PR DESCRIPTION
### Checklist prior to review

Metrics server was enabled in this PR https://github.com/kumahq/kuma/pull/9892/files#diff-6a9a6d7b0c33e516a1579d4ea2ccdfdbec5bd689d4f15bcab302e2a80b0d7ee4L45 but it's not clear why.

Every now and then we have a flake in e2e tests where we cannot terminate namespace. The reason is
```
NamespaceCondition{Type:NamespaceDeletionDiscoveryFailure,Status:True,LastTransitionTime:2024-10-03 18:48:53 +0000 UTC,Reason:DiscoveryFailed,Message:Discovery failed for some groups, 1 failing: unable to retrieve the complete list of server APIs: metrics.k8s.io/v1beta1: the server is currently unable to handle the request,}
```
An example of such run https://github.com/kumahq/kuma/actions/runs/11167497534/job/31044250187

According to the Internet, communication to the metrics server is broken (the metrics server is most likely down). We could try to debug why the metrics server is unavailable, but we can just disable this since we don't need it.

It could also slightly speed up cluster creation, because it's one less component.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
