### PR TITLE
test(e2e): disable helm deploy / admin ops test while investigating flake

### DIFF
--- a/test/e2e/helm/kuma_helm_deploy_global_zone.go
+++ b/test/e2e/helm/kuma_helm_deploy_global_zone.go
@@ -171,7 +171,8 @@ interCp:
 		})
 	})
 
-	It("should execute admin operations on Global CP", func() {
+	// TODO(bartsmykla): disabled while investingating flake
+	XIt("should execute admin operations on Global CP", func() {
 		// given DP available on Global CP
 		Eventually(func(g Gomega) {
 			dataplanes, err := c1.GetKumactlOptions().KumactlList("dataplanes", "default")


### PR DESCRIPTION
## Motivation

This test was flaking, so it's disabled for the investigation, which I'm currently conducting

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
