### PR TITLE
feat(meshmetrics): add dns metrics to basic profile

### DIFF
--- a/app/kuma-dp/pkg/dataplane/metrics/profiles.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/profiles.go
@@ -152,6 +152,16 @@ var basicProfile = []selectorFunction{
 		Match: "envoy_cluster_membership_total",
 	}),
 	// end of dashboards
+	// start of dns stats
+	selectorToFilterFunction(v1alpha1.Selector{
+		Type:  v1alpha1.PrefixSelectorType,
+		Match: "envoy_dns_filter",
+	}),
+	selectorToFilterFunction(v1alpha1.Selector{
+		Type:  v1alpha1.PrefixSelectorType,
+		Match: "envoy_dns_cares",
+	}),
+	// end of dns stats
 }
 
 var basicProfileLabels = []selectorFunction{

--- a/app/kuma-dp/pkg/dataplane/metrics/testdata/profiles/basic_and_none.golden
+++ b/app/kuma-dp/pkg/dataplane/metrics/testdata/profiles/basic_and_none.golden
@@ -106,3 +106,18 @@ envoy_server_memory_heap_size{envoy_cluster_name="example"} 1
 # TYPE envoy_server_uptime counter
 envoy_server_uptime{envoy_cluster_name="example"} 1
 
+# TYPE envoy_dns_cares_not_found counter
+envoy_dns_cares_not_found 1
+
+# TYPE envoy_dns_cares_resolve_total counter
+envoy_dns_cares_resolve_total 1
+
+# TYPE envoy_dns_filter_srv_record_queries counter
+envoy_dns_filter_srv_record_queries{envoy_dns_filter_prefix="kuma_dns"} 1
+
+# TYPE envoy_dns_filter_unanswered_queries counter
+envoy_dns_filter_unanswered_queries{envoy_dns_filter_prefix="kuma_dns"} 1
+
+# TYPE envoy_dns_filter_unsupported_queries counter
+envoy_dns_filter_unsupported_queries{envoy_dns_filter_prefix="kuma_dns"} 1
+

--- a/app/kuma-dp/pkg/dataplane/metrics/testdata/profiles/basic_and_none.in
+++ b/app/kuma-dp/pkg/dataplane/metrics/testdata/profiles/basic_and_none.in
@@ -109,3 +109,18 @@ envoy_server_memory_heap_size{envoy_cluster_name="example"} 1
 
 # TYPE envoy_server_uptime counter
 envoy_server_uptime{envoy_cluster_name="example"} 1
+
+# TYPE envoy_dns_cares_not_found counter
+envoy_dns_cares_not_found{} 1
+
+# TYPE envoy_dns_cares_resolve_total counter
+envoy_dns_cares_resolve_total{} 1
+
+# TYPE envoy_dns_filter_srv_record_queries counter
+envoy_dns_filter_srv_record_queries{envoy_dns_filter_prefix="kuma_dns"} 1
+
+# TYPE envoy_dns_filter_unanswered_queries counter
+envoy_dns_filter_unanswered_queries{envoy_dns_filter_prefix="kuma_dns"} 1
+
+# TYPE envoy_dns_filter_unsupported_queries counter
+envoy_dns_filter_unsupported_queries{envoy_dns_filter_prefix="kuma_dns"} 1


### PR DESCRIPTION
## Motivation

DNS statistics seem important and should be included in the default profile.

## Implementation information

Added a filter which matches 2 sections
```
envoy_dns_care
```
Which provides a lot of interesting data about DNS queries 


https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/dns_resolution
Name | Type | Description
-- | -- | --
resolve_total | Count | Number of DNS queries
pending_resolutions | Gauge | Number of pending DNS queries
not_found | Counter | Number of DNS queries that returned NXDOMAIN or NODATA response
timeout | Counter | Number of DNS queries that resulted in timeout
get_addr_failure | Counter | Number of general failures during DNS quries

and `envoy_dns_filter` which has more detailed metrics. I would consider maybe reducing them but I would like to get your opinion:

```
envoy_dns_filter_a_record_queries{envoy_dns_filter_prefix="kuma_dns"} 0
# TYPE envoy_dns_filter_aaaa_record_queries counter
envoy_dns_filter_aaaa_record_queries{envoy_dns_filter_prefix="kuma_dns"} 0
# TYPE envoy_dns_filter_cluster_a_record_answers counter
envoy_dns_filter_cluster_a_record_answers{envoy_dns_filter_prefix="kuma_dns"} 0
# TYPE envoy_dns_filter_cluster_aaaa_record_answers counter
envoy_dns_filter_cluster_aaaa_record_answers{envoy_dns_filter_prefix="kuma_dns"} 0
# TYPE envoy_dns_filter_cluster_srv_record_answers counter
envoy_dns_filter_cluster_srv_record_answers{envoy_dns_filter_prefix="kuma_dns"} 0
# TYPE envoy_dns_filter_cluster_unsupported_answers counter
envoy_dns_filter_cluster_unsupported_answers{envoy_dns_filter_prefix="kuma_dns"} 0
# TYPE envoy_dns_filter_downstream_rx_errors counter
envoy_dns_filter_downstream_rx_errors{envoy_dns_filter_prefix="kuma_dns"} 0
# TYPE envoy_dns_filter_downstream_rx_invalid_queries counter
envoy_dns_filter_downstream_rx_invalid_queries{envoy_dns_filter_prefix="kuma_dns"} 0
# TYPE envoy_dns_filter_downstream_rx_queries counter
envoy_dns_filter_downstream_rx_queries{envoy_dns_filter_prefix="kuma_dns"} 0
# TYPE envoy_dns_filter_downstream_tx_responses counter
envoy_dns_filter_downstream_tx_responses{envoy_dns_filter_prefix="kuma_dns"} 0
# TYPE envoy_dns_filter_external_a_record_answers counter
envoy_dns_filter_external_a_record_answers{envoy_dns_filter_prefix="kuma_dns"} 0
# TYPE envoy_dns_filter_external_a_record_queries counter
envoy_dns_filter_external_a_record_queries{envoy_dns_filter_prefix="kuma_dns"} 0
# TYPE envoy_dns_filter_external_aaaa_record_answers counter
envoy_dns_filter_external_aaaa_record_answers{envoy_dns_filter_prefix="kuma_dns"} 0
# TYPE envoy_dns_filter_external_aaaa_record_queries counter
envoy_dns_filter_external_aaaa_record_queries{envoy_dns_filter_prefix="kuma_dns"} 0
# TYPE envoy_dns_filter_external_unsupported_answers counter
envoy_dns_filter_external_unsupported_answers{envoy_dns_filter_prefix="kuma_dns"} 0
# TYPE envoy_dns_filter_external_unsupported_queries counter
envoy_dns_filter_external_unsupported_queries{envoy_dns_filter_prefix="kuma_dns"} 0
# TYPE envoy_dns_filter_externally_resolved_queries counter
envoy_dns_filter_externally_resolved_queries{envoy_dns_filter_prefix="kuma_dns"} 0
# TYPE envoy_dns_filter_known_domain_queries counter
envoy_dns_filter_known_domain_queries{envoy_dns_filter_prefix="kuma_dns"} 0
# TYPE envoy_dns_filter_local_a_record_answers counter
envoy_dns_filter_local_a_record_answers{envoy_dns_filter_prefix="kuma_dns"} 0
# TYPE envoy_dns_filter_local_aaaa_record_answers counter
envoy_dns_filter_local_aaaa_record_answers{envoy_dns_filter_prefix="kuma_dns"} 0
# TYPE envoy_dns_filter_local_srv_record_answers counter
envoy_dns_filter_local_srv_record_answers{envoy_dns_filter_prefix="kuma_dns"} 0
# TYPE envoy_dns_filter_local_unsupported_answers counter
envoy_dns_filter_local_unsupported_answers{envoy_dns_filter_prefix="kuma_dns"} 0
# TYPE envoy_dns_filter_queries_with_additional_rrs counter
envoy_dns_filter_queries_with_additional_rrs{envoy_dns_filter_prefix="kuma_dns"} 0
# TYPE envoy_dns_filter_queries_with_ans_or_authority_rrs counter
envoy_dns_filter_queries_with_ans_or_authority_rrs{envoy_dns_filter_prefix="kuma_dns"} 0
# TYPE envoy_dns_filter_query_buffer_underflow counter
envoy_dns_filter_query_buffer_underflow{envoy_dns_filter_prefix="kuma_dns"} 0
# TYPE envoy_dns_filter_query_parsing_failure counter
envoy_dns_filter_query_parsing_failure{envoy_dns_filter_prefix="kuma_dns"} 0
# TYPE envoy_dns_filter_record_name_overflow counter
envoy_dns_filter_record_name_overflow{envoy_dns_filter_prefix="kuma_dns"} 0
# TYPE envoy_dns_filter_srv_record_queries counter
envoy_dns_filter_srv_record_queries{envoy_dns_filter_prefix="kuma_dns"} 0
# TYPE envoy_dns_filter_unanswered_queries counter
envoy_dns_filter_unanswered_queries{envoy_dns_filter_prefix="kuma_dns"} 0
# TYPE envoy_dns_filter_unsupported_queries counter
envoy_dns_filter_unsupported_queries{envoy_dns_filter_prefix="kuma_dns"} 0
```

We could maybe show only 
* unsupported_queries
* unanswered_queries
* name_overflow
* query_parsing_failure

What are your options on this?

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix https://github.com/kumahq/kuma/issues/12188

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
