### PR TITLE
ci(hadolint): make hadolint fail if there aren't any dockerfiles found

### DIFF
--- a/mk/check.mk
+++ b/mk/check.mk
@@ -56,7 +56,11 @@ kube-lint:
 
 .PHONY: hadolint
 hadolint:
-	find ./tools/releases/dockerfiles/ -type f -iname "Dockerfile*" | grep -v dockerignore | xargs -I {} $(HADOLINT) {}
+	@if [ `find ./tools/releases/dockerfiles/ -type f -iname "*Dockerfile" | grep -vc dockerignore` -eq 0 ]; then \
+	  echo "No Dockerfiles found, exiting with failure."; \
+	  exit 1; \
+	fi; \
+	find ./tools/releases/dockerfiles/ -type f -iname "*Dockerfile" | grep -v dockerignore | xargs -I {} $(HADOLINT) {}
 
 .PHONY: lint
 lint: helm-lint golangci-lint shellcheck kube-lint hadolint ginkgo/lint


### PR DESCRIPTION
## Motivation

I noticed that we renamed the dockerfiles but we did not change the hadolint target. Notice the `*` is not at the beginning.
<!-- Why are we doing this change -->

## Implementation information

Add a check to see if the find command found any files or not and modify the glob.
<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Not reported anywhere.

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
