### PR TITLE
ci(gatewayapi): update crd version

### DIFF
--- a/test/framework/k8s.go
+++ b/test/framework/k8s.go
@@ -70,7 +70,7 @@ func GatewayAPICRDs(cluster Cluster) error {
 	return k8s.RunKubectlE(
 		cluster.GetTesting(),
 		cluster.GetKubectlOptions(),
-		"apply", "-f", "https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml")
+		"apply", "-f", "https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml")
 }
 
 func UpdateKubeObject(


### PR DESCRIPTION
## Motivation

GatewayApi tests are failing after upgrade of k8s lib

## Implementation information

Upgrade CRDs version in tests

## Supporting documentation

We should document it somewhere

xref: https://github.com/kumahq/kuma/commit/f01183becd9c4398fd1a17071070f88ecdd4d01f

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
