### PR TITLE
ci(renovate): enable dockerfile manager and clear ignorePaths

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
   ],
   "enabledManagers": [
     "custom.regex",
+    "dockerfile",
     "github-actions",
     "gomod"
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
     "github-actions",
     "gomod"
   ],
+  "ignorePaths": [],
   "packageRules": [
     {
       "description": "Skip tests for GitHub Actions updates. We match by depType because there isn’t an idiomatic way to target custom manager from Kong/public-shared-renovate:backend preset, which handles Kong/public-shared-actions",


### PR DESCRIPTION
## Motivation

Configure Renovate so it can fully replace Dependabot

## Implementation information

Added `dockerfile` manager to the Renovate configuration to automate updates for Dockerfiles

Set `ignorePaths` to an empty array in Renovate config to stop ignoring the `test` directory. By default, `Kong/public-shared-renovate:backend` extends settings that ignore `test`, which we use for e2e framework code and Dockerfiles. Other default ignored paths are not relevant to our project.

## Supporting documentation

Related to: https://github.com/kumahq/kuma/issues/12529
