### PR TITLE
fix(meshtimeout): don't set default timeouts on inbound cluster and listener

### DIFF
--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/basic_without_defaults_inbound_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/basic_without_defaults_inbound_cluster.golden.yaml
@@ -1,0 +1,9 @@
+connectTimeout: 5s
+name: localhost:8080
+typedExtensionProtocolOptions:
+  envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+    '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+    commonHttpProtocolOptions:
+      idleTimeout: 3600s
+      maxConnectionDuration: 5s
+      maxStreamDuration: 0s

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/basic_without_defaults_inbound_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/basic_without_defaults_inbound_cluster.golden.yaml
@@ -1,9 +1,1 @@
-connectTimeout: 5s
 name: localhost:8080
-typedExtensionProtocolOptions:
-  envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-    '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-    commonHttpProtocolOptions:
-      idleTimeout: 3600s
-      maxConnectionDuration: 5s
-      maxStreamDuration: 0s

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/basic_without_defaults_inbound_listener.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/basic_without_defaults_inbound_listener.golden.yaml
@@ -8,13 +8,10 @@ filterChains:
   - name: envoy.filters.network.http_connection_manager
     typedConfig:
       '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-      commonHttpProtocolOptions:
-        idleTimeout: 0s
       httpFilters:
       - name: envoy.filters.http.router
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-      requestHeadersTimeout: 0s
       routeConfig:
         name: inbound:backend
         requestHeadersToRemove:
@@ -29,8 +26,7 @@ filterChains:
               prefix: /
             route:
               cluster: backend
-              idleTimeout: 5s
-              timeout: 15s
+              timeout: 0s
       statPrefix: inbound_127_0_0_1_80
 name: inbound:127.0.0.1:80
 trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/basic_without_defaults_inbound_listener.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/basic_without_defaults_inbound_listener.golden.yaml
@@ -1,0 +1,36 @@
+address:
+  socketAddress:
+    address: 127.0.0.1
+    portValue: 80
+enableReusePort: false
+filterChains:
+- filters:
+  - name: envoy.filters.network.http_connection_manager
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+      commonHttpProtocolOptions:
+        idleTimeout: 0s
+      httpFilters:
+      - name: envoy.filters.http.router
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+      requestHeadersTimeout: 0s
+      routeConfig:
+        name: inbound:backend
+        requestHeadersToRemove:
+        - x-kuma-tags
+        validateClusters: false
+        virtualHosts:
+        - domains:
+          - '*'
+          name: backend
+          routes:
+          - match:
+              prefix: /
+            route:
+              cluster: backend
+              idleTimeout: 5s
+              timeout: 15s
+      statPrefix: inbound_127_0_0_1_80
+name: inbound:127.0.0.1:80
+trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
@@ -93,7 +93,7 @@ func applyToInbounds(fromRules core_rules.FromRules, inboundListeners map[core_r
 		protocol := core_mesh.ParseProtocol(inbound.GetProtocol())
 		conf := getConf(fromRules.Rules[listenerKey], core_rules.MeshSubset())
 		if conf == nil {
-			conf = &plugin_xds.DefaultTimeoutConf
+			continue
 		}
 		configurer := plugin_xds.ListenerConfigurer{
 			Conf:     *conf,

--- a/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin_test.go
@@ -247,6 +247,30 @@ var _ = Describe("MeshTimeout", func() {
 			expectedClusters:  []string{"basic_inbound_cluster.golden.yaml"},
 			expectedListeners: []string{"basic_inbound_listener.golden.yaml"},
 		}),
+		Entry("basic inbound route without defaults", sidecarTestCase{
+			resources: []core_xds.Resource{
+				{
+					Name:     "inbound",
+					Origin:   generator.OriginInbound,
+					Resource: httpInboundListenerWith(),
+				},
+				{
+					Name:     "inbound",
+					Origin:   generator.OriginInbound,
+					Resource: test_xds.ClusterWithName(fmt.Sprintf("localhost:%d", builders.FirstInboundServicePort)),
+				},
+			},
+			fromRules: core_rules.FromRules{
+				Rules: map[core_rules.InboundListener]core_rules.Rules{
+					{
+						Address: "127.0.0.1",
+						Port:    80,
+					}: []*core_rules.Rule{},
+				},
+			},
+			expectedClusters:  []string{"basic_without_defaults_inbound_cluster.golden.yaml"},
+			expectedListeners: []string{"basic_without_defaults_inbound_listener.golden.yaml"},
+		}),
 		Entry("outbound with defaults when http conf missing", sidecarTestCase{
 			resources: []core_xds.Resource{
 				{


### PR DESCRIPTION
## Motivation

We noticed that when a user upgrades to version 2.9.x without a default MeshTimeout/Timeout policy, default timeouts are applied on inbound clusters and listeners. This could disrupt the existing behavior of the environment.

## Implementation information

When no policy is present, we simply skip configuration and do not set up the timeouts for inbound cluster or listener.

## Supporting documentation


Fix https://github.com/kumahq/kuma/issues/12033

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
