### PR TITLE
chore(distribution): run dev/tools if cache entry doesn't exist

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -129,6 +129,8 @@ jobs:
           echo "Disk usage after cleanup"
           sudo df -h
       - run: |
+          make dev/tools
+      - run: |
           make build
       - run: |
           make -j build/distributions


### PR DESCRIPTION
## Motivation

Sometimes cache entry might not be available and in this case job can fail. Noticed in Kong-mesh

## Implementation information

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
