### PR TITLE
test(conformance): restore skipped gatewayapi cases when it's stable now

### DIFF
--- a/test/e2e_env/gatewayapi/conformance_test.go
+++ b/test/e2e_env/gatewayapi/conformance_test.go
@@ -136,9 +136,6 @@ func TestConformance(t *testing.T) {
 		),
 		Implementation:      implementation,
 		ConformanceProfiles: sets.New(suite.GatewayHTTPConformanceProfileName, suite.MeshHTTPConformanceProfileName),
-		// We are seeing flaky runs which are related to headless service cases, so ignoring them temporarily
-		// See https://github.com/kumahq/kuma/pull/11463
-		SkipTests: []string{tests.HTTPRouteServiceTypes.ShortName},
 	}
 
 	conformanceSuite, err := suite.NewConformanceTestSuite(options)


### PR DESCRIPTION
## Motivation

restore skipped gatewayapi cases when it's stable now

## Implementation information

<!-- Explain how this was done and potentially alternatives considered and discarded -->
Remove names of skipped conformance tests.

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

fixes https://github.com/kumahq/kuma/issues/11464

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
