### PR TITLE
feat(oapi): fix out dir

### DIFF
--- a/tools/resource-gen/main.go
+++ b/tools/resource-gen/main.go
@@ -487,7 +487,7 @@ func openApiGenerator(pkg string, resources []ResourceInfo) error {
 			return fmt.Errorf("failed to create directory: %w", err)
 		}
 
-		err = os.WriteFile(path.Join(rootDir, outDir, "schema.yaml"), out, 0o600)
+		err = os.WriteFile(path.Join(outDir, "schema.yaml"), out, 0o600)
 		if err != nil {
 			return err
 		}
@@ -507,7 +507,7 @@ func openApiGenerator(pkg string, resources []ResourceInfo) error {
 			"Scope":   scope,
 			"Path":    r.WsPath,
 		}
-		err = save.PlainTemplate(tmpl, opts, path.Join(rootDir, outDir, "rest.yaml"))
+		err = save.PlainTemplate(tmpl, opts, path.Join(outDir, "rest.yaml"))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Motivation

still failing https://github.com/Kong/kong-mesh/actions/runs/12410164787/job/34645214875?pr=7179#step:13:74 probably had the wrong path, not sure why it worked locally

<!-- Why are we doing this change -->

## Implementation information

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix https://github.com/Kong/kong-mesh/actions/runs/12410164787/job/34645214875?pr=7179#step:13:74

> Changelog: feat(oapi): add mesh and meshgateway to oapi spec

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
