### PR TITLE
fix(kuma-cp): resources that were created on 2.7.x are missing namespace labels when synced on global

### DIFF
--- a/pkg/kds/context/context.go
+++ b/pkg/kds/context/context.go
@@ -103,6 +103,7 @@ func DefaultContext(
 			util.WithLabel(mesh_proto.ResourceOriginLabel, string(mesh_proto.ZoneResourceOrigin)),
 			util.WithLabel(mesh_proto.ZoneTag, cfg.Multizone.Zone.Name),
 			util.WithoutLabel(mesh_proto.DeletionGracePeriodStartedLabel),
+			util.If(util.IsKubernetes(cfg.Store.Type), util.PopulateNamespaceLabelFromNameExtension()),
 		),
 		MapInsightResourcesZeroGeneration,
 		reconcile_v2.If(

--- a/pkg/kds/util/meta.go
+++ b/pkg/kds/util/meta.go
@@ -40,7 +40,7 @@ func WithLabel(key, value string) CloneResourceMetaOpt {
 // before syncing them to Global.
 //
 // In 2.7.x method 'GetMeta().GetLabels()' on Kubernetes returned a label map with 'k8s.kuma.io/namespace' added
-// dynamically. This behaviour was changed in 2.9.x by https://github.com/kumahq/kuma/pull/11020, the namespace label is now
+// dynamically. This behavior was changed in 2.9.x by https://github.com/kumahq/kuma/pull/11020, the namespace label is now
 // supposed to be set in ComputeLabels function. But this functions is called only on Create/Update of the resources.
 // This means policies that were created on 2.7.x won't have 'k8s.kuma.io/namespace' label when synced to Global.
 // Even though the lack of namespace labels affects only how resource looks in GUI on Global it's still worth setting it.


### PR DESCRIPTION
## Motivation

In 2.7.x method `GetMeta().GetLabels()` on Kubernetes returned a label map with `k8s.kuma.io/namespace` added dynamically. This behaviour was changed in 2.9.x by https://github.com/kumahq/kuma/pull/11020, the namespace label is now supposed to be set in ComputeLabels function. But this functions is called only on Create/Update of the resources. This means policies that were created on 2.7.x won't have `k8s.kuma.io/namespace` label when synced to Global. Even though the lack of namespace labels affects only how resource looks in GUI on Global it's still worth setting it.

<!-- Why are we doing this change -->

## Implementation information

Set `k8s.kuma.io/namespace` label if not exist to the resources before syncing them to Global.
<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
