### PR TITLE
test(e2e): retry build images

### DIFF
--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -57,9 +57,12 @@ jobs:
           make build
       - run: |
           make -j build/distributions
-      - run: |
-          make -j images
-          make -j docker/save
+      - uses: nick-fields/retry@v3
+        id: retry
+        with:
+          max_attempts: 3
+          retry_wait_seconds: 15s
+          command: make -j images && make -j docker/save
       - run: |
           make dev/set-kuma-helm-repo
       - name: "Enable ipv6 for docker"

--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -62,6 +62,7 @@ jobs:
         with:
           max_attempts: 3
           retry_wait_seconds: 15s
+          timeout_minutes: 30
           command: make -j images && make -j docker/save
       - run: |
           make dev/set-kuma-helm-repo


### PR DESCRIPTION
## Motivation

Every now and then we see this
https://github.com/Kong/kong-mesh/actions/runs/11439316275/job/31823270265

```
envoy.Dockerfile:1
--------------------
   1 | >>> FROM debian:12.7@sha256:27586f4609433f2f49a9157405b473c62c3cb28a581c413393975b4e8496d0ab AS envoy
   2 |     ARG ARCH
   3 |     
--------------------
ERROR: failed to solve: debian:12.7@sha256:27586f4609433f2f49a9157405b473c62c3cb28a581c413393975b4e8496d0ab: failed to resolve source metadata for docker.io/library/debian:12.7@sha256:27586f4609433f2f49a9157405b473c62c3cb28a581c413393975b4e8496d0ab: failed to authorize: failed to fetch oauth token: unexpected status from POST request to https://auth.docker.io/token: 502 Bad Gateway
```
Auth server of docker has problems. I found a solution to just not use auth, but then we get rate limited on docker images :( 


## Implementation information

Let's try to retry

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
