### PR TITLE
docs(MADR): improve state of the ci on release branches - periodic runs

### DIFF
--- a/docs/madr/decisions/068-improve-the-state-of-the-ci-on-release-branches-periodic-ci-runs.md
+++ b/docs/madr/decisions/068-improve-the-state-of-the-ci-on-release-branches-periodic-ci-runs.md
@@ -1,0 +1,7 @@
+# Improve the state of the CI on release branches - Periodic CI Runs
+
+* Status: accepted
+
+Technical Story: https://github.com/kumahq/kuma/issues/12163
+
+Contents: https://docs.google.com/document/d/1-t8aa3uxdFEaZOpAAN7ojRVn4AnjVUqdd4HXlSN7U9I


### PR DESCRIPTION
## Motivation

We don’t know how stable our CI is on release branches because we don’t make changes to them often. This means we don’t get enough feedback about their status.

## Implementation information

[MADR-068 Improve the state of the CI on release branches - Periodic CI Runs](https://docs.google.com/document/d/1-t8aa3uxdFEaZOpAAN7ojRVn4AnjVUqdd4HXlSN7U9I)

## Supporting documentation

Part of: https://github.com/kumahq/kuma/issues/12163

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
