### PR TITLE
fix(cni): support bound service account token by reloading periodically (backport of #12592)

### DIFF
--- a/app/cni/pkg/install/installer_config.go
+++ b/app/cni/pkg/install/installer_config.go
@@ -36,6 +36,7 @@ type InstallerConfig struct {
 	KubernetesServiceProtocol string `envconfig:"kubernetes_service_protocol" default:"https"`
 	MountedCniNetDir          string `envconfig:"mounted_cni_net_dir" default:"/host/etc/cni/net.d"`
 	ShouldSleep               bool   `envconfig:"sleep" default:"true"`
+	RefreshSATokenInterval    int    `envconfig:"refresh_sa_token_interval" default:"60"`
 }
 
 func (i InstallerConfig) Validate() error {

--- a/app/cni/pkg/install/installer_config.go
+++ b/app/cni/pkg/install/installer_config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/config"
+	"github.com/kumahq/kuma/pkg/util/files"
 )
 
 const (
@@ -100,7 +101,11 @@ func prepareKubeconfig(ic *InstallerConfig, serviceAccountPath string) error {
 	caData := base64.StdEncoding.EncodeToString(kubeCa)
 
 	kubeconfig := kubeconfigTemplate(ic.KubernetesServiceProtocol, ic.KubernetesServiceHost, ic.KubernetesServicePort, string(serviceAccountToken), caData)
-	log.Info("writing kubernetes config", "path", kubeconfigPath)
+	logLevel := 0
+	if files.FileExists(kubeconfigPath) {
+		logLevel = 1
+	}
+	log.V(logLevel).Info("writing kubernetes config", "path", kubeconfigPath)
 	err = atomic.WriteFile(kubeconfigPath, strings.NewReader(kubeconfig))
 	if err != nil {
 		return err


### PR DESCRIPTION
## Motivation

Manual backport of https://github.com/kumahq/kuma/pull/12592 to `release-2.7`

## Implementation information

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
