### PR TITLE
ci(.github): don't require tests for build_publish

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -93,7 +93,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    needs: ["check", "test"]
+    needs: ["check"]
     uses: ./.github/workflows/_build_publish.yaml
     if: ${{ fromJSON(needs.check.outputs.BUILD) }}
     with:


### PR DESCRIPTION
## Motivation

The existence of `master` images should not be predicated on tests passing.
