### PR TITLE
test(e2e): upload e2e reports

### DIFF
--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -138,7 +138,7 @@ jobs:
       - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         if: always()
         with:
-          name: e2e-reports
+          name: e2e-reports-${{ env.E2E_PARAM_TARGET }}-${{ env.E2E_PARAM_ARCH }}-${{ env.E2E_PARAM_K8S_VERSION }}-${{ env.E2E_PARAM_CNI_NETWORK_PLUGIN }}-${{ matrix.parallelRunnerId }}
           if-no-files-found: ignore
           path: |
             build/reports

--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -135,3 +135,11 @@ jobs:
           path: |
             /tmp/e2e-debug/
           retention-days: ${{ github.event_name == 'pull_request' && 5 || 30 }}
+      - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+        if: always()
+        with:
+          name: e2e-reports
+          if-no-files-found: ignore
+          path: |
+            build/reports
+          retention-days: ${{ github.event_name == 'pull_request' && 5 || 30 }}

--- a/mk/test.mk
+++ b/mk/test.mk
@@ -16,7 +16,7 @@ endif
 
 # -race requires CGO_ENABLED=1 https://go.dev/doc/articles/race_detector and https://github.com/golang/go/issues/27089
 UNIT_TEST_ENV=$(GOENV) CGO_ENABLED=1 KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) TMPDIR=/tmp UPDATE_GOLDEN_FILES=$(UPDATE_GOLDEN_FILES) $(if $(CI),TESTCONTAINERS_RYUK_DISABLED=true,GINKGO_EDITOR_INTEGRATION=true)
-GINKGO_TEST=$(GINKGO) $(GOFLAGS) $(call LD_FLAGS,$(GOOS),$(GOARCH)) --keep-going --keep-separate-reports --junit-report results.xml --output-dir $(REPORTS_DIR) $(GINKGO_OPTS)
+GINKGO_TEST=$(GINKGO) $(GOFLAGS) $(call LD_FLAGS,$(GOOS),$(GOARCH)) --keep-going --keep-separate-reports --junit-report results.xml --json-report report.json --output-dir $(REPORTS_DIR) $(GINKGO_OPTS)
 
 .PHONY: test
 test: build/ebpf | $(REPORTS_DIR) ## Dev: Run tests for all modules. to include reports set `make TEST_REPORTS=1` and `make TEST_REPORTS=coverage` to include coverage. To run only some tests by set `TEST_PKG_LIST=./pkg/...` for example


### PR DESCRIPTION
## Motivation

Those kind of reports
```
❯❯❯ python3 script.py
Test: [It] > MeshRetry > should retry on GRPC connection failure, Duration: 158.285 seconds
Test: [It] > Retry > should retry on HTTP connection failure, Duration: 154.582 seconds
Test: [SynchronizedAfterSuite] > , Duration: 125.061 seconds
Test: [It] > External Services through Zone Egress > should not access external service when zone egress is down, Duration: 54.543 seconds
Test: [It] > Resilience > should mark data plane proxy as offline after it is killed forcefully when control-plane is down, Duration: 41.954 seconds
Test: [It] > Gateway - Cross-mesh > when mTLS is enabled > should proxy HTTP requests from a different mesh, Duration: 38.306 seconds
Test: [It] > Compatibility > connection between old and new DPP > from version: 2.8.4, Duration: 34.654 seconds
Test: [It] > MeshLoadBalancingStrategy > should use ring hash load balancing strategy, Duration: 31.549 seconds
Test: [It] > Reachable Services > should not be able to non reachable services, Duration: 30.538 seconds
Test: [It] > Compatibility > connection between old and new DPP > from version: 2.7.8, Duration: 28.289 seconds
Test: [It] > MeshHealthCheck > gRPC > should mark host as unhealthy if it doesn't reply to health checks, Duration: 24.961 seconds
Test: [It] > MeshHealthCheck > TCP with permissive mTLS > should mark host as unhealthy if it doesn't reply to health checks when Permissive mTLS enabled, Duration: 24.310 seconds
Test: [It] > MeshHealthCheck > TCP > should mark host as unhealthy if it doesn't reply on health checks, Duration: 23.665 seconds
Test: [It] > Mesh External Services > without default policies > should route to mesh-external-service over tls, Duration: 23.403 seconds
Test: [It] > Mesh External Services > MeshExternalService with MeshTimeout > should target real MeshExternalService resource, Duration: 21.357 seconds
Test: [It] > Traffic Route > should access all instances of the service, Duration: 21.189 seconds
Test: [It] > HealthCheck panic threshold > should switch to panic mode and dismiss all requests, Duration: 21.098 seconds
Test: [It] > Tracing > should emit traces to jaeger, Duration: 20.918 seconds
Test: [It] > Traffic Logging > TrafficLog Logging to TCP > should send a traffic log to TCP port, Duration: 20.718 seconds
Test: [It] > External Services > without default policies > should route to external-service, Duration: 20.436 seconds
Test: [It] > MeshAccessLog > should log outgoing traffic, Duration: 20.379 seconds
Test: [It] > Leader Election > should elect only one leader and drop the leader on DB disconnect, Duration: 20.251 seconds
Test: [It] > Timeout > should reset the connection by timeout, Duration: 19.754 seconds
```
I want to collect json report so we can build this thing ^

## Implementation information

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

No issue

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
