### PR TITLE
fix(kuma-cp): map port to section name for reachable backends

### DIFF
--- a/pkg/core/resources/apis/mesh/dataplane_validator.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator.go
@@ -280,9 +280,6 @@ func validateTransparentProxying(tp *mesh_proto.Dataplane_Networking_Transparent
 			if (backendRef.Name != "" || backendRef.Namespace != "") && len(backendRef.Labels) > 0 {
 				result.AddViolationAt(path.Index(i).Field("labels"), "labels cannot be defined when name is specified")
 			}
-			if len(backendRef.Labels) > 0 && backendRef.Port != nil {
-				result.AddViolationAt(path.Index(i).Field("port"), "port cannot be defined when labels are specified")
-			}
 		}
 	}
 	return result

--- a/pkg/core/resources/apis/mesh/dataplane_validator.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator.go
@@ -280,6 +280,9 @@ func validateTransparentProxying(tp *mesh_proto.Dataplane_Networking_Transparent
 			if (backendRef.Name != "" || backendRef.Namespace != "") && len(backendRef.Labels) > 0 {
 				result.AddViolationAt(path.Index(i).Field("labels"), "labels cannot be defined when name is specified")
 			}
+			if len(backendRef.Labels) > 0 && backendRef.Port != nil {
+				result.AddViolationAt(path.Index(i).Field("port"), "port cannot be defined when labels are specified")
+			}
 		}
 	}
 	return result

--- a/pkg/core/resources/apis/mesh/dataplane_validator_test.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator_test.go
@@ -1334,10 +1334,6 @@ var _ = Describe("Dataplane", func() {
                   - kind: MeshService
                   - kind: MeshService
                     namespace: xyz
-                  - kind: MeshService
-                    labels:
-                      kuma.io/test: test
-                    port: 8080
 `,
 			expected: `
                 violations:
@@ -1354,9 +1350,7 @@ var _ = Describe("Dataplane", func() {
                 - field: networking.transparentProxing.reachableBackends.refs[4].name
                   message: name or labels are required
                 - field: networking.transparentProxing.reachableBackends.refs[5].name
-                  message: name is required, when namespace is defined
-                - field: networking.transparentProxing.reachableBackends.refs[6].port
-                  message: port cannot be defined when labels are specified`,
+                  message: name is required, when namespace is defined`,
 		}),
 	)
 })

--- a/pkg/core/resources/apis/mesh/dataplane_validator_test.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator_test.go
@@ -330,6 +330,7 @@ var _ = Describe("Dataplane", func() {
                   refs:
                   - kind: MeshService
                     name: a
+                    port: 9090
                   - kind: MeshExternalService
                     name: es
                     namespace: es1
@@ -1333,6 +1334,10 @@ var _ = Describe("Dataplane", func() {
                   - kind: MeshService
                   - kind: MeshService
                     namespace: xyz
+                  - kind: MeshService
+                    labels:
+                      kuma.io/test: test
+                    port: 8080
 `,
 			expected: `
                 violations:
@@ -1349,7 +1354,9 @@ var _ = Describe("Dataplane", func() {
                 - field: networking.transparentProxing.reachableBackends.refs[4].name
                   message: name or labels are required
                 - field: networking.transparentProxing.reachableBackends.refs[5].name
-                  message: name is required, when namespace is defined`,
+                  message: name is required, when namespace is defined
+                - field: networking.transparentProxing.reachableBackends.refs[6].port
+                  message: port cannot be defined when labels are specified`,
 		}),
 	)
 })

--- a/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/helpers.go
+++ b/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/helpers.go
@@ -26,13 +26,20 @@ func (t *MeshMultiZoneServiceResource) AllocateVIP(vip string) {
 	})
 }
 
