### PR TITLE
chore(oapi): move CreateOrUpdateSuccessResponse under `components.responses`

### DIFF
--- a/api/mesh/v1alpha1/mesh/rest.yaml
+++ b/api/mesh/v1alpha1/mesh/rest.yaml
@@ -46,13 +46,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshCreateOrUpdateSuccessResponse'
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: delete-m
@@ -84,6 +84,7 @@ components:
   schemas:
     MeshItem:
       $ref: 'schema.yaml'
+  responses:
     MeshCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -94,8 +95,6 @@ components:
             Warning messages describe a problem the client making the API request should correct or be aware of.
           items:
             type: string
-
-  responses:
     MeshItem:
       description: Successful response
       content:

--- a/api/mesh/v1alpha1/meshgateway/rest.yaml
+++ b/api/mesh/v1alpha1/meshgateway/rest.yaml
@@ -58,13 +58,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshGatewayCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshGatewayCreateOrUpdateSuccessResponse'
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshGatewayCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshGatewayCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: delete-mgw
@@ -109,6 +109,7 @@ components:
   schemas:
     MeshGatewayItem:
       $ref: 'schema.yaml'
+  responses:
     MeshGatewayCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -119,8 +120,6 @@ components:
             Warning messages describe a problem the client making the API request should correct or be aware of.
           items:
             type: string
-
-  responses:
     MeshGatewayItem:
       description: Successful response
       content:

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -288,14 +288,14 @@ paths:
             application/json:
               schema:
                 $ref: >-
-                  #/components/schemas/MeshAccessLogCreateOrUpdateSuccessResponse
+                  #/components/responses/MeshAccessLogCreateOrUpdateSuccessResponse
         '201':
           description: Created
           content:
             application/json:
               schema:
                 $ref: >-
-                  #/components/schemas/MeshAccessLogCreateOrUpdateSuccessResponse
+                  #/components/responses/MeshAccessLogCreateOrUpdateSuccessResponse
     delete:
       operationId: delete-mal
       summary: Deletes MeshAccessLog entity
@@ -389,14 +389,14 @@ paths:
             application/json:
               schema:
                 $ref: >-
-                  #/components/schemas/MeshCircuitBreakerCreateOrUpdateSuccessResponse
+                  #/components/responses/MeshCircuitBreakerCreateOrUpdateSuccessResponse
         '201':
           description: Created
           content:
             application/json:
               schema:
                 $ref: >-
-                  #/components/schemas/MeshCircuitBreakerCreateOrUpdateSuccessResponse
+                  #/components/responses/MeshCircuitBreakerCreateOrUpdateSuccessResponse
     delete:
       operationId: delete-mcb
       summary: Deletes MeshCircuitBreaker entity
@@ -490,14 +490,14 @@ paths:
             application/json:
               schema:
                 $ref: >-
-                  #/components/schemas/MeshFaultInjectionCreateOrUpdateSuccessResponse
+                  #/components/responses/MeshFaultInjectionCreateOrUpdateSuccessResponse
         '201':
           description: Created
           content:
             application/json:
               schema:
                 $ref: >-
-                  #/components/schemas/MeshFaultInjectionCreateOrUpdateSuccessResponse
+                  #/components/responses/MeshFaultInjectionCreateOrUpdateSuccessResponse
     delete:
       operationId: delete-mfi
       summary: Deletes MeshFaultInjection entity
@@ -591,14 +591,14 @@ paths:
             application/json:
               schema:
                 $ref: >-
-                  #/components/schemas/MeshHealthCheckCreateOrUpdateSuccessResponse
+                  #/components/responses/MeshHealthCheckCreateOrUpdateSuccessResponse
         '201':
           description: Created
           content:
             application/json:
               schema:
                 $ref: >-
-                  #/components/schemas/MeshHealthCheckCreateOrUpdateSuccessResponse
+                  #/components/responses/MeshHealthCheckCreateOrUpdateSuccessResponse
     delete:
       operationId: delete-mhc
       summary: Deletes MeshHealthCheck entity
@@ -692,14 +692,14 @@ paths:
             application/json:
               schema:
                 $ref: >-
-                  #/components/schemas/MeshHTTPRouteCreateOrUpdateSuccessResponse
+                  #/components/responses/MeshHTTPRouteCreateOrUpdateSuccessResponse
         '201':
           description: Created
           content:
             application/json:
               schema:
                 $ref: >-
-                  #/components/schemas/MeshHTTPRouteCreateOrUpdateSuccessResponse
+                  #/components/responses/MeshHTTPRouteCreateOrUpdateSuccessResponse
     delete:
       operationId: delete-mhttpr
       summary: Deletes MeshHTTPRoute entity
@@ -793,14 +793,14 @@ paths:
             application/json:
               schema:
                 $ref: >-
