### PR TITLE
chore(deps): upgrade security-actions/sign-docker-image to v4.0.1

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -192,7 +192,7 @@ jobs:
       - name: sign image
         if: ${{ fromJSON(inputs.ALLOW_PUSH) }}
         id: sign
-        uses: Kong/public-shared-actions/security-actions/sign-docker-image@0ccacffed804d85da3f938a1b78c12831935f992 # v2.8.0
+        uses: Kong/public-shared-actions/security-actions/sign-docker-image@fbf0fcb6762ab4080fd2813d2e3eec0564cbdbf0 # v4.0.1
         with:
           image_digest: ${{ steps.image_digest.outputs.digest }}
           tags: ${{ steps.image_meta.outputs.image }}


### PR DESCRIPTION
## Motivation

Sometimes we can observe sign image errors related to token validation. This version has a fix which should solve the problem

```
Retrieving signed certificate...
Non-interactive mode detected, using device flow.
Enter the verification code DZXT-XKLG in your browser at: https://oauth2.sigstore.dev/auth/device?user_code=DZXT-XKLG
Code will be valid for 300 seconds
Error: signing [docker.io/kumahq/kuma-cp@sha256:f1798ae5df07acf3968a23f44fd73e1d47ba998ad1ec2612efb92ba752ead4ec]: getting signer: getting key from Fulcio: retrieving cert: error obtaining token: expired_token
main.go:74: error during command execution: signing [docker.io/kumahq/kuma-cp@sha256:f1798ae5df07acf3968a23f44fd73e1d47ba998ad1ec2612efb92ba752ead4ec]: getting signer: getting key from Fulcio: retrieving cert: error obtaining token: expired_token
```