### PR TITLE
fix(postgres-leader): add proper error logging in postgres leader elector

### DIFF
--- a/pkg/plugins/leader/postgres/leader_elector.go
+++ b/pkg/plugins/leader/postgres/leader_elector.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"fmt"
+	"github.com/pkg/errors"
 	"sync/atomic"
 	"time"
 
@@ -111,7 +112,16 @@ func (p *postgresLeaderElector) IsLeader() bool {
 type KumaPqLockLogger struct{}
 
 func (k *KumaPqLockLogger) Error(msg string, args ...interface{}) {
-	log.Error(nil, fmt.Sprintf(msg, args...))
+	if len(args) > 0 {
+		err, ok := args[0].(error)
+		if ok {
+			if !errors.Is(err, context.Canceled) {
+				log.Error(err, fmt.Sprintf(msg, args...))
+			}
+		}
+	} else {
+		log.Error(nil, fmt.Sprintf(msg, args...))
+	}
 }
 
 func (k *KumaPqLockLogger) Debug(msg string, args ...interface{}) {

--- a/pkg/plugins/leader/postgres/leader_elector.go
+++ b/pkg/plugins/leader/postgres/leader_elector.go
@@ -6,9 +6,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"cirello.io/pglock"
 	"github.com/pkg/errors"
 
-	"cirello.io/pglock"
 	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/runtime/component"
 	util_channels "github.com/kumahq/kuma/pkg/util/channels"

--- a/pkg/plugins/leader/postgres/leader_elector.go
+++ b/pkg/plugins/leader/postgres/leader_elector.go
@@ -3,12 +3,12 @@ package postgres
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
 	"sync/atomic"
 	"time"
 
-	"cirello.io/pglock"
+	"github.com/pkg/errors"
 
+	"cirello.io/pglock"
 	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/runtime/component"
 	util_channels "github.com/kumahq/kuma/pkg/util/channels"


### PR DESCRIPTION
## Motivation

We saw this error without any information: 
<img width="421" alt="image" src="https://github.com/user-attachments/assets/c9bf06f4-e94f-4322-9baa-fba0b5f56933" />
I've added proper error logging in postgres leader elector to see more details, and to skip the context cancelled error

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
