### PR TITLE
docs(UPGRADE.md): remove links to docs that are not longer published

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -994,8 +994,7 @@ Every item in the `items` array now has a `kind` property of either:
 * `MeshGatewayDataplane`: a `MeshGateway`-configured `Dataplane` with a new
   structure representing the `MeshGateway` it serves.
 
-Some examples can be found in the [Inspect API
-docs](https://kuma.io/docs/1.6.x/reference/http-api/#inspect-api).
+Some examples can be found in the Inspect API docs.
 
 ## Upgrade to `1.5.x`
 
@@ -1027,9 +1026,6 @@ tokens. In order to continue using client certificates (the previous default
 method), you'll need to explicitly set the authentication method to client
 certificates. This can be done by setting the `KUMA_API_SERVER_AUTHN_TYPE` variable to
 `"clientCerts"`.
-
-See [Configuration - Control plane](https://kuma.io/docs/1.3.1/documentation/configuration/#control-plane)
-for how to set this variable.
 
 ## Upgrade to `1.3.0`
 


### PR DESCRIPTION
## Motivation

These were not super useful and are for very old version. Should be fine removing them.

## Supporting documentation

Part of https://github.com/kumahq/kuma-website/issues/2072