### PR TITLE
fix(MeshLoadBalancingStrategy): set all priorities equal if localityAware is disabled

### DIFF
--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
@@ -233,6 +233,15 @@ func configureEndpoints(
 			}
 		}
 	}
+	if conf.LocalityAwareness != nil && pointer.Deref(conf.LocalityAwareness.Disabled) {
+		for _, cla := range endpoints {
+			for _, localityLbEndpoints := range cla.Endpoints {
+				if localityLbEndpoints.Locality != nil && localityLbEndpoints.Locality.Zone != localZone {
+					localityLbEndpoints.Priority = 0
+				}
+			}
+		}
+	}
 	return nil
 }
 

--- a/test/e2e_env/multizone/localityawarelb/meshmultizoneservice.go
+++ b/test/e2e_env/multizone/localityawarelb/meshmultizoneservice.go
@@ -49,6 +49,7 @@ spec:
 				testserver.WithMesh(meshName),
 				testserver.WithEchoArgs("echo", "--instance", "kube-test-server-1"),
 			)).
+			Install(democlient.Install(democlient.WithNamespace(namespace), democlient.WithMesh(meshName))).
 			SetupInGroup(multizone.KubeZone1, &group)
 
 		NewClusterSetup().
@@ -115,7 +116,9 @@ spec:
 	It("should fallback only to first zone", func() {
 		// given traffic to other zones
 		Eventually(responseFromInstance(multizone.KubeZone2), "30s", "1s").
-			MustPassRepeatedly(5).Should(Or(Equal("kube-test-server-1"), Equal("uni-test-server")))
+			Should(Equal("kube-test-server-1"))
+		Eventually(responseFromInstance(multizone.KubeZone2), "30s", "1s").
+			Should(Equal("uni-test-server"))
 
 		// when
 		policy := `
@@ -129,7 +132,7 @@ spec:
   - targetRef:
       kind: MeshMultiZoneService
       labels:
-        kuma.io/display-name: test-server 
+        kuma.io/display-name: test-server
     default:
       localityAwareness:
         crossZone:
@@ -150,5 +153,36 @@ spec:
 
 		Eventually(responseFromInstance(multizone.KubeZone2), "30s", "1s").
 			MustPassRepeatedly(5).Should(Equal("kube-test-server-1"))
+	})
+
+	It("should be locality aware unless disabled", func() {
+		// given traffic only to the local zone
+		Eventually(responseFromInstance(multizone.KubeZone1), "30s", "1s").
+			MustPassRepeatedly(5).Should(Equal("kube-test-server-1"))
+
+		// when
+		policy := `
+type: MeshLoadBalancingStrategy
+name: mlb-mzms
+mesh: mlb-mzms
+spec:
+  targetRef:
+    kind: Mesh
+  to:
+  - targetRef:
+      kind: MeshMultiZoneService
+      labels:
+        kuma.io/display-name: test-server
+    default:
+      localityAwareness:
+        disabled: true
+`
+		err := multizone.Global.Install(YamlUniversal(policy))
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+
+		Eventually(responseFromInstance(multizone.KubeZone1), "30s", "1s").
+			Should(Equal("uni-test-server"))
 	})
 }


### PR DESCRIPTION
## Motivation

We already set `priority: 1` for remote zones in `fillRemoteMeshServices` so we need to explicitly set `priority: 0` if we _don't_ want locality awareness.

Also fix an insufficient condition in an existing case, where we weren't verifying that requests really go to all zones, only that it's OK if they do.

## Supporting documentation

Fixes https://github.com/kumahq/kuma/issues/11968

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
