### PR TITLE
chore(deps): bump golang from 1.23.4 to 1.23.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kumahq/kuma
 
-go 1.23.4
+go 1.23.5
 
 require (
 	cirello.io/pglock v1.16.0


### PR DESCRIPTION
## Motivation

bump golang from 1.23.4 to 1.23.5

Go 1.23.5 milestone: https://github.com/golang/go/issues?q=milestone%3AGo1.23.5+label%3ACherryPickApproved

## Implementation information

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
