### PR TITLE
fix(kds): do not log error when context canceled

### DIFF
--- a/pkg/kds/context/context.go
+++ b/pkg/kds/context/context.go
@@ -324,7 +324,9 @@ func GlobalProvidedFilter(rm manager.ResourceManager, configs map[string]bool) r
 
 			zone := system.NewZoneResource()
 			if err := rm.Get(ctx, zone, store.GetByKey(zoneTag, core_model.NoMesh)); err != nil {
-				log.Error(err, "failed to get zone", "zone", zoneTag)
+				if !errors.Is(err, context.Canceled) {
+					log.Error(err, "failed to get zone", "zone", zoneTag)
+				}
 				// since there is no explicit 'enabled: false' then we don't
 				// make any strong decisions which might affect connectivity
 				return true


### PR DESCRIPTION
## Motivation

We shouldn't log an error when a user disconnects and we observe `context canceled`.

## Implementation information

Added a condition to check if an error is `context canceled` and if is to don't login an error.

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix: https://github.com/Kong/kong-mesh/issues/6467

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
