### PR TITLE
ci(.github): use latest version of ubuntu runner image to build kuma-init image

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -88,7 +88,7 @@ jobs:
         run: |
           make publish/pulp
   build-images:
-    runs-on: ubuntu-22.04 # pining to this version until https://github.com/actions/runner-images/issues/10636#issuecomment-2397720931 has a better solution
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -196,6 +196,7 @@ jobs:
   digest-images:
     needs: [build-images]
     runs-on: ubuntu-latest
+    if: ${{ fromJSON(inputs.ALLOW_PUSH) }}
     outputs:
       DIGESTS: ${{ steps.compute-digests.outputs.digests }}
     steps:


### PR DESCRIPTION
## Motivation

Restore the changes we'd done to work around these issues:
* https://github.com/kumahq/kuma/issues/11804
* https://github.com/kumahq/kuma/issues/11809

## Implementation information

Use `ubuntu-latest` runner images.
I'm creating the PR from the same repo to maintain parity between runs here and those of master branches.

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
