### PR TITLE
Revert "fix(MeshLoadBalancingStrategy): set all priorities equal if localityAware is disabled"

### DIFF
--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
@@ -233,15 +233,6 @@ func configureEndpoints(
 			}
 		}
 	}
-	if conf.LocalityAwareness != nil && pointer.Deref(conf.LocalityAwareness.Disabled) {
-		for _, cla := range endpoints {
-			for _, localityLbEndpoints := range cla.Endpoints {
-				if localityLbEndpoints.Locality != nil && localityLbEndpoints.Locality.Zone != localZone {
-					localityLbEndpoints.Priority = 0
-				}
-			}
-		}
-	}
 	return nil
 }
 

--- a/test/e2e_env/multizone/localityawarelb/meshmultizoneservice.go
+++ b/test/e2e_env/multizone/localityawarelb/meshmultizoneservice.go
@@ -49,7 +49,6 @@ spec:
 				testserver.WithMesh(meshName),
 				testserver.WithEchoArgs("echo", "--instance", "kube-test-server-1"),
 			)).
-			Install(democlient.Install(democlient.WithNamespace(namespace), democlient.WithMesh(meshName))).
 			SetupInGroup(multizone.KubeZone1, &group)
 
 		NewClusterSetup().
@@ -96,9 +95,7 @@ spec:
 	It("should fallback only to first zone", func() {
 		// given traffic to other zones
 		Eventually(responseFromInstance(multizone.KubeZone2), "30s", "1s").
-			Should(Equal("kube-test-server-1"))
-		Eventually(responseFromInstance(multizone.KubeZone2), "30s", "1s").
-			Should(Equal("uni-test-server"))
+			MustPassRepeatedly(5).Should(Or(Equal("kube-test-server-1"), Equal("uni-test-server")))
 
 		// when
 		policy := `
@@ -112,7 +109,7 @@ spec:
   - targetRef:
       kind: MeshMultiZoneService
       labels:
-        kuma.io/display-name: test-server
+        kuma.io/display-name: test-server 
     default:
       localityAwareness:
         crossZone:
@@ -133,36 +130,5 @@ spec:
 
 		Eventually(responseFromInstance(multizone.KubeZone2), "30s", "1s").
 			MustPassRepeatedly(5).Should(Equal("kube-test-server-1"))
-	})
-
-	It("should be locality aware unless disabled", func() {
-		// given traffic only to the local zone
-		Eventually(responseFromInstance(multizone.KubeZone1), "30s", "1s").
-			MustPassRepeatedly(5).Should(Equal("kube-test-server-1"))
-
-		// when
-		policy := `
-type: MeshLoadBalancingStrategy
-name: mlb-mzms
-mesh: mlb-mzms
-spec:
-  targetRef:
-    kind: Mesh
-  to:
-  - targetRef:
-      kind: MeshMultiZoneService
-      labels:
-        kuma.io/display-name: test-server
-    default:
-      localityAwareness:
-        disabled: true
-`
-		err := multizone.Global.Install(YamlUniversal(policy))
-
-		// then
-		Expect(err).ToNot(HaveOccurred())
-
-		Eventually(responseFromInstance(multizone.KubeZone1), "30s", "1s").
-			Should(Equal("uni-test-server"))
 	})
 }


### PR DESCRIPTION
Reverts kumahq/kuma#11980

The test is failing, lets find out what is the cause and add the change again