### PR TITLE
fix(kumactl): remove metrics, logging, tracing columns in `get meshes`

### DIFF
--- a/app/kumactl/cmd/get/table_printer.go
+++ b/app/kumactl/cmd/get/table_printer.go
@@ -43,7 +43,7 @@ var CustomTablePrinters = map[model.ResourceType]RowPrinter{
 		},
 	},
 	model.ScopeMesh: {
-		Headers: []string{"NAME", "mTLS", "METRICS", "LOGGING", "TRACING", "LOCALITY", "ZONEEGRESS", "AGE"},
+		Headers: []string{"NAME", "mTLS", "LOCALITY", "ZONEEGRESS", "AGE"},
 		RowFn: func(rootTime time.Time, item model.Resource) []string {
 			mesh := item.(*mesh.MeshResource)
 
@@ -53,25 +53,6 @@ var CustomTablePrinters = map[model.ResourceType]RowPrinter{
 				mtls = fmt.Sprintf("%s/%s", backend.Type, backend.Name)
 			}
 
-			metrics := "off"
-			if mesh.Spec.GetMetrics().GetEnabledBackend() != "" {
-				backend := mesh.GetEnabledMetricsBackend()
-				metrics = fmt.Sprintf("%s/%s", backend.Type, backend.Name)
-			}
-			logging := "off"
-			if mesh.Spec.GetLogging() != nil {
-				logging = mesh.GetLoggingBackends()
-				if len(logging) == 0 {
-					logging = "off"
-				}
-			}
-			tracing := "off"
-			if mesh.Spec.GetTracing() != nil {
-				tracing = mesh.GetTracingBackends()
-				if len(tracing) == 0 {
-					tracing = "off"
-				}
-			}
 			locality := "off"
 			if mesh.Spec.GetRouting().GetLocalityAwareLoadBalancing() {
 				locality = "on"
@@ -83,9 +64,6 @@ var CustomTablePrinters = map[model.ResourceType]RowPrinter{
 			return []string{
 				mesh.GetMeta().GetName(), // NAME
 				mtls,                     // mTLS
-				metrics,                  // METRICS
-				logging,                  // LOGGING
-				tracing,                  // TRACING
 				locality,                 // LOCALITY
 				zoneEgress,               // ZONEEGRESS
 				table.TimeSince(mesh.GetMeta().GetModificationTime(), rootTime), // AGE

--- a/app/kumactl/cmd/get/testdata/get/get-mesh.golden.txt
+++ b/app/kumactl/cmd/get/testdata/get/get-mesh.golden.txt
@@ -1,2 +1,2 @@
-NAME     mTLS                METRICS                   LOGGING                   TRACING                              LOCALITY   ZONEEGRESS   AGE
-mesh-1   builtin/builtin-1   prometheus/prometheus-1   tcp/logstash, file/file   zipkin/zipkin-us, zipkin/zipkin-eu   on         on           292y
+NAME     mTLS                LOCALITY   ZONEEGRESS   AGE
+mesh-1   builtin/builtin-1   on         on           292y

--- a/app/kumactl/cmd/get/testdata/list/get-meshes.golden.txt
+++ b/app/kumactl/cmd/get/testdata/list/get-meshes.golden.txt
@@ -1,3 +1,3 @@
-NAME    mTLS                METRICS                   LOGGING                   TRACING                              LOCALITY   ZONEEGRESS   AGE
-mesh1   builtin/builtin-1   prometheus/prometheus-1   tcp/logstash, file/file   zipkin/zipkin-us, zipkin/zipkin-eu   on         on           292y
-mesh2   off                 off                       off                       off                                  off        off          292y
+NAME    mTLS                LOCALITY   ZONEEGRESS   AGE
+mesh1   builtin/builtin-1   on         on           292y
+mesh2   off                 off        off          292y

--- a/app/kumactl/cmd/get/testdata/list/get-meshes.pagination.golden.txt
+++ b/app/kumactl/cmd/get/testdata/list/get-meshes.pagination.golden.txt
@@ -1,4 +1,4 @@
-NAME    mTLS                METRICS                   LOGGING                   TRACING                              LOCALITY   ZONEEGRESS   AGE
-mesh1   builtin/builtin-1   prometheus/prometheus-1   tcp/logstash, file/file   zipkin/zipkin-us, zipkin/zipkin-eu   on         on           292y
+NAME    mTLS                LOCALITY   ZONEEGRESS   AGE
+mesh1   builtin/builtin-1   on         on           292y
 
 Rerun command with --offset=1 argument to retrieve more resources


### PR DESCRIPTION
## Motivation

These columns no longer make sense with new policies that configure these aspects of the data plane.

Closes https://github.com/kumahq/kuma/issues/10973