### PR TITLE
feat(kuma-cp): clock skew for generated certs

### DIFF
--- a/pkg/tls/cert.go
+++ b/pkg/tls/cert.go
@@ -111,7 +111,7 @@ func NewCert(
 }
 
 func newCert(issuer *pkix.Name, certType CertType, hosts ...string) (x509.Certificate, error) {
-	notBefore := time.Now()
+	notBefore := time.Now().Add(-DefaultAllowedClockSkew)
 	notAfter := notBefore.Add(DefaultValidityPeriod)
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)


### PR DESCRIPTION
## Motivation

We noticed that in this run of E2E tests admin operation failed.
https://github.com/kumahq/kuma/actions/runs/11406777608/job/31744572466
with
```
2024-10-18T17:01:59.005Z	ERROR	rest	Could not execute admin operation	{"error": "unable to send GET to config_dump: Get \"https://10.42.0.16:9901/config_dump\": remote error: tls: expired certificate", "errorVerbose": "Get ...
```
while the cert from config dump says
```
        Validity
            Not Before: Oct 18 17:01:55 2024 GMT
            Not After : Oct 16 17:01:55 2034 GMT
```
Go will report expired if we violate either not before or not after
```
	if now.Before(c.NotBefore) {
		return CertificateInvalidError{
			Cert:   c,
			Reason: Expired,
			Detail: fmt.Sprintf("current time %s is before %s", now.Format(time.RFC3339), c.NotBefore.Format(time.RFC3339)),
		}
	} else if now.After(c.NotAfter) {
		return CertificateInvalidError{
			Cert:   c,
			Reason: Expired,
			Detail: fmt.Sprintf("current time %s is after %s", now.Format(time.RFC3339), c.NotAfter.Format(time.RFC3339)),
		}
	}
```
It's not realistic that we violated Not After, but technically it's possible with Not Before.

<!-- Why are we doing this change -->

## Implementation information

We use clock skew already when we generate CA.
We should also use it for certs. This applies for certs generated for
* inter cp
* cp -> envoy admin
* certs generated by kumactl generate cert
* cfg.General.TlsCertFile if no cert is provided

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

No issue, noticed failing CI.

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
