### PR TITLE
fix(autoreachableservices): do not filter out MeshMultiZoneService

### DIFF
--- a/pkg/plugins/policies/meshtrafficpermission/graph/reachable_graph.go
+++ b/pkg/plugins/policies/meshtrafficpermission/graph/reachable_graph.go
@@ -38,7 +38,7 @@ func (r *Graph) CanReach(fromTags map[string]string, toTags map[string]string) b
 }
 
 func (r *Graph) CanReachBackend(fromTags map[string]string, backendIdentifier core_model.TypedResourceIdentifier) bool {
-	if backendIdentifier.ResourceType == core_model.ResourceType(common_api.MeshExternalService) {
+	if backendIdentifier.ResourceType == core_model.ResourceType(common_api.MeshExternalService) || backendIdentifier.ResourceType == core_model.ResourceType(common_api.MeshMultiZoneService) {
 		return true
 	}
 	noPort := core_model.TypedResourceIdentifier{


### PR DESCRIPTION
## Motivation

When auto reachable services are enabled, we had no MeshMultiZoneServices.

## Implementation information

Support for MeshMultiZoneService for auto reachable services is not there and we shouldn't filter out MeshMultiZoneService.

Auto reachable services therefore works this way:

- For MeshService it works
- For MeshExternalService and MeshMultiZoneService are just ignored and therefore always present regardless of MTP

## Supporting documentation

Reported during tests
Proper fix to support auto reachable services tracked in:
- https://github.com/kumahq/kuma/issues/11748
- https://github.com/kumahq/kuma/issues/11077

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
