### PR TITLE
test(e2e): fix the flaky test in the gateway scenario

### DIFF
--- a/test/e2e_env/kubernetes/gateway/gateway.go
+++ b/test/e2e_env/kubernetes/gateway/gateway.go
@@ -573,7 +573,8 @@ spec:
 
 			for _, fn := range []InstallFunc{
 				WaitNumPods(namespace, 3, testServerApp),
-				WaitPodsAvailable(namespace, testServerApp)} {
+				WaitPodsAvailable(namespace, testServerApp),
+			} {
 				Expect(fn(kubernetes.Cluster)).To(Succeed())
 			}
 		})


### PR DESCRIPTION
## Motivation

Trying to fix the flaky test here: https://github.com/kumahq/kuma/actions/runs/12880363478/job/35911983525#step:12:11928

## Implementation information

Wait for readiness of the `test-server-mlbs` app before using it.

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
