### PR TITLE
test(meshtimeout): fix golden file tests to handle IPv4 and IPv6

### DIFF
--- a/test/e2e_env/universal/envoyconfig/envoyconfig.go
+++ b/test/e2e_env/universal/envoyconfig/envoyconfig.go
@@ -71,8 +71,41 @@ func EnvoyConfigTest() {
 	})
 
 	redactIPs := func(jsonStr string) string {
-		ipRegex := regexp.MustCompile(`\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b`)
-		return ipRegex.ReplaceAllString(jsonStr, "IP_REDACTED")
+		ipv6Regex := `\[?` + // Optional opening square bracket for IPv6 in URLs (e.g., [2001:db8::1])
+			`(` +
+			// Full IPv6 address with 8 segments (e.g., 2001:0db8:85a3:0000:0000:8a2e:0370:7334)
+			`([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|` +
+			// IPv6 with leading compression (e.g., ::1, ::8a2e:0370:7334)
+			`([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|` +
+			// IPv6 with trailing compression (e.g., 2001:db8::, 2001:db8::1:2)
+			`([0-9a-fA-F]{1,4}:){1,7}:|` +
+			// IPv6 with mixed compression (e.g., 2001:db8:0:0::1:2)
+			`([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|` +
+			`([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|` +
+			`([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|` +
+			`([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|` +
+			// IPv6 with only one segment and compression (e.g., 2001::1:2:3:4:5:6)
+			`[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|` +
+			// Fully compressed IPv6 (::) or with trailing segments (::1, ::8a2e:0370:7334)
+			`:((:[0-9a-fA-F]{1,4}){1,7}|:)|` +
+			// Link-local IPv6 with zone identifiers (e.g., fe80::1%eth0)
+			`fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]+|` +
+			// IPv6 with embedded IPv4 (e.g., ::ffff:192.168.1.1)
+			`::(ffff(:0{1,4})?:)?((25[0-5]|(2[0-4]|1?[0-9])?[0-9])\.){3}` +
+			`(25[0-5]|(2[0-4]|1?[0-9])?[0-9])|` +
+			// Mixed IPv6 and IPv4 (e.g., 2001:db8::192.168.1.1)
+			`([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1?[0-9])?[0-9])\.){3}` +
+			`(25[0-5]|(2[0-4]|1?[0-9])?[0-9])` +
+			`)` +
+			`]?` // Optional closing square bracket for IPv6 in URLs (e.g., [2001:db8::1])
+
+		ipv4Regex := `\b` + // Word boundary to ensure we match standalone IPv4 addresses
+			`\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}` + // Matches IPv4 format (e.g., 192.168.0.1)
+			`\b`
+
+		return regexp.
+			MustCompile(ipv4Regex+"|"+ipv6Regex).
+			ReplaceAllString(jsonStr, "IP_REDACTED")
 	}
 
 	getConfig := func(dpp string) string {

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound.demo-client.golden.json
@@ -153,7 +153,7 @@
     "lbPolicy": "CLUSTER_PROVIDED",
     "upstreamBindConfig": {
      "sourceAddress": {
-      "address": "::6",
+      "address": "IP_REDACTED",
       "portValue": 0
      }
     }
@@ -349,7 +349,7 @@
     "name": "inbound:passthrough:ipv6",
     "address": {
      "socketAddress": {
-      "address": "::",
+      "address": "IP_REDACTED",
       "portValue": 15006
      }
     },
@@ -498,7 +498,7 @@
     "name": "outbound:passthrough:ipv6",
     "address": {
      "socketAddress": {
-      "address": "::",
+      "address": "IP_REDACTED",
       "portValue": 15001
      }
     },

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound.test-server.golden.json
@@ -203,7 +203,7 @@
     "lbPolicy": "CLUSTER_PROVIDED",
     "upstreamBindConfig": {
      "sourceAddress": {
-      "address": "::6",
+      "address": "IP_REDACTED",
       "portValue": 0
      }
     }
@@ -457,7 +457,7 @@
     "name": "inbound:passthrough:ipv6",
     "address": {
      "socketAddress": {
-      "address": "::",
+      "address": "IP_REDACTED",
       "portValue": 15006
      }
     },
@@ -606,7 +606,7 @@
     "name": "outbound:passthrough:ipv6",
     "address": {
      "socketAddress": {
-      "address": "::",
+      "address": "IP_REDACTED",
       "portValue": 15001
      }
     },

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/no-policies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/no-policies.demo-client.golden.json
@@ -59,7 +59,7 @@
     "lbPolicy": "CLUSTER_PROVIDED",
     "upstreamBindConfig": {
      "sourceAddress": {
-      "address": "::6",
+      "address": "IP_REDACTED",
       "portValue": 0
      }
     }
@@ -255,7 +255,7 @@
     "name": "inbound:passthrough:ipv6",
     "address": {
      "socketAddress": {
-      "address": "::",
+      "address": "IP_REDACTED",
       "portValue": 15006
      }
     },
@@ -398,7 +398,7 @@
     "name": "outbound:passthrough:ipv6",
     "address": {
      "socketAddress": {
-      "address": "::",
+      "address": "IP_REDACTED",
       "portValue": 15001
      }
     },

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/no-policies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/no-policies.test-server.golden.json
@@ -59,7 +59,7 @@
     "lbPolicy": "CLUSTER_PROVIDED",
     "upstreamBindConfig": {
      "sourceAddress": {
-      "address": "::6",
+      "address": "IP_REDACTED",
       "portValue": 0
      }
     }
@@ -309,7 +309,7 @@
     "name": "inbound:passthrough:ipv6",
     "address": {
      "socketAddress": {
-      "address": "::",
+      "address": "IP_REDACTED",
       "portValue": 15006
      }
     },
@@ -452,7 +452,7 @@
     "name": "outbound:passthrough:ipv6",
     "address": {
      "socketAddress": {
-      "address": "::",
+      "address": "IP_REDACTED",
       "portValue": 15001
      }
     },

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/outbound.demo-client.golden.json
@@ -123,7 +123,7 @@
     "lbPolicy": "CLUSTER_PROVIDED",
     "upstreamBindConfig": {
      "sourceAddress": {
-      "address": "::6",
+      "address": "IP_REDACTED",
       "portValue": 0
      }
     }
@@ -319,7 +319,7 @@
     "name": "inbound:passthrough:ipv6",
     "address": {
      "socketAddress": {
-      "address": "::",
+      "address": "IP_REDACTED",
       "portValue": 15006
      }
     },
@@ -468,7 +468,7 @@
     "name": "outbound:passthrough:ipv6",
     "address": {
      "socketAddress": {
-      "address": "::",
+      "address": "IP_REDACTED",
       "portValue": 15001
      }
     },

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/outbound.test-server.golden.json
@@ -123,7 +123,7 @@
     "lbPolicy": "CLUSTER_PROVIDED",
     "upstreamBindConfig": {
      "sourceAddress": {
-      "address": "::6",
+      "address": "IP_REDACTED",
       "portValue": 0
      }
     }
@@ -373,7 +373,7 @@
     "name": "inbound:passthrough:ipv6",
     "address": {
      "socketAddress": {
-      "address": "::",
+      "address": "IP_REDACTED",
       "portValue": 15006
      }
     },
@@ -522,7 +522,7 @@
     "name": "outbound:passthrough:ipv6",
     "address": {
      "socketAddress": {
-      "address": "::",
+      "address": "IP_REDACTED",
       "portValue": 15001
      }
     },


### PR DESCRIPTION
## Motivation & Implementation information

Updated tests to replace both IPv4 and IPv6 addresses with "IP_REDACTED" in generated golden files. This fixes issues with e2e tests checking golden envoy configs (introduced in https://github.com/kumahq/kuma/pull/12650)