### PR TITLE
feat(kuma-cp): add new targetRef kind Dataplane

### DIFF
--- a/api/common/v1alpha1/ref.go
+++ b/api/common/v1alpha1/ref.go
@@ -14,6 +14,7 @@ type TargetRefKind string
 
 var (
 	Mesh                 TargetRefKind = "Mesh"
+	Dataplane            TargetRefKind = "Dataplane"
 	MeshSubset           TargetRefKind = "MeshSubset"
 	MeshGateway          TargetRefKind = "MeshGateway"
 	MeshService          TargetRefKind = "MeshService"
@@ -25,13 +26,14 @@ var (
 
 var order = map[TargetRefKind]int{
 	Mesh:                 1,
-	MeshSubset:           2,
-	MeshGateway:          3,
-	MeshService:          4,
-	MeshExternalService:  5,
-	MeshMultiZoneService: 6,
-	MeshServiceSubset:    7,
-	MeshHTTPRoute:        8,
+	Dataplane:            2,
+	MeshSubset:           3,
+	MeshGateway:          4,
+	MeshService:          5,
+	MeshExternalService:  6,
+	MeshMultiZoneService: 7,
+	MeshServiceSubset:    8,
+	MeshHTTPRoute:        9,
 }
 
 // +kubebuilder:validation:Enum=Sidecar;Gateway

--- a/pkg/core/resources/apis/mesh/validators_test.go
+++ b/pkg/core/resources/apis/mesh/validators_test.go
@@ -164,6 +164,52 @@ name: backend
 				},
 			},
 		}),
+		Entry("Dataplane", testCase{
+			inputYaml: `
+kind: Dataplane
+`,
+			opts: &ValidateTargetRefOpts{
+				SupportedKinds: []common_api.TargetRefKind{
+					common_api.Dataplane,
+				},
+			},
+		}),
+		Entry("Dataplane by name", testCase{
+			inputYaml: `
+kind: Dataplane
+name: backend-asb3210d
+`,
+			opts: &ValidateTargetRefOpts{
+				SupportedKinds: []common_api.TargetRefKind{
+					common_api.Dataplane,
+				},
+			},
+		}),
+		Entry("Dataplane by labels", testCase{
+			inputYaml: `
+kind: Dataplane
+labels:
+  app: demo-app
+`,
+			opts: &ValidateTargetRefOpts{
+				SupportedKinds: []common_api.TargetRefKind{
+					common_api.Dataplane,
+				},
+			},
+		}),
+		Entry("Dataplane with sectionName", testCase{
+			inputYaml: `
+kind: Dataplane
+name: backend-asb3210d
+sectionName: http-port
+`,
+			opts: &ValidateTargetRefOpts{
+				SupportedKinds: []common_api.TargetRefKind{
+					common_api.Dataplane,
+				},
+				IsInboundPolicy: true,
+			},
+		}),
 		Entry("MeshGateway", testCase{
 			inputYaml: `
 kind: MeshGateway
@@ -914,6 +960,82 @@ violations:
   message: must not be set with kind MeshServiceSubset
 - field: targetRef.sectionName
   message: must not be set with kind MeshServiceSubset
+`,
+		}),
+		Entry("Dataplane both labels and name", testCase{
+			inputYaml: `
+kind: Dataplane
+name: test
+namespace: test-ns
+labels:
+  kuma.io/zone: east
+`,
+			opts: &ValidateTargetRefOpts{
+				SupportedKinds: []common_api.TargetRefKind{
+					common_api.Dataplane,
+				},
+			},
+			expected: `
+violations:
+- field: targetRef.labels
+  message: either labels or name and namespace must be specified
+`,
+		}),
+		Entry("Dataplane with tags and mesh", testCase{
+			inputYaml: `
+kind: Dataplane
+name: test
+namespace: test-ns
+mesh: mesh-1
+tags:
+  app: demo
+`,
+			opts: &ValidateTargetRefOpts{
+				SupportedKinds: []common_api.TargetRefKind{
+					common_api.Dataplane,
+				},
+			},
+			expected: `
+violations:
+- field: targetRef.tags
+  message: must not be set with kind Dataplane
+- field: targetRef.mesh
+  message: must not be set with kind Dataplane
+`,
+		}),
+		Entry("Dataplane with proxyTypes", testCase{
+			inputYaml: `
+kind: Dataplane
+name: test
+namespace: test-ns
+proxyTypes: ["Sidecar"]
+`,
+			opts: &ValidateTargetRefOpts{
+				SupportedKinds: []common_api.TargetRefKind{
+					common_api.Dataplane,
+				},
+			},
+			expected: `
+violations:
+- field: targetRef.proxyTypes
+  message: must not be set with kind Dataplane
+`,
+		}),
+		Entry("Dataplane with proxyTypes", testCase{
+			inputYaml: `
+kind: Dataplane
+name: test
+sectionName: http-port
+`,
+			opts: &ValidateTargetRefOpts{
+				SupportedKinds: []common_api.TargetRefKind{
+					common_api.Dataplane,
+				},
+			},
+			expected: `
+violations:
+- field: targetRef.sectionName
+  message: can only be used with inbound policies
 `,
 		}),
 	)


### PR DESCRIPTION

## Motivation

As discussed in Inbound policies madr we need a new kind Dataplane, this pr introduces API for this kind

Fix #12358

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
