### PR TITLE
fix(egress): same external service tag in multiple meshes

### DIFF
--- a/pkg/xds/generator/egress/external_services_generator.go
+++ b/pkg/xds/generator/egress/external_services_generator.go
@@ -127,7 +127,7 @@ func (*ExternalServicesGenerator) generateCDS(
 		}
 
 		resource := &core_xds.Resource{
-			Name:     serviceName,
+			Name:     clusterName,
 			Origin:   OriginEgress,
 			Resource: cluster,
 		}

--- a/pkg/xds/generator/egress/generator_test.go
+++ b/pkg/xds/generator/egress/generator_test.go
@@ -234,5 +234,9 @@ var _ = Describe("EgressGenerator", func() {
 			fileWithResourcesName: "subsets-with-external-meshhttproute.yaml",
 			expected:              "subsets-with-external-meshhttproute.golden.yaml",
 		}),
+		Entry("same kuma.io/service", testCase{
+			fileWithResourcesName: "same-kuma-io-service.yaml",
+			expected:              "same-kuma-io-service.golden.yaml",
+		}),
 	)
 })

--- a/pkg/xds/generator/egress/testdata/input/same-kuma-io-service.yaml
+++ b/pkg/xds/generator/egress/testdata/input/same-kuma-io-service.yaml
@@ -1,0 +1,90 @@
+type: ZoneEgress
+name: zoneegress-1
+zone: zone-1
+networking:
+  address: 192.168.0.1
+  port: 10002
+---
+type: Mesh
+name: mesh-1
+mtls:
+  enabledBackend: ca-1
+  backends:
+    - name: ca-1
+      type: builtin
+---
+type: TrafficPermission
+name: allow-all-traffic-1
+mesh: mesh-1
+sources:
+  - match:
+      kuma.io/service: '*'
+destinations:
+  - match:
+      kuma.io/service: '*'
+---
+type: TrafficRoute
+name: trafficroute-1
+mesh: mesh-1
+sources:
+  - match:
+      kuma.io/service: "*"
+destinations:
+  - match:
+      kuma.io/service: "*"
+conf:
+  loadBalancer:
+    roundRobin: {}
+  destination:
+    kuma.io/service: "*"
+---
+type: ExternalService
+name: externalservice-1
+mesh: mesh-1
+tags:
+  kuma.io/service: externalservice # same kuma.io/service
+  kuma.io/protocol: http
+networking:
+  address: kuma.io:80
+---
+type: Mesh
+name: mesh-2
+mtls:
+  enabledBackend: ca-1
+  backends:
+    - name: ca-1
+      type: builtin
+---
+type: TrafficPermission
+name: allow-all-traffic-2
+mesh: mesh-2
+sources:
+  - match:
+      kuma.io/service: '*'
+destinations:
+  - match:
+      kuma.io/service: '*'
+---
+type: TrafficRoute
+name: trafficroute-2
+mesh: mesh-2
+sources:
+  - match:
+      kuma.io/service: "*"
+destinations:
+  - match:
+      kuma.io/service: "*"
+conf:
+  loadBalancer:
+    roundRobin: {}
+  destination:
+    kuma.io/service: "*"
+---
+type: ExternalService
+name: externalservice-2
+mesh: mesh-2
+tags:
+  kuma.io/service: externalservice # same kuma.io/service
+  kuma.io/protocol: http
+networking:
+  address: kuma.io:80