-                  #/components/schemas/MeshLoadBalancingStrategyCreateOrUpdateSuccessResponse
+                  #/components/responses/MeshLoadBalancingStrategyCreateOrUpdateSuccessResponse
         '201':
           description: Created
           content:
             application/json:
               schema:
                 $ref: >-
-                  #/components/schemas/MeshLoadBalancingStrategyCreateOrUpdateSuccessResponse
+                  #/components/responses/MeshLoadBalancingStrategyCreateOrUpdateSuccessResponse
     delete:
       operationId: delete-mlbs
       summary: Deletes MeshLoadBalancingStrategy entity
@@ -893,13 +893,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshMetricCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshMetricCreateOrUpdateSuccessResponse'
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshMetricCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshMetricCreateOrUpdateSuccessResponse'
     delete:
       operationId: delete-mm
       summary: Deletes MeshMetric entity
@@ -993,14 +993,14 @@ paths:
             application/json:
               schema:
                 $ref: >-
-                  #/components/schemas/MeshPassthroughCreateOrUpdateSuccessResponse
+                  #/components/responses/MeshPassthroughCreateOrUpdateSuccessResponse
         '201':
           description: Created
           content:
             application/json:
               schema:
                 $ref: >-
-                  #/components/schemas/MeshPassthroughCreateOrUpdateSuccessResponse
+                  #/components/responses/MeshPassthroughCreateOrUpdateSuccessResponse
     delete:
       operationId: delete-mp
       summary: Deletes MeshPassthrough entity
@@ -1094,14 +1094,14 @@ paths:
             application/json:
               schema:
                 $ref: >-
-                  #/components/schemas/MeshProxyPatchCreateOrUpdateSuccessResponse
+                  #/components/responses/MeshProxyPatchCreateOrUpdateSuccessResponse
         '201':
           description: Created
           content:
             application/json:
               schema:
                 $ref: >-
-                  #/components/schemas/MeshProxyPatchCreateOrUpdateSuccessResponse
+                  #/components/responses/MeshProxyPatchCreateOrUpdateSuccessResponse
     delete:
       operationId: delete-mpp
       summary: Deletes MeshProxyPatch entity
@@ -1195,14 +1195,14 @@ paths:
             application/json:
               schema:
                 $ref: >-
-                  #/components/schemas/MeshRateLimitCreateOrUpdateSuccessResponse
+                  #/components/responses/MeshRateLimitCreateOrUpdateSuccessResponse
         '201':
           description: Created
           content:
             application/json:
               schema:
                 $ref: >-
-                  #/components/schemas/MeshRateLimitCreateOrUpdateSuccessResponse
+                  #/components/responses/MeshRateLimitCreateOrUpdateSuccessResponse
     delete:
       operationId: delete-mrl
       summary: Deletes MeshRateLimit entity
@@ -1295,13 +1295,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshRetryCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshRetryCreateOrUpdateSuccessResponse'
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshRetryCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshRetryCreateOrUpdateSuccessResponse'
     delete:
       operationId: delete-mr
       summary: Deletes MeshRetry entity
@@ -1394,13 +1394,15 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshTCPRouteCreateOrUpdateSuccessResponse'
+                $ref: >-
+                  #/components/responses/MeshTCPRouteCreateOrUpdateSuccessResponse
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshTCPRouteCreateOrUpdateSuccessResponse'
+                $ref: >-
+                  #/components/responses/MeshTCPRouteCreateOrUpdateSuccessResponse
     delete:
       operationId: delete-mtcpr
       summary: Deletes MeshTCPRoute entity
@@ -1493,13 +1495,15 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshTimeoutCreateOrUpdateSuccessResponse'
+                $ref: >-
+                  #/components/responses/MeshTimeoutCreateOrUpdateSuccessResponse
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshTimeoutCreateOrUpdateSuccessResponse'
+                $ref: >-
+                  #/components/responses/MeshTimeoutCreateOrUpdateSuccessResponse
     delete:
       operationId: delete-mt
       summary: Deletes MeshTimeout entity
@@ -1592,13 +1596,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshTLSCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshTLSCreateOrUpdateSuccessResponse'
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshTLSCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshTLSCreateOrUpdateSuccessResponse'
     delete:
       operationId: delete-mtls
       summary: Deletes MeshTLS entity
@@ -1691,13 +1695,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshTraceCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshTraceCreateOrUpdateSuccessResponse'
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshTraceCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshTraceCreateOrUpdateSuccessResponse'
     delete:
       operationId: delete-mtr
       summary: Deletes MeshTrace entity
@@ -1791,14 +1795,14 @@ paths:
             application/json:
               schema:
                 $ref: >-
-                  #/components/schemas/MeshTrafficPermissionCreateOrUpdateSuccessResponse
+                  #/components/responses/MeshTrafficPermissionCreateOrUpdateSuccessResponse
         '201':
           description: Created
           content:
             application/json:
               schema:
                 $ref: >-
-                  #/components/schemas/MeshTrafficPermissionCreateOrUpdateSuccessResponse
+                  #/components/responses/MeshTrafficPermissionCreateOrUpdateSuccessResponse
     delete:
       operationId: delete-mtp
       summary: Deletes MeshTrafficPermission entity
@@ -1879,13 +1883,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshCreateOrUpdateSuccessResponse'
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshCreateOrUpdateSuccessResponse'
     delete:
       operationId: delete-m
       summary: Deletes Mesh entity
@@ -1965,13 +1969,15 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshGatewayCreateOrUpdateSuccessResponse'
+                $ref: >-
+                  #/components/responses/MeshGatewayCreateOrUpdateSuccessResponse
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshGatewayCreateOrUpdateSuccessResponse'
+                $ref: >-
+                  #/components/responses/MeshGatewayCreateOrUpdateSuccessResponse
     delete:
       operationId: delete-mgw
       summary: Deletes MeshGateway entity
@@ -2053,14 +2059,14 @@ paths:
             application/json:
               schema:
                 $ref: >-
-                  #/components/schemas/HostnameGeneratorCreateOrUpdateSuccessResponse
+                  #/components/responses/HostnameGeneratorCreateOrUpdateSuccessResponse
         '201':
           description: Created
           content:
             application/json:
               schema:
                 $ref: >-
-                  #/components/schemas/HostnameGeneratorCreateOrUpdateSuccessResponse
+                  #/components/responses/HostnameGeneratorCreateOrUpdateSuccessResponse
     delete:
       operationId: delete-hg
       summary: Deletes HostnameGenerator entity
@@ -2141,14 +2147,14 @@ paths:
             application/json:
               schema:
                 $ref: >-
-                  #/components/schemas/MeshExternalServiceCreateOrUpdateSuccessResponse
+                  #/components/responses/MeshExternalServiceCreateOrUpdateSuccessResponse
         '201':
           description: Created
           content:
             application/json:
               schema:
                 $ref: >-
-                  #/components/schemas/MeshExternalServiceCreateOrUpdateSuccessResponse
+                  #/components/responses/MeshExternalServiceCreateOrUpdateSuccessResponse
     delete:
       operationId: delete-extsvc
       summary: Deletes MeshExternalService entity
@@ -2242,14 +2248,14 @@ paths:
             application/json:
               schema:
                 $ref: >-
-                  #/components/schemas/MeshMultiZoneServiceCreateOrUpdateSuccessResponse
+                  #/components/responses/MeshMultiZoneServiceCreateOrUpdateSuccessResponse
         '201':
           description: Created
           content:
             application/json:
               schema:
                 $ref: >-
-                  #/components/schemas/MeshMultiZoneServiceCreateOrUpdateSuccessResponse
+                  #/components/responses/MeshMultiZoneServiceCreateOrUpdateSuccessResponse
     delete:
       operationId: delete-mzsvc
       summary: Deletes MeshMultiZoneService entity
@@ -2342,13 +2348,15 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshServiceCreateOrUpdateSuccessResponse'
+                $ref: >-
+                  #/components/responses/MeshServiceCreateOrUpdateSuccessResponse
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshServiceCreateOrUpdateSuccessResponse'
+                $ref: >-
+                  #/components/responses/MeshServiceCreateOrUpdateSuccessResponse
     delete:
       operationId: delete-msvc
       summary: Deletes MeshService entity
@@ -3683,19 +3691,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-    MeshAccessLogCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
     MeshCircuitBreakerItem:
       type: object
       required:
@@ -4902,19 +4897,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-    MeshCircuitBreakerCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
     MeshFaultInjectionItem:
       type: object
       required:
@@ -5415,19 +5397,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-    MeshFaultInjectionCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
     MeshHealthCheckItem:
       type: object
       required:
@@ -5902,19 +5871,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-    MeshHealthCheckCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
     MeshHTTPRouteItem:
       type: object
       required:
@@ -6706,19 +6662,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-    MeshHTTPRouteCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
     MeshLoadBalancingStrategyItem:
       type: object
       required:
@@ -7469,19 +7412,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-    MeshLoadBalancingStrategyCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
     MeshMetricItem:
       type: object
       required:
@@ -7801,19 +7731,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-    MeshMetricCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
     MeshPassthroughItem:
       type: object
       required:
@@ -7986,19 +7903,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-    MeshPassthroughCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
     MeshProxyPatchItem:
       type: object
       required:
@@ -8703,19 +8607,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-    MeshProxyPatchCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
     MeshRateLimitItem:
       type: object
       required:
@@ -9290,19 +9181,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-    MeshRateLimitCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
     MeshRetryItem:
       type: object
       required:
@@ -9936,19 +9814,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-    MeshRetryCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
     MeshTCPRouteItem:
       type: object
       required:
@@ -10276,19 +10141,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-    MeshTCPRouteCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
     MeshTimeoutItem:
       type: object
       required:
