### PR TITLE
feat(kuma-cp): deprecate MeshSubset kind in top level targetRef

### DIFF
--- a/pkg/plugins/policies/core/jsonpatch/validators/validator.go
+++ b/pkg/plugins/policies/core/jsonpatch/validators/validator.go
@@ -128,5 +128,10 @@ func TopLevelTargetRefDeprecations(targetRef *common_api.TargetRef) []string {
 			fmt.Sprintf("%s value for 'targetRef.kind' is deprecated, use %s with '%s' tag instead", common_api.MeshService, common_api.MeshSubset, mesh_proto.ServiceTag),
 		}
 	}
+	if targetRef.Kind == common_api.MeshSubset {
+		return []string{
+			fmt.Sprintf("%s value for 'targetRef.kind' is deprecated, use %s with labels instead", common_api.MeshSubset, common_api.Dataplane),
+		}
+	}
 	return nil
 }

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-origin-global-mesh-subset.federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-origin-global-mesh-subset.federated.golden.yaml
@@ -1,0 +1,15 @@
+Patches: null
+allowed: false
+status:
+  code: 403
+  details:
+    causes:
+    - field: metadata.labels[kuma.io/origin]
+      message: cannot be empty
+      reason: FieldValueInvalid
+  message: Operation not allowed. Applying policies on Zone CP requires 'kuma.io/origin'
+    label to be set to 'zone'.
+  metadata: {}
+  reason: Forbidden
+  status: Failure
+uid: "12345"

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-origin-global-mesh-subset.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-origin-global-mesh-subset.global.golden.yaml
@@ -1,0 +1,8 @@
+Patches: null
+allowed: true
+status:
+  code: 200
+  metadata: {}
+uid: "12345"
+warnings:
+- MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-origin-global-mesh-subset.input.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-origin-global-mesh-subset.input.yaml
@@ -1,0 +1,20 @@
+# user=cli-user,operation=CREATE,namespace=kuma-system
+apiVersion: kuma.io/v1alpha1
+kind: MeshTimeout
+metadata:
+  name: backend-v3
+  labels:
+    kuma.io/origin: global
+    kuma.io/mesh: default
+spec:
+  targetRef:
+    kind: MeshSubset
+    tags:
+      app: demo-app
+  to:
+    - targetRef:
+        kind: Mesh
+      default:
+        http:
+          requestTimeout: 19s
+          streamIdleTimeout: 1h

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-origin-global-mesh-subset.non-federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-origin-global-mesh-subset.non-federated.golden.yaml
@@ -1,0 +1,8 @@
+Patches: null
+allowed: true
+status:
+  code: 200
+  metadata: {}
+uid: "12345"
+warnings:
+- MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead


### PR DESCRIPTION
Fix: #12362

## Motivation

Since we've introduced new Dataplane kind we can deprecate usage of MeshSubset for selecting proxies. Dataplane is more powerful and better matches our approach for selecting real resources. 

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
