### PR TITLE
test(e2e): improve reachable services expectation to allow DNS timeouts

### DIFF
--- a/test/e2e_env/kubernetes/reachableservices/reachableservices.go
+++ b/test/e2e_env/kubernetes/reachableservices/reachableservices.go
@@ -67,7 +67,7 @@ func ReachableServices() {
 			)
 			// then it fails because Kuma DP has no such DNS
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(response.Exitcode).To(Equal(6))
+			g.Expect(response.Exitcode).To(Or(Equal(6), Equal(28)))
 		}).Should(Succeed())
 
 		Consistently(func(g Gomega) {


### PR DESCRIPTION
## Motivation

We suspect DNS lookups themselves are timing out and [causing flakes](https://github.com/kumahq/kuma/actions/runs/11514774996/job/32152139325). This may be related to https://github.com/kumahq/kuma/pull/11862

Similar to https://github.com/kumahq/kuma/pull/11874