### PR TITLE
ci(update-insecure-dependencies): fix osv-scanner failure

### DIFF
--- a/.github/workflows/update-insecure-dependencies.yaml
+++ b/.github/workflows/update-insecure-dependencies.yaml
@@ -42,7 +42,7 @@ jobs:
           go-version-file: go.mod
       - name: "Install tools"
         run: |
-          go install github.com/google/osv-scanner/cmd/osv-scanner@037c3543ac60359190459b10fbb5331568b4c8f5 # v1.7.0
+          go install github.com/google/osv-scanner/cmd/osv-scanner@b13f37e1a1e4cb98556c1d34cd3256a876929be1 # v1.9.1
       - name: "Prepare commit body - before"
         id: prepare_commit_body_before
         run: |

--- a/tools/ci/update-vulnerable-dependencies/update-vulnerable-dependencies.sh
+++ b/tools/ci/update-vulnerable-dependencies/update-vulnerable-dependencies.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -Eeuo pipefail
 
 command -v osv-scanner >/dev/null 2>&1 || { echo >&2 "osv-scanner not installed!"; exit 1; }
 command -v jq >/dev/null 2>&1 || { echo >&2 "jq not installed!"; exit 1; }


### PR DESCRIPTION
## Motivation

[Fails atm](https://github.com/kumahq/kuma/actions/runs/11696575060/job/32573910890#step:7:10):

```
Scanned /home/runner/work/kuma/kuma/go.mod file and found 222 packages
panic: Cannot range over: func(yield func(K, V) bool)

goroutine 40815 [running]:
golang.org/x/tools/go/ssa.(*builder).rangeStmt(0xc0053d0770, 0xc0ea4c1520, 0xc006c5cd20, 0x0)
	/home/runner/go/pkg/mod/golang.org/x/tools@v0.19.0/go/ssa/builder.go:2279 +0x805
golang.org/x/tools/go/ssa.(*builder).stmt(0xc0053d0770, 0xc0ea4c1520, {0x1911160?, 0xc006c5cd20?})
	/home/runner/go/pkg/mod/golang.org/x/tools@v0.19.0/go/ssa/builder.go:2503 +0x205
golang.org/x/tools/go/ssa.(*builder).stmtList(...)
	/home/runner/go/pkg/mod/golang.org/x/tools@v0.19.0/go/ssa/builder.go:909
golang.org/x/tools/go/ssa.(*builder).stmt(0xc0053d0770, 0xc0ea4c1520, {0x191
...
```

[See successful run](https://github.com/kumahq/kuma/actions/runs/11702199507)

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
