### PR TITLE
test(e2e): improve assertion on reachable services

### DIFF
--- a/test/e2e_env/universal/reachableservices/reachableservices.go
+++ b/test/e2e_env/universal/reachableservices/reachableservices.go
@@ -39,7 +39,7 @@ func ReachableServices() {
 			)
 			// then
 			g.Expect(err).ToNot(HaveOccurred())
-		}, "30s", "500ms", MustPassRepeatedly(10)).Should(Succeed())
+		}, "30s", "500ms").MustPassRepeatedly(10).Should(Succeed())
 	})
 
 	It("should not be able to non reachable services", func() {
@@ -50,7 +50,7 @@ func ReachableServices() {
 			)
 			// then
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(response.Exitcode).To(Equal(6))
-		}, "30s", "500ms", MustPassRepeatedly(10)).Should(Succeed())
+			g.Expect(response.Exitcode).To(Or(Equal(6), Equal(28)))
+		}, "5s", "500ms").Should(Succeed())
 	})
 }


### PR DESCRIPTION
## Motivation

CI flaked with
```
2024-10-27T05:07:14.6972309Z   [38;5;9m[FAILED] Failed after 20.468s.
2024-10-27T05:07:14.6973849Z   The function passed to Consistently failed at github.com/kumahq/kuma/test/e2e_env/universal/reachableservices/reachableservices.go:53 with:
2024-10-27T05:07:14.6975235Z   Expected
2024-10-27T05:07:14.6975644Z       <int>: 28
2024-10-27T05:07:14.6976051Z   to equal
2024-10-27T05:07:14.6976544Z       <int>: 6[0m
```

I checked the debug data from the dump, we don't have `second-test-server.mesh` in the config dump. In logs we see


```
[2024-10-27 05:07:10.969][166][debug][filter] [source/extensions/filters/udp/dns_filter/dns_parser.cc:238] Ignoring additional RRs in a query because Envoy does not support. This could be an EDNS query.
[2024-10-27 05:07:10.969][166][debug][filter] [source/extensions/filters/udp/dns_filter/dns_filter.cc:394] No domain configuration exists for [second-test-server.mesh]
[2024-10-27 05:07:10.969][166][debug][filter] [source/extensions/filters/udp/dns_filter/dns_filter.cc:394] No domain configuration exists for [second-test-server.mesh]
[2024-10-27 05:07:10.969][168][debug][misc] [source/common/network/utility.cc:679] Receive a packet with 104 bytes from 127.0.0.1:47654
[2024-10-27 05:07:10.969][168][debug][filter] [source/extensions/filters/udp/dns_filter/dns_parser.cc:238] Ignoring additional RRs in a query because Envoy does not support. This could be an EDNS query.
[2024-10-27 05:07:10.969][168][debug][filter] [source/extensions/filters/udp/dns_filter/dns_filter.cc:394] No domain configuration exists for [second-test-server.mesh.j2xen23xrnaetdgy434mngmvif.cx.internal.cloudapp.net]
[2024-10-27 05:07:10.969][168][debug][filter] [source/extensions/filters/udp/dns_filter/dns_filter.cc:394] No domain configuration exists for [second-test-server.mesh.j2xen23xrnaetdgy434mngmvif.cx.internal.cloudapp.net]
```

28 is timeout. My theory is that either
* It resolves to something (because of fallback to real DNS) and tries to connect to it
* It's stuck on resolving DNS and it times out because of `--max-time 5` to curl.

## Implementation information

Introduce or "error code 28".

Also MustPassRepeatedly does not make sense with Consistently. Also this is very long consistently, 5s/500ms = 10 times.

## Supporting documentation

Failed CI. https://github.com/kumahq/kuma/actions/runs/11537578898/job/32115442269