### PR TITLE
test(lb): loosen up assertion lb weights

### DIFF
--- a/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid_egress.go
+++ b/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid_egress.go
@@ -173,7 +173,7 @@ spec:
 		Eventually(func() (map[string]int, error) {
 			return client.CollectResponsesByInstance(multizone.UniZone1, "demo-client_locality-aware-lb-egress_svc", "test-server_locality-aware-lb-egress_svc_80.mesh", client.WithNumberOfRequests(50))
 		}, "1m", "10s").Should(
-			HaveKeyWithValue(Equal(`test-server-zone-4`), BeNumerically("~", 50, 10)),
+			HaveKeyWithValue(Equal(`test-server-zone-4`), BeNumerically("~", 50, 25)),
 		)
 
 		// kill test-server in kuma-4 zone
@@ -183,7 +183,7 @@ spec:
 		Eventually(func() (map[string]int, error) {
 			return client.CollectResponsesByInstance(multizone.UniZone1, "demo-client_locality-aware-lb-egress_svc", "test-server_locality-aware-lb-egress_svc_80.mesh", client.WithNumberOfRequests(50))
 		}, "1m", "10s").Should(
-			HaveKeyWithValue(Equal(`test-server-zone-1`), BeNumerically("~", 50, 10)),
+			HaveKeyWithValue(Equal(`test-server-zone-1`), BeNumerically("~", 50, 25)),
 		)
 
 		// apply lb policy with new priorities
@@ -205,7 +205,7 @@ spec:
 		Eventually(func() (map[string]int, error) {
 			return client.CollectResponsesByInstance(multizone.UniZone1, "demo-client_locality-aware-lb-egress_svc", "test-server_locality-aware-lb-egress_svc_80.mesh", client.WithNumberOfRequests(50))
 		}, "1m", "10s").Should(
-			HaveKeyWithValue(Equal(`test-server-zone-5`), BeNumerically("~", 50, 10)),
+			HaveKeyWithValue(Equal(`test-server-zone-5`), BeNumerically("~", 50, 25)),
 		)
 
 		// kill test-server from kuma-5 zone
@@ -215,7 +215,7 @@ spec:
 		Eventually(func() (map[string]int, error) {
 			return client.CollectResponsesByInstance(multizone.UniZone1, "demo-client_locality-aware-lb-egress_svc", "test-server_locality-aware-lb-egress_svc_80.mesh", client.WithNumberOfRequests(50))
 		}, "1m", "10s").Should(
-			HaveKeyWithValue(Equal(`test-server-zone-1`), BeNumerically("~", 50, 10)),
+			HaveKeyWithValue(Equal(`test-server-zone-1`), BeNumerically("~", 50, 25)),
 		)
 	})
 }

--- a/test/e2e_env/universal/trafficroute/traffic_route.go
+++ b/test/e2e_env/universal/trafficroute/traffic_route.go
@@ -600,8 +600,8 @@ conf:
 
 			Expect(client.CollectResponsesByInstance(universal.Cluster, "demo-client", "test-server.mesh", client.WithNumberOfRequests(100))).
 				Should(And(
-					HaveKeyWithValue("echo-v1", BeNumerically("~", 50, 10)),
-					HaveKeyWithValue("route-es-http", BeNumerically("~", 50, 10)),
+					HaveKeyWithValue("echo-v1", BeNumerically("~", 50, 25)),
+					HaveKeyWithValue("route-es-http", BeNumerically("~", 50, 25)),
 				))
 		})
 	})


### PR DESCRIPTION
## Motivation

Envoy is not stable enough with the LB weights, we need to loosen up our assertions: https://github.com/kumahq/kuma/actions/runs/11248559631/job/31274149810#step:12:8505

![image](https://github.com/user-attachments/assets/2b055c76-e7db-4ec5-b267-482588b36466)

## Implementation information

Change 10 error bars to 25.

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
