### PR TITLE
test(e2e): increase leader election lease and renew duration

### DIFF
--- a/test/framework/envs/kubernetes/env.go
+++ b/test/framework/envs/kubernetes/env.go
@@ -31,6 +31,11 @@ func SetupAndGetState() []byte {
 			framework.WithCtlOpts(map[string]string{
 				"--set": "controlPlane.supportGatewaySecretsInAllNamespaces=true", // needed for test/e2e_env/kubernetes/gateway/gatewayapi.go:470
 			}),
+			// Occasionally CP will lose a leader in the E2E test just because of this deadline,
+			// which does not make sense in such controlled environment (one k3d node, one instance of the CP).
+			// 100s and 80s are values that we also use in mesh-perf when we put a lot of pressure on the CP.
+			framework.WithEnv("KUMA_RUNTIME_KUBERNETES_LEADER_ELECTION_LEASE_DURATION", "100s"),
+			framework.WithEnv("KUMA_RUNTIME_KUBERNETES_LEADER_ELECTION_RENEW_DEADLINE", "80s"),
 		},
 		framework.KumaDeploymentOptionsFromConfig(framework.Config.KumaCpConfig.Standalone.Kubernetes)...,
 	)

--- a/test/framework/envs/multizone/env.go
+++ b/test/framework/envs/multizone/env.go
@@ -62,6 +62,11 @@ func setupKubeZone(wg *sync.WaitGroup, clusterName string, extraOptions ...frame
 		WithEgress(),
 		WithEgressEnvoyAdminTunnel(),
 		WithGlobalAddress(Global.GetKuma().GetKDSServerAddress()),
+		// Occasionally CP will lose a leader in the E2E test just because of this deadline,
+		// which does not make sense in such controlled environment (one k3d node, one instance of the CP).
+		// 100s and 80s are values that we also use in mesh-perf when we put a lot of pressure on the CP.
+		framework.WithEnv("KUMA_RUNTIME_KUBERNETES_LEADER_ELECTION_LEASE_DURATION", "100s"),
+		framework.WithEnv("KUMA_RUNTIME_KUBERNETES_LEADER_ELECTION_RENEW_DEADLINE", "80s"),
 	}
 	options = append(options, extraOptions...)
 	zone := NewK8sCluster(NewTestingT(), clusterName, Verbose)


### PR DESCRIPTION
## Motivation

Every now and then we hit a problem when CP on Kube drops a leader, then the test fails because we have an assertion that CP did not restart. Additionally, I'm testing speeding up tests here https://github.com/kumahq/kuma/pull/11791 which puts more pressure on CP and increases the chances of it happening.

<!-- Why are we doing this change -->

## Implementation information

Just increase lease and renew duration. It makes sense to have those higher in case of local kube cluster. Why we won't change defaults? Because on real kube clusters with multiple nodes and multiple instances of Kuma CP, the chance of switching a leader because of random event in the cluster is much much higher.

We do exact same thing in mesh-perf scenario when we stress CP out.

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

may solve xref https://github.com/kumahq/kuma/issues/11090 but not in 100% of cases.

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
