### PR TITLE
fix(policy): use new compute for rules and fix rules intersect (backport of  #12340)

### DIFF
--- a/pkg/core/xds/inspect/rules.go
+++ b/pkg/core/xds/inspect/rules.go
@@ -119,8 +119,7 @@ func getOutboundRuleAttachments(rules core_rules.Rules, networking *mesh_proto.D
 		}
 		attachment := byUniqueClusterName[name]
 		if attachment == nil {
-			subset := core_rules.SubsetFromTags(outboundTags)
-			computedRule := rules.Compute(subset)
+			computedRule := rules.Compute(core_rules.Element(outboundTags))
 			if computedRule == nil {
 				continue
 			}

--- a/pkg/plugins/policies/core/rules/rules.go
+++ b/pkg/plugins/policies/core/rules/rules.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"encoding"
 	"fmt"
+	"maps"
 	"sort"
 	"strings"
 
@@ -130,6 +131,66 @@ func NewSubset(m map[string]string) Subset {
 	return s
 }
 
+// ContainsElement returns true if there exists a key in 'other' that matches the current set,
+// and the corresponding k-v pair must match the set rule. Also, the left set rules of the current set can't make an impact.
+// Empty set is a superset for all elements.
+//
+// For example if you have a Subset with Tags: [{key: zone, value: east, not: true}, {key: service, value: frontend, not: false}]
+// an Element with k-v pairs: 1) service: frontend  2) version: zone1
+// there's a k-v pair 'service: frontend' in Element that matches the set rule {key: service, value: frontend, not: false}
+// the left set rule of Subset {key: zone, value: east, not: true} won't make an impact because of 'not: true'
+func (ss Subset) ContainsElement(other Element) bool {
+	// 1. find the overlaps of element and current subset
+	// 2. verify the overlaps
+	// 3. verify the left of current subset
+	// 4. if no overlaps, verify if all the Subset rules are negative
+
+	if len(ss) == 0 {
+		return true
+	}
+	if len(other) == 0 {
+		return false
+	}
+
+	hasOverlapKey := false
+	for _, tag := range ss {
+		otherVal, ok := other[tag.Key]
+		if ok {
+			hasOverlapKey = true
+
+			// contradict
+			if tag.Value == otherVal && tag.Not {
+				return false
+			}
+			// intersect
+			if tag.Value == otherVal && !tag.Not {
+				continue
+			}
+			// intersect
+			if tag.Value != otherVal && tag.Not {
+				continue
+			}
+			// contradict
+			if tag.Value != otherVal && !tag.Not {
+				return false
+			}
+		} else if !tag.Not {
+			// For those items that don't exist in element should not make an impact.
+			// For example, the DP with tag {"service: frontend"} doesn't match
+			// the policy with matching tags [{"service: frontend"}, {"zone": "east"}]
+			return false
+		}
+	}
+
+	// if the current Subset owns all of negative rules and no overlapped keys in Element,
+	// we can also regard the Subset contains Element
+	if !hasOverlapKey && ss.NumPositive() == 0 {
+		return true
+	}
+
+	return hasOverlapKey
+}
+
 // IsSubset returns true if 'other' is a subset of the current set.
 // Empty set is a superset for all subsets.
 func (ss Subset) IsSubset(other Subset) bool {
@@ -179,6 +240,36 @@ func isSubset(t1, t2 Tag) bool {
 
 // Intersect returns true if there exists an element that belongs both to 'other' and current set.
 // Empty set intersects with all sets.
+//
+// We're using this function to check if 2 'from' rules of MeshTrafficPermission can be applied to the same client DPP.
+// For example:
+//
+//	from:
+//	  - targetRef:
+//	      kind: MeshSubset
+//	      tags:
+//	        team: team-a
+//	  - targetRef:
+//	      kind: MeshSubset
+//	      tags:
+//	        zone: east
+//
+// there is a DPP with tags 'team: team-a' and 'zone: east' that's subjected to both these rules.
+// So 'from[0]' and 'from[1]' have an intersection.
+// However, in another example:
+//
+//	from:
+//	 - targetRef:
+//	     kind: MeshSubset
+//	     tags:
+//	       team: team-a
+//	 - targetRef:
+//	     kind: MeshSubset
+//	     tags:
+//	       team: team-b
+//	       zone: east
+//
+// there is no DPP that'd hit both 'from[0]' and 'from[1]'. So in this case they don't have an intersection.
 func (ss Subset) Intersect(other Subset) bool {
 	if len(ss) == 0 || len(other) == 0 {
 		return true
@@ -196,7 +287,7 @@ func (ss Subset) Intersect(other Subset) bool {
 		}
 		oTags, ok := otherByKeysOnlyPositive[tag.Key]
 		if !ok {
-			return true
+			continue
 		}
 		for _, otherTag := range oTags {
 			if otherTag != tag {
@@ -233,6 +324,26 @@ func SubsetFromTags(tags map[string]string) Subset {
 		subset = append(subset, Tag{Key: k, Value: v})
 	}
 	return subset
+}
+
+type Element map[string]string
+
+func (e Element) WithKeyValue(key, value string) Element {
+	c := maps.Clone(e)
+	if c == nil {
+		c = Element{}
+	}
+
+	c[key] = value
+	return c
+}
+
+func MeshElement() Element {
+	return Element{}
+}
+
+func MeshServiceElement(name string) Element {
+	return Element{mesh_proto.ServiceTag: name}
 }
 
 // NumPositive returns a number of tags without negation
@@ -290,20 +401,23 @@ func (r *Rule) GetBackendRefOrigin(hash common_api.MatchesHash) (core_model.Reso
 
 type Rules []*Rule
 
-// Compute returns configuration for the given subset.
-func (rs Rules) Compute(sub Subset) *Rule {
+// Compute returns Rule for the given element.
+func (rs Rules) Compute(element Element) *Rule {
 	for _, rule := range rs {
-		if rule.Subset.IsSubset(sub) {
+		if rule.Subset.ContainsElement(element) {
 			return rule
 		}
 	}
 	return nil
 }
 
-func ComputeConf[T any](rs Rules, sub Subset) *T {
-	if computed := rs.Compute(sub); computed != nil {
+// ComputeConf returns configuration for the given element.
+func ComputeConf[T any](rs Rules, element Element) *T {
+	computed := rs.Compute(element)
+	if computed != nil {
 		return pointer.To(computed.Conf.(T))
 	}
+
 	return nil
 }
 

--- a/pkg/plugins/policies/core/rules/rules_test.go
+++ b/pkg/plugins/policies/core/rules/rules_test.go
@@ -241,58 +241,174 @@ var _ = Describe("Rules", func() {
 			func(given testCase) {
 				Expect(given.s1.Intersect(given.s2)).To(Equal(given.intersect))
 			},
-			Entry("entry 1", testCase{
+			Entry("positive, same key and value", testCase{
 				s1: []core_rules.Tag{
-					{Key: "service", Value: "backend"},
-				},
-				s2: []core_rules.Tag{
-					{Key: "service", Not: true, Value: "frontend"},
-					{Key: "version", Value: "v2"},
-				},
-				intersect: true,
-			}),
-			Entry("entry 2", testCase{
-				s1: []core_rules.Tag{
-					{Key: "service", Value: "backend"},
+					{Key: "service", Value: "frontend"},
 				},
 				s2: []core_rules.Tag{
 					{Key: "service", Value: "frontend"},
-					{Key: "version", Value: "v2"},
+				},
+				intersect: true,
+			}),
+			Entry("positive, same key, different value", testCase{
+				s1: []core_rules.Tag{
+					{Key: "service", Value: "frontend"},
+				},
+				s2: []core_rules.Tag{
+					{Key: "service", Value: "backend"},
 				},
 				intersect: false,
 			}),
-			Entry("entry 3", testCase{
+			Entry("positive, multiple key-values with overlap key-value", testCase{
 				s1: []core_rules.Tag{
-					{Key: "service", Not: true, Value: "backend"},
+					{Key: "service", Value: "frontend"},
+					{Key: "version", Value: "v1"},
 				},
 				s2: []core_rules.Tag{
-					{Key: "service", Not: true, Value: "backend"},
-					{Key: "version", Value: "v2"},
+					{Key: "service", Value: "frontend"},
 				},
 				intersect: true,
 			}),
-			Entry("entry 4", testCase{
+			Entry("positive, multiple key-values with overlap key but different value", testCase{
 				s1: []core_rules.Tag{
-					{Key: "service", Not: true, Value: "backend"},
-					{Key: "version", Not: true, Value: "v1"},
+					{Key: "service", Value: "frontend"},
 				},
 				s2: []core_rules.Tag{
-					{Key: "service", Not: true, Value: "backend"},
-					{Key: "version", Not: true, Value: "v1"},
-					{Key: "zone", Value: "east"},
+					{Key: "service", Value: "backend"},
+					{Key: "version", Value: "v1"},
+				},
+				intersect: false,
+			}),
+			Entry("positive, different key, different value", testCase{
+				s1: []core_rules.Tag{
+					{Key: "service", Value: "frontend"},
+				},
+				s2: []core_rules.Tag{
+					{Key: "version", Value: "v1"},
 				},
 				intersect: true,
 			}),
-			Entry("entry 5", testCase{
+			Entry("positive, superset", testCase{
 				s1: []core_rules.Tag{},
 				s2: []core_rules.Tag{
+					{Key: "service", Value: "backend"},
+					{Key: "version", Value: "v1"},
+					{Key: "zone", Value: "east"},
+				},
+				intersect: true,
+			}),
+			Entry("a part of negation, same key and value", testCase{
+				s1: []core_rules.Tag{
+					{Key: "service", Not: true, Value: "frontend"},
+				},
+				s2: []core_rules.Tag{
+					{Key: "service", Value: "frontend"},
+				},
+				intersect: true,
+			}),
+			Entry("a part of negation, same key, different value", testCase{
+				s1: []core_rules.Tag{
+					{Key: "service", Not: true, Value: "frontend"},
+				},
+				s2: []core_rules.Tag{
+					{Key: "service", Value: "backend"},
+				},
+				intersect: true,
+			}),
+			Entry("a part of negation, multiple key-values with overlap key-value", testCase{
+				s1: []core_rules.Tag{
+					{Key: "service", Not: true, Value: "frontend"},
+					{Key: "version", Value: "v1"},
+				},
+				s2: []core_rules.Tag{
+					{Key: "service", Value: "frontend"},
+				},
+				intersect: true,
+			}),
+			Entry("a part of negation, multiple key-values with overlap key but different value", testCase{
+				s1: []core_rules.Tag{
+					{Key: "service", Not: true, Value: "frontend"},
+					{Key: "version", Value: "v1"},
+				},
+				s2: []core_rules.Tag{
+					{Key: "service", Value: "backend"},
+				},
+				intersect: true,
+			}),
+			Entry("a part of negation, different key, different value", testCase{
+				s1: []core_rules.Tag{
+					{Key: "service", Not: true, Value: "frontend"},
+				},
+				s2: []core_rules.Tag{
+					{Key: "version", Value: "v1"},
+				},
+				intersect: true,
+			}),
+			Entry("negation, same key and value", testCase{
+				s1: []core_rules.Tag{
+					{Key: "service", Not: true, Value: "backend"},
+				},
+				s2: []core_rules.Tag{
+					{Key: "service", Not: true, Value: "backend"},
+				},
+				intersect: true,
+			}),
+			Entry("negation, same key, different value", testCase{
+				s1: []core_rules.Tag{
+					{Key: "service", Not: true, Value: "frontend"},
+				},
+				s2: []core_rules.Tag{
+					{Key: "service", Not: true, Value: "backend"},
+				},
+				intersect: true,
+			}),
+			Entry("negation, multiple key-values with overlap key-value", testCase{
+				s1: []core_rules.Tag{
+					{Key: "service", Not: true, Value: "backend"},
+					{Key: "version", Not: true, Value: "v1"},
+				},
+				s2: []core_rules.Tag{
 					{Key: "service", Not: true, Value: "backend"},
 					{Key: "version", Not: true, Value: "v1"},
 					{Key: "zone", Value: "east"},
 				},
 				intersect: true,
 			}),
-			Entry("entry 6", testCase{
+			Entry("negation, multiple key-values with overlap key but different value", testCase{
+				s1: []core_rules.Tag{
+					{Key: "service", Not: true, Value: "frontend"},
+					{Key: "version", Not: true, Value: "v1"},
+				},
+				s2: []core_rules.Tag{
+					{Key: "service", Not: true, Value: "backend"},
+					{Key: "version", Not: true, Value: "v1"},
+					{Key: "zone", Value: "east"},
+				},
+				intersect: true,
+			}),
+			Entry("negation, multiple key-values with overlap key but different value", testCase{
+				s1: []core_rules.Tag{
+					{Key: "service", Not: true, Value: "frontend"},
+					{Key: "version", Not: true, Value: "v1"},
+				},
+				s2: []core_rules.Tag{
+					{Key: "service", Not: true, Value: "backend"},
+					{Key: "version", Not: true, Value: "v1"},
+					{Key: "zone", Value: "east"},
+				},
+				intersect: true,
+			}),
+			Entry("negation, different key, different value", testCase{
+				s1: []core_rules.Tag{
+					{Key: "service", Not: true, Value: "frontend"},
+				},
+				s2: []core_rules.Tag{
+					{Key: "version", Not: true, Value: "v1"},
+					{Key: "zone", Value: "east"},
+				},
+				intersect: true,
+			}),
+			Entry("negation, superset", testCase{
 				s1: []core_rules.Tag{
 					{Key: "service", Not: true, Value: "backend"},
 					{Key: "version", Not: true, Value: "v1"},
@@ -366,16 +482,215 @@ var _ = Describe("Rules", func() {
 		)
 	})
 
+	Describe("ContainsElement", func() {
+		type testCase struct {
+			ss       core_rules.Subset
+			other    core_rules.Element
+			contains bool
+		}
+
+		DescribeTable("should respond if subset ss contains element other",
+			func(given testCase) {
+				Expect(given.ss.ContainsElement(given.other)).To(Equal(given.contains))
+			},
+			Entry("single matched rule by single rule and elements", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1"},
+				},
+				other: core_rules.Element{
+					"key1": "val1",
+					"key2": "val2",
+				},
+				contains: true,
+			}),
+			Entry("single matched rule by single rule and element", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1"},
+				},
+				other: core_rules.Element{
+					"key1": "val1",
+				},
+				contains: true,
+			}),
+			Entry("single matched rule, rule with negation, element has key with another value", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1", Not: true},
+				},
+				other: core_rules.Element{
+					"key1": "val2",
+				},
+				contains: true,
+			}),
+			Entry("empty set is a superset for all element", testCase{
+				ss: []core_rules.Tag{},
+				other: core_rules.Element{
+					"key1": "val2",
+				},
+				contains: true,
+			}),
+			Entry("empty element", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1"},
+				},
+				other:    core_rules.Element{},
+				contains: false,
+			}),
+			Entry("no rules matched, rule with negation, element has same key value", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1", Not: true},
+				},
+				other: core_rules.Element{
+					"key1": "val1",
+				},
+				contains: false,
+			}),
+			Entry("no rules matched, rule with negation, element has another key", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1", Not: true},
+				},
+				other: core_rules.Element{
+					"key2": "val2",
+				},
+				contains: true,
+			}),
+			Entry("no rules matched, element has key which is not presented in superset", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1"},
+				},
+				other: core_rules.Element{
+					"key2": "val2",
+				},
+				contains: false,
+			}),
+
+			Entry("no rules matched, rules with positive, element has key with another value", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1"},
+				},
+				other: core_rules.Element{
+					"key1": "val2",
+				},
+				contains: false,
+			}),
+			Entry("no rules matched, rules with positive, element has only one overlapped key value", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1"},
+					{Key: "key2", Value: "val2"},
+				},
+				other: core_rules.Element{
+					"key1": "val1",
+				},
+				contains: false,
+			}),
+			Entry("single matched rule by rules and element, rules with a part of negation", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1"},
+					{Key: "key2", Value: "val2", Not: true},
+				},
+				other: core_rules.Element{
+					"key1": "val1",
+				},
+				contains: true,
+			}),
+			Entry("single matched rule by rules and element, rules with a part of negation, element has key with another value", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1", Not: true},
+					{Key: "key2", Value: "val2"},
+				},
+				other: core_rules.Element{
+					"key1": "val2",
+				},
+				contains: false,
+			}),
+			Entry("no rules matched, rules with negation, element has same key value", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1", Not: true},
+					{Key: "key2", Value: "val2", Not: true},
+				},
+				other: core_rules.Element{
+					"key1": "val1",
+				},
+				contains: false,
+			}),
+			Entry("no rules matched, rules with a part of negation, element has another key", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1"},
+					{Key: "key2", Value: "val2", Not: true},
+				},
+				other: core_rules.Element{
+					"key3": "val3",
+				},
+				contains: false,
+			}),
+			Entry("no rules matched, rules with positive, element has another key", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1"},
+					{Key: "key2", Value: "val2"},
+				},
+				other: core_rules.Element{
+					"key3": "val3",
+				},
+				contains: false,
+			}),
+			Entry("rules matched, rules with negation, element has another key", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1", Not: true},
+					{Key: "key2", Value: "val2", Not: true},
+				},
+				other: core_rules.Element{
+					"key3": "val3",
+				},
+				contains: true,
+			}),
+			Entry("no rules matched, n dimensions rules and n-1 dimensions elements, rules with positive, elements have another keys", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1"},
+					{Key: "key2", Value: "val2"},
+					{Key: "key3", Value: "val3"},
+				},
+				other: core_rules.Element{
+					"key4": "val4",
+					"key5": "val5",
+				},
+				contains: false,
+			}),
+			Entry("no rules matched, n dimensions rules and n-1 dimensions elements, rules with positive, elements have overlapped key by rules", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1"},
+					{Key: "key2", Value: "val2"},
+					{Key: "key3", Value: "val3"},
+				},
+				other: core_rules.Element{
+					"key3": "val3",
+					"key4": "val4",
+				},
+				contains: false,
+			}),
+			Entry("rules matched, n dimensions rules and n-1 dimensions elements, rules with a part of negation, elements have overlapped key by rules", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1", Not: true},
+					{Key: "key2", Value: "val2", Not: true},
+					{Key: "key3", Value: "val3"},
+				},
+				other: core_rules.Element{
+					"key3": "val3",
+					"key4": "val4",
+				},
+				contains: true,
+			}),
+		)
+	})
+
 	Describe("Eval", func() {
 		type testCase struct {
 			rules    core_rules.Rules
-			subset   core_rules.Subset
+			element  core_rules.Element
 			confYAML []byte
 		}
 
 		DescribeTable("should compute conf for subset based on rules",
 			func(given testCase) {
-				conf := given.rules.Compute(given.subset)
+				conf := given.rules.Compute(given.element)
 				if given.confYAML == nil {
 					Expect(conf).To(BeNil())
 				} else {
@@ -384,7 +699,7 @@ var _ = Describe("Rules", func() {
 					Expect(actualYAML).To(MatchYAML(given.confYAML))
 				}
 			},
-			Entry("single matched rule", testCase{
+			Entry("single matched rule by single rule and elements", testCase{
 				rules: core_rules.Rules{
 					{
 						Subset: []core_rules.Tag{
@@ -395,13 +710,29 @@ var _ = Describe("Rules", func() {
 						},
 					},
 				},
-				subset: []core_rules.Tag{
-					{Key: "key1", Value: "val1"},
-					{Key: "key2", Value: "val2"},
+				element: core_rules.Element{
+					"key1": "val1",
+					"key2": "val2",
 				},
 				confYAML: []byte(`action: Allow`),
 			}),
-			Entry("single matched not", testCase{
+			Entry("single matched rule by single rule and element", testCase{
+				rules: core_rules.Rules{
+					{
+						Subset: []core_rules.Tag{
+							{Key: "key1", Value: "val1"},
+						},
+						Conf: meshtrafficpermission_api.Conf{
+							Action: "Allow",
+						},
+					},
+				},
+				element: core_rules.Element{
+					"key1": "val1",
+				},
+				confYAML: []byte(`action: Allow`),
+			}),
+			Entry("single matched rule, rule with negation, element has key with another value", testCase{
 				rules: core_rules.Rules{
 					{
 						Subset: []core_rules.Tag{
@@ -412,28 +743,12 @@ var _ = Describe("Rules", func() {
 						},
 					},
 				},
-				subset: []core_rules.Tag{
-					{Key: "key1", Value: "val2"},
+				element: core_rules.Element{
+					"key1": "val2",
 				},
 				confYAML: []byte(`action: Allow`),
 			}),
-			Entry("single matched rule, rule and subset with negation", testCase{
-				rules: core_rules.Rules{
-					{
-						Subset: []core_rules.Tag{
-							{Key: "key1", Value: "val1", Not: true},
-						},
-						Conf: meshtrafficpermission_api.Conf{
-							Action: "Allow",
-						},
-					},
-				},
-				subset: []core_rules.Tag{
-					{Key: "key1", Value: "val1", Not: true},
-				},
-				confYAML: []byte(`action: Allow`),
-			}),
-			Entry("empty set is a superset for all subset", testCase{
+			Entry("empty set is a superset for all element", testCase{
 				rules: core_rules.Rules{
 					{
 						Subset: []core_rules.Tag{}, // empty set
@@ -442,13 +757,13 @@ var _ = Describe("Rules", func() {
 						},
 					},
 				},
-				subset: []core_rules.Tag{
-					{Key: "key1", Value: "val1"},
-					{Key: "key2", Value: "val2"},
+				element: core_rules.Element{
+					"key1": "val1",
+					"key2": "val2",
 				},
 				confYAML: []byte(`action: Allow`),
 			}),
-			Entry("no rules matched, rule with negation, subset without key", testCase{
+			Entry("empty element", testCase{
 				rules: core_rules.Rules{
 					{
 						Subset: []core_rules.Tag{
@@ -459,44 +774,10 @@ var _ = Describe("Rules", func() {
 						},
 					},
 				},
-				subset: []core_rules.Tag{
-					{Key: "key2", Value: "val2"},
-				},
+				element:  core_rules.Element{},
 				confYAML: nil,
 			}),
-			Entry("no rules matched, subset has key which is not presented in superset", testCase{
-				rules: core_rules.Rules{
-					{
-						Subset: []core_rules.Tag{
-							{Key: "key1", Value: "val1"},
-						},
-						Conf: meshtrafficpermission_api.Conf{
-							Action: "Allow",
-						},
-					},
-				},
-				subset: []core_rules.Tag{
-					{Key: "key2", Value: "val2"}, // key2 is not in rules[0].Subset
-				},
-				confYAML: nil,
-			}),
-			Entry("no rules matched, subset has key with another value", testCase{
-				rules: core_rules.Rules{
-					{
-						Subset: []core_rules.Tag{
-							{Key: "key1", Value: "val1"},
-						},
-						Conf: meshtrafficpermission_api.Conf{
-							Action: "Allow",
-						},
-					},
-				},
-				subset: []core_rules.Tag{
-					{Key: "key1", Value: "val2"}, // val2 is not equal to rules[0].Subset["key1"]
-				},
-				confYAML: nil,
-			}),
-			Entry("no rules matched, rule with negation", testCase{
+			Entry("no rules matched, rule with negation, element has same key value", testCase{
 				rules: core_rules.Rules{
 					{
 						Subset: []core_rules.Tag{
@@ -507,12 +788,28 @@ var _ = Describe("Rules", func() {
 						},
 					},
 				},
-				subset: []core_rules.Tag{
-					{Key: "key1", Value: "val1"}, // rule has "key1: !val1"
+				element: core_rules.Element{
+					"key1": "val1",
 				},
 				confYAML: nil,
 			}),
-			Entry("no rules matched, subset with negation", testCase{
+			Entry("no rules matched, rule with negation, element has another key", testCase{
+				rules: core_rules.Rules{
+					{
+						Subset: []core_rules.Tag{
+							{Key: "key1", Value: "val1", Not: true},
+						},
+						Conf: meshtrafficpermission_api.Conf{
+							Action: "Allow",
+						},
+					},
+				},
+				element: core_rules.Element{
+					"key2": "val2",
+				},
+				confYAML: []byte(`action: Allow`),
+			}),
+			Entry("no rules matched, element has key which is not presented in superset", testCase{
 				rules: core_rules.Rules{
 					{
 						Subset: []core_rules.Tag{
@@ -523,8 +820,24 @@ var _ = Describe("Rules", func() {
 						},
 					},
 				},
-				subset: []core_rules.Tag{
-					{Key: "key1", Value: "val1", Not: true}, // rule has "key1: val1"
+				element: core_rules.Element{
+					"key2": "val2", // key2 is not in rules[0].Subset
+				},
+				confYAML: nil,
+			}),
+			Entry("no rules matched, element has key with another value", testCase{
+				rules: core_rules.Rules{
+					{
+						Subset: []core_rules.Tag{
+							{Key: "key1", Value: "val1"},
+						},
+						Conf: meshtrafficpermission_api.Conf{
+							Action: "Allow",
+						},
+					},
+				},
+				element: core_rules.Element{
+					"key1": "val2", // val2 is not equal to rules[0].Subset["key1"]
 				},
 				confYAML: nil,
 			}),
@@ -553,11 +866,28 @@ var _ = Describe("Rules", func() {
 						},
 					},
 				},
-				subset: []core_rules.Tag{
-					{Key: "key2", Value: "val2"},
-					{Key: "key3", Value: "val3"},
+				element: core_rules.Element{
+					"key2": "val2",
+					"key3": "val3",
 				},
 				confYAML: []byte(`action: Deny`),
+			}),
+			Entry("n dimensions subset and n-1 dimensions elements", testCase{
+				rules: core_rules.Rules{
+					{
+						Subset: []core_rules.Tag{
+							{Key: "key1", Value: "val1"},
+							{Key: "key2", Value: "val1", Not: true},
+						},
+						Conf: meshtrafficpermission_api.Conf{
+							Action: "Allow",
+						},
+					},
+				},
+				element: core_rules.Element{
+					"key1": "val1",
+				},
+				confYAML: []byte(`action: Allow`),
 			}),
 		)
 	})

--- a/pkg/plugins/policies/core/rules/testdata/rules/from/06.golden.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/rules/from/06.golden.yaml
@@ -1,0 +1,31 @@
+Rules:
+  127.0.0.1:80:
+    - BackendRefOriginIndex: {}
+      Conf:
+        action: Allow
+      Origin:
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: default
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: mtp-allow-kuma-other-ns-and-tag
+          type: MeshTrafficPermission
+      Subset:
+        - Key: abcd
+          Not: false
+          Value: abcd
+        - Key: k8s.kuma.io/namespace
+          Not: false
+          Value: kuma-other
+    - BackendRefOriginIndex: {}
+      Conf:
+        action: Allow
+      Origin:
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: default
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: mtp-allow-kuma-one
+          type: MeshTrafficPermission
+      Subset:
+        - Key: k8s.kuma.io/namespace
+          Not: false
+          Value: kuma-one

--- a/pkg/plugins/policies/core/rules/testdata/rules/from/06.input.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/rules/from/06.input.yaml
@@ -1,0 +1,29 @@
+# Multiple MeshTrafficPermission policies
+type: MeshTrafficPermission
+mesh: default
+name: mtp-allow-kuma-one
+spec:
+  targetRef:
+    kind: Mesh
+  from:
+    - targetRef:
+        kind: MeshSubset
+        tags:
+          k8s.kuma.io/namespace: kuma-one
+      default:
+        action: Allow
+---
+type: MeshTrafficPermission
+mesh: default
+name: mtp-allow-kuma-other-ns-and-tag
+spec:
+  targetRef:
+    kind: Mesh
+  from:
+    - targetRef:
+        kind: MeshSubset
+        tags:
+          abcd: abcd
+          k8s.kuma.io/namespace: kuma-other
+      default:
+        action: Allow

--- a/pkg/plugins/policies/core/rules/testdata/rules/from/07.golden.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/rules/from/07.golden.yaml
@@ -1,0 +1,34 @@
+Rules:
+  127.0.0.1:80:
+    - BackendRefOriginIndex: {}
+      Conf:
+        action: Deny
+      Origin:
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: default
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: mtp-allow-kuma-one
+          type: MeshTrafficPermission
+      Subset:
+        - Key: app
+          Not: false
+          Value: demo
+        - Key: k8s.kuma.io/namespace
+          Not: false
+          Value: kuma-one
+    - BackendRefOriginIndex: {}
+      Conf:
+        action: Allow
+      Origin:
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: default
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: mtp-allow-kuma-one
+          type: MeshTrafficPermission
+      Subset:
+        - Key: app
+          Not: true
+          Value: demo
+        - Key: k8s.kuma.io/namespace
+          Not: false
+          Value: kuma-one

--- a/pkg/plugins/policies/core/rules/testdata/rules/from/07.input.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/rules/from/07.input.yaml
@@ -1,0 +1,21 @@
+# MeshTrafficPermission with 2 from tags which one is a subset of another one
+type: MeshTrafficPermission
+mesh: default
+name: mtp-allow-kuma-one
+spec:
+  targetRef:
+    kind: Mesh
+  from:
+    - targetRef:
+        kind: MeshSubset
+        tags:
+          k8s.kuma.io/namespace: kuma-one
+      default:
+        action: Allow
+    - targetRef:
+        kind: MeshSubset
+        tags:
+          app: demo
+          k8s.kuma.io/namespace: kuma-one
+      default:
+        action: Deny

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin.go
@@ -112,7 +112,7 @@ func applyToOutbounds(
 
 		serviceName := outbound.LegacyOutbound.GetService()
 
-		if err := configureOutbound(rules.Rules, dataplane, core_rules.MeshService(serviceName), serviceName, listener, backends, path); err != nil {
+		if err := configureOutbound(rules.Rules, dataplane, core_rules.MeshServiceElement(serviceName), serviceName, listener, backends, path); err != nil {
 			return err
 		}
 	}
@@ -128,7 +128,7 @@ func applyToTransparentProxyListeners(
 		if err := configureOutbound(
 			policies.ToRules.Rules,
 			dataplane,
-			core_rules.MeshService(core_mesh.PassThroughService),
+			core_rules.MeshServiceElement(core_mesh.PassThroughService),
 			"external",
 			ipv4,
 			backends,
@@ -142,7 +142,7 @@ func applyToTransparentProxyListeners(
 		return configureOutbound(
 			policies.ToRules.Rules,
 			dataplane,
-			core_rules.MeshService(core_mesh.PassThroughService),
+			core_rules.MeshServiceElement(core_mesh.PassThroughService),
 			"external",
 			ipv6,
 			backends,
@@ -162,7 +162,7 @@ func applyToDirectAccess(
 		return configureOutbound(
 			rules.Rules,
 			dataplane,
-			core_rules.MeshService(core_mesh.PassThroughService),
+			core_rules.MeshServiceElement(core_mesh.PassThroughService),
 			name,
 			listener,
 			backends,
@@ -209,7 +209,7 @@ func applyToGateway(
 			if err := configureOutbound(
 				toListenerRules.Rules,
 				proxy.Dataplane,
-				core_rules.Subset{},
+				core_rules.MeshElement(),
 				mesh_proto.MatchAllTag,
 				listener,
 				backends,
@@ -239,7 +239,7 @@ func configureInbound(
 	serviceName := dataplane.Spec.GetIdentifyingService()
 
 	// `from` section of MeshAccessLog only allows Mesh targetRef
-	conf := core_rules.ComputeConf[api.Conf](fromRules, core_rules.MeshSubset())
+	conf := core_rules.ComputeConf[api.Conf](fromRules, core_rules.MeshElement())
 	if conf == nil {
 		return nil
 	}
@@ -268,7 +268,7 @@ func configureInbound(
 func configureOutbound(
 	toRules core_rules.Rules,
 	dataplane *core_mesh.DataplaneResource,
-	subset core_rules.Subset,
+	element core_rules.Element,
 	destinationServiceName string,
 	listener *envoy_listener.Listener,
 	backendsAcc *plugin_xds.EndpointAccumulator,
@@ -276,7 +276,7 @@ func configureOutbound(
 ) error {
 	sourceService := dataplane.Spec.GetIdentifyingService()
 
-	conf := core_rules.ComputeConf[api.Conf](toRules, subset)
+	conf := core_rules.ComputeConf[api.Conf](toRules, element)
 	if conf == nil {
 		return nil
 	}

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin.go
@@ -98,7 +98,7 @@ func applyToInbounds(
 			continue
 		}
 
-		if err := configure(rules, core_rules.MeshSubset(), cluster); err != nil {
+		if err := configure(rules, core_rules.MeshElement(), cluster); err != nil {
 			return err
 		}
 	}
@@ -119,7 +119,7 @@ func applyToOutbounds(
 	)
 
 	for cluster, serviceName := range targetedClusters {
-		if err := configure(rules.Rules, core_rules.MeshService(serviceName), cluster); err != nil {
+		if err := configure(rules.Rules, core_rules.MeshServiceElement(serviceName), cluster); err != nil {
 			return err
 		}
 	}
@@ -161,7 +161,7 @@ func applyToGateways(
 
 					if err := configure(
 						rules.Rules,
-						core_rules.MeshService(serviceName),
+						core_rules.MeshServiceElement(serviceName),
 						cluster,
 					); err != nil {
 						return err
@@ -192,10 +192,10 @@ func applyToGateways(
 
 func configure(
 	rules core_rules.Rules,
-	subset core_rules.Subset,
+	element core_rules.Element,
 	cluster *envoy_cluster.Cluster,
 ) error {
-	if computed := rules.Compute(subset); computed != nil {
+	if computed := rules.Compute(element); computed != nil {
 		return plugin_xds.NewConfigurer(computed.Conf.(api.Conf)).ConfigureCluster(cluster)
 	}
 

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin.go
@@ -78,7 +78,7 @@ func applyToOutbounds(
 	)
 
 	for cluster, serviceName := range targetedClusters {
-		if err := configure(dataplane, rules.Rules, core_rules.MeshService(serviceName), meshCtx.GetServiceProtocol(serviceName), cluster); err != nil {
+		if err := configure(dataplane, rules.Rules, core_rules.MeshServiceElement(serviceName), meshCtx.GetServiceProtocol(serviceName), cluster); err != nil {
 			return err
 		}
 	}
@@ -123,7 +123,7 @@ func applyToGateways(
 					if err := configure(
 						proxy.Dataplane,
 						rules.Rules,
-						core_rules.MeshService(serviceName),
+						core_rules.MeshServiceElement(serviceName),
 						toProtocol(listenerInfo.Listener.Protocol),
 						cluster,
 					); err != nil {
@@ -166,11 +166,11 @@ func toProtocol(p mesh_proto.MeshGateway_Listener_Protocol) core_mesh.Protocol {
 func configure(
 	dataplane *core_mesh.DataplaneResource,
 	rules core_rules.Rules,
-	subset core_rules.Subset,
+	element core_rules.Element,
 	protocol core_mesh.Protocol,
 	cluster *envoy_cluster.Cluster,
 ) error {
-	conf := core_rules.ComputeConf[api.Conf](rules, subset)
+	conf := core_rules.ComputeConf[api.Conf](rules, element)
 	if conf == nil {
 		return nil
 	}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
@@ -146,7 +146,7 @@ func ComputeHTTPRouteConf(toRules rules.ToRules, svc meshroute_xds.DestinationSe
 	var conf *api.PolicyDefault
 	backendRefOrigin := map[common_api.MatchesHash]core_model.ResourceMeta{}
 
-	ruleHTTP := toRules.Rules.Compute(core_rules.MeshService(svc.ServiceName))
+	ruleHTTP := toRules.Rules.Compute(core_rules.MeshServiceElement(svc.ServiceName))
 	if ruleHTTP != nil {
 		conf = pointer.To(ruleHTTP.Conf.(api.PolicyDefault))
 		for hash := range ruleHTTP.BackendRefOriginIndex {

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
@@ -96,7 +96,7 @@ func (p plugin) configureDPP(
 		oface := proxy.Dataplane.Spec.Networking.ToOutboundInterface(outbound.LegacyOutbound)
 		serviceName := outbound.LegacyOutbound.GetService()
 
-		computed := toRules.Rules.Compute(core_rules.MeshService(serviceName))
+		computed := toRules.Rules.Compute(core_rules.MeshServiceElement(serviceName))
 		if computed == nil {
 			continue
 		}
@@ -285,7 +285,7 @@ func (p plugin) configureGateway(
 					}
 
 					serviceName := dest.Destination[mesh_proto.ServiceTag]
-					if localityConf := core_rules.ComputeConf[api.Conf](rules.Rules, core_rules.MeshService(serviceName)); localityConf != nil {
+					if localityConf := core_rules.ComputeConf[api.Conf](rules.Rules, core_rules.MeshServiceElement(serviceName)); localityConf != nil {
 						perServiceConfiguration[serviceName] = localityConf
 
 						if err := p.configureCluster(cluster, *localityConf); err != nil {
@@ -403,7 +403,7 @@ func (p plugin) computeFrom(fr core_rules.FromRules) *core_rules.Rule {
 	if len(rules) == 0 {
 		return nil
 	}
-	return rules[0].Compute(core_rules.MeshSubset())
+	return rules[0].Compute(core_rules.MeshElement())
 }
 
 func (p plugin) configureListener(

--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/plugin.go
@@ -38,7 +38,7 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, _ xds_context.Context, proxy *co
 	if len(policies.SingleItemRules.Rules) == 0 {
 		return nil
 	}
-	rule := policies.SingleItemRules.Rules.Compute(rules.MeshSubset())
+	rule := policies.SingleItemRules.Rules.Compute(rules.MeshElement())
 	conf := rule.Conf.(api.Conf)
 	if err := ApplyMods(rs, conf.AppendModifications); err != nil {
 		return err

--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin.go
@@ -155,8 +155,8 @@ func applyToEgress(rs *core_xds.ResourceSet, proxy *core_xds.Proxy) error {
 				for _, filterChain := range listeners.Egress.FilterChains {
 					if filterChain.Name == names.GetEgressFilterChainName(esName, meshName) {
 						configurer := plugin_xds.Configurer{
-							Rules:  rule,
-							Subset: core_rules.MeshSubset(),
+							Rules:   rule,
+							Element: core_rules.MeshElement(),
 						}
 						if err := configurer.ConfigureFilterChain(filterChain); err != nil {
 							return err
@@ -177,7 +177,7 @@ func configure(
 	configurer := plugin_xds.Configurer{
 		Rules: fromRules,
 		// Currently, `from` section of MeshRateLimit only allows Mesh targetRef
-		Subset: core_rules.MeshSubset(),
+		Element: core_rules.MeshElement(),
 	}
 
 	for _, chain := range listener.FilterChains {
@@ -198,8 +198,8 @@ func configureGateway(
 	route *envoy_route.RouteConfiguration,
 ) error {
 	configurer := plugin_xds.Configurer{
-		Rules:  fromRules,
-		Subset: core_rules.MeshSubset(),
+		Rules:   fromRules,
+		Element: core_rules.MeshElement(),
 	}
 
 	for _, chain := range listener.FilterChains {

--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin.go
@@ -68,7 +68,7 @@ func applyToOutbounds(
 		serviceName := outbound.LegacyOutbound.GetService()
 
 		configurer := plugin_xds.DeprecatedConfigurer{
-			Subset:   core_rules.MeshService(serviceName),
+			Element:  core_rules.MeshServiceElement(serviceName),
 			Rules:    rules.Rules,
 			Protocol: meshCtx.GetServiceProtocol(serviceName),
 		}
@@ -117,7 +117,7 @@ func applyToGateway(
 		configurer := plugin_xds.DeprecatedConfigurer{
 			Rules:    toRules.Rules,
 			Protocol: protocol,
-			Subset:   core_rules.MeshSubset(),
+			Element:  core_rules.MeshElement(),
 		}
 
 		if err := configurer.ConfigureListener(listener); err != nil {

--- a/pkg/plugins/policies/meshretry/plugin/xds/configurer.go
+++ b/pkg/plugins/policies/meshretry/plugin/xds/configurer.go
@@ -37,13 +37,13 @@ const (
 // It should be removed after we stop using kuma.io/service tag, and move fully to new MeshService
 // Deprecated
 type DeprecatedConfigurer struct {
-	Subset   core_rules.Subset
+	Element  core_rules.Element
 	Rules    core_rules.Rules
 	Protocol core_mesh.Protocol
 }
 
 func (c *DeprecatedConfigurer) ConfigureListener(ln *envoy_listener.Listener) error {
-	conf := c.getConf(c.Subset)
+	conf := c.getConf(c.Element)
 
 	for _, fc := range ln.FilterChains {
 		if c.Protocol == core_mesh.ProtocolTCP && conf != nil && conf.TCP != nil && conf.TCP.MaxConnectAttempt != nil {
@@ -66,13 +66,13 @@ func (c *DeprecatedConfigurer) ConfigureRoute(route *envoy_route.RouteConfigurat
 		return nil
 	}
 
-	defaultPolicy, err := getRouteRetryConfig(c.getConf(c.Subset), c.Protocol)
+	defaultPolicy, err := getRouteRetryConfig(c.getConf(c.Element), c.Protocol)
 	if err != nil {
 		return err
 	}
 	for _, virtualHost := range route.VirtualHosts {
 		for _, route := range virtualHost.Routes {
-			routeConfig := c.getConf(c.Subset.WithTag(core_rules.RuleMatchesHashTag, route.Name, false))
+			routeConfig := c.getConf(c.Element.WithKeyValue(core_rules.RuleMatchesHashTag, route.Name))
 			policy, err := getRouteRetryConfig(routeConfig, c.Protocol)
 			if err != nil {
 				return err
@@ -419,11 +419,11 @@ func ensureRetriableStatusCodes(policyRetryOn string) string {
 	return policyRetryOn
 }
 
-func (c *DeprecatedConfigurer) getConf(subset core_rules.Subset) *api.Conf {
+func (c *DeprecatedConfigurer) getConf(element core_rules.Element) *api.Conf {
 	if c.Rules == nil {
 		return nil
 	}
-	return core_rules.ComputeConf[api.Conf](c.Rules, subset)
+	return core_rules.ComputeConf[api.Conf](c.Rules, element)
 }
 
 type Configurer struct {

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners_backendrefs.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners_backendrefs.go
@@ -16,7 +16,7 @@ func computeConf(toRules core_xds.ToRules, svc meshroute_xds.DestinationService,
 	var tcpConf *api.Rule
 	var origin core_model.ResourceMeta
 
-	ruleTCP := toRules.Rules.Compute(core_xds.MeshService(svc.ServiceName))
+	ruleTCP := toRules.Rules.Compute(core_xds.MeshServiceElement(svc.ServiceName))
 	if ruleTCP != nil {
 		tcpConf = pointer.To(ruleTCP.Conf.(api.Rule))
 		if o, ok := ruleTCP.GetBackendRefOrigin(core_xds.EmptyMatches); ok {

--- a/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
@@ -91,7 +91,7 @@ func applyToInbounds(fromRules core_rules.FromRules, inboundListeners map[core_r
 		}
 
 		protocol := core_mesh.ParseProtocol(inbound.GetProtocol())
-		conf := getConf(fromRules.Rules[listenerKey], core_rules.MeshSubset())
+		conf := getConf(fromRules.Rules[listenerKey], core_rules.MeshElement())
 		if conf == nil {
 			continue
 		}
@@ -137,7 +137,7 @@ func applyToOutbounds(
 		configurer := plugin_xds.DeprecatedListenerConfigurer{
 			Rules:    rules.Rules,
 			Protocol: meshCtx.GetServiceProtocol(serviceName),
-			Subset:   core_rules.MeshService(serviceName),
+			Element:  core_rules.MeshServiceElement(serviceName),
 		}
 
 		if err := configurer.ConfigureListener(listener); err != nil {
@@ -154,7 +154,7 @@ func applyToClusters(
 	protocol core_mesh.Protocol,
 	clusters ...*envoy_cluster.Cluster,
 ) error {
-	conf := getConf(rules, core_rules.MeshService(serviceName))
+	conf := getConf(rules, core_rules.MeshServiceElement(serviceName))
 	if conf == nil {
 		return nil
 	}
@@ -182,7 +182,7 @@ func applyToGateway(
 			Port:    listenerInfo.Listener.Port,
 		}
 
-		conf := getConf(gatewayRules.FromRules[key], core_rules.MeshSubset())
+		conf := getConf(gatewayRules.FromRules[key], core_rules.MeshElement())
 		if err := plugin_xds.ConfigureGatewayListener(
 			conf,
 			listenerInfo.Listener.Protocol,
@@ -196,14 +196,14 @@ func applyToGateway(
 			continue
 		}
 
-		conf = getConf(toRules.Rules, core_rules.MeshSubset())
+		conf = getConf(toRules.Rules, core_rules.MeshElement())
 		for _, listenerHostname := range listenerInfo.ListenerHostnames {
 			route, ok := gatewayRoutes[listenerHostname.EnvoyRouteName(listenerInfo.Listener.EnvoyListenerName)]
 
 			if ok {
 				for _, vh := range route.VirtualHosts {
 					for _, r := range vh.Routes {
-						routeConf := getConf(toRules.Rules, core_rules.MeshSubset().WithTag(core_rules.RuleMatchesHashTag, r.Name, false))
+						routeConf := getConf(toRules.Rules, core_rules.MeshElement().WithKeyValue(core_rules.RuleMatchesHashTag, r.Name))
 						if routeConf == nil {
 							if conf == nil {
 								continue
@@ -236,7 +236,7 @@ func applyToGateway(
 
 					serviceName := dest.Destination[mesh_proto.ServiceTag]
 
-					conf := getConf(toRules.Rules, core_rules.MeshService(serviceName))
+					conf := getConf(toRules.Rules, core_rules.MeshServiceElement(serviceName))
 					if conf == nil {
 						continue
 					}
@@ -259,12 +259,12 @@ func applyToGateway(
 
 func getConf(
 	rules core_rules.Rules,
-	subset core_rules.Subset,
+	element core_rules.Element,
 ) *api.Conf {
 	if rules == nil {
 		return &api.Conf{}
 	} else {
-		if computed := rules.Compute(subset); computed != nil {
+		if computed := rules.Compute(element); computed != nil {
 			return pointer.To(computed.Conf.(api.Conf))
 		} else {
 			return nil

--- a/pkg/plugins/policies/meshtimeout/plugin/xds/configurer.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/xds/configurer.go
@@ -31,7 +31,7 @@ import (
 type DeprecatedListenerConfigurer struct {
 	Rules    rules.Rules
 	Protocol core_mesh.Protocol
-	Subset   rules.Subset
+	Element  rules.Element
 }
 
 func (c *DeprecatedListenerConfigurer) ConfigureListener(listener *envoy_listener.Listener) error {
@@ -51,7 +51,7 @@ func (c *DeprecatedListenerConfigurer) ConfigureListener(listener *envoy_listene
 		return nil
 	}
 	tcpTimeouts := func(proxy *envoy_tcp.TcpProxy) error {
-		if conf := c.getConf(c.Subset); conf != nil {
+		if conf := c.getConf(c.Element); conf != nil {
 			proxy.IdleTimeout = toProtoDurationOrDefault(conf.IdleTimeout, policies_defaults.DefaultIdleTimeout)
 		}
 		return nil
@@ -76,9 +76,9 @@ func (c *DeprecatedListenerConfigurer) configureRequestTimeout(routeConfiguratio
 	if routeConfiguration != nil {
 		for _, vh := range routeConfiguration.VirtualHosts {
 			for _, route := range vh.Routes {
-				conf := c.getConf(c.Subset.WithTag(rules.RuleMatchesHashTag, route.Name, false))
+				conf := c.getConf(c.Element.WithKeyValue(rules.RuleMatchesHashTag, route.Name))
 				if conf == nil {
-					conf = c.getConf(c.Subset)
+					conf = c.getConf(c.Element)
 				}
 				if conf == nil {
 					continue
@@ -94,7 +94,7 @@ func (c *DeprecatedListenerConfigurer) configureRequestTimeout(routeConfiguratio
 }
 
 func (c *DeprecatedListenerConfigurer) configureRequestHeadersTimeout(hcm *envoy_hcm.HttpConnectionManager) {
-	if conf := c.getConf(c.Subset); conf != nil {
+	if conf := c.getConf(c.Element); conf != nil {
 		hcm.RequestHeadersTimeout = toProtoDurationOrDefault(
 			pointer.Deref(conf.Http).RequestHeadersTimeout,
 			policies_defaults.DefaultRequestHeadersTimeout,
@@ -102,11 +102,11 @@ func (c *DeprecatedListenerConfigurer) configureRequestHeadersTimeout(hcm *envoy
 	}
 }
 
-func (c *DeprecatedListenerConfigurer) getConf(subset rules.Subset) *api.Conf {
+func (c *DeprecatedListenerConfigurer) getConf(element rules.Element) *api.Conf {
 	if c.Rules == nil {
 		return &api.Conf{}
 	}
-	return rules.ComputeConf[api.Conf](c.Rules, subset)
+	return rules.ComputeConf[api.Conf](c.Rules, element)
 }
 
 type ClusterConfigurer struct {

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin.go
@@ -97,7 +97,7 @@ func applyToInbounds(
 		if !ok {
 			continue
 		}
-		conf := core_rules.ComputeConf[api.Conf](fromRules.Rules[listenerKey], core_rules.MeshSubset())
+		conf := core_rules.ComputeConf[api.Conf](fromRules.Rules[listenerKey], core_rules.MeshElement())
 		if conf == nil {
 			continue
 		}
@@ -138,7 +138,7 @@ func applyToOutbounds(
 		// there is only one rule always because we're in `Mesh/Mesh`
 		var conf *api.Conf
 		for _, r := range fromRules.Rules {
-			conf = core_rules.ComputeConf[api.Conf](r, core_rules.MeshSubset())
+			conf = core_rules.ComputeConf[api.Conf](r, core_rules.MeshElement())
 			break
 		}
 		if conf == nil {
@@ -166,7 +166,7 @@ func applyToGateways(
 		// there is only one rule always because we're in `Mesh/Mesh`
 		var conf *api.Conf
 		for _, r := range gatewayRules.FromRules {
-			conf = core_rules.ComputeConf[api.Conf](r, core_rules.MeshSubset())
+			conf = core_rules.ComputeConf[api.Conf](r, core_rules.MeshElement())
 			break
 		}
 		if conf == nil {
@@ -187,7 +187,7 @@ func applyToRealResources(
 		// there is only one rule always because we're in `Mesh/Mesh`
 		var conf *api.Conf
 		for _, r := range fromRules.Rules {
-			conf = core_rules.ComputeConf[api.Conf](r, core_rules.MeshSubset())
+			conf = core_rules.ComputeConf[api.Conf](r, core_rules.MeshElement())
 			break
 		}
 		if conf == nil {

--- a/pkg/plugins/policies/meshtrafficpermission/graph/reachable_graph.go
+++ b/pkg/plugins/policies/meshtrafficpermission/graph/reachable_graph.go
@@ -29,7 +29,7 @@ func (r *Graph) CanReach(fromTags map[string]string, toTags map[string]string) b
 		// we cannot compute graph for cross mesh, so it's better to allow the traffic
 		return true
 	}
-	rule := r.rules[toTags[mesh_proto.ServiceTag]].Compute(core_rules.SubsetFromTags(fromTags))
+	rule := r.rules[toTags[mesh_proto.ServiceTag]].Compute(core_rules.Element(fromTags))
 	if rule == nil {
 		return false
 	}
@@ -45,7 +45,7 @@ func (r *Graph) CanReachBackend(fromTags map[string]string, backendIdentifier co
 		ResourceIdentifier: backendIdentifier.ResourceIdentifier,
 		ResourceType:       backendIdentifier.ResourceType,
 	}
-	rule := r.backendRules[noPort].Compute(core_rules.SubsetFromTags(fromTags))
+	rule := r.backendRules[noPort].Compute(core_rules.Element(fromTags))
 	if rule == nil {
 		return false
 	}


### PR DESCRIPTION
## Motivation

1. When I went through the policy matching subset `Intersect` method, I found the behavior is incorrect with one case
2. Rewrite the rule's `Compute` method to use the new `ContainsElement` method instead of using the old `IsSubset` method

## Implementation information

Introduce one new type `type Element map[string]string` for differentiation by `IsSubset`.

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)? -->

## Backport

cherry-picked commit 3a00363b331f92278c57caa3b47e6113e83e7525

