### PR TITLE
test(framework): replace bitnami helm chart with oci one (backport #12489)

### DIFF
--- a/test/framework/deployments/postgres/kubernetes.go
+++ b/test/framework/deployments/postgres/kubernetes.go
@@ -13,7 +13,10 @@ type k8SDeployment struct {
 	options *deployOptions
 }
 
-const releaseName = "postgres-release"
+const (
+	releaseName = "postgres-release"
+	chart       = "oci://registry-1.docker.io/bitnamicharts/postgresql"
+)
 
 func (t *k8SDeployment) GetEnvVars() map[string]string {
 	return t.envVars
@@ -55,12 +58,7 @@ data:
 		helmOpts.SetValues["primary.initdb.password"] = t.options.postgresPassword
 	}
 
-	err := helm.AddRepoE(cluster.GetTesting(), helmOpts, "bitnami", "https://charts.bitnami.com/bitnami")
-	if err != nil {
-		return err
-	}
-
-	return helm.InstallE(cluster.GetTesting(), helmOpts, "bitnami/postgresql", releaseName)
+	return helm.InstallE(cluster.GetTesting(), helmOpts, chart, releaseName)
 }
 
 func (t *k8SDeployment) Delete(cluster framework.Cluster) error {


### PR DESCRIPTION
## Motivation

Issues with adding the Bitnami repository caused by Cloudflare instability made our CI very unstable ([example CI run](https://github.com/kumahq/kuma/actions/runs/12669382227/job/35307422204))

```
"Error: looks like \"[https://charts.bitnami.com/bitnami\](https://charts.bitnami.com/bitnami/)" is not a valid chart repository or cannot be reached: stream error: stream ID 1; INTERNAL_ERROR; received from peer",
```

## Implementation information

Switched from the Bitnami Helm chart to the OCI-based chart, resolving issues with adding the Bitnami repository caused by Cloudflare instability. This change allows the complete removal of the Bitnami repository.

## Supporting documentation

- bitnami/charts issue 31257
- https://blog.bitnami.com/2024/10/bitnami-helm-charts-moving-to-oci.html