### PR TITLE
ci(renovate): add initial renovate.json configuration file

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "schedule": "before 5am every weekday",
+  "extends": [
+    "config:best-practices",
+    ":automergeDisabled",
+    ":gitSignOff"
+  ],
+  "baseBranches": [
+    "release-2.6",
+    "release-2.7",
+    "release-2.8",
+    "release-2.9",
+    "master"
+  ],
+  "enabledManagers": [
+    "dockerfile",
+    "github-actions",
+    "gomod",
+    "helm-values"
+  ],
+  "ignorePaths": [
+    "(^|/)([Dd]ocker|[Cc]ontainer)file[^/]*\\.dockerignore$"
+  ],
+  "labels": [
+    "dependencies"
+  ],
+  "packageRules": [
+    {
+      "description": "go-control-plane v0.12.0 introduced a potential deadlock issue. This issue is being tracked in https://github.com/envoyproxy/go-control-plane/issues/875. Remove this once the issue is resolved",
+      "enabled": false,
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["github.com/envoyproxy/go-control-plane"]
+    },
+    {
+      "description": "No need to run tests on github actions updates",
+      "matchManagers": ["github-actions"],
+      "addLabels": ["ci/skip-test"]
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -27,12 +27,6 @@
   ],
   "packageRules": [
     {
-      "description": "go-control-plane v0.12.0 introduced a potential deadlock issue. This issue is being tracked in https://github.com/envoyproxy/go-control-plane/issues/875. Remove this once the issue is resolved",
-      "enabled": false,
-      "matchManagers": ["gomod"],
-      "matchPackageNames": ["github.com/envoyproxy/go-control-plane"]
-    },
-    {
       "description": "No need to run tests on github actions updates",
       "matchManagers": ["github-actions"],
       "addLabels": ["ci/skip-test"]

--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,10 @@
     "gomod",
     "helm-values"
   ],
+  "postUpdateOptions": [
+    "gomodMassage",
+    "gomodTidy"
+  ],
   "ignorePaths": [
     "(^|/)([Dd]ocker|[Cc]ontainer)file[^/]*\\.dockerignore$"
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -7,10 +7,6 @@
     ":gitSignOff"
   ],
   "baseBranches": [
-    "release-2.6",
-    "release-2.7",
-    "release-2.8",
-    "release-2.9",
     "master"
   ],
   "enabledManagers": [


### PR DESCRIPTION
## Motivation

We want to move from dependabot to renovate

## Implementation information

This file is not final, but it should be a good base. I can't find any builtin way to dynamically provide `baseBranches` or read them from `active-branches.json` file, so our release scripts should be updated to update them on the same tame as `active-branches.json`.

## Supporting documentation

Part of https://github.com/kumahq/kuma/issues/12529
