### PR TITLE
fix(meshloadbalancingstrategy): deprecate SourceIP and use Connection

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,15 @@ with `x.y.z` being the version you are planning to upgrade to.
 If such a section does not exist, the upgrade you want to perform
 does not have any particular instructions.
 
+## Upgrade to `2.10.x`
+
+### MeshLoadBalancingStrategy
+
+#### Deprecation of `hashPolicies.type: SourceIP` and `maglev.type: SourceIP`
+
+The documentation did not mention the `SourceIP` type, but it was possible to create a policy using it instead of `Connection`. Since `SourceIP` 
+is not a correct value, we have decided to deprecate it. If you are using `SourceIP` in your policy, please update it to use `Connection` instead.
+
 ## Upgrade to `2.9.x`
 
 ### MeshAccessLog

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -3066,6 +3066,7 @@ spec:
                                         enum:
                                         - Header
                                         - Cookie
+                                        - Connection
                                         - SourceIP
                                         - QueryParameter
                                         - FilterState
@@ -3187,6 +3188,7 @@ spec:
                                         enum:
                                         - Header
                                         - Cookie
+                                        - Connection
                                         - SourceIP
                                         - QueryParameter
                                         - FilterState

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -3066,6 +3066,7 @@ spec:
                                         enum:
                                         - Header
                                         - Cookie
+                                        - Connection
                                         - SourceIP
                                         - QueryParameter
                                         - FilterState
@@ -3187,6 +3188,7 @@ spec:
                                         enum:
                                         - Header
                                         - Cookie
+                                        - Connection
                                         - SourceIP
                                         - QueryParameter
                                         - FilterState

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -3086,6 +3086,7 @@ spec:
                                         enum:
                                         - Header
                                         - Cookie
+                                        - Connection
                                         - SourceIP
                                         - QueryParameter
                                         - FilterState
@@ -3207,6 +3208,7 @@ spec:
                                         enum:
                                         - Header
                                         - Cookie
+                                        - Connection
                                         - SourceIP
                                         - QueryParameter
                                         - FilterState

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -4622,6 +4622,7 @@ spec:
                                         enum:
                                         - Header
                                         - Cookie
+                                        - Connection
                                         - SourceIP
                                         - QueryParameter
                                         - FilterState
@@ -4743,6 +4744,7 @@ spec:
                                         enum:
                                         - Header
                                         - Cookie
+                                        - Connection
                                         - SourceIP
                                         - QueryParameter
                                         - FilterState

--- a/deployments/charts/kuma/crds/kuma.io_meshloadbalancingstrategies.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshloadbalancingstrategies.yaml
@@ -235,6 +235,7 @@ spec:
                                         enum:
                                         - Header
                                         - Cookie
+                                        - Connection
                                         - SourceIP
                                         - QueryParameter
                                         - FilterState
@@ -356,6 +357,7 @@ spec:
                                         enum:
                                         - Header
                                         - Cookie
+                                        - Connection
                                         - SourceIP
                                         - QueryParameter
                                         - FilterState

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -6609,6 +6609,7 @@ components:
                                       enum:
                                         - Header
                                         - Cookie
+                                        - Connection
                                         - SourceIP
                                         - QueryParameter
                                         - FilterState
@@ -6781,6 +6782,7 @@ components:
                                       enum:
                                         - Header
                                         - Cookie
+                                        - Connection
                                         - SourceIP
                                         - QueryParameter
                                         - FilterState

--- a/docs/generated/raw/crds/kuma.io_meshloadbalancingstrategies.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshloadbalancingstrategies.yaml
@@ -235,6 +235,7 @@ spec:
                                         enum:
                                         - Header
                                         - Cookie
+                                        - Connection
                                         - SourceIP
                                         - QueryParameter
                                         - FilterState
@@ -356,6 +357,7 @@ spec:
                                         enum:
                                         - Header
                                         - Cookie
