### PR TITLE
feat(oapi): properly map proto types likes DoubleValue

### DIFF
--- a/api/mesh/v1alpha1/mesh/schema.yaml
+++ b/api/mesh/v1alpha1/mesh/schema.yaml
@@ -203,10 +203,7 @@ properties:
         properties:
           passthrough:
             description: Control the passthrough cluster
-            properties:
-              value:
-                type: boolean
-            type: object
+            type: boolean
         type: object
     type: object
   routing:
@@ -257,10 +254,7 @@ properties:
               description: |-
                 Percentage of traces that will be sent to the backend (range 0.0 - 100.0).
                 Empty value defaults to 100.0%
-              properties:
-                value:
-                  type: number
-              type: object
+              type: number
             type:
               description: Type of the backend (Kuma ships with 'zipkin')
               type: string

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -12012,10 +12012,7 @@ components:
               properties:
                 passthrough:
                   description: Control the passthrough cluster
-                  properties:
-                    value:
-                      type: boolean
-                  type: object
+                  type: boolean
               type: object
           type: object
         routing:
@@ -12076,10 +12073,7 @@ components:
                       (range 0.0 - 100.0).
 
                       Empty value defaults to 100.0%
-                    properties:
-                      value:
-                        type: number
-                    type: object
+                    type: number
                   type:
                     description: Type of the backend (Kuma ships with 'zipkin')
                     type: string

--- a/tools/resource-gen/main.go
+++ b/tools/resource-gen/main.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
 	structpb "google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 	"sigs.k8s.io/yaml"
 
 	"github.com/kumahq/kuma/api/mesh/v1alpha1"
@@ -448,6 +449,7 @@ func openApiGenerator(pkg string, resources []ResourceInfo) error {
 			DoNotReference:            true,
 			AllowAdditionalProperties: true,
 			IgnoredTypes:              []any{structpb.Struct{}},
+			Mapper:                    typeMapper,
 		}
 		err := reflector.AddGoComments("github.com/kumahq/kuma/", path.Join(rootDir, "api/"))
 		if err != nil {
@@ -539,6 +541,50 @@ func TemplateGeneratorFn(tmpl *template.Template) GeneratorFn {
 		if _, err := os.Stdout.Write(out); err != nil {
 			return err
 		}
+		return nil
+	}
+}
+
+func typeMapper(r reflect.Type) *jsonschema.Schema {
+	switch r {
+	case reflect.TypeOf(wrapperspb.DoubleValue{}), reflect.TypeOf(wrapperspb.FloatValue{}):
+		return &jsonschema.Schema{
+			Type: "number",
+		}
+	case reflect.TypeOf(wrapperspb.Int64Value{}):
+		return &jsonschema.Schema{
+			Type:   "integer",
+			Format: "int64",
+		}
+	case reflect.TypeOf(wrapperspb.UInt64Value{}):
+		return &jsonschema.Schema{
+			Type:   "integer",
+			Format: "uint64",
+		}
+	case reflect.TypeOf(wrapperspb.Int32Value{}):
+		return &jsonschema.Schema{
+			Type:   "integer",
+			Format: "int32",
+		}
+	case reflect.TypeOf(wrapperspb.UInt32Value{}):
+		return &jsonschema.Schema{
+			Type:   "integer",
+			Format: "uint32",
+		}
+	case reflect.TypeOf(wrapperspb.BoolValue{}):
+		return &jsonschema.Schema{
+			Type: "boolean",
+		}
+	case reflect.TypeOf(wrapperspb.StringValue{}):
+		return &jsonschema.Schema{
+			Type: "string",
+		}
+	case reflect.TypeOf(wrapperspb.BytesValue{}):
+		return &jsonschema.Schema{
+			Type:   "string",
+			Format: "byte",
+		}
+	default:
 		return nil
 	}
 }


### PR DESCRIPTION
## Motivation

The default mapper configuration wraps these values in `{ value: 100 }` and that results in the following errors in TF:

```
│ Error: failure to invoke API
│
│ error unmarshalling json response body: json: cannot unmarshal bool into Go struct field Outbound.networking.outbound.passthrough of type shared.Passthrough
╵
```

## Implementation information

Use a mapper to map these types properly.

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

xrel https://github.com/Kong/kong-mesh/issues/7201

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
