### PR TITLE
ci(github): make workflow id to trigger for ci-stability-release-branches workflow configurable

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -1,4 +1,4 @@
-name: "build-test-distribute"
+name: "build-test-distribute" # This name is used by ci-stability-release-branches workflow. Update there too if you change this name.
 on:
   push:
     branches: ["master", "release-*", "!*-merge-master"]

--- a/.github/workflows/ci-stability-release-branches.yaml
+++ b/.github/workflows/ci-stability-release-branches.yaml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
+env:
+  WORKFLOW_ID_TO_TRIGGER: build-test-distribute
+
 jobs:
   get-active-release-branches:
     runs-on: ubuntu-24.04
@@ -69,7 +72,7 @@ jobs:
 
             await github.rest.actions.createWorkflowDispatch({
               ...context.repo,
-              workflow_id: 'build-test-distribute.yaml',
+              workflow_id: process.env.WORKFLOW_ID_TO_TRIGGER,
               ref: process.env.BRANCH,
             });
 
@@ -92,7 +95,7 @@ jobs:
 
               const response = await github.rest.actions.listWorkflowRuns({
                 ...context.repo,
-                workflow_id: 'build-test-distribute.yaml',
+                workflow_id: process.env.WORKFLOW_ID_TO_TRIGGER,
                 branch: process.env.BRANCH,
                 created: `${process.env.STARTED}..${process.env.FINISHED}`,
                 per_page: 1,
@@ -149,15 +152,10 @@ jobs:
                   { data: 'Conclusion', header: true },
                 ];
                 
-                const rows = jobs.map(job => {
-                  const finishedSteps = job.steps.filter(s => s.conclusion).length;
-                  
-                  return [
-                    { data: `<a href="${job.html_url}">${job.name}</a>` },
-                    { data: `${finishedSteps}/${job.steps.length}` },
-                    { data: job.conclusion || 'in_progress' },
-                  ];
-                });
+                const rows = jobs.map(job => [
+                  { data: `<a href="${job.html_url}">${job.name}</a>` },
+                  { data: job.conclusion || 'in_progress' },
+                ]);
                 
                 return core.summary.addTable([headers, ...rows]).write();
               } else {


### PR DESCRIPTION
## Motivation

We are reusing this workflow in other project, which has different name for the file containing build-test-distribute workflow so I added option to configure it.

At resulting in summary table, we don't need to information with amount of steps, so I'm getting rid of it as well.
<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
