### PR TITLE
ci(.github): don't fail merge release to master if versions.yml isn't updated

### DIFF
--- a/.github/workflows/merge-release-to-master.yaml
+++ b/.github/workflows/merge-release-to-master.yaml
@@ -29,7 +29,9 @@ jobs:
         run: |
           echo "branch=$(make dev/print-latest-release-branch)" >> $GITHUB_OUTPUT
       - run: |
-          make dev/merge-release
+          if [[ "refs/heads/${{ steps.latest-branch.outputs.branch }}" == "${{ github.ref }}" ]]; then
+            make dev/merge-release
+          fi
       - id: commit-changes
         run: |
           git status


### PR DESCRIPTION
## Motivation

As is the job fails because it's taking `release-2.8`, we should just not try to do the merge if we're not merging the right branch.

## Implementation information

Don't try to merge, the rest of the job should just proceed as if there's no merge necessary.