### PR TITLE
feat(kds): use compressor to make requests and responses smaller

### DIFF
--- a/pkg/kds/mux/client.go
+++ b/pkg/kds/mux/client.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -64,6 +65,7 @@ func (c *client) Start(stop <-chan struct{}) (errs error) {
 	}
 	dialOpts := c.metrics.GRPCClientInterceptors()
 	dialOpts = append(dialOpts, grpc.WithUserAgent(version.Build.UserAgent("kds")), grpc.WithDefaultCallOptions(
+		grpc.UseCompressor(gzip.Name),
 		grpc.MaxCallSendMsgSize(int(c.config.MaxMsgSize)),
 		grpc.MaxCallRecvMsgSize(int(c.config.MaxMsgSize))),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{


### PR DESCRIPTION
## Motivation

<!-- Why are we doing this change -->

We're seeing errors like this https://github.com/kumahq/kuma/issues/12183.

## Implementation information

According to the docs https://github.com/grpc/grpc-go/blob/master/Documentation/compression.md#compression if turned on on the client side it will automatically make server also respond with compressed responses.

![image](https://github.com/user-attachments/assets/fc597133-3935-4830-8591-6ba67b81de01)


<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix https://github.com/kumahq/kuma/issues/12183

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
