### PR TITLE
chore(e2e): remove ENABLE_E2E_DEBUG_GLOBALLY env and rely on github

### DIFF
--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -80,7 +80,7 @@ jobs:
       - name: "Run E2E tests"
         env:
           DOCKERHUB_PULL_CREDENTIAL: ${{ secrets.DOCKERHUB_PULL_CREDENTIAL }}
-          KUMA_DEBUG: ${{ runner.debug == '1' || vars.ENABLE_E2E_DEBUG_GLOBALLY == 'true' }}
+          KUMA_DEBUG: ${{ runner.debug == '1' }}
         run: |
           if [[ "${{ env.E2E_PARAM_K8S_VERSION }}" == "kindIpv6" ]]; then
             export IPV6=true


### PR DESCRIPTION
## Motivation

GitHub Actions provides the `ACTIONS_RUNNER_DEBUG` environment variable to enable debugging. We should leverage it.

## Implementation information

Instead of using `ENABLE_E2E_DEBUG_GLOBALLY` we can rely on `ACTIONS_RUNNER_DEBUG` env.

## Supporting documentation

https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/troubleshooting-workflows/enabling-debug-logging
