### PR TITLE
ci(gha): fix pr-modifications workflow to skip dependabot and renovate PRs

### DIFF
--- a/.github/workflows/pr-modification.yaml
+++ b/.github/workflows/pr-modification.yaml
@@ -31,7 +31,10 @@ jobs:
         name: Get recent PRs
         run: |
           echo "out<<EOF" >> $GITHUB_OUTPUT
-          gh pr list -R ${{ github.repository }} --json number,title,url --search "updated:>=$(date --date='${{ env.LOOK_BACK }} ago' +'%Y-%m-%dT%H:%M:%S%z') -author:dependabot" >> $GITHUB_OUTPUT
+          gh pr list \
+            --repo ${{ github.repository }} \
+            --json number,title,url \
+            --search "updated:>=$(date --date='${{ env.LOOK_BACK }} ago' +'%Y-%m-%dT%H:%M:%S%z') -author:app/dependabot -author:app/renovate" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
       - name: Show outputs
         env:


### PR DESCRIPTION
## Motivation

Reviewers checklist comment was unnecessarily being added to dependabot PRs

## Implementation information

Fixed `pr-modifications.yaml` where `-author:dependabot` was not working. Updated it to skip PRs from `app/dependabot` and `app/renovate`. Made minor improvements to the workflow script