### PR TITLE
fix(cni): delegated gateway was not correctly injected

### DIFF
--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
@@ -827,6 +827,23 @@ spec:
                   kuma.io/sidecar-injection: enabled`,
 			cfgFile: "inject.vp-disabled.config.yaml",
 		}),
+		Entry("41. gateway provided with cni enabled", testCase{
+			num: "41",
+			mesh: `
+              apiVersion: kuma.io/v1alpha1
+              kind: Mesh
+              metadata:
+                name: default
+              spec: {}`,
+			namespace: `
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: default
+                labels:
+                  kuma.io/sidecar-injection: enabled`,
+			cfgFile: "inject.config-cni.yaml",
+		}),
 	)
 
 	DescribeTable("should not inject Kuma into a Pod",

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.41.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.41.golden.yaml
@@ -1,0 +1,139 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    k8s.v1.cni.cncf.io/networks: kuma-cni
+    kubectl.kubernetes.io/default-container: busybox
+    kuma.io/application-probe-proxy-port: "0"
+    kuma.io/envoy-admin-port: "9901"
+    kuma.io/gateway: enabled
+    kuma.io/sidecar-injected: "true"
+    kuma.io/sidecar-uid: "5678"
+    kuma.io/transparent-proxying: enabled
+    kuma.io/transparent-proxying-inbound-port: "15055"
+    kuma.io/transparent-proxying-ip-family-mode: ipv4
+    kuma.io/transparent-proxying-outbound-port: "15001"
+    kuma.io/virtual-probes: disabled
+    kuma.io/virtual-probes-port: "9000"
+  creationTimestamp: null
+  labels:
+    kuma.io/mesh: default
+    run: busybox
+  name: busybox
+spec:
+  containers:
+  - args:
+    - run
+    - --log-level=info
+    - --concurrency=2
+    env:
+    - name: INSTANCE_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.podIP
+    - name: KUMA_APPLICATION_PROBE_PROXY_PORT
+      value: "0"
+    - name: KUMA_CONTROL_PLANE_CA_CERT
+      value: |
+        -----BEGIN CERTIFICATE-----
+        MIIDMzCCAhugAwIBAgIQDhlInfsXYHamKN+29qnQvzANBgkqhkiG9w0BAQsFADAP
+        MQ0wCwYDVQQDEwRrdW1hMB4XDTIxMDQwMjEwMjIyNloXDTMxMDMzMTEwMjIyNlow
+        DzENMAsGA1UEAxMEa3VtYTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+        AL4GGg+e2O7eA12F0F6v2rr8j2iVSFKepnZtL15lrCds6lqK50sXWOw8PKZp2ihA
+        XJVTSZzKasyLDTAR9VYQjTpE526EzvtdthSagf32QWW+wY6LMpEdexKOOCx2se55
+        Rd97L33yYPfgX15OYliHPD056jjhotHLdN2lpy7+STDvQyRnXAu73YkY37Ed4hI4
+        t/V6soHyEGNcDhm9p5fBGqz0njBbQkp2lTY5/kj42qB7Q6rCM2tbPsEMooeAAw5m
+        hyY4xj0tP9ucqlUz8gc+6o8HDNst8NeJXZktWn+COytjr/NzGgS22kvSDphisJot
+        o0FyoIOdAtxC1qxXXR+XuUUCAwEAAaOBijCBhzAOBgNVHQ8BAf8EBAMCAqQwHQYD
+        VR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMBMA8GA1UdEwEB/wQFMAMBAf8wHQYD
+        VR0OBBYEFKRLkgIzX/OjKw9idepuQ/RMtT+AMCYGA1UdEQQfMB2CCWxvY2FsaG9z
+        dIcQ/QChIwAAAAAAAAAAAAAAATANBgkqhkiG9w0BAQsFAAOCAQEAPs5yJZhoYlGW
+        CpA8dSISivM8/8iBNQ3fVwP63ft0EJLMVGu2RFZ4/UAJ/rUPSGN8xhXSk5+1d56a
+        /kaH9rX0HaRIHHlxA7iPUKxAj44x9LKmqPHToL3XlWY1AXzvicW9d+GM2FaQee+I
+        leaqLbz0AZvlnu271Z1CeaACuU9GljujvyiTTE9naHUEqvHgSpPtilJalyJ5/zIl
+        Z9F0+UWt3TOYMs5g+SCt0MwHTNbisbmewpcFFJzjt2kvtrc9t9dkF81xhcS19w7q
+        h1AeP3RRlLl7bv9EAVXEmIavih/29PA3ZSy+pbYNW7jNJHjMQ4hQ0E+xcCazU/O4
+        ypWGaanvPg==
+        -----END CERTIFICATE-----
+    - name: KUMA_CONTROL_PLANE_URL
+      value: http://kuma-control-plane.kuma-system:5681
+    - name: KUMA_DATAPLANE_DRAIN_TIME
+      value: 31s
+    - name: KUMA_DATAPLANE_MESH
+      value: default
+    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
+      value: /var/run/secrets/kubernetes.io/serviceaccount/token
+    - name: KUMA_DNS_ENABLED
+      value: "false"
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.namespace
+    image: kuma/kuma-sidecar:latest
+    imagePullPolicy: IfNotPresent
+    livenessProbe:
+      failureThreshold: 212
+      httpGet:
+        path: /ready
+        port: 9901
+      initialDelaySeconds: 260
+      periodSeconds: 25
+      successThreshold: 1
+      timeoutSeconds: 23
+    name: kuma-sidecar
+    readinessProbe:
+      failureThreshold: 112
+      httpGet:
+        path: /ready
+        port: 9901
+      initialDelaySeconds: 11
+      periodSeconds: 15
+      successThreshold: 11
+      timeoutSeconds: 13
+    resources:
+      limits:
+        cpu: 1100m
+        ephemeral-storage: 1G
+        memory: 1512Mi
+      requests:
+        cpu: 150m
+        ephemeral-storage: 50M
+        memory: 164Mi
+    securityContext:
+      capabilities:
+        drop:
+        - ALL
+      readOnlyRootFilesystem: true
+      runAsGroup: 5678
+      runAsUser: 5678
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-w7dxf
+      readOnly: true
+    - mountPath: /tmp
+      name: kuma-sidecar-tmp
+  - image: busybox
+    name: busybox
+    resources: {}
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-w7dxf
+      readOnly: true
+  volumes:
+  - name: default-token-w7dxf
+    secret:
+      secretName: default-token-w7dxf
+  - emptyDir:
+      sizeLimit: 10M
+    name: kuma-init-tmp
+  - emptyDir:
+      sizeLimit: 10M
+    name: kuma-sidecar-tmp
+status: {}

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.41.input.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.41.input.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  annotations:
+    kuma.io/gateway: enabled
+  labels:
+    run: busybox
+spec:
+  volumes:
+  - name: default-token-w7dxf
+    secret:
+      secretName: default-token-w7dxf
+  containers:
+  - name: busybox
+    image: busybox
+    resources: {}
+    volumeMounts:
+    - name: default-token-w7dxf
+      readOnly: true
+      mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.41.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.41.golden.yaml
@@ -1,0 +1,153 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    k8s.v1.cni.cncf.io/networks: kuma-cni
+    kubectl.kubernetes.io/default-container: busybox
+    kuma.io/application-probe-proxy-port: "0"
+    kuma.io/envoy-admin-port: "9901"
+    kuma.io/gateway: enabled
+    kuma.io/sidecar-injected: "true"
+    kuma.io/sidecar-uid: "5678"
+    kuma.io/transparent-proxying: enabled
+    kuma.io/transparent-proxying-inbound-port: "15055"
+    kuma.io/transparent-proxying-ip-family-mode: ipv4
+    kuma.io/transparent-proxying-outbound-port: "15001"
+    kuma.io/virtual-probes: disabled
+    kuma.io/virtual-probes-port: "9000"
+  creationTimestamp: null
+  labels:
+    kuma.io/mesh: default
+    run: busybox
+  name: busybox
+spec:
+  containers:
+  - image: busybox
+    name: busybox
+    resources: {}
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-w7dxf
+      readOnly: true
+  initContainers:
+  - args:
+    - run
+    - --log-level=info
+    - --concurrency=2
+    env:
+    - name: INSTANCE_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.podIP
+    - name: KUMA_APPLICATION_PROBE_PROXY_PORT
+      value: "0"
+    - name: KUMA_CONTROL_PLANE_CA_CERT
+      value: |
+        -----BEGIN CERTIFICATE-----
+        MIIDMzCCAhugAwIBAgIQDhlInfsXYHamKN+29qnQvzANBgkqhkiG9w0BAQsFADAP
+        MQ0wCwYDVQQDEwRrdW1hMB4XDTIxMDQwMjEwMjIyNloXDTMxMDMzMTEwMjIyNlow
+        DzENMAsGA1UEAxMEa3VtYTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+        AL4GGg+e2O7eA12F0F6v2rr8j2iVSFKepnZtL15lrCds6lqK50sXWOw8PKZp2ihA
+        XJVTSZzKasyLDTAR9VYQjTpE526EzvtdthSagf32QWW+wY6LMpEdexKOOCx2se55
+        Rd97L33yYPfgX15OYliHPD056jjhotHLdN2lpy7+STDvQyRnXAu73YkY37Ed4hI4
+        t/V6soHyEGNcDhm9p5fBGqz0njBbQkp2lTY5/kj42qB7Q6rCM2tbPsEMooeAAw5m
+        hyY4xj0tP9ucqlUz8gc+6o8HDNst8NeJXZktWn+COytjr/NzGgS22kvSDphisJot
+        o0FyoIOdAtxC1qxXXR+XuUUCAwEAAaOBijCBhzAOBgNVHQ8BAf8EBAMCAqQwHQYD
+        VR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMBMA8GA1UdEwEB/wQFMAMBAf8wHQYD
+        VR0OBBYEFKRLkgIzX/OjKw9idepuQ/RMtT+AMCYGA1UdEQQfMB2CCWxvY2FsaG9z
+        dIcQ/QChIwAAAAAAAAAAAAAAATANBgkqhkiG9w0BAQsFAAOCAQEAPs5yJZhoYlGW
+        CpA8dSISivM8/8iBNQ3fVwP63ft0EJLMVGu2RFZ4/UAJ/rUPSGN8xhXSk5+1d56a
+        /kaH9rX0HaRIHHlxA7iPUKxAj44x9LKmqPHToL3XlWY1AXzvicW9d+GM2FaQee+I
+        leaqLbz0AZvlnu271Z1CeaACuU9GljujvyiTTE9naHUEqvHgSpPtilJalyJ5/zIl
+        Z9F0+UWt3TOYMs5g+SCt0MwHTNbisbmewpcFFJzjt2kvtrc9t9dkF81xhcS19w7q
+        h1AeP3RRlLl7bv9EAVXEmIavih/29PA3ZSy+pbYNW7jNJHjMQ4hQ0E+xcCazU/O4
+        ypWGaanvPg==
+        -----END CERTIFICATE-----
+    - name: KUMA_CONTROL_PLANE_URL
+      value: http://kuma-control-plane.kuma-system:5681
+    - name: KUMA_DATAPLANE_DRAIN_TIME
+      value: 31s
+    - name: KUMA_DATAPLANE_MESH
+      value: default
+    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
+      value: /var/run/secrets/kubernetes.io/serviceaccount/token
+    - name: KUMA_DNS_ENABLED
+      value: "false"
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.namespace
+    image: kuma/kuma-sidecar:latest
+    imagePullPolicy: IfNotPresent
+    lifecycle:
+      preStop:
+        exec:
+          command:
+          - killall
+          - -USR2
+          - kuma-dp
+    livenessProbe:
+      failureThreshold: 212
+      httpGet:
+        path: /ready
+        port: 9901
+      initialDelaySeconds: 260
+      periodSeconds: 25
+      successThreshold: 1
+      timeoutSeconds: 23
+    name: kuma-sidecar
+    readinessProbe:
+      failureThreshold: 112
+      httpGet:
+        path: /ready
+        port: 9901
+      initialDelaySeconds: 11
+      periodSeconds: 15
+      successThreshold: 11
+      timeoutSeconds: 13
+    resources:
+      limits:
+        cpu: 1100m
+        ephemeral-storage: 1G
+        memory: 1512Mi
+      requests:
+        cpu: 150m
+        ephemeral-storage: 50M
+        memory: 164Mi
+    restartPolicy: Always
+    securityContext:
+      capabilities:
+        drop:
+        - ALL
+      readOnlyRootFilesystem: true
+      runAsGroup: 5678
+      runAsUser: 5678
+    startupProbe:
+      httpGet:
+        path: /ready
+        port: 9901
+      successThreshold: 1
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-w7dxf
+      readOnly: true
+    - mountPath: /tmp
+      name: kuma-sidecar-tmp
+  volumes:
+  - name: default-token-w7dxf
+    secret:
+      secretName: default-token-w7dxf
+  - emptyDir:
+      sizeLimit: 10M
+    name: kuma-init-tmp
+  - emptyDir:
+      sizeLimit: 10M
+    name: kuma-sidecar-tmp
+status: {}

--- a/test/framework/envs/multizone/env.go
+++ b/test/framework/envs/multizone/env.go
@@ -131,6 +131,7 @@ func SetupAndGetState() []byte {
 	KubeZone1 = setupKubeZone(&wg, Kuma1, kubeZone1Options...)
 
 	kubeZone2Options := framework.KumaDeploymentOptionsFromConfig(framework.Config.KumaCpConfig.Multizone.KubeZone2)
+	kubeZone2Options = append(kubeZone2Options, WithCNI())
 	KubeZone2 = setupKubeZone(&wg, Kuma2, kubeZone2Options...)
 
 	UniZone1 = setupUniZone(&wg, Kuma4, framework.KumaDeploymentOptionsFromConfig(framework.Config.KumaCpConfig.Multizone.UniZone1)...)


### PR DESCRIPTION
## Motivation

I wanted to run Zone 2 in e2e tests in CNI mode and I encountered a problem with injection.
We were injecting such init container
```
  initContainers:
  - name: ""
    resources: {}
```
I fixed it and switched one zone to CNI to avoid this in the future.

## Implementation information

Inject container only if it's created

Placing run-full-matrix, because I need to see if all variants are ok. I checked locally and e2e is fine with CNI.