### PR TITLE
chore(kuma-cp): remove old meshservice feature flags

### DIFF
--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -766,11 +766,6 @@ experimental:
   # Enables sidecar containers in Kubernetes if supported by the Kubernetes
   # environment.
   sidecarContainers: false # ENV: KUMA_EXPERIMENTAL_SIDECAR_CONTAINERS
-  # If true then it generates MeshServices from Kubernetes Service.
-  generateMeshServices: false # ENV: KUMA_EXPERIMENTAL_GENERATE_MESH_SERVICES
-  # If true skips persisted VIPs. Change to true only if generateMeshServices is enabled.
-  # Do not enable on production.
-  skipPersistedVIPs: false # ENV: KUMA_EXPERIMENTAL_SKIP_PERSISTED_VIPS
 proxy:
   gateway:
     # Sets the envoy runtime value to limit maximum number of incoming

--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -459,11 +459,6 @@ type ExperimentalConfig struct {
 	// Enables sidecar containers in Kubernetes if supported by the Kubernetes
 	// environment.
 	SidecarContainers bool `json:"sidecarContainers" envconfig:"KUMA_EXPERIMENTAL_SIDECAR_CONTAINERS"`
-	// If true then it generates MeshServices from Kubernetes Service.
-	GenerateMeshServices bool `json:"generateMeshServices" envconfig:"KUMA_EXPERIMENTAL_GENERATE_MESH_SERVICES"`
-	// If true skips persisted VIPs. Change to true only if generateMeshServices is enabled.
-	// Do not enable on production.
-	SkipPersistedVIPs bool `json:"skipPersistedVIPs" envconfig:"KUMA_EXPERIMENTAL_SKIP_PERSISTED_VIPS"`
 }
 
 type ExperimentalKDSEventBasedWatchdog struct {

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -766,11 +766,6 @@ experimental:
   # Enables sidecar containers in Kubernetes if supported by the Kubernetes
   # environment.
   sidecarContainers: false # ENV: KUMA_EXPERIMENTAL_SIDECAR_CONTAINERS
-  # If true then it generates MeshServices from Kubernetes Service.
-  generateMeshServices: false # ENV: KUMA_EXPERIMENTAL_GENERATE_MESH_SERVICES
-  # If true skips persisted VIPs. Change to true only if generateMeshServices is enabled.
-  # Do not enable on production.
-  skipPersistedVIPs: false # ENV: KUMA_EXPERIMENTAL_SKIP_PERSISTED_VIPS
 proxy:
   gateway:
     # Sets the envoy runtime value to limit maximum number of incoming

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -370,8 +370,6 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.Experimental.KDSEventBasedWatchdog.DelayFullResync).To(BeTrue())
 			Expect(cfg.Experimental.AutoReachableServices).To(BeTrue())
 			Expect(cfg.Experimental.SidecarContainers).To(BeTrue())
-			Expect(cfg.Experimental.SkipPersistedVIPs).To(BeTrue())
-			Expect(cfg.Experimental.GenerateMeshServices).To(BeTrue())
 
 			Expect(cfg.Proxy.Gateway.GlobalDownstreamMaxConnections).To(BeNumerically("==", 1))
 			Expect(cfg.EventBus.BufferSize).To(Equal(uint(30)))
@@ -1063,8 +1061,6 @@ meshService:
 				"KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_DELAY_FULL_RESYNC":                             "true",
 				"KUMA_EXPERIMENTAL_AUTO_REACHABLE_SERVICES":                                                "true",
 				"KUMA_EXPERIMENTAL_SIDECAR_CONTAINERS":                                                     "true",
-				"KUMA_EXPERIMENTAL_GENERATE_MESH_SERVICES":                                                 "true",
-				"KUMA_EXPERIMENTAL_SKIP_PERSISTED_VIPS":                                                    "true",
 				"KUMA_PROXY_GATEWAY_GLOBAL_DOWNSTREAM_MAX_CONNECTIONS":                                     "1",
 				"KUMA_TRACING_OPENTELEMETRY_ENDPOINT":                                                      "otel-collector:4317",
 				"KUMA_TRACING_OPENTELEMETRY_ENABLED":                                                       "true",


### PR DESCRIPTION
## Motivation

These are no longer used since 2.9