### PR TITLE
fix(kuma-cp): remove automatically created MeshServices when mode is switched to `Disabled`

### DIFF
--- a/pkg/core/resources/apis/meshservice/generate/generator.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator.go
@@ -23,7 +23,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/user"
 	core_metrics "github.com/kumahq/kuma/pkg/metrics"
 	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/metadata"
-	"github.com/kumahq/kuma/pkg/xds/cache/mesh"
+	mesh_cache "github.com/kumahq/kuma/pkg/xds/cache/mesh"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 )
 
@@ -39,7 +39,7 @@ type Generator struct {
 	deletionGracePeriod time.Duration
 	metric              prometheus.Summary
 	resManager          manager.ResourceManager
-	meshCache           *mesh.Cache
+	meshCache           *mesh_cache.Cache
 }
 
 var _ component.Component = &Generator{}
@@ -50,7 +50,7 @@ func New(
 	deletionGracePeriod time.Duration,
 	metrics core_metrics.Metrics,
 	resManager manager.ResourceManager,
-	meshCache *mesh.Cache,
+	meshCache *mesh_cache.Cache,
 ) (*Generator, error) {
 	metric := prometheus.NewSummary(prometheus.SummaryOpts{
 		Name:       "component_meshservice_generator",
@@ -290,6 +290,19 @@ func (g *Generator) Start(stop <-chan struct{}) error {
 					dataplanes := meshCtx.Resources.Dataplanes()
 					meshServices := meshCtx.Resources.MeshServices()
 					g.generate(ctx, mesh, dataplanes.Items, meshServices.Items)
+				} else {
+					log := g.logger.WithValues("mesh", mesh)
+					for _, meshService := range meshCtx.Resources.MeshServices().Items {
+						if managedBy, ok := meshService.GetMeta().GetLabels()[mesh_proto.ManagedByLabel]; !ok || managedBy != managedByValue {
+							continue
+						}
+						log := log.WithValues("MeshService", meshService.GetMeta().GetName())
+						if err := g.resManager.Delete(ctx, meshservice_api.NewMeshServiceResource(), store.DeleteBy(model.MetaToResourceKey(meshService.GetMeta()))); err != nil {
+							log.Error(err, "couldn't delete MeshService")
+							continue
+						}
+						log.Info("deleted MeshService")
+					}
 				}
 			}
 			g.metric.Observe(float64(time.Since(start).Milliseconds()))

--- a/pkg/plugins/runtime/k8s/controllers/meshservice_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/meshservice_controller.go
@@ -113,7 +113,10 @@ func (r *MeshServiceReconciler) Reconcile(ctx context.Context, req kube_ctrl.Req
 	}
 
 	if mesh.Spec.MeshServicesMode() == mesh_proto.Mesh_MeshServices_Disabled {
-		log.V(1).Info("MeshServices not enabled on Mesh, ignoring")
+		log.V(1).Info("MeshServices not enabled on Mesh, deleting existing")
+		if err := r.deleteIfExist(ctx, req.NamespacedName); err != nil {
+			return kube_ctrl.Result{}, err
+		}
 		return kube_ctrl.Result{}, nil
 	}
 

--- a/test/e2e_env/multizone/meshservice/migration.go
+++ b/test/e2e_env/multizone/meshservice/migration.go
@@ -65,7 +65,7 @@ func Migration() {
 
 	unmarshal := func(out string) *meshServiceList {
 		l := &meshServiceList{}
-		Expect(yaml.Unmarshal([]byte(out), l))
+		Expect(yaml.Unmarshal([]byte(out), l)).To(Succeed())
 		return l
 	}
 

--- a/test/e2e_env/multizone/meshservice/migration.go
+++ b/test/e2e_env/multizone/meshservice/migration.go
@@ -1,0 +1,144 @@
+package meshservice
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/yaml"
+
+	"github.com/kumahq/kuma/pkg/kds/hash"
+	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/deployments/testserver"
+	"github.com/kumahq/kuma/test/framework/envs/multizone"
+)
+
+func Migration() {
+	namespace := "msmigration"
+	meshName := "msmigration"
+
+	BeforeAll(func() {
+		err := NewClusterSetup().
+			Install(MTLSMeshUniversal(meshName)).
+			Setup(multizone.Global)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = NewClusterSetup().
+			Install(NamespaceWithSidecarInjection(namespace)).
+			Install(testserver.Install(
+				testserver.WithName("demo-client"),
+				testserver.WithMesh(meshName),
+				testserver.WithNamespace(namespace),
+			)).
+			Install(testserver.Install(
+				testserver.WithName("test-server"),
+				testserver.WithNamespace(namespace),
+				testserver.WithMesh(meshName),
+			)).
+			Setup(multizone.KubeZone1)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = NewClusterSetup().
+			Install(TestServerUniversal("test-server", meshName)).
+			Setup(multizone.UniZone1)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEachFailure(func() {
+		DebugUniversal(multizone.Global, meshName)
+		DebugUniversal(multizone.UniZone1, meshName)
+		DebugKube(multizone.KubeZone1, meshName, namespace)
+	})
+
+	E2EAfterAll(func() {
+		Expect(multizone.KubeZone1.TriggerDeleteNamespace(namespace)).To(Succeed())
+		Expect(multizone.UniZone1.DeleteMeshApps(meshName)).To(Succeed())
+		Expect(multizone.Global.DeleteMesh(meshName)).To(Succeed())
+	})
+
+	type meshServiceList struct {
+		Total int `json:"total"`
+		Items []struct {
+			Name string `json:"name"`
+		} `json:"items"`
+	}
+
+	unmarshal := func(out string) *meshServiceList {
+		l := &meshServiceList{}
+		Expect(yaml.Unmarshal([]byte(out), l))
+		return l
+	}
+
+	hasMeshServices := func(names ...string) {
+		Eventually(func(g Gomega) {
+			// when
+			out, err := multizone.Global.GetKumactlOptions().RunKumactlAndGetOutput("get", "meshservices", "-m", meshName, "-o", "yaml")
+			// then
+			g.Expect(err).ToNot(HaveOccurred())
+			response := unmarshal(out)
+			g.Expect(response.Total).To(Equal(len(names)))
+			var actualNames []string
+			for _, name := range response.Items {
+				actualNames = append(actualNames, name.Name)
+			}
+			g.Expect(actualNames).To(ConsistOf(names))
+		}).Should(Succeed())
+	}
+
+	noMeshServices := func() {
+		// call hasMeshServices with no names
+		hasMeshServices()
+	}
+
+	It("should automatically create MeshServices when the mode is 'Exclusive'", func() {
+		// given
+		noMeshServices()
+
+		// when enable 'mode: Exclusive'
+		Expect(MTLSMeshWithMeshServicesUniversal(meshName, "Exclusive")(multizone.Global)).To(Succeed())
+
+		// then
+		hasMeshServices(
+			hash.HashedName(meshName, "demo-client", Kuma1, namespace),
+			hash.HashedName(meshName, "test-server", Kuma1, namespace),
+			hash.HashedName(meshName, "test-server", Kuma4),
+		)
+	})
+
+	It("should be possible to manually create MeshService on Universal", func() {
+		// when
+		Expect(YamlUniversal(fmt.Sprintf(`
+type: MeshService
+name: manually-created-ms
+mesh: %s
+labels:
+  kuma.io/origin: zone
+spec:
+  selector:
+    dataplaneTags:
+      kuma.io/service: manually-created-ms
+  ports:
+  - port: 80
+    targetPort: 80
+    appProtocol: http
+`, meshName))(multizone.UniZone1)).To(Succeed())
+
+		// then
+		hasMeshServices(
+			hash.HashedName(meshName, "demo-client", Kuma1, namespace),
+			hash.HashedName(meshName, "test-server", Kuma1, namespace),
+			hash.HashedName(meshName, "test-server", Kuma4),
+			hash.HashedName(meshName, "manually-created-ms", Kuma4),
+		)
+	})
+
+	It("should delete automatically created MeshServices when the mode is 'Disabled'", func() {
+		// when mode is 'Disabled'
+		Expect(MTLSMeshWithMeshServicesUniversal(meshName, "Disabled")(multizone.Global)).To(Succeed())
+
+		// then
+		hasMeshServices(
+			hash.HashedName(meshName, "manually-created-ms", Kuma4),
+		)
+	})
+}

--- a/test/e2e_env/multizone/multizone_suite_test.go
+++ b/test/e2e_env/multizone/multizone_suite_test.go
@@ -77,6 +77,7 @@ var (
 	_ = Describe("Defaults", defaults.Defaults, Ordered)
 	_ = Describe("MeshService Sync", meshservice.Sync, Ordered)
 	_ = Describe("MeshService Connectivity", meshservice.Connectivity, Ordered)
+	_ = Describe("MeshService Migration", meshservice.Migration, Ordered)
 	_ = Describe("Targeting real MeshService in policies", meshservice.MeshServiceTargeting, Ordered)
 	_ = Describe("MeshMultiZoneService Connectivity", meshmultizoneservice.Connectivity, Ordered)
 	_ = Describe("MeshMultiZoneService MeshLbStrategy", localityawarelb.MeshMzService, Ordered)


### PR DESCRIPTION
## Motivation

<!-- Why are we doing this change -->

Users should have a safe way to rollback the MeshService migration. Today switching from Disabled to Exclusive to Disabled leads to a situation when MeshServices are not deleted.

## Implementation information

<!-- Explain how this was done and potentially alternatives considered and discarded -->
There are 2 changes for Kubernetes and Universal. When mode is Disabled we remove automatically created MeshServices.

The alternative would be to keep generated MeshServices when mode is switched to Disabled, but check the mode on mesh every time we generate Listeners and Clusters. That creates another potential state of the cluster that we should take into account. The cleanest approach is to rollback to the exact state user had before the migration.

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix https://github.com/kumahq/kuma/issues/11634

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
