### PR TITLE
ci(gh): allow to run build-test-distribute on workflow_dispatch

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -5,6 +5,7 @@ on:
     tags: ["*"]
   pull_request:
     branches: ["master", "release-*"]
+  workflow_dispatch: # Allows manual trigger from GitHub Actions UI or via REST call
 permissions:
   contents: write # To upload assets
   id-token: write # For using token to sign images
@@ -17,7 +18,7 @@ env:
   # on the runner).
   CI_TOOLS_DIR: "/home/runner/work/kuma/.ci_tools"
 concurrency:
-  group: ${{github.workflow}}-${{ github.event_name == 'push' && github.sha || github.event.pull_request.number }}
+  group: ${{ format('{0}-{1}-{2}', github.workflow, github.event_name, github.event_name == 'push' && github.sha || github.event_name == 'pull_request' && github.event.pull_request.number || github.event_name == 'workflow_dispatch' && github.ref_name) }}
   cancel-in-progress: ${{ github.event_name == 'push' && false || true }}
 jobs:
   check:
@@ -25,10 +26,10 @@ jobs:
       contents: read
       # golangci-lint-action
       checks: write
-    timeout-minutes: 20
+    timeout-minutes: 25
     runs-on: ubuntu-latest
     env:
-      FULL_MATRIX: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') }}
+      FULL_MATRIX: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') }}
       ALLOW_PUSH: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci/force-publish') }}
       BUILD: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci/run-build') || contains(github.event.pull_request.labels.*.name, 'ci/force-publish') }}
       FORCE_PUBLISH_FROM_FORK: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci/force-publish') && github.event.pull_request.head.repo.full_name != github.repository }}
@@ -107,7 +108,7 @@ jobs:
     uses: ./.github/workflows/_test.yaml
     with:
       FULL_MATRIX: ${{ needs.check.outputs.FULL_MATRIX }}
-      RUNNERS_BY_ARCH: ${{ (github.event_name == 'push' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) && '{"amd64":"ubuntu-latest-kong","arm64":"ubuntu-latest-arm64-kong"}' || '{"amd64":"ubuntu-latest","arm64":""}' }}
+      RUNNERS_BY_ARCH: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) && '{"amd64":"ubuntu-latest-kong","arm64":"ubuntu-latest-arm64-kong"}' || '{"amd64":"ubuntu-latest","arm64":""}' }}
     secrets: inherit
   build_publish:
     permissions:


### PR DESCRIPTION
## Motivation

We don’t know how stable our CI is on release branches because we don’t make changes to them often. This means we don’t get enough feedback about their status.

## Implementation information

This is a part of the effort to run tests on CI for release branches on schedule. As GitHub doesn't allow to run workflows on schedule from branches other than default (master in our case), the best solution I could find is to allow to run `build-test-distribute` workflow on `workflow_dispatch` event and then in master on schedule send a REST call to manually trigger these workflows on wanted release branches.

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Part of:
- https://github.com/kumahq/kuma/pull/12164
- https://github.com/kumahq/kuma/issues/12163

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
