### PR TITLE
test(e2e): fix MMZS + MLBS test after merge

### DIFF
--- a/test/e2e_env/multizone/localityawarelb/meshmultizoneservice.go
+++ b/test/e2e_env/multizone/localityawarelb/meshmultizoneservice.go
@@ -31,7 +31,6 @@ spec:
     meshService:
       matchLabels:
         kuma.io/display-name: test-server
-        k8s.kuma.io/namespace: mlb-mzms
   ports:
   - name: "80"
     port: 80


### PR DESCRIPTION
The uni MeshService is autogenerated, without the namespace tag, since #11978 and the first condition in "should fallback only to first zone" was fixed in #11980. This caused the test to start failing on master.