### PR TITLE
fix(kuma-cp): deprecate use kuma.io/mesh annotation and use label instead

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -159,6 +159,3 @@ issues:
     - linters:
         - staticcheck
       text: "SA1019: .* is deprecated: use FullResyncInterval instead"
-    - linters:
-        - staticcheck
-      text: "SA1019: .* is deprecated: use KumaMeshLabel from pkg/plugins/runtime/k8s/metadata/labels.go instead."

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -159,3 +159,6 @@ issues:
     - linters:
         - staticcheck
       text: "SA1019: .* is deprecated: use FullResyncInterval instead"
+    - linters:
+        - staticcheck
+      text: "SA1019: .* is deprecated: use KumaMeshLabel from pkg/plugins/runtime/k8s/metadata/labels.go instead."

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -233,6 +233,12 @@ The values `yes` and `no` are deprecated for specifying boolean values in switch
 
 Please use `true` and `false` as replacements; some boolean switches also support `enabled` and `disabled`. [Check the documentation](https://kuma.io/docs/latest/reference/kubernetes-annotations/) for the specific annotation to confirm the correct replacements.
 
+#### Deprecation of `kuma.io/mesh` annotation
+
+It was previously possible to create a resource in a `Mesh` by providing the `Mesh` name as an annotation, but this support has been deprecated and will be removed in the future.
+
+Please use the `kuma.io/mesh` label instead.
+
 ## Upgrade to `2.8.x`
 
 ### MeshFaultInjection responseBandwidth.limit

--- a/app/kumactl/cmd/install/testdata/install-observability.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.defaults.golden.yaml
@@ -6,7 +6,6 @@ metadata:
   name: mesh-observability
   labels:
     kuma.io/sidecar-injection: disabled
-  annotations:
     kuma.io/mesh: default
 ---
 apiVersion: v1

--- a/app/kumactl/cmd/install/testdata/install-observability.no-grafana.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-grafana.golden.yaml
@@ -6,7 +6,6 @@ metadata:
   name: mesh-observability
   labels:
     kuma.io/sidecar-injection: disabled
-  annotations:
     kuma.io/mesh: default
 ---
 apiVersion: v1

--- a/app/kumactl/cmd/install/testdata/install-observability.no-jaeger.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-jaeger.golden.yaml
@@ -6,7 +6,6 @@ metadata:
   name: mesh-observability
   labels:
     kuma.io/sidecar-injection: disabled
-  annotations:
     kuma.io/mesh: default
 ---
 apiVersion: v1

--- a/app/kumactl/cmd/install/testdata/install-observability.no-loki.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-loki.golden.yaml
@@ -6,7 +6,6 @@ metadata:
   name: mesh-observability
   labels:
     kuma.io/sidecar-injection: disabled
-  annotations:
     kuma.io/mesh: default
 ---
 apiVersion: v1

--- a/app/kumactl/cmd/install/testdata/install-observability.no-prometheus.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-prometheus.golden.yaml
@@ -6,7 +6,6 @@ metadata:
   name: mesh-observability
   labels:
     kuma.io/sidecar-injection: disabled
-  annotations:
     kuma.io/mesh: default
 ---
 apiVersion: v1

--- a/app/kumactl/cmd/install/testdata/install-observability.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.overrides.golden.yaml
@@ -6,7 +6,6 @@ metadata:
   name: kuma
   labels:
     kuma.io/sidecar-injection: disabled
-  annotations:
     kuma.io/mesh: mesh-1
 ---
 apiVersion: v1

--- a/app/kumactl/data/install/k8s-deprecated/metrics/namespace.yaml
+++ b/app/kumactl/data/install/k8s-deprecated/metrics/namespace.yaml
@@ -6,5 +6,4 @@ metadata:
   name: {{ .Namespace }}
   labels:
     kuma.io/sidecar-injection: enabled
-  annotations:
     kuma.io/mesh: {{ .Mesh }}

--- a/app/kumactl/data/install/k8s/metrics/namespace.yaml
+++ b/app/kumactl/data/install/k8s/metrics/namespace.yaml
@@ -5,5 +5,4 @@ metadata:
   name: {{ .Namespace }}
   labels:
     kuma.io/sidecar-injection: disabled
-  annotations:
     kuma.io/mesh: {{ .Mesh }}

--- a/pkg/plugins/runtime/k8s/controllers/configmap_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/configmap_controller.go
@@ -121,7 +121,7 @@ func ServiceToConfigMapsMapper(client kube_client.Reader, l logr.Logger, systemN
 
 		meshSet := map[string]struct{}{}
 		for i := range pods.Items {
-			meshSet[k8s_util.MeshOfByAnnotation(&pods.Items[i], &ns)] = struct{}{}
+			meshSet[k8s_util.MeshOfByLabelOrAnnotation(l, &pods.Items[i], &ns)] = struct{}{}
 		}
 		var req []kube_reconile.Request
 		for mesh := range meshSet {

--- a/pkg/plugins/runtime/k8s/controllers/configmap_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/configmap_controller_test.go
@@ -201,7 +201,7 @@ var _ = Describe("ServiceToConfigMapMapper", func() {
 				},
 			},
 			[]kube_core.Pod{
-				podFn("pod1", map[string]string{"app": "app1"}, map[string]string{metadata.KumaMeshLabel: "mesh1"}),
+				podFn("pod1", map[string]string{"app": "app1"}, map[string]string{metadata.KumaMeshAnnotation: "mesh1"}),
 				podFn("pod2", map[string]string{"app": "app1"}, nil),
 			},
 			[]string{"kuma-mesh1-dns-vips"},

--- a/pkg/plugins/runtime/k8s/controllers/configmap_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/configmap_controller_test.go
@@ -115,7 +115,7 @@ var _ = Describe("ServiceToConfigMapMapper", func() {
 			defaultNs,
 			[]kube_core.Pod{
 				podFn("pod1", map[string]string{"app": "app2"}, nil),
-				podFn("pod2", map[string]string{"app": "app2"}, map[string]string{metadata.KumaMeshAnnotation: "mesh2"}),
+				podFn("pod2", map[string]string{"app": "app2", metadata.KumaMeshLabel: "mesh2"}, map[string]string{}),
 			},
 			[]string{},
 		),
@@ -124,7 +124,7 @@ var _ = Describe("ServiceToConfigMapMapper", func() {
 			defaultNs,
 			[]kube_core.Pod{
 				podFn("pod1", map[string]string{"app": "app1"}, nil),
-				podFn("pod2", map[string]string{"app": "app2"}, map[string]string{metadata.KumaMeshAnnotation: "mesh2"}),
+				podFn("pod2", map[string]string{"app": "app2", metadata.KumaMeshLabel: "mesh2"}, map[string]string{}),
 			},
 			[]string{"kuma-default-dns-vips"},
 		),
@@ -132,8 +132,8 @@ var _ = Describe("ServiceToConfigMapMapper", func() {
 			serviceFn(map[string]string{"app": "app1"}),
 			defaultNs,
 			[]kube_core.Pod{
-				podFn("pod1", map[string]string{"app": "app1"}, map[string]string{metadata.KumaMeshAnnotation: "mesh1"}),
-				podFn("pod2", map[string]string{"app": "app2"}, map[string]string{metadata.KumaMeshAnnotation: "mesh2"}),
+				podFn("pod1", map[string]string{"app": "app1", metadata.KumaMeshLabel: "mesh1"}, map[string]string{}),
+				podFn("pod2", map[string]string{"app": "app2", metadata.KumaMeshLabel: "mesh2"}, map[string]string{}),
 			},
 			[]string{"kuma-mesh1-dns-vips"},
 		),
@@ -141,8 +141,8 @@ var _ = Describe("ServiceToConfigMapMapper", func() {
 			serviceFn(map[string]string{"app": "app1"}),
 			defaultNs,
 			[]kube_core.Pod{
-				podFn("pod1", map[string]string{"app": "app1"}, map[string]string{metadata.KumaMeshAnnotation: "mesh1"}),
-				podFn("pod2", map[string]string{"app": "app1"}, map[string]string{metadata.KumaMeshAnnotation: "mesh2"}),
+				podFn("pod1", map[string]string{"app": "app1", metadata.KumaMeshLabel: "mesh1"}, map[string]string{}),
+				podFn("pod2", map[string]string{"app": "app1", metadata.KumaMeshLabel: "mesh2"}, map[string]string{}),
 			},
 			[]string{"kuma-mesh1-dns-vips", "kuma-mesh2-dns-vips"},
 		),
@@ -151,7 +151,7 @@ var _ = Describe("ServiceToConfigMapMapper", func() {
 			kube_core.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						metadata.KumaMeshAnnotation: "mesh1",
+						metadata.KumaMeshLabel: "mesh1",
 					},
 				},
 			},
@@ -166,15 +166,45 @@ var _ = Describe("ServiceToConfigMapMapper", func() {
 			kube_core.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						metadata.KumaMeshAnnotation: "mesh1",
+						metadata.KumaMeshLabel: "mesh1",
 					},
 				},
 			},
 			[]kube_core.Pod{
-				podFn("pod1", map[string]string{"app": "app1"}, map[string]string{metadata.KumaMeshAnnotation: "mesh2"}),
+				podFn("pod1", map[string]string{"app": "app1"}, map[string]string{metadata.KumaMeshLabel: "mesh2"}),
 				podFn("pod2", map[string]string{"app": "app1"}, nil),
 			},
 			[]string{"kuma-mesh1-dns-vips", "kuma-mesh2-dns-vips"},
+		),
+		Entry("namespace label pod has label",
+			serviceFn(map[string]string{"app": "app1"}),
+			kube_core.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						metadata.KumaMeshLabel: "mesh1",
+					},
+				},
+			},
+			[]kube_core.Pod{
+				podFn("pod1", map[string]string{"app": "app1", metadata.KumaMeshLabel: "mesh1"}, map[string]string{}),
+				podFn("pod2", map[string]string{"app": "app1"}, nil),
+			},
+			[]string{"kuma-mesh1-dns-vips"},
+		),
+		Entry("namespace label pod has annotation",
+			serviceFn(map[string]string{"app": "app1"}),
+			kube_core.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						metadata.KumaMeshLabel: "mesh1",
+					},
+				},
+			},
+			[]kube_core.Pod{
+				podFn("pod1", map[string]string{"app": "app1"}, map[string]string{metadata.KumaMeshLabel: "mesh1"}),
+				podFn("pod2", map[string]string{"app": "app1"}, nil),
+			},
+			[]string{"kuma-mesh1-dns-vips"},
 		),
 	)
 })

