### PR TITLE
feat(Mesh*Service): add first hostname as kubectl column

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -263,7 +263,11 @@ spec:
     singular: meshexternalservice
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.addresses[0].hostname
+      name: Hostname
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:
@@ -573,6 +577,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -3706,7 +3711,11 @@ spec:
     singular: meshmultizoneservice
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.addresses[0].hostname
+      name: Hostname
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:
@@ -3882,6 +3891,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -5620,7 +5630,11 @@ spec:
     singular: meshservice
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.addresses[0].hostname
+      name: Hostname
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:
@@ -5815,6 +5829,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -263,7 +263,11 @@ spec:
     singular: meshexternalservice
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.addresses[0].hostname
+      name: Hostname
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:
@@ -573,6 +577,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -3706,7 +3711,11 @@ spec:
     singular: meshmultizoneservice
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.addresses[0].hostname
+      name: Hostname
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:
@@ -3882,6 +3891,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -5620,7 +5630,11 @@ spec:
     singular: meshservice
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.addresses[0].hostname
+      name: Hostname
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:
@@ -5815,6 +5829,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -283,7 +283,11 @@ spec:
     singular: meshexternalservice
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.addresses[0].hostname
+      name: Hostname
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:
@@ -593,6 +597,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -3726,7 +3731,11 @@ spec:
     singular: meshmultizoneservice
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.addresses[0].hostname
+      name: Hostname
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:
@@ -3902,6 +3911,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -5640,7 +5650,11 @@ spec:
     singular: meshservice
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.addresses[0].hostname
+      name: Hostname
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:
@@ -5835,6 +5849,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -1869,7 +1869,11 @@ spec:
     singular: meshexternalservice
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.addresses[0].hostname
+      name: Hostname
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:
@@ -2179,6 +2183,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -5262,7 +5267,11 @@ spec:
     singular: meshmultizoneservice
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.addresses[0].hostname
+      name: Hostname
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:
@@ -5438,6 +5447,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -7176,7 +7186,11 @@ spec:
     singular: meshservice
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.addresses[0].hostname
+      name: Hostname
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:
@@ -7371,6 +7385,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/deployments/charts/kuma/crds/kuma.io_meshexternalservices.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshexternalservices.yaml
@@ -16,7 +16,11 @@ spec:
     singular: meshexternalservice
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.addresses[0].hostname
+      name: Hostname
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:
@@ -326,3 +330,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/deployments/charts/kuma/crds/kuma.io_meshmultizoneservices.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshmultizoneservices.yaml
@@ -16,7 +16,11 @@ spec:
     singular: meshmultizoneservice
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.addresses[0].hostname
+      name: Hostname
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:
@@ -192,3 +196,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/deployments/charts/kuma/crds/kuma.io_meshservices.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshservices.yaml
@@ -16,7 +16,11 @@ spec:
     singular: meshservice
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.addresses[0].hostname
+      name: Hostname
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:
@@ -211,3 +215,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/docs/generated/raw/crds/kuma.io_meshexternalservices.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshexternalservices.yaml
@@ -16,7 +16,11 @@ spec:
     singular: meshexternalservice
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.addresses[0].hostname
+      name: Hostname
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:
@@ -326,3 +330,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/docs/generated/raw/crds/kuma.io_meshmultizoneservices.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshmultizoneservices.yaml
@@ -16,7 +16,11 @@ spec:
     singular: meshmultizoneservice
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.addresses[0].hostname
+      name: Hostname
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:
@@ -192,3 +196,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/docs/generated/raw/crds/kuma.io_meshservices.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshservices.yaml
@@ -16,7 +16,11 @@ spec:
     singular: meshservice
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.addresses[0].hostname
+      name: Hostname
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:
@@ -211,3 +215,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/meshexternalservice.go
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/meshexternalservice.go
@@ -15,6 +15,7 @@ import (
 // +kuma:policy:allowed_on_system_namespace_only=true
 // +kuma:policy:has_status=true
 // +kuma:policy:is_referenceable_in_to=true
+// +kubebuilder:printcolumn:name=Hostname,type=string,JSONPath=".status.addresses[0].hostname"
 type MeshExternalService struct {
 	// Match defines traffic that should be routed through the sidecar.
 	Match Match `json:"match"`

--- a/pkg/core/resources/apis/meshexternalservice/k8s/crd/kuma.io_meshexternalservices.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/k8s/crd/kuma.io_meshexternalservices.yaml
@@ -16,7 +16,11 @@ spec:
     singular: meshexternalservice
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.addresses[0].hostname
+      name: Hostname
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:
@@ -326,3 +330,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/pkg/core/resources/apis/meshexternalservice/k8s/v1alpha1/zz_generated.types.go
+++ b/pkg/core/resources/apis/meshexternalservice/k8s/v1alpha1/zz_generated.types.go
@@ -18,6 +18,7 @@ import (
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:categories=kuma,scope=Namespaced
+// +kubebuilder:printcolumn:name=Hostname,type=string,JSONPath=".status.addresses[0].hostname"
 type MeshExternalService struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/meshmultizoneservice.go
+++ b/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/meshmultizoneservice.go
@@ -14,6 +14,7 @@ import (
 // +kuma:policy:is_policy=false
 // +kuma:policy:has_status=true
 // +kuma:policy:is_referenceable_in_to=true
+// +kubebuilder:printcolumn:JSONPath=".status.addresses[0].hostname",name=Hostname,type=string
 type MeshMultiZoneService struct {
 	// Selector is a way to select multiple MeshServices
 	Selector Selector `json:"selector"`

--- a/pkg/core/resources/apis/meshmultizoneservice/k8s/crd/kuma.io_meshmultizoneservices.yaml
+++ b/pkg/core/resources/apis/meshmultizoneservice/k8s/crd/kuma.io_meshmultizoneservices.yaml
@@ -16,7 +16,11 @@ spec:
     singular: meshmultizoneservice
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.addresses[0].hostname
+      name: Hostname
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:
@@ -192,3 +196,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/pkg/core/resources/apis/meshmultizoneservice/k8s/v1alpha1/zz_generated.types.go
+++ b/pkg/core/resources/apis/meshmultizoneservice/k8s/v1alpha1/zz_generated.types.go
@@ -18,6 +18,7 @@ import (
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:categories=kuma,scope=Namespaced
+// +kubebuilder:printcolumn:JSONPath=".status.addresses[0].hostname",name=Hostname,type=string
 type MeshMultiZoneService struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/meshservice.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/meshservice.go
@@ -34,6 +34,7 @@ const maxNameLength = 63
 // +kuma:policy:has_status=true
 // +kuma:policy:kds_flags=model.ZoneToGlobalFlag | model.GlobalToAllButOriginalZoneFlag
 // +kuma:policy:is_referenceable_in_to=true
+// +kubebuilder:printcolumn:JSONPath=".status.addresses[0].hostname",name=Hostname,type=string
 type MeshService struct {
 	// State of MeshService. Available if there is at least one healthy endpoint. Otherwise, Unavailable.
 	// It's used for cross zone communication to check if we should send traffic to it, when MeshService is aggregated into MeshMultiZoneService.

--- a/pkg/core/resources/apis/meshservice/k8s/crd/kuma.io_meshservices.yaml
+++ b/pkg/core/resources/apis/meshservice/k8s/crd/kuma.io_meshservices.yaml
@@ -16,7 +16,11 @@ spec:
     singular: meshservice
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.addresses[0].hostname
+      name: Hostname
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:
@@ -211,3 +215,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/pkg/core/resources/apis/meshservice/k8s/v1alpha1/zz_generated.types.go
+++ b/pkg/core/resources/apis/meshservice/k8s/v1alpha1/zz_generated.types.go
@@ -18,6 +18,7 @@ import (
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:categories=kuma,scope=Namespaced
+// +kubebuilder:printcolumn:JSONPath=".status.addresses[0].hostname",name=Hostname,type=string
 type MeshService struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/tools/policy-gen/generator/cmd/k8s_resource.go
+++ b/tools/policy-gen/generator/cmd/k8s_resource.go
@@ -115,8 +115,8 @@ import (
 )
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:categories=kuma,scope=Namespaced
-{{- if .IsPolicy }} 
+// +kubebuilder:resource:categories=kuma,scope=Namespaced{{ range $marker := .KubebuilderMarkers }}
+{{ $marker }}{{ end }}{{- if .IsPolicy }} 
 // +kubebuilder:printcolumn:name="TargetRef Kind",type="string",JSONPath=".spec.targetRef.kind"
 // +kubebuilder:printcolumn:name="TargetRef Name",type="string",JSONPath=".spec.targetRef.name"
 {{- end }}

--- a/tools/policy-gen/generator/pkg/parse/policyconfig.go
+++ b/tools/policy-gen/generator/pkg/parse/policyconfig.go
@@ -41,6 +41,7 @@ type PolicyConfig struct {
 	Scope                        ResourceScope
 	AllowedOnSystemNamespaceOnly bool
 	IsReferenceableInTo          bool
+	KubebuilderMarkers           []string
 }
 
 func Policy(path string) (PolicyConfig, error) {
@@ -85,28 +86,38 @@ func Policy(path string) (PolicyConfig, error) {
 		}
 	}
 
-	markers, err := parseMarkers(mainComment)
+	markers, kubebuilderMarkers, err := parseMarkers(mainComment)
 	if err != nil {
 		return PolicyConfig{}, err
 	}
 
-	return newPolicyConfig(packageName, mainStruct.Name.String(), markers, fields)
+	cfg, err := newPolicyConfig(packageName, mainStruct.Name.String(), markers, fields)
+	if err != nil {
+		return PolicyConfig{}, err
+	}
+	cfg.KubebuilderMarkers = kubebuilderMarkers
+	return cfg, nil
 }
 
-func parseMarkers(cg *ast.CommentGroup) (map[string]string, error) {
+func parseMarkers(cg *ast.CommentGroup) (map[string]string, []string, error) {
 	result := map[string]string{}
+	var kubebuilderMarkers []string
 	for _, comment := range cg.List {
 		if !strings.HasPrefix(comment.Text, "// +") {
+			continue
+		}
+		if strings.HasPrefix(comment.Text, "// +kubebuilder") {
+			kubebuilderMarkers = append(kubebuilderMarkers, comment.Text)
 			continue
 		}
 		trimmed := strings.TrimPrefix(comment.Text, "// +")
 		mrkr := strings.Split(trimmed, "=")
 		if len(mrkr) != 2 {
-			return nil, errors.Errorf("marker %s has wrong format", trimmed)
+			return nil, nil, errors.Errorf("marker %s has wrong format", trimmed)
 		}
 		result[mrkr[0]] = mrkr[1]
 	}
-	return result, nil
+	return result, kubebuilderMarkers, nil
 }
 
 func parseBool(markers map[string]string, key string) (bool, bool) {


### PR DESCRIPTION
## Motivation

Always nice to not have to go to the YAML

```
❯ kubectl get meshservice -A
NAMESPACE     NAME                        HOSTNAME
kuma-demo     demo-app
kuma-demo     redis
kuma-demo     redis-v1
kuma-demo     redis-v2
kuma-system   demo-app-dxxvv72fvx2wcx9d   demo-app.kuma-demo.svc.east.mesh.local
kuma-system   redis-x5874724v674bxb2      redis.kuma-demo.svc.east.mesh.local
```