### PR TITLE
chore(oapi): rename resources to responses

### DIFF
--- a/api/openapi/specs/api.yaml
+++ b/api/openapi/specs/api.yaml
@@ -10,7 +10,7 @@ paths:
       summary: The index endpoint
       description: The index endpoint, some common metadata
       tags: ["System"]
-      resources:
+      responses:
         '200':
           $ref: '#/components/responses/IndexResponse'
         '400':

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -12,7 +12,7 @@ paths:
       description: The index endpoint, some common metadata
       tags:
         - System
-      resources:
+      responses:
         '200':
           $ref: '#/components/responses/IndexResponse'
         '400':
@@ -2494,6 +2494,61 @@ components:
     GlobalInsight:
       allOf:
         - $ref: '#/components/schemas/schemas-GlobalInsight'
+    InvalidParameters:
+      type: object
+      title: Invalid Parameters
+      properties:
+        field:
+          type: string
+        reason:
+          type: string
+        rule:
+          type: string
+        choices:
+          type: array
+          items:
+            type: string
+    Error:
+      type: object
+      title: Error
+      description: standard error
+      x-examples:
+        Example 1:
+          status: 404
+          title: Not Found
+          type: https://kongapi.info/konnect/not-found
+          instance: portal:trace:2287285207635123011
+          detail: The requested document was not found
+      required:
+        - status
+        - title
+        - instance
+      properties:
+        status:
+          type: integer
+          description: The HTTP status code.
+          example: 404
+        title:
+          type: string
+          description: The error response code.
+          example: Not Found
+        type:
+          type: string
+          description: The error type.
+          example: Not Found
+        instance:
+          type: string
+          example: portal:trace:2287285207635123011
+          description: The portal traceback code
+        detail:
+          type: string
+          example: The requested team was not found
+          description: Details about the error.
+        invalid_parameters:
+          type: array
+          description: TODO
+          items:
+            $ref: '#/components/schemas/InvalidParameters'
     PolicyDescription:
       type: object
       required:
@@ -2553,61 +2608,6 @@ components:
           type: boolean
         policy:
           $ref: '#/components/schemas/PolicyDescription'
-    InvalidParameters:
-      type: object
-      title: Invalid Parameters
-      properties:
-        field:
-          type: string
-        reason:
-          type: string
-        rule:
-          type: string
-        choices:
-          type: array
-          items:
-            type: string
-    Error:
-      type: object
-      title: Error
-      description: standard error
-      x-examples:
-        Example 1:
-          status: 404
-          title: Not Found
-          type: https://kongapi.info/konnect/not-found
-          instance: portal:trace:2287285207635123011
-          detail: The requested document was not found
-      required:
-        - status
-        - title
-        - instance
-      properties:
-        status:
-          type: integer
-          description: The HTTP status code.
-          example: 404
-        title:
-          type: string
-          description: The error response code.
-          example: Not Found
-        type:
-          type: string
-          description: The error type.
-          example: Not Found
-        instance:
-          type: string
-          example: portal:trace:2287285207635123011
-          description: The portal traceback code
-        detail:
-          type: string
-          example: The requested team was not found
-          description: Details about the error.
-        invalid_parameters:
-          type: array
-          description: TODO
-          items:
-            $ref: '#/components/schemas/InvalidParameters'
     Meta:
       type: object
       required:


### PR DESCRIPTION
## Motivation

There is no such a things as "resources" this was probably a typo because a field nearby is "_resources".
<!-- Why are we doing this change -->

## Implementation information

Rename "resources" to the correct "responses".
<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

xrel https://github.com/Kong/kong-mesh/issues/7202

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