--- a/pkg/plugins/runtime/k8s/controllers/configmap_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/configmap_controller_test.go
@@ -201,7 +201,7 @@ var _ = Describe("ServiceToConfigMapMapper", func() {
 				},
 			},
 			[]kube_core.Pod{
-				podFn("pod1", map[string]string{"app": "app1"}, map[string]string{metadata.KumaMeshAnnotation: "mesh1"}),
+				podFn("pod1", map[string]string{"app": "app1"}, map[string]string{metadata.KumaMeshAnnotation: "mesh1"}), // nolint:staticcheck
 				podFn("pod2", map[string]string{"app": "app1"}, nil),
 			},
 			[]string{"kuma-mesh1-dns-vips"},

--- a/pkg/plugins/runtime/k8s/controllers/gateway_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/gateway_converter.go
@@ -25,7 +25,7 @@ func (r *PodReconciler) createorUpdateBuiltinGatewayDataplane(ctx context.Contex
 			Namespace: pod.Namespace,
 			Name:      pod.Name,
 		},
-		Mesh: k8s_util.MeshOfByAnnotation(pod, ns),
+		Mesh: k8s_util.MeshOfByLabelOrAnnotation(r.Log, pod, ns),
 	}
 
 	tagsAnnotation, ok := pod.Annotations[metadata.KumaTagsAnnotation]

