### PR TITLE
fix(k8s): check if labels has changed when reconciling

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/pod_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter.go
@@ -59,7 +59,7 @@ func (p *PodConverter) PodToDataplane(
 	if err != nil {
 		return err
 	}
-	// we need to validate if labels has changed
+	// we need to validate if the labels have changed
 	labels, err := model.ComputeLabels(
 		core_mesh.DataplaneResourceTypeDescriptor,
 		currentSpec,
@@ -99,6 +99,7 @@ func (p *PodConverter) PodToIngress(ctx context.Context, zoneIngress *mesh_k8s.Z
 	if err != nil {
 		return err
 	}
+	// we need to validate if the labels have changed
 	labels, err := model.ComputeLabels(
 		core_mesh.ZoneIngressResourceTypeDescriptor,
 		currentSpec,
@@ -138,6 +139,7 @@ func (p *PodConverter) PodToEgress(ctx context.Context, zoneEgress *mesh_k8s.Zon
 	if err != nil {
 		return err
 	}
+	// we need to validate if the labels have changed
 	labels, err := model.ComputeLabels(
 		core_mesh.ZoneEgressResourceTypeDescriptor,
 		currentSpec,

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"regexp"
 
 	"github.com/pkg/errors"
@@ -11,6 +12,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	config_core "github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/pkg/core"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
@@ -33,6 +35,8 @@ type PodConverter struct {
 	ResourceConverter   k8s_common.Converter
 	InboundConverter    InboundConverter
 	Zone                string
+	SystemNamespace     string
+	Mode                config_core.CpMode
 	KubeOutboundsAsVIPs bool
 }
 
@@ -55,8 +59,22 @@ func (p *PodConverter) PodToDataplane(
 	if err != nil {
 		return err
 	}
-
-	if model.Equal(currentSpec, dataplaneProto) && previousMesh == dataplane.Mesh {
+	// we need to validate if labels has changed
+	labels, err := model.ComputeLabels(
+		core_mesh.DataplaneResourceTypeDescriptor,
+		currentSpec,
+		map[string]string{},
+		k8s_common.ResourceNameExtensions(pod.Namespace, pod.Name),
+		dataplane.Mesh,
+		p.Mode,
+		true,
+		p.SystemNamespace,
+		p.Zone,
+	)
+	if err != nil {
+		return err
+	}
+	if model.Equal(currentSpec, dataplaneProto) && previousMesh == dataplane.Mesh && reflect.DeepEqual(labels, dataplane.GetLabels()) {
 		logger.V(1).Info("resource hasn't changed, skip")
 		return nil
 	}
@@ -81,7 +99,22 @@ func (p *PodConverter) PodToIngress(ctx context.Context, zoneIngress *mesh_k8s.Z
 	if err != nil {
 		return err
 	}
-	if model.Equal(currentSpec, zoneIngressRes.Spec) {
+	labels, err := model.ComputeLabels(
+		core_mesh.ZoneIngressResourceTypeDescriptor,
+		currentSpec,
+		map[string]string{},
+		k8s_common.ResourceNameExtensions(pod.Namespace, pod.Name),
+		model.NoMesh,
+		p.Mode,
+		true,
+		p.SystemNamespace,
+		p.Zone,
+	)
+	if err != nil {
+		return err
+	}
+
+	if model.Equal(currentSpec, zoneIngressRes.Spec) && reflect.DeepEqual(labels, zoneIngress.GetLabels()) {
 		logger.V(1).Info("resource hasn't changed, skip")
 		return nil
 	}
@@ -105,7 +138,21 @@ func (p *PodConverter) PodToEgress(ctx context.Context, zoneEgress *mesh_k8s.Zon
 	if err != nil {
 		return err
 	}
-	if model.Equal(currentSpec, zoneEgressRes.Spec) {
+	labels, err := model.ComputeLabels(
+		core_mesh.ZoneEgressResourceTypeDescriptor,
+		currentSpec,
+		map[string]string{},
+		k8s_common.ResourceNameExtensions(pod.Namespace, pod.Name),
+		model.NoMesh,
+		p.Mode,
+		true,
+		p.SystemNamespace,
+		p.Zone,
+	)
+	if err != nil {
+		return err
+	}
+	if model.Equal(currentSpec, zoneEgressRes.Spec) && reflect.DeepEqual(labels, zoneEgress.GetLabels()) {
 		logger.V(1).Info("resource hasn't changed, skip")
 		return nil
 	}

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -189,6 +189,8 @@ func addPodReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter 
 				NodeLabelsToCopy: rt.Config().Runtime.Kubernetes.Injector.NodeLabelsToCopy,
 			},
 			Zone:                rt.Config().Multizone.Zone.Name,
+			SystemNamespace:     rt.Config().Store.Kubernetes.SystemNamespace,
+			Mode:                rt.Config().Mode,
 			ResourceConverter:   converter,
 			KubeOutboundsAsVIPs: rt.Config().Experimental.KubeOutboundsAsVIPs,
 		},


### PR DESCRIPTION
## Motivation

When upgrading from 2.8.4 to 2.9, I noticed that Dataplane labels were not propagated, and the Dataplane object wasn't reconciled.

## Implementation information

We introduced a performance optimization that compares an object before adding it to the database on Kubernetes: https://github.com/kumahq/kuma/pull/11327. Unfortunately, this check only covers the Spec and Mesh. In the 2.9 release, we added functionality to set common labels on the Dataplane object: https://github.com/kumahq/kuma/blob/master/pkg/core/managers/apis/dataplane/dataplane_manager.go#L59. The issue is that this is called much later. At the controller level, we had no information about label changes. To fix this, I added a change in the controller that generates labels, and if the existing labels differ from those returned by `ComputeLabels`, we trigger an update.

## Supporting documentation


Fix https://github.com/kumahq/kuma/issues/11755

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
