### PR TITLE
ci(gha): adjust timeout for check

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -22,7 +22,7 @@ jobs:
       contents: read
       # golangci-lint-action
       checks: write
-    timeout-minutes: 15
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     env:
       FULL_MATRIX: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') }}


### PR DESCRIPTION
## Motivation

It's about 12min in KM, because of slower machines and extra checks. We hit a limit once or twice already.

## Implementation information

Let's increase it to 20. The alternative would be to replace it with yq.

## Supporting documentation

No issue. Failed CI.
