### PR TITLE
fix(policy): use new compute for rules and fix rules intersect (backport of #12340)

### DIFF
--- a/pkg/core/xds/inspect/rules.go
+++ b/pkg/core/xds/inspect/rules.go
@@ -112,8 +112,7 @@ func getOutboundRuleAttachments(rules core_rules.Rules, networking *mesh_proto.D
 		}
 		attachment := byUniqueClusterName[name]
 		if attachment == nil {
-			subset := core_rules.SubsetFromTags(outboundTags)
-			computedRule := rules.Compute(subset)
+			computedRule := rules.Compute(core_rules.Element(outboundTags))
 			if computedRule == nil {
 				continue
 			}

--- a/pkg/plugins/policies/core/rules/rules.go
+++ b/pkg/plugins/policies/core/rules/rules.go
@@ -113,6 +113,66 @@ type Tag struct {
 // Subset represents a group of proxies
 type Subset []Tag
 
+// ContainsElement returns true if there exists a key in 'other' that matches the current set,
+// and the corresponding k-v pair must match the set rule. Also, the left set rules of the current set can't make an impact.
+// Empty set is a superset for all elements.
+//
+// For example if you have a Subset with Tags: [{key: zone, value: east, not: true}, {key: service, value: frontend, not: false}]
+// an Element with k-v pairs: 1) service: frontend  2) version: zone1
+// there's a k-v pair 'service: frontend' in Element that matches the set rule {key: service, value: frontend, not: false}
+// the left set rule of Subset {key: zone, value: east, not: true} won't make an impact because of 'not: true'
+func (ss Subset) ContainsElement(other Element) bool {
+	// 1. find the overlaps of element and current subset
+	// 2. verify the overlaps
+	// 3. verify the left of current subset
+	// 4. if no overlaps, verify if all the Subset rules are negative
+
+	if len(ss) == 0 {
+		return true
+	}
+	if len(other) == 0 {
+		return false
+	}
+
+	hasOverlapKey := false
+	for _, tag := range ss {
+		otherVal, ok := other[tag.Key]
+		if ok {
+			hasOverlapKey = true
+
+			// contradict
+			if tag.Value == otherVal && tag.Not {
+				return false
+			}
+			// intersect
+			if tag.Value == otherVal && !tag.Not {
+				continue
+			}
+			// intersect
+			if tag.Value != otherVal && tag.Not {
+				continue
+			}
+			// contradict
+			if tag.Value != otherVal && !tag.Not {
+				return false
+			}
+		} else if !tag.Not {
+			// For those items that don't exist in element should not make an impact.
+			// For example, the DP with tag {"service: frontend"} doesn't match
+			// the policy with matching tags [{"service: frontend"}, {"zone": "east"}]
+			return false
+		}
+	}
+
+	// if the current Subset owns all of negative rules and no overlapped keys in Element,
+	// we can also regard the Subset contains Element
+	if !hasOverlapKey && ss.NumPositive() == 0 {
+		return true
+	}
+
+	return hasOverlapKey
+}
+
 // IsSubset returns true if 'other' is a subset of the current set.
 // Empty set is a superset for all subsets.
 func (ss Subset) IsSubset(other Subset) bool {
@@ -162,6 +222,36 @@ func isSubset(t1, t2 Tag) bool {
 
 // Intersect returns true if there exists an element that belongs both to 'other' and current set.
 // Empty set intersects with all sets.
+//
+// We're using this function to check if 2 'from' rules of MeshTrafficPermission can be applied to the same client DPP.
+// For example:
+//
+//	from:
+//	  - targetRef:
+//	      kind: MeshSubset
+//	      tags:
+//	        team: team-a
+//	  - targetRef:
+//	      kind: MeshSubset
+//	      tags:
+//	        zone: east
+//
+// there is a DPP with tags 'team: team-a' and 'zone: east' that's subjected to both these rules.
+// So 'from[0]' and 'from[1]' have an intersection.
+// However, in another example:
+//
+//	from:
+//	 - targetRef:
+//	     kind: MeshSubset
+//	     tags:
+//	       team: team-a
+//	 - targetRef:
+//	     kind: MeshSubset
+//	     tags:
+//	       team: team-b
+//	       zone: east
+//
+// there is no DPP that'd hit both 'from[0]' and 'from[1]'. So in this case they don't have an intersection.
 func (ss Subset) Intersect(other Subset) bool {
 	if len(ss) == 0 || len(other) == 0 {
 		return true
@@ -179,7 +269,7 @@ func (ss Subset) Intersect(other Subset) bool {
 		}
 		oTags, ok := otherByKeysOnlyPositive[tag.Key]
 		if !ok {
-			return true
+			continue
 		}
 		for _, otherTag := range oTags {
 			if otherTag != tag {
@@ -210,6 +300,26 @@ func SubsetFromTags(tags map[string]string) Subset {
 		subset = append(subset, Tag{Key: k, Value: v})
 	}
 	return subset
+}
+
+type Element map[string]string
+
+func (e Element) WithKeyValue(key, value string) Element {
+	c := maps.Clone(e)
+	if c == nil {
+		c = Element{}
+	}
+
+	c[key] = value
+	return c
+}
+
+func MeshElement() Element {
+	return Element{}
+}
+
+func MeshServiceElement(name string) Element {
+	return Element{mesh_proto.ServiceTag: name}
 }
 
 // NumPositive returns a number of tags without negation
@@ -243,20 +353,23 @@ type Rule struct {
 
 type Rules []*Rule
 
-// Compute returns configuration for the given subset.
-func (rs Rules) Compute(sub Subset) *Rule {
+// Compute returns Rule for the given element.
+func (rs Rules) Compute(element Element) *Rule {
 	for _, rule := range rs {
-		if rule.Subset.IsSubset(sub) {
+		if rule.Subset.ContainsElement(element) {
 			return rule
 		}
 	}
 	return nil
 }
 
-func ComputeConf[T any](rs Rules, sub Subset) *T {
-	if computed := rs.Compute(sub); computed != nil {
+// ComputeConf returns configuration for the given element.
+func ComputeConf[T any](rs Rules, element Element) *T {
+	computed := rs.Compute(element)
+	if computed != nil {
 		return pointer.To(computed.Conf.(T))
 	}
+
 	return nil
 }
 

--- a/pkg/plugins/policies/core/rules/rules_test.go
+++ b/pkg/plugins/policies/core/rules/rules_test.go
@@ -243,58 +243,174 @@ var _ = Describe("Rules", func() {
 			func(given testCase) {
 				Expect(given.s1.Intersect(given.s2)).To(Equal(given.intersect))
 			},
-			Entry("entry 1", testCase{
+			Entry("positive, same key and value", testCase{
 				s1: []core_rules.Tag{
-					{Key: "service", Value: "backend"},
-				},
-				s2: []core_rules.Tag{
-					{Key: "service", Not: true, Value: "frontend"},
-					{Key: "version", Value: "v2"},
-				},
-				intersect: true,
-			}),
-			Entry("entry 2", testCase{
-				s1: []core_rules.Tag{
-					{Key: "service", Value: "backend"},
+					{Key: "service", Value: "frontend"},
 				},
 				s2: []core_rules.Tag{
 					{Key: "service", Value: "frontend"},
-					{Key: "version", Value: "v2"},
+				},
+				intersect: true,
+			}),
+			Entry("positive, same key, different value", testCase{
+				s1: []core_rules.Tag{
+					{Key: "service", Value: "frontend"},
+				},
+				s2: []core_rules.Tag{
+					{Key: "service", Value: "backend"},
 				},
 				intersect: false,
 			}),
-			Entry("entry 3", testCase{
+			Entry("positive, multiple key-values with overlap key-value", testCase{
 				s1: []core_rules.Tag{
-					{Key: "service", Not: true, Value: "backend"},
+					{Key: "service", Value: "frontend"},
+					{Key: "version", Value: "v1"},
 				},
 				s2: []core_rules.Tag{
-					{Key: "service", Not: true, Value: "backend"},
-					{Key: "version", Value: "v2"},
+					{Key: "service", Value: "frontend"},
 				},
 				intersect: true,
 			}),
-			Entry("entry 4", testCase{
+			Entry("positive, multiple key-values with overlap key but different value", testCase{
 				s1: []core_rules.Tag{
-					{Key: "service", Not: true, Value: "backend"},
-					{Key: "version", Not: true, Value: "v1"},
+					{Key: "service", Value: "frontend"},
 				},
 				s2: []core_rules.Tag{
-					{Key: "service", Not: true, Value: "backend"},
-					{Key: "version", Not: true, Value: "v1"},
-					{Key: "zone", Value: "east"},
+					{Key: "service", Value: "backend"},
+					{Key: "version", Value: "v1"},
+				},
+				intersect: false,
+			}),
+			Entry("positive, different key, different value", testCase{
+				s1: []core_rules.Tag{
+					{Key: "service", Value: "frontend"},
+				},
+				s2: []core_rules.Tag{
+					{Key: "version", Value: "v1"},
 				},
 				intersect: true,
 			}),
-			Entry("entry 5", testCase{
+			Entry("positive, superset", testCase{
 				s1: []core_rules.Tag{},
 				s2: []core_rules.Tag{
+					{Key: "service", Value: "backend"},
+					{Key: "version", Value: "v1"},
+					{Key: "zone", Value: "east"},
+				},
+				intersect: true,
+			}),
+			Entry("a part of negation, same key and value", testCase{
+				s1: []core_rules.Tag{
+					{Key: "service", Not: true, Value: "frontend"},
+				},
+				s2: []core_rules.Tag{
+					{Key: "service", Value: "frontend"},
+				},
+				intersect: true,
+			}),
+			Entry("a part of negation, same key, different value", testCase{
+				s1: []core_rules.Tag{
+					{Key: "service", Not: true, Value: "frontend"},
+				},
+				s2: []core_rules.Tag{
+					{Key: "service", Value: "backend"},
+				},
+				intersect: true,
+			}),
+			Entry("a part of negation, multiple key-values with overlap key-value", testCase{
+				s1: []core_rules.Tag{
+					{Key: "service", Not: true, Value: "frontend"},
+					{Key: "version", Value: "v1"},
+				},
+				s2: []core_rules.Tag{
+					{Key: "service", Value: "frontend"},
+				},
+				intersect: true,
+			}),
+			Entry("a part of negation, multiple key-values with overlap key but different value", testCase{
+				s1: []core_rules.Tag{
+					{Key: "service", Not: true, Value: "frontend"},
+					{Key: "version", Value: "v1"},
+				},
+				s2: []core_rules.Tag{
+					{Key: "service", Value: "backend"},
+				},
+				intersect: true,
+			}),
+			Entry("a part of negation, different key, different value", testCase{
+				s1: []core_rules.Tag{
+					{Key: "service", Not: true, Value: "frontend"},
+				},
+				s2: []core_rules.Tag{
+					{Key: "version", Value: "v1"},
+				},
+				intersect: true,
+			}),
+			Entry("negation, same key and value", testCase{
+				s1: []core_rules.Tag{
+					{Key: "service", Not: true, Value: "backend"},
+				},
+				s2: []core_rules.Tag{
+					{Key: "service", Not: true, Value: "backend"},
+				},
+				intersect: true,
+			}),
+			Entry("negation, same key, different value", testCase{
+				s1: []core_rules.Tag{
+					{Key: "service", Not: true, Value: "frontend"},
+				},
+				s2: []core_rules.Tag{
+					{Key: "service", Not: true, Value: "backend"},
+				},
+				intersect: true,
+			}),
+			Entry("negation, multiple key-values with overlap key-value", testCase{
+				s1: []core_rules.Tag{
+					{Key: "service", Not: true, Value: "backend"},
+					{Key: "version", Not: true, Value: "v1"},
+				},
+				s2: []core_rules.Tag{
 					{Key: "service", Not: true, Value: "backend"},
 					{Key: "version", Not: true, Value: "v1"},
 					{Key: "zone", Value: "east"},
 				},
 				intersect: true,
 			}),
-			Entry("entry 6", testCase{
+			Entry("negation, multiple key-values with overlap key but different value", testCase{
+				s1: []core_rules.Tag{
+					{Key: "service", Not: true, Value: "frontend"},
+					{Key: "version", Not: true, Value: "v1"},
+				},
+				s2: []core_rules.Tag{
+					{Key: "service", Not: true, Value: "backend"},
+					{Key: "version", Not: true, Value: "v1"},
+					{Key: "zone", Value: "east"},
+				},
+				intersect: true,
+			}),
+			Entry("negation, multiple key-values with overlap key but different value", testCase{
+				s1: []core_rules.Tag{
+					{Key: "service", Not: true, Value: "frontend"},
+					{Key: "version", Not: true, Value: "v1"},
+				},
+				s2: []core_rules.Tag{
+					{Key: "service", Not: true, Value: "backend"},
+					{Key: "version", Not: true, Value: "v1"},
+					{Key: "zone", Value: "east"},
+				},
+				intersect: true,
+			}),
+			Entry("negation, different key, different value", testCase{
+				s1: []core_rules.Tag{
+					{Key: "service", Not: true, Value: "frontend"},
+				},
+				s2: []core_rules.Tag{
+					{Key: "version", Not: true, Value: "v1"},
+					{Key: "zone", Value: "east"},
+				},
+				intersect: true,
+			}),
+			Entry("negation, superset", testCase{
 				s1: []core_rules.Tag{
 					{Key: "service", Not: true, Value: "backend"},
 					{Key: "version", Not: true, Value: "v1"},
@@ -377,16 +493,215 @@ var _ = Describe("Rules", func() {
 		)
 	})
 
+	Describe("ContainsElement", func() {
+		type testCase struct {
+			ss       core_rules.Subset
+			other    core_rules.Element
+			contains bool
+		}
+
+		DescribeTable("should respond if subset ss contains element other",
+			func(given testCase) {
+				Expect(given.ss.ContainsElement(given.other)).To(Equal(given.contains))
+			},
+			Entry("single matched rule by single rule and elements", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1"},
+				},
+				other: core_rules.Element{
+					"key1": "val1",
+					"key2": "val2",
+				},
+				contains: true,
+			}),
+			Entry("single matched rule by single rule and element", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1"},
+				},
+				other: core_rules.Element{
+					"key1": "val1",
+				},
+				contains: true,
+			}),
+			Entry("single matched rule, rule with negation, element has key with another value", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1", Not: true},
+				},
+				other: core_rules.Element{
+					"key1": "val2",
+				},
+				contains: true,
+			}),
+			Entry("empty set is a superset for all element", testCase{
+				ss: []core_rules.Tag{},
+				other: core_rules.Element{
+					"key1": "val2",
+				},
+				contains: true,
+			}),
+			Entry("empty element", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1"},
+				},
+				other:    core_rules.Element{},
+				contains: false,
+			}),
+			Entry("no rules matched, rule with negation, element has same key value", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1", Not: true},
+				},
+				other: core_rules.Element{
+					"key1": "val1",
+				},
+				contains: false,
+			}),
+			Entry("no rules matched, rule with negation, element has another key", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1", Not: true},
+				},
+				other: core_rules.Element{
+					"key2": "val2",
+				},
+				contains: true,
+			}),
+			Entry("no rules matched, element has key which is not presented in superset", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1"},
+				},
+				other: core_rules.Element{
+					"key2": "val2",
+				},
+				contains: false,
+			}),
+
+			Entry("no rules matched, rules with positive, element has key with another value", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1"},
+				},
+				other: core_rules.Element{
+					"key1": "val2",
+				},
+				contains: false,
+			}),
+			Entry("no rules matched, rules with positive, element has only one overlapped key value", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1"},
+					{Key: "key2", Value: "val2"},
+				},
+				other: core_rules.Element{
+					"key1": "val1",
+				},
+				contains: false,
+			}),
+			Entry("single matched rule by rules and element, rules with a part of negation", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1"},
+					{Key: "key2", Value: "val2", Not: true},
+				},
+				other: core_rules.Element{
+					"key1": "val1",
+				},
+				contains: true,
+			}),
+			Entry("single matched rule by rules and element, rules with a part of negation, element has key with another value", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1", Not: true},
+					{Key: "key2", Value: "val2"},
+				},
+				other: core_rules.Element{
+					"key1": "val2",
+				},
+				contains: false,
+			}),
+			Entry("no rules matched, rules with negation, element has same key value", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1", Not: true},
+					{Key: "key2", Value: "val2", Not: true},
+				},
+				other: core_rules.Element{
+					"key1": "val1",
+				},
+				contains: false,
+			}),
+			Entry("no rules matched, rules with a part of negation, element has another key", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1"},
+					{Key: "key2", Value: "val2", Not: true},
+				},
+				other: core_rules.Element{
+					"key3": "val3",
+				},
+				contains: false,
+			}),
+			Entry("no rules matched, rules with positive, element has another key", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1"},
+					{Key: "key2", Value: "val2"},
+				},
+				other: core_rules.Element{
+					"key3": "val3",
+				},
+				contains: false,
+			}),
+			Entry("rules matched, rules with negation, element has another key", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1", Not: true},
+					{Key: "key2", Value: "val2", Not: true},
+				},
+				other: core_rules.Element{
+					"key3": "val3",
+				},
+				contains: true,
+			}),
+			Entry("no rules matched, n dimensions rules and n-1 dimensions elements, rules with positive, elements have another keys", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1"},
+					{Key: "key2", Value: "val2"},
+					{Key: "key3", Value: "val3"},
+				},
+				other: core_rules.Element{
+					"key4": "val4",
+					"key5": "val5",
+				},
+				contains: false,
+			}),
+			Entry("no rules matched, n dimensions rules and n-1 dimensions elements, rules with positive, elements have overlapped key by rules", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1"},
+					{Key: "key2", Value: "val2"},
+					{Key: "key3", Value: "val3"},
+				},
+				other: core_rules.Element{
+					"key3": "val3",
+					"key4": "val4",
+				},
+				contains: false,
+			}),
+			Entry("rules matched, n dimensions rules and n-1 dimensions elements, rules with a part of negation, elements have overlapped key by rules", testCase{
+				ss: []core_rules.Tag{
+					{Key: "key1", Value: "val1", Not: true},
+					{Key: "key2", Value: "val2", Not: true},
+					{Key: "key3", Value: "val3"},
+				},
+				other: core_rules.Element{
+					"key3": "val3",
+					"key4": "val4",
+				},
+				contains: true,
+			}),
+		)
+	})
+
 	Describe("Eval", func() {
 		type testCase struct {
 			rules    core_rules.Rules
-			subset   core_rules.Subset
+			element  core_rules.Element
 			confYAML []byte
 		}
 
 		DescribeTable("should compute conf for subset based on rules",
 			func(given testCase) {
-				conf := given.rules.Compute(given.subset)
+				conf := given.rules.Compute(given.element)
 				if given.confYAML == nil {
 					Expect(conf).To(BeNil())
 				} else {
@@ -395,7 +710,7 @@ var _ = Describe("Rules", func() {
 					Expect(actualYAML).To(MatchYAML(given.confYAML))
 				}
 			},
-			Entry("single matched rule", testCase{
+			Entry("single matched rule by single rule and elements", testCase{
 				rules: core_rules.Rules{
 					{
 						Subset: []core_rules.Tag{
@@ -406,13 +721,29 @@ var _ = Describe("Rules", func() {
 						},
 					},
 				},
-				subset: []core_rules.Tag{
-					{Key: "key1", Value: "val1"},
-					{Key: "key2", Value: "val2"},
+				element: core_rules.Element{
+					"key1": "val1",
+					"key2": "val2",
 				},
 				confYAML: []byte(`action: Allow`),
 			}),
-			Entry("single matched not", testCase{
+			Entry("single matched rule by single rule and element", testCase{
+				rules: core_rules.Rules{
+					{
+						Subset: []core_rules.Tag{
+							{Key: "key1", Value: "val1"},
+						},
+						Conf: meshtrafficpermission_api.Conf{
+							Action: "Allow",
+						},
+					},
+				},
+				element: core_rules.Element{
+					"key1": "val1",
+				},
+				confYAML: []byte(`action: Allow`),
+			}),
+			Entry("single matched rule, rule with negation, element has key with another value", testCase{
 				rules: core_rules.Rules{
 					{
 						Subset: []core_rules.Tag{
@@ -423,28 +754,12 @@ var _ = Describe("Rules", func() {
 						},
 					},
 				},
-				subset: []core_rules.Tag{
-					{Key: "key1", Value: "val2"},
+				element: core_rules.Element{
+					"key1": "val2",
 				},
 				confYAML: []byte(`action: Allow`),
 			}),
-			Entry("single matched rule, rule and subset with negation", testCase{
-				rules: core_rules.Rules{
-					{
-						Subset: []core_rules.Tag{
-							{Key: "key1", Value: "val1", Not: true},
-						},
-						Conf: meshtrafficpermission_api.Conf{
-							Action: "Allow",
-						},
-					},
-				},
-				subset: []core_rules.Tag{
-					{Key: "key1", Value: "val1", Not: true},
-				},
-				confYAML: []byte(`action: Allow`),
-			}),
-			Entry("empty set is a superset for all subset", testCase{
+			Entry("empty set is a superset for all element", testCase{
 				rules: core_rules.Rules{
 					{
 						Subset: []core_rules.Tag{}, // empty set
@@ -453,13 +768,13 @@ var _ = Describe("Rules", func() {
 						},
 					},
 				},
-				subset: []core_rules.Tag{
-					{Key: "key1", Value: "val1"},
-					{Key: "key2", Value: "val2"},
+				element: core_rules.Element{
+					"key1": "val1",
+					"key2": "val2",
 				},
 				confYAML: []byte(`action: Allow`),
 			}),
-			Entry("no rules matched, rule with negation, subset without key", testCase{
+			Entry("empty element", testCase{
 				rules: core_rules.Rules{
 					{
 						Subset: []core_rules.Tag{
@@ -470,44 +785,10 @@ var _ = Describe("Rules", func() {
 						},
 					},
 				},
-				subset: []core_rules.Tag{
-					{Key: "key2", Value: "val2"},
-				},
+				element:  core_rules.Element{},
 				confYAML: nil,
 			}),
-			Entry("no rules matched, subset has key which is not presented in superset", testCase{
-				rules: core_rules.Rules{
-					{
-						Subset: []core_rules.Tag{
-							{Key: "key1", Value: "val1"},
-						},
-						Conf: meshtrafficpermission_api.Conf{
-							Action: "Allow",
-						},
-					},
-				},
-				subset: []core_rules.Tag{
-					{Key: "key2", Value: "val2"}, // key2 is not in rules[0].Subset
-				},
-				confYAML: nil,
-			}),
-			Entry("no rules matched, subset has key with another value", testCase{
-				rules: core_rules.Rules{
-					{
-						Subset: []core_rules.Tag{
-							{Key: "key1", Value: "val1"},
-						},
-						Conf: meshtrafficpermission_api.Conf{
-							Action: "Allow",
-						},
-					},
-				},
-				subset: []core_rules.Tag{
-					{Key: "key1", Value: "val2"}, // val2 is not equal to rules[0].Subset["key1"]
-				},
-				confYAML: nil,
-			}),
-			Entry("no rules matched, rule with negation", testCase{
+			Entry("no rules matched, rule with negation, element has same key value", testCase{
 				rules: core_rules.Rules{
 					{
 						Subset: []core_rules.Tag{
@@ -518,12 +799,28 @@ var _ = Describe("Rules", func() {
 						},
 					},
 				},
-				subset: []core_rules.Tag{
-					{Key: "key1", Value: "val1"}, // rule has "key1: !val1"
+				element: core_rules.Element{
+					"key1": "val1",
 				},
 				confYAML: nil,
 			}),
-			Entry("no rules matched, subset with negation", testCase{
+			Entry("no rules matched, rule with negation, element has another key", testCase{
+				rules: core_rules.Rules{
+					{
+						Subset: []core_rules.Tag{
+							{Key: "key1", Value: "val1", Not: true},
+						},
+						Conf: meshtrafficpermission_api.Conf{
+							Action: "Allow",
+						},
+					},
+				},
+				element: core_rules.Element{
+					"key2": "val2",
+				},
+				confYAML: []byte(`action: Allow`),
+			}),
+			Entry("no rules matched, element has key which is not presented in superset", testCase{
 				rules: core_rules.Rules{
 					{
 						Subset: []core_rules.Tag{
@@ -534,8 +831,24 @@ var _ = Describe("Rules", func() {
 						},
 					},
 				},
-				subset: []core_rules.Tag{
-					{Key: "key1", Value: "val1", Not: true}, // rule has "key1: val1"
+				element: core_rules.Element{
+					"key2": "val2", // key2 is not in rules[0].Subset
+				},
+				confYAML: nil,
+			}),
+			Entry("no rules matched, element has key with another value", testCase{
+				rules: core_rules.Rules{
+					{
+						Subset: []core_rules.Tag{
+							{Key: "key1", Value: "val1"},
+						},
+						Conf: meshtrafficpermission_api.Conf{
+							Action: "Allow",
+						},
+					},
+				},
+				element: core_rules.Element{
+					"key1": "val2", // val2 is not equal to rules[0].Subset["key1"]
 				},
 				confYAML: nil,
 			}),
@@ -564,11 +877,28 @@ var _ = Describe("Rules", func() {
 						},
 					},
 				},
-				subset: []core_rules.Tag{
-					{Key: "key2", Value: "val2"},
-					{Key: "key3", Value: "val3"},
+				element: core_rules.Element{
+					"key2": "val2",
+					"key3": "val3",
 				},
 				confYAML: []byte(`action: Deny`),
+			}),
+			Entry("n dimensions subset and n-1 dimensions elements", testCase{
+				rules: core_rules.Rules{
+					{
+						Subset: []core_rules.Tag{
+							{Key: "key1", Value: "val1"},
+							{Key: "key2", Value: "val1", Not: true},
+						},
+						Conf: meshtrafficpermission_api.Conf{
+							Action: "Allow",
+						},
+					},
+				},
+				element: core_rules.Element{
+					"key1": "val1",
+				},
+				confYAML: []byte(`action: Allow`),
 			}),
 		)
 	})

--- a/pkg/plugins/policies/core/rules/testdata/rules/from/06.golden.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/rules/from/06.golden.yaml
@@ -1,0 +1,31 @@
+Rules:
+  127.0.0.1:80:
+    - BackendRefOriginIndex: {}
+      Conf:
+        action: Allow
+      Origin:
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: default
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: mtp-allow-kuma-other-ns-and-tag
+          type: MeshTrafficPermission
+      Subset:
+        - Key: abcd
+          Not: false
+          Value: abcd
+        - Key: k8s.kuma.io/namespace
+          Not: false
+          Value: kuma-other
+    - BackendRefOriginIndex: {}
+      Conf:
+        action: Allow
+      Origin:
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: default
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: mtp-allow-kuma-one
+          type: MeshTrafficPermission
+      Subset:
+        - Key: k8s.kuma.io/namespace
+          Not: false
+          Value: kuma-one

--- a/pkg/plugins/policies/core/rules/testdata/rules/from/06.input.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/rules/from/06.input.yaml
@@ -1,0 +1,29 @@
+# Multiple MeshTrafficPermission policies
+type: MeshTrafficPermission
+mesh: default
+name: mtp-allow-kuma-one
+spec:
+  targetRef:
+    kind: Mesh
+  from:
+    - targetRef:
+        kind: MeshSubset
+        tags:
+          k8s.kuma.io/namespace: kuma-one
+      default:
+        action: Allow
+---
+type: MeshTrafficPermission
+mesh: default
+name: mtp-allow-kuma-other-ns-and-tag
+spec:
+  targetRef:
+    kind: Mesh
+  from:
+    - targetRef:
+        kind: MeshSubset
+        tags:
+          abcd: abcd
+          k8s.kuma.io/namespace: kuma-other
+      default:
+        action: Allow

--- a/pkg/plugins/policies/core/rules/testdata/rules/from/07.golden.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/rules/from/07.golden.yaml
@@ -1,0 +1,34 @@
+Rules:
+  127.0.0.1:80:
+    - BackendRefOriginIndex: {}
+      Conf:
+        action: Deny
+      Origin:
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: default
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: mtp-allow-kuma-one
+          type: MeshTrafficPermission
+      Subset:
+        - Key: app
+          Not: false
+          Value: demo
+        - Key: k8s.kuma.io/namespace
+          Not: false
+          Value: kuma-one
+    - BackendRefOriginIndex: {}
+      Conf:
+        action: Allow
+      Origin:
+        - creationTime: "0001-01-01T00:00:00Z"
+          mesh: default
+          modificationTime: "0001-01-01T00:00:00Z"
+          name: mtp-allow-kuma-one
+          type: MeshTrafficPermission
+      Subset:
+        - Key: app
+          Not: true
+          Value: demo
+        - Key: k8s.kuma.io/namespace
+          Not: false
+          Value: kuma-one

--- a/pkg/plugins/policies/core/rules/testdata/rules/from/07.input.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/rules/from/07.input.yaml
@@ -1,0 +1,21 @@
+# MeshTrafficPermission with 2 from tags which one is a subset of another one
+type: MeshTrafficPermission
+mesh: default
+name: mtp-allow-kuma-one
+spec:
+  targetRef:
+    kind: Mesh
+  from:
+    - targetRef:
+        kind: MeshSubset
+        tags:
+          k8s.kuma.io/namespace: kuma-one
+      default:
+        action: Allow
+    - targetRef:
+        kind: MeshSubset
+        tags:
+          app: demo
+          k8s.kuma.io/namespace: kuma-one
+      default:
+        action: Deny

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin.go
@@ -98,7 +98,7 @@ func applyToOutbounds(rules core_rules.ToRules, outboundListeners map[mesh_proto
 
 		serviceName := outbound.GetService()
 
-		if err := configureOutbound(rules.Rules, dataplane, core_rules.MeshService(serviceName), serviceName, listener, backends, path); err != nil {
+		if err := configureOutbound(rules.Rules, dataplane, core_rules.MeshServiceElement(serviceName), serviceName, listener, backends, path); err != nil {
 			return err
 		}
 	}
@@ -114,7 +114,7 @@ func applyToTransparentProxyListeners(
 		if err := configureOutbound(
 			policies.ToRules.Rules,
 			dataplane,
-			core_rules.MeshService(core_mesh.PassThroughService),
+			core_rules.MeshServiceElement(core_mesh.PassThroughService),
 			"external",
 			ipv4,
 			backends,
@@ -128,7 +128,7 @@ func applyToTransparentProxyListeners(
 		return configureOutbound(
 			policies.ToRules.Rules,
 			dataplane,
-			core_rules.MeshService(core_mesh.PassThroughService),
+			core_rules.MeshServiceElement(core_mesh.PassThroughService),
 			"external",
 			ipv6,
 			backends,
@@ -148,7 +148,7 @@ func applyToDirectAccess(
 		return configureOutbound(
 			rules.Rules,
 			dataplane,
-			core_rules.MeshService(core_mesh.PassThroughService),
+			core_rules.MeshServiceElement(core_mesh.PassThroughService),
 			name,
 			listener,
 			backends,
@@ -195,7 +195,7 @@ func applyToGateway(
 			if err := configureOutbound(
 				toListenerRules,
 				proxy.Dataplane,
-				core_rules.Subset{},
+				core_rules.MeshElement(),
 				mesh_proto.MatchAllTag,
 				listener,
 				backends,
@@ -225,7 +225,7 @@ func configureInbound(
 	serviceName := dataplane.Spec.GetIdentifyingService()
 
 	// `from` section of MeshAccessLog only allows Mesh targetRef
-	conf := core_rules.ComputeConf[api.Conf](fromRules, core_rules.MeshSubset())
+	conf := core_rules.ComputeConf[api.Conf](fromRules, core_rules.MeshElement())
 	if conf == nil {
 		return nil
 	}
@@ -254,7 +254,7 @@ func configureInbound(
 func configureOutbound(
 	toRules core_rules.Rules,
 	dataplane *core_mesh.DataplaneResource,
-	subset core_rules.Subset,
+	element core_rules.Element,
 	destinationServiceName string,
 	listener *envoy_listener.Listener,
 	backendsAcc *plugin_xds.EndpointAccumulator,
@@ -262,7 +262,7 @@ func configureOutbound(
 ) error {
 	sourceService := dataplane.Spec.GetIdentifyingService()
 
-	conf := core_rules.ComputeConf[api.Conf](toRules, subset)
+	conf := core_rules.ComputeConf[api.Conf](toRules, element)
 	if conf == nil {
 		return nil
 	}

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin.go
@@ -82,7 +82,7 @@ func applyToInbounds(
 			continue
 		}
 
-		if err := configure(rules, core_rules.MeshSubset(), cluster); err != nil {
+		if err := configure(rules, core_rules.MeshElement(), cluster); err != nil {
 			return err
 		}
 	}
@@ -99,7 +99,7 @@ func applyToOutbounds(
 	targetedClusters := policies_xds.GatherTargetedClusters(dataplane.Spec.Networking.GetOutbound(), outboundSplitClusters, outboundClusters)
 
 	for cluster, serviceName := range targetedClusters {
-		if err := configure(rules.Rules, core_rules.MeshService(serviceName), cluster); err != nil {
+		if err := configure(rules.Rules, core_rules.MeshServiceElement(serviceName), cluster); err != nil {
 			return err
 		}
 	}
@@ -137,7 +137,7 @@ func applyToGateways(
 
 					if err := configure(
 						rules,
-						core_rules.MeshService(serviceName),
+						core_rules.MeshServiceElement(serviceName),
 						cluster,
 					); err != nil {
 						return err
@@ -152,10 +152,10 @@ func applyToGateways(
 
 func configure(
 	rules core_rules.Rules,
-	subset core_rules.Subset,
+	element core_rules.Element,
 	cluster *envoy_cluster.Cluster,
 ) error {
-	if computed := rules.Compute(subset); computed != nil {
+	if computed := rules.Compute(element); computed != nil {
 		return plugin_xds.NewConfigurer(computed.Conf.(api.Conf)).ConfigureCluster(cluster)
 	}
 

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin.go
@@ -57,7 +57,7 @@ func applyToOutbounds(
 	targetedClusters := policies_xds.GatherTargetedClusters(dataplane.Spec.Networking.GetOutbound(), outboundSplitClusters, outboundClusters)
 
 	for cluster, serviceName := range targetedClusters {
-		if err := configure(dataplane, rules.Rules, core_rules.MeshService(serviceName), meshCtx.GetServiceProtocol(serviceName), cluster); err != nil {
+		if err := configure(dataplane, rules.Rules, core_rules.MeshServiceElement(serviceName), meshCtx.GetServiceProtocol(serviceName), cluster); err != nil {
 			return err
 		}
 	}
@@ -96,7 +96,7 @@ func applyToGateways(
 					if err := configure(
 						proxy.Dataplane,
 						rules,
-						core_rules.MeshService(serviceName),
+						core_rules.MeshServiceElement(serviceName),
 						toProtocol(listenerInfo.Listener.Protocol),
 						cluster,
 					); err != nil {
@@ -123,11 +123,11 @@ func toProtocol(p mesh_proto.MeshGateway_Listener_Protocol) core_mesh.Protocol {
 func configure(
 	dataplane *core_mesh.DataplaneResource,
 	rules core_rules.Rules,
-	subset core_rules.Subset,
+	element core_rules.Element,
 	protocol core_mesh.Protocol,
 	cluster *envoy_cluster.Cluster,
 ) error {
-	conf := core_rules.ComputeConf[api.Conf](rules, subset)
+	conf := core_rules.ComputeConf[api.Conf](rules, element)
 	if conf == nil {
 		return nil
 	}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
@@ -118,7 +118,7 @@ func prepareRoutes(
 	protocol core_mesh.Protocol,
 	tags map[string]string,
 ) []Route {
-	conf := rules.ComputeConf[api.PolicyDefault](toRules, core_rules.MeshService(serviceName))
+	conf := rules.ComputeConf[api.PolicyDefault](toRules, core_rules.MeshServiceElement(serviceName))
 
 	var apiRules []api.Rule
 	if conf != nil {

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
@@ -81,7 +81,7 @@ func (p plugin) configureDPP(
 		oface := proxy.Dataplane.Spec.Networking.ToOutboundInterface(outbound)
 		serviceName := outbound.GetService()
 
-		computed := toRules.Rules.Compute(core_rules.MeshService(serviceName))
+		computed := toRules.Rules.Compute(core_rules.MeshServiceElement(serviceName))
 		if computed == nil {
 			continue
 		}
@@ -187,7 +187,7 @@ func (p plugin) configureGateway(
 			continue
 		}
 
-		meshConf := core_rules.ComputeConf[api.Conf](rules, core_rules.MeshSubset())
+		meshConf := core_rules.ComputeConf[api.Conf](rules, core_rules.MeshElement())
 
 		if err := p.configureListener(listener, gatewayRoutes, meshConf); err != nil {
 			return err
@@ -207,7 +207,7 @@ func (p plugin) configureGateway(
 					}
 
 					serviceName := dest.Destination[mesh_proto.ServiceTag]
-					localityConf := core_rules.ComputeConf[api.Conf](rules, core_rules.MeshService(serviceName))
+					localityConf := core_rules.ComputeConf[api.Conf](rules, core_rules.MeshServiceElement(serviceName))
 					if localityConf == nil {
 						continue
 					}
@@ -262,7 +262,7 @@ func (p plugin) computeFrom(fr core_rules.FromRules) *core_rules.Rule {
 	if len(rules) == 0 {
 		return nil
 	}
-	return rules[0].Compute(core_rules.MeshSubset())
+	return rules[0].Compute(core_rules.MeshElement())
 }
 
 func (p plugin) configureListener(

--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/plugin.go
@@ -38,7 +38,7 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, _ xds_context.Context, proxy *co
 	if len(policies.SingleItemRules.Rules) == 0 {
 		return nil
 	}
-	rule := policies.SingleItemRules.Rules.Compute(rules.MeshSubset())
+	rule := policies.SingleItemRules.Rules.Compute(rules.MeshElement())
 	conf := rule.Conf.(api.Conf)
 	if err := ApplyMods(rs, conf.AppendModifications); err != nil {
 		return err

--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin.go
@@ -155,7 +155,7 @@ func applyToEgress(rs *core_xds.ResourceSet, proxy *core_xds.Proxy) error {
 				for _, filterChain := range listeners.Egress.FilterChains {
 					if filterChain.Name == names.GetEgressFilterChainName(esName, meshName) {
 						var conf api.Conf
-						if computed := rule.Compute(core_rules.MeshSubset()); computed != nil {
+						if computed := rule.Compute(core_rules.MeshElement()); computed != nil {
 							conf = computed.Conf.(api.Conf)
 						} else {
 							continue
@@ -182,7 +182,7 @@ func configure(
 ) error {
 	var conf api.Conf
 	// Currently, `from` section of MeshRateLimit only allows Mesh targetRef
-	if computed := fromRules.Compute(core_rules.MeshSubset()); computed != nil {
+	if computed := fromRules.Compute(core_rules.MeshElement()); computed != nil {
 		conf = computed.Conf.(api.Conf)
 	} else {
 		return nil

--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin.go
@@ -60,7 +60,7 @@ func applyToOutbounds(
 		serviceName := outbound.GetService()
 
 		configurer := plugin_xds.Configurer{
-			Retry:    core_rules.ComputeConf[api.Conf](rules.Rules, core_rules.MeshService(serviceName)),
+			Retry:    core_rules.ComputeConf[api.Conf](rules.Rules, core_rules.MeshServiceElement(serviceName)),
 			Protocol: meshCtx.GetServiceProtocol(serviceName),
 		}
 
@@ -106,7 +106,7 @@ func applyToGateway(
 			protocol = core_mesh.ProtocolTCP
 		}
 		configurer := plugin_xds.Configurer{
-			Retry:    core_rules.ComputeConf[api.Conf](toRules, core_rules.MeshSubset()),
+			Retry:    core_rules.ComputeConf[api.Conf](toRules, core_rules.MeshElement()),
 			Protocol: protocol,
 		}
 

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners_backendrefs.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners_backendrefs.go
@@ -16,9 +16,9 @@ func getBackendRefs(
 	protocol core_mesh.Protocol,
 	tags map[string]string,
 ) []common_api.BackendRef {
-	service := core_xds.MeshService(serviceName)
+	serviceElement := core_xds.MeshServiceElement(serviceName)
 
-	tcpConf := core_xds.ComputeConf[api.Rule](toRulesTCP, service)
+	tcpConf := core_xds.ComputeConf[api.Rule](toRulesTCP, serviceElement)
 
 	// If the outbounds protocol is http-like and there exists MeshHTTPRoute
 	// with rule targeting the same MeshService as MeshTCPRoute, it should take
@@ -30,7 +30,7 @@ func getBackendRefs(
 		// MeshHTTPRoutes
 		httpConf := core_xds.ComputeConf[meshhttproute_api.PolicyDefault](
 			toRulesHTTP,
-			service,
+			serviceElement,
 		)
 		if tcpConf == nil || httpConf != nil {
 			return nil

--- a/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
@@ -85,7 +85,7 @@ func applyToInbounds(fromRules core_rules.FromRules, inboundListeners map[core_r
 		protocol := core_mesh.ParseProtocol(inbound.GetProtocol())
 		configurer := plugin_xds.ListenerConfigurer{
 			Rules:    fromRules.Rules[listenerKey],
-			Subset:   core_rules.MeshSubset(),
+			Element:  core_rules.MeshElement(),
 			Protocol: protocol,
 		}
 
@@ -98,7 +98,7 @@ func applyToInbounds(fromRules core_rules.FromRules, inboundListeners map[core_r
 			continue
 		}
 
-		conf := getConf(fromRules.Rules[listenerKey], core_rules.MeshSubset())
+		conf := getConf(fromRules.Rules[listenerKey], core_rules.MeshElement())
 		if conf == nil {
 			continue
 		}
@@ -130,7 +130,7 @@ func applyToOutbounds(
 		configurer := plugin_xds.ListenerConfigurer{
 			Rules:    rules.Rules,
 			Protocol: meshCtx.GetServiceProtocol(serviceName),
-			Subset:   core_rules.MeshService(serviceName),
+			Element:  core_rules.MeshServiceElement(serviceName),
 		}
 
 		if err := configurer.ConfigureListener(listener); err != nil {
@@ -147,7 +147,7 @@ func applyToClusters(
 	protocol core_mesh.Protocol,
 	clusters ...*envoy_cluster.Cluster,
 ) error {
-	conf := getConf(rules, core_rules.MeshService(serviceName))
+	conf := getConf(rules, core_rules.MeshServiceElement(serviceName))
 	if conf == nil {
 		return nil
 	}
@@ -175,7 +175,7 @@ func applyToGateway(
 			Port:    listenerInfo.Listener.Port,
 		}
 
-		conf := getConf(gatewayRules.FromRules[key], core_rules.MeshSubset())
+		conf := getConf(gatewayRules.FromRules[key], core_rules.MeshElement())
 		if err := plugin_xds.ConfigureGatewayListener(
 			conf,
 			listenerInfo.Listener.Protocol,
@@ -189,7 +189,7 @@ func applyToGateway(
 			continue
 		}
 
-		conf = getConf(toRules, core_rules.MeshSubset())
+		conf = getConf(toRules, core_rules.MeshElement())
 		for _, listenerHostname := range listenerInfo.ListenerHostnames {
 			route, ok := gatewayRoutes[listenerHostname.EnvoyRouteName(listenerInfo.Listener.EnvoyListenerName)]
 
@@ -221,7 +221,7 @@ func applyToGateway(
 
 					serviceName := dest.Destination[mesh_proto.ServiceTag]
 
-					conf := getConf(toRules, core_rules.MeshService(serviceName))
+					conf := getConf(toRules, core_rules.MeshServiceElement(serviceName))
 					if conf == nil {
 						continue
 					}
@@ -244,12 +244,12 @@ func applyToGateway(
 
 func getConf(
 	rules core_rules.Rules,
-	subset core_rules.Subset,
+	element core_rules.Element,
 ) *api.Conf {
 	if rules == nil {
 		return &api.Conf{}
 	} else {
-		if computed := rules.Compute(subset); computed != nil {
+		if computed := rules.Compute(element); computed != nil {
 			return pointer.To(computed.Conf.(api.Conf))
 		} else {
 			return nil

--- a/pkg/plugins/policies/meshtrafficpermission/graph/reachable_services_graph.go
+++ b/pkg/plugins/policies/meshtrafficpermission/graph/reachable_services_graph.go
@@ -36,7 +36,7 @@ func (r *Graph) CanReach(fromTags map[string]string, toTags map[string]string) b
 		// we cannot compute graph for cross mesh, so it's better to allow the traffic
 		return true
 	}
-	rule := r.rules[toTags[mesh_proto.ServiceTag]].Compute(core_rules.SubsetFromTags(fromTags))
+	rule := r.rules[toTags[mesh_proto.ServiceTag]].Compute(core_rules.Element(fromTags))
 	if rule == nil {
 		return false
 	}


### PR DESCRIPTION
## Motivation

1. When I went through the policy matching subset `Intersect` method, I found the behavior is incorrect with one case
2. Rewrite the rule's `Compute` method to use the new `ContainsElement` method instead of using the old `IsSubset` method

## Implementation information

Introduce one new type `type Element map[string]string` for differentiation by `IsSubset`.

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)? -->

## Backport

cherry-picked commit 3a00363b331f92278c57caa3b47e6113e83e7525

