### PR TITLE
fix(api): return 499 when client cancel context

### DIFF
--- a/pkg/core/rest/errors/error_handler.go
+++ b/pkg/core/rest/errors/error_handler.go
@@ -153,6 +153,12 @@ func HandleError(ctx context.Context, response *restful.Response, err error, tit
 			Title:  title,
 			Detail: err.Error(),
 		}
+	case errors.Is(err, context.Canceled):
+		kumaErr = &types.Error{
+			Status: 499,
+			Title:  title,
+			Detail: err.Error(),
+		}
 	case errors.As(err, &kumaErr):
 	default:
 		log.Error(err, title)


### PR DESCRIPTION
## Motivation

A client requesting a resource from the service might close the connection, canceling the context. In this case, the API throws a 5xx server error, but this is more of a client-side issue.

## Implementation information

I used status code 499 as the response code for this situation, which is commonly used in NGINX to indicate that the client closed the connection before the server could send a response.

## Supporting documentation

https://github.com/pocketbase/pocketbase/discussions/834

Fix https://github.com/Kong/kong-mesh/issues/6468

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
