### PR TITLE
ci(gh): allow to run `build-test-distribute` on `workflow_dispatch`

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -5,6 +5,7 @@ on:
     tags: ["*"]
   pull_request:
     branches: ["master", "release-*"]
+  workflow_dispatch: # Allows manual trigger from GitHub Actions UI or via REST call
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -21,7 +22,7 @@ env:
   GH_EMAIL: "<41898282+github-actions[bot]@users.noreply.github.com>"
 jobs:
   check:
-    timeout-minutes: 15
+    timeout-minutes: 25
     runs-on: ubuntu-latest
     steps:
       - name: "Fail when 'ci/force-publish' label is present on PRs from forks"
@@ -90,7 +91,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: "Maybe set full matrix"
-        if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix')
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix')
         id: set-full-matrix-switches
         run: |
           echo 'ENABLED_GOARCHES=arm64 amd64' >> $GITHUB_ENV
@@ -213,7 +214,7 @@ jobs:
       - id: generate-matrix
         name: Generate matrix
         env:
-          RUN_FULL_MATRIX: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') }}
+          RUN_FULL_MATRIX: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') }}
           BASE_MATRIX: |-
             {
               "test_e2e": {


### PR DESCRIPTION
## Motivation

We don’t know how stable our CI is on release branches because we don’t make changes to them often. This means we don’t get enough feedback about their status.

## Implementation information

This is a part of the effort to run tests on CI for release branches on schedule. As GitHub doesn't allow to run workflows on schedule from branches other than default (master in our case), the best solution I could find is to allow to run `build-test-distribute` workflow on `workflow_dispatch` event and then in master on schedule send a REST call to manually trigger these workflows on wanted release branches.

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Part of:
- https://github.com/kumahq/kuma/pull/12164
- https://github.com/kumahq/kuma/issues/12163

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
