### PR TITLE
ci(gha): add back contents: read permission to check job

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -20,6 +20,7 @@ concurrency:
 jobs:
   check:
     permissions:
+      contents: read
       checks: write # needed for golangci/golangci-lint-action to add code annotations in PRs
     timeout-minutes: 25
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Motivation

When job has any permission provided any other, non specified ones are treated like they would have permission `none` and global permissions block is not merged with them, so we have to add back `contents: read` permission to `check` job.

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
