### PR TITLE
ci(gha): reduce permissions in workflows based on scorecard alerts

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -32,7 +32,6 @@ on:
         value: ${{ jobs.digest-images.outputs.DIGESTS }}
 permissions:
   contents: read
-  id-token: write # Required for image signing
 env:
   CI_TOOLS_DIR: "/home/runner/work/kuma/kuma/.ci_tools"
   FULL_MATRIX: ${{ inputs.FULL_MATRIX }}
@@ -93,6 +92,8 @@ jobs:
           make publish/pulp
   build-images:
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write # Required for image signing
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/_provenance.yaml
+++ b/.github/workflows/_provenance.yaml
@@ -22,11 +22,11 @@ on:
         required: true
         type: string
         description: notary repository
-permissions:
-  contents: read
+permissions: {}
 jobs:
   artifact-provenance:
     permissions:
+      contents: read
       actions: read # For getting workflow run info to build provenance
       id-token: write # needed for signing the images
       packages: write # Required for publishing provenance. Issue: https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/container#known-issues
@@ -49,6 +49,7 @@ jobs:
   #   Split provenance jobs for internal / official releases when repositories are split
   images-provenance:
     permissions:
+      contents: read
       actions: read # For getting workflow run info to build provenance
       id-token: write # needed for signing the images
       packages: write # Required for publishing provenance. Issue: https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/container#known-issues

--- a/.github/workflows/_provenance.yaml
+++ b/.github/workflows/_provenance.yaml
@@ -26,10 +26,9 @@ permissions: {}
 jobs:
   artifact-provenance:
     permissions:
-      contents: read
+      contents: write # To add assets to a release
       actions: read # For getting workflow run info to build provenance
       id-token: write # needed for signing the images
-      packages: write # Required for publishing provenance. Issue: https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/container#known-issues
     # need to use non hash version because of: https://github.com/slsa-framework/slsa-github-generator/issues/3498
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
     with:

--- a/.github/workflows/_provenance.yaml
+++ b/.github/workflows/_provenance.yaml
@@ -23,12 +23,13 @@ on:
         type: string
         description: notary repository
 permissions:
-  contents: write
-  id-token: write # needed for signing the images
-  actions: read # For getting workflow run info to build provenance
-  packages: write # Required for publishing provenance. Issue: https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/container#known-issues
+  contents: read
 jobs:
   artifact-provenance:
+    permissions:
+      actions: read # For getting workflow run info to build provenance
+      id-token: write # needed for signing the images
+      packages: write # Required for publishing provenance. Issue: https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/container#known-issues
     # need to use non hash version because of: https://github.com/slsa-framework/slsa-github-generator/issues/3498
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
     with:
@@ -47,6 +48,10 @@ jobs:
   # TODO:
   #   Split provenance jobs for internal / official releases when repositories are split
   images-provenance:
+    permissions:
+      actions: read # For getting workflow run info to build provenance
+      id-token: write # needed for signing the images
+      packages: write # Required for publishing provenance. Issue: https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/container#known-issues
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -7,10 +7,7 @@ on:
     branches: ["master", "release-*"]
   workflow_dispatch: # Allows manual trigger from GitHub Actions UI or via REST call
 permissions:
-  contents: write # To upload assets
-  id-token: write # For using token to sign images
-  actions: read # For getting workflow run info to build provenance
-  packages: write # Required for publishing provenance. Issue: https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/container#known-issues
+  contents: read
 env:
   KUMA_DIR: "."
   # To keep CI tools out of the SBOM, we use a `.ci_tools` directory in the parent
@@ -23,9 +20,8 @@ concurrency:
 jobs:
   check:
     permissions:
-      contents: read
-      # golangci-lint-action
-      checks: write
+      checks: write # needed for golangci/golangci-lint-action to add code annotations in PRs
+      contents: write # needed for sca-project to upload sbom to release assets
     timeout-minutes: 25
     runs-on: ubuntu-24.04
     env:
@@ -102,8 +98,6 @@ jobs:
           config: .syft.yaml
           upload-sbom-release-assets: true
   test:
-    permissions:
-      contents: read
     needs: ["check"]
     uses: ./.github/workflows/_test.yaml
     with:
@@ -112,8 +106,7 @@ jobs:
     secrets: inherit
   build_publish:
     permissions:
