### PR TITLE
test(e2e): speed up reachable services

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -91,6 +91,8 @@ require (
 	sigs.k8s.io/yaml v1.4.0
 )
 
+require golang.org/x/sync v0.8.0
+
 require (
 	cel.dev/expr v0.16.0 // indirect
 	dario.cat/mergo v1.0.1 // indirect
@@ -216,7 +218,6 @@ require (
 	golang.org/x/crypto v0.28.0 // indirect
 	golang.org/x/mod v0.21.0 // indirect
 	golang.org/x/oauth2 v0.23.0 // indirect
-	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/term v0.25.0 // indirect
 	golang.org/x/time v0.6.0 // indirect
 	golang.org/x/tools v0.26.0 // indirect

--- a/test/e2e/reachableservices/auto_reachable_mesh_services_k8s.go
+++ b/test/e2e/reachableservices/auto_reachable_mesh_services_k8s.go
@@ -54,6 +54,7 @@ spec:
 			Install(testserver.Install(testserver.WithName("first-test-server"), testserver.WithMesh(meshName), testserver.WithNamespace(namespace))).
 			Install(testserver.Install(testserver.WithName("second-test-server"), testserver.WithMesh(meshName), testserver.WithNamespace(namespace))).
 			SetupInParallel(KubeCluster)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	E2EAfterEach(func() {

--- a/test/e2e/reachableservices/auto_reachable_mesh_services_k8s.go
+++ b/test/e2e/reachableservices/auto_reachable_mesh_services_k8s.go
@@ -45,13 +45,15 @@ spec:
 						WithMeshServicesEnabled(mesh_proto.Mesh_MeshServices_Exclusive),
 				),
 			).
+			Install(YamlK8s(hostnameGenerator)).
+			Setup(KubeCluster)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = NewClusterSetup().
 			Install(testserver.Install(testserver.WithName("client-server"), testserver.WithMesh(meshName), testserver.WithNamespace(namespace))).
 			Install(testserver.Install(testserver.WithName("first-test-server"), testserver.WithMesh(meshName), testserver.WithNamespace(namespace))).
 			Install(testserver.Install(testserver.WithName("second-test-server"), testserver.WithMesh(meshName), testserver.WithNamespace(namespace))).
-			Install(YamlK8s(hostnameGenerator)).
-			Setup(KubeCluster)
-
-		Expect(err).ToNot(HaveOccurred())
+			SetupInParallel(KubeCluster)
 	})
 
 	E2EAfterEach(func() {

--- a/test/e2e/reachableservices/auto_reachable_mesh_services_k8s.go
+++ b/test/e2e/reachableservices/auto_reachable_mesh_services_k8s.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	config_core "github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/test/resources/builders"
 	. "github.com/kumahq/kuma/test/framework"
@@ -16,7 +15,6 @@ import (
 )
 
 func AutoReachableMeshServices() {
-	var k8sCluster Cluster
 	meshName := "auto-reachable-backends"
 	namespace := "auto-reachable-backends"
 
@@ -37,12 +35,7 @@ spec:
 `, meshName, Config.KumaNamespace, namespace)
 
 	BeforeAll(func() {
-		k8sCluster = NewK8sCluster(NewTestingT(), Kuma1, Silent)
-
 		err := NewClusterSetup().
-			Install(Kuma(config_core.Zone,
-				WithEnv("KUMA_EXPERIMENTAL_AUTO_REACHABLE_SERVICES", "true"),
-			)).
 			Install(NamespaceWithSidecarInjection(namespace)).
 			Install(
 				Yaml(
@@ -56,19 +49,18 @@ spec:
 			Install(testserver.Install(testserver.WithName("first-test-server"), testserver.WithMesh(meshName), testserver.WithNamespace(namespace))).
 			Install(testserver.Install(testserver.WithName("second-test-server"), testserver.WithMesh(meshName), testserver.WithNamespace(namespace))).
 			Install(YamlK8s(hostnameGenerator)).
-			Setup(k8sCluster)
+			Setup(KubeCluster)
 
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	E2EAfterEach(func() {
-		Expect(DeleteMeshResources(k8sCluster, meshName, v1alpha1.MeshTrafficPermissionResourceTypeDescriptor)).To(Succeed())
+		Expect(DeleteMeshResources(KubeCluster, meshName, v1alpha1.MeshTrafficPermissionResourceTypeDescriptor)).To(Succeed())
 	})
 
 	E2EAfterAll(func() {
-		Expect(k8sCluster.DeleteNamespace(namespace)).To(Succeed())
-		Expect(k8sCluster.DeleteKuma()).To(Succeed())
-		Expect(k8sCluster.DismissCluster()).To(Succeed())
+		Expect(KubeCluster.DeleteNamespace(namespace)).To(Succeed())
+		Expect(KubeCluster.DeleteMesh(meshName)).To(Succeed())
 	})
 
 	It("should not connect to non auto reachable service", func() {
@@ -97,28 +89,28 @@ spec:
           app: client-server
       default:
         action: Allow
-`, Config.KumaNamespace, meshName))(k8sCluster)).To(Succeed())
+`, Config.KumaNamespace, meshName))(KubeCluster)).To(Succeed())
 
 		// then
 		Eventually(func(g Gomega) {
-			pod, err := PodNameOfApp(k8sCluster, "second-test-server", namespace)
+			pod, err := PodNameOfApp(KubeCluster, "second-test-server", namespace)
 			g.Expect(err).ToNot(HaveOccurred())
-			stdout, err := k8sCluster.GetKumactlOptions().RunKumactlAndGetOutput("inspect", "dataplane", pod+"."+namespace, "--type=clusters", fmt.Sprintf("--mesh=%s", meshName))
+			stdout, err := KubeCluster.GetKumactlOptions().RunKumactlAndGetOutput("inspect", "dataplane", pod+"."+namespace, "--type=clusters", fmt.Sprintf("--mesh=%s", meshName))
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(stdout).To(Not(ContainSubstring(fmt.Sprintf("%s_first-test-server_%s_defaul_msvc_80", meshName, namespace))))
 		}, "30s", "1s").Should(Succeed())
 
 		Eventually(func(g Gomega) {
-			pod, err := PodNameOfApp(k8sCluster, "client-server", namespace)
+			pod, err := PodNameOfApp(KubeCluster, "client-server", namespace)
 			g.Expect(err).ToNot(HaveOccurred())
-			stdout, err := k8sCluster.GetKumactlOptions().RunKumactlAndGetOutput("inspect", "dataplane", pod+"."+namespace, "--type=clusters", fmt.Sprintf("--mesh=%s", meshName))
+			stdout, err := KubeCluster.GetKumactlOptions().RunKumactlAndGetOutput("inspect", "dataplane", pod+"."+namespace, "--type=clusters", fmt.Sprintf("--mesh=%s", meshName))
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(stdout).To(ContainSubstring(fmt.Sprintf("%s_first-test-server_%s_default_msvc_80", meshName, namespace)))
 		}, "30s", "1s").Should(Succeed())
 
 		Consistently(func(g Gomega) {
 			failures, err := client.CollectFailure(
-				k8sCluster,
+				KubeCluster,
 				"second-test-server",
 				"first-test-server.mesh",
 				client.FromKubernetesPod(namespace, "second-test-server"),

--- a/test/e2e/reachableservices/auto_reachable_services_k8s.go
+++ b/test/e2e/reachableservices/auto_reachable_services_k8s.go
@@ -6,7 +6,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	config_core "github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1"
 	. "github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/framework/client"
@@ -14,39 +13,36 @@ import (
 )
 
 func AutoReachableServices() {
-	var k8sCluster Cluster
 	esNamespace := "external-service"
+	namespace := "reachable-services"
+	meshName := "reachable-services"
+
 	BeforeAll(func() {
-		k8sCluster = NewK8sCluster(NewTestingT(), Kuma1, Silent)
 		err := NewClusterSetup().
-			Install(Kuma(config_core.Zone,
-				WithEnv("KUMA_EXPERIMENTAL_AUTO_REACHABLE_SERVICES", "true"),
-			)).
-			Install(NamespaceWithSidecarInjection(TestNamespace)).
+			Install(NamespaceWithSidecarInjection(namespace)).
 			Install(Namespace(esNamespace)).
-			Install(MTLSMeshKubernetes("default")).
-			Install(testserver.Install(testserver.WithName("client-server"), testserver.WithMesh("default"))).
-			Install(testserver.Install(testserver.WithName("first-test-server"), testserver.WithMesh("default"))).
-			Install(testserver.Install(testserver.WithName("second-test-server"), testserver.WithMesh("default"))).
+			Install(MTLSMeshKubernetes(meshName)).
+			Install(testserver.Install(testserver.WithName("client-server"), testserver.WithMesh(meshName), testserver.WithNamespace(namespace))).
+			Install(testserver.Install(testserver.WithName("first-test-server"), testserver.WithMesh(meshName), testserver.WithNamespace(namespace))).
+			Install(testserver.Install(testserver.WithName("second-test-server"), testserver.WithMesh(meshName), testserver.WithNamespace(namespace))).
 			Install(testserver.Install(
 				testserver.WithName("external-http-service"),
 				testserver.WithNamespace(esNamespace),
 				testserver.WithEchoArgs("echo", "--instance", "external-http-service"),
 			)).
-			Setup(k8sCluster)
+			Setup(KubeCluster)
 
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	E2EAfterEach(func() {
-		Expect(DeleteMeshResources(k8sCluster, "default", v1alpha1.MeshTrafficPermissionResourceTypeDescriptor)).To(Succeed())
+		Expect(DeleteMeshResources(KubeCluster, meshName, v1alpha1.MeshTrafficPermissionResourceTypeDescriptor)).To(Succeed())
 	})
 
 	E2EAfterAll(func() {
-		Expect(k8sCluster.DeleteNamespace(TestNamespace)).To(Succeed())
-		Expect(k8sCluster.DeleteNamespace(esNamespace)).To(Succeed())
-		Expect(k8sCluster.DeleteKuma()).To(Succeed())
-		Expect(k8sCluster.DismissCluster()).To(Succeed())
+		Expect(KubeCluster.DeleteNamespace(namespace)).To(Succeed())
+		Expect(KubeCluster.DeleteNamespace(esNamespace)).To(Succeed())
+		Expect(KubeCluster.DeleteMesh(meshName)).To(Succeed())
 	})
 
 	It("should not connect to non auto reachable service", func() {
@@ -55,14 +51,14 @@ func AutoReachableServices() {
 apiVersion: kuma.io/v1alpha1
 kind: MeshTrafficPermission
 metadata:
-  name: mtp1
+  name: rs-client-to-server
   namespace: %s
   labels:
-    kuma.io/mesh: default
+    kuma.io/mesh: %s
 spec:
   targetRef:
     kind: MeshService
-    name: first-test-server_kuma-test_svc_80
+    name: first-test-server_reachable-services_svc_80
   from:
     - targetRef:
         kind: Mesh
@@ -70,38 +66,38 @@ spec:
         action: Deny
     - targetRef:
         kind: MeshService
-        name: client-server_kuma-test_svc_80
+        name: client-server_reachable-services_svc_80
       default:
         action: Allow
-`, Config.KumaNamespace))(k8sCluster)).To(Succeed())
+`, Config.KumaNamespace, meshName))(KubeCluster)).To(Succeed())
 
 		// then
 		Eventually(func(g Gomega) {
-			pod, err := PodNameOfApp(k8sCluster, "second-test-server", TestNamespace)
+			pod, err := PodNameOfApp(KubeCluster, "second-test-server", namespace)
 			g.Expect(err).ToNot(HaveOccurred())
-			stdout, err := k8sCluster.GetKumactlOptions().RunKumactlAndGetOutput("inspect", "dataplane", pod+"."+TestNamespace, "--type=clusters")
+			stdout, err := KubeCluster.GetKumactlOptions().RunKumactlAndGetOutput("inspect", "dataplane", pod+"."+namespace, "--mesh", meshName, "--type=clusters")
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(stdout).To(Not(ContainSubstring("first-test-server_kuma-test_svc_80")))
+			g.Expect(stdout).To(Not(ContainSubstring("first-test-server_reachable-services_svc_80")))
 		}, "30s", "1s").Should(Succeed())
 
 		Eventually(func(g Gomega) {
-			pod, err := PodNameOfApp(k8sCluster, "client-server", TestNamespace)
+			pod, err := PodNameOfApp(KubeCluster, "client-server", namespace)
 			g.Expect(err).ToNot(HaveOccurred())
-			stdout, err := k8sCluster.GetKumactlOptions().RunKumactlAndGetOutput("inspect", "dataplane", pod+"."+TestNamespace, "--type=clusters")
+			stdout, err := KubeCluster.GetKumactlOptions().RunKumactlAndGetOutput("inspect", "dataplane", pod+"."+namespace, "--mesh", meshName, "--type=clusters")
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(stdout).To(ContainSubstring("first-test-server_kuma-test_svc_80"))
+			g.Expect(stdout).To(ContainSubstring("first-test-server_reachable-services_svc_80"))
 		}, "30s", "1s").Should(Succeed())
 
 		Consistently(func(g Gomega) {
 			failures, err := client.CollectFailure(
-				k8sCluster,
+				KubeCluster,
 				"second-test-server",
 				"first-test-server:80",
-				client.FromKubernetesPod(TestNamespace, "second-test-server"),
+				client.FromKubernetesPod(namespace, "second-test-server"),
 			)
 			g.Expect(err).To(Not(HaveOccurred()))
 			g.Expect(failures.Exitcode).To(Equal(52))
-		}, "30s", "1s").Should(Succeed())
+		}, "5s", "1s").Should(Succeed())
 	})
 
 	It("should connect to ExternalService when MeshTrafficPermission defined", func() {
@@ -109,7 +105,7 @@ spec:
 		Expect(YamlK8s(`
 apiVersion: kuma.io/v1alpha1
 kind: ExternalService