-func (m *MeshMultiZoneServiceResource) FindPort(port uint32) (Port, bool) {
+func (m *MeshMultiZoneServiceResource) findPort(port uint32) (Port, bool) {
 	for _, p := range m.Spec.Ports {
 		if p.Port == port {
 			return p, true
 		}
 	}
 	return Port{}, false
+}
+
+func (m *MeshMultiZoneServiceResource) FindSectionNameByPort(port uint32) (string, bool) {
+	if port, found := m.findPort(port); found {
+		return port.GetName(), true
+	}
+	return "", false
 }
 
 func (m *MeshMultiZoneServiceResource) FindPortByName(name string) (Port, bool) {

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/helpers.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/helpers.go
@@ -15,13 +15,20 @@ func (m *MeshServiceResource) DestinationName(port uint32) string {
 	return fmt.Sprintf("%s_%s_%s_%s_msvc_%d", id.Mesh, id.Name, id.Namespace, id.Zone, port)
 }
 
-func (m *MeshServiceResource) FindPort(port uint32) (Port, bool) {
+func (m *MeshServiceResource) findPort(port uint32) (Port, bool) {
 	for _, p := range m.Spec.Ports {
 		if p.Port == port {
 			return p, true
 		}
 	}
 	return Port{}, false
+}
+
+func (m *MeshServiceResource) FindSectionNameByPort(port uint32) (string, bool) {
+	if port, found := m.findPort(port); found {
+		return port.GetName(), true
+	}
+	return "", false
 }
 
 func (m *MeshServiceResource) FindPortByName(name string) (Port, bool) {

--- a/pkg/xds/context/context.go
+++ b/pkg/xds/context/context.go
@@ -162,7 +162,7 @@ func (mc *MeshContext) GetReachableBackends(dataplane *core_mesh.DataplaneResour
 				}),
 			}
 			if port := reachableBackend.Port; port != nil {
-				key.SectionName = fmt.Sprintf("%d", port.GetValue())
+				key.SectionName = mc.getSectionName(key.ResourceType, key.ResourceIdentifier, reachableBackend.Port.GetValue())
 			}
 			reachableBackends[key] = true
 		}
@@ -183,6 +183,33 @@ func (mc *MeshContext) resolveResourceIdentifiersForLabels(kind string, labels m
 		}
 	}
 	return result
+}
+
+func (mc *MeshContext) getSectionName(kind core_model.ResourceType, key core_model.ResourceIdentifier, port uint32) string {
+	switch kind {
+	case meshservice_api.MeshServiceType:
+		ms, found := mc.MeshServiceByIdentifier[key]
+		if !found {
+			return fmt.Sprintf("%d", port)
+		}
+		servicePort, portFound := ms.FindPort(port)
+		if !portFound {
+			return fmt.Sprintf("%d", port)
+		}
+		return servicePort.GetName()
+	case meshmzservice_api.MeshMultiZoneServiceType:
+		mmzs, found := mc.MeshMultiZoneServiceByIdentifier[key]
+		if !found {
+			return fmt.Sprintf("%d", port)
+		}
+		servicePort, portFound := mmzs.FindPort(port)
+		if !portFound {
+			return fmt.Sprintf("%d", port)
+		}
+		return servicePort.GetName()
+	default:
+		return fmt.Sprintf("%d", port)
+	}
 }
 
 func (mc *MeshContext) getResourceNamesForLabels(kind string, labels map[string]string) map[core_model.ResourceIdentifier]int {

--- a/test/e2e_env/multizone/reachablebackends/reachablebackends_meshservices.go
+++ b/test/e2e_env/multizone/reachablebackends/reachablebackends_meshservices.go
@@ -22,6 +22,7 @@ func MeshServicesWithReachableBackendsOption() {
           kuma.io/display-name: other-zone-test-server
       - kind: MeshService
         name: local-test-server
+        port: 80
 `
 
 	mesh := fmt.Sprintf(`


### PR DESCRIPTION
## Motivation

While testing reachable backends, I noticed that when a port is specified but the port name is not a string (i.e., it's not the actual port name), I got 0 clusters.

## Implementation information

Once we retrieve a ResourceIdentifier and the port is provided, we look up the MeshService or MeshMultiZoneService from the map of resources and attempt to find a matching port name, if one exists. If no port name is found, we treat the port as a string.

## Supporting documentation


Noticed once testing

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
