### PR TITLE
fix(k8s): clone map before changing

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/mesh_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/mesh_controller.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"maps"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -72,10 +73,12 @@ func (r *MeshReconciler) ensureDefaultResources(ctx context.Context, mesh *core_
 		return errors.Wrap(err, "could not create default mesh resources")
 	}
 
+	annotations := maps.Clone(mesh.GetMeta().(*k8s.KubernetesMetaAdapter).Annotations)
 	if mesh.GetMeta().(*k8s.KubernetesMetaAdapter).GetAnnotations() == nil {
-		mesh.GetMeta().(*k8s.KubernetesMetaAdapter).Annotations = map[string]string{}
+		annotations = map[string]string{}
 	}
-	mesh.GetMeta().(*k8s.KubernetesMetaAdapter).GetAnnotations()[common_k8s.K8sMeshDefaultsGenerated] = "true"
+	annotations[common_k8s.K8sMeshDefaultsGenerated] = "true"
+	mesh.GetMeta().(*k8s.KubernetesMetaAdapter).Annotations = annotations
 
 	r.Log.Info("marking mesh that default resources were generated", "mesh", mesh.GetMeta().GetName())
 

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter.go
@@ -169,6 +169,7 @@ func (p *PodConverter) dataplaneFor(
 	dataplane := &mesh_proto.Dataplane{
 		Networking: &mesh_proto.Dataplane_Networking{},
 	}
+	// we don't modify `annotations` so there is no need to clone
 	annotations := metadata.Annotations(pod.Annotations)
 
 	enabled, exist, err := annotations.GetEnabled(metadata.KumaTransparentProxyingAnnotation)

--- a/pkg/plugins/runtime/k8s/controllers/service_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/service_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -68,7 +69,7 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req kube_ctrl.Request
 	}
 
 	log.Info("annotating service which is part of the mesh", "annotation", fmt.Sprintf("%s=%s", metadata.IngressServiceUpstream, metadata.AnnotationTrue))
-	annotations := metadata.Annotations(svc.Annotations)
+	annotations := metadata.Annotations(maps.Clone(svc.Annotations))
 	if annotations == nil {
 		annotations = metadata.Annotations{}
 	}

--- a/pkg/plugins/runtime/k8s/probes/probe.go
+++ b/pkg/plugins/runtime/k8s/probes/probe.go
@@ -80,7 +80,7 @@ func (p KumaProbe) Path() string {
 	return p.HTTPGet.Path
 }
 
