### PR TITLE
fix(kds): remove context from map on stream close (backport of #12243)

### DIFF
--- a/pkg/kds/v2/server/tenant_callback.go
+++ b/pkg/kds/v2/server/tenant_callback.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync"
 
+	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_sd "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	envoy_xds "github.com/envoyproxy/go-control-plane/pkg/server/v3"
 
@@ -49,4 +50,10 @@ func (c *tenancyCallbacks) OnStreamDeltaRequest(streamID int64, request *envoy_s
 	}
 	util.FillTenantMetadata(tenantID, request.Node)
 	return nil
+}
+
+func (c *tenancyCallbacks) OnDeltaStreamClosed(streamID int64, _ *envoy_core.Node) {
+	c.Lock()
+	delete(c.streamToCtx, streamID)
+	c.Unlock()
 }


### PR DESCRIPTION
## Motivation

Backport https://github.com/kumahq/kuma/pull/12243

I had to do a manual backport because GitHub changed my merge method to merge commit and this one cannot be backported.

## Implementation information

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
