### PR TITLE
test(e2e): add sidecar containers param to uploaded file names

### DIFF
--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -130,7 +130,7 @@ jobs:
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         if: always()
         with:
-          name: e2e-debug-${{ env.E2E_PARAM_TARGET }}-${{ env.E2E_PARAM_ARCH }}-${{ env.E2E_PARAM_K8S_VERSION }}-${{ env.E2E_PARAM_CNI_NETWORK_PLUGIN }}-${{ matrix.parallelRunnerId }}
+          name: e2e-debug-${{ env.E2E_PARAM_TARGET }}-${{ env.E2E_PARAM_ARCH }}-${{ env.E2E_PARAM_K8S_VERSION }}-${{ env.E2E_PARAM_CNI_NETWORK_PLUGIN }}-${{ env.E2E_PARAM_SIDECAR_CONTAINERS }}-${{ matrix.parallelRunnerId }}
           if-no-files-found: ignore
           path: |
             /tmp/e2e-debug/
@@ -138,7 +138,7 @@ jobs:
       - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         if: always()
         with:
-          name: e2e-reports-${{ env.E2E_PARAM_TARGET }}-${{ env.E2E_PARAM_ARCH }}-${{ env.E2E_PARAM_K8S_VERSION }}-${{ env.E2E_PARAM_CNI_NETWORK_PLUGIN }}-${{ matrix.parallelRunnerId }}
+          name: e2e-reports-${{ env.E2E_PARAM_TARGET }}-${{ env.E2E_PARAM_ARCH }}-${{ env.E2E_PARAM_K8S_VERSION }}-${{ env.E2E_PARAM_CNI_NETWORK_PLUGIN }}-${{ env.E2E_PARAM_SIDECAR_CONTAINERS }}-${{ matrix.parallelRunnerId }}
           if-no-files-found: ignore
           path: |
             build/reports


### PR DESCRIPTION
## Motivation

The uploaded names should contain all the params.
Technically we were fine in Kuma without sidecar containers param, because we run
* sidecars containers: true, k8s version: max, cni: empty
* sidecars containers: false, k8s version: max, cni: flannel
so CNI was different.

However, in KM we also add another target
* sidecars containers: false, k8s version: max, cni: empty, other param: true
and we hit the conflict.

Ideally we should also add this other param to file name in KM, but adding this in Kuma is correct and is a good start.

## Implementation information

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

No issue. KM CI broken.

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