-func SetVirtualProbesEnabledAnnotation(annotations metadata.Annotations, podAnnotations map[string]string, cfgVirtualProbesEnabled bool) error {
+func SetVirtualProbesEnabledAnnotation(annotations metadata.Annotations, podAnnotations metadata.Annotations, cfgVirtualProbesEnabled bool) error {
 	str := func(b bool) string {
 		if b {
 			return metadata.AnnotationEnabled
@@ -88,11 +88,11 @@ func SetVirtualProbesEnabledAnnotation(annotations metadata.Annotations, podAnno
 		return metadata.AnnotationDisabled
 	}
 
-	vpEnabled, vpExist, err := metadata.Annotations(podAnnotations).GetEnabled(metadata.KumaVirtualProbesAnnotation)
+	vpEnabled, vpExist, err := podAnnotations.GetEnabled(metadata.KumaVirtualProbesAnnotation)
 	if err != nil {
 		return err
 	}
-	gwEnabled, _, err := metadata.Annotations(podAnnotations).GetEnabled(metadata.KumaGatewayAnnotation)
+	gwEnabled, _, err := podAnnotations.GetEnabled(metadata.KumaGatewayAnnotation)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
@@ -793,7 +793,7 @@ func (i *KumaInjector) NewAnnotations(podAnnotations map[string]string, logger l
 		)
 	}
 
-	if err := setVirtualProbesPortAnnotation(result, podAnnotations, i.cfg); err != nil {
+	if err := setVirtualProbesPortAnnotation(result, annotations, i.cfg); err != nil {
 		return nil, errors.Wrap(
 			err,
 			fmt.Sprintf("unable to set %s", metadata.KumaVirtualProbesPortAnnotation),

--- a/pkg/plugins/runtime/k8s/webhooks/injector/probes.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/probes.go
@@ -12,9 +12,9 @@ import (
 	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/util"
 )
 
-func (i *KumaInjector) overrideHTTPProbes(pod *kube_core.Pod) error {
+func (i *KumaInjector) overrideHTTPProbes(pod *kube_core.Pod, annotations map[string]string) error {
 	log.WithValues("name", pod.Name, "namespace", pod.Namespace)
-	enabled, _, err := metadata.Annotations(pod.Annotations).GetEnabled(metadata.KumaVirtualProbesAnnotation)
+	enabled, _, err := metadata.Annotations(annotations).GetEnabled(metadata.KumaVirtualProbesAnnotation)
 	if err != nil {
 		return err
 	}
@@ -23,7 +23,7 @@ func (i *KumaInjector) overrideHTTPProbes(pod *kube_core.Pod) error {
 		return err
 	}
 
-	port, _, err := metadata.Annotations(pod.Annotations).GetUint32(metadata.KumaVirtualProbesPortAnnotation)
+	port, _, err := metadata.Annotations(annotations).GetUint32(metadata.KumaVirtualProbesPortAnnotation)
 	if err != nil {
 		return err
 	}
@@ -93,8 +93,8 @@ func overrideHTTPProbe(probe *kube_core.Probe, virtualPort uint32) error {
 	return nil
 }
 
-func setVirtualProbesPortAnnotation(annotations metadata.Annotations, pod *kube_core.Pod, cfg runtime_k8s.Injector) error {
-	port, _, err := metadata.Annotations(pod.Annotations).GetUint32WithDefault(cfg.VirtualProbesPort, metadata.KumaVirtualProbesPortAnnotation)
+func setVirtualProbesPortAnnotation(annotations metadata.Annotations, podAnnotations metadata.Annotations, cfg runtime_k8s.Injector) error {
+	port, _, err := podAnnotations.GetUint32WithDefault(cfg.VirtualProbesPort, metadata.KumaVirtualProbesPortAnnotation)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Motivation

I was investigating a test fail on release-2.8 and noticed that we had a panic https://github.com/kumahq/kuma/actions/runs/12401863260/job/34624092612

```
fatal error: concurrent map read and map write
 
  goroutine 1264 [running]:
github.com/kumahq/kuma/pkg/plugins/runtime/k8s/metadata.Annotations.getWithDefault(0x4004194e70, {0x247fb40?, 0x505e860?}, 0x4001a8d7c8, {0x4001a8d848?, 0x3272270?, 0x4001a8d7f8?})
	github.com/kumahq/kuma/pkg/plugins/runtime/k8s/metadata/annotations.go:347 +0x94
github.com/kumahq/kuma/pkg/plugins/runtime/k8s/metadata.Annotations.GetBooleanWithDefault(0x4001a8d858?, 0x0, 0x3c?, {0x4001a8d848?, 0x2203be4?, 0x25c85e0?})
	github.com/kumahq/kuma/pkg/plugins/runtime/k8s/metadata/annotations.go:231 +0x64
github.com/kumahq/kuma/pkg/plugins/runtime/k8s/metadata.Annotations.GetEnabledWithDefault(...)
	github.com/kumahq/kuma/pkg/plugins/runtime/k8s/metadata/annotations.go:227
github.com/kumahq/kuma/pkg/plugins/runtime/k8s/metadata.Annotations.GetEnabled(0x1?, {0x4001a8d848?, 0x4000cc6d88?, 0x40008b1590?})
	github.com/kumahq/kuma/pkg/plugins/runtime/k8s/metadata/annotations.go:219 +0x34
github.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers.(*PodReconciler).findMatchingServices.Ignored.func1(0x25deb80?)
	github.com/kumahq/kuma/pkg/plugins/runtime/k8s/util/util.go:56 +0x4c
github.com/kumahq/kuma/pkg/plugins/runtime/k8s/util.MatchService(...)
	github.com/kumahq/kuma/pkg/plugins/runtime/k8s/util/util.go:63
github.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers.(*PodReconciler).findMatchingServices(0x400069ab40, {0x32d27f0, 0x4003e92ab0}, 0x4000cc6d88)
	github.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers/pod_controller.go:264 +0x5b4
github.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers.(*PodReconciler).reconcileDataplane(0x400069ab40, {0x32d27f0, 0x4003e92ab0}, 0x4000cc6d88, {{0x32da180?, 0x4003e92ae0?}, 0x0?})
	github.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers/pod_controller.go:132 +0x2a0
github.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers.(*PodReconciler).Reconcile(0x400069ab40, {0x32d27f0, 0x4003e92ab0}, {{{0x40026b05a0, 0x11}, {0x4002644ba0, 0x22}}})
	github.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers/pod_controller.go:101 +0x41c
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x32da180?, {0x32d27f0?, 0x4003e92ab0?}, {{{0x40026b05a0?, 0xb?}, {0x4002644ba0?, 0x0?}}})
	sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:119 +0x8c
```

## Implementation information

While investigating a stack trace, I noticed that another goroutine was modifying a service object that we were also working with. I realized that we were not cloning the map before making edits to it. After reviewing the Kubernetes controller code, I identified the areas where these changes occur. I updated a few places to clone the map first before adding labels or making modifications.

```
goroutine 867 [runnable]:
github.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers.(*ServiceReconciler).Reconcile(0x40007a8cf0, {0x32d27f0, 0x4004043320}, {{{0x40027c2c48, 0x11}, {0x4003e3e447, 0x7}}})
	github.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers/service_controller.go:83 +0x7f4
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x32da180?, {0x32d27f0?, 0x4004043320?}, {{{0x40027c2c48?, 0xb?}, {0x4003e3e447?, 0x0?}}})
	sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:119 +0x8c
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0x4000651220, {0x32d2828, 0x40009d0370}, {0x27baca0, 0x40012fb460})
```

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
