### PR TITLE
ci(github): fix release.yaml to use label:dev in version.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,6 @@ env:
   CHECK: ${{ inputs.check || 'false' }}
   EDITION: kuma
   MIN_VERSION: "1.2.0"
-  USE_LABEL_IN_VERSION: "true"
 permissions:
   contents: read
 jobs:
@@ -45,7 +44,7 @@ jobs:
       - name: install-kuma-ci-tools
         run: |
           echo $(go env GOPATH)/bin >> $GITHUB_PATH
-          go install github.com/kumahq/ci-tools/cmd/release-tool@v0.13.1
+          go install github.com/kumahq/ci-tools/cmd/release-tool@v1.0.0
       - name: Generate GitHub app token
         id: github-app-token
         uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
@@ -85,7 +84,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
         run: |
-          release-tool version-file --repo ${{ github.repository }} --edition ${{ env.EDITION }} --min-version ${{ env.MIN_VERSION }} --use-label-for-dev=${{ env.USE_LABEL_IN_VERSION }} > versions.yml
+          release-tool version-file --repo ${{ github.repository }} --edition ${{ env.EDITION }} --min-version ${{ env.MIN_VERSION }} > versions.yml
       - name: update-CHANGELOG.md
         env:
           GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ env:
   CHECK: ${{ inputs.check || 'false' }}
   EDITION: kuma
   MIN_VERSION: "1.2.0"
-  USE_LABEL_IN_VERSION: "false"
+  USE_LABEL_IN_VERSION: "true"
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
## Motivation

This fixes: https://github.com/kumahq/kuma-website/pull/2073 which is needed as we moved to the latest site-generator with: https://github.com/kumahq/kuma-website/pull/1623.

