### PR TITLE
chore(gha): replace new line with whitespace and change to array

### DIFF
--- a/.github/workflows/ci-stability.yaml
+++ b/.github/workflows/ci-stability.yaml
@@ -40,8 +40,8 @@ jobs:
         id: process_prs
         run: |
           cat open_prs.json
-          pr_numbers_with_verify_stability=$(jq -r '.[] | select(.labels[]?.name == "ci/verify-stability") | .number' open_prs.json)
-          pr_numbers_with_verify_stability_merge_master=$(jq -r '.[] | select(.labels[]?.name == "ci/verify-stability-merge-master") | .number' open_prs.json)
+          pr_numbers_with_verify_stability=$(jq -r -c '.[] | select(.labels[]?.name == "ci/verify-stability") | .number' open_prs.json | tr '\n' ' ')
+          pr_numbers_with_verify_stability_merge_master=$(jq -r '.[] | select(.labels[]?.name == "ci/verify-stability-merge-master") | .number' open_prs.json | tr '\n' ' ')
           echo "PRs with 'ci/verify-stability' label: $pr_numbers_with_verify_stability"
           echo "PRs with 'ci/verify-stability-merge-master' label: $pr_numbers_with_verify_stability_merge_master"
           echo "pr_numbers_with_verify_stability=$pr_numbers_with_verify_stability" >> $GITHUB_OUTPUT
@@ -51,7 +51,8 @@ jobs:
       - name: Merge master branch (if applicable) and push a single commit
         if: steps.process_prs.outputs.pr_numbers_with_verify_stability != ''
         run: |
-          for pr_number in ${{ steps.process_prs.outputs.pr_numbers_with_verify_stability }}; do
+          eval "pr_numbers=(${{ steps.process_prs.outputs.pr_numbers_with_verify_stability }})" 
+          for pr_number in $pr_numbers; do
             current_datetime=$(date +"%Y-%m-%d %H:%M:%S")
             echo "Processing PR #$pr_number"
 


### PR DESCRIPTION
## Motivation

After adding a label to the second PR, I noticed that the job failed. This was caused by the value being split across multiple lines. Additionally, the subsequent loop didn't recognize it as an array but instead treated it as an array of individual characters.

```
PRs with 'ci/verify-stability' label: 11672
11296
PRs with 'ci/verify-stability-merge-master' label: 1[16](https://github.com/kumahq/kuma/actions/runs/12000059034/job/33448712899#step:5:17)72
Error: Unable to process file command 'output' successfully.
Error: Invalid format '11296'
```

## Implementation information

* Changed new line to whitespace
* Change the string into an array and iterate over it

## Supporting documentation

https://github.com/kumahq/kuma/actions/runs/12000059034/job/33448712899

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
