### PR TITLE
chore(kumactl): upgrade grafana/grafana to 11.4.0 in observability manifests

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-observability.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.defaults.golden.yaml
@@ -12005,7 +12005,7 @@ spec:
               mountPath: /var/lib/grafana/plugins
       containers:
         - name: grafana
-          image: "grafana/grafana:8.5.2"
+          image: "grafana/grafana:11.4.0"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: config

--- a/app/kumactl/cmd/install/testdata/install-observability.no-jaeger.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-jaeger.golden.yaml
@@ -12005,7 +12005,7 @@ spec:
               mountPath: /var/lib/grafana/plugins
       containers:
         - name: grafana
-          image: "grafana/grafana:8.5.2"
+          image: "grafana/grafana:11.4.0"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: config

--- a/app/kumactl/cmd/install/testdata/install-observability.no-loki.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-loki.golden.yaml
@@ -12005,7 +12005,7 @@ spec:
               mountPath: /var/lib/grafana/plugins
       containers:
         - name: grafana
-          image: "grafana/grafana:8.5.2"
+          image: "grafana/grafana:11.4.0"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: config

--- a/app/kumactl/cmd/install/testdata/install-observability.no-prometheus.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-prometheus.golden.yaml
@@ -11455,7 +11455,7 @@ spec:
               mountPath: /var/lib/grafana/plugins
       containers:
         - name: grafana
-          image: "grafana/grafana:8.5.2"
+          image: "grafana/grafana:11.4.0"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: config

--- a/app/kumactl/cmd/install/testdata/install-observability.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.overrides.golden.yaml
@@ -12005,7 +12005,7 @@ spec:
               mountPath: /var/lib/grafana/plugins
       containers:
         - name: grafana
-          image: "grafana/grafana:8.5.2"
+          image: "grafana/grafana:11.4.0"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: config

--- a/app/kumactl/data/install/k8s/metrics/grafana/grafana.yaml
+++ b/app/kumactl/data/install/k8s/metrics/grafana/grafana.yaml
@@ -265,7 +265,7 @@ spec:
               mountPath: /var/lib/grafana/plugins
       containers:
         - name: grafana
-          image: "grafana/grafana:8.5.2"
+          image: "grafana/grafana:11.4.0"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: config


### PR DESCRIPTION
## Motivation

I know we plan to remove `kumactl install observability` eventually, but I think we should update its components for now, especially if it’s easy to do. Once the versions are more current, Renovate can take care of updates going forward.

## Implementation information

Upgraded `grafana/grafana` from 8.5.2 to 11.4.0 in the Kubernetes manifest used by `kumactl install observability`. [Checked all intermediate versions](https://grafana.com/docs/grafana/latest/upgrade-guide/), and no configuration changes were needed. Tested locally to make sure it works.

## Supporting documentation

Related to: https://github.com/kumahq/kuma/issues/11693

<img width="432" alt="Screenshot 2025-01-22 at 16 02 32" src="https://github.com/user-attachments/assets/cbb1a8dd-300c-4c7d-8ade-fe2521ebaa1b" />
<img width="3303" alt="Screenshot 2025-01-22 at 16 02 54" src="https://github.com/user-attachments/assets/6070bc8f-23da-4dd9-b57f-c593ee980d2e" />
<img width="3303" alt="Screenshot 2025-01-22 at 16 03 02" src="https://github.com/user-attachments/assets/117b7f8f-4a0b-4e84-b64a-caf555ec2910" />
<img width="3303" alt="Screenshot 2025-01-22 at 16 03 24" src="https://github.com/user-attachments/assets/95a8c3aa-2091-4aff-b6f6-ed2053bfdcc2" />
<img width="3303" alt="Screenshot 2025-01-22 at 16 03 32" src="https://github.com/user-attachments/assets/b5be2875-af66-4ce7-a3aa-ce6299636c29" />
<img width="3303" alt="Screenshot 2025-01-22 at 16 03 43" src="https://github.com/user-attachments/assets/7eb68c65-96bc-4aec-836b-b40450cb8239" />
