### PR TITLE
chore(gha): remove whitespace

### DIFF
--- a/.github/workflows/ci-stability.yaml
+++ b/.github/workflows/ci-stability.yaml
@@ -51,8 +51,7 @@ jobs:
       - name: Merge master branch (if applicable) and push a single commit
         if: steps.process_prs.outputs.pr_numbers_with_verify_stability != ''
         run: |
-          # Get string to array
-          eval "pr_numbers=(${{ steps.process_prs.outputs.pr_numbers_with_verify_stability }})" 
+          eval "pr_numbers=(${{ steps.process_prs.outputs.pr_numbers_with_verify_stability }})"
           for pr_number in $pr_numbers; do
             current_datetime=$(date +"%Y-%m-%d %H:%M:%S")
             echo "Processing PR #$pr_number"

--- a/.github/workflows/ci-stability.yaml
+++ b/.github/workflows/ci-stability.yaml
@@ -51,6 +51,7 @@ jobs:
       - name: Merge master branch (if applicable) and push a single commit
         if: steps.process_prs.outputs.pr_numbers_with_verify_stability != ''
         run: |
+          # Get string to array
           eval "pr_numbers=(${{ steps.process_prs.outputs.pr_numbers_with_verify_stability }})" 
           for pr_number in $pr_numbers; do
             current_datetime=$(date +"%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
## Motivation

When processing a workflow file through the `yq`, the format is destroyed because of whitespace at the end

## Implementation information

Removed a whitespace

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
