### PR TITLE
ci(renovate): match by depType to skip tests for GitHub Actions updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -46,8 +46,10 @@
       "matchPackageNames": ["google.golang.org/genproto/googleapis/**"],
     },
     {
-      // Skip tests for GitHub Actions updates
-      "matchManagers": ["github-actions"],
+      // Skip tests for GitHub Actions updates. We match by depType because
+      // there isn’t an idiomatic way to target our custom manager, which handles
+      // Kong/public-shared-actions
+      "matchDepTypes": ["action"],
       "addLabels": ["ci/skip-test"],
     },
     {


### PR DESCRIPTION
## Motivation

Missing `ci/skip-test` label when updating `Kong/public-shared-actions/*` github actions

## Implementation information

This commit fixes an issue where updates to `Kong/public-shared-actions/*` were not getting the `ci/skip-test` label. Since these updates are managed by a custom manager instead of the default `github-actions`, the rule was updated to match by `depType: action`.

## Supporting documentation

Related: https://github.com/kumahq/kuma/issues/12529