### PR TITLE
fix(xds): ignore watchdog error on context cancelled

### DIFF
--- a/pkg/util/watchdog/watchdog.go
+++ b/pkg/util/watchdog/watchdog.go
@@ -44,7 +44,7 @@ func (w *SimpleWatchdog) Start(ctx context.Context) {
 	defer ticker.Stop()
 	for {
 		if err := w.onTick(ctx); err != nil {
-			if !errors.Is(err, context.Canceled) && w.OnError != nil {
+			if !channels.IsClosed(ctx.Done()) && !errors.Is(err, context.Canceled) && w.OnError != nil {
 				w.OnError(err)
 			}
 		}

--- a/pkg/util/watchdog/watchdog_test.go
+++ b/pkg/util/watchdog/watchdog_test.go
@@ -231,6 +231,7 @@ var _ = Describe("SimpleWatchdog", func() {
 		Expect(hasTicked).Should(BeClosed())
 
 		cancel()
+		Eventually(doneCh).Should(BeClosed())
 	})
 
 	It("should not produce error on context cancelled", func() {

--- a/pkg/util/watchdog/watchdog_test.go
+++ b/pkg/util/watchdog/watchdog_test.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/test"
 	. "github.com/kumahq/kuma/pkg/util/watchdog"
@@ -230,5 +231,34 @@ var _ = Describe("SimpleWatchdog", func() {
 		Expect(hasTicked).Should(BeClosed())
 
 		cancel()
+	})
+
+	It("should not produce error on context cancelled", func() {
+		// given
+		watchdog := &SimpleWatchdog{
+			NewTicker: func() *time.Ticker {
+				return &time.Ticker{
+					C: timeTicks,
+				}
+			},
+			OnTick: func(ctx context.Context) error {
+				return errors.New("missing data")
+			},
+			OnError: func(err error) {
+				onErrorCalls <- err
+			},
+		}
+
+		// when context is cancelled
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		watchdog.Start(ctx)
+
+		// then no error is produced
+		select {
+		case <-onErrorCalls:
+			Fail("error should not be produced")
+		default:
+		}
 	})
 })


### PR DESCRIPTION
## Motivation

We are producing logs that we should ignore

## Implementation information

I made a change to ignore OnError callback in case of ctx is cancelled.
Other option would be to change log level from ERROR to INFO dynamically in OnError callback implementation, but we would need to repeat this across all watchdog implems. I'm not sure we care about this error. The intention of already existing `!errors.Is(err, context.Canceled)` seems to be to ignore such errors.

While this is fix, I don't think it's worth to backport it. It's not a stability issue, it's just a slight noise in logs.

## Supporting documentation

Fix #12663 

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
