### PR TITLE
ci(docs): remove version before 2.2.x from automation of versions.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ env:
   RELEASE: ${{ inputs.release || '0.0.0' }}
   CHECK: ${{ inputs.check || 'false' }}
   EDITION: kuma
-  MIN_VERSION: "1.2.0"
+  MIN_VERSION: "2.2.0"
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
## Motivation

We're cleaning up some old docs. This will stop generating versions before 2.2.x in the `versions.yaml` which will remove them from the docs website.

Once this is done and pushed to the docs website we'll be able to cleanup stuff.

## Supporting documentation

Part of https://github.com/kumahq/kuma-website/issues/2072

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
