### PR TITLE
chore(heartbeat): properly log new leader address

### DIFF
--- a/pkg/intercp/catalog/heartbeat_component.go
+++ b/pkg/intercp/catalog/heartbeat_component.go
@@ -136,7 +136,7 @@ func (h *heartbeatComponent) connectToLeader(ctx context.Context) error {
 	}
 	heartbeatLog.Info("leader has changed. Creating connection to the new leader.",
 		"previousLeaderAddress", h.leader.Address,
-		"newLeaderAddress", newLeader.Leader,
+		"newLeaderAddress", newLeader.Address,
 	)
 	_, err = h.getClientFn(h.leader.InterCpURL())
 	if err != nil {


### PR DESCRIPTION
## Motivation

We were logging a bool instead of the address.

Found during a heartbeat problem - xrel https://github.com/kumahq/kuma/issues/11718

## Implementation information

Change the bool to the address.

## Supporting documentation

Nothing really.

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