--- a/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
@@ -309,7 +309,6 @@ func (r *GatewayInstanceReconciler) createOrUpdateDeployment(
 			podAnnotations := map[string]string{
 				metadata.KumaGatewayAnnotation: metadata.AnnotationBuiltin,
 				metadata.KumaTagsAnnotation:    string(jsonTags),
-				metadata.KumaMeshAnnotation:    mesh,
 			}
 
 			if obj != nil {
@@ -324,6 +323,7 @@ func (r *GatewayInstanceReconciler) createOrUpdateDeployment(
 
 			podLabels := k8sSelector(gatewayInstance.Name)
 			podLabels[metadata.KumaSidecarInjectionAnnotation] = metadata.AnnotationDisabled
+			podLabels[metadata.KumaMeshLabel] = mesh
 
 			for k, v := range gatewayInstance.Spec.PodTemplate.Metadata.Labels {
 				podLabels[k] = v

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
@@ -146,7 +146,7 @@ func (r *GatewayReconciler) createOrUpdateInstance(ctx context.Context, mesh str
 		if instance.Labels == nil {
 			instance.Labels = map[string]string{}
 		}
-		instance.Labels[metadata.KumaMeshAnnotation] = mesh
+		instance.Labels[metadata.KumaMeshLabel] = mesh
 
 		instance.Spec = mesh_k8s.MeshGatewayInstanceSpec{
 			Tags:                    config.Tags,

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
@@ -82,7 +82,7 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req kube_ctrl.Request
 		return kube_ctrl.Result{}, errors.Wrap(err, "unable to get Namespace of MeshGateway")
 	}
 
-	mesh := k8s_util.MeshOfByAnnotation(gateway, &ns)
+	mesh := k8s_util.MeshOfByLabelOrAnnotation(r.Log, gateway, &ns)
 	gatewaySpec, listenerConditions, err := r.gapiToKumaGateway(ctx, mesh, gateway, config)
 	if err != nil {
 		return kube_ctrl.Result{}, errors.Wrap(err, "error generating MeshGateway.kuma.io")

--- a/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
@@ -193,7 +193,7 @@ func InboundTagsForService(zone string, pod *kube_core.Pod, svc *kube_core.Servi
 		tags[key] = value
 	}
 	if len(ignoredLabels) > 0 {
-		logger.Info("ignoring internal labels when converting labels to tags", "label", strings.Join(ignoredLabels, ","))
+		logger.V(1).Info("ignoring internal labels when converting labels to tags", "label", strings.Join(ignoredLabels, ","))
 	}
 
 	tags[mesh_proto.KubeNamespaceTag] = pod.Namespace

--- a/pkg/plugins/runtime/k8s/controllers/pod_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller.go
@@ -293,7 +293,7 @@ func (r *PodReconciler) findOtherDataplanes(ctx context.Context, pod *kube_core.
 	}
 
 	// only consider Dataplanes in the same Mesh as Pod
-	mesh := util_k8s.MeshOfByAnnotation(pod, ns)
+	mesh := util_k8s.MeshOfByLabelOrAnnotation(converterLog, pod, ns)
 	otherDataplanes := make([]*mesh_k8s.Dataplane, 0)
 	for i := range allDataplanes.Items {
 		dataplane := allDataplanes.Items[i]

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter.go
@@ -46,7 +46,7 @@ func (p *PodConverter) PodToDataplane(
 ) error {
 	logger := converterLog.WithValues("Dataplane.name", dataplane.Name, "Pod.name", pod.Name)
 	previousMesh := dataplane.Mesh
-	dataplane.Mesh = util_k8s.MeshOfByAnnotation(pod, ns)
+	dataplane.Mesh = util_k8s.MeshOfByLabelOrAnnotation(logger, pod, ns)
 	dataplaneProto, err := p.dataplaneFor(ctx, pod, services, others)
 	if err != nil {
 		return err

--- a/pkg/plugins/runtime/k8s/metadata/annotations.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations.go
@@ -11,6 +11,13 @@ import (
 
 // Annotations that can be used by the end users.
 const (
+	// Deprecated: use KumaMeshLabel from pkg/plugins/runtime/k8s/metadata/labels.go instead.
+	//
+	// KumaMeshAnnotation defines a Pod annotation that
+	// associates a given Pod with a particular Mesh.
+	// Annotation value must be the name of a Mesh resource.
+	KumaMeshAnnotation = "kuma.io/mesh"
+
 	// KumaSidecarInjectionAnnotation defines a Pod/Namespace annotation that
 	// gives users an ability to enable or disable sidecar-injection
 	KumaSidecarInjectionAnnotation = "kuma.io/sidecar-injection"

--- a/pkg/plugins/runtime/k8s/metadata/annotations.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations.go
@@ -11,11 +11,6 @@ import (
 
 // Annotations that can be used by the end users.
 const (
-	// KumaMeshAnnotation defines a Pod annotation that
-	// associates a given Pod with a particular Mesh.
-	// Annotation value must be the name of a Mesh resource.
-	KumaMeshAnnotation = "kuma.io/mesh"
-
 	// KumaSidecarInjectionAnnotation defines a Pod/Namespace annotation that
 	// gives users an ability to enable or disable sidecar-injection
 	KumaSidecarInjectionAnnotation = "kuma.io/sidecar-injection"

--- a/pkg/plugins/runtime/k8s/metadata/annotations.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations.go
@@ -11,7 +11,7 @@ import (
 
 // Annotations that can be used by the end users.
 const (
-	// Deprecated: use KumaMeshLabel from pkg/plugins/runtime/k8s/metadata/labels.go instead.
+	// Deprecated: use KumaMeshLabel as a label from pkg/plugins/runtime/k8s/metadata/labels.go instead of this annotation.
 	//
 	// KumaMeshAnnotation defines a Pod annotation that
 	// associates a given Pod with a particular Mesh.

--- a/pkg/plugins/runtime/k8s/util/util.go
+++ b/pkg/plugins/runtime/k8s/util/util.go
@@ -144,7 +144,7 @@ func MeshOfByLabelOrAnnotation(log logr.Logger, obj kube_client.Object, namespac
 		return mesh
 	}
 	if mesh, exists := metadata.Annotations(obj.GetAnnotations()).GetString(metadata.KumaMeshAnnotation); exists && mesh != "" { // nolint:staticcheck
-		log.Info("WARNING: The kuma.io/mesh annotation is deprecated for this object kind. Use label instead", "name", obj.GetName(), "namespace", obj.GetNamespace(), "kind", obj.GetObjectKind().GroupVersionKind().Kind)
+		log.Info("WARNING: The kuma.io/mesh annotation is no longer supported. Use label instead", "name", obj.GetName(), "namespace", obj.GetNamespace(), "kind", obj.GetObjectKind().GroupVersionKind().Kind)
 		return mesh
 	}
 
@@ -154,7 +154,7 @@ func MeshOfByLabelOrAnnotation(log logr.Logger, obj kube_client.Object, namespac
 	}
 
 	if mesh, exists := metadata.Annotations(namespace.GetAnnotations()).GetString(metadata.KumaMeshAnnotation); exists && mesh != "" { // nolint:staticcheck
-		log.Info("WARNING: The kuma.io/mesh annotation is deprecated for this object kind. Use label instead", "name", obj.GetName(), "namespace", obj.GetNamespace(), "kind", obj.GetObjectKind().GroupVersionKind().Kind)
+		log.Info("WARNING: The kuma.io/mesh annotation is no longer supported. Use label instead", "name", obj.GetName(), "namespace", obj.GetNamespace(), "kind", obj.GetObjectKind().GroupVersionKind().Kind)
 		return mesh
 	}
 

--- a/pkg/plugins/runtime/k8s/util/util.go
+++ b/pkg/plugins/runtime/k8s/util/util.go
@@ -143,7 +143,7 @@ func MeshOfByLabelOrAnnotation(log logr.Logger, obj kube_client.Object, namespac
 	if mesh, exists := metadata.Annotations(obj.GetLabels()).GetString(metadata.KumaMeshLabel); exists && mesh != "" {
 		return mesh
 	}
-	if mesh, exists := metadata.Annotations(obj.GetAnnotations()).GetString(metadata.KumaMeshLabel); exists && mesh != "" {
+	if mesh, exists := metadata.Annotations(obj.GetAnnotations()).GetString(metadata.KumaMeshAnnotation); exists && mesh != "" {
 		log.Info("WARNING: The kuma.io/mesh annotation is deprecated for this object kind. Use label instead", "name", obj.GetName(), "namespace", obj.GetNamespace(), "kind", obj.GetObjectKind().GroupVersionKind().Kind)
 		return mesh
 	}
@@ -153,7 +153,7 @@ func MeshOfByLabelOrAnnotation(log logr.Logger, obj kube_client.Object, namespac
 		return mesh
 	}
 
-	if mesh, exists := metadata.Annotations(namespace.GetAnnotations()).GetString(metadata.KumaMeshLabel); exists && mesh != "" {
+	if mesh, exists := metadata.Annotations(namespace.GetAnnotations()).GetString(metadata.KumaMeshAnnotation); exists && mesh != "" {
 		log.Info("WARNING: The kuma.io/mesh annotation is deprecated for this object kind. Use label instead", "name", obj.GetName(), "namespace", obj.GetNamespace(), "kind", obj.GetObjectKind().GroupVersionKind().Kind)
 		return mesh
 	}

--- a/pkg/plugins/runtime/k8s/util/util.go
+++ b/pkg/plugins/runtime/k8s/util/util.go
@@ -143,7 +143,7 @@ func MeshOfByLabelOrAnnotation(log logr.Logger, obj kube_client.Object, namespac
 	if mesh, exists := metadata.Annotations(obj.GetLabels()).GetString(metadata.KumaMeshLabel); exists && mesh != "" {
 		return mesh
 	}
-	if mesh, exists := metadata.Annotations(obj.GetAnnotations()).GetString(metadata.KumaMeshAnnotation); exists && mesh != "" {
+	if mesh, exists := metadata.Annotations(obj.GetAnnotations()).GetString(metadata.KumaMeshAnnotation); exists && mesh != "" { // nolint:staticcheck
 		log.Info("WARNING: The kuma.io/mesh annotation is deprecated for this object kind. Use label instead", "name", obj.GetName(), "namespace", obj.GetNamespace(), "kind", obj.GetObjectKind().GroupVersionKind().Kind)
 		return mesh
 	}
@@ -153,7 +153,7 @@ func MeshOfByLabelOrAnnotation(log logr.Logger, obj kube_client.Object, namespac
 		return mesh
 	}
 
-	if mesh, exists := metadata.Annotations(namespace.GetAnnotations()).GetString(metadata.KumaMeshAnnotation); exists && mesh != "" {
+	if mesh, exists := metadata.Annotations(namespace.GetAnnotations()).GetString(metadata.KumaMeshAnnotation); exists && mesh != "" { // nolint:staticcheck
 		log.Info("WARNING: The kuma.io/mesh annotation is deprecated for this object kind. Use label instead", "name", obj.GetName(), "namespace", obj.GetNamespace(), "kind", obj.GetObjectKind().GroupVersionKind().Kind)
 		return mesh
 	}

--- a/pkg/plugins/runtime/k8s/util/util.go
+++ b/pkg/plugins/runtime/k8s/util/util.go
@@ -143,17 +143,17 @@ func MeshOfByLabelOrAnnotation(log logr.Logger, obj kube_client.Object, namespac
 	if mesh, exists := metadata.Annotations(obj.GetLabels()).GetString(metadata.KumaMeshLabel); exists && mesh != "" {
 		return mesh
 	}
-	if mesh, exists := metadata.Annotations(obj.GetAnnotations()).GetString(metadata.KumaMeshAnnotation); exists && mesh != "" {
+	if mesh, exists := metadata.Annotations(obj.GetAnnotations()).GetString(metadata.KumaMeshLabel); exists && mesh != "" {
 		log.Info("WARNING: The kuma.io/mesh annotation is deprecated for this object kind. Use label instead", "name", obj.GetName(), "namespace", obj.GetNamespace(), "kind", obj.GetObjectKind().GroupVersionKind().Kind)
 		return mesh
 	}
 
 	// Label wasn't found on the object, let's look on the namespace instead
-	if mesh, exists := metadata.Annotations(namespace.GetLabels()).GetString(metadata.KumaMeshAnnotation); exists && mesh != "" {
+	if mesh, exists := metadata.Annotations(namespace.GetLabels()).GetString(metadata.KumaMeshLabel); exists && mesh != "" {
 		return mesh
 	}
 
-	if mesh, exists := metadata.Annotations(namespace.GetAnnotations()).GetString(metadata.KumaMeshAnnotation); exists && mesh != "" {
+	if mesh, exists := metadata.Annotations(namespace.GetAnnotations()).GetString(metadata.KumaMeshLabel); exists && mesh != "" {
 		log.Info("WARNING: The kuma.io/mesh annotation is deprecated for this object kind. Use label instead", "name", obj.GetName(), "namespace", obj.GetNamespace(), "kind", obj.GetObjectKind().GroupVersionKind().Kind)
 		return mesh
 	}

--- a/pkg/plugins/runtime/k8s/util/util.go
+++ b/pkg/plugins/runtime/k8s/util/util.go
@@ -7,7 +7,6 @@ import (
 	"github.com/go-logr/logr"
 	"golang.org/x/exp/maps"
 	kube_core "k8s.io/api/core/v1"
-	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_labels "k8s.io/apimachinery/pkg/labels"
 	kube_types "k8s.io/apimachinery/pkg/types"
 	kube_intstr "k8s.io/apimachinery/pkg/util/intstr"
@@ -135,19 +134,6 @@ func CopyStringMap(in map[string]string) map[string]string {
 		out[key] = value
 	}
 	return out
-}
-
-// MeshOfByAnnotation returns the mesh of the given object according to its own annotations
-// or those of its namespace.
-func MeshOfByAnnotation(obj kube_meta.Object, namespace *kube_core.Namespace) string {
-	if mesh, exists := metadata.Annotations(obj.GetAnnotations()).GetString(metadata.KumaMeshAnnotation); exists && mesh != "" {
-		return mesh
-	}
-	if mesh, exists := metadata.Annotations(namespace.GetAnnotations()).GetString(metadata.KumaMeshAnnotation); exists && mesh != "" {
-		return mesh
-	}
-
-	return model.DefaultMesh
 }
 
 // MeshOfByLabelOrAnnotation returns the mesh of the given object according to its own

--- a/pkg/plugins/runtime/k8s/util/util_test.go
+++ b/pkg/plugins/runtime/k8s/util/util_test.go
@@ -232,7 +232,7 @@ var _ = Describe("Util", func() {
 				}
 
 				// then
-				Expect(util.MeshOfByAnnotation(pod, ns)).To(Equal(given.expected))
+				Expect(util.MeshOfByLabelOrAnnotation(logr.Discard(), pod, ns)).To(Equal(given.expected))
 			},
 			Entry("Pod without annotations", testCase{
 				podAnnotations: nil,

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
@@ -159,7 +159,6 @@ func (i *KumaInjector) InjectKuma(ctx context.Context, pod *kube_core.Pod) error
 			tproxyCfg,
 			i.cfg,
 			pod.Annotations,
-			meshName,
 			i.defaultAdminPort,
 		); err != nil {
 			return errors.Wrap(err, "could not generate annotations for pod")
@@ -167,6 +166,14 @@ func (i *KumaInjector) InjectKuma(ctx context.Context, pod *kube_core.Pod) error
 
 		for key, value := range annotations {
 			pod.Annotations[key] = value
+		}
+
+		if pod.Labels != nil {
+			pod.Labels[metadata.KumaMeshLabel] = meshName
+		} else {
+			pod.Labels = map[string]string{
+				metadata.KumaMeshLabel: meshName,
+			}
 		}
 
 		switch {
@@ -189,12 +196,20 @@ func (i *KumaInjector) InjectKuma(ctx context.Context, pod *kube_core.Pod) error
 			pod.Annotations[metadata.KumaTrafficTransparentProxyConfig] = tproxyCfgYAML
 		}
 	} else { // this is legacy and deprecated - will be removed soon
-		if annotations, err = i.NewAnnotations(pod, meshName, logger); err != nil {
+		if annotations, err = i.NewAnnotations(pod, logger); err != nil {
 			return errors.Wrap(err, "could not generate annotations for pod")
 		}
 
 		for key, value := range annotations {
 			pod.Annotations[key] = value
+		}
+
+		if pod.Labels != nil {
+			pod.Labels[metadata.KumaMeshLabel] = meshName
+		} else {
+			pod.Labels = map[string]string{
+				metadata.KumaMeshLabel: meshName,
+			}
 		}
 
 		podRedirect, err := tproxy_k8s.NewPodRedirectFromAnnotations(pod.Annotations)
@@ -662,12 +677,11 @@ func (i *KumaInjector) NewValidationContainer(ipFamilyMode, inboundRedirectPort 
 }
 
 // Deprecated
-func (i *KumaInjector) NewAnnotations(pod *kube_core.Pod, mesh string, logger logr.Logger) (map[string]string, error) {
+func (i *KumaInjector) NewAnnotations(pod *kube_core.Pod, logger logr.Logger) (map[string]string, error) {
 	portOutbound := i.cfg.SidecarContainer.RedirectPortOutbound
 	portInbound := i.cfg.SidecarContainer.RedirectPortInbound
 
 	result := map[string]string{
-		metadata.KumaMeshAnnotation:                            mesh, // either user-defined value or default
 		metadata.KumaSidecarInjectedAnnotation:                 metadata.AnnotationTrue,
 		metadata.KumaTransparentProxyingAnnotation:             metadata.AnnotationEnabled,
 		metadata.KumaSidecarUID:                                fmt.Sprintf("%d", i.cfg.SidecarContainer.UID),

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
@@ -168,13 +168,10 @@ func (i *KumaInjector) InjectKuma(ctx context.Context, pod *kube_core.Pod) error
 			pod.Annotations[key] = value
 		}
 
-		if pod.Labels != nil {
-			pod.Labels[metadata.KumaMeshLabel] = meshName
-		} else {
-			pod.Labels = map[string]string{
-				metadata.KumaMeshLabel: meshName,
-			}
+		if pod.Labels == nil {
+			pod.Labels = map[string]string{}
 		}
+		pod.Labels[metadata.KumaMeshLabel] = meshName
 
 		switch {
 		case !tproxyCfg.CNIMode:
@@ -204,13 +201,10 @@ func (i *KumaInjector) InjectKuma(ctx context.Context, pod *kube_core.Pod) error
 			pod.Annotations[key] = value
 		}
 
-		if pod.Labels != nil {
-			pod.Labels[metadata.KumaMeshLabel] = meshName
-		} else {
-			pod.Labels = map[string]string{
-				metadata.KumaMeshLabel: meshName,
-			}
+		if pod.Labels == nil {
+			pod.Labels = map[string]string{}
 		}
+		pod.Labels[metadata.KumaMeshLabel] = meshName
 
 		podRedirect, err := tproxy_k8s.NewPodRedirectFromAnnotations(pod.Annotations)
 		if err != nil {

--- a/pkg/plugins/runtime/k8s/webhooks/injector/precheck.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/precheck.go
@@ -35,7 +35,7 @@ func (i *KumaInjector) preCheck(ctx context.Context, pod *kube_core.Pod, logger 
 		return "", nil
 	}
 
-	meshName := k8s_util.MeshOfByAnnotation(pod, ns)
+	meshName := k8s_util.MeshOfByLabelOrAnnotation(logger, pod, ns)
 	logger = logger.WithValues("mesh", meshName)
 	// Check mesh exists
 	if err := i.client.Get(ctx, kube_types.NamespacedName{Name: meshName}, &mesh_k8s.Mesh{}); err != nil {

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.01.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.01.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -16,6 +15,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.02.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.02.golden.yaml
@@ -6,7 +6,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -17,6 +16,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.03.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.03.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: coredns
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -18,6 +17,7 @@ metadata:
   generateName: coredns-fb8b8dccf-
   labels:
     k8s-app: kube-dns
+    kuma.io/mesh: default
     pod-template-hash: fb8b8dccf
   ownerReferences:
   - apiVersion: apps/v1

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.04.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.04.golden.yaml
@@ -16,6 +16,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: demo
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.05.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.05.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -16,6 +15,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.06.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.06.golden.yaml
@@ -6,7 +6,6 @@ metadata:
     kuma.io/application-probe-proxy-port: "0"
     kuma.io/envoy-admin-port: "9901"
     kuma.io/gateway: enabled
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -17,6 +16,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.07.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.07.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -16,6 +15,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.08.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.08.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -19,6 +18,7 @@ metadata:
     prometheus.io/scrape: "true"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.09.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.09.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -18,6 +17,7 @@ metadata:
     prometheus.metrics.kuma.io/port: "5678"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.10.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.10.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -16,6 +15,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     kuma.io/sidecar-injection: enabled
     run: busybox
   name: busybox

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.11.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.11.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: mesh-name-from-ns
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -16,6 +15,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: mesh-name-from-ns
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.12.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.12.golden.yaml
@@ -16,6 +16,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: mesh-name-from-pod
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.13.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.13.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -16,6 +15,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.14.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.14.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "19000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -16,6 +15,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.15.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.15.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "0"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -16,6 +15,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.16.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.16.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -18,6 +17,7 @@ metadata:
     traffic.kuma.io/exclude-outbound-ports: "1236"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.17.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.17.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "0"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -18,6 +17,7 @@ metadata:
     traffic.kuma.io/exclude-outbound-ports: 4321,7654
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.18.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.18.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "0"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -18,6 +17,7 @@ metadata:
     traffic.kuma.io/exclude-outbound-ports: ""
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.19.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.19.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "0"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -16,6 +15,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.20.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.20.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "0"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -16,6 +15,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.21.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.21.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -16,6 +15,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.22.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.22.golden.yaml
@@ -6,7 +6,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "0"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-env-vars: KUMA_DATAPLANE_DRAIN_TIME=5s;NEW_ENV_VAR=123
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
@@ -18,6 +17,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.23.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.23.golden.yaml
@@ -9,7 +9,6 @@ metadata:
     kuma.io/builtin-dns-logging: "false"
     kuma.io/builtin-dns-port: "25053"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-env-vars: KUMA_DATAPLANE_DRAIN_TIME=5s;NEW_ENV_VAR=123
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
@@ -21,6 +20,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.24.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.24.golden.yaml
@@ -9,7 +9,6 @@ metadata:
     kuma.io/builtin-dns-logging: "false"
     kuma.io/builtin-dns-port: "25053"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-env-vars: KUMA_DATAPLANE_DRAIN_TIME=5s;NEW_ENV_VAR=123
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-proxy-concurrency: "99"
@@ -22,6 +21,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.25.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.25.golden.yaml
@@ -9,7 +9,6 @@ metadata:
     kuma.io/builtin-dns-logging: "false"
     kuma.io/builtin-dns-port: "25053"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-env-vars: KUMA_DATAPLANE_DRAIN_TIME=5s;NEW_ENV_VAR=123
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
@@ -21,6 +20,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.26.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.26.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/service-account-token-volume: token
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
@@ -17,6 +16,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.27.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.27.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-drain-time: 10s
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
@@ -17,6 +16,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.28.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.28.golden.yaml
@@ -7,7 +7,6 @@ metadata:
     kuma.io/container-patches: container-patch-1
     kuma.io/envoy-admin-port: "9901"
     kuma.io/envoy-log-level: trace
-    kuma.io/mesh: default
     kuma.io/sidecar-drain-time: 10s
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
@@ -19,6 +18,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.29.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.29.golden.yaml
@@ -8,7 +8,6 @@ metadata:
     kuma.io/builtin-dns-logging: "false"
     kuma.io/builtin-dns-port: "25053"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -19,6 +18,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.30.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.30.golden.yaml
@@ -6,7 +6,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "0"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -22,6 +21,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.31.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.31.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -16,6 +15,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.32.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.32.golden.yaml
@@ -6,7 +6,6 @@ metadata:
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
     kuma.io/init-first: "true"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -17,6 +16,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.33.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.33.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "0"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -16,6 +15,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.34.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.34.golden.yaml
@@ -7,7 +7,6 @@ metadata:
     kuma.io/application-probe-proxy-port: "0"
     kuma.io/envoy-admin-port: "9901"
     kuma.io/init-first: "true"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -18,6 +17,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.35.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.35.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: init
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -16,6 +15,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.36.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.36.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -17,6 +16,7 @@ metadata:
     traffic.kuma.io/drop-invalid-packets: "true"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.37.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.37.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -17,6 +16,7 @@ metadata:
     traffic.kuma.io/iptables-logs: "true"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.38.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.38.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -17,6 +16,7 @@ metadata:
     traffic.kuma.io/exclude-outbound-ips: 10.0.0.1,172.16.0.0/16,fe80::1,fe80::/10
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.39.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.39.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -17,6 +16,7 @@ metadata:
     traffic.kuma.io/exclude-inbound-ips: 192.168.0.1,172.32.16.8/16,a81b:a033:6399:73c7:72b6:aa8c:6f22:7098,fe80::/10
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.40.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.40.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -16,6 +15,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.01.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.01.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -16,6 +15,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.02.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.02.golden.yaml
@@ -6,7 +6,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -17,6 +16,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.03.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.03.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: coredns
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -18,6 +17,7 @@ metadata:
   generateName: coredns-fb8b8dccf-
   labels:
     k8s-app: kube-dns
+    kuma.io/mesh: default
     pod-template-hash: fb8b8dccf
   ownerReferences:
   - apiVersion: apps/v1

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.04.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.04.golden.yaml
@@ -16,6 +16,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: demo
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.05.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.05.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -16,6 +15,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.06.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.06.golden.yaml
@@ -6,7 +6,6 @@ metadata:
     kuma.io/application-probe-proxy-port: "0"
     kuma.io/envoy-admin-port: "9901"
     kuma.io/gateway: enabled
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -17,6 +16,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.07.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.07.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -16,6 +15,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.08.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.08.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -19,6 +18,7 @@ metadata:
     prometheus.io/scrape: "true"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.09.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.09.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -18,6 +17,7 @@ metadata:
     prometheus.metrics.kuma.io/port: "5678"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.10.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.10.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -16,6 +15,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     kuma.io/sidecar-injection: enabled
     run: busybox
   name: busybox

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.11.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.11.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: mesh-name-from-ns
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -16,6 +15,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: mesh-name-from-ns
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.12.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.12.golden.yaml
@@ -16,6 +16,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: mesh-name-from-pod
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.13.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.13.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -16,6 +15,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.14.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.14.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "19000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -16,6 +15,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.15.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.15.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "0"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -16,6 +15,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.16.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.16.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -18,6 +17,7 @@ metadata:
     traffic.kuma.io/exclude-outbound-ports: "1236"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.17.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.17.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "0"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -18,6 +17,7 @@ metadata:
     traffic.kuma.io/exclude-outbound-ports: 4321,7654
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.18.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.18.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "0"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -18,6 +17,7 @@ metadata:
     traffic.kuma.io/exclude-outbound-ports: ""
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.19.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.19.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "0"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -16,6 +15,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.20.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.20.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "0"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -16,6 +15,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.21.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.21.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -16,6 +15,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.22.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.22.golden.yaml
@@ -6,7 +6,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "0"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-env-vars: KUMA_DATAPLANE_DRAIN_TIME=5s;NEW_ENV_VAR=123
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
@@ -18,6 +17,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.23.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.23.golden.yaml
@@ -9,7 +9,6 @@ metadata:
     kuma.io/builtin-dns-logging: "false"
     kuma.io/builtin-dns-port: "25053"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-env-vars: KUMA_DATAPLANE_DRAIN_TIME=5s;NEW_ENV_VAR=123
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
@@ -21,6 +20,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.24.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.24.golden.yaml
@@ -9,7 +9,6 @@ metadata:
     kuma.io/builtin-dns-logging: "false"
     kuma.io/builtin-dns-port: "25053"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-env-vars: KUMA_DATAPLANE_DRAIN_TIME=5s;NEW_ENV_VAR=123
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-proxy-concurrency: "99"
@@ -22,6 +21,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.25.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.25.golden.yaml
@@ -9,7 +9,6 @@ metadata:
     kuma.io/builtin-dns-logging: "false"
     kuma.io/builtin-dns-port: "25053"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-env-vars: KUMA_DATAPLANE_DRAIN_TIME=5s;NEW_ENV_VAR=123
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
@@ -21,6 +20,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.26.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.26.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/service-account-token-volume: token
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
@@ -17,6 +16,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.27.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.27.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-drain-time: 10s
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
@@ -17,6 +16,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.28.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.28.golden.yaml
@@ -7,7 +7,6 @@ metadata:
     kuma.io/container-patches: container-patch-1
     kuma.io/envoy-admin-port: "9901"
     kuma.io/envoy-log-level: trace
-    kuma.io/mesh: default
     kuma.io/sidecar-drain-time: 10s
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
@@ -19,6 +18,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.29.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.29.golden.yaml
@@ -8,7 +8,6 @@ metadata:
     kuma.io/builtin-dns-logging: "false"
     kuma.io/builtin-dns-port: "25053"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -19,6 +18,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.30.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.30.golden.yaml
@@ -6,7 +6,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "0"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -22,6 +21,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.31.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.31.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -16,6 +15,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.32.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.32.golden.yaml
@@ -6,7 +6,6 @@ metadata:
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
     kuma.io/init-first: "true"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -17,6 +16,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.33.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.33.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "0"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -16,6 +15,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.34.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.34.golden.yaml
@@ -7,7 +7,6 @@ metadata:
     kuma.io/application-probe-proxy-port: "0"
     kuma.io/envoy-admin-port: "9901"
     kuma.io/init-first: "true"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -18,6 +17,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.35.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.35.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: init
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -16,6 +15,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.36.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.36.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -17,6 +16,7 @@ metadata:
     traffic.kuma.io/drop-invalid-packets: "true"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.37.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.37.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -17,6 +16,7 @@ metadata:
     traffic.kuma.io/iptables-logs: "true"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.38.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.38.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -17,6 +16,7 @@ metadata:
     traffic.kuma.io/exclude-outbound-ips: 10.0.0.1,172.16.0.0/16,fe80::1,fe80::/10
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.39.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.39.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -17,6 +16,7 @@ metadata:
     traffic.kuma.io/exclude-inbound-ips: 192.168.0.1,172.32.16.8/16,a81b:a033:6399:73c7:72b6:aa8c:6f22:7098,fe80::/10
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.40.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.40.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/application-probe-proxy-port: "9000"
     kuma.io/envoy-admin-port: "9901"
-    kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -16,6 +15,7 @@ metadata:
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
   labels:
+    kuma.io/mesh: default
     run: busybox
   name: busybox
 spec:

--- a/pkg/transparentproxy/kubernetes/kubernetes_config.go
+++ b/pkg/transparentproxy/kubernetes/kubernetes_config.go
@@ -484,13 +484,11 @@ func ConfigToAnnotations(
 	cfg tproxy_config.Config,
 	runtimeCfg k8s.Injector,
 	annotations map[string]string,
-	mesh string,
 	defaultAdminPort uint32,
 ) (map[string]string, error) {
 	result := map[string]string{
 		k8s_metadata.KumaSidecarInjectedAnnotation:                 k8s_metadata.AnnotationTrue,
 		k8s_metadata.KumaTransparentProxyingAnnotation:             k8s_metadata.AnnotationEnabled,
-		k8s_metadata.KumaMeshAnnotation:                            mesh, // either user-defined value or default
 		k8s_metadata.KumaSidecarUID:                                cfg.KumaDPUser,
 		k8s_metadata.KumaTransparentProxyingOutboundPortAnnotation: cfg.Redirect.Outbound.Port.String(),
 		k8s_metadata.KumaTransparentProxyingInboundPortAnnotation:  cfg.Redirect.Inbound.Port.String(),

--- a/test/e2e_env/kubernetes/appprobeproxy/probe_proxy.go
+++ b/test/e2e_env/kubernetes/appprobeproxy/probe_proxy.go
@@ -173,7 +173,7 @@ func ApplicationProbeProxy() {
 		By("patch the application pod and disabling application probe proxy using annotation")
 		kubectlOptsApps := kubernetes.Cluster.GetKubectlOptions(namespace)
 		nextTemplateHash := patchAndWait(kubernetes.Cluster.GetTesting(), Default, kubernetes.Cluster, kubectlOptsApps, httpAppName,
-			`[{"op":"add", "path":"/spec/template/metadata/annotations/kuma.io~1application-probe-proxy-port", "value":"0"}]`)
+			`[{"op": "add", "path": "/spec/template/metadata/annotations", "value": {}},{"op":"add", "path":"/spec/template/metadata/annotations/kuma.io~1application-probe-proxy-port", "value":"0"}]`)
 
 		By("checking virtual probes annotations on the new pod")
 		var nextRevPodName string

--- a/test/e2e_env/kubernetes/gateway/cross-mesh.go
+++ b/test/e2e_env/kubernetes/gateway/cross-mesh.go
@@ -204,7 +204,7 @@ kind: Gateway
 metadata:
   name: %s
   namespace: %s
-  annotations:
+  labels:
     kuma.io/mesh: %s
 spec:
   gatewayClassName: kuma-cross-mesh
@@ -220,7 +220,7 @@ kind: HTTPRoute
 metadata:
   name: %s
   namespace: %s
-  annotations:
+  labels:
     kuma.io/mesh: %s
 spec:
   parentRefs:

--- a/test/e2e_env/kubernetes/gateway/gatewayapi.go
+++ b/test/e2e_env/kubernetes/gateway/gatewayapi.go
@@ -119,7 +119,7 @@ kind: Gateway
 metadata:
   name: %s
   namespace: %s
-  annotations:
+  labels:
     kuma.io/mesh: %s
 spec:
   gatewayClassName: ha-kuma
@@ -168,7 +168,7 @@ kind: Gateway
 metadata:
   name: %s
   namespace: %s
-  annotations:
+  labels:
     kuma.io/mesh: %s
 spec:
   gatewayClassName: kuma
@@ -214,7 +214,7 @@ kind: HTTPRoute
 metadata:
   name: test-server-paths
   namespace: %s
-  annotations:
+  labels:
     kuma.io/mesh: %s
 spec:
   parentRefs:
@@ -269,7 +269,7 @@ kind: HTTPRoute
 metadata:
   name: test-server-1
   namespace: %s
-  annotations:
+  labels:
     kuma.io/mesh: %s
 spec:
   parentRefs:
@@ -286,7 +286,7 @@ kind: HTTPRoute
 metadata:
   name: test-server-2
   namespace: %s
-  annotations:
+  labels:
     kuma.io/mesh: %s
 spec:
   parentRefs:
@@ -332,7 +332,7 @@ kind: HTTPRoute
 metadata:
   name: external-service
   namespace: %s
-  annotations:
+  labels:
     kuma.io/mesh: %s
 spec:
   parentRefs:
@@ -388,7 +388,7 @@ kind: Gateway
 metadata:
   name: %s
   namespace: %s
-  annotations:
+  labels:
     kuma.io/mesh: %s
 spec:
   gatewayClassName: kuma
@@ -428,7 +428,7 @@ kind: HTTPRoute
 metadata:
   name: test-server-paths
   namespace: %s
-  annotations:
+  labels:
     kuma.io/mesh: %s
 spec:
   parentRefs:

--- a/test/e2e_env/kubernetes/graceful/eviction.go
+++ b/test/e2e_env/kubernetes/graceful/eviction.go
@@ -36,7 +36,7 @@ kind: Pod
 metadata:
   name: to-be-evicted
   namespace: eviction
-  annotations:
+  labels:
     kuma.io/mesh: eviction
 spec:
   volumes:

--- a/test/e2e_env/kubernetes/graceful/graceful.go
+++ b/test/e2e_env/kubernetes/graceful/graceful.go
@@ -41,7 +41,7 @@ kind: MeshGatewayInstance
 metadata:
   name: edge-gateway
   namespace: graceful
-  annotations:
+  labels:
     kuma.io/mesh: graceful
 spec:
   replicas: %d

--- a/test/e2e_env/kubernetes/graceful/wait_for_envoy.go
+++ b/test/e2e_env/kubernetes/graceful/wait_for_envoy.go
@@ -49,8 +49,8 @@ metadata:
   namespace: %s
   labels:
     app: wait-for-envoy
-  annotations:
     kuma.io/mesh: %s
+  annotations:
     kuma.io/wait-for-dataplane-ready: "true"
 spec:
   restartPolicy: Never

--- a/test/e2e_env/kubernetes/membership/membership.go
+++ b/test/e2e_env/kubernetes/membership/membership.go
@@ -70,7 +70,7 @@ spec:
 			testserver.WithMesh(mesh2),
 			testserver.WithoutWaitingToBeReady(),
 		)(kubernetes.Cluster)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).To(HaveOccurred())
 
 		// then the client is not allowed to do it
 		// then it's not allowed

--- a/test/framework/deployments/democlient/kubernetes.go
+++ b/test/framework/deployments/democlient/kubernetes.go
@@ -43,7 +43,7 @@ func (k *k8SDeployment) deployment() *appsv1.Deployment {
 func (k *k8SDeployment) podSpec() corev1.PodTemplateSpec {
 	return corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:      map[string]string{"app": k.Name()},
+			Labels:      map[string]string{"app": k.Name(), "kuma.io/mesh": k.opts.Mesh},
 			Annotations: k.getAnnotations(),
 		},
 		Spec: corev1.PodSpec{
@@ -97,7 +97,6 @@ func (k *k8SDeployment) service() *corev1.Service {
 
 func (k *k8SDeployment) getAnnotations() map[string]string {
 	annotations := make(map[string]string)
-	annotations["kuma.io/mesh"] = k.opts.Mesh
 	for key, value := range k.opts.PodAnnotations {
 		annotations[key] = value
 	}

--- a/test/framework/deployments/testserver/kubernetes.go
+++ b/test/framework/deployments/testserver/kubernetes.go
@@ -258,7 +258,6 @@ func (k *k8SDeployment) podSpec() corev1.PodTemplateSpec {
 
 func (k *k8SDeployment) getAnnotations() map[string]string {
 	annotations := make(map[string]string)
-	annotations["kuma.io/mesh"] = k.opts.Mesh
 	for key, value := range k.opts.PodAnnotations {
 		annotations[key] = value
 	}
@@ -268,6 +267,7 @@ func (k *k8SDeployment) getAnnotations() map[string]string {
 func (k *k8SDeployment) getLabels() map[string]string {
 	labels := make(map[string]string)
 	labels["app"] = k.Name()
+	labels["kuma.io/mesh"] = k.opts.Mesh
 	for key, value := range k.opts.PodLabels {
 		labels[key] = value
 	}

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -712,8 +712,8 @@ func DemoClientJobK8s(namespace, mesh, destination string) InstallFunc {
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"kuma.io/mesh": mesh},
-					Labels:      map[string]string{"app": name},
+					Annotations: map[string]string{},
+					Labels:      map[string]string{"app": name, "kuma.io/mesh": mesh},
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{


### PR DESCRIPTION
## Motivation

We changed the logic to retrieve the mesh name from the namespace's labels instead of annotations https://github.com/kumahq/kuma/pull/10580. However, the change wasn't applied everywhere, so the `kuma.io/mesh` label didn't work properly on the namespace.

## Implementation information

Instead of using `MeshOfByAnnotation`, I've updated the code to use `MeshOfByLabelOrAnnotation` for consistency. This ensures that the deprecation message will be displayed correctly and the label will be used. Also, we now set `labels` with `kuma.io/mesh` instead of setting the annotations.

## Supporting documentation

Suggests to use a label
https://kuma.io/docs/2.8.x/reference/kubernetes-annotations/#kumaiomesh

Fix https://github.com/kumahq/kuma/issues/11124

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
