### PR TITLE
ci(gh): allow to run `build-test-distribute` on `workflow_dispatch`

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -5,6 +5,7 @@ on:
     tags: ["*"]
   pull_request:
     branches: ["master", "release-*"]
+  workflow_dispatch: # Allows manual trigger from GitHub Actions UI or via REST call
 concurrency:
   group: ${{github.workflow}}-${{ github.ref_name }} # group all runs by branch or tag
   cancel-in-progress: ${{ github.event_name == 'pull_request' }} # only cancel previous runs on PRs, we want each commit to build on branches
@@ -22,10 +23,10 @@ jobs:
       contents: read
       # golangci-lint-action
       checks: write
-    timeout-minutes: 15
+    timeout-minutes: 25
     runs-on: ubuntu-latest
     env:
-      FULL_MATRIX: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') }}
+      FULL_MATRIX: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') }}
       ALLOW_PUSH: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci/force-publish') }}
       BUILD: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci/run-build') || contains(github.event.pull_request.labels.*.name, 'ci/force-publish') }}
       FORCE_PUBLISH_FROM_FORK: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci/force-publish') && github.event.pull_request.head.repo.full_name != github.repository }}


### PR DESCRIPTION
## Motivation

We don’t know how stable our CI is on release branches because we don’t make changes to them often. This means we don’t get enough feedback about their status.

## Implementation information

This is a part of the effort to run tests on CI for release branches on schedule. As GitHub doesn't allow to run workflows on schedule from branches other than default (master in our case), the best solution I could find is to allow to run `build-test-distribute` workflow on `workflow_dispatch` event and then in master on schedule send a REST call to manually trigger these workflows on wanted release branches.

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Part of:
- https://github.com/kumahq/kuma/pull/12164
- https://github.com/kumahq/kuma/issues/12163

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
