### PR TITLE
chore(oapi): rename InternalServerError to Internal

### DIFF
--- a/api/openapi/specs/api.yaml
+++ b/api/openapi/specs/api.yaml
@@ -16,7 +16,7 @@ paths:
         '400':
           $ref: '#/components/responses/BadRequest'
         '500':
-          $ref: '#/components/responses/InternalServerError'
+          $ref: '#/components/responses/Internal'
   /_resources:
     get:
       operationId: get-resource-type-description
@@ -29,7 +29,7 @@ paths:
         '400':
           $ref: '#/components/responses/BadRequest'
         '500':
-          $ref: '#/components/responses/InternalServerError'
+          $ref: '#/components/responses/Internal'
   /global-insight:
     get:
       operationId: get-global-insight
@@ -42,7 +42,7 @@ paths:
         '400':
           $ref: '#/components/responses/BadRequest'
         '500':
-          $ref: '#/components/responses/InternalServerError'
+          $ref: '#/components/responses/Internal'
   /meshes/{mesh}/{resourceType}/{resourceName}/_rules:
     get:
       operationId: inspect-dataplanes-rules
@@ -77,7 +77,7 @@ paths:
         '400':
           $ref: '#/components/responses/BadRequest'
         '500':
-          $ref: '#/components/responses/InternalServerError'
+          $ref: '#/components/responses/Internal'
   /meshes/{mesh}/dataplanes/{name}/_config:
     get:
       summary: Get a proxy XDS config on a CP
@@ -118,7 +118,7 @@ paths:
         '400':
           $ref: '#/components/responses/BadRequest'
         '500':
-          $ref: '#/components/responses/InternalServerError'
+          $ref: '#/components/responses/Internal'
   /meshes/{mesh}/{policyType}/{policyName}/_resources/dataplanes:
     get:
       operationId: inspect-resources
@@ -171,7 +171,7 @@ paths:
         '400':
           $ref: '#/components/responses/BadRequest'
         '500':
-          $ref: '#/components/responses/InternalServerError'
+          $ref: '#/components/responses/Internal'
 components:
   schemas:
     Index:
@@ -485,7 +485,7 @@ components:
         application/problem+json:
           schema:
             $ref: './common/error_schema.yaml#/components/schemas/Error'
-    InternalServerError:
+    Internal:
       description: Internal Server Error
       content:
         application/problem+json:

--- a/api/openapi/types/zz_generated.api.go
+++ b/api/openapi/types/zz_generated.api.go
@@ -189,8 +189,8 @@ type InspectDataplanesForPolicyResponse = InspectDataplanesForPolicy
 // InspectRulesResponse A list of rules for a dataplane
 type InspectRulesResponse = InspectRules
 
-// InternalServerError standard error
-type InternalServerError = externalRef0.Error
+// Internal standard error
+type Internal = externalRef0.Error
 
 // ResourceTypeDescriptionListResponse A list of all resources install
 type ResourceTypeDescriptionListResponse = ResourceTypeDescriptionList

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -18,7 +18,7 @@ paths:
         '400':
           $ref: '#/components/responses/BadRequest'
         '500':
-          $ref: '#/components/responses/InternalServerError'
+          $ref: '#/components/responses/Internal'
   /_resources:
     get:
       operationId: get-resource-type-description
@@ -32,7 +32,7 @@ paths:
         '400':
           $ref: '#/components/responses/BadRequest'
         '500':
-          $ref: '#/components/responses/InternalServerError'
+          $ref: '#/components/responses/Internal'
   /global-insight:
     get:
       operationId: get-global-insight
@@ -46,7 +46,7 @@ paths:
         '400':
           $ref: '#/components/responses/BadRequest'
         '500':
-          $ref: '#/components/responses/InternalServerError'
+          $ref: '#/components/responses/Internal'
   /meshes/{mesh}/{resourceType}/{resourceName}/_rules:
     get:
       operationId: inspect-dataplanes-rules
@@ -84,7 +84,7 @@ paths:
         '400':
           $ref: '#/components/responses/BadRequest'
         '500':
-          $ref: '#/components/responses/InternalServerError'
+          $ref: '#/components/responses/Internal'
   /meshes/{mesh}/dataplanes/{name}/_config:
     get:
       summary: Get a proxy XDS config on a CP
@@ -133,7 +133,7 @@ paths:
         '400':
           $ref: '#/components/responses/BadRequest'
         '500':
-          $ref: '#/components/responses/InternalServerError'
+          $ref: '#/components/responses/Internal'
   /meshes/{mesh}/{policyType}/{policyName}/_resources/dataplanes:
     get:
       operationId: inspect-resources
@@ -189,7 +189,7 @@ paths:
         '400':
           $ref: '#/components/responses/BadRequest'
         '500':
-          $ref: '#/components/responses/InternalServerError'
+          $ref: '#/components/responses/Internal'
   /meshes/{mesh}/meshaccesslogs/{name}:
     get:
       summary: Returns MeshAccessLog entity
@@ -12880,7 +12880,7 @@ components:
         application/problem+json:
           schema:
             $ref: '#/components/schemas/Error'
-    InternalServerError:
+    Internal:
       description: Internal Server Error
       content:
         application/problem+json:


### PR DESCRIPTION
## Motivation

Rename InternalServerError to Internal so it gets correctly deduplicated in parent project

<!-- Why are we doing this change -->

## Implementation information

Rename the field.

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

xrel https://github.com/Kong/kong-mesh/issues/7202

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
