### PR TITLE
feat(tools/policy-gen/templates/schema): add creationTime and modificationTime to policy specs

### DIFF
--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -3278,6 +3278,16 @@ components:
                 type: object
               type: array
           type: object
+        creationTime:
+          type: string
+          description: Time at which the resource was created
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
+        modificationTime:
+          type: string
+          description: Time at which the resource was updated
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
     MeshAccessLogCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -4487,6 +4497,16 @@ components:
                 type: object
               type: array
           type: object
+        creationTime:
+          type: string
+          description: Time at which the resource was created
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
+        modificationTime:
+          type: string
+          description: Time at which the resource was updated
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
     MeshCircuitBreakerCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -4990,6 +5010,16 @@ components:
                 type: object
               type: array
           type: object
+        creationTime:
+          type: string
+          description: Time at which the resource was created
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
+        modificationTime:
+          type: string
+          description: Time at which the resource was updated
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
     MeshFaultInjectionCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -5467,6 +5497,16 @@ components:
                 type: object
               type: array
           type: object
+        creationTime:
+          type: string
+          description: Time at which the resource was created
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
+        modificationTime:
+          type: string
+          description: Time at which the resource was updated
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
     MeshHealthCheckCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -6261,6 +6301,16 @@ components:
                 type: object
               type: array
           type: object
+        creationTime:
+          type: string
+          description: Time at which the resource was created
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
+        modificationTime:
+          type: string
+          description: Time at which the resource was updated
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
     MeshHTTPRouteCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -7012,6 +7062,16 @@ components:
                 type: object
               type: array
           type: object
+        creationTime:
+          type: string
+          description: Time at which the resource was created
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
+        modificationTime:
+          type: string
+          description: Time at which the resource was updated
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
     MeshLoadBalancingStrategyCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -7334,6 +7394,16 @@ components:
                   type: object
               type: object
           type: object
+        creationTime:
+          type: string
+          description: Time at which the resource was created
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
+        modificationTime:
+          type: string
+          description: Time at which the resource was updated
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
     MeshMetricCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -7508,6 +7578,16 @@ components:
                   type: object
               type: object
           type: object
+        creationTime:
+          type: string
+          description: Time at which the resource was created
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
+        modificationTime:
+          type: string
+          description: Time at which the resource was updated
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
     MeshPassthroughCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -8215,6 +8295,16 @@ components:
           required:
             - default
           type: object
+        creationTime:
+          type: string
+          description: Time at which the resource was created
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
+        modificationTime:
+          type: string
+          description: Time at which the resource was updated
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
     MeshProxyPatchCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -8792,6 +8882,16 @@ components:
                 type: object
               type: array
           type: object
+        creationTime:
+          type: string
+          description: Time at which the resource was created
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
+        modificationTime:
+          type: string
+          description: Time at which the resource was updated
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
     MeshRateLimitCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -9428,6 +9528,16 @@ components:
                 type: object
               type: array
           type: object
+        creationTime:
+          type: string
+          description: Time at which the resource was created
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
+        modificationTime:
+          type: string
+          description: Time at which the resource was updated
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
     MeshRetryCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -9758,6 +9868,16 @@ components:
               minItems: 1
               type: array
           type: object
+        creationTime:
+          type: string
+          description: Time at which the resource was created
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
+        modificationTime:
+          type: string
+          description: Time at which the resource was updated
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
     MeshTCPRouteCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -10227,6 +10347,16 @@ components:
                 type: object
               type: array
           type: object
+        creationTime:
+          type: string
+          description: Time at which the resource was created
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
+        modificationTime:
+          type: string
+          description: Time at which the resource was updated
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
     MeshTimeoutCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -10497,6 +10627,16 @@ components:
                   type: object
               type: object
           type: object
+        creationTime:
+          type: string
+          description: Time at which the resource was created
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
+        modificationTime:
+          type: string
+          description: Time at which the resource was updated
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
     MeshTLSCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -10837,6 +10977,16 @@ components:
                   type: object
               type: object
           type: object
+        creationTime:
+          type: string
+          description: Time at which the resource was created
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
+        modificationTime:
+          type: string
+          description: Time at which the resource was updated
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
     MeshTraceCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -11068,6 +11218,16 @@ components:
                   type: object
               type: object
           type: object
+        creationTime:
+          type: string
+          description: Time at which the resource was created
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
+        modificationTime:
+          type: string
+          description: Time at which the resource was updated
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
     MeshTrafficPermissionCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -11131,6 +11291,16 @@ components:
             template:
               type: string
           type: object
+        creationTime:
+          type: string
+          description: Time at which the resource was created
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
+        modificationTime:
+          type: string
+          description: Time at which the resource was updated
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
     HostnameGeneratorCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -11375,6 +11545,16 @@ components:
           required:
             - match
           type: object
+        creationTime:
+          type: string
+          description: Time at which the resource was created
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
+        modificationTime:
+          type: string
+          description: Time at which the resource was updated
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
         status:
           description: >-
             Status is the current status of the Kuma MeshExternalService
@@ -11558,6 +11738,16 @@ components:
           required:
             - selector
           type: object
+        creationTime:
+          type: string
+          description: Time at which the resource was created
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
+        modificationTime:
+          type: string
+          description: Time at which the resource was updated
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
         status:
           description: >-
             Status is the current status of the Kuma MeshMultiZoneService
@@ -11787,6 +11977,16 @@ components:
                 - Unavailable
               type: string
           type: object
+        creationTime:
+          type: string
+          description: Time at which the resource was created
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
+        modificationTime:
+          type: string
+          description: Time at which the resource was updated
+          format: date-time
+          example: '0001-01-01T00:00:00Z'
         status:
           description: Status is the current status of the Kuma MeshService resource.
           properties:

--- a/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/schema.yaml
+++ b/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/schema.yaml
@@ -44,3 +44,13 @@ properties:
       template:
         type: string
     type: object
+  creationTime:
+    type: string
+    description: 'Time at which the resource was created'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+  modificationTime:
+    type: string
+    description: 'Time at which the resource was updated'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/schema.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/schema.yaml
@@ -196,6 +196,16 @@ properties:
     required:
       - match
     type: object
+  creationTime:
+    type: string
+    description: 'Time at which the resource was created'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+  modificationTime:
+    type: string
+    description: 'Time at which the resource was updated'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
   status:
     description: Status is the current status of the Kuma MeshExternalService resource.
     properties:

--- a/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/schema.yaml
+++ b/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/schema.yaml
@@ -59,6 +59,16 @@ properties:
     required:
       - selector
     type: object
+  creationTime:
+    type: string
+    description: 'Time at which the resource was created'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+  modificationTime:
+    type: string
+    description: 'Time at which the resource was updated'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
   status:
     description: Status is the current status of the Kuma MeshMultiZoneService resource.
     properties:

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/schema.yaml
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/schema.yaml
@@ -81,6 +81,16 @@ properties:
           - Unavailable
         type: string
     type: object
+  creationTime:
+    type: string
+    description: 'Time at which the resource was created'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+  modificationTime:
+    type: string
+    description: 'Time at which the resource was updated'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
   status:
     description: Status is the current status of the Kuma MeshService resource.
     properties:

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/schema.yaml
@@ -514,3 +514,13 @@ properties:
           type: object
         type: array
     type: object
+  creationTime:
+    type: string
+    description: 'Time at which the resource was created'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+  modificationTime:
+    type: string
+    description: 'Time at which the resource was updated'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/schema.yaml
@@ -698,3 +698,13 @@ properties:
           type: object
         type: array
     type: object
+  creationTime:
+    type: string
+    description: 'Time at which the resource was created'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+  modificationTime:
+    type: string
+    description: 'Time at which the resource was updated'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/schema.yaml
@@ -372,3 +372,13 @@ properties:
           type: object
         type: array
     type: object
+  creationTime:
+    type: string
+    description: 'Time at which the resource was created'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+  modificationTime:
+    type: string
+    description: 'Time at which the resource was updated'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/schema.yaml
@@ -342,3 +342,13 @@ properties:
           type: object
         type: array
     type: object
+  creationTime:
+    type: string
+    description: 'Time at which the resource was created'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+  modificationTime:
+    type: string
+    description: 'Time at which the resource was updated'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/schema.yaml
@@ -620,3 +620,13 @@ properties:
           type: object
         type: array
     type: object
+  creationTime:
+    type: string
+    description: 'Time at which the resource was created'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+  modificationTime:
+    type: string
+    description: 'Time at which the resource was updated'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/schema.yaml
@@ -515,3 +515,13 @@ properties:
           type: object
         type: array
     type: object
+  creationTime:
+    type: string
+    description: 'Time at which the resource was created'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+  modificationTime:
+    type: string
+    description: 'Time at which the resource was updated'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/schema.yaml
@@ -243,3 +243,13 @@ properties:
             type: object
         type: object
     type: object
+  creationTime:
+    type: string
+    description: 'Time at which the resource was created'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+  modificationTime:
+    type: string
+    description: 'Time at which the resource was updated'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'

--- a/pkg/plugins/policies/meshpassthrough/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshpassthrough/api/v1alpha1/schema.yaml
@@ -127,3 +127,13 @@ properties:
             type: object
         type: object
     type: object
+  creationTime:
+    type: string
+    description: 'Time at which the resource was created'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+  modificationTime:
+    type: string
+    description: 'Time at which the resource was updated'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'

--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/schema.yaml
@@ -485,3 +485,13 @@ properties:
     required:
       - default
     type: object
+  creationTime:
+    type: string
+    description: 'Time at which the resource was created'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+  modificationTime:
+    type: string
+    description: 'Time at which the resource was updated'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/schema.yaml
@@ -446,3 +446,13 @@ properties:
           type: object
         type: array
     type: object
+  creationTime:
+    type: string
+    description: 'Time at which the resource was created'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+  modificationTime:
+    type: string
+    description: 'Time at which the resource was updated'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/schema.yaml
@@ -462,3 +462,13 @@ properties:
           type: object
         type: array
     type: object
+  creationTime:
+    type: string
+    description: 'Time at which the resource was created'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+  modificationTime:
+    type: string
+    description: 'Time at which the resource was updated'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/schema.yaml
@@ -245,3 +245,13 @@ properties:
         minItems: 1
         type: array
     type: object
+  creationTime:
+    type: string
+    description: 'Time at which the resource was created'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+  modificationTime:
+    type: string
+    description: 'Time at which the resource was updated'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/schema.yaml
@@ -324,3 +324,13 @@ properties:
           type: object
         type: array
     type: object
+  creationTime:
+    type: string
+    description: 'Time at which the resource was created'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+  modificationTime:
+    type: string
+    description: 'Time at which the resource was updated'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'

--- a/pkg/plugins/policies/meshtls/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtls/api/v1alpha1/schema.yaml
@@ -201,3 +201,13 @@ properties:
             type: object
         type: object
     type: object
+  creationTime:
+    type: string
+    description: 'Time at which the resource was created'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+  modificationTime:
+    type: string
+    description: 'Time at which the resource was updated'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/schema.yaml
@@ -249,3 +249,13 @@ properties:
             type: object
         type: object
     type: object
+  creationTime:
+    type: string
+    description: 'Time at which the resource was created'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+  modificationTime:
+    type: string
+    description: 'Time at which the resource was updated'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'

--- a/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/schema.yaml
@@ -166,3 +166,13 @@ properties:
             type: object
         type: object
     type: object
+  creationTime:
+    type: string
+    description: 'Time at which the resource was created'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+  modificationTime:
+    type: string
+    description: 'Time at which the resource was updated'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'

--- a/tools/policy-gen/templates/schema.yaml
+++ b/tools/policy-gen/templates/schema.yaml
@@ -20,3 +20,13 @@ properties:
     description: 'The labels to help identity resources'
     type: object
   spec: {}
+  creationTime:
+    type: string
+    description: 'Time at which the resource was created'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+  modificationTime:
+    type: string
+    description: 'Time at which the resource was updated'
+    format: date-time
+    example: '0001-01-01T00:00:00Z'


### PR DESCRIPTION
## Motivation

In order to further complete the openAPI specs, we need to add `creationTime` and `modificationTime`. These properties are already part of the response payload (see context below). Since the GUI project started to generate the TypeScript types from the specs, there is a high demand in having complete specs to avoid manual backfilling.

## Implementation information

Added `modificationTime` and `creationTime` to `tools/policy-gen/templates/schema.yaml`. Afterwards ran `make check`.

## Context
<details>
<summary>Example Payloads</summary>

```json
  {
   "type": "MeshMetric",
   "mesh": "default",
   "name": "otel-metrics.kuma-system",
   "creationTime": "2024-11-05T13:50:03Z",
   "modificationTime": "2024-11-05T13:50:03Z",
   "labels": {
    "k8s.kuma.io/namespace": "kuma-system",
    "kuma.io/display-name": "otel-metrics",
    "kuma.io/mesh": "default",
    "kuma.io/policy-role": "system"
   },
   "spec": {
    "targetRef": {
     "kind": "Mesh"
    },
    "default": {
     "backends": [
      {
       "type": "OpenTelemetry",
       "openTelemetry": {
        "endpoint": "opentelemetry-collector.mesh-observability.svc:4317"
       }
      }
     ]
    }
   }
  }
```

```json
  {
   "type": "HostnameGenerator",
   "name": "local-mesh-external-service-45zv4bv8cv5v8444.kuma-system",
   "creationTime": "2024-11-05T09:48:59Z",
   "modificationTime": "2024-11-05T09:48:59Z",
   "labels": {
    "k8s.kuma.io/namespace": "kuma-system",
    "kuma.io/display-name": "local-mesh-external-service",
    "kuma.io/env": "kubernetes",
    "kuma.io/mesh": "",
    "kuma.io/origin": "zone",
    "kuma.io/zone": "east"
   },
   "spec": {
    "selector": {
     "meshExternalService": {
      "matchLabels": {
       "kuma.io/origin": "zone"
      }
     }
    },
    "template": "{{ .DisplayName }}.extsvc.mesh.local"
   }
  }
```

</details>

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
