### PR TITLE
ci(gha): adjust retention days

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -83,7 +83,7 @@ jobs:
             ./build/distributions/out/*.tar.gz
             ./build/distributions/out/*.sha256
             !./build/distributions/out/*.tar.gz.sha256
-          retention-days: ${{ github.event_name == 'pull_request' && 1 || 30 }}
+          retention-days: ${{ github.event_name == 'pull_request' && 1 || 10 }}
       - name: publish binaries
         env:
           PULP_USERNAME: ${{ vars.PULP_USERNAME }}
@@ -179,14 +179,14 @@ jobs:
           name: image_${{ matrix.image }}
           path: |
             ./build/docker/*.tar
-          retention-days: ${{ github.event_name == 'pull_request' && 1 || 30 }}
+          retention-days: ${{ github.event_name == 'pull_request' && 1 || 10 }}
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         id: image-digest-artifacts
         with:
           name: image_${{ matrix.image }}.digest.json
           path: |
             ./build/docker/${{ matrix.image }}.digest.json
-          retention-days: ${{ github.event_name == 'pull_request' && 1 || 30 }}
+          retention-days: ${{ github.event_name == 'pull_request' && 1 || 10 }}
       - name: sign image
         if: ${{ fromJSON(inputs.ALLOW_PUSH) }}
         id: sign
@@ -264,7 +264,7 @@ jobs:
         with:
           name: ${{ steps.package-helm.outputs.filename }}
           path: .cr-release-packages/${{ steps.package-helm.outputs.filename }}
-          retention-days: ${{ github.event_name == 'pull_request' && 1 || 30 }}
+          retention-days: ${{ github.event_name == 'pull_request' && 1 || 10 }}
       # Everything from here is only running on releases.
       # Ideally we'd finish the workflow early, but this isn't possible: https://github.com/actions/runner/issues/662
       - name: Generate GitHub app token

--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -138,7 +138,7 @@ jobs:
           if-no-files-found: ignore
           path: |
             /tmp/e2e-debug/
-          retention-days: ${{ github.event_name == 'pull_request' && 5 || 30 }}
+          retention-days: ${{ github.event_name == 'pull_request' && 5 || 10 }}
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         if: always()
         with:
@@ -146,4 +146,4 @@ jobs:
           if-no-files-found: ignore
           path: |
             build/reports
-          retention-days: ${{ github.event_name == 'pull_request' && 5 || 30 }}
+          retention-days: ${{ github.event_name == 'pull_request' && 5 || 10 }}

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -65,7 +65,7 @@ jobs:
         with:
           name: ${{ steps.package.outputs.filename }}
           path: .cr-release-packages/${{ steps.package.outputs.filename }}
-          retention-days: ${{ github.event_name == 'pull_request' && 1 || 30 }}
+          retention-days: ${{ github.event_name == 'pull_request' && 1 || 10 }}
       # Everything from here is only running on releases.
       # Ideally we'd finish the workflow early but this isn't possible: https://github.com/actions/runner/issues/662
       - name: Generate GitHub app token


### PR DESCRIPTION
## Motivation

Retention days in KM is set to 10 days max, because of that there are a lot of warning noise in KM jobs.

## Implementation information

We could do some yq magic to replace it, but maybe we don't need 30 here as well?

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