--- a/pkg/xds/generator/egress/testdata/same-kuma-io-service.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/same-kuma-io-service.golden.yaml
@@ -1,0 +1,232 @@
+resources:
+- name: mesh-1:externalservice
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    altStatName: mesh-1_externalservice
+    connectTimeout: 5s
+    dnsLookupFamily: V4_ONLY
+    loadAssignment:
+      clusterName: mesh-1:externalservice
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: kuma.io
+                portValue: 80
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+                mesh: mesh-1
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
+                mesh: mesh-1
+    name: mesh-1:externalservice
+    type: STRICT_DNS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          httpProtocolOptions: {}
+- name: mesh-2:externalservice
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    altStatName: mesh-2_externalservice
+    connectTimeout: 5s
+    dnsLookupFamily: V4_ONLY
+    loadAssignment:
+      clusterName: mesh-2:externalservice
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: kuma.io
+                portValue: 80
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+                mesh: mesh-2
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
+                mesh: mesh-2
+    name: mesh-2:externalservice
+    type: STRICT_DNS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          httpProtocolOptions: {}
+- name: inbound:192.168.0.1:10002
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.1
+        portValue: 10002
+    enableReusePort: false
+    filterChains:
+    - filterChainMatch:
+        serverNames:
+        - externalservice{mesh=mesh-1}
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.rbac
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
+          rules:
+            policies:
+              allow-all-traffic-1:
+                permissions:
+                - any: true
+                principals:
+                - any: true
+          statPrefix: externalservice.
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          httpFilters:
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          routeConfig:
+            name: outbound:externalservice
+            validateClusters: false
+            virtualHosts:
+            - domains:
+              - '*'
+              name: externalservice
+              routes:
+              - match:
+                  prefix: /
+                route:
+                  autoHostRewrite: true
+                  cluster: mesh-1:externalservice
+                  timeout: 0s
+          statPrefix: externalservice
+      name: externalservice_mesh-1
+      transportSocket:
+        name: envoy.transport_sockets.tls
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          commonTlsContext:
+            combinedValidationContext:
+              defaultValidationContext:
+                matchTypedSubjectAltNames:
+                - matcher:
+                    prefix: spiffe://mesh-1/
+                  sanType: URI
+              validationContextSdsSecretConfig:
+                name: mesh_ca:secret:mesh-1
+                sdsConfig:
+                  ads: {}
+                  resourceApiVersion: V3
+            tlsCertificateSdsSecretConfigs:
+            - name: identity_cert:secret:mesh-1
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+          requireClientCertificate: true
+    - filterChainMatch:
+        serverNames:
+        - externalservice{mesh=mesh-2}
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.rbac
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
+          rules:
+            policies:
+              allow-all-traffic-1:
+                permissions:
+                - any: true
+                principals:
+                - any: true
+          statPrefix: externalservice.
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          httpFilters:
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          routeConfig:
+            name: outbound:externalservice
+            validateClusters: false
+            virtualHosts:
+            - domains:
+              - '*'
+              name: externalservice
+              routes:
+              - match:
+                  prefix: /
+                route:
+                  autoHostRewrite: true
+                  cluster: mesh-2:externalservice
+                  timeout: 0s
+          statPrefix: externalservice
+      name: externalservice_mesh-2
+      transportSocket:
+        name: envoy.transport_sockets.tls
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          commonTlsContext:
+            combinedValidationContext:
+              defaultValidationContext:
+                matchTypedSubjectAltNames:
+                - matcher:
+                    prefix: spiffe://mesh-2/
+                  sanType: URI
+              validationContextSdsSecretConfig:
+                name: mesh_ca:secret:mesh-2
+                sdsConfig:
+                  ads: {}
+                  resourceApiVersion: V3
+            tlsCertificateSdsSecretConfigs:
+            - name: identity_cert:secret:mesh-2
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+          requireClientCertificate: true
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: inbound:192.168.0.1:10002
+    trafficDirection: INBOUND
+- name: identity_cert:secret:mesh-1
+  resource:
+    '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
+    name: identity_cert:secret:mesh-1
+    tlsCertificate:
+      certificateChain:
+        inlineBytes: Q0VSVA==
+      privateKey:
+        inlineBytes: S0VZ
+- name: identity_cert:secret:mesh-2
+  resource:
+    '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
+    name: identity_cert:secret:mesh-2
+    tlsCertificate:
+      certificateChain:
+        inlineBytes: Q0VSVA==
+      privateKey:
+        inlineBytes: S0VZ
+- name: mesh_ca:secret:mesh-1
+  resource:
+    '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
+    name: mesh_ca:secret:mesh-1
+    validationContext:
+      trustedCa:
+        inlineBytes: Q0E=
+- name: mesh_ca:secret:mesh-2
+  resource:
+    '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
+    name: mesh_ca:secret:mesh-2
+    validationContext:
+      trustedCa:
+        inlineBytes: Q0E=


### PR DESCRIPTION
## Motivation

We had a problem when you used Zone Egress with `ExternalService` with the same `kuma.io/service` in multiple meshes.

## Implementation information

Whenever we added a Resource to ResourceSet, we added it with `serviceName` instead of `clusterName` (which contains mesh information as well). This way if you added both Clusters from multiple meshes, one replaced another.

## Supporting documentation

No issue. I noticed the flake in E2E test.

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
