### PR TITLE
chore(images): pin ubuntu version

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -78,7 +78,7 @@ jobs:
   distributions:
     needs: ["check", "test", "test_e2e", "test_e2e_env"]
     if: ${{ always() }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # pining to this version since we use older base image for kuma-init and we don't want to change it since it can break users environment
     steps:
       - name: "Halt due to previous failures"
         if: ${{ contains(needs.*.result, 'failure')|| contains(needs.*.result, 'cancelled') }}


### PR DESCRIPTION
## Motivation

The `kuma-init` image fails to build on Ubuntu versions newer than 22. To avoid this issue, we plan to use an older runner image. This problem does not occur on the `master` branch because we use a different base image for `kuma-init`. Additionally, on `release-2.9`, we are already using Ubuntu 22.04.

## Implementation information

Use ubuntu 22

## Supporting documentation

https://github.com/actions/runner-images/issues/10636#issuecomment-2397720931
https://github.com/kumahq/kuma/pull/5945
https://github.com/kumahq/kuma/pull/11826

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
