### PR TITLE
test(e2e): reenable amd64 self-hosted runners

### DIFF
--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -72,7 +72,7 @@ jobs:
           cat <<'EOF' | sudo tee /etc/docker/daemon.json
           {
             "ipv6": true,
-            "fixed-cidr-v6": "fd00:fd12:3456::0/64",
+            "fixed-cidr-v6": "2001:db8:1::/64",
             "dns-search": ["."]
           }
           EOF

--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -72,8 +72,7 @@ jobs:
           cat <<'EOF' | sudo tee /etc/docker/daemon.json
           {
             "ipv6": true,
-            "fixed-cidr-v6": "2001:db8:1::/64",
-            "dns": ["8.8.8.8"],
+            "fixed-cidr-v6": "fd00:fd12:3456::0/64",
             "dns-search": ["."]
           }
           EOF

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -87,7 +87,7 @@ jobs:
     uses: ./.github/workflows/_test.yaml
     with:
       FULL_MATRIX: ${{ needs.check.outputs.FULL_MATRIX }}
-      RUNNERS_BY_ARCH: ${{ (github.event_name == 'push' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) && '{"amd64":"ubuntu-latest","arm64":"ubuntu-latest-arm64-kong"}' || '{"amd64":"ubuntu-latest","arm64":""}' }}
+      RUNNERS_BY_ARCH: ${{ (github.event_name == 'push' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) && '{"amd64":"ubuntu-latest-kong","arm64":"ubuntu-latest-arm64-kong"}' || '{"amd64":"ubuntu-latest","arm64":""}' }}
     secrets: inherit
   build_publish:
     permissions:


### PR DESCRIPTION
## Motivation

Renable self-hosted runners that were disabled here
https://github.com/kumahq/kuma/pull/11862

## Implementation information

Docker changes were tested here https://github.com/kumahq/kuma/pull/11872