### PR TITLE
chore(deps): bump golang from 1.22.10 to 1.22.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kumahq/kuma
 
-go 1.22.10
+go 1.22.11
 
 require (
 	cirello.io/pglock v1.14.2


### PR DESCRIPTION
## Motivation

bump golang from 1.22.10 to 1.22.11



## Implementation information

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
