### PR TITLE
chore(kuma-cp): expose keep alive const

### DIFF
--- a/pkg/dp-server/server/server.go
+++ b/pkg/dp-server/server/server.go
@@ -29,7 +29,7 @@ var log = core.Log.WithName("dp-server")
 
 const (
 	grpcMaxConcurrentStreams = 1000000
-	grpcKeepAliveTime        = 15 * time.Second
+	GrpcKeepAliveTime        = 15 * time.Second
 )
 
 type Filter func(writer http.ResponseWriter, request *http.Request) bool
@@ -49,11 +49,11 @@ func NewDpServer(config dp_server.DpServerConfig, metrics metrics.Metrics, filte
 	grpcOptions := []grpc.ServerOption{
 		grpc.MaxConcurrentStreams(grpcMaxConcurrentStreams),
 		grpc.KeepaliveParams(keepalive.ServerParameters{
-			Time:    grpcKeepAliveTime,
-			Timeout: grpcKeepAliveTime,
+			Time:    GrpcKeepAliveTime,
+			Timeout: GrpcKeepAliveTime,
 		}),
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
-			MinTime:             grpcKeepAliveTime,
+			MinTime:             GrpcKeepAliveTime,
 			PermitWithoutStream: true,
 		}),
 	}


### PR DESCRIPTION
## Motivation

Expose GrpcKeepAlive so that we can use it in KM on the client side of OPA Discovery Service instead of repeating.

## Implementation information

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
