### PR TITLE
ci(renovate): support updates for public-shared-actions without digests

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -30,11 +30,11 @@
       "customType": "regex",
       "fileMatch": ["\\.github\/.*\\.ya?ml$"],
       "matchStrings": [
-        "(?<packageName>Kong\\/public-shared-actions\\/(?<depName>[^\\s@]+))@(?:(?<currentDigest>[^\\s]+) # v?)?(?<currentValue>[^\\s]+)",
+        "(?<packageName>Kong\\/public-shared-actions\\/(?<depName>[^\\s@]+))@(?:(?<currentDigest>[^\\s]+) # )?v(?<currentValue>[^\\s]+)",
       ],
       "datasourceTemplate": "github-tags",
       "extractVersionTemplate": "^(?:@{{{depName}}}@|v)(?<version>[0-9\\.]+)$",
-      "autoReplaceStringTemplate": "{{{packageName}}}@{{{newDigest}}} # v{{{newVersion}}}",
+      "autoReplaceStringTemplate": "{{{packageName}}}@{{#if newDigest}}{{{newDigest}}} # {{/if}}v{{{newVersion}}}",
       "versioningTemplate": "semver",
     },
   ],


### PR DESCRIPTION
## Motivation

Renovate couldn't update `Kong/public-shared-actions/*` which were not pinned by digest

## Implementation information

This change updates the `renovate.json5` configuration to handle cases where `Kong/public-shared-actions` dependencies are specified using only the version (e.g., `Kong/public-shared-actions/security-actions/sca@v2.8.0`) instead of including a digest (e.g.,
`Kong/public-shared-actions/security-actions/sca@0ccacffed804d85da3f938a1b78c12831935f992 # v2.8.0`). The `matchStrings` pattern was adjusted to account for version strings without a digest, and the `autoReplaceStringTemplate` was updated to support optional digests, ensuring Renovate correctly processes and updates these dependencies.

## Supporting documentation

Related to: https://github.com/kumahq/kuma/issues/12529