### PR TITLE
ci(github): downgrade github action runner from ubuntu-latest to ubuntu-22.04 for images building

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -88,7 +88,7 @@ jobs:
         run: |
           make publish/pulp
   build-images:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # pining to this version until https://github.com/actions/runner-images/issues/10636#issuecomment-2397720931 has a better solution
     timeout-minutes: 30
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Motivation

We hit the cross compiling error once building the `kuma-init` ARM64 image on github CI runner (X86 platform) with the `ubuntu-latest` runner.

Here's the context
```text
#5 31.28 dpkg: error processing package libc-bin (--configure):
#5 31.28  installed libc-bin package post-installation script subprocess returned error exit status 139
#5 31.29 Errors were encountered while processing:
#5 31.29  libc-bin
#5 31.36 E: Sub-process /usr/bin/dpkg returned an error code (1)
#5 ERROR: process "/bin/sh -c apt-get update &&     apt-get install --no-install-recommends -y iptables=1.8.7-1ubuntu5.2 iproute2=5.15.0-1ubuntu2 &&     rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 100
------
 > [2/6] RUN apt-get update &&     apt-get install --no-install-recommends -y iptables=1.8.7-1ubuntu5.2 iproute2=5.15.0-1ubuntu2 &&     rm -rf /var/lib/apt/lists/*:
30.66 debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/aarch64-linux-gnu/perl/5.34.0 /usr/local/share/perl/5.34.0 /usr/lib/aarch64-linux-gnu/perl5/5.34 /usr/share/perl5 /usr/lib/aarch64-linux-gnu/perl-base /usr/lib/aarch64-linux-gnu/perl/5.34 /usr/share/perl/5.34 /usr/local/lib/site_perl) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
30.66 debconf: falling back to frontend: Teletype
30.93 Processing triggers for libc-bin (2.35-0ubuntu3.8) ...
31.12 Segmentation fault (core dumped)
31.28 Segmentation fault (core dumped)
31.28 dpkg: error processing package libc-bin (--configure):
31.28  installed libc-bin package post-installation script subprocess returned error exit status 139
31.29 Errors were encountered while processing:
31.29  libc-bin
31.36 E: Sub-process /usr/bin/dpkg returned an error code (1)
------
kuma-init.Dockerfile:5
--------------------
   4 |     
   5 | >>> RUN apt-get update && \
   6 | >>>     apt-get install --no-install-recommends -y iptables=1.8.7-1ubuntu5.2 iproute2=5.15.0-1ubuntu2 && \
   7 | >>>     rm -rf /var/lib/apt/lists/*
```

https://github.com/kumahq/kuma/actions/runs/11294867947/job/31442107968#step:9:4051

## Implementation information

Downgrade the runner version from `ubuntu-latest` to `ubuntu-22.04`

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
