### PR TITLE
fix(e2e): port forward to service instead of pod of kuma-cp to improve test stability

### DIFF
--- a/test/framework/k8s_controlplane.go
+++ b/test/framework/k8s_controlplane.go
@@ -81,7 +81,7 @@ func (c *K8sControlPlane) GetKubectlOptions(namespace ...string) *k8s.KubectlOpt
 func (c *K8sControlPlane) PortForwardKumaCP() {
 	kumaCpSvc := c.GetKumaCPSvc()
 	if k8s.IsServiceAvailable(&kumaCpSvc) {
-		k8s.NewTunnel(c.GetKubectlOptions(Config.KumaNamespace), k8s.ResourceTypePod, kumaCpSvc.Name, 0, 5681)
+		c.portFwd.apiServerTunnel = k8s.NewTunnel(c.GetKubectlOptions(Config.KumaNamespace), k8s.ResourceTypePod, kumaCpSvc.Name, 0, 5681)
 		c.portFwd.apiServerTunnel.ForwardPort(c.t)
 		c.portFwd.ApiServerEndpoint = c.portFwd.apiServerTunnel.Endpoint()
 

--- a/test/framework/k8s_controlplane.go
+++ b/test/framework/k8s_controlplane.go
@@ -81,11 +81,11 @@ func (c *K8sControlPlane) GetKubectlOptions(namespace ...string) *k8s.KubectlOpt
 func (c *K8sControlPlane) PortForwardKumaCP() {
 	kumaCpSvc := c.GetKumaCPSvc()
 	if k8s.IsServiceAvailable(&kumaCpSvc) {
-		c.portFwd.apiServerTunnel = k8s.NewTunnel(c.GetKubectlOptions(Config.KumaNamespace), k8s.ResourceTypePod, kumaCpSvc.Name, 0, 5681)
+		c.portFwd.apiServerTunnel = k8s.NewTunnel(c.GetKubectlOptions(Config.KumaNamespace), k8s.ResourceTypeService, kumaCpSvc.Name, 0, 5681)
 		c.portFwd.apiServerTunnel.ForwardPort(c.t)
 		c.portFwd.ApiServerEndpoint = c.portFwd.apiServerTunnel.Endpoint()
 
-		c.madsFwd.apiServerTunnel = k8s.NewTunnel(c.GetKubectlOptions(Config.KumaNamespace), k8s.ResourceTypePod, kumaCpSvc.Name, 0, 5676)
+		c.madsFwd.apiServerTunnel = k8s.NewTunnel(c.GetKubectlOptions(Config.KumaNamespace), k8s.ResourceTypeService, kumaCpSvc.Name, 0, 5676)
 		c.madsFwd.apiServerTunnel.ForwardPort(c.t)
 		c.madsFwd.ApiServerEndpoint = c.madsFwd.apiServerTunnel.Endpoint()
 		return

--- a/test/framework/k8s_controlplane.go
+++ b/test/framework/k8s_controlplane.go
@@ -79,21 +79,19 @@ func (c *K8sControlPlane) GetKubectlOptions(namespace ...string) *k8s.KubectlOpt
 }
 
 func (c *K8sControlPlane) PortForwardKumaCP() {
-	kumaCpPods := c.GetKumaCPPods()
-	// There could be multiple pods still starting so pick one that's available already
-	for i := range kumaCpPods {
-		if k8s.IsPodAvailable(&kumaCpPods[i]) {
-			c.portFwd.apiServerTunnel = k8s.NewTunnel(c.GetKubectlOptions(Config.KumaNamespace), k8s.ResourceTypePod, kumaCpPods[i].Name, 0, 5681)
-			c.portFwd.apiServerTunnel.ForwardPort(c.t)
-			c.portFwd.ApiServerEndpoint = c.portFwd.apiServerTunnel.Endpoint()
+	kumaCpSvc := c.GetKumaCPSvc()
+	if k8s.IsServiceAvailable(&kumaCpSvc) {
+		k8s.NewTunnel(c.GetKubectlOptions(Config.KumaNamespace), k8s.ResourceTypePod, kumaCpSvc.Name, 0, 5681)
+		c.portFwd.apiServerTunnel.ForwardPort(c.t)
+		c.portFwd.ApiServerEndpoint = c.portFwd.apiServerTunnel.Endpoint()
 
-			c.madsFwd.apiServerTunnel = k8s.NewTunnel(c.GetKubectlOptions(Config.KumaNamespace), k8s.ResourceTypePod, kumaCpPods[i].Name, 0, 5676)
-			c.madsFwd.apiServerTunnel.ForwardPort(c.t)
-			c.madsFwd.ApiServerEndpoint = c.madsFwd.apiServerTunnel.Endpoint()
-			return
-		}
+		c.madsFwd.apiServerTunnel = k8s.NewTunnel(c.GetKubectlOptions(Config.KumaNamespace), k8s.ResourceTypePod, kumaCpSvc.Name, 0, 5676)
+		c.madsFwd.apiServerTunnel.ForwardPort(c.t)
+		c.madsFwd.ApiServerEndpoint = c.madsFwd.apiServerTunnel.Endpoint()
+		return
 	}
-	c.t.Fatalf("Failed finding an available pod, allPods: %v", kumaCpPods)
+
+	c.t.Fatalf("Failed finding an available service, service: %v", kumaCpSvc)
 }
 
 func (c *K8sControlPlane) ClosePortForwards() {


### PR DESCRIPTION


## Motivation

From time to time we were experiencing issues in upgrade test because we were starting port forward to wrong pod of kuma-cp, pod that was already terminating. This fix should mitigate this issue

## Implementation information

port forward to service instead of pod


<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
