### PR TITLE
test(e2e): use MeshService mode and generated hostname

### DIFF
--- a/test/e2e_env/universal/meshhealthcheck/policy.go
+++ b/test/e2e_env/universal/meshhealthcheck/policy.go
@@ -136,16 +136,6 @@ spec:
 					WithTransparentProxy(true)),
 				).
 				Install(TestServerUniversal("test-server", meshName, WithArgs([]string{"health-check", "http"}), WithProtocol(mesh.ProtocolHTTP))).
-				Install(YamlUniversal(`
-type: HostnameGenerator
-name: uni-ms-mhc
-spec:
-  template: '{{ .DisplayName }}.universal.ms'
-  selector:
-    meshService:
-      matchLabels:
-        kuma.io/origin: zone
-        kuma.io/env: universal`)).
 				Setup(universal.Cluster)
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -163,7 +153,7 @@ spec:
 			// check that test-server is healthy
 			Eventually(func(g Gomega) {
 				stdout, _, err := client.CollectResponse(
-					universal.Cluster, "dp-demo-client", "test-server.universal.ms/content",
+					universal.Cluster, "dp-demo-client", "test-server.svc.mesh.local/content",
 				)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(stdout).To(ContainSubstring("response"))
@@ -183,7 +173,7 @@ spec:
 			// check that test-server is unhealthy
 			Consistently(func(g Gomega) {
 				response, err := client.CollectFailure(
-					universal.Cluster, "dp-demo-client", "test-server.universal.ms/content",
+					universal.Cluster, "dp-demo-client", "test-server.svc.mesh.local/content",
 				)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(response.ResponseCode).To(Equal(503))


### PR DESCRIPTION
## Motivation

I've noticed a flake of the test

## Implementation information

I switched to using MeshService mode instead of manually creating a MeshService. I'm not sure if MeshService might be removed since the Mesh has `meshServices.mode` disabled. Additionally, I changed the hostname to use generated one.

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
