### PR TITLE
fix(e2e): loosen up assertion on traffic route test

### DIFF
--- a/test/e2e_env/universal/trafficroute/traffic_route.go
+++ b/test/e2e_env/universal/trafficroute/traffic_route.go
@@ -402,7 +402,7 @@ conf:
 				Should(And(
 					HaveLen(2),
 					HaveKey(`echo-v3`),
-					HaveKeyWithValue(`echo-v4`, BeNumerically("~", 80, 10)),
+					HaveKeyWithValue(`echo-v4`, BeNumerically("~", 80, 25)),
 				))
 		})
 

--- a/test/e2e_env/universal/trafficroute/traffic_route.go
+++ b/test/e2e_env/universal/trafficroute/traffic_route.go
@@ -402,7 +402,7 @@ conf:
 				Should(And(
 					HaveLen(2),
 					HaveKey(`echo-v3`),
-					HaveKeyWithValue(`echo-v4`, BeNumerically("~", 80, 25)),
+					HaveKeyWithValue(`echo-v4`, BeNumerically("~", 80, 20)),
 				))
 		})
 


### PR DESCRIPTION
## Motivation

We have seen flake on master recently:

<img width="643" alt="Screenshot 2024-10-11 at 09 31 42" src="https://github.com/user-attachments/assets/267fa881-00c9-4bc5-891a-66758ba0f905">

I think we could loosen up the assertions to make it more stable

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
