### PR TITLE
test(e2e): loosen up assertions on traffic split

### DIFF
--- a/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid_gateway.go
+++ b/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid_gateway.go
@@ -153,9 +153,9 @@ conf:
 			return client.CollectResponsesByInstance(multizone.UniZone1, "gateway-client", fmt.Sprintf("http://%s", net.JoinHostPort(gatewayIP, "8080")), client.WithHeader("Host", "example.kuma.io"), client.WithNumberOfRequests(200))
 		}, "2m", "10s").Should(
 			And(
-				HaveKeyWithValue(Equal(`test-server-zone-4`), BeNumerically("~", 100, 40)),
-				HaveKeyWithValue(Equal(`test-server-zone-5`), BeNumerically("~", 50, 20)),
-				HaveKeyWithValue(Equal(`test-server-zone-1`), BeNumerically("~", 50, 20)),
+				HaveKeyWithValue(Equal(`test-server-zone-4`), BeNumerically("~", 100, 50)),
+				HaveKeyWithValue(Equal(`test-server-zone-5`), BeNumerically("~", 50, 25)),
+				HaveKeyWithValue(Equal(`test-server-zone-1`), BeNumerically("~", 50, 25)),
 			),
 		)
 


### PR DESCRIPTION
## Motivation

The test seems to be a bit flaky, but not frequently. The difference in test values was small.
## Implementation information

I have increased the traffic split values slightly.

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
