### PR TITLE
chore(mk): fix k3d start errors when using calico CNI

### DIFF
--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -106,7 +106,7 @@ k3d/cleanup-docker-credentials:
 	@rm -f /tmp/.kuma-dev/k3d-registry.yaml
 
 .PHONY: k3d/start
-k3d/start: ${KIND_KUBECONFIG_DIR} k3d/network/create k3d/setup-docker-credentials
+k3d/start: ${KIND_KUBECONFIG_DIR} k3d/network/create k3d/setup-docker-credentials \
 	$(if $(findstring calico,$(K3D_NETWORK_CNI)),$(TOP)/$(KUMA_DIR)/test/k3d/calico.$(K3D_VERSION).yaml)
 	@echo "PORT_PREFIX=$(PORT_PREFIX)"
 	@KUBECONFIG=$(KIND_KUBECONFIG) \


### PR DESCRIPTION
## Motivation

To fix k3d start errors when using calica CNI

It's reported in CI run of the latest commit on `release-2.8` and older release versions:

https://github.com/kumahq/kuma/actions/runs/12357114240/job/34492385775

<!-- Why are we doing this change -->

## Implementation information

During backport `\` was forgotten which caused that calico step wasn't a prerequisite for running k3d.



## Supporting documentation

Code on master: https://github.com/kumahq/kuma/pull/12277/files#diff-6a9a6d7b0c33e516a1579d4ea2ccdfdbec5bd689d4f15bcab302e2a80b0d7ee4R109