### PR TITLE
fix(k8s): always authenticate with latest service account token (backport #11399)

### DIFF
--- a/pkg/config/dp-server/config.go
+++ b/pkg/config/dp-server/config.go
@@ -112,6 +112,7 @@ type DpServerAuthnConfig struct {
 	// Configuration for zone proxy authentication.
 	ZoneProxy ZoneProxyAuthnConfig `json:"zoneProxy"`
 	// If true then Envoy uses Google gRPC instead of Envoy gRPC which lets a proxy reload the auth data (service account token, dp token etc.) from path without proxy restart.
+	// This is enabled on Kubernetes.
 	EnableReloadableTokens bool `json:"enableReloadableTokens" envconfig:"kuma_dp_server_authn_enable_reloadable_tokens"`
 }
 

--- a/pkg/xds/bootstrap/components.go
+++ b/pkg/xds/bootstrap/components.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/pkg/config/core/resources/store"
 	dp_server "github.com/kumahq/kuma/pkg/config/dp-server"
 	core_runtime "github.com/kumahq/kuma/pkg/core/runtime"
 )
@@ -17,7 +18,7 @@ func RegisterBootstrap(rt core_runtime.Runtime) error {
 			string(mesh_proto.IngressProxyType):   rt.Config().DpServer.Authn.ZoneProxy.Type != dp_server.DpServerAuthNone,
 			string(mesh_proto.EgressProxyType):    rt.Config().DpServer.Authn.ZoneProxy.Type != dp_server.DpServerAuthNone,
 		},
-		rt.Config().DpServer.Authn.EnableReloadableTokens,
+		rt.Config().DpServer.Authn.EnableReloadableTokens || rt.Config().Store.Type == store.KubernetesStore,
 		rt.Config().DpServer.Hds.Enabled,
 		rt.Config().GetEnvoyAdminPort(),
 	)


### PR DESCRIPTION
## Motivation

Backport of https://github.com/kumahq/kuma/pull/11399
