### PR TITLE
ci(github): fix PR comment action

### DIFF
--- a/.github/workflows/pr-modification.yaml
+++ b/.github/workflows/pr-modification.yaml
@@ -13,26 +13,45 @@ permissions:
 jobs:
   find-prs:
     env:
-      LOOK_BACK: ${{ github.event.inputs.lookback }} || "10 minutes"
+      LOOK_BACK: ${{ github.event.inputs.lookback || '10 minutes' }}
+      GH_TOKEN: ${{ github.token }}
     runs-on: ubuntu-24.04
     outputs:
       recent_prs: ${{ steps.get-recent-prs.outputs.out }}
       active_branches: ${{ steps.active-branches.outputs.out }}
     steps:
       - id: active-branches
+        name: Get active branches
         run: |
-          echo "out=$(gh api /repos/${{ github.repository }}/contents/active-branches.json --jq '.content | @base64d')" >> $GITHUB_OUTPUT
+          echo "out<<EOF" >> $GITHUB_OUTPUT
+          gh api /repos/${{ github.repository }}/contents/active-branches.json --jq '.content | @base64d' >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
       - id: get-recent-prs
+        name: Get recent PRs
         run: |
-          prs=$(gh pr list --json number,title,url --search "updated:>=$(date --date='${{ env.LOOK_BACK }} ago' +'%Y-%m-%dT%H:%M:%S%z') -author:app/github-actions -author:dependabot")
-          echo "out=$prs" >> $GITHUB_OUTPUT
+          echo "out<<EOF" >> $GITHUB_OUTPUT
+          gh pr list -R ${{ github.repository }} --json number,title,url --search "updated:>=$(date --date='${{ env.LOOK_BACK }} ago' +'%Y-%m-%dT%H:%M:%S%z') -author:dependabot" | jq -c '{include: .}'>> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+      - name: Show outputs
+        env:
+          RECENT_PRS: ${{ steps.get-recent-prs.outputs.out }}
+          ACTIVE_BRANCHES: ${{ steps.active-branches.outputs.out }}
+        run: |
+          echo "::group::recent-prs"
+          echo "${RECENT_PRS}"
+          echo "::endgroup::"
+          echo "::group::active-branches"
+          echo "${ACTIVE_BRANCHES}"
+          echo "::endgroup::"
 
   pr-comment:
     needs: find-prs
     runs-on: ubuntu-24.04
     strategy:
-      matrix: ${{ fromJson(needs.get-prs.outputs.recent_prs) }}
+      matrix: ${{ fromJson(needs.find-prs.outputs.recent_prs) }}
       max-parallel: 1 # to avoid using too many runners
+    permissions:
+      pull-requests: write
     steps:
       - uses: marocchino/sticky-pull-request-comment@daa4a82a0a3f6c162c02b83fa44b3ab83946f7cb # v2.9.0
         with:


### PR DESCRIPTION
## Motivation

The job wasn't implemented correctly

## Implementation information

We now retrieve all recently updated PR and add the checklist as a stick comment.
This is completely safe as it only executes on master and runs trusted code