### PR TITLE
fix(cni): support bound service account token by reloading periodically

### DIFF
--- a/app/cni/pkg/install/installer_config.go
+++ b/app/cni/pkg/install/installer_config.go
@@ -36,6 +36,7 @@ type InstallerConfig struct {
 	KubernetesServiceProtocol string `envconfig:"kubernetes_service_protocol" default:"https"`
 	MountedCniNetDir          string `envconfig:"mounted_cni_net_dir" default:"/host/etc/cni/net.d"`
 	ShouldSleep               bool   `envconfig:"sleep" default:"true"`
+	RefreshSATokenInterval    int    `envconfig:"refresh_sa_token_interval" default:"60"`
 }
 
 func (i InstallerConfig) Validate() error {


### PR DESCRIPTION
## Motivation

this should solve https://github.com/kumahq/kuma/issues/12567 as a simplified implementation.

Bart will come up with a more complete version based on his upcoming refatoring.

## Implementation information

Setup a ticker and sync service account token into kubeconfig file periodically

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

the official client-go SDK re-reads the token once a minute:

https://github.com/kubernetes/client-go/issues/1255

> that method initiates a background process that rereads the token file once a minute.

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
