### PR TITLE
chore(deps): upgrade security-actions/sign-docker-image to v4.0.1

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -188,7 +188,7 @@ jobs:
       - name: sign image
         if: ${{ fromJSON(inputs.ALLOW_PUSH) }}
         id: sign
-        uses: Kong/public-shared-actions/security-actions/sign-docker-image@28d20a1f492927f35b00b317acd78f669c45f88b # v2.7.3
+        uses: Kong/public-shared-actions/security-actions/sign-docker-image@fbf0fcb6762ab4080fd2813d2e3eec0564cbdbf0 # v4.0.1
         with:
           image_digest: ${{ steps.image_digest.outputs.digest }}
           tags: ${{ steps.image_meta.outputs.image }}


### PR DESCRIPTION
## Motivation

backport https://github.com/kumahq/kuma/pull/12540/