### PR TITLE
fix(meshtrafficpermission): nil pointer for autoreachableservice when no top targetRef

### DIFF
--- a/pkg/plugins/policies/meshtrafficpermission/graph/backends/reachable_backend_refs_graph.go
+++ b/pkg/plugins/policies/meshtrafficpermission/graph/backends/reachable_backend_refs_graph.go
@@ -41,7 +41,7 @@ func BuildRules(meshServices []*ms_api.MeshServiceResource, mtps []*mtp_api.Mesh
 func trimNotSupportedTags(mtps []*mtp_api.MeshTrafficPermissionResource, supportedTags map[string]string) []*mtp_api.MeshTrafficPermissionResource {
 	newMtps := make([]*mtp_api.MeshTrafficPermissionResource, len(mtps))
 	for i, mtp := range mtps {
-		if len(mtp.Spec.TargetRef.Tags) > 0 {
+		if mtp.Spec != nil && mtp.Spec.TargetRef != nil && len(mtp.Spec.TargetRef.Tags) > 0 {
 			filteredTags := map[string]string{}
 			for tag, val := range mtp.Spec.TargetRef.Tags {
 				if _, ok := supportedTags[tag]; ok {

--- a/pkg/plugins/policies/meshtrafficpermission/graph/reachable_backend_refs_graph_test.go
+++ b/pkg/plugins/policies/meshtrafficpermission/graph/reachable_backend_refs_graph_test.go
@@ -72,6 +72,14 @@ var _ = Describe("Reachable Backends Graph", func() {
 			},
 			expectedFromAll: fromAllServices,
 		}),
+		Entry("allow all no top targetRef", testCase{
+			mtps: []*v1alpha1.MeshTrafficPermissionResource{
+				builders.MeshTrafficPermission().
+					AddFrom(builders.TargetRefMesh(), v1alpha1.Allow).
+					Build(),
+			},
+			expectedFromAll: fromAllServices,
+		}),
 		Entry("deny all", testCase{
 			mtps: []*v1alpha1.MeshTrafficPermissionResource{
 				builders.MeshTrafficPermission().

--- a/pkg/plugins/policies/meshtrafficpermission/graph/reachable_services_graph_test.go
+++ b/pkg/plugins/policies/meshtrafficpermission/graph/reachable_services_graph_test.go
@@ -61,6 +61,14 @@ var _ = Describe("Reachable Services Graph", func() {
 			},
 			expectedFromAll: fromAllServices,
 		}),
+		Entry("allow all no top targetRef", testCase{
+			mtps: []*v1alpha1.MeshTrafficPermissionResource{
+				builders.MeshTrafficPermission().
+					AddFrom(builders.TargetRefMesh(), v1alpha1.Allow).
+					Build(),
+			},
+			expectedFromAll: fromAllServices,
+		}),
 		Entry("deny all", testCase{
 			mtps: []*v1alpha1.MeshTrafficPermissionResource{
 				builders.MeshTrafficPermission().

--- a/pkg/plugins/policies/meshtrafficpermission/graph/services/reachable_services_graph.go
+++ b/pkg/plugins/policies/meshtrafficpermission/graph/services/reachable_services_graph.go
@@ -92,7 +92,7 @@ func BuildRules(services map[string]mesh_proto.SingleValueTagSet, mtps []*mtp_ap
 func trimNotSupportedTags(mtps []*mtp_api.MeshTrafficPermissionResource) []*mtp_api.MeshTrafficPermissionResource {
 	newMtps := make([]*mtp_api.MeshTrafficPermissionResource, len(mtps))
 	for i, mtp := range mtps {
-		if len(mtp.Spec.TargetRef.Tags) > 0 {
+		if mtp.Spec != nil && mtp.Spec.TargetRef != nil && len(mtp.Spec.TargetRef.Tags) > 0 {
 			filteredTags := map[string]string{}
 			for tag, val := range mtp.Spec.TargetRef.Tags {
 				if _, ok := SupportedTags[tag]; ok {


### PR DESCRIPTION
## Motivation

Since 2.9 we don't require top-level target ref. If it's empty we assume it's a `kind: Mesh`. We can observe nil pointer once the user provides a policy without top-level target ref.

## Implementation information

Added check for nil top target ref and test

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
