### PR TITLE
feat(oapi): properly marshal proto struct and set paths

### DIFF
--- a/api/mesh/v1alpha1/mesh/schema.yaml
+++ b/api/mesh/v1alpha1/mesh/schema.yaml
@@ -63,15 +63,7 @@ properties:
           properties:
             conf:
               description: Configuration of the backend
-              properties:
-                fields:
-                  additionalProperties:
-                    properties:
-                      Kind: true
-                    required:
-                    - Kind
-                    type: object
-                  type: object
+              properties: {}
               type: object
             format:
               description: |-
@@ -115,15 +107,7 @@ properties:
           properties:
             conf:
               description: Configuration of the backend
-              properties:
-                fields:
-                  additionalProperties:
-                    properties:
-                      Kind: true
-                    required:
-                    - Kind
-                    type: object
-                  type: object
+              properties: {}
               type: object
             name:
               description: Name of the backend, can be then used in Mesh.metrics.enabledBackend
@@ -149,15 +133,7 @@ properties:
           properties:
             conf:
               description: Configuration of the backend
-              properties:
-                fields:
-                  additionalProperties:
-                    properties:
-                      Kind: true
-                    required:
-                    - Kind
-                    type: object
-                  type: object
+              properties: {}
               type: object
             dpCert:
               description: Dataplane certificate settings
@@ -270,15 +246,7 @@ properties:
           properties:
             conf:
               description: Configuration of the backend
-              properties:
-                fields:
-                  additionalProperties:
-                    properties:
-                      Kind: true
-                    required:
-                    - Kind
-                    type: object
-                  type: object
+              properties: {}
               type: object
             name:
               description: |-

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -11491,15 +11491,7 @@ components:
                 properties:
                   conf:
                     description: Configuration of the backend
-                    properties:
-                      fields:
-                        additionalProperties:
-                          properties:
-                            Kind: true
-                          required:
-                            - Kind
-                          type: object
-                        type: object
+                    properties: {}
                     type: object
                   format:
                     description: >-
@@ -11552,15 +11544,7 @@ components:
                 properties:
                   conf:
                     description: Configuration of the backend
-                    properties:
-                      fields:
-                        additionalProperties:
-                          properties:
-                            Kind: true
-                          required:
-                            - Kind
-                          type: object
-                        type: object
+                    properties: {}
                     type: object
                   name:
                     description: >-
@@ -11590,15 +11574,7 @@ components:
                 properties:
                   conf:
                     description: Configuration of the backend
-                    properties:
-                      fields:
-                        additionalProperties:
-                          properties:
-                            Kind: true
-                          required:
-                            - Kind
-                          type: object
-                        type: object
+                    properties: {}
                     type: object
                   dpCert:
                     description: Dataplane certificate settings
@@ -11725,15 +11701,7 @@ components:
                 properties:
                   conf:
                     description: Configuration of the backend
-                    properties:
-                      fields:
-                        additionalProperties:
-                          properties:
-                            Kind: true
-                          required:
-                            - Kind
-                          type: object
-                        type: object
+                    properties: {}
                     type: object
                   name:
                     description: >-

--- a/mk/generate.mk
+++ b/mk/generate.mk
@@ -109,7 +109,7 @@ generate/oas: $(GENERATE_OAS_PREREQUISITES)
 		DEST=$${endpoint#"api/openapi/specs"}; \
 		PATH=$(CI_TOOLS_BIN_DIR):$$PATH oapi-codegen -config api/openapi/openapi.cfg.yaml -o api/openapi/types/$$(dirname $${DEST}})/zz_generated.$$(basename $${DEST}).go $${endpoint}.yaml; \
 	done
-	$(RESOURCE_GEN) -package mesh -generator openapi
+	$(RESOURCE_GEN) -package mesh -generator openapi -rootDir $(KUMA_DIR)
 
 .PHONY: generate/oas-for-ts
 generate/oas-for-ts: generate/oas docs/generated/openapi.yaml ## Regenerate OpenAPI spec from `/api/openapi/specs` ready for typescript type generation


### PR DESCRIPTION
## Motivation

The build was failing in parent repo because of:

https://github.com/kumahq/kuma/blob/39a5f176c7bd1f608fdc0a6e834d33289256d108/docs/generated/openapi.yaml#L11498

Also the paths in the parent repo were not properly set

<!-- Why are we doing this change -->

## Implementation information

We're ignoring the `structpb.Struct` so that it is effectively any JSON map.

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fixes this error:

```
error loading swagger spec in api/openapi/specs/global_insight.yaml
: failed to load OpenAPI specification: error resolving reference "../kuma/openapi.yaml#/components/schemas/GlobalInsight": failed to unmarshal data: json error: invalid character 'o' looking for beginning of value, yaml error: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal bool into field Schema.properties of type openapi3.Schema
make: *** [kuma/mk/generate.mk:108: generate/oas] Error 1
```


> Changelog: feat(oapi): add mesh and meshgateway to oapi spec

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