@@ -10755,19 +10607,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-    MeshTimeoutCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
     MeshTLSItem:
       type: object
       required:
@@ -11035,19 +10874,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-    MeshTLSCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
     MeshTraceItem:
       type: object
       required:
@@ -11385,19 +11211,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-    MeshTraceCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
     MeshTrafficPermissionItem:
       type: object
       required:
@@ -11626,19 +11439,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-    MeshTrafficPermissionCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
     MeshItem:
       properties:
         constraints:
@@ -11969,19 +11769,6 @@ components:
         - type
         - name
       type: object
-    MeshCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
     MeshGatewayItem:
       properties:
         conf:
@@ -12167,19 +11954,6 @@ components:
         - name
         - mesh
       type: object
-    MeshGatewayCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
     HostnameGeneratorItem:
       type: object
       required:
@@ -12240,19 +12014,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-    HostnameGeneratorCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
     MeshExternalServiceItem:
       type: object
       required:
@@ -12597,19 +12358,6 @@ components:
                   type: string
               type: object
           type: object
-    MeshExternalServiceCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
     MeshMultiZoneServiceItem:
       type: object
       required:
@@ -12810,19 +12558,6 @@ components:
                 type: object
               type: array
           type: object
-    MeshMultiZoneServiceCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
     MeshServiceItem:
       type: object
       required:
@@ -13049,19 +12784,6 @@ components:
                 type: object
               type: array
           type: object
-    MeshServiceCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
   responses:
     IndexResponse:
       description: A response for the index endpoint
@@ -13132,6 +12854,19 @@ components:
         application/problem+json:
           schema:
             $ref: '#/components/schemas/NotFoundError'
+    MeshAccessLogCreateOrUpdateSuccessResponse:
+      type: object
+      properties:
+        warnings:
+          type: array
+          description: >
+            warnings is a list of warning messages to return to the requesting
+            Kuma API clients.
+
+            Warning messages describe a problem the client making the API
+            request should correct or be aware of.
+          items:
+            type: string
     MeshAccessLogItem:
       description: Successful response
       content:
@@ -13155,6 +12890,19 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshCircuitBreakerCreateOrUpdateSuccessResponse:
+      type: object
+      properties:
+        warnings:
+          type: array
+          description: >
+            warnings is a list of warning messages to return to the requesting
+            Kuma API clients.
+
+            Warning messages describe a problem the client making the API
+            request should correct or be aware of.
+          items:
+            type: string
     MeshCircuitBreakerItem:
       description: Successful response
       content:
@@ -13178,6 +12926,19 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshFaultInjectionCreateOrUpdateSuccessResponse:
+      type: object
+      properties:
+        warnings:
+          type: array
+          description: >
+            warnings is a list of warning messages to return to the requesting
+            Kuma API clients.
+
+            Warning messages describe a problem the client making the API
+            request should correct or be aware of.
+          items:
+            type: string
     MeshFaultInjectionItem:
       description: Successful response
       content:
@@ -13201,6 +12962,19 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshHealthCheckCreateOrUpdateSuccessResponse:
+      type: object
+      properties:
+        warnings:
+          type: array
+          description: >
+            warnings is a list of warning messages to return to the requesting
+            Kuma API clients.
+
+            Warning messages describe a problem the client making the API
+            request should correct or be aware of.
+          items:
+            type: string
     MeshHealthCheckItem:
       description: Successful response
       content:
@@ -13224,6 +12998,19 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshHTTPRouteCreateOrUpdateSuccessResponse:
+      type: object
+      properties:
+        warnings:
+          type: array
+          description: >
+            warnings is a list of warning messages to return to the requesting
+            Kuma API clients.
+
+            Warning messages describe a problem the client making the API
+            request should correct or be aware of.
+          items:
+            type: string
     MeshHTTPRouteItem:
       description: Successful response
       content:
@@ -13247,6 +13034,19 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshLoadBalancingStrategyCreateOrUpdateSuccessResponse:
+      type: object
+      properties:
+        warnings:
+          type: array
+          description: >
+            warnings is a list of warning messages to return to the requesting
+            Kuma API clients.
+
+            Warning messages describe a problem the client making the API
+            request should correct or be aware of.
+          items:
+            type: string
     MeshLoadBalancingStrategyItem:
       description: Successful response
       content:
@@ -13270,6 +13070,19 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshMetricCreateOrUpdateSuccessResponse:
+      type: object
+      properties:
+        warnings:
+          type: array
+          description: >
+            warnings is a list of warning messages to return to the requesting
+            Kuma API clients.
+
+            Warning messages describe a problem the client making the API
+            request should correct or be aware of.
+          items:
+            type: string
     MeshMetricItem:
       description: Successful response
       content:
@@ -13293,6 +13106,19 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshPassthroughCreateOrUpdateSuccessResponse:
+      type: object
+      properties:
+        warnings:
+          type: array
+          description: >
+            warnings is a list of warning messages to return to the requesting
+            Kuma API clients.
+
+            Warning messages describe a problem the client making the API
+            request should correct or be aware of.
+          items:
+            type: string
     MeshPassthroughItem:
       description: Successful response
       content:
@@ -13316,6 +13142,19 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshProxyPatchCreateOrUpdateSuccessResponse:
+      type: object
+      properties:
+        warnings:
+          type: array
+          description: >
+            warnings is a list of warning messages to return to the requesting
+            Kuma API clients.
+
+            Warning messages describe a problem the client making the API
+            request should correct or be aware of.
+          items:
+            type: string
     MeshProxyPatchItem:
       description: Successful response
       content:
@@ -13339,6 +13178,19 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshRateLimitCreateOrUpdateSuccessResponse:
+      type: object
+      properties:
+        warnings:
+          type: array
+          description: >
+            warnings is a list of warning messages to return to the requesting
+            Kuma API clients.
+
+            Warning messages describe a problem the client making the API
+            request should correct or be aware of.
+          items:
+            type: string
     MeshRateLimitItem:
       description: Successful response
       content:
@@ -13362,6 +13214,19 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshRetryCreateOrUpdateSuccessResponse:
+      type: object
+      properties:
+        warnings:
+          type: array
+          description: >
+            warnings is a list of warning messages to return to the requesting
+            Kuma API clients.
+
+            Warning messages describe a problem the client making the API
+            request should correct or be aware of.
+          items:
+            type: string
     MeshRetryItem:
       description: Successful response
       content:
@@ -13385,6 +13250,19 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshTCPRouteCreateOrUpdateSuccessResponse:
+      type: object
+      properties:
+        warnings:
+          type: array
+          description: >
+            warnings is a list of warning messages to return to the requesting
+            Kuma API clients.
+
+            Warning messages describe a problem the client making the API
+            request should correct or be aware of.
+          items:
+            type: string
     MeshTCPRouteItem:
       description: Successful response
       content:
@@ -13408,6 +13286,19 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshTimeoutCreateOrUpdateSuccessResponse:
+      type: object
+      properties:
+        warnings:
+          type: array
+          description: >
+            warnings is a list of warning messages to return to the requesting
+            Kuma API clients.
+
+            Warning messages describe a problem the client making the API
+            request should correct or be aware of.
+          items:
+            type: string
     MeshTimeoutItem:
       description: Successful response
       content:
@@ -13431,6 +13322,19 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshTLSCreateOrUpdateSuccessResponse:
+      type: object
+      properties:
+        warnings:
+          type: array
+          description: >
+            warnings is a list of warning messages to return to the requesting
+            Kuma API clients.
+
+            Warning messages describe a problem the client making the API
+            request should correct or be aware of.
+          items:
+            type: string
     MeshTLSItem:
       description: Successful response
       content:
@@ -13454,6 +13358,19 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshTraceCreateOrUpdateSuccessResponse:
+      type: object
+      properties:
+        warnings:
+          type: array
+          description: >
+            warnings is a list of warning messages to return to the requesting
+            Kuma API clients.
+
+            Warning messages describe a problem the client making the API
+            request should correct or be aware of.
+          items:
+            type: string
     MeshTraceItem:
       description: Successful response
       content:
@@ -13477,6 +13394,19 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshTrafficPermissionCreateOrUpdateSuccessResponse:
+      type: object
+      properties:
+        warnings:
+          type: array
+          description: >
+            warnings is a list of warning messages to return to the requesting
+            Kuma API clients.
+
+            Warning messages describe a problem the client making the API
+            request should correct or be aware of.
+          items:
+            type: string
     MeshTrafficPermissionItem:
       description: Successful response
       content:
@@ -13500,6 +13430,19 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshCreateOrUpdateSuccessResponse:
+      type: object
+      properties:
+        warnings:
+          type: array
+          description: >
+            warnings is a list of warning messages to return to the requesting
+            Kuma API clients.
+
+            Warning messages describe a problem the client making the API
+            request should correct or be aware of.
+          items:
+            type: string
     MeshItem:
       description: Successful response
       content:
@@ -13523,6 +13466,19 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshGatewayCreateOrUpdateSuccessResponse:
+      type: object
+      properties:
+        warnings:
+          type: array
+          description: >
+            warnings is a list of warning messages to return to the requesting
+            Kuma API clients.
+
+            Warning messages describe a problem the client making the API
+            request should correct or be aware of.
+          items:
+            type: string
     MeshGatewayItem:
       description: Successful response
       content:
@@ -13546,6 +13502,19 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    HostnameGeneratorCreateOrUpdateSuccessResponse:
+      type: object
+      properties:
+        warnings:
+          type: array
+          description: >
+            warnings is a list of warning messages to return to the requesting
+            Kuma API clients.
+
+            Warning messages describe a problem the client making the API
+            request should correct or be aware of.
+          items:
+            type: string
     HostnameGeneratorItem:
       description: Successful response
       content:
