### PR TITLE
Revert "test(e2e): move isolated e2e to arm"

### DIFF
--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -51,7 +51,7 @@ jobs:
               "test_e2e": {
                 "target": [""],
                 "k8sVersion": ["kindIpv6", "${{ env.K8S_MIN_VERSION }}", "${{ env.K8S_MAX_VERSION }}"],
-                "arch": ["arm64"],
+                "arch": ["amd64"],
                 "parallelism": [4],
                 "cniNetworkPlugin": ["flannel"],
                 "sidecarContainers": [""]


### PR DESCRIPTION
Reverts kumahq/kuma#11689 because CI is really unstable on arm

<img width="662" alt="image" src="https://github.com/user-attachments/assets/40a17bf8-a33d-44ed-899c-8dd0ccfa0082">
