### PR TITLE
ci(github): set the correct id of workflow to trigger for CI stability

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -1,4 +1,4 @@
-name: "build-test-distribute" # This name is used by ci-stability-release-branches workflow. Update there too if you change this name.
+name: "build-test-distribute"
 on:
   push:
     branches: ["master", "release-*", "!*-merge-master"]

--- a/.github/workflows/ci-stability-release-branches.yaml
+++ b/.github/workflows/ci-stability-release-branches.yaml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  WORKFLOW_ID_TO_TRIGGER: build-test-distribute
+  WORKFLOW_ID_TO_TRIGGER: build-test-distribute.yaml
 
 jobs:
   get-active-release-branches:


### PR DESCRIPTION
## Motivation

Correct ID for the workflow to trigger in ci-stability-release-branches is the name of the workflow file.
