### PR TITLE
feat(oapi): fix missing dependency

### DIFF
--- a/mk/generate.mk
+++ b/mk/generate.mk
@@ -104,7 +104,7 @@ generate/policy-helm:
 
 endpoints = $(foreach dir,$(shell find api/openapi/specs -type f | sort),$(basename $(dir)))
 
-generate/oas: $(GENERATE_OAS_PREREQUISITES)
+generate/oas: $(GENERATE_OAS_PREREQUISITES) $(RESOURCE_GEN)
 	for endpoint in $(endpoints); do \
 		DEST=$${endpoint#"api/openapi/specs"}; \
 		PATH=$(CI_TOOLS_BIN_DIR):$$PATH oapi-codegen -config api/openapi/openapi.cfg.yaml -o api/openapi/types/$$(dirname $${DEST}})/zz_generated.$$(basename $${DEST}).go $${endpoint}.yaml; \


### PR DESCRIPTION
## Motivation

Because otherwise this is not built and fails https://github.com/Kong/kong-mesh/actions/runs/12408432049/job/34640101247?pr=7179#step:13:69

<!-- Why are we doing this change -->

## Implementation information

Add dependency in makefile

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix https://github.com/Kong/kong-mesh/actions/runs/12408432049/job/34640101247?pr=7179#step:13:69

> Changelog: feat(oapi): add mesh and meshgateway to oapi spec

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
