### PR TITLE
fix(k8s): only run necessary controllers on global

### DIFF
--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -78,7 +78,7 @@ func addControllers(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter k8
 	if err := addNamespaceReconciler(mgr, rt); err != nil {
 		return err
 	}
-	if err := addServiceReconciler(mgr); err != nil {
+	if err := addServiceReconciler(mgr, rt); err != nil {
 		return err
 	}
 	if err := addMeshServiceReconciler(mgr, rt, converter); err != nil {
@@ -102,7 +102,7 @@ func addControllers(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter k8
 
 	nodeTaintController := rt.Config().Runtime.Kubernetes.NodeTaintController
 	if nodeTaintController.Enabled {
-		if err := addCniNodeTaintReconciler(mgr, nodeTaintController.CniApp, nodeTaintController.CniNamespace); err != nil {
+		if err := addCniNodeTaintReconciler(mgr, rt, nodeTaintController.CniApp, nodeTaintController.CniNamespace); err != nil {
 			return err
 		}
 	}
@@ -110,7 +110,10 @@ func addControllers(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter k8
 	return nil
 }
 
-func addCniNodeTaintReconciler(mgr kube_ctrl.Manager, cniApp string, cniNamespace string) error {
+func addCniNodeTaintReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime, cniApp string, cniNamespace string) error {
+	if rt.Config().Mode == config_core.Global {
+		return nil
+	}
 	reconciler := &k8s_controllers.CniNodeTaintReconciler{
 		Client:       mgr.GetClient(),
 		Log:          core.Log.WithName("controllers").WithName("NodeTaint"),
@@ -122,6 +125,9 @@ func addCniNodeTaintReconciler(mgr kube_ctrl.Manager, cniApp string, cniNamespac
 }
 
 func addNamespaceReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime) error {
+	if rt.Config().Mode == config_core.Global {
+		return nil
+	}
 	reconciler := &k8s_controllers.NamespaceReconciler{
 		Client:     mgr.GetClient(),
 		Log:        core.Log.WithName("controllers").WithName("Namespace"),
@@ -130,7 +136,10 @@ func addNamespaceReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime) erro
 	return reconciler.SetupWithManager(mgr)
 }
 
-func addServiceReconciler(mgr kube_ctrl.Manager) error {
+func addServiceReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime) error {
+	if rt.Config().Mode == config_core.Global {
+		return nil
+	}
 	reconciler := &k8s_controllers.ServiceReconciler{
 		Client: mgr.GetClient(),
 		Log:    core.Log.WithName("controllers").WithName("Service"),
@@ -172,6 +181,9 @@ func addMeshReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime) error {
 }
 
 func addPodReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter k8s_common.Converter) error {
+	if rt.Config().Mode == config_core.Global {
+		return nil
+	}
 	reconciler := &k8s_controllers.PodReconciler{
 		Client:        mgr.GetClient(),
 		EventRecorder: mgr.GetEventRecorderFor("k8s.kuma.io/dataplane-generator"),
@@ -202,6 +214,9 @@ func addPodReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter 
 }
 
 func addPodStatusReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter k8s_common.Converter) error {
+	if rt.Config().Mode == config_core.Global {
+		return nil
+	}
 	reconciler := &k8s_controllers.PodStatusReconciler{
 		Client:            mgr.GetClient(),
 		EventRecorder:     mgr.GetEventRecorderFor("k8s.kuma.io/dataplane-jobs-syncer"),


### PR DESCRIPTION
## Motivation

These aren't needed on global.