@@ -13569,6 +13538,19 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshExternalServiceCreateOrUpdateSuccessResponse:
+      type: object
+      properties:
+        warnings:
+          type: array
+          description: >
+            warnings is a list of warning messages to return to the requesting
+            Kuma API clients.
+
+            Warning messages describe a problem the client making the API
+            request should correct or be aware of.
+          items:
+            type: string
     MeshExternalServiceItem:
       description: Successful response
       content:
@@ -13592,6 +13574,19 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshMultiZoneServiceCreateOrUpdateSuccessResponse:
+      type: object
+      properties:
+        warnings:
+          type: array
+          description: >
+            warnings is a list of warning messages to return to the requesting
+            Kuma API clients.
+
+            Warning messages describe a problem the client making the API
+            request should correct or be aware of.
+          items:
+            type: string
     MeshMultiZoneServiceItem:
       description: Successful response
       content:
@@ -13615,6 +13610,19 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshServiceCreateOrUpdateSuccessResponse:
+      type: object
+      properties:
+        warnings:
+          type: array
+          description: >
+            warnings is a list of warning messages to return to the requesting
+            Kuma API clients.
+
+            Warning messages describe a problem the client making the API
+            request should correct or be aware of.
+          items:
+            type: string
     MeshServiceItem:
       description: Successful response
       content:

--- a/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/rest.yaml
@@ -46,13 +46,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HostnameGeneratorCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/HostnameGeneratorCreateOrUpdateSuccessResponse'
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HostnameGeneratorCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/HostnameGeneratorCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: delete-hg
@@ -84,6 +84,7 @@ components:
   schemas:
     HostnameGeneratorItem:
       $ref: 'schema.yaml'
+  responses:
     HostnameGeneratorCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -94,8 +95,6 @@ components:
             Warning messages describe a problem the client making the API request should correct or be aware of.
           items:
             type: string
-
-  responses:
     HostnameGeneratorItem:
       description: Successful response
       content:

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/rest.yaml
@@ -58,13 +58,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshExternalServiceCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshExternalServiceCreateOrUpdateSuccessResponse'
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshExternalServiceCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshExternalServiceCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: delete-extsvc
@@ -109,6 +109,7 @@ components:
   schemas:
     MeshExternalServiceItem:
       $ref: 'schema.yaml'
+  responses:
     MeshExternalServiceCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -119,8 +120,6 @@ components:
             Warning messages describe a problem the client making the API request should correct or be aware of.
           items:
             type: string
-
-  responses:
     MeshExternalServiceItem:
       description: Successful response
       content:

--- a/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/rest.yaml
@@ -58,13 +58,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshMultiZoneServiceCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshMultiZoneServiceCreateOrUpdateSuccessResponse'
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshMultiZoneServiceCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshMultiZoneServiceCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: delete-mzsvc
@@ -109,6 +109,7 @@ components:
   schemas:
     MeshMultiZoneServiceItem:
       $ref: 'schema.yaml'
+  responses:
     MeshMultiZoneServiceCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -119,8 +120,6 @@ components:
             Warning messages describe a problem the client making the API request should correct or be aware of.
           items:
             type: string
-
-  responses:
     MeshMultiZoneServiceItem:
       description: Successful response
       content:

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/rest.yaml
@@ -58,13 +58,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshServiceCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshServiceCreateOrUpdateSuccessResponse'
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshServiceCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshServiceCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: delete-msvc
@@ -109,6 +109,7 @@ components:
   schemas:
     MeshServiceItem:
       $ref: 'schema.yaml'
+  responses:
     MeshServiceCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -119,8 +120,6 @@ components:
             Warning messages describe a problem the client making the API request should correct or be aware of.
           items:
             type: string
-
-  responses:
     MeshServiceItem:
       description: Successful response
       content:

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/rest.yaml
@@ -58,13 +58,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshAccessLogCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshAccessLogCreateOrUpdateSuccessResponse'
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshAccessLogCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshAccessLogCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: delete-mal
@@ -109,6 +109,7 @@ components:
   schemas:
     MeshAccessLogItem:
       $ref: 'schema.yaml'
+  responses:
     MeshAccessLogCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -119,8 +120,6 @@ components:
             Warning messages describe a problem the client making the API request should correct or be aware of.
           items:
             type: string
-
-  responses:
     MeshAccessLogItem:
       description: Successful response
       content:

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/rest.yaml
@@ -58,13 +58,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshCircuitBreakerCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshCircuitBreakerCreateOrUpdateSuccessResponse'
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshCircuitBreakerCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshCircuitBreakerCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: delete-mcb
@@ -109,6 +109,7 @@ components:
   schemas:
     MeshCircuitBreakerItem:
       $ref: 'schema.yaml'
