### PR TITLE
fix(kuma-cp): fix issue with pod labels overriding existing dataplane labels

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/pod_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller_test.go
@@ -811,6 +811,7 @@ var _ = Describe("PodReconciler", func() {
 					mesh_proto.MeshTag:             "poc",
 					mesh_proto.ResourceOriginLabel: "zone",
 					mesh_proto.EnvTag:              mesh_proto.KubernetesEnvironment,
+					mesh_proto.ProxyTypeLabel:      "sidecar",
 				},
 				OwnerReferences: []kube_meta.OwnerReference{
 					{
@@ -893,6 +894,7 @@ var _ = Describe("PodReconciler", func() {
           labels:
             app: sample
             k8s.kuma.io/namespace: demo
+            kuma.io/display-name: pod-with-custom-admin-port
             kuma.io/env: kubernetes
             kuma.io/mesh: poc
             kuma.io/origin: zone

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter.go
@@ -63,7 +63,7 @@ func (p *PodConverter) PodToDataplane(
 	labels, err := model.ComputeLabels(
 		core_mesh.DataplaneResourceTypeDescriptor,
 		currentSpec,
-		pod.Labels,
+		mergeLabels(dataplane.GetLabels(), pod.Labels),
 		model.NewNamespace(pod.Namespace, pod.Namespace == p.SystemNamespace),
 		dataplane.Mesh,
 		p.Mode,
@@ -103,7 +103,7 @@ func (p *PodConverter) PodToIngress(ctx context.Context, zoneIngress *mesh_k8s.Z
 	labels, err := model.ComputeLabels(
 		core_mesh.ZoneIngressResourceTypeDescriptor,
 		currentSpec,
-		pod.Labels,
+		mergeLabels(zoneIngress.GetLabels(), pod.Labels),
 		model.NewNamespace(pod.Namespace, pod.Namespace == p.SystemNamespace),
 		model.NoMesh,
 		p.Mode,
@@ -142,7 +142,7 @@ func (p *PodConverter) PodToEgress(ctx context.Context, zoneEgress *mesh_k8s.Zon
 	labels, err := model.ComputeLabels(
 		core_mesh.ZoneEgressResourceTypeDescriptor,
 		currentSpec,
-		pod.Labels,
+		mergeLabels(zoneEgress.GetLabels(), pod.Labels),
 		model.NewNamespace(pod.Namespace, pod.Namespace == p.SystemNamespace),
 		model.NoMesh,
 		p.Mode,
@@ -409,6 +409,16 @@ func MetricsAggregateFor(pod *kube_core.Pod) ([]*mesh_proto.PrometheusAggregateM
 		aggregateConfig = append(aggregateConfig, config)
 	}
 	return aggregateConfig, nil
+}
+
+func mergeLabels(existingLabels map[string]string, podLabels map[string]string) map[string]string {
+	if existingLabels == nil {
+		return podLabels
+	}
+	for k, v := range podLabels {
+		existingLabels[k] = v
+	}
+	return existingLabels
 }
 
 type ReachableBackendRefs struct {

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"maps"
 	"reflect"
 	"regexp"
 
@@ -412,13 +413,14 @@ func MetricsAggregateFor(pod *kube_core.Pod) ([]*mesh_proto.PrometheusAggregateM
 }
 
 func mergeLabels(existingLabels map[string]string, podLabels map[string]string) map[string]string {
-	if existingLabels == nil {
-		return podLabels
+	mergedLabels := map[string]string{}
+	if existingLabels != nil {
+		mergedLabels = maps.Clone(existingLabels)
 	}
 	for k, v := range podLabels {
-		existingLabels[k] = v
+		mergedLabels[k] = v
 	}
-	return existingLabels
+	return mergedLabels
 }
 
 type ReachableBackendRefs struct {

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter.go
@@ -120,6 +120,7 @@ func (p *PodConverter) PodToIngress(ctx context.Context, zoneIngress *mesh_k8s.Z
 		return nil
 	}
 	zoneIngress.SetSpec(zoneIngressRes.Spec)
+	zoneIngress.SetLabels(labels)
 	return nil
 }
 
@@ -159,6 +160,7 @@ func (p *PodConverter) PodToEgress(ctx context.Context, zoneEgress *mesh_k8s.Zon
 	}
 
 	zoneEgress.SetSpec(zoneEgressRes.Spec)
+	zoneEgress.SetLabels(labels)
 	return nil
 }
 

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
@@ -144,7 +144,6 @@ var _ = Describe("PodToDataplane(..)", func() {
 			}
 
 			// when
-			// dataplane := &mesh_k8s.Dataplane{}
 			err = converter.PodToDataplane(context.Background(), existingDataplane, pod, &namespace, services, otherDataplanes)
 
 			// then

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
@@ -120,6 +120,15 @@ var _ = Describe("PodToDataplane(..)", func() {
 				Expect(err).ToNot(HaveOccurred())
 			}
 
+			// existing dataplane
+			existingDataplane := &mesh_k8s.Dataplane{}
+			if given.existingDataplane != "" {
+				bytes, err := os.ReadFile(filepath.Join("testdata", given.existingDataplane))
+				Expect(err).ToNot(HaveOccurred())
+				err = yaml.Unmarshal(bytes, existingDataplane)
+				Expect(err).ToNot(HaveOccurred())
+			}
+
 			converter := PodConverter{
 				ServiceGetter: serviceGetter,
 				InboundConverter: InboundConverter{
@@ -135,13 +144,13 @@ var _ = Describe("PodToDataplane(..)", func() {
 			}
 
 			// when
-			dataplane := &mesh_k8s.Dataplane{}
-			err = converter.PodToDataplane(context.Background(), dataplane, pod, &namespace, services, otherDataplanes)
+			// dataplane := &mesh_k8s.Dataplane{}
+			err = converter.PodToDataplane(context.Background(), existingDataplane, pod, &namespace, services, otherDataplanes)
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
 
-			actual, err := yaml.Marshal(dataplane)
+			actual, err := yaml.Marshal(existingDataplane)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(actual).To(MatchGoldenYAML("testdata", given.dataplane))
 		},
@@ -312,6 +321,13 @@ var _ = Describe("PodToDataplane(..)", func() {
 			servicesForPod: "30.services-for-pod.yaml",
 			dataplane:      "30.dataplane.yaml",
 		}),
+		Entry("Update existing dataplane with pod labels", testCase{
+			pod:               "update-dataplane.pod.yaml",
+			servicesForPod:    "update-dataplane.services-for-pod.yaml",
+			existingDataplane: "update-dataplane.existing-dataplane.yaml",
+			otherServices:     "update-dataplane.other-services.yaml",
+			dataplane:         "update-dataplane.dataplane.yaml",
+		}),
 	)
 
 	DescribeTable("should convert Ingress Pod into an Ingress Dataplane YAML version",
@@ -404,6 +420,18 @@ var _ = Describe("PodToDataplane(..)", func() {
 			existingDataplane: "ingress-exists.existing-dataplane.yaml",
 			dataplane:         "ingress-exists.dataplane.yaml",
 		}),
+		Entry("Existing ZoneIngress with load balancer and ip should not be updated when no change", testCase{
+			pod:               "ingress-exists.pod.yaml",
+			servicesForPod:    "ingress-exists.services-for-pod.yaml",
+			existingDataplane: "ingress-exists.existing-dataplane.yaml",
+			dataplane:         "ingress-exists.dataplane.yaml",
+		}),
+		Entry("Existing ZoneIngress should be updated when pod labels changes", testCase{
+			pod:               "ingress-exists-labels.pod.yaml",
+			servicesForPod:    "ingress-exists-labels.services-for-pod.yaml",
+			existingDataplane: "ingress-exists-labels.existing-dataplane.yaml",
+			dataplane:         "ingress-exists-labels.dataplane.yaml",
+		}),
 	)
 
 	DescribeTable("should convert Egress Pod into an Egress Dataplane YAML version",
@@ -442,8 +470,15 @@ var _ = Describe("PodToDataplane(..)", func() {
 				},
 			}
 
-			// when
 			egress := &mesh_k8s.ZoneEgress{}
+			if given.existingDataplane != "" {
+				bytes, err = os.ReadFile(filepath.Join("testdata", "egress", given.existingDataplane))
+				Expect(err).ToNot(HaveOccurred())
+				err = yaml.Unmarshal(bytes, egress)
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			// when
 			err = converter.PodToEgress(ctx, egress, pod, services)
 
 			// then
@@ -479,6 +514,13 @@ var _ = Describe("PodToDataplane(..)", func() {
 			servicesForPod: "05.services-for-pod.yaml",
 			dataplane:      "05.dataplane.yaml",
 			node:           "05.node.yaml",
+		}),
+		Entry("Existing ZoneEgress should be updated when pod labels changes", testCase{ // KIND / Minikube use case
+			pod:               "egress-exists-labels.pod.yaml",
+			servicesForPod:    "egress-exists-labels.services-for-pod.yaml",
+			dataplane:         "egress-exists-labels.dataplane.yaml",
+			node:              "egress-exists-labels.node.yaml",
+			existingDataplane: "egress-exists-labels.existing-dataplane.yaml",
 		}),
 	)
 })

--- a/pkg/plugins/runtime/k8s/controllers/testdata/egress/01.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/egress/01.dataplane.yaml
@@ -1,5 +1,9 @@
 metadata:
   creationTimestamp: null
+  labels:
+    app: kuma-egress
+    k8s.kuma.io/namespace: kuma-system
+    kuma.io/proxy-type: zoneegress
 spec:
   networking:
     address: 192.168.0.1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/egress/02.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/egress/02.dataplane.yaml
@@ -1,5 +1,9 @@
 metadata:
   creationTimestamp: null
+  labels:
+    app: kuma-egress
+    k8s.kuma.io/namespace: kuma-system
+    kuma.io/proxy-type: zoneegress
 spec:
   networking:
     address: 192.168.0.1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/egress/03.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/egress/03.dataplane.yaml
@@ -1,5 +1,9 @@
 metadata:
   creationTimestamp: null
+  labels:
+    app: kuma-egress
+    k8s.kuma.io/namespace: kuma-system
+    kuma.io/proxy-type: zoneegress
 spec:
   networking:
     address: 192.168.0.1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/egress/04.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/egress/04.dataplane.yaml
@@ -1,5 +1,9 @@
 metadata:
   creationTimestamp: null
+  labels:
+    app: kuma-egress
+    k8s.kuma.io/namespace: kuma-system
+    kuma.io/proxy-type: zoneegress
 spec:
   networking:
     address: 192.168.0.1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/egress/05.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/egress/05.dataplane.yaml
@@ -1,5 +1,9 @@
 metadata:
   creationTimestamp: null
+  labels:
+    app: kuma-egress
+    k8s.kuma.io/namespace: kuma-system
+    kuma.io/proxy-type: zoneegress
 spec:
   networking:
     address: 192.168.0.1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/egress/egress-exists-labels.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/egress/egress-exists-labels.dataplane.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kuma-egress
+    k8s.kuma.io/namespace: kuma-system
+    kuma.io/proxy-type: zoneegress
+    test: new
+spec:
+  networking:
+    address: 192.168.0.1
+    port: 10002
+  zone: zone-1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/egress/egress-exists-labels.existing-dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/egress/egress-exists-labels.existing-dataplane.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kuma-egress
+    k8s.kuma.io/namespace: kuma-system
+    kuma.io/proxy-type: zoneegress
+    test: old
+spec:
+  networking:
+    address: 192.168.0.1
+    port: 10002
+  zone: zone-1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/egress/egress-exists-labels.node.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/egress/egress-exists-labels.node.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Node
+metadata:
+  name: sample-node
+status:
+  addresses:
+    - address: 10.128.15.193
+      type: InternalIP

--- a/pkg/plugins/runtime/k8s/controllers/testdata/egress/egress-exists-labels.pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/egress/egress-exists-labels.pod.yaml
@@ -1,0 +1,14 @@
+metadata:
+  namespace: kuma-system
+  name: kuma-egress
+  labels:
+    app: kuma-egress
+    test: new
+  annotations:
+    kuma.io/egress: enabled
+spec:
+  containers:
+    - ports:
+        - containerPort: 10002
+status:
+  podIP: 192.168.0.1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/egress/egress-exists-labels.services-for-pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/egress/egress-exists-labels.services-for-pod.yaml
@@ -1,0 +1,12 @@
+---
+metadata:
+  namespace: kuma-system
+  name: kuma-egress
+spec:
+  type: NodePort
+  ports:
+    - port: 10002
+      targetPort: 10002
+      nodePort: 12345
+  selector:
+    app: kuma-egress

--- a/pkg/plugins/runtime/k8s/controllers/testdata/ingress/01.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/ingress/01.dataplane.yaml
@@ -1,5 +1,9 @@
 metadata:
   creationTimestamp: null
+  labels:
+    app: kuma-ingress
+    k8s.kuma.io/namespace: kuma-system
+    kuma.io/proxy-type: zoneingress
 spec:
   networking:
     address: 192.168.0.1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/ingress/02.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/ingress/02.dataplane.yaml
@@ -1,5 +1,9 @@
 metadata:
   creationTimestamp: null
+  labels:
+    app: kuma-ingress
+    k8s.kuma.io/namespace: kuma-system
+    kuma.io/proxy-type: zoneingress
 spec:
   networking:
     address: 192.168.0.1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/ingress/03.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/ingress/03.dataplane.yaml
@@ -1,5 +1,9 @@
 metadata:
   creationTimestamp: null
+  labels:
+    app: kuma-ingress
+    k8s.kuma.io/namespace: kuma-system
+    kuma.io/proxy-type: zoneingress
 spec:
   networking:
     address: 192.168.0.1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/ingress/04.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/ingress/04.dataplane.yaml
@@ -1,5 +1,9 @@
 metadata:
   creationTimestamp: null
+  labels:
+    app: kuma-ingress
+    k8s.kuma.io/namespace: kuma-system
+    kuma.io/proxy-type: zoneingress
 spec:
   networking:
     address: 192.168.0.1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/ingress/05.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/ingress/05.dataplane.yaml
@@ -1,5 +1,9 @@
 metadata:
   creationTimestamp: null
+  labels:
+    app: kuma-ingress
+    k8s.kuma.io/namespace: kuma-system
+    kuma.io/proxy-type: zoneingress
 spec:
   networking:
     address: 192.168.0.1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/ingress/06.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/ingress/06.dataplane.yaml
@@ -1,5 +1,9 @@
 metadata:
   creationTimestamp: null
+  labels:
+    app: kuma-ingress
+    k8s.kuma.io/namespace: kuma-system
+    kuma.io/proxy-type: zoneingress
 spec:
   networking:
     address: 192.168.0.1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/ingress/ingress-exists-labels.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/ingress/ingress-exists-labels.dataplane.yaml
@@ -1,0 +1,19 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kuma-ingress
+    k8s.kuma.io/namespace: kuma-system
+    kuma.io/proxy-type: zoneingress
+    test: new
+spec:
+  availableServices:
+  - instances: 3
+    mesh: mesh-1
+    tags:
+      kuma.io/protocol: http
+      kuma.io/service: service-1-zone-2
+  networking:
+    address: 192.168.0.1
+    advertisedAddress: 192.168.100.1
+    advertisedPort: 10001
+    port: 10001

--- a/pkg/plugins/runtime/k8s/controllers/testdata/ingress/ingress-exists-labels.existing-dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/ingress/ingress-exists-labels.existing-dataplane.yaml
@@ -1,0 +1,16 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    test: old
+spec:
+  availableServices:
+  - instances: 3
+    mesh: mesh-1
+    tags:
+      kuma.io/protocol: http
+      kuma.io/service: service-1-zone-2
+  networking:
+    address: 192.168.0.1
+    advertisedAddress: 192.168.100.1
+    advertisedPort: 10001
+    port: 10001

--- a/pkg/plugins/runtime/k8s/controllers/testdata/ingress/ingress-exists-labels.pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/ingress/ingress-exists-labels.pod.yaml
@@ -1,0 +1,14 @@
+metadata:
+  namespace: kuma-system
+  name: kuma-ingress
+  labels:
+    app: kuma-ingress
+    test: new
+  annotations:
+    kuma.io/ingress: enabled
+spec:
+  containers:
+    - ports:
+        - containerPort: 10001
+status:
+  podIP: 192.168.0.1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/ingress/ingress-exists-labels.services-for-pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/ingress/ingress-exists-labels.services-for-pod.yaml
@@ -1,0 +1,15 @@
+---
+metadata:
+  namespace: kuma-system
+  name: kuma-ingress
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 10001
+      targetPort: 10001
+  selector:
+    app: kuma-ingress
+status:
+  loadBalancer:
+    ingress:
+      - ip: 192.168.100.1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/ingress/ingress-exists.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/ingress/ingress-exists.dataplane.yaml
@@ -1,5 +1,9 @@
 metadata:
   creationTimestamp: null
+  labels:
+    app: kuma-ingress
+    k8s.kuma.io/namespace: kuma-system
+    kuma.io/proxy-type: zoneingress
 spec:
   availableServices:
   - instances: 3

--- a/pkg/plugins/runtime/k8s/controllers/testdata/update-dataplane.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/update-dataplane.dataplane.yaml
@@ -1,0 +1,30 @@
+apiVersion: kuma.io/v1alpha1
+kind: Dataplane
+mesh: default
+metadata:
+  creationTimestamp: null
+  labels:
+    app: example
+    k8s.kuma.io/namespace: demo
+    kuma.io/mesh: default
+    kuma.io/proxy-type: sidecar
+    kuma.io/zone: default
+    version: "0.1"
+  name: test-app-8646b8bbc8-5qbl2
+  namespace: playground
+spec:
+  networking:
+    address: 192.168.0.1
+    inbound:
+    - health:
+        ready: true
+      port: 8080
+      tags:
+        app: example
+        k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: example
+        k8s.kuma.io/service-port: "80"
+        kuma.io/protocol: tcp
+        kuma.io/service: example_demo_svc_80
+        kuma.io/zone: zone-1
+        version: "0.1"

--- a/pkg/plugins/runtime/k8s/controllers/testdata/update-dataplane.existing-dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/update-dataplane.existing-dataplane.yaml
@@ -1,0 +1,24 @@
+apiVersion: kuma.io/v1alpha1
+kind: Dataplane
+mesh: default
+metadata:
+  name: test-app-8646b8bbc8-5qbl2
+  namespace: playground
+  labels:
+    kuma.io/zone: default
+spec:
+  networking:
+    address: 10.244.0.25
+    inbound:
+      - port: 80
+        tags:
+          app: test-app
+          pod-template-hash: 8646b8bbc8
+          kuma.io/service: test-app_playground_svc_80
+      - port: 443
+        tags:
+          app: test-app
+          pod-template-hash: 8646b8bbc8
+          kuma.io/service: test-app_playground_svc_443
+    transparentProxying:
+      redirectPort: 15001

--- a/pkg/plugins/runtime/k8s/controllers/testdata/update-dataplane.other-services.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/update-dataplane.other-services.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-app
+  namespace: playground
+spec:
+  clusterIP: 10.108.144.24
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 80
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: 80
+  selector:
+    app: test-app
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/plugins/runtime/k8s/controllers/testdata/update-dataplane.pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/update-dataplane.pod.yaml
@@ -1,0 +1,20 @@
+metadata:
+  namespace: demo
+  name: example
+  labels:
+    app: example
+    version: "0.1"
+spec:
+  containers:
+    - ports: []
+      # when a 'targetPort' in a ServicePort is a number,
+      # it should not be mandatory to list container ports explicitly
+      #
+      # containerPort: 8080
+      # containerPort: 8443
+    - ports:
+        - containerPort: 7070
+        - containerPort: 6060
+          name: metrics
+status:
+  podIP: 192.168.0.1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/update-dataplane.services-for-pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/update-dataplane.services-for-pod.yaml
@@ -1,0 +1,9 @@
+metadata:
+  namespace: demo
+  name: example
+spec:
+  clusterIP: 192.168.0.1
+  ports:
+    - # protocol defaults to TCP
+      port: 80
+      targetPort: 8080

--- a/test/e2e/federation/federation_suite_test.go
+++ b/test/e2e/federation/federation_suite_test.go
@@ -14,7 +14,6 @@ func TestE2E(t *testing.T) {
 }
 
 var (
-	// TODO(bartsmykla): disabled while investingating flake (https://github.com/kumahq/kuma/issues/12142)
-	_ = XDescribe("Federation with Kube Global", Label("job-3"), federation.FederateKubeZoneCPToKubeGlobal, Ordered)
-	_ = XDescribe("Federation with Universal Global", Label("job-3"), federation.FederateKubeZoneCPToUniversalGlobal, Ordered)
+	_ = Describe("Federation with Kube Global", Label("job-3"), federation.FederateKubeZoneCPToKubeGlobal, Ordered)
+	_ = Describe("Federation with Universal Global", Label("job-3"), federation.FederateKubeZoneCPToUniversalGlobal, Ordered)
 )


### PR DESCRIPTION
Fixes: #12142

## Motivation

We should not override already present dataplane labels with pod labels

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