+                                        - Connection
                                         - SourceIP
                                         - QueryParameter
                                         - FilterState

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/deprecated.go
@@ -18,7 +18,7 @@ func validateHashPoliciesType(confs []To) []string {
 		if conf.Default.LoadBalancer == nil {
 			continue
 		}
-	
+
 		switch conf.Default.LoadBalancer.Type {
 		case RingHashType:
 			if conf.Default.LoadBalancer.RingHash == nil || conf.Default.LoadBalancer.RingHash.HashPolicies == nil {

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/deprecated.go
@@ -15,25 +15,27 @@ func (t *MeshLoadBalancingStrategyResource) Deprecations() []string {
 func validateHashPoliciesType(confs []To) []string {
 	deprecations := []string{}
 	for ruleIdx, conf := range confs {
-		if conf.Default.LoadBalancer != nil {
-			switch conf.Default.LoadBalancer.Type {
-			case RingHashType:
-				if conf.Default.LoadBalancer.RingHash == nil || conf.Default.LoadBalancer.RingHash.HashPolicies == nil {
-					continue
+		if conf.Default.LoadBalancer == nil {
+			continue
+		}
+	
+		switch conf.Default.LoadBalancer.Type {
+		case RingHashType:
+			if conf.Default.LoadBalancer.RingHash == nil || conf.Default.LoadBalancer.RingHash.HashPolicies == nil {
+				continue
+			}
+			for lbIdx, lbConf := range *conf.Default.LoadBalancer.RingHash.HashPolicies {
+				if lbConf.Type == SourceIPType {
+					deprecations = append(deprecations, fmt.Sprintf("%s type for 'spec.to[%d].default.loadBalancer.ringHash.hashPolicies[%d].type' is deprecated, use %s instead", SourceIPType, ruleIdx, lbIdx, ConnectionType))
 				}
-				for lbIdx, lbConf := range *conf.Default.LoadBalancer.RingHash.HashPolicies {
-					if lbConf.Type == SourceIPType {
-						deprecations = append(deprecations, fmt.Sprintf("%s type for 'spec.to[%d].default.loadBalancer.ringHash.hashPolicies[%d].type' is deprecated, use %s instead", SourceIPType, ruleIdx, lbIdx, ConnectionType))
-					}
-				}
-			case MaglevType:
-				if conf.Default.LoadBalancer.Maglev == nil || conf.Default.LoadBalancer.Maglev.HashPolicies == nil {
-					continue
-				}
-				for lbIdx, lbConf := range *conf.Default.LoadBalancer.Maglev.HashPolicies {
-					if lbConf.Type == SourceIPType {
-						deprecations = append(deprecations, fmt.Sprintf("%s type for 'spec.to[%d].default.loadBalancer.maglev.hashPolicies[%d].type' is deprecated, use %s instead", SourceIPType, ruleIdx, lbIdx, ConnectionType))
-					}
+			}
+		case MaglevType:
+			if conf.Default.LoadBalancer.Maglev == nil || conf.Default.LoadBalancer.Maglev.HashPolicies == nil {
+				continue
+			}
+			for lbIdx, lbConf := range *conf.Default.LoadBalancer.Maglev.HashPolicies {
+				if lbConf.Type == SourceIPType {
+					deprecations = append(deprecations, fmt.Sprintf("%s type for 'spec.to[%d].default.loadBalancer.maglev.hashPolicies[%d].type' is deprecated, use %s instead", SourceIPType, ruleIdx, lbIdx, ConnectionType))
 				}
 			}
 		}

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/deprecated.go
@@ -1,9 +1,42 @@
 package v1alpha1
 
 import (
+	"fmt"
+
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/jsonpatch/validators"
 )
 
 func (t *MeshLoadBalancingStrategyResource) Deprecations() []string {
-	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
+	deprecations := validateHashPoliciesType(t.Spec.To)
+	deprecations = append(deprecations, validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)...)
+	return deprecations
+}
+
+func validateHashPoliciesType(confs []To) []string {
+	deprecations := []string{}
+	for ruleIdx, conf := range confs {
+		if conf.Default.LoadBalancer != nil {
+			switch conf.Default.LoadBalancer.Type {
+			case RingHashType:
+				if conf.Default.LoadBalancer.RingHash == nil || conf.Default.LoadBalancer.RingHash.HashPolicies == nil {
+					continue
+				}
+				for lbIdx, lbConf := range *conf.Default.LoadBalancer.RingHash.HashPolicies {
+					if lbConf.Type == SourceIPType {
+						deprecations = append(deprecations, fmt.Sprintf("%s type for 'spec.to[%d].default.loadBalancer.ringHash.hashPolicies[%d].type' is deprecated, use %s instead", SourceIPType, ruleIdx, lbIdx, ConnectionType))
+					}
+				}
+			case MaglevType:
+				if conf.Default.LoadBalancer.Maglev == nil || conf.Default.LoadBalancer.Maglev.HashPolicies == nil {
+					continue
+				}
+				for lbIdx, lbConf := range *conf.Default.LoadBalancer.Maglev.HashPolicies {
+					if lbConf.Type == SourceIPType {
+						deprecations = append(deprecations, fmt.Sprintf("%s type for 'spec.to[%d].default.loadBalancer.maglev.hashPolicies[%d].type' is deprecated, use %s instead", SourceIPType, ruleIdx, lbIdx, ConnectionType))
+					}
+				}
+			}
+		}
+	}
+	return deprecations
 }

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/meshloadbalancingstrategy.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/meshloadbalancingstrategy.go
@@ -197,13 +197,14 @@ type RingHash struct {
 	HashPolicies *[]HashPolicy `json:"hashPolicies,omitempty"`
 }
 
-// +kubebuilder:validation:Enum=Header;Cookie;SourceIP;QueryParameter;FilterState
+// +kubebuilder:validation:Enum=Header;Cookie;Connection;SourceIP;QueryParameter;FilterState
 type HashPolicyType string
 
 const (
 	HeaderType         HashPolicyType = "Header"
 	CookieType         HashPolicyType = "Cookie"
 	ConnectionType     HashPolicyType = "Connection"
+	SourceIPType       HashPolicyType = "SourceIP"
 	QueryParameterType HashPolicyType = "QueryParameter"
 	FilterStateType    HashPolicyType = "FilterState"
 )

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/schema.yaml
@@ -199,6 +199,7 @@ properties:
                                 enum:
                                   - Header
                                   - Cookie
+                                  - Connection
                                   - SourceIP
                                   - QueryParameter
                                   - FilterState
@@ -314,6 +315,7 @@ properties:
                                 enum:
                                   - Header
                                   - Cookie
+                                  - Connection
                                   - SourceIP
                                   - QueryParameter
                                   - FilterState

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator.go
@@ -249,7 +249,7 @@ func validateHashPolicies(conf *[]HashPolicy) validators.ValidationError {
 			if policy.FilterState == nil {
 				verr.AddViolationAt(path.Field("filterState"), validators.MustBeDefined)
 			}
-		case ConnectionType:
+		case ConnectionType, SourceIPType:
 			if policy.Connection == nil {
 				verr.AddViolationAt(path.Field("connection"), validators.MustBeDefined)
 			}

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator_test.go
@@ -147,6 +147,10 @@ to:
 					Field:   "spec.to[0].default.loadBalancer.maglev.hashPolicies[1].cookie",
 					Message: "must be defined",
 				},
+        {
+					Field:   "spec.to[0].default.loadBalancer.maglev.hashPolicies[2].connection",
+					Message: "must be defined",
+				},
 				{
 					Field:   "spec.to[0].default.loadBalancer.maglev.hashPolicies[3].queryParameter",
 					Message: "must be defined",

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator_test.go
@@ -147,7 +147,7 @@ to:
 					Field:   "spec.to[0].default.loadBalancer.maglev.hashPolicies[1].cookie",
 					Message: "must be defined",
 				},
-        {
+				{
 					Field:   "spec.to[0].default.loadBalancer.maglev.hashPolicies[2].connection",
 					Message: "must be defined",
 				},

--- a/pkg/plugins/policies/meshloadbalancingstrategy/k8s/crd/kuma.io_meshloadbalancingstrategies.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/k8s/crd/kuma.io_meshloadbalancingstrategies.yaml
@@ -235,6 +235,7 @@ spec:
                                         enum:
                                         - Header
                                         - Cookie
+                                        - Connection
                                         - SourceIP
                                         - QueryParameter
                                         - FilterState
@@ -356,6 +357,7 @@ spec:
                                         enum:
                                         - Header
                                         - Cookie
+                                        - Connection
                                         - SourceIP
                                         - QueryParameter
                                         - FilterState

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtlbs.federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtlbs.federated.golden.yaml
@@ -1,0 +1,15 @@
+Patches: null
+allowed: false
+status:
+  code: 403
+  details:
+    causes:
+    - field: metadata.labels[kuma.io/origin]
+      message: cannot be empty
+      reason: FieldValueInvalid
+  message: Operation not allowed. Applying policies on Zone CP requires 'kuma.io/origin'
+    label to be set to 'zone'.
+  metadata: {}
+  reason: Forbidden
+  status: Failure
+uid: "12345"

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtlbs.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtlbs.global.golden.yaml
@@ -1,0 +1,11 @@
+Patches: null
+allowed: true
+status:
+  code: 200
+  metadata: {}
+uid: "12345"
+warnings:
+- SourceIP type for 'spec.to[0].default.loadBalancer.ringHash.hashPolicies[0].type'
+  is deprecated, use Connection instead
+- MeshService value for 'targetRef.kind' is deprecated, use MeshSubset with 'kuma.io/service'
+  tag instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtlbs.input.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtlbs.input.yaml
@@ -1,0 +1,23 @@
+# user=cli-user,operation=CREATE,namespace=kuma-system
+apiVersion: kuma.io/v1alpha1
+kind: MeshLoadBalancingStrategy
+metadata:
+  name: mlbs-deprecated
+  labels:
+    kuma.io/mesh: default
+spec:
+  targetRef:
+    kind: MeshService
+    name: frontend
+  to:
+  - targetRef:
+      kind: MeshService
+      name: backend
+    default:
+      loadBalancer:
+        type: RingHash
+        ringHash:
+          hashPolicies:
+          - type: SourceIP
+            connection:
+              sourceIP: true

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtlbs.non-federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtlbs.non-federated.golden.yaml
@@ -1,0 +1,11 @@
+Patches: null
+allowed: true
+status:
+  code: 200
+  metadata: {}
+uid: "12345"
+warnings:
+- SourceIP type for 'spec.to[0].default.loadBalancer.ringHash.hashPolicies[0].type'
+  is deprecated, use Connection instead
+- MeshService value for 'targetRef.kind' is deprecated, use MeshSubset with 'kuma.io/service'
+  tag instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.federated.golden.yaml
@@ -1,0 +1,16 @@
+Patches: null
+allowed: false
+status:
+  code: 422
+  details:
+    causes:
+    - field: spec.from
+      message: needs at least one item
+      reason: FieldValueInvalid
+    kind: MeshTrafficPermission
+    name: mtp-es
+  message: 'spec.from: needs at least one item'
+  metadata: {}
+  reason: Invalid
+  status: Failure
+uid: "12345"

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.federated.golden.yaml
@@ -1,16 +1,11 @@
 Patches: null
-allowed: false
+allowed: true
 status:
-  code: 422
-  details:
-    causes:
-    - field: spec.from
-      message: needs at least one item
-      reason: FieldValueInvalid
-    kind: MeshTrafficPermission
-    name: mtp-es
-  message: 'spec.from: needs at least one item'
+  code: 200
   metadata: {}
-  reason: Invalid
-  status: Failure
 uid: "12345"
+warnings:
+- SourceIP type for 'spec.to[0].default.loadBalancer.ringHash.hashPolicies[0].type'
+  is deprecated, use Connection instead
+- MeshService value for 'targetRef.kind' is deprecated, use MeshSubset with 'kuma.io/service'
+  tag instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.global.golden.yaml
@@ -1,0 +1,16 @@
+Patches: null
+allowed: false
+status:
+  code: 422
+  details:
+    causes:
+    - field: spec.from
+      message: needs at least one item
+      reason: FieldValueInvalid
+    kind: MeshTrafficPermission
+    name: mtp-es
+  message: 'spec.from: needs at least one item'
+  metadata: {}
+  reason: Invalid
+  status: Failure
+uid: "12345"

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.global.golden.yaml
@@ -1,16 +1,11 @@
 Patches: null
-allowed: false
+allowed: true
 status:
-  code: 422
-  details:
-    causes:
-    - field: spec.from
-      message: needs at least one item
-      reason: FieldValueInvalid
-    kind: MeshTrafficPermission
-    name: mtp-es
-  message: 'spec.from: needs at least one item'
+  code: 200
   metadata: {}
-  reason: Invalid
-  status: Failure
 uid: "12345"
+warnings:
+- SourceIP type for 'spec.to[0].default.loadBalancer.ringHash.hashPolicies[0].type'
+  is deprecated, use Connection instead
+- MeshService value for 'targetRef.kind' is deprecated, use MeshSubset with 'kuma.io/service'
+  tag instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.input.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.input.yaml
@@ -1,0 +1,24 @@
+# user=system:serviceaccount:kuma-system:kuma-control-plane,operation=CREATE
+apiVersion: kuma.io/v1alpha1
+kind: MeshTrafficPermission
+metadata:
+  name: mtp-es
+  namespace: kuma-system
+  labels:
+    kuma.io/mesh: default
+spec:
+  targetRef:
+    kind: MeshService
+    name: frontend
+  to:
+  - targetRef:
+      kind: MeshService
+      name: backend
+    default:
+      loadBalancer:
+        type: RingHash
+        ringHash:
+          hashPolicies:
+          - type: SourceIP
+            connection:
+              sourceIP: true

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.input.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.input.yaml
@@ -1,8 +1,8 @@
 # user=system:serviceaccount:kuma-system:kuma-control-plane,operation=CREATE
+kind: MeshLoadBalancingStrategy
 apiVersion: kuma.io/v1alpha1
-kind: MeshTrafficPermission
 metadata:
-  name: mtp-es
+  name: ring-hash
   namespace: kuma-system
   labels:
     kuma.io/mesh: default

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.non-federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.non-federated.golden.yaml
@@ -1,0 +1,16 @@
+Patches: null
+allowed: false
+status:
+  code: 422
+  details:
+    causes:
+    - field: spec.from
+      message: needs at least one item
+      reason: FieldValueInvalid
+    kind: MeshTrafficPermission
+    name: mtp-es
+  message: 'spec.from: needs at least one item'
+  metadata: {}
+  reason: Invalid
+  status: Failure
+uid: "12345"

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.non-federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.non-federated.golden.yaml
@@ -1,16 +1,11 @@
 Patches: null
-allowed: false
+allowed: true
 status:
-  code: 422
-  details:
-    causes:
-    - field: spec.from
-      message: needs at least one item
-      reason: FieldValueInvalid
-    kind: MeshTrafficPermission
-    name: mtp-es
-  message: 'spec.from: needs at least one item'
+  code: 200
   metadata: {}
-  reason: Invalid
-  status: Failure
 uid: "12345"
+warnings:
+- SourceIP type for 'spec.to[0].default.loadBalancer.ringHash.hashPolicies[0].type'
+  is deprecated, use Connection instead
+- MeshService value for 'targetRef.kind' is deprecated, use MeshSubset with 'kuma.io/service'
+  tag instead


### PR DESCRIPTION
## Motivation

While investigating [kuma#12110](https://github.com/kumahq/kuma/issues/12110), we noticed that the following policy is rejected:

```yaml
kind: MeshLoadBalancingStrategy
apiVersion: kuma.io/v1alpha1
metadata:
  name: ring-hash
  namespace: kuma-system
  labels:
    kuma.io/mesh: default
spec:
  targetRef:
    kind: MeshSubset
    tags: 
      kuma.io/service: demo-app_kuma-demo_svc_5000
  to:
  - targetRef:
      kind: MeshService
      name: redis_kuma-demo_svc_6379
    default:
      loadBalancer:
        type: RingHash
        ringHash:
          hashPolicies:
          - type: Connection
            connection:
              sourceIP: true
```

However, a policy with `type: SourceIP` passes validation, which seems incorrect based on the [documentation](https://kuma.io/docs/2.9.x/policies/meshloadbalancingstrategy/#ringhash). Upon checking the code, I found that the kubebuilder validation uses the incorrect enum `SourceIP`, whereas the correct enum `Connection` should be defined.

## Implementation information

To avoid breaking existing customer policies, I’ve added a new type to the enum while deprecating the old one.

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
