### PR TITLE
test(e2e): move isolated e2e to arm

### DIFF
--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -51,7 +51,7 @@ jobs:
               "test_e2e": {
                 "target": [""],
                 "k8sVersion": ["kindIpv6", "${{ env.K8S_MIN_VERSION }}", "${{ env.K8S_MAX_VERSION }}"],
-                "arch": ["amd64"],
+                "arch": ["arm64"],
                 "parallelism": [4],
                 "cniNetworkPlugin": ["flannel"],
                 "sidecarContainers": [""]


### PR DESCRIPTION
## Motivation

We are not utilizing arm runners enough. Right now we have 33 arm runners idle and a big queue.
Isolated/old e2e is half of runs of our e2e tests
![image](https://github.com/user-attachments/assets/408c6128-4964-42fa-ae95-2d516a124b11)
![image](https://github.com/user-attachments/assets/76a660e9-7723-4e56-a24c-7c3d51f7aba3)

Let's move them to arm

<!-- Why are we doing this change -->

## Implementation information

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

No issue. CI queues.

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
