### PR TITLE
fix(kuma-cp): Global Inspect API returns incorrect list of affected gateways dataplanes

### DIFF
--- a/pkg/plugins/policies/core/matchers/dataplane.go
+++ b/pkg/plugins/policies/core/matchers/dataplane.go
@@ -22,7 +22,8 @@ import (
 func PolicyMatches(resource core_model.Resource, dpp *core_mesh.DataplaneResource, referencableResources xds_context.Resources) (bool, error) {
 	var gateway *core_mesh.MeshGatewayResource
 	if dpp.Spec.IsBuiltinGateway() {
-		gateway = xds_topology.SelectGateway(referencableResources.Gateways().Items, dpp.Spec.Matches)
+		zoneGateways := filterGatewaysByZone(referencableResources.Gateways().Items, dpp)
+		gateway = xds_topology.SelectGateway(zoneGateways, dpp.Spec.Matches)
 	}
 	refPolicy, ok := resource.GetSpec().(core_model.Policy)
 	if !ok {


### PR DESCRIPTION
## Motivation

<!-- Why are we doing this change -->

Affected Dataplanes list was incorrect for policies targeting builtin gateways.

## Implementation information

<!-- Explain how this was done and potentially alternatives considered and discarded -->

The call of `filterGatewaysByZone` was missing in `PolicyMatches` method.

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

No issue

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