+  responses:
     MeshCircuitBreakerCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -119,8 +120,6 @@ components:
             Warning messages describe a problem the client making the API request should correct or be aware of.
           items:
             type: string
-
-  responses:
     MeshCircuitBreakerItem:
       description: Successful response
       content:

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/rest.yaml
@@ -58,13 +58,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshFaultInjectionCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshFaultInjectionCreateOrUpdateSuccessResponse'
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshFaultInjectionCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshFaultInjectionCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: delete-mfi
@@ -109,6 +109,7 @@ components:
   schemas:
     MeshFaultInjectionItem:
       $ref: 'schema.yaml'
+  responses:
     MeshFaultInjectionCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -119,8 +120,6 @@ components:
             Warning messages describe a problem the client making the API request should correct or be aware of.
           items:
             type: string
-
-  responses:
     MeshFaultInjectionItem:
       description: Successful response
       content:

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/rest.yaml
@@ -58,13 +58,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshHealthCheckCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshHealthCheckCreateOrUpdateSuccessResponse'
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshHealthCheckCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshHealthCheckCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: delete-mhc
@@ -109,6 +109,7 @@ components:
   schemas:
     MeshHealthCheckItem:
       $ref: 'schema.yaml'
+  responses:
     MeshHealthCheckCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -119,8 +120,6 @@ components:
             Warning messages describe a problem the client making the API request should correct or be aware of.
           items:
             type: string
-
-  responses:
     MeshHealthCheckItem:
       description: Successful response
       content:

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/rest.yaml
@@ -58,13 +58,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshHTTPRouteCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshHTTPRouteCreateOrUpdateSuccessResponse'
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshHTTPRouteCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshHTTPRouteCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: delete-mhttpr
@@ -109,6 +109,7 @@ components:
   schemas:
     MeshHTTPRouteItem:
       $ref: 'schema.yaml'
+  responses:
     MeshHTTPRouteCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -119,8 +120,6 @@ components:
             Warning messages describe a problem the client making the API request should correct or be aware of.
           items:
             type: string
-
-  responses:
     MeshHTTPRouteItem:
       description: Successful response
       content:

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/rest.yaml
@@ -58,13 +58,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshLoadBalancingStrategyCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshLoadBalancingStrategyCreateOrUpdateSuccessResponse'
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshLoadBalancingStrategyCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshLoadBalancingStrategyCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: delete-mlbs
@@ -109,6 +109,7 @@ components:
   schemas:
     MeshLoadBalancingStrategyItem:
       $ref: 'schema.yaml'
+  responses:
     MeshLoadBalancingStrategyCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -119,8 +120,6 @@ components:
             Warning messages describe a problem the client making the API request should correct or be aware of.
           items:
             type: string
-
-  responses:
     MeshLoadBalancingStrategyItem:
       description: Successful response
       content:

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/rest.yaml
@@ -58,13 +58,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshMetricCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshMetricCreateOrUpdateSuccessResponse'
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshMetricCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshMetricCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: delete-mm
@@ -109,6 +109,7 @@ components:
   schemas:
     MeshMetricItem:
       $ref: 'schema.yaml'
+  responses:
     MeshMetricCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -119,8 +120,6 @@ components:
             Warning messages describe a problem the client making the API request should correct or be aware of.
           items:
             type: string
-
-  responses:
     MeshMetricItem:
       description: Successful response
       content:

--- a/pkg/plugins/policies/meshpassthrough/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshpassthrough/api/v1alpha1/rest.yaml
@@ -58,13 +58,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshPassthroughCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshPassthroughCreateOrUpdateSuccessResponse'
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshPassthroughCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshPassthroughCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: delete-mp
@@ -109,6 +109,7 @@ components:
   schemas:
     MeshPassthroughItem:
       $ref: 'schema.yaml'
+  responses:
     MeshPassthroughCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -119,8 +120,6 @@ components:
             Warning messages describe a problem the client making the API request should correct or be aware of.
           items:
             type: string
-
-  responses:
     MeshPassthroughItem:
       description: Successful response
       content:

--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/rest.yaml
@@ -58,13 +58,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshProxyPatchCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshProxyPatchCreateOrUpdateSuccessResponse'
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshProxyPatchCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshProxyPatchCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: delete-mpp
@@ -109,6 +109,7 @@ components:
   schemas:
     MeshProxyPatchItem:
       $ref: 'schema.yaml'
+  responses:
     MeshProxyPatchCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -119,8 +120,6 @@ components:
             Warning messages describe a problem the client making the API request should correct or be aware of.
           items:
             type: string
-
-  responses:
     MeshProxyPatchItem:
       description: Successful response
       content:

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/rest.yaml
@@ -58,13 +58,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshRateLimitCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshRateLimitCreateOrUpdateSuccessResponse'
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshRateLimitCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshRateLimitCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: delete-mrl
@@ -109,6 +109,7 @@ components:
   schemas:
     MeshRateLimitItem:
       $ref: 'schema.yaml'
