### PR TITLE
chore(deps): upgrade envoy version from 1.28.7 to 1.29.10

### DIFF
--- a/tools/releases/version.sh
+++ b/tools/releases/version.sh
@@ -8,7 +8,7 @@ function envoy_version() {
   # - if ENVOY_TAG is a real git tag like 'v1.20.0' then the version is equal to '1.20.0' (without the first letter 'v').
   # - if ENVOY_TAG is a commit hash then the version will look like '1.20.1-dev-b16d390f'
 
-  ENVOY_TAG=${ENVOY_TAG:-"v1.28.7"}
+  ENVOY_TAG=${ENVOY_TAG:-"v1.29.10"}
 
   if [[ "${ENVOY_TAG}" =~ ^v[0-9]*\.[0-9]*\.[0-9]* ]]; then
     echo "${ENVOY_TAG#v}"


### PR DESCRIPTION
## Motivation

Envoy 1.28 is out of life, we should upgrade to 1.29

## Implementation information

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
