### PR TITLE
feat(meshcircuitbreaker): set track_remaining connection to true by default

### DIFF
--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/basic.gateway_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/basic.gateway_cluster.golden.yaml
@@ -9,6 +9,7 @@ resources:
         maxPendingRequests: 3333
         maxRequests: 4444
         maxRetries: 5555
+        trackRemaining: true
     connectTimeout: 5s
     edsClusterConfig:
       edsConfig:

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/inbound_cluster_connection_limits.golden.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/inbound_cluster_connection_limits.golden.yaml
@@ -5,4 +5,5 @@ circuitBreakers:
     maxPendingRequests: 3333
     maxRequests: 4444
     maxRetries: 5555
+    trackRemaining: true
 name: localhost:80

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/inbound_cluster_connection_limits_outlier_detection.golden.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/inbound_cluster_connection_limits_outlier_detection.golden.yaml
@@ -5,6 +5,7 @@ circuitBreakers:
     maxPendingRequests: 3333
     maxRequests: 4444
     maxRetries: 5555
+    trackRemaining: true
 name: localhost:80
 outlierDetection:
   baseEjectionTime: 8s

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/inbound_cluster_connection_limits_outlier_detection_disabled.golden.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/inbound_cluster_connection_limits_outlier_detection_disabled.golden.yaml
@@ -5,4 +5,5 @@ circuitBreakers:
     maxPendingRequests: 3333
     maxRequests: 4444
     maxRetries: 5555
+    trackRemaining: true
 name: localhost:80

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/outbound_cluster_connection_limits.golden.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/outbound_cluster_connection_limits.golden.yaml
@@ -5,4 +5,5 @@ circuitBreakers:
     maxPendingRequests: 3333
     maxRequests: 4444
     maxRetries: 5555
+    trackRemaining: true
 name: other-service

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/outbound_cluster_connection_limits_outlier_detection.golden.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/outbound_cluster_connection_limits_outlier_detection.golden.yaml
@@ -5,6 +5,7 @@ circuitBreakers:
     maxPendingRequests: 3333
     maxRequests: 4444
     maxRetries: 5555
+    trackRemaining: true
 name: second-service
 outlierDetection:
   baseEjectionTime: 8s

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/outbound_cluster_connection_limits_outlier_detection_disabled.golden.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/outbound_cluster_connection_limits_outlier_detection_disabled.golden.yaml
@@ -5,4 +5,5 @@ circuitBreakers:
     maxPendingRequests: 3333
     maxRequests: 4444
     maxRetries: 5555
+    trackRemaining: true
 name: second-service

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/outbound_cluster_connection_limits_real_resource.golden.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/outbound_cluster_connection_limits_real_resource.golden.yaml
@@ -5,6 +5,7 @@ circuitBreakers:
     maxPendingRequests: 3333
     maxRequests: 4444
     maxRetries: 5555
+    trackRemaining: true
 name: backend
 outlierDetection:
   baseEjectionTime: 8s

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/outbound_split_cluster_0_connection_limits_outlier_detection.golden.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/outbound_split_cluster_0_connection_limits_outlier_detection.golden.yaml
@@ -5,6 +5,7 @@ circuitBreakers:
     maxPendingRequests: 3333
     maxRequests: 4444
     maxRetries: 5555
+    trackRemaining: true
 name: other-service-5ab6003f460fabce
 outlierDetection:
   baseEjectionTime: 8s

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/outbound_split_cluster_connection_limits_outlier_detection.golden.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/outbound_split_cluster_connection_limits_outlier_detection.golden.yaml
@@ -5,6 +5,7 @@ circuitBreakers:
     maxPendingRequests: 3333
     maxRequests: 4444
     maxRetries: 5555
+    trackRemaining: true
 name: other-service
 outlierDetection:
   baseEjectionTime: 8s

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/real-MeshService-targeted-to-real-MeshService.gateway_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/real-MeshService-targeted-to-real-MeshService.gateway_cluster.golden.yaml
@@ -9,6 +9,7 @@ resources:
         maxPendingRequests: 3333
         maxRequests: 4444
         maxRetries: 5555
+        trackRemaining: true
     edsClusterConfig:
       edsConfig:
         ads: {}

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/xds/configurer.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/xds/configurer.go
@@ -30,7 +30,8 @@ func configureCircuitBreakers(cluster *envoy_cluster.Cluster, conf *api.Connecti
 	}
 
 	defaultThreshold := &envoy_cluster.CircuitBreakers_Thresholds{
-		Priority: envoy_config_core_v3.RoutingPriority_DEFAULT,
+		Priority:       envoy_config_core_v3.RoutingPriority_DEFAULT,
+		TrackRemaining: true,
 	}
 
 	if conf.MaxConnectionPools != nil {

--- a/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -31,6 +32,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -31,6 +32,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -31,6 +32,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -31,6 +32,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -55,6 +57,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -79,6 +82,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -31,6 +32,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -31,6 +32,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -55,6 +57,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 20s
       edsClusterConfig:
         edsConfig:
@@ -29,6 +30,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 300s
       edsClusterConfig:
         edsConfig:
@@ -51,6 +53,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 10s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -37,6 +38,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -67,6 +69,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/18-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/18-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       dnsLookupFamily: V4_ONLY
       loadAssignment:

--- a/pkg/plugins/runtime/gateway/testdata/http/19-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/19-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       dnsLookupFamily: V4_ONLY
       loadAssignment:

--- a/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 10s
       edsClusterConfig:
         edsConfig:
@@ -29,6 +30,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 300s
       edsClusterConfig:
         edsConfig:
@@ -51,6 +53,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 20s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/21-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/21-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -31,6 +32,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -55,6 +57,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/22-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/22-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -31,6 +32,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/23-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/23-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -31,6 +32,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -55,6 +57,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/24-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/24-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -31,6 +32,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/25-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/25-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/26-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/26-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/cross-mesh-gateway.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/cross-mesh-gateway.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -55,6 +56,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -103,6 +105,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -151,6 +154,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       dnsLookupFamily: V4_ONLY
       loadAssignment:
@@ -202,6 +206,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       dnsLookupFamily: V4_ONLY
       loadAssignment:
@@ -253,6 +258,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       dnsLookupFamily: V4_ONLY
       loadAssignment:

--- a/pkg/plugins/runtime/gateway/testdata/http/drop-prefix-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/drop-prefix-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/external-service-with-timeout-no-egress.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/external-service-with-timeout-no-egress.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 113s
       dnsLookupFamily: V4_ONLY
       loadAssignment:

--- a/pkg/plugins/runtime/gateway/testdata/http/external-service-without-default-traffic-permission.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/external-service-without-default-traffic-permission.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       dnsLookupFamily: V4_ONLY
       loadAssignment:

--- a/pkg/plugins/runtime/gateway/testdata/http/no-timeout.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/no-timeout.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/response-header-set-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/response-header-set-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/retry-policy.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/retry-policy.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -31,6 +32,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -55,6 +57,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-root-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-root-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-trailing-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-trailing-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/sni-isolation-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/sni-isolation-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -31,6 +32,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -31,6 +32,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -31,6 +32,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -31,6 +32,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -31,6 +32,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -55,6 +57,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -79,6 +82,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -31,6 +32,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -31,6 +32,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -55,6 +57,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 20s
       edsClusterConfig:
         edsConfig:
@@ -29,6 +30,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 300s
       edsClusterConfig:
         edsConfig:
@@ -51,6 +53,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 10s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -37,6 +38,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -67,6 +69,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       dnsLookupFamily: V4_ONLY
       loadAssignment:

--- a/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       dnsLookupFamily: V4_ONLY
       loadAssignment:

--- a/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 10s
       edsClusterConfig:
         edsConfig:
@@ -29,6 +30,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 300s
       edsClusterConfig:
         edsConfig:
@@ -51,6 +53,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 20s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/21-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/21-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -31,6 +32,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -55,6 +57,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/22-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/22-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -31,6 +32,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/23-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/23-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -31,6 +32,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -55,6 +57,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/24-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/24-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -31,6 +32,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/25-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/25-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/26-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/26-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/cross-mesh-gateway.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/cross-mesh-gateway.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -55,6 +56,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -103,6 +105,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -151,6 +154,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       dnsLookupFamily: V4_ONLY
       loadAssignment:
@@ -202,6 +206,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       dnsLookupFamily: V4_ONLY
       loadAssignment:
@@ -253,6 +258,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       dnsLookupFamily: V4_ONLY
       loadAssignment:

--- a/pkg/plugins/runtime/gateway/testdata/https/drop-prefix-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/drop-prefix-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/external-service-with-timeout-no-egress.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/external-service-with-timeout-no-egress.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 113s
       dnsLookupFamily: V4_ONLY
       loadAssignment:

--- a/pkg/plugins/runtime/gateway/testdata/https/external-service-without-default-traffic-permission.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/external-service-without-default-traffic-permission.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       dnsLookupFamily: V4_ONLY
       loadAssignment:

--- a/pkg/plugins/runtime/gateway/testdata/https/no-timeout.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/no-timeout.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/response-header-set-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/response-header-set-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/retry-policy.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/retry-policy.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -31,6 +32,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -55,6 +57,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-root-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-root-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-trailing-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-trailing-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/sni-isolation-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/sni-isolation-gateway-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -31,6 +32,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/tcp/tcp-route-no-egress.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/tcp/tcp-route-no-egress.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 12s
       dnsLookupFamily: V4_ONLY
       loadAssignment:

--- a/pkg/plugins/runtime/gateway/testdata/tcp/tcp-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/tcp/tcp-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 10s
       edsClusterConfig:
         edsConfig:
@@ -46,6 +47,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 10s
       edsClusterConfig:
         edsConfig:
@@ -85,6 +87,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 10s
       edsClusterConfig:
         edsConfig:

--- a/pkg/plugins/runtime/gateway/testdata/tls/tcp-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/tls/tcp-route.yaml
@@ -7,6 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -46,6 +47,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
@@ -85,6 +87,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
+          trackRemaining: true
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:


### PR DESCRIPTION
## Motivation

It would be nice to see how many connections can be open before hitting CB.

## Implementation information

Enabled by the default. A user can disable it by using MeshProxyPatch

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix https://github.com/kumahq/kuma/issues/12195

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
