### PR TITLE
fix(distributions): exclude group and passwd from packaged binaries

### DIFF
--- a/mk/distribution.mk
+++ b/mk/distribution.mk
@@ -15,6 +15,7 @@ ifneq (,$(findstring preview,$(BUILD_INFO_VERSION)))
 	PULP_DIST_VERSION=preview
 endif
 DISTRIBUTION_FOLDER=build/distributions/$(GOOS)-$(GOARCH)/$(DISTRIBUTION_TARGET_NAME)
+TAR_EXCLUDES=--exclude=passwd --exclude=group
 
 # This function dynamically builds targets for building distribution packages and uploading them to pulp with a set of parameters
 # $(1) - GOOS to build for
@@ -56,9 +57,9 @@ build/distributions/out/$(DISTRIBUTION_TARGET_NAME)-$(1)-$(2).tar.gz: build/dist
 	# Have the tar be just the `kuma-version` folder and nothing else at root
 	# tar is different between darwin and Linux so executre different commands
 ifeq ($(shell uname),Darwin)
-	tar --strip-components 3 --numeric-owner -czvf $$@ $$<
+	tar $(TAR_EXCLUDES) --strip-components 3 --numeric-owner -czvf $$@ $$<
 else
-	tar --mtime='1970-01-01 00:00:00' -C $$(dir $$<) --sort=name --owner=root:0 --group=root:0 --numeric-owner -czvf $$@ $$(notdir $$<)
+	tar $(TAR_EXCLUDES) --mtime='1970-01-01 00:00:00' -C $$(dir $$<) --sort=name --owner=root:0 --group=root:0 --numeric-owner -czvf $$@ $$(notdir $$<)
 endif
 	cd $$(@D) && shasum -a 256 $$(notdir $$@) > $$(notdir $$@).sha256
 


### PR DESCRIPTION
## Motivation

In https://github.com/kumahq/kuma/pull/5945/files#diff-1fb040b6f3b38a29c5de5a15f9633430c8e613a076e0de67c6e0902a4130062a I added `group` and `passwd` to docker images because distroless doesn't have `useradd` binary. I did not know that packaged binaries are copied from dockerfile and this is how these files got in.

## Implementation information

I added `--exclude` for both of these files.

Output of `make build/distributions`:

```
a kuma-0.0.0-preview.vlocal-build
a kuma-0.0.0-preview.vlocal-build/LICENSE
a kuma-0.0.0-preview.vlocal-build/bin
a kuma-0.0.0-preview.vlocal-build/README
a kuma-0.0.0-preview.vlocal-build/NOTICE
a kuma-0.0.0-preview.vlocal-build/conf
a kuma-0.0.0-preview.vlocal-build/conf/kuma-cp.defaults.yaml
a kuma-0.0.0-preview.vlocal-build/bin/kuma-cp
a kuma-0.0.0-preview.vlocal-build/bin/kumactl
a kuma-0.0.0-preview.vlocal-build/bin/envoy
a kuma-0.0.0-preview.vlocal-build/bin/kuma-dp
a kuma-0.0.0-preview.vlocal-build/bin/coredns
cd build/distributions/out && shasum -a 256 kuma-0.0.0-preview.vlocal-build-darwin-arm64.tar.gz > kuma-0.0.0-preview.vlocal-build-darwin-arm64.tar.gz.sha256
cd build/distributions/out; sha256sum *.tar.gz > kuma-0.0.0-preview.vlocal-build.sha256
cat build/distributions/out/kuma-0.0.0-preview.vlocal-build.sha256 | base64 > build/distributions/artifact_digest_file.text
```

## Supporting documentation

Reported on slack.

> Changelog: skip
