### PR TITLE
feat(kuma-dp): disable application probe proxy by default on Universal

### DIFF
--- a/pkg/config/app/kuma-dp/config.go
+++ b/pkg/config/app/kuma-dp/config.go
@@ -49,7 +49,7 @@ var DefaultConfig = func() Config {
 			CoreDNSLogging:            false,
 		},
 		ApplicationProbeProxyServer: ApplicationProbeProxyServer{
-			Port: 9001,
+			Port: 0,
 		},
 	}
 }

--- a/pkg/config/app/kuma-dp/testdata/default-config.golden.yaml
+++ b/pkg/config/app/kuma-dp/testdata/default-config.golden.yaml
@@ -1,5 +1,4 @@
-applicationProbeProxyServer:
-  port: 9001
+applicationProbeProxyServer: {}
 controlPlane:
   caCert: ""
   caCertFile: ""


### PR DESCRIPTION
## Motivation

fixes https://github.com/kumahq/kuma/issues/11854

## Implementation information

`kuma-dp` decides whether to start the application probe proxy according to port settings on `applicationProbeProxyServer.port`, when it's configured to `0`, the server won't start. 

It was set to `9001` by default. So now change this default value to "not set", which will be actually `0`.  
On Kubernetes, we have another injector configuration item which still defaults to `9901`, it will eventually be applied to the `kuma-dp` process in the pod. Users can use environment variable and data plane pod annotation to configure this port. So the functionality of the feature is not impacted at all.

## Supporting documentation

https://kuma.io/docs/2.9.x/policies/service-health-probes/#application-probe-proxy

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