-mesh: default
+mesh: reachable-services
 metadata:
   name: external-service-1
 spec:
@@ -118,29 +114,29 @@ spec:
     kuma.io/protocol: http
   networking:
     address: external-http-service.external-service.svc.cluster.local:80 # .svc.cluster.local is needed, otherwise Kubernetes will resolve this to the real IP
-`)(k8sCluster)).To(Succeed())
+`)(KubeCluster)).To(Succeed())
 
 		// then
 		Consistently(func(g Gomega) {
 			failures, err := client.CollectFailure(
-				k8sCluster,
+				KubeCluster,
 				"client-server",
 				"external-http-service.mesh",
-				client.FromKubernetesPod(TestNamespace, "client-server"),
+				client.FromKubernetesPod(namespace, "client-server"),
 			)
 			g.Expect(err).To(Not(HaveOccurred()))
 			g.Expect(failures.Exitcode).To(Equal(6))
-		}, "30s", "1s").Should(Succeed())
+		}, "5s", "1s").Should(Succeed())
 
 		// when
 		Expect(YamlK8s(fmt.Sprintf(`
 apiVersion: kuma.io/v1alpha1
 kind: MeshTrafficPermission
 metadata:
-  name: mtp-es
+  name: rs-mtp-es
   namespace: %s
   labels:
-    kuma.io/mesh: default
+    kuma.io/mesh: reachable-services
 spec:
   targetRef:
     kind: MeshService
@@ -148,18 +144,18 @@ spec:
   from:
     - targetRef:
         kind: MeshService
-        name: client-server_kuma-test_svc_80
+        name: client-server_reachable-services_svc_80
       default:
         action: Allow
-`, Config.KumaNamespace))(k8sCluster)).To(Succeed())
+`, Config.KumaNamespace))(KubeCluster)).To(Succeed())
 
 		// then
 		Eventually(func(g Gomega) {
 			resp, err := client.CollectEchoResponse(
-				k8sCluster,
+				KubeCluster,
 				"client-server",
 				"external-http-service.mesh",
-				client.FromKubernetesPod(TestNamespace, "client-server"),
+				client.FromKubernetesPod(namespace, "client-server"),
 			)
 			g.Expect(err).To(Not(HaveOccurred()))
 			g.Expect(resp.Instance).To(Equal("external-http-service"))

--- a/test/e2e/reachableservices/auto_reachable_services_k8s.go
+++ b/test/e2e/reachableservices/auto_reachable_services_k8s.go
@@ -22,6 +22,10 @@ func AutoReachableServices() {
 			Install(NamespaceWithSidecarInjection(namespace)).
 			Install(Namespace(esNamespace)).
 			Install(MTLSMeshKubernetes(meshName)).
+			Setup(KubeCluster)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = NewClusterSetup().
 			Install(testserver.Install(testserver.WithName("client-server"), testserver.WithMesh(meshName), testserver.WithNamespace(namespace))).
 			Install(testserver.Install(testserver.WithName("first-test-server"), testserver.WithMesh(meshName), testserver.WithNamespace(namespace))).
 			Install(testserver.Install(testserver.WithName("second-test-server"), testserver.WithMesh(meshName), testserver.WithNamespace(namespace))).
@@ -30,8 +34,7 @@ func AutoReachableServices() {
 				testserver.WithNamespace(esNamespace),
 				testserver.WithEchoArgs("echo", "--instance", "external-http-service"),
 			)).
-			Setup(KubeCluster)
-
+			SetupInParallel(KubeCluster)
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/test/e2e/reachableservices/cluster.go
+++ b/test/e2e/reachableservices/cluster.go
@@ -1,0 +1,5 @@
+package reachableservices
+
+import "github.com/kumahq/kuma/test/framework"
+
+var KubeCluster *framework.K8sCluster

--- a/test/e2e/reachableservices/e2e_suite_test.go
+++ b/test/e2e/reachableservices/e2e_suite_test.go
@@ -4,14 +4,34 @@ import (
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
+	config_core "github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/pkg/test"
 	"github.com/kumahq/kuma/test/e2e/reachableservices"
+	"github.com/kumahq/kuma/test/framework"
 )
 
 func TestE2E(t *testing.T) {
 	test.RunE2ESpecs(t, "E2E Auto Reachable Services Kubernetes Suite")
 }
+
+var _ = framework.E2EBeforeSuite(func() {
+	reachableservices.KubeCluster = framework.NewK8sCluster(framework.NewTestingT(), framework.Kuma1, framework.Silent)
+
+	err := framework.NewClusterSetup().
+		Install(framework.Kuma(config_core.Zone,
+			framework.WithEnv("KUMA_EXPERIMENTAL_AUTO_REACHABLE_SERVICES", "true"),
+		)).
+		Setup(reachableservices.KubeCluster)
+
+	Expect(err).ToNot(HaveOccurred())
+})
+
+var _ = framework.E2EAfterSuite(func() {
+	Expect(reachableservices.KubeCluster.DeleteKuma()).To(Succeed())
+	Expect(reachableservices.KubeCluster.DismissCluster()).To(Succeed())
+})
 
 var (
 	_ = Describe("Auto Reachable Services on Kubernetes", Label("job-3"), reachableservices.AutoReachableServices, Ordered)

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -992,6 +993,17 @@ func (cs *ClusterSetup) Install(fn InstallFunc) *ClusterSetup {
 
 func (cs *ClusterSetup) Setup(cluster Cluster) error {
 	return Combine(cs.installFuncs...)(cluster)
+}
+
+func (cs *ClusterSetup) SetupInParallel(cluster Cluster) error {
+	errGroup := errgroup.Group{}
+	for _, f := range cs.installFuncs {
+		fn := f
+		errGroup.Go(func() error {
+			return fn(cluster)
+		})
+	}
+	return errGroup.Wait()
 }
 
 func (cs *ClusterSetup) SetupWithRetries(cluster Cluster, maxRetries int) error {


### PR DESCRIPTION
## Motivation

Let's try to speed up some non-shared e2e tests.
They take as much resources as all e2e_env combined.

Before
```
❯❯❯ python test-time.py
Test: [It] > Auto Reachable Services on Kubernetes > should not connect to non auto reachable service, Duration: 74.248 seconds
Test: [It] > Auto Reachable Mesh Services on Kubernetes > should not connect to non auto reachable service, Duration: 61.293 seconds
Test: [It] > Auto Reachable Services on Kubernetes > should connect to ExternalService when MeshTrafficPermission defined, Duration: 60.537 seconds
```
196s

```
Test: [It] > Auto Reachable Mesh Services on Kubernetes > should not connect to non auto reachable service, Duration: 24.698 seconds
Test: [It] > Auto Reachable Services on Kubernetes > should connect to ExternalService when MeshTrafficPermission defined, Duration: 23.711 seconds
Test: [It] > Auto Reachable Services on Kubernetes > should not connect to non auto reachable service, Duration: 19.414 seconds
Test: [BeforeSuite] > , Duration: 17.187 seconds
Test: [AfterSuite] > , Duration: 15.619 seconds
```
100s

## Implementation information

1) Reuse created Kuma deployment for reachable services and reachable backends
2) Adjust Consistently to more reasonable times
3) Setup deployments in parallel (gives 38s boost)

This strategy is useful, because
1) we can merge it with for example CNI to save cluster setup / cleanup.
2) potentially we can run this in parallel just like `e2e_env`
3) potentially we can later move this as a separate zone that we spawn in `e2e_env`

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