-      contents: read
-      id-token: write
+      id-token: write # Required for image signing
     needs: ["check", "test"]
     uses: ./.github/workflows/_build_publish.yaml
     if: ${{ fromJSON(needs.check.outputs.BUILD) }}
@@ -133,9 +126,8 @@ jobs:
     uses: ./.github/workflows/_provenance.yaml
     secrets: inherit
     permissions:
-      contents: write
-      id-token: write # For using token to sign images
       actions: read # For getting workflow run info to build provenance
+      id-token: write # For using token to sign images
       packages: write # Required for publishing provenance. Issue: https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/container#known-issues
     with:
       BINARY_ARTIFACTS_HASH_AS_FILE: ${{ needs.build_publish.outputs.BINARY_ARTIFACT_DIGEST_BASE64 }}
@@ -148,9 +140,6 @@ jobs:
     timeout-minutes: 10
     if: ${{ always() }}
     runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      actions: read # For getting workflow run info
     env:
       SECURITY_ASSETS_DOWNLOAD_PATH: "${{ github.workspace }}/security-assets"
       SECURITY_ASSETS_PACKAGE_NAME: "security-assets" # Cloudsmith package for hosting security assets
@@ -170,8 +159,6 @@ jobs:
           path: ${{ env.SECURITY_ASSETS_DOWNLOAD_PATH }}
           pattern: "*sbom.{cyclonedx,spdx}.json"
           merge-multiple: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "Download binary artifact provenance"
         if: ${{ needs.provenance.result == 'success' && github.ref_type == 'tag' }}
         id: collect_provenance
@@ -180,8 +167,6 @@ jobs:
           path: ${{ env.SECURITY_ASSETS_DOWNLOAD_PATH }}
           pattern: ${{ github.event.repository.name }}.intoto.jsonl
           merge-multiple: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "Generate security assets TAR"
         if: ${{ needs.build_publish.result == 'success' }}
         id: security_assets_metadata

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -127,8 +127,8 @@ jobs:
     uses: ./.github/workflows/_provenance.yaml
     secrets: inherit
     permissions:
-      contents: read
       actions: read # For getting workflow run info to build provenance
+      contents: write # To add assets to a release
       id-token: write # For using token to sign images
       packages: write # Required for publishing provenance. Issue: https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/container#known-issues
     with:

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -106,6 +106,7 @@ jobs:
     secrets: inherit
   build_publish:
     permissions:
+      contents: read
       id-token: write # Required for image signing
     needs: ["check", "test"]
     uses: ./.github/workflows/_build_publish.yaml

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -21,7 +21,6 @@ jobs:
   check:
     permissions:
       checks: write # needed for golangci/golangci-lint-action to add code annotations in PRs
-      contents: write # needed for sca-project to upload sbom to release assets
     timeout-minutes: 25
     runs-on: ubuntu-24.04
     env:

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -127,6 +127,7 @@ jobs:
     uses: ./.github/workflows/_provenance.yaml
     secrets: inherit
     permissions:
+      contents: read
       actions: read # For getting workflow run info to build provenance
       id-token: write # For using token to sign images
       packages: write # Required for publishing provenance. Issue: https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/container#known-issues

--- a/.github/workflows/ci-stability.yaml
+++ b/.github/workflows/ci-stability.yaml
@@ -16,6 +16,7 @@ on:
 env:
   GH_USER: "github-actions[bot]"
   GH_EMAIL: "<41898282+github-actions[bot]@users.noreply.github.com>"
+permissions: {}
 jobs:
   trigger-ci:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Motivation

This change reduces GitHub Actions workflow permissions to follow the principle of least privilege, addressing security alerts from Scorecard and improving overall workflow security.

## Implementation information

- `_build_publish.yaml`:
  - Moved `id-token: write` to `build-images` job
  - Removed global `id-token: write` permission

- `_provenance.yaml`:
  - Added `permissions: {}` globally
  - Set specific permissions (`contents`, `actions`, `id-token`, `packages`) per job

- `build-test-distribute.yaml`:
  - Removed global permissions
  - Added job-specific permissions for `checks`, `contents`, `id-token`, and `packages`

- `ci-stability.yaml`:
  - Added explicit `permissions: {}` globally

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