+  responses:
     MeshRateLimitCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -119,8 +120,6 @@ components:
             Warning messages describe a problem the client making the API request should correct or be aware of.
           items:
             type: string
-
-  responses:
     MeshRateLimitItem:
       description: Successful response
       content:

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/rest.yaml
@@ -58,13 +58,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshRetryCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshRetryCreateOrUpdateSuccessResponse'
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshRetryCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshRetryCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: delete-mr
@@ -109,6 +109,7 @@ components:
   schemas:
     MeshRetryItem:
       $ref: 'schema.yaml'
+  responses:
     MeshRetryCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -119,8 +120,6 @@ components:
             Warning messages describe a problem the client making the API request should correct or be aware of.
           items:
             type: string
-
-  responses:
     MeshRetryItem:
       description: Successful response
       content:

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/rest.yaml
@@ -58,13 +58,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshTCPRouteCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshTCPRouteCreateOrUpdateSuccessResponse'
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshTCPRouteCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshTCPRouteCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: delete-mtcpr
@@ -109,6 +109,7 @@ components:
   schemas:
     MeshTCPRouteItem:
       $ref: 'schema.yaml'
+  responses:
     MeshTCPRouteCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -119,8 +120,6 @@ components:
             Warning messages describe a problem the client making the API request should correct or be aware of.
           items:
             type: string
-
-  responses:
     MeshTCPRouteItem:
       description: Successful response
       content:

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/rest.yaml
@@ -58,13 +58,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshTimeoutCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshTimeoutCreateOrUpdateSuccessResponse'
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshTimeoutCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshTimeoutCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: delete-mt
@@ -109,6 +109,7 @@ components:
   schemas:
     MeshTimeoutItem:
       $ref: 'schema.yaml'
+  responses:
     MeshTimeoutCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -119,8 +120,6 @@ components:
             Warning messages describe a problem the client making the API request should correct or be aware of.
           items:
             type: string
-
-  responses:
     MeshTimeoutItem:
       description: Successful response
       content:

--- a/pkg/plugins/policies/meshtls/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtls/api/v1alpha1/rest.yaml
@@ -58,13 +58,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshTLSCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshTLSCreateOrUpdateSuccessResponse'
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshTLSCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshTLSCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: delete-mtls
@@ -109,6 +109,7 @@ components:
   schemas:
     MeshTLSItem:
       $ref: 'schema.yaml'
+  responses:
     MeshTLSCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -119,8 +120,6 @@ components:
             Warning messages describe a problem the client making the API request should correct or be aware of.
           items:
             type: string
-
-  responses:
     MeshTLSItem:
       description: Successful response
       content:

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/rest.yaml
@@ -58,13 +58,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshTraceCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshTraceCreateOrUpdateSuccessResponse'
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshTraceCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshTraceCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: delete-mtr
@@ -109,6 +109,7 @@ components:
   schemas:
     MeshTraceItem:
       $ref: 'schema.yaml'
+  responses:
     MeshTraceCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -119,8 +120,6 @@ components:
             Warning messages describe a problem the client making the API request should correct or be aware of.
           items:
             type: string
-
-  responses:
     MeshTraceItem:
       description: Successful response
       content:

--- a/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/rest.yaml
@@ -58,13 +58,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshTrafficPermissionCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshTrafficPermissionCreateOrUpdateSuccessResponse'
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MeshTrafficPermissionCreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/MeshTrafficPermissionCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: delete-mtp
@@ -109,6 +109,7 @@ components:
   schemas:
     MeshTrafficPermissionItem:
       $ref: 'schema.yaml'
+  responses:
     MeshTrafficPermissionCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -119,8 +120,6 @@ components:
             Warning messages describe a problem the client making the API request should correct or be aware of.
           items:
             type: string
-
-  responses:
     MeshTrafficPermissionItem:
       description: Successful response
       content:

--- a/tools/openapi/templates/endpoints.yaml
+++ b/tools/openapi/templates/endpoints.yaml
@@ -62,13 +62,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/{{.Name}}CreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/{{.Name}}CreateOrUpdateSuccessResponse'
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/{{.Name}}CreateOrUpdateSuccessResponse'
+                $ref: '#/components/responses/{{.Name}}CreateOrUpdateSuccessResponse'
 
     delete:
       operationId: delete-{{ .ShortName }}
@@ -117,6 +117,7 @@ components:
   schemas:
     {{.Name}}Item:
       $ref: 'schema.yaml'
+  responses:
     {{.Name}}CreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -127,8 +128,6 @@ components:
             Warning messages describe a problem the client making the API request should correct or be aware of.
           items:
             type: string
-
-  responses:
     {{.Name}}Item:
       description: Successful response
       content:


### PR DESCRIPTION
## Motivation

because it makes more sense under there

## Implementation information

move the definition

## Supporting documentation

closes https://github.com/kumahq/kuma/issues/12322
