### PR TITLE
ci(renovatae): set PR title semmantic type to be always "chore"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "schedule": "before 5am every weekday",
   "extends": [
     "config:best-practices",
+    ":semanticCommitTypeAll(chore)",
     ":automergeDisabled",
     ":gitSignOff"
   ],


### PR DESCRIPTION
## Motivation

Currently some PRs have prefix `fix(deps)` when it should be `chore(deps)`

## Supporting documentation

Part of https://github.com/kumahq/kuma/issues/12529