### PR TITLE
ci(github): add read content permissions to build-images

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -94,6 +94,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       id-token: write # Required for image signing
+      contents: read
     timeout-minutes: 30
     strategy:
       fail-fast: false


### PR DESCRIPTION
This was not the case anymore
