### PR TITLE
test(e2e): only run kube max version on old e2e tests

### DIFF
--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -50,7 +50,7 @@ jobs:
             {
               "test_e2e": {
                 "target": [""],
-                "k8sVersion": ["kindIpv6", "${{ env.K8S_MIN_VERSION }}", "${{ env.K8S_MAX_VERSION }}"],
+                "k8sVersion": ["${{ env.K8S_MAX_VERSION }}"],
                 "arch": ["amd64"],
                 "parallelism": [4],
                 "cniNetworkPlugin": ["flannel"],


### PR DESCRIPTION
## Motivation

I don't see good reason to run old e2e tests with min version of kube or ipv6.
We test 90% in the shared `e2e_env`, but old tests spawns 12 VMs (as much as all variants of new tests) and runs longer than them.
I see minimal risk of not running those tests with IPV6 and old kube and huge win for CI time.