### PR TITLE
ci(renovate): fix config to properly update Kong/public-shared-actions versions

### DIFF
--- a/.github/workflows/lifecycle.yml
+++ b/.github/workflows/lifecycle.yml
@@ -14,7 +14,7 @@ jobs:
   lifecycle:
     permissions:
       issues: write
-    uses: kumahq/.github/.github/workflows/wfc_lifecycle.yml@main
+    uses: kumahq/.github/.github/workflows/wfc_lifecycle.yml@740c51473d116d4cde037dc33869b409a14878d6
     with:
       filesToIgnore: CONTRIBUTING.md
     secrets:

--- a/renovate.json5
+++ b/renovate.json5
@@ -3,10 +3,10 @@
   "schedule": "before 5am every weekday",
   "extends": [
     "config:best-practices",
-    ":semanticCommitTypeAll(chore)",
     ":automergeDisabled",
     ":gitSignOff",
     ":label(dependencies)",
+    ":semanticCommitTypeAll(chore)",
   ],
   "baseBranches": [
     "master",
@@ -19,73 +19,50 @@
     "helm-values",
   ],
   "postUpdateOptions": [
-    "gomodMassage",
-    "gomodTidy",
+    "gomodMassage", // Adjust Go module replacements after updates
+    "gomodTidy", // Run `go mod tidy` after updates
   ],
   "ignorePaths": [
     "(^|/)([Dd]ocker|[Cc]ontainer)file[^/]*\\.dockerignore$",
   ],
-  "customDatasources": {
-    "public-shared-actions": {
-      "defaultRegistryUrlTemplate": "https://api.github.com/repos/Kong/public-shared-actions/tags?per_page=100",
-      "transformTemplates": [
-        '( \
-          $url_base := "https://github.com/Kong/public-shared-actions"; \
-          { \
-            "sourceUrl": $url_base, \
-            "homepage": $url_base, \
-            "releases": $[$contains(name, /^@/)].( \
-              $dep_with_version := $.name ~> $substringAfter("@"); \
-              $dep_name := $dep_with_version ~> $substringBefore("@"); \
-              $url_sha := $url_base & "/tree/" & $.commit.sha & "/"; \
-              { \
-                "version" : $dep_with_version, \
-                "digest": $v.commit.sha, \
-                "sourceUrl": $url_sha, \
-                "sourceDirectory": $dep_name, \
-                "changelogUrl": $url_sha & $dep_name & "/CHANGELOG.md" \
-              } \
-            ) \
-          } \
-        )',
-      ],
-    },
-  },
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": [
-        // taken from github-actions builtin manager ref. https://docs.renovatebot.com/modules/manager/github-actions/
-        "(^|/)(workflow-templates|\\.(?:github|gitea|forgejo)/(?:workflows|actions))/.+\\.ya?ml$",
-        "(^|/)action\\.ya?ml$",
-      ],
+      "fileMatch": ["\\.github\/.*\\.ya?ml$"],
       "matchStrings": [
-        "Kong/public-shared-actions/(?<depName>[^\\s@])@(?<currentDigest>[^\\s]+) # (?<currentValue>[^\\s]+)",
-        "Kong/public-shared-actions/(?<depName>[^\\s@])@(?<currentValue>[^\\s]+)",
+        "(?<packageName>Kong\\/public-shared-actions\\/(?<depName>[^\\s@]+))@(?:(?<currentDigest>[^\\s]+) # v?)?(?<currentValue>[^\\s]+)",
       ],
-      "autoReplaceStringTemplate": "Kong/public-shared-actions/{{{depName}}}@{{{newDigest}}} # {{{newVersion}}}",
-      "datasourceTemplate": "custom.public-shared-actions",
+      "datasourceTemplate": "github-tags",
+      "extractVersionTemplate": "^(?:@{{{depName}}}@|v)(?<version>[0-9\\.]+)$",
+      "autoReplaceStringTemplate": "{{{packageName}}}@{{{newDigest}}} # v{{{newVersion}}}",
       "versioningTemplate": "semver",
-      "extractVersionTemplate": "^{{{depName}}}@(?<version>.*)$",
-    }
+    },
   ],
   "packageRules": [
-    {
-      "description": "No need to run tests on github actions updates",
-      "matchManagers": ["github-actions"],
-      "addLabels": ["ci/skip-test"]
-    },
     {
       "groupName": "google.golang.org/genproto/googleapis/*",
       "groupSlug": "genproto-googleapis",
       "matchDatasources": ["go"],
-      "matchPackageNames": ["google.golang.org/genproto/googleapis/**"]
+      "matchPackageNames": ["google.golang.org/genproto/googleapis/**"],
     },
     {
-      "matchPackageNames": ["Kong/public-shared-actions"],
-      "matchDatasources": ["github-tags"],
-      "matchCurrentVersion": ">=4",
-      "enabled": false
+      // Skip tests for GitHub Actions updates
+      "matchManagers": ["github-actions"],
+      "addLabels": ["ci/skip-test"],
     },
-  ]
+    {
+      // Manage Kong/public-shared-actions updates using the custom manager,
+      // so disable the default GitHub Actions manager for these
+      "matchPackageNames": ["Kong/public-shared-actions"],
+      "matchManagers": ["github-actions"],
+      "enabled": false,
+    },
+    {
+      // SLSA-GitHub-Generator cannot be pinned by digest
+      // More info: https://github.com/slsa-framework/slsa-github-generator/blob/main/RENOVATE.md
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["slsa-framework/slsa-github-generator"],
+      "pinDigests": false,
+    },
+  ],
 }


### PR DESCRIPTION
## Motivation

Renovate couldn't update `Kong/public-shared-actions/*`

## Implementation information

- Fixed `customManagers` configuration to correctly update `Kong/public-shared-actions` GitHub Actions versions using `github-tags` datasource
- Pinned `kumahq/.github/.github/workflows/wfc_lifecycle.yml` to a specific commit which will be updated by renovate
- Removed unused `customDatasources` for public-shared-actions
- Adjusted `packageRules` to disable default GitHub Actions manager for `Kong/public-shared-actions`
- Cleaned up comments and aligned settings for clarity

## Supporting documentation

Related: https://github.com/kumahq/kuma/issues/12529
