### PR TITLE
chore(app): add common logging of version, config on startup

### DIFF
--- a/app/kuma-dp/cmd/run.go
+++ b/app/kuma-dp/cmd/run.go
@@ -61,12 +61,11 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 
 			kumadp.PrintDeprecations(cfg, cmd.OutOrStdout())
 
-			if conf, err := config.ToJson(cfg); err == nil {
-				runLog.Info("effective configuration", "config", string(conf))
-			} else {
-				runLog.Error(err, "unable to format effective configuration", "config", cfg)
-				return err
+			cfgForDisplay, err := config.ConfigForDisplay(cfg)
+			if err != nil {
+				runLog.Error(err, "unable to format effective configuration")
 			}
+			runLog.Info("starting Data Plane", "version", kuma_version.Build.Version, "config", cfgForDisplay)
 
 			// Map the resource types that are acceptable depending on the value of the `--proxy-type` flag.
 			proxyTypeMap := map[string]model.ResourceType{

--- a/pkg/api-server/config_ws.go
+++ b/pkg/api-server/config_ws.go
@@ -14,10 +14,6 @@ func addConfigEndpoints(ws *restful.WebService, access access.ControlPlaneMetada
 	if err != nil {
 		return err
 	}
-	json, err := config.ToJson(cfgForDisplay)
-	if err != nil {
-		return err
-	}
 	ws.Route(ws.GET("/config").To(func(req *restful.Request, resp *restful.Response) {
 		ctx := req.Request.Context()
 		if err := access.ValidateView(ctx, user.FromCtx(ctx)); err != nil {
@@ -25,7 +21,7 @@ func addConfigEndpoints(ws *restful.WebService, access access.ControlPlaneMetada
 			return
 		}
 		resp.AddHeader("content-type", "application/json")
-		if _, err := resp.Write(json); err != nil {
+		if _, err := resp.Write([]byte(cfgForDisplay)); err != nil {
 			log.Error(err, "Could not write the index response")
 		}
 	}))

--- a/pkg/config/display.go
+++ b/pkg/config/display.go
@@ -8,14 +8,18 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-func ConfigForDisplay(cfg Config) (Config, error) {
+func ConfigForDisplay(cfg Config) (string, error) {
 	// copy config so we don't override values, because nested structs in config are pointers
 	newCfg, err := copyConfig(cfg)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	newCfg.Sanitize()
-	return newCfg, nil
+	b, err := json.Marshal(newCfg)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
 }
 
 func copyConfig(cfg Config) (Config, error) {

--- a/pkg/kds/envoyadmin/kds_client_test.go
+++ b/pkg/kds/envoyadmin/kds_client_test.go
@@ -11,7 +11,6 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/api/system/v1alpha1"
 	"github.com/kumahq/kuma/pkg/config"
-	config_util "github.com/kumahq/kuma/pkg/config"
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
 	store_config "github.com/kumahq/kuma/pkg/config/core/resources/store"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
@@ -33,11 +32,10 @@ var _ = Describe("KDS client", func() {
 		cfg := kuma_cp.DefaultConfig()
 		cfg.Store.Type = storeType
 		displayCfg, _ := config.ConfigForDisplay(&cfg)
-		bytes, _ := config_util.ToJson(displayCfg)
 		zoneInsight.Spec.Subscriptions = []*v1alpha1.KDSSubscription{
 			{
 				ConnectTime: util_proto.MustTimestampProto(t1),
-				Config:      string(bytes),
+				Config:      displayCfg,
 			},
 		}
 		return zoneInsight

--- a/pkg/kds/zone/components.go
+++ b/pkg/kds/zone/components.go
@@ -54,11 +54,7 @@ func Setup(rt core_runtime.Runtime) error {
 	}
 	kubeFactory := resources_k8s.NewSimpleKubeFactory()
 	cfg := rt.Config()
-	cfgForDisplay, err := config.ConfigForDisplay(&cfg)
-	if err != nil {
-		return errors.Wrap(err, "could not construct config for display")
-	}
-	cfgJson, err := config.ToJson(cfgForDisplay)
+	cfgJson, err := config.ConfigForDisplay(&cfg)
 	if err != nil {
 		return errors.Wrap(err, "could not marshall config to json")
 	}
@@ -68,7 +64,7 @@ func Setup(rt core_runtime.Runtime) error {
 		syncClient := kds_client_v2.NewKDSSyncClient(
 			log,
 			reg.ObjectTypes(model.HasKDSFlag(model.GlobalToZoneSelector)),
-			kds_client_v2.NewDeltaKDSStream(stream, zone, rt, string(cfgJson)),
+			kds_client_v2.NewDeltaKDSStream(stream, zone, rt, cfgJson),
 			kds_sync_store_v2.ZoneSyncCallback(
 				stream.Context(),
 				rt.KDSContext().Configs,


### PR DESCRIPTION
## Motivation

In a customer investigation it took a while to figure what the version of the dp was.
Also the logs between the CP and DP were quite different.

## Implementation

- Log version and config as early as possible on startup of cp and dp
- Use similar log messages for cp and dp to develop muscle memory
- Simplify api to get json safe to print

