### PR TITLE
ci(github): use on.push to notify about updates (backport of #12424)

### DIFF
--- a/.github/workflows/pr-merged.yaml
+++ b/.github/workflows/pr-merged.yaml
@@ -3,8 +3,6 @@ on:
   push:
     tags:
       - '*'
-  pull_request_target:
-    types: [closed]
     branches:
       - master
       - release-*
@@ -13,7 +11,6 @@ permissions:
 jobs:
   notify-about-merged-pr:
     timeout-minutes: 10
-    if: github.event_name != 'pull_request_target' || github.event.pull_request.merged
     name: "Notify about merged PR"
     runs-on: ubuntu-24.04
     steps:
@@ -22,11 +19,8 @@ jobs:
         with:
           github-token: ${{ secrets.NOTIFY_BOT_PAT_TOKEN }}
           script: |
-            let branch, pr;
-            if (context.eventName == "pull_request_target") {
-              branch = context.payload.pull_request.base.ref;
-              pr = context.payload.pull_request.number;
-            } else if (context.eventName == "push") {
+            let branch = process.env.GITHUB_REF_NAME;
+            if (process.env.GITHUB_REF_TYPE === "tag") {
               const versionRegex = /v?(\d+)\.(\d+)\.\d+/;
               const versionMatch = process.env.GITHUB_REF_NAME.match(versionRegex);
               if (!versionMatch) {
@@ -41,6 +35,5 @@ jobs:
               event_type: '${{ secrets.NOTIFY_EVENT_TYPE }}',
               client_payload: {
                 branch,
-                pr,
               },
             });


### PR DESCRIPTION
Cherry-picking commit 5067a4e3192f44baa22f9afa652a1f1ac85b59b5 to release-2.7 branch