### PR TITLE
test(e2e): wait for CRDs

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -61,4 +61,4 @@ jobs:
             - [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
             [1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
 
-        run: gh pr comment -R "${{ github.repository }}" "${{ github.event.pull_request.number }}" -b ${{ env.CHECKLIST_MESSAGE}}
+        run: echo '${{ env.CHECKLIST_MESSAGE }}' | gh pr comment -R "${{ github.repository }}" "${{ github.event.pull_request.number }}" -F -


### PR DESCRIPTION
## Motivation

Very rarely we see a flake on the CI that looks like this
```
2024-10-03T13:54:30.911Z	ERROR	kuma-cp.run	problem running Control Plane	{"error": "error running Kubernetes Manager: no matches for kind \"MeshCircuitBreaker\" in version \"kuma.io/v1alpha1\"", "errorVerbose": "no matches for kind \"MeshCircuitBreaker\" in version \"kuma.io/v1alpha1\"\nerror running Kubernetes Manager\ngithub.com/kumahq/kuma/pkg/plugins/bootstrap/k8s.(*kubeComponentManager).Start\n\tgithub.com/kumahq/kuma/pkg/plugins/bootstrap/k8s/plugin.go:208\ngithub.com/kumahq/kuma/app/kuma-cp/cmd.newRunCmdWithOpts.func1\n\tgithub.com/kumahq/kuma/app/kuma-cp/cmd/run.go:170\ngithub.com/spf13/cobra.(*Command).execute\n\tgithub.com/spf13/cobra@v1.8.1/command.go:985\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\tgithub.com/spf13/cobra@v1.8.1/command.go:1117\ngithub.com/spf13/cobra.(*Command).Execute\n\tgithub.com/spf13/cobra@v1.8.1/command.go:1041\ngithub.com/kumahq/kuma/app/kuma-cp/cmd.Execute\n\tgithub.com/kumahq/kuma/app/kuma-cp/cmd/root.go:83\nmain.main\n\tgithub.com/kumahq/kuma/app/kuma-cp/main.go:6\nruntime.main\n\truntime/proc.go:272\nruntime.goexit\n\truntime/asm_arm64.s:1223"}
```
While it does not mess with any test, it causes CP to restart on which we have assertion after all tests are run.

Here is an example https://github.com/Kong/kong-mesh/actions/runs/11144879402/job/30973956156

We may be starting CP too soon. When we deploy using kumactl we install CRDs and CP deployment at the same time.

<!-- Why are we doing this change -->

## Implementation information

The solution is to first install CRD, wait for them using kumactl and only then install the CP.

I did not fix it for HELM because HELM installs CRDs via hook so there is much more time between CP installation and CP start, I don't think we ever saw this problem with HELM.

I checked that it takes about ~3s to wait for all CRDs so it's not a big overhead.

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

No issue, just a flake that we noticed

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
