### PR TITLE
chore(oapi): update oapi tool

### DIFF
--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -3,7 +3,6 @@ info:
   title: Kuma API
   description: Kuma API
   version: v1alpha1
-  x-ref-schema-name: MeshService
 paths:
   /:
     get:

--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -44,7 +44,7 @@ docs/generated/openapi.yaml:
 	for i in $$( find $(MESH_API_DIR) -name '*.yaml'); do DIR=$(OAPI_TMP_DIR)/protoresources/$$(echo $${i} | awk -F/ '{print $$(NF-1)}'); mkdir -p $${DIR}; cp $${i} $${DIR}/$$(echo $${i} | awk -F/ '{print $$(NF)}'); done
 
 ifdef BASE_API
-	docker run --rm -v $$PWD/$(dir $(BASE_API)):/base -v $(OAPI_TMP_DIR):/specs ghcr.io/kumahq/openapi-tool:v0.12.0 generate /base/$(notdir $(BASE_API)) '/specs/**/*.yaml'  '!/specs/kuma/**' > $@
+	docker run --rm -v $$PWD/$(dir $(BASE_API)):/base -v $(OAPI_TMP_DIR):/specs ghcr.io/kumahq/openapi-tool:v1.1.3 generate /base/$(notdir $(BASE_API)) '/specs/**/*.yaml'  '!/specs/kuma/**' > $@
 else
-	docker run --rm -v $(OAPI_TMP_DIR):/specs ghcr.io/kumahq/openapi-tool:v0.12.0 generate '/specs/**/*.yaml' > $@
+	docker run --rm -v $(OAPI_TMP_DIR):/specs ghcr.io/kumahq/openapi-tool:v1.1.3 generate '/specs/**/*.yaml' > $@
 endif


### PR DESCRIPTION
## Motivation

Because there was a bug in previous one that polluted the top level of the doc.

## Implementation information

All in https://github.com/kumahq/ci-tools/pull/60

## Supporting documentation

Just version bump