### PR TITLE
chore(gha): cancel in progress on prs to not clog up CI

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -14,8 +14,8 @@ env:
   KUMA_DIR: "."
   CI_TOOLS_DIR: "/home/runner/work/kuma/kuma/.ci_tools"
 concurrency:
-  group: ${{github.workflow}}-${{ github.ref == 'refs/heads/master' && github.sha || github.event.pull_request.number }}
-  cancel-in-progress: ${{ github.ref == 'refs/heads/master' && false || true }}
+  group: ${{github.workflow}}-${{ github.event_name == 'push' && github.sha || github.event.pull_request.number }}
+  cancel-in-progress: ${{ github.event_name == 'push' && false || true }}
 jobs:
   check:
     permissions:

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -15,7 +15,7 @@ env:
   CI_TOOLS_DIR: "/home/runner/work/kuma/kuma/.ci_tools"
 concurrency:
   group: ${{github.workflow}}-${{ github.ref == 'refs/heads/master' && github.sha || github.event.pull_request.number }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref == 'refs/heads/master' && false || true }}
 jobs:
   check:
     permissions:

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -13,6 +13,9 @@ permissions:
 env:
   KUMA_DIR: "."
   CI_TOOLS_DIR: "/home/runner/work/kuma/kuma/.ci_tools"
+concurrency:
+  group: ${{github.workflow}}-${{ github.ref == 'refs/heads/master' && github.sha || github.event.pull_request.number }}
+  cancel-in-progress: true
 jobs:
   check:
     permissions:


### PR DESCRIPTION
## Motivation

We're sometimes seeing long queue times and that can be partially due to people pushing to PRs often.

## Implementation information

I'm adding a concurrency group to cancel jobs in progress on PRs only.

## Supporting documentation

xrel https://github.com/kumahq/kuma/pull/10146/files

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
