### PR TITLE
fix(kuma-cp): handle conn closed issue when creating saving stream connection

### DIFF
--- a/pkg/kds/service/server.go
+++ b/pkg/kds/service/server.go
@@ -165,7 +165,7 @@ func (g *GlobalKDSServiceServer) streamEnvoyAdminRPC(
 	logger.Info("Envoy Admin RPC stream started")
 	rpc.ClientConnected(tenantZoneID.String(), stream)
 	if err := g.storeStreamConnection(stream.Context(), zone, rpcName, g.instanceID); err != nil {
-		if errors.Is(err, context.Canceled) {
+		if errors.Is(err, context.Canceled) && errors.Is(stream.Context().Err(), context.Canceled) {
 			return status.Error(codes.Canceled, "stream was cancelled")
 		}
 		logger.Error(err, "could not store stream connection")


### PR DESCRIPTION
## Motivation

We have seen `conn closed` errors on live environment when trying to save connection info: 

```
failed to execute query UPDATE resources SET spec=$1, version=$2, modification_time=$3, labels=$4, status=$5 WHERE name=$6 AND mesh=$7 AND type=$8 AND version=$9;: conn closed
```

When we look into logs, the stream is closed just before we see this error: 

<img width="525" alt="image" src="https://github.com/user-attachments/assets/cd49e805-245f-4543-8e0b-2b8170f570ab" />

I think that we just need better handling of cancelled streams.


<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
