### PR TITLE
test(e2e): drop assertion on weight

### DIFF
--- a/test/e2e_env/kubernetes/gateway/delegated/meshhttproute.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshhttproute.go
@@ -204,7 +204,7 @@ spec:
 					HaveKey(Equal(`test-server-0`)),
 					HaveKey(Equal(`test-server-1`)),
 					HaveKey(Equal(`test-server-2`)),
-					HaveKeyWithValue(ContainSubstring(`external-service`), BeNumerically("~", 50, 15)),
+					HaveKey(ContainSubstring(`external-service`)),
 				))
 			}, "30s", "5s").Should(Succeed())
 		})


### PR DESCRIPTION
## Motivation

This test flaked over the weekend
```
2024-10-26T19:13:28.3720416Z   [38;5;9m[FAILED] Timed out after 30.326s.
2024-10-26T19:13:28.3722049Z   The function passed to Eventually failed at github.com/kumahq/kuma/test/e2e_env/kubernetes/gateway/delegated/meshhttproute.go:203 with:
2024-10-26T19:13:28.3723375Z   Expected
2024-10-26T19:13:28.3723895Z       <map[string]int | len:4>: {
2024-10-26T19:13:28.3724696Z           "test-server-2": 12,
2024-10-26T19:13:28.3725408Z           "test-server-1": 11,
2024-10-26T19:13:28.3726273Z           "external-service-6dc7fff645-l9g9g": 66,
2024-10-26T19:13:28.3727140Z           "test-server-0": 11,
2024-10-26T19:13:28.3727711Z       }
2024-10-26T19:13:28.3728168Z   to have {key: value} matching
2024-10-26T19:13:28.3728921Z       <map[interface {}]interface {} | len:1>: {
2024-10-26T19:13:28.3729973Z           <*matchers.ContainSubstringMatcher | 0xc0043e5ec0>{
2024-10-26T19:13:28.3731080Z               Substr: "external-service",
2024-10-26T19:13:28.3731759Z               Args: nil,
2024-10-26T19:13:28.3744267Z           }: <*matchers.BeNumericallyMatcher | 0xc0043e5ef0>{
2024-10-26T19:13:28.3745191Z               Comparator: "~",
2024-10-26T19:13:28.3746175Z               CompareTo: [<int>50, <int>15],
2024-10-26T19:13:28.3746807Z           },
2024-10-26T19:13:28.3747278Z       }[0m
2024-10-26T19:13:28.3812729Z ##[error]It 10/26/24 19:13:15.686
```

66 > 50+15

I saw this test flake the same way a couple fo times.

## Implementation information

We could adjust BeNumerically to 20, but we will probably eventually hit the same problem. We can change it to 25, but then, IMHO, it's pretty much the same as just `HaveKey`. Since we can't control RNG that much, I'd just change the assertion to HaveKey.

## Supporting documentation

No issue. CI that flaked https://github.com/kumahq/kuma/actions/runs/11534040229/job/32107956499
