### PR TITLE
fix(kuma-cp): don't run MeshService reconciler on global

### DIFF
--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -81,7 +81,7 @@ func addControllers(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter k8
 	if err := addServiceReconciler(mgr); err != nil {
 		return err
 	}
-	if err := addMeshServiceReconciler(mgr, converter); err != nil {
+	if err := addMeshServiceReconciler(mgr, rt, converter); err != nil {
 		return err
 	}
 	if err := addMeshReconciler(mgr, rt); err != nil {
@@ -138,7 +138,10 @@ func addServiceReconciler(mgr kube_ctrl.Manager) error {
 	return reconciler.SetupWithManager(mgr)
 }
 
-func addMeshServiceReconciler(mgr kube_ctrl.Manager, converter k8s_common.Converter) error {
+func addMeshServiceReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter k8s_common.Converter) error {
+	if rt.Config().Mode == config_core.Global {
+		return nil
+	}
 	reconciler := &k8s_controllers.MeshServiceReconciler{
 		Client:            mgr.GetClient(),
 		Log:               core.Log.WithName("controllers").WithName("MeshService"),


### PR DESCRIPTION
## Motivation

This reconciler shouldn't run on global.

I'm at least seeing errors:

```
2024-10-09T09:22:39.277Z	ERROR	kube-manager	Reconciler error	{"controller": "kuma-mesh-service-controller", "controllerGroup": "", "controllerKind": "Service", "Service": {"name":"kube-dns","namespace":"kube-system"}, "namespace": "kube-system", "name": "kube-dns", "reconcileID": "101c399a-4733-4afe-b4f5-f7a3ae25b7eb", "error": "could not delete MeshService: meshservices.kuma.io \"kube-dns\" is forbidden: User \"system:serviceaccount:kuma-system:kuma-control-plane\" cannot delete resource \"meshservices\" in API group \"kuma.io\" in the namespace \"kube-system\": 
```

> Changelog: skip
