### PR TITLE
chore(oapi): move global inisight schema to separate object

### DIFF
--- a/api/openapi/specs/api.yaml
+++ b/api/openapi/specs/api.yaml
@@ -390,7 +390,7 @@ components:
           type: integer
           description: Number of meshes
           example: 3
-    GlobalInsight:
+    schemas-GlobalInsight:
       type: object
       title: GlobalInsight
       description: Global Insight contains statistics for all main resources
@@ -433,6 +433,9 @@ components:
           additionalProperties:
             $ref: '#/components/schemas/ResourceStats'
           description: A map of resource names to their corresponding statistics
+    GlobalInsight:
+      allOf:
+        - $ref: '#/components/schemas/schemas-GlobalInsight'
   responses:
     IndexResponse:
       description: A response for the index endpoint

--- a/api/openapi/types/zz_generated.api.go
+++ b/api/openapi/types/zz_generated.api.go
@@ -47,28 +47,7 @@ type FullStatus struct {
 }
 
 // GlobalInsight Global Insight contains statistics for all main resources
-type GlobalInsight struct {
-	// CreatedAt Time of Global Insight creation
-	CreatedAt time.Time `json:"createdAt"`
-
-	// Dataplanes Dataplane proxy statistics
-	Dataplanes DataplanesStats `json:"dataplanes"`
-
-	// Meshes Mesh statistics
-	Meshes MeshesStats `json:"meshes"`
-
-	// Policies Policies statistics
-	Policies PoliciesStats `json:"policies"`
-
-	// Resources A map of resource names to their corresponding statistics
-	Resources map[string]ResourceStats `json:"resources"`
-
-	// Services Mesh services statistics
-	Services ServicesStats `json:"services"`
-
-	// Zones Zones statistics
-	Zones ZonesStats `json:"zones"`
-}
+type GlobalInsight = SchemasGlobalInsight
 
 // Index Some metadata about the service
 type Index struct {
@@ -168,10 +147,34 @@ type ZonesStats struct {
 	ZoneIngresses BaseStatus `json:"zoneIngresses"`
 }
 
+// SchemasGlobalInsight Global Insight contains statistics for all main resources
+type SchemasGlobalInsight struct {
+	// CreatedAt Time of Global Insight creation
+	CreatedAt time.Time `json:"createdAt"`
+
+	// Dataplanes Dataplane proxy statistics
+	Dataplanes DataplanesStats `json:"dataplanes"`
+
+	// Meshes Mesh statistics
+	Meshes MeshesStats `json:"meshes"`
+
+	// Policies Policies statistics
+	Policies PoliciesStats `json:"policies"`
+
+	// Resources A map of resource names to their corresponding statistics
+	Resources map[string]ResourceStats `json:"resources"`
+
+	// Services Mesh services statistics
+	Services ServicesStats `json:"services"`
+
+	// Zones Zones statistics
+	Zones ZonesStats `json:"zones"`
+}
+
 // BadRequest standard error
 type BadRequest = externalRef0.Error
 
-// GlobalInsightResponse Global Insight contains statistics for all main resources
+// GlobalInsightResponse defines model for GlobalInsightResponse.
 type GlobalInsightResponse = GlobalInsight
 
 // IndexResponse Some metadata about the service

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -2448,7 +2448,7 @@ components:
           type: integer
           description: Number of meshes
           example: 3
-    GlobalInsight:
+    schemas-GlobalInsight:
       type: object
       title: GlobalInsight
       description: Global Insight contains statistics for all main resources
@@ -2491,6 +2491,9 @@ components:
           additionalProperties:
             $ref: '#/components/schemas/ResourceStats'
           description: A map of resource names to their corresponding statistics
+    GlobalInsight:
+      allOf:
+        - $ref: '#/components/schemas/schemas-GlobalInsight'
     PolicyDescription:
       type: object
       required:


### PR DESCRIPTION
## Motivation

So it's properly merged in parent object. Otherwise we end up with both `properties` and `allOf` on the same level which doesn't play nicely with parent project validator.

<!-- Why are we doing this change -->

## Implementation information

Move to separate object.

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

xrel https://github.com/kumahq/ci-tools/issues/59

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
