### PR TITLE
fix(gateway): invalid Envoy resources with real MeshService backends and `appProtocol: tcp`

### DIFF
--- a/pkg/plugins/runtime/gateway/cluster_generator.go
+++ b/pkg/plugins/runtime/gateway/cluster_generator.go
@@ -152,11 +152,11 @@ func (c *ClusterGenerator) generateRealBackendRefCluster(
 	systemNamespace string,
 	identifyingTags map[string]string,
 ) (*core_xds.Resource, string, error) {
-	service, destProtocol, _, ok := meshroute.GetServiceProtocolPortFromRef(meshCtx, backendRef)
+	service, _, _, ok := meshroute.GetServiceProtocolPortFromRef(meshCtx, backendRef)
 	if !ok {
 		return nil, "", nil
 	}
-	protocol := route.InferServiceProtocol(destProtocol, routeProtocol)
+	protocol := route.ProtocolOr(routeProtocol, core_mesh.ProtocolHTTP)
 
 	edsClusterBuilder := clusters.NewClusterBuilder(proxy.APIVersion, service).
 		Configure(
@@ -196,8 +196,7 @@ func (c *ClusterGenerator) generateMeshCluster(
 	upstreamServiceName string,
 	identifyingTags map[string]string,
 ) (*core_xds.Resource, error) {
-	destProtocol := core_mesh.ParseProtocol(dest.Destination[mesh_proto.ProtocolTag])
-	protocol := route.InferServiceProtocol(destProtocol, dest.RouteProtocol)
+	protocol := route.ProtocolOr(dest.RouteProtocol, core_mesh.ProtocolHTTP)
 
 	builder := newClusterBuilder(info.Proxy.APIVersion, dest.Destination[mesh_proto.ServiceTag], protocol, dest).Configure(
 		clusters.EdsCluster(),

--- a/pkg/plugins/runtime/gateway/route/util.go
+++ b/pkg/plugins/runtime/gateway/route/util.go
@@ -9,17 +9,16 @@ import (
 	util_protocol "github.com/kumahq/kuma/pkg/util/protocol"
 )
 
+func ProtocolOr(protocol, fallback core_mesh.Protocol) core_mesh.Protocol {
+	if protocol == core_mesh.ProtocolUnknown {
+		return fallback
+	}
+	return protocol
+}
+
 func InferServiceProtocol(serviceProtocol core_mesh.Protocol, routeProtocol core_mesh.Protocol) core_mesh.Protocol {
 	if serviceProtocol == core_mesh.ProtocolUnknown || serviceProtocol == "" {
-		switch routeProtocol {
-		case core_mesh.ProtocolHTTP:
-			return core_mesh.ProtocolHTTP
-		case core_mesh.ProtocolTCP:
-			return core_mesh.ProtocolTCP
-		default:
-			// HTTP is a better default than "unknown".
-			return core_mesh.ProtocolHTTP
-		}
+		return ProtocolOr(routeProtocol, core_mesh.ProtocolHTTP)
 	}
 	return serviceProtocol
 }


### PR DESCRIPTION
## Motivation

We were generating invalid Envoy resources if using MeshHTTPRoute and the real backend had `appProtocol: tcp`.

We already weren't setting
`dest.Destination[mesh_proto.ServiceProtocol]` when calling `generateMeshCluster`.