### PR TITLE
test(e2e): fix the flaky test in the gateway scenario

### DIFF
--- a/test/e2e_env/kubernetes/gateway/gateway.go
+++ b/test/e2e_env/kubernetes/gateway/gateway.go
@@ -569,7 +569,8 @@ spec:
 
 			for _, fn := range []InstallFunc{
 				WaitNumPods(namespace, 3, testServerApp),
-				WaitPodsAvailable(namespace, testServerApp)} {
+				WaitPodsAvailable(namespace, testServerApp),
+			} {
 				Expect(fn(kubernetes.Cluster)).To(Succeed())
 			}
 		})

--- a/test/e2e_env/kubernetes/gateway/gateway.go
+++ b/test/e2e_env/kubernetes/gateway/gateway.go
@@ -554,17 +554,24 @@ spec:
 		routes := httpRoute("test-server-mlbs", "/mlbs", "test-server-mlbs_simple-gateway_svc_80")
 
 		BeforeAll(func() {
+			testServerApp := "test-server-mlbs"
 			err := NewClusterSetup().
 				Install(testserver.Install(
 					testserver.WithMesh(meshName),
 					testserver.WithNamespace(namespace),
-					testserver.WithName("test-server-mlbs"),
+					testserver.WithName(testServerApp),
 					testserver.WithStatefulSet(true),
 					testserver.WithReplicas(3),
 				)).
 				Install(YamlK8s(routes...)).
 				Setup(kubernetes.Cluster)
 			Expect(err).ToNot(HaveOccurred())
+
+			for _, fn := range []InstallFunc{
+				WaitNumPods(namespace, 3, testServerApp),
+				WaitPodsAvailable(namespace, testServerApp)} {
+				Expect(fn(kubernetes.Cluster)).To(Succeed())
+			}
 		})
 
 		AfterAll(func() {


### PR DESCRIPTION
## Motivation

Manual backport of PR https://github.com/kumahq/kuma/pull/12633

Trying to fix the flaky test here: https://github.com/kumahq/kuma/actions/runs/12880363478/job/35911983525#step:12:11928

## Implementation information

Wait for readiness of the `test-server-mlbs` app before using it.

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
