### PR TITLE
chore(kds): ignore error log on zone not found

### DIFF
--- a/pkg/kds/service/server.go
+++ b/pkg/kds/service/server.go
@@ -106,7 +106,7 @@ func (g *GlobalKDSServiceServer) HealthCheck(ctx context.Context, _ *mesh_proto.
 		return nil
 	}, manager.WithConflictRetry(
 		g.upsertCfg.ConflictRetryBaseBackoff.Duration, g.upsertCfg.ConflictRetryMaxTimes, g.upsertCfg.ConflictRetryJitterPercent,
-	)); err != nil && !errors.Is(err, context.Canceled) {
+	)); err != nil && !errors.Is(err, context.Canceled) && !core_store.IsResourceNotFound(err) {
 		log.Error(err, "couldn't update zone insight", "zone", zone)
 	}
 


### PR DESCRIPTION
## Motivation

Sometimes we see
```
Resource not found: type="Zone" name="zone-01" mesh=""
```
It can happen when we disconnect and remove zone immediately, but HC handler will be executed after that. There is no point in logging it. We already ignore context cancelled.

## Implementation information

Alternatively, we could log this on debug level, but I don't think it's worth it.

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
