### PR TITLE
fix(kumactl): mark valid-for as required for command kumactl generate dataplane-token

### DIFF
--- a/app/kumactl/cmd/completion/testdata/bash.golden
+++ b/app/kumactl/cmd/completion/testdata/bash.golden
@@ -886,7 +886,6 @@ _kumactl_generate_dataplane-token()
     flags+=("--no-config")
 
     must_have_one_flag=()
-    must_have_one_flag+=("--valid-for=")
     must_have_one_noun=()
     noun_aliases=()
 }

--- a/app/kumactl/cmd/completion/testdata/bash.golden
+++ b/app/kumactl/cmd/completion/testdata/bash.golden
@@ -886,6 +886,7 @@ _kumactl_generate_dataplane-token()
     flags+=("--no-config")
 
     must_have_one_flag=()
+    must_have_one_flag+=("--valid-for=")
     must_have_one_noun=()
     noun_aliases=()
 }

--- a/app/kumactl/cmd/generate/generate_dataplane_token.go
+++ b/app/kumactl/cmd/generate/generate_dataplane_token.go
@@ -99,5 +99,8 @@ $ kumactl generate dataplane-token --mesh demo --tag kuma.io/service=web,web-api
 	cmd.Flags().DurationVar(&ctx.args.validFor, "valid-for", 0, `how long the token will be valid (for example "24h")`)
 	cmd.Flags().StringVar(&ctx.args.signingKeyPath, "signing-key-path", "", "path to a file that contains private signing key. When specified, control plane won't be used to issue the token.")
 	cmd.Flags().StringVar(&ctx.args.kid, "kid", "", "ID of the key that is used to issue a token. Required when --signing-key-path is used.")
+
+	_ = cmd.MarkFlagRequired("name")
+	_ = cmd.MarkFlagRequired("valid-for")
 	return cmd
 }

--- a/app/kumactl/cmd/generate/generate_dataplane_token.go
+++ b/app/kumactl/cmd/generate/generate_dataplane_token.go
@@ -100,7 +100,6 @@ $ kumactl generate dataplane-token --mesh demo --tag kuma.io/service=web,web-api
 	cmd.Flags().StringVar(&ctx.args.signingKeyPath, "signing-key-path", "", "path to a file that contains private signing key. When specified, control plane won't be used to issue the token.")
 	cmd.Flags().StringVar(&ctx.args.kid, "kid", "", "ID of the key that is used to issue a token. Required when --signing-key-path is used.")
 
-	_ = cmd.MarkFlagRequired("name")
 	_ = cmd.MarkFlagRequired("valid-for")
 	return cmd
 }

--- a/app/kumactl/cmd/generate/generate_dataplane_token_test.go
+++ b/app/kumactl/cmd/generate/generate_dataplane_token_test.go
@@ -71,11 +71,11 @@ var _ = Describe("kumactl generate dataplane-token", func() {
 			Expect(buf.String()).To(Equal(given.result))
 		},
 		Entry("for default mesh when it is not specified", testCase{
-			args:   []string{"generate", "dataplane-token", "--name=example"},
+			args:   []string{"generate", "dataplane-token", "--name=example", "--valid-for", "30s"},
 			result: "token-for-example-default--",
 		}),
 		Entry("for all arguments", testCase{
-			args:   []string{"generate", "dataplane-token", "--mesh=demo", "--name=example", "--proxy-type=dataplane", "--tag", "kuma.io/service=web"},
+			args:   []string{"generate", "dataplane-token", "--mesh=demo", "--name=example", "--proxy-type=dataplane", "--tag", "kuma.io/service=web", "--valid-for", "30s"},
 			result: "token-for-example-demo-kuma.io/service=web-dataplane",
 		}),
 	)
@@ -111,7 +111,7 @@ var _ = Describe("kumactl generate dataplane-token", func() {
 		generator.err = errors.New("could not connect to API")
 
 		// when
-		rootCmd.SetArgs([]string{"generate", "dataplane-token", "--name=example"})
+		rootCmd.SetArgs([]string{"generate", "dataplane-token", "--name=example", "--valid-for", "30s"})
 		err := rootCmd.Execute()
 
 		// then

--- a/app/kumactl/cmd/generate/generate_user_token.go
+++ b/app/kumactl/cmd/generate/generate_user_token.go
@@ -72,11 +72,12 @@ $ kumactl generate user-token --name john.doe@example.com --group users --valid-
 		},
 	}
 	cmd.Flags().StringVar(&args.name, "name", "", "name of the user")
-	_ = cmd.MarkFlagRequired("name")
 	cmd.Flags().StringSliceVar(&args.groups, "group", nil, "group of the user")
 	cmd.Flags().DurationVar(&args.validFor, "valid-for", 0, `how long the token will be valid (for example "24h")`)
 	cmd.Flags().StringVar(&args.signingKeyPath, "signing-key-path", "", "path to a file that contains private signing key. When specified, control plane won't be used to issue the token.")
 	cmd.Flags().StringVar(&args.kid, "kid", "", "ID of the key that is used to issue a token. Required when --signing-key-path is used.")
+
+	_ = cmd.MarkFlagRequired("name")
 	_ = cmd.MarkFlagRequired("valid-for")
 	return cmd
 }

--- a/pkg/xds/envoy/names/resource_names.go
+++ b/pkg/xds/envoy/names/resource_names.go
@@ -66,7 +66,7 @@ func GetMetricsHijackerClusterName() string {
 }
 
 func GetDPPReadinessClusterName() string {
-	return Join("_kuma", "readiness")
+	return Join("kuma", "readiness")
 }
 
 func GetInternalClusterNamePrefix() string {

--- a/pkg/xds/envoy/names/resource_names.go
+++ b/pkg/xds/envoy/names/resource_names.go
@@ -66,7 +66,7 @@ func GetMetricsHijackerClusterName() string {
 }
 
 func GetDPPReadinessClusterName() string {
-	return Join("kuma", "readiness")
+	return Join("_kuma", "readiness")
 }
 
 func GetInternalClusterNamePrefix() string {


### PR DESCRIPTION

## Motivation

fixes https://github.com/kumahq/kuma/issues/11848
<!-- Why are we doing this change -->

## Implementation information

Mark the option as required.

Includes a small fixes  that resolves https://github.com/kumahq/kuma/pull/11107#discussion_r1751419328

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

fixes https://github.com/kumahq/kuma/issues/11848

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
