### PR TITLE
feat(meshservices): opt-in ignore converting

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/meshservice_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/meshservice_controller.go
@@ -121,6 +121,12 @@ func (r *MeshServiceReconciler) Reconcile(ctx context.Context, req kube_ctrl.Req
 	}
 
 	if len(svc.GetAnnotations()) > 0 {
+		if ignored, _, _ := metadata.Annotations(svc.GetAnnotations()).GetBoolean(metadata.KumaIgnoreAnnotation); ignored {
+			if err := r.deleteIfExist(ctx, req.NamespacedName); err != nil {
+				return kube_ctrl.Result{}, err
+			}
+			return kube_ctrl.Result{}, nil
+		}
 		if _, ok := svc.GetAnnotations()[metadata.KumaGatewayAnnotation]; ok {
 			log.V(1).Info("service is for gateway. Ignoring.")
 			return kube_ctrl.Result{}, nil

--- a/pkg/plugins/runtime/k8s/controllers/meshservice_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/meshservice_controller_test.go
@@ -114,5 +114,9 @@ var _ = Describe("MeshServiceController", func() {
 			inputFile:  "headless.resources.yaml",
 			outputFile: "headless.meshservice.yaml",
 		}),
+		Entry("with kuma.io/ignore", testCase{
+			inputFile:  "ignore.resources.yaml",
+			outputFile: "ignore.meshservice.yaml",
+		}),
 	)
 })

--- a/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/ignore.meshservice.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/ignore.meshservice.yaml
@@ -1,0 +1,2 @@
+items: null
+metadata: {}

--- a/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/ignore.resources.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/ignore.resources.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: demo
+  name: example
+  annotations:
+    kuma.io/ignore: "true"
+spec:
+  clusterIP: 192.168.0.1
+  ports:
+    - name: http-port
+      appProtocol: http
+      port: 80
+      targetPort: 8080
+      protocol: TCP
+    - name: tcp-port
+      port: 443
+      targetPort: 8443
+      protocol: TCP
+    - port: 1234 # ignored because it's UDP
+      targetPort: 4444
+      protocol: UDP
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: demo
+  labels:
+    kuma.io/sidecar-injection: enabled
+---
+apiVersion: kuma.io/v1alpha1
+kind: Mesh
+metadata:
+  name: default
+spec:
+  meshServices:
+    mode: Everywhere


### PR DESCRIPTION
## Motivation

We need to have a way to opt out one service

## Implementation information

Support existing kuma.io/ignore annotation.

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix https://github.com/kumahq/kuma/issues/11784

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
