### PR TITLE
chore(kumactl): upgrade grafana/promtail to 3.3.2 in observability manifests

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-observability.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.defaults.golden.yaml
@@ -12022,7 +12022,6 @@ spec:
               readOnly: true
             - name: plugins-volume
               mountPath: /var/lib/grafana/plugins
-              readOnly: true
           ports:
             - name: service
               containerPort: 80
@@ -12692,7 +12691,7 @@ spec:
       serviceAccountName: loki-promtail
       containers:
         - name: promtail
-          image: "grafana/promtail:2.4.1"
+          image: "grafana/promtail:3.3.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-config.file=/etc/promtail/promtail.yaml"

--- a/app/kumactl/cmd/install/testdata/install-observability.no-grafana.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-grafana.golden.yaml
@@ -1169,7 +1169,7 @@ spec:
       serviceAccountName: loki-promtail
       containers:
         - name: promtail
-          image: "grafana/promtail:2.4.1"
+          image: "grafana/promtail:3.3.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-config.file=/etc/promtail/promtail.yaml"

--- a/app/kumactl/cmd/install/testdata/install-observability.no-jaeger.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-jaeger.golden.yaml
@@ -12022,7 +12022,6 @@ spec:
               readOnly: true
             - name: plugins-volume
               mountPath: /var/lib/grafana/plugins
-              readOnly: true
           ports:
             - name: service
               containerPort: 80
@@ -12692,7 +12691,7 @@ spec:
       serviceAccountName: loki-promtail
       containers:
         - name: promtail
-          image: "grafana/promtail:2.4.1"
+          image: "grafana/promtail:3.3.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-config.file=/etc/promtail/promtail.yaml"

--- a/app/kumactl/cmd/install/testdata/install-observability.no-loki.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-loki.golden.yaml
@@ -12022,7 +12022,6 @@ spec:
               readOnly: true
             - name: plugins-volume
               mountPath: /var/lib/grafana/plugins
-              readOnly: true
           ports:
             - name: service
               containerPort: 80

--- a/app/kumactl/cmd/install/testdata/install-observability.no-prometheus.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-prometheus.golden.yaml
@@ -11472,7 +11472,6 @@ spec:
               readOnly: true
             - name: plugins-volume
               mountPath: /var/lib/grafana/plugins
-              readOnly: true
           ports:
             - name: service
               containerPort: 80
@@ -12036,7 +12035,7 @@ spec:
       serviceAccountName: loki-promtail
       containers:
         - name: promtail
-          image: "grafana/promtail:2.4.1"
+          image: "grafana/promtail:3.3.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-config.file=/etc/promtail/promtail.yaml"

--- a/app/kumactl/cmd/install/testdata/install-observability.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.overrides.golden.yaml
@@ -12022,7 +12022,6 @@ spec:
               readOnly: true
             - name: plugins-volume
               mountPath: /var/lib/grafana/plugins
-              readOnly: true
           ports:
             - name: service
               containerPort: 80
@@ -12692,7 +12691,7 @@ spec:
       serviceAccountName: loki-promtail
       containers:
         - name: promtail
-          image: "grafana/promtail:2.4.1"
+          image: "grafana/promtail:3.3.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-config.file=/etc/promtail/promtail.yaml"

--- a/app/kumactl/data/install/k8s/logging/loki/loki.yaml
+++ b/app/kumactl/data/install/k8s/logging/loki/loki.yaml
@@ -504,7 +504,7 @@ spec:
       serviceAccountName: loki-promtail
       containers:
         - name: promtail
-          image: "grafana/promtail:2.4.1"
+          image: "grafana/promtail:3.3.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-config.file=/etc/promtail/promtail.yaml"

--- a/app/kumactl/data/install/k8s/metrics/grafana/grafana.yaml
+++ b/app/kumactl/data/install/k8s/metrics/grafana/grafana.yaml
@@ -282,7 +282,6 @@ spec:
               readOnly: true
             - name: plugins-volume
               mountPath: /var/lib/grafana/plugins
-              readOnly: true
           ports:
             - name: service
               containerPort: 80


### PR DESCRIPTION
## Motivation

I know we plan to remove `kumactl install observability` eventually, but I think we should update its components for now, especially if it’s easy to do. Once the versions are more current, Renovate can take care of updates going forward.

## Implementation information
Upgraded `grafana/promtail` from 2.4.1 to 3.3.2 in the Kubernetes manifest used by `kumactl install observability`. No configuration changes were needed, but removed `readOnly: true` from the `/var/lib/grafana/plugins` volume mount to allow Grafana to install the `grafana-lokiexplore-app` plugin. Tested locally to ensure everything works.

## Supporting documentation

Related to: https://github.com/kumahq/kuma/issues/11693

<img width="3303" alt="Screenshot 2025-01-23 at 07 31 52" src="https://github.com/user-attachments/assets/c9c74c42-f23c-46ab-8d73-3fd6ef04e2d7" />
<img width="3303" alt="Screenshot 2025-01-23 at 07 32 20" src="https://github.com/user-attachments/assets/57d2c563-1446-43a9-a4ca-cc17c7bd411c" />

