### PR TITLE
fix(kds): remove context from map on stream close

### DIFF
--- a/pkg/kds/v2/server/tenant_callback.go
+++ b/pkg/kds/v2/server/tenant_callback.go
@@ -52,7 +52,7 @@ func (c *tenancyCallbacks) OnStreamDeltaRequest(streamID int64, request *envoy_s
 	return nil
 }
 
-func (c *tenancyCallbacks) OnDeltaStreamClosed(streamID int64, node *envoy_core.Node) {
+func (c *tenancyCallbacks) OnDeltaStreamClosed(streamID int64, _ *envoy_core.Node) {
 	c.Lock()
 	delete(c.streamToCtx, streamID)
 	c.Unlock()

--- a/pkg/kds/v2/server/tenant_callback.go
+++ b/pkg/kds/v2/server/tenant_callback.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync"
 
+	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_sd "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	envoy_xds "github.com/envoyproxy/go-control-plane/pkg/server/v3"
 
@@ -49,4 +50,10 @@ func (c *tenancyCallbacks) OnStreamDeltaRequest(streamID int64, request *envoy_s
 	}
 	util.FillTenantMetadata(tenantID, request.Node)
 	return nil
+}
+
+func (c *tenancyCallbacks) OnDeltaStreamClosed(streamID int64, node *envoy_core.Node) {
+	c.Lock()
+	delete(c.streamToCtx, streamID)
+	c.Unlock()
 }


### PR DESCRIPTION
## Motivation

The application's memory usage was slowly increasing but did not correlate with the number of active connections. I decided to investigate the memory usage and noticed some context entries. While reviewing the code, I discovered that we are not cleaning up the map of streams and contexts. I'm not certain if this is the primary issue, but it could be a contributing factor.

## Implementation information

Implemented the `OnDeltaStreamClosed` method to remove entries from the map when a stream is closed.

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

xref: https://github.com/Kong/kong-mesh/issues/6616

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
