### PR TITLE
test(meshtimeout): stable sort the `.diff` list after redacting IPs

### DIFF
--- a/test/e2e_env/universal/envoyconfig/envoyconfig.go
+++ b/test/e2e_env/universal/envoyconfig/envoyconfig.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -19,7 +20,6 @@ import (
 	. "github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/framework/client"
 	"github.com/kumahq/kuma/test/framework/envs/universal"
-	"slices"
 )
 
 func EnvoyConfigTest() {

--- a/test/e2e_env/universal/envoyconfig/envoyconfig.go
+++ b/test/e2e_env/universal/envoyconfig/envoyconfig.go
@@ -10,12 +10,16 @@ import (
 	. "github.com/onsi/gomega"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/api/openapi/types"
+	api_common "github.com/kumahq/kuma/api/openapi/types/common"
 	"github.com/kumahq/kuma/pkg/test"
 	"github.com/kumahq/kuma/pkg/test/matchers"
 	"github.com/kumahq/kuma/pkg/test/resources/builders"
+	"github.com/kumahq/kuma/pkg/util/pointer"
 	. "github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/framework/client"
 	"github.com/kumahq/kuma/test/framework/envs/universal"
+	"slices"
 )
 
 func EnvoyConfigTest() {
@@ -70,49 +74,25 @@ func EnvoyConfigTest() {
 		}
 	})
 
-	redactIPs := func(jsonStr string) string {
-		ipv6Regex := `\[?` + // Optional opening square bracket for IPv6 in URLs (e.g., [2001:db8::1])
-			`(` +
-			// Full IPv6 address with 8 segments (e.g., 2001:0db8:85a3:0000:0000:8a2e:0370:7334)
-			`([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|` +
-			// IPv6 with leading compression (e.g., ::1, ::8a2e:0370:7334)
-			`([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|` +
-			// IPv6 with trailing compression (e.g., 2001:db8::, 2001:db8::1:2)
-			`([0-9a-fA-F]{1,4}:){1,7}:|` +
-			// IPv6 with mixed compression (e.g., 2001:db8:0:0::1:2)
-			`([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|` +
-			`([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|` +
-			`([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|` +
-			`([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|` +
-			// IPv6 with only one segment and compression (e.g., 2001::1:2:3:4:5:6)
-			`[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|` +
-			// Fully compressed IPv6 (::) or with trailing segments (::1, ::8a2e:0370:7334)
-			`:((:[0-9a-fA-F]{1,4}){1,7}|:)|` +
-			// Link-local IPv6 with zone identifiers (e.g., fe80::1%eth0)
-			`fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]+|` +
-			// IPv6 with embedded IPv4 (e.g., ::ffff:192.168.1.1)
-			`::(ffff(:0{1,4})?:)?((25[0-5]|(2[0-4]|1?[0-9])?[0-9])\.){3}` +
-			`(25[0-5]|(2[0-4]|1?[0-9])?[0-9])|` +
-			// Mixed IPv6 and IPv4 (e.g., 2001:db8::192.168.1.1)
-			`([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1?[0-9])?[0-9])\.){3}` +
-			`(25[0-5]|(2[0-4]|1?[0-9])?[0-9])` +
-			`)` +
-			`]?` // Optional closing square bracket for IPv6 in URLs (e.g., [2001:db8::1])
-
-		ipv4Regex := `\b` + // Word boundary to ensure we match standalone IPv4 addresses
-			`\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}` + // Matches IPv4 format (e.g., 192.168.0.1)
-			`\b`
-
-		return regexp.
-			MustCompile(ipv4Regex+"|"+ipv6Regex).
-			ReplaceAllString(jsonStr, "IP_REDACTED")
-	}
-
 	getConfig := func(dpp string) string {
 		output, err := universal.Cluster.GetKumactlOptions().
 			RunKumactlAndGetOutput("inspect", "dataplane", dpp, "--type", "config", "--mesh", meshName, "--shadow", "--include=diff")
 		Expect(err).ToNot(HaveOccurred())
-		return redactIPs(output)
+		redacted := redactIPs(output)
+
+		response := types.InspectDataplanesConfig{}
+		Expect(json.Unmarshal([]byte(redacted), &response)).To(Succeed())
+		Expect(response.Diff).ToNot(BeNil())
+		response.Diff = pointer.To(slices.DeleteFunc(*response.Diff, func(item api_common.JsonPatchItem) bool {
+			return item.Op == api_common.Test
+		}))
+		slices.SortStableFunc(*response.Diff, func(a, b api_common.JsonPatchItem) int {
+			return strings.Compare(a.Path, b.Path)
+		})
+
+		result, err := json.MarshalIndent(response, "", "  ")
+		Expect(err).ToNot(HaveOccurred())
+		return string(result)
 	}
 
 	DescribeTable("should generate proper Envoy config",
@@ -131,4 +111,42 @@ func EnvoyConfigTest() {
 			Expect(getConfig("test-server")).To(matchers.MatchGoldenJSON(strings.Replace(inputFile, "input.yaml", "test-server.golden.json", 1)))
 		}, test.EntriesForFolder("meshtimeout", "envoyconfig"),
 	)
+}
+
+var ipv6Regex = `\[?` + // Optional opening square bracket for IPv6 in URLs (e.g., [2001:db8::1])
+	`(` +
+	// Full IPv6 address with 8 segments (e.g., 2001:0db8:85a3:0000:0000:8a2e:0370:7334)
+	`([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|` +
+	// IPv6 with leading compression (e.g., ::1, ::8a2e:0370:7334)
+	`([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|` +
+	// IPv6 with trailing compression (e.g., 2001:db8::, 2001:db8::1:2)
+	`([0-9a-fA-F]{1,4}:){1,7}:|` +
+	// IPv6 with mixed compression (e.g., 2001:db8:0:0::1:2)
+	`([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|` +
+	`([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|` +
+	`([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|` +
+	`([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|` +
+	// IPv6 with only one segment and compression (e.g., 2001::1:2:3:4:5:6)
+	`[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|` +
+	// Fully compressed IPv6 (::) or with trailing segments (::1, ::8a2e:0370:7334)
+	`:((:[0-9a-fA-F]{1,4}){1,7}|:)|` +
+	// Link-local IPv6 with zone identifiers (e.g., fe80::1%eth0)
+	`fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]+|` +
+	// IPv6 with embedded IPv4 (e.g., ::ffff:192.168.1.1)
+	`::(ffff(:0{1,4})?:)?((25[0-5]|(2[0-4]|1?[0-9])?[0-9])\.){3}` +
+	`(25[0-5]|(2[0-4]|1?[0-9])?[0-9])|` +
+	// Mixed IPv6 and IPv4 (e.g., 2001:db8::192.168.1.1)
+	`([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1?[0-9])?[0-9])\.){3}` +
+	`(25[0-5]|(2[0-4]|1?[0-9])?[0-9])` +
+	`)` +
+	`]?` // Optional closing square bracket for IPv6 in URLs (e.g., [2001:db8::1])
+
+var ipv4Regex = `\b` + // Word boundary to ensure we match standalone IPv4 addresses
+	`\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}` + // Matches IPv4 format (e.g., 192.168.0.1)
+	`\b`
+
+var ipRegex = regexp.MustCompile(ipv4Regex + "|" + ipv6Regex)
+
+func redactIPs(jsonStr string) string {
+	return ipRegex.ReplaceAllString(jsonStr, "IP_REDACTED")
 }

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound.demo-client.golden.json
@@ -1,524 +1,509 @@
 {
- "diff": [
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_demo-client__kuma-3_msvc_3000/connectTimeout",
-   "value": "5s"
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions",
-   "value": {
-    "idleTimeout": "3600s",
-    "maxConnectionDuration": "5s",
-    "maxStreamDuration": "0s"
-   }
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/connectTimeout",
-   "value": "5s"
-  },
-  {
-   "op": "test",
-   "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:3000/connectTimeout",
-   "value": "10s"
-  },
-  {
-   "op": "remove",
-   "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:3000/connectTimeout",
-   "value": "10s"
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:3000/connectTimeout",
-   "value": "51s"
-  },
-  {
-   "op": "test",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:3000/filterChains/0/filters/0/typedConfig/idleTimeout",
-   "value": "7200s"
-  },
-  {
-   "op": "remove",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:3000/filterChains/0/filters/0/typedConfig/idleTimeout",
-   "value": "7200s"
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:3000/filterChains/0/filters/0/typedConfig/idleTimeout",
-   "value": "50s"
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:3000/filterChains/0/filters/0/typedConfig/idleTimeout",
-   "value": "3600s"
-  },
-  {
-   "op": "test",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
-   "value": "0s"
-  },
-  {
-   "op": "remove",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
-   "value": "0s"
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
-   "value": "15s"
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/idleTimeout",
-   "value": "5s"
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/commonHttpProtocolOptions",
-   "value": {
-    "idleTimeout": "0s"
-   }
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/requestHeadersTimeout",
-   "value": "0s"
-  }
- ],
- "xds": {
-  "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
-   "envoyconfig_demo-client__kuma-3_msvc_3000": {
-    "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
-    "type": "EDS",
-    "edsClusterConfig": {
-     "edsConfig": {
-      "ads": {},
-      "resourceApiVersion": "V3"
-     }
+  "diff": [
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_demo-client__kuma-3_msvc_3000/connectTimeout",
+      "value": "5s"
     },
-    "connectTimeout": "5s",
-    "typedExtensionProtocolOptions": {
-     "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
-      "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-      "explicitHttpConfig": {
-       "http2ProtocolOptions": {}
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/connectTimeout",
+      "value": "5s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions",
+      "value": {
+        "idleTimeout": "3600s",
+        "maxConnectionDuration": "5s",
+        "maxStreamDuration": "0s"
       }
-     }
-    }
-   },
-   "envoyconfig_test-server__kuma-3_msvc_80": {
-    "name": "envoyconfig_test-server__kuma-3_msvc_80",
-    "type": "EDS",
-    "edsClusterConfig": {
-     "edsConfig": {
-      "ads": {},
-      "resourceApiVersion": "V3"
-     }
     },
-    "connectTimeout": "5s",
-    "typedExtensionProtocolOptions": {
-     "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
-      "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-      "commonHttpProtocolOptions": {
-       "idleTimeout": "3600s",
-       "maxConnectionDuration": "5s",
-       "maxStreamDuration": "0s"
+    {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:3000/connectTimeout",
+      "value": "10s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:3000/connectTimeout",
+      "value": "51s"
+    },
+    {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:3000/filterChains/0/filters/0/typedConfig/idleTimeout",
+      "value": "7200s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:3000/filterChains/0/filters/0/typedConfig/idleTimeout",
+      "value": "50s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:3000/filterChains/0/filters/0/typedConfig/idleTimeout",
+      "value": "3600s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/commonHttpProtocolOptions",
+      "value": {
+        "idleTimeout": "0s"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/requestHeadersTimeout",
+      "value": "0s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/idleTimeout",
+      "value": "5s"
+    },
+    {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
+      "value": "0s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
+      "value": "15s"
+    }
+  ],
+  "xds": {
+    "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
+      "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
+        "edsClusterConfig": {
+          "edsConfig": {
+            "ads": {},
+            "resourceApiVersion": "V3"
+          }
+        },
+        "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "type": "EDS",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicitHttpConfig": {
+              "http2ProtocolOptions": {}
+            }
+          }
+        }
       },
-      "explicitHttpConfig": {
-       "http2ProtocolOptions": {}
+      "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
+        "edsClusterConfig": {
+          "edsConfig": {
+            "ads": {},
+            "resourceApiVersion": "V3"
+          }
+        },
+        "name": "envoyconfig_test-server__kuma-3_msvc_80",
+        "type": "EDS",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "5s",
+              "maxStreamDuration": "0s"
+            },
+            "explicitHttpConfig": {
+              "http2ProtocolOptions": {}
+            }
+          }
+        }
+      },
+      "inbound:passthrough:ipv4": {
+        "altStatName": "inbound_passthrough_ipv4",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "inbound:passthrough:ipv4",
+        "type": "ORIGINAL_DST",
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "inbound:passthrough:ipv6": {
+        "altStatName": "inbound_passthrough_ipv6",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "inbound:passthrough:ipv6",
+        "type": "ORIGINAL_DST",
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "localhost:3000": {
+        "altStatName": "localhost_3000",
+        "connectTimeout": "51s",
+        "loadAssignment": {
+          "clusterName": "localhost:3000",
+          "endpoints": [
+            {
+              "lbEndpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socketAddress": {
+                        "address": "IP_REDACTED",
+                        "portValue": 3000
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "name": "localhost:3000",
+        "type": "STATIC",
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "outbound:passthrough:ipv4": {
+        "altStatName": "outbound_passthrough_ipv4",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "outbound:passthrough:ipv4",
+        "type": "ORIGINAL_DST"
+      },
+      "outbound:passthrough:ipv6": {
+        "altStatName": "outbound_passthrough_ipv6",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "outbound:passthrough:ipv6",
+        "type": "ORIGINAL_DST"
       }
-     }
-    }
-   },
-   "inbound:passthrough:ipv4": {
-    "name": "inbound:passthrough:ipv4",
-    "altStatName": "inbound_passthrough_ipv4",
-    "type": "ORIGINAL_DST",
-    "connectTimeout": "5s",
-    "lbPolicy": "CLUSTER_PROVIDED",
-    "upstreamBindConfig": {
-     "sourceAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 0
-     }
-    }
-   },
-   "inbound:passthrough:ipv6": {
-    "name": "inbound:passthrough:ipv6",
-    "altStatName": "inbound_passthrough_ipv6",
-    "type": "ORIGINAL_DST",
-    "connectTimeout": "5s",
-    "lbPolicy": "CLUSTER_PROVIDED",
-    "upstreamBindConfig": {
-     "sourceAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 0
-     }
-    }
-   },
-   "localhost:3000": {
-    "name": "localhost:3000",
-    "altStatName": "localhost_3000",
-    "type": "STATIC",
-    "connectTimeout": "51s",
-    "loadAssignment": {
-     "clusterName": "localhost:3000",
-     "endpoints": [
-      {
-       "lbEndpoints": [
-        {
-         "endpoint": {
-          "address": {
-           "socketAddress": {
+    },
+    "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment": {
+      "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "clusterName": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "IP_REDACTED",
+                      "portValue": 3000
+                    }
+                  }
+                },
+                "loadBalancingWeight": 1,
+                "metadata": {
+                  "filterMetadata": {
+                    "envoy.lb": {
+                      "kuma.io/zone": "kuma-3",
+                      "team": "client-owners"
+                    },
+                    "envoy.transport_socket_match": {
+                      "kuma.io/zone": "kuma-3",
+                      "team": "client-owners"
+                    }
+                  }
+                }
+              }
+            ],
+            "locality": {
+              "zone": "kuma-3"
+            }
+          }
+        ]
+      },
+      "envoyconfig_test-server__kuma-3_msvc_80": {
+        "clusterName": "envoyconfig_test-server__kuma-3_msvc_80",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "IP_REDACTED",
+                      "portValue": 80
+                    }
+                  }
+                },
+                "loadBalancingWeight": 1,
+                "metadata": {
+                  "filterMetadata": {
+                    "envoy.lb": {
+                      "instance": "1",
+                      "kuma.io/protocol": "http",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "server-owners",
+                      "version": "v1"
+                    },
+                    "envoy.transport_socket_match": {
+                      "instance": "1",
+                      "kuma.io/protocol": "http",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "server-owners",
+                      "version": "v1"
+                    }
+                  }
+                }
+              }
+            ],
+            "locality": {
+              "zone": "kuma-3"
+            }
+          }
+        ]
+      }
+    },
+    "type.googleapis.com/envoy.config.listener.v3.Listener": {
+      "inbound:IP_REDACTED:3000": {
+        "address": {
+          "socketAddress": {
             "address": "IP_REDACTED",
             "portValue": 3000
-           }
           }
-         }
-        }
-       ]
-      }
-     ]
-    },
-    "upstreamBindConfig": {
-     "sourceAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 0
-     }
-    }
-   },
-   "outbound:passthrough:ipv4": {
-    "name": "outbound:passthrough:ipv4",
-    "altStatName": "outbound_passthrough_ipv4",
-    "type": "ORIGINAL_DST",
-    "connectTimeout": "5s",
-    "lbPolicy": "CLUSTER_PROVIDED"
-   },
-   "outbound:passthrough:ipv6": {
-    "name": "outbound:passthrough:ipv6",
-    "altStatName": "outbound_passthrough_ipv6",
-    "type": "ORIGINAL_DST",
-    "connectTimeout": "5s",
-    "lbPolicy": "CLUSTER_PROVIDED"
-   }
-  },
-  "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment": {
-   "envoyconfig_demo-client__kuma-3_msvc_3000": {
-    "clusterName": "envoyconfig_demo-client__kuma-3_msvc_3000",
-    "endpoints": [
-     {
-      "locality": {
-       "zone": "kuma-3"
-      },
-      "lbEndpoints": [
-       {
-        "endpoint": {
-         "address": {
-          "socketAddress": {
-           "address": "IP_REDACTED",
-           "portValue": 3000
-          }
-         }
         },
-        "metadata": {
-         "filterMetadata": {
-          "envoy.lb": {
-           "kuma.io/zone": "kuma-3",
-           "team": "client-owners"
-          },
-          "envoy.transport_socket_match": {
-           "kuma.io/zone": "kuma-3",
-           "team": "client-owners"
-          }
-         }
-        },
-        "loadBalancingWeight": 1
-       }
-      ]
-     }
-    ]
-   },
-   "envoyconfig_test-server__kuma-3_msvc_80": {
-    "clusterName": "envoyconfig_test-server__kuma-3_msvc_80",
-    "endpoints": [
-     {
-      "locality": {
-       "zone": "kuma-3"
-      },
-      "lbEndpoints": [
-       {
-        "endpoint": {
-         "address": {
-          "socketAddress": {
-           "address": "IP_REDACTED",
-           "portValue": 80
-          }
-         }
-        },
-        "metadata": {
-         "filterMetadata": {
-          "envoy.lb": {
-           "instance": "1",
-           "kuma.io/protocol": "http",
-           "kuma.io/zone": "kuma-3",
-           "team": "server-owners",
-           "version": "v1"
-          },
-          "envoy.transport_socket_match": {
-           "instance": "1",
-           "kuma.io/protocol": "http",
-           "kuma.io/zone": "kuma-3",
-           "team": "server-owners",
-           "version": "v1"
-          }
-         }
-        },
-        "loadBalancingWeight": 1
-       }
-      ]
-     }
-    ]
-   }
-  },
-  "type.googleapis.com/envoy.config.listener.v3.Listener": {
-   "inbound:IP_REDACTED:3000": {
-    "name": "inbound:IP_REDACTED:3000",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 3000
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.tcp_proxy",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-         "statPrefix": "localhost_3000",
-         "cluster": "localhost:3000",
-         "idleTimeout": "50s"
-        }
-       }
-      ]
-     }
-    ],
-    "metadata": {
-     "filterMetadata": {
-      "io.kuma.tags": {
-       "kuma.io/service": "demo-client",
-       "kuma.io/zone": "kuma-3",
-       "team": "client-owners"
-      }
-     }
-    },
-    "trafficDirection": "INBOUND",
-    "enableReusePort": false,
-    "bindToPort": false
-   },
-   "inbound:passthrough:ipv4": {
-    "name": "inbound:passthrough:ipv4",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 15006
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.tcp_proxy",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-         "statPrefix": "inbound_passthrough_ipv4",
-         "cluster": "inbound:passthrough:ipv4"
-        }
-       }
-      ]
-     }
-    ],
-    "useOriginalDst": true,
-    "trafficDirection": "INBOUND",
-    "enableReusePort": false
-   },
-   "inbound:passthrough:ipv6": {
-    "name": "inbound:passthrough:ipv6",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 15006
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.tcp_proxy",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-         "statPrefix": "inbound_passthrough_ipv6",
-         "cluster": "inbound:passthrough:ipv6"
-        }
-       }
-      ]
-     }
-    ],
-    "useOriginalDst": true,
-    "trafficDirection": "INBOUND",
-    "enableReusePort": false
-   },
-   "outbound:IP_REDACTED:3000": {
-    "name": "outbound:IP_REDACTED:3000",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 3000
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.tcp_proxy",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-         "statPrefix": "envoyconfig_demo-client__kuma-3_msvc_3000",
-         "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
-         "idleTimeout": "3600s"
-        }
-       }
-      ]
-     }
-    ],
-    "metadata": {
-     "filterMetadata": {
-      "io.kuma.tags": {}
-     }
-    },
-    "trafficDirection": "OUTBOUND",
-    "bindToPort": false
-   },
-   "outbound:IP_REDACTED:80": {
-    "name": "outbound:IP_REDACTED:80",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 80
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.http_connection_manager",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-         "statPrefix": "envoyconfig_test-server__kuma-3_msvc_80",
-         "routeConfig": {
-          "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
-          "virtualHosts": [
-           {
-            "name": "envoyconfig_test-server__kuma-3_msvc_80",
-            "domains": [
-             "*"
-            ],
-            "routes": [
-             {
-              "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
-              "match": {
-               "prefix": "/"
-              },
-              "route": {
-               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-               "timeout": "15s",
-               "idleTimeout": "5s"
-              }
-             }
-            ]
-           }
-          ],
-          "validateClusters": false
-         },
-         "httpFilters": [
+        "bindToPort": false,
+        "enableReusePort": false,
+        "filterChains": [
           {
-           "name": "envoy.filters.http.router",
-           "typedConfig": {
-            "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
-           }
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "localhost:3000",
+                  "idleTimeout": "50s",
+                  "statPrefix": "localhost_3000"
+                }
+              }
+            ]
           }
-         ],
-         "commonHttpProtocolOptions": {
-          "idleTimeout": "0s"
-         },
-         "requestHeadersTimeout": "0s",
-         "normalizePath": true
-        }
-       }
-      ]
-     }
-    ],
-    "metadata": {
-     "filterMetadata": {
-      "io.kuma.tags": {}
-     }
-    },
-    "trafficDirection": "OUTBOUND",
-    "bindToPort": false
-   },
-   "outbound:passthrough:ipv4": {
-    "name": "outbound:passthrough:ipv4",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 15001
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.tcp_proxy",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-         "statPrefix": "outbound_passthrough_ipv4",
-         "cluster": "outbound:passthrough:ipv4"
-        }
-       }
-      ]
-     }
-    ],
-    "useOriginalDst": true,
-    "trafficDirection": "OUTBOUND"
-   },
-   "outbound:passthrough:ipv6": {
-    "name": "outbound:passthrough:ipv6",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 15001
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.tcp_proxy",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-         "statPrefix": "outbound_passthrough_ipv6",
-         "cluster": "outbound:passthrough:ipv6"
-        }
-       }
-      ]
-     }
-    ],
-    "useOriginalDst": true,
-    "trafficDirection": "OUTBOUND"
-   }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {
+              "kuma.io/service": "demo-client",
+              "kuma.io/zone": "kuma-3",
+              "team": "client-owners"
+            }
+          }
+        },
+        "name": "inbound:IP_REDACTED:3000",
+        "trafficDirection": "INBOUND"
+      },
+      "inbound:passthrough:ipv4": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15006
+          }
+        },
+        "enableReusePort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "inbound:passthrough:ipv4",
+                  "statPrefix": "inbound_passthrough_ipv4"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "inbound:passthrough:ipv4",
+        "trafficDirection": "INBOUND",
+        "useOriginalDst": true
+      },
+      "inbound:passthrough:ipv6": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15006
+          }
+        },
+        "enableReusePort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "inbound:passthrough:ipv6",
+                  "statPrefix": "inbound_passthrough_ipv6"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "inbound:passthrough:ipv6",
+        "trafficDirection": "INBOUND",
+        "useOriginalDst": true
+      },
+      "outbound:IP_REDACTED:3000": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 3000
+          }
+        },
+        "bindToPort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
+                  "statPrefix": "envoyconfig_demo-client__kuma-3_msvc_3000"
+                }
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {}
+          }
+        },
+        "name": "outbound:IP_REDACTED:3000",
+        "trafficDirection": "OUTBOUND"
+      },
+      "outbound:IP_REDACTED:80": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 80
+          }
+        },
+        "bindToPort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
+                  "httpFilters": [
+                    {
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
+                    }
+                  ],
+                  "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
+                  "routeConfig": {
+                    "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
+                    "validateClusters": false,
+                    "virtualHosts": [
+                      {
+                        "domains": [
+                          "*"
+                        ],
+                        "name": "envoyconfig_test-server__kuma-3_msvc_80",
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/"
+                            },
+                            "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
+                            "route": {
+                              "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
+                              "idleTimeout": "5s",
+                              "timeout": "15s"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "statPrefix": "envoyconfig_test-server__kuma-3_msvc_80"
+                }
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {}
+          }
+        },
+        "name": "outbound:IP_REDACTED:80",
+        "trafficDirection": "OUTBOUND"
+      },
+      "outbound:passthrough:ipv4": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15001
+          }
+        },
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "outbound:passthrough:ipv4",
+                  "statPrefix": "outbound_passthrough_ipv4"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "outbound:passthrough:ipv4",
+        "trafficDirection": "OUTBOUND",
+        "useOriginalDst": true
+      },
+      "outbound:passthrough:ipv6": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15001
+          }
+        },
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "outbound:passthrough:ipv6",
+                  "statPrefix": "outbound_passthrough_ipv6"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "outbound:passthrough:ipv6",
+        "trafficDirection": "OUTBOUND",
+        "useOriginalDst": true
+      }
+    }
   }
- }
 }

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound.test-server.golden.json
@@ -1,632 +1,607 @@
 {
- "diff": [
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_demo-client__kuma-3_msvc_3000/connectTimeout",
-   "value": "5s"
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions",
-   "value": {
-    "idleTimeout": "3600s",
-    "maxConnectionDuration": "5s",
-    "maxStreamDuration": "0s"
-   }
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/connectTimeout",
-   "value": "5s"
-  },
-  {
-   "op": "test",
-   "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/connectTimeout",
-   "value": "10s"
-  },
-  {
-   "op": "remove",
-   "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/connectTimeout",
-   "value": "10s"
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/connectTimeout",
-   "value": "51s"
-  },
-  {
-   "op": "test",
-   "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/idleTimeout",
-   "value": "7200s"
-  },
-  {
-   "op": "remove",
-   "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/idleTimeout",
-   "value": "7200s"
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/idleTimeout",
-   "value": "50s"
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/maxConnectionDuration",
-   "value": "55s"
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/maxStreamDuration",
-   "value": "54s"
-  },
-  {
-   "op": "test",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/commonHttpProtocolOptions/idleTimeout",
-   "value": "7200s"
-  },
-  {
-   "op": "remove",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/commonHttpProtocolOptions/idleTimeout",
-   "value": "7200s"
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/commonHttpProtocolOptions/idleTimeout",
-   "value": "0s"
-  },
-  {
-   "op": "test",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
-   "value": "0s"
-  },
-  {
-   "op": "remove",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
-   "value": "0s"
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
-   "value": "52s"
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/idleTimeout",
-   "value": "53s"
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/requestHeadersTimeout",
-   "value": "0s"
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:3000/filterChains/0/filters/0/typedConfig/idleTimeout",
-   "value": "3600s"
-  },
-  {
-   "op": "test",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
-   "value": "0s"
-  },
-  {
-   "op": "remove",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
-   "value": "0s"
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
-   "value": "15s"
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/idleTimeout",
-   "value": "5s"
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/commonHttpProtocolOptions",
-   "value": {
-    "idleTimeout": "0s"
-   }
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/requestHeadersTimeout",
-   "value": "0s"
-  }
- ],
- "xds": {
-  "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
-   "envoyconfig_demo-client__kuma-3_msvc_3000": {
-    "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
-    "type": "EDS",
-    "edsClusterConfig": {
-     "edsConfig": {
-      "ads": {},
-      "resourceApiVersion": "V3"
-     }
+  "diff": [
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_demo-client__kuma-3_msvc_3000/connectTimeout",
+      "value": "5s"
     },
-    "connectTimeout": "5s",
-    "typedExtensionProtocolOptions": {
-     "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
-      "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-      "explicitHttpConfig": {
-       "http2ProtocolOptions": {}
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/connectTimeout",
+      "value": "5s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions",
+      "value": {
+        "idleTimeout": "3600s",
+        "maxConnectionDuration": "5s",
+        "maxStreamDuration": "0s"
       }
-     }
-    }
-   },
-   "envoyconfig_test-server__kuma-3_msvc_80": {
-    "name": "envoyconfig_test-server__kuma-3_msvc_80",
-    "type": "EDS",
-    "edsClusterConfig": {
-     "edsConfig": {
-      "ads": {},
-      "resourceApiVersion": "V3"
-     }
     },
-    "connectTimeout": "5s",
-    "typedExtensionProtocolOptions": {
-     "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
-      "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-      "commonHttpProtocolOptions": {
-       "idleTimeout": "3600s",
-       "maxConnectionDuration": "5s",
-       "maxStreamDuration": "0s"
+    {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/connectTimeout",
+      "value": "10s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/connectTimeout",
+      "value": "51s"
+    },
+    {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/idleTimeout",
+      "value": "7200s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/idleTimeout",
+      "value": "50s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/maxConnectionDuration",
+      "value": "55s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/maxStreamDuration",
+      "value": "54s"
+    },
+    {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/commonHttpProtocolOptions/idleTimeout",
+      "value": "7200s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/commonHttpProtocolOptions/idleTimeout",
+      "value": "0s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/requestHeadersTimeout",
+      "value": "0s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/idleTimeout",
+      "value": "53s"
+    },
+    {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
+      "value": "0s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
+      "value": "52s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:3000/filterChains/0/filters/0/typedConfig/idleTimeout",
+      "value": "3600s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/commonHttpProtocolOptions",
+      "value": {
+        "idleTimeout": "0s"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/requestHeadersTimeout",
+      "value": "0s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/idleTimeout",
+      "value": "5s"
+    },
+    {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
+      "value": "0s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
+      "value": "15s"
+    }
+  ],
+  "xds": {
+    "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
+      "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
+        "edsClusterConfig": {
+          "edsConfig": {
+            "ads": {},
+            "resourceApiVersion": "V3"
+          }
+        },
+        "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "type": "EDS",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicitHttpConfig": {
+              "http2ProtocolOptions": {}
+            }
+          }
+        }
       },
-      "explicitHttpConfig": {
-       "http2ProtocolOptions": {}
-      }
-     }
-    }
-   },
-   "inbound:passthrough:ipv4": {
-    "name": "inbound:passthrough:ipv4",
-    "altStatName": "inbound_passthrough_ipv4",
-    "type": "ORIGINAL_DST",
-    "connectTimeout": "5s",
-    "lbPolicy": "CLUSTER_PROVIDED",
-    "upstreamBindConfig": {
-     "sourceAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 0
-     }
-    }
-   },
-   "inbound:passthrough:ipv6": {
-    "name": "inbound:passthrough:ipv6",
-    "altStatName": "inbound_passthrough_ipv6",
-    "type": "ORIGINAL_DST",
-    "connectTimeout": "5s",
-    "lbPolicy": "CLUSTER_PROVIDED",
-    "upstreamBindConfig": {
-     "sourceAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 0
-     }
-    }
-   },
-   "localhost:8080": {
-    "name": "localhost:8080",
-    "altStatName": "localhost_8080",
-    "type": "STATIC",
-    "connectTimeout": "51s",
-    "loadAssignment": {
-     "clusterName": "localhost:8080",
-     "endpoints": [
-      {
-       "lbEndpoints": [
-        {
-         "endpoint": {
-          "address": {
-           "socketAddress": {
+      "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
+        "edsClusterConfig": {
+          "edsConfig": {
+            "ads": {},
+            "resourceApiVersion": "V3"
+          }
+        },
+        "name": "envoyconfig_test-server__kuma-3_msvc_80",
+        "type": "EDS",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "5s",
+              "maxStreamDuration": "0s"
+            },
+            "explicitHttpConfig": {
+              "http2ProtocolOptions": {}
+            }
+          }
+        }
+      },
+      "inbound:passthrough:ipv4": {
+        "altStatName": "inbound_passthrough_ipv4",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "inbound:passthrough:ipv4",
+        "type": "ORIGINAL_DST",
+        "upstreamBindConfig": {
+          "sourceAddress": {
             "address": "IP_REDACTED",
-            "portValue": 8080
-           }
+            "portValue": 0
           }
-         }
         }
-       ]
-      }
-     ]
-    },
-    "typedExtensionProtocolOptions": {
-     "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
-      "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-      "commonHttpProtocolOptions": {
-       "idleTimeout": "50s",
-       "maxConnectionDuration": "55s",
-       "maxStreamDuration": "54s"
       },
-      "explicitHttpConfig": {
-       "httpProtocolOptions": {}
+      "inbound:passthrough:ipv6": {
+        "altStatName": "inbound_passthrough_ipv6",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "inbound:passthrough:ipv6",
+        "type": "ORIGINAL_DST",
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "localhost:8080": {
+        "altStatName": "localhost_8080",
+        "connectTimeout": "51s",
+        "loadAssignment": {
+          "clusterName": "localhost:8080",
+          "endpoints": [
+            {
+              "lbEndpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socketAddress": {
+                        "address": "IP_REDACTED",
+                        "portValue": 8080
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "name": "localhost:8080",
+        "type": "STATIC",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "50s",
+              "maxConnectionDuration": "55s",
+              "maxStreamDuration": "54s"
+            },
+            "explicitHttpConfig": {
+              "httpProtocolOptions": {}
+            }
+          }
+        },
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "outbound:passthrough:ipv4": {
+        "altStatName": "outbound_passthrough_ipv4",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "outbound:passthrough:ipv4",
+        "type": "ORIGINAL_DST"
+      },
+      "outbound:passthrough:ipv6": {
+        "altStatName": "outbound_passthrough_ipv6",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "outbound:passthrough:ipv6",
+        "type": "ORIGINAL_DST"
       }
-     }
     },
-    "upstreamBindConfig": {
-     "sourceAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 0
-     }
+    "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment": {
+      "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "clusterName": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "IP_REDACTED",
+                      "portValue": 3000
+                    }
+                  }
+                },
+                "loadBalancingWeight": 1,
+                "metadata": {
+                  "filterMetadata": {
+                    "envoy.lb": {
+                      "kuma.io/zone": "kuma-3",
+                      "team": "client-owners"
+                    },
+                    "envoy.transport_socket_match": {
+                      "kuma.io/zone": "kuma-3",
+                      "team": "client-owners"
+                    }
+                  }
+                }
+              }
+            ],
+            "locality": {
+              "zone": "kuma-3"
+            }
+          }
+        ]
+      },
+      "envoyconfig_test-server__kuma-3_msvc_80": {
+        "clusterName": "envoyconfig_test-server__kuma-3_msvc_80",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "IP_REDACTED",
+                      "portValue": 80
+                    }
+                  }
+                },
+                "loadBalancingWeight": 1,
+                "metadata": {
+                  "filterMetadata": {
+                    "envoy.lb": {
+                      "instance": "1",
+                      "kuma.io/protocol": "http",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "server-owners",
+                      "version": "v1"
+                    },
+                    "envoy.transport_socket_match": {
+                      "instance": "1",
+                      "kuma.io/protocol": "http",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "server-owners",
+                      "version": "v1"
+                    }
+                  }
+                }
+              }
+            ],
+            "locality": {
+              "zone": "kuma-3"
+            }
+          }
+        ]
+      }
+    },
+    "type.googleapis.com/envoy.config.listener.v3.Listener": {
+      "inbound:IP_REDACTED:80": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 80
+          }
+        },
+        "bindToPort": false,
+        "enableReusePort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
+                  "forwardClientCertDetails": "SANITIZE_SET",
+                  "httpFilters": [
+                    {
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
+                    }
+                  ],
+                  "requestHeadersTimeout": "0s",
+                  "routeConfig": {
+                    "name": "inbound:test-server",
+                    "requestHeadersToRemove": [
+                      "x-kuma-tags"
+                    ],
+                    "validateClusters": false,
+                    "virtualHosts": [
+                      {
+                        "domains": [
+                          "*"
+                        ],
+                        "name": "test-server",
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/"
+                            },
+                            "route": {
+                              "cluster": "localhost:8080",
+                              "idleTimeout": "53s",
+                              "timeout": "52s"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "setCurrentClientCertDetails": {
+                    "uri": true
+                  },
+                  "statPrefix": "localhost_8080",
+                  "streamIdleTimeout": "3600s"
+                }
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {
+              "instance": "1",
+              "kuma.io/protocol": "http",
+              "kuma.io/service": "test-server",
+              "kuma.io/zone": "kuma-3",
+              "team": "server-owners",
+              "version": "v1"
+            }
+          }
+        },
+        "name": "inbound:IP_REDACTED:80",
+        "trafficDirection": "INBOUND"
+      },
+      "inbound:passthrough:ipv4": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15006
+          }
+        },
+        "enableReusePort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "inbound:passthrough:ipv4",
+                  "statPrefix": "inbound_passthrough_ipv4"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "inbound:passthrough:ipv4",
+        "trafficDirection": "INBOUND",
+        "useOriginalDst": true
+      },
+      "inbound:passthrough:ipv6": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15006
+          }
+        },
+        "enableReusePort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "inbound:passthrough:ipv6",
+                  "statPrefix": "inbound_passthrough_ipv6"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "inbound:passthrough:ipv6",
+        "trafficDirection": "INBOUND",
+        "useOriginalDst": true
+      },
+      "outbound:IP_REDACTED:3000": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 3000
+          }
+        },
+        "bindToPort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
+                  "statPrefix": "envoyconfig_demo-client__kuma-3_msvc_3000"
+                }
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {}
+          }
+        },
+        "name": "outbound:IP_REDACTED:3000",
+        "trafficDirection": "OUTBOUND"
+      },
+      "outbound:IP_REDACTED:80": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 80
+          }
+        },
+        "bindToPort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
+                  "httpFilters": [
+                    {
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
+                    }
+                  ],
+                  "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
+                  "routeConfig": {
+                    "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
+                    "validateClusters": false,
+                    "virtualHosts": [
+                      {
+                        "domains": [
+                          "*"
+                        ],
+                        "name": "envoyconfig_test-server__kuma-3_msvc_80",
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/"
+                            },
+                            "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
+                            "route": {
+                              "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
+                              "idleTimeout": "5s",
+                              "timeout": "15s"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "statPrefix": "envoyconfig_test-server__kuma-3_msvc_80"
+                }
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {}
+          }
+        },
+        "name": "outbound:IP_REDACTED:80",
+        "trafficDirection": "OUTBOUND"
+      },
+      "outbound:passthrough:ipv4": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15001
+          }
+        },
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "outbound:passthrough:ipv4",
+                  "statPrefix": "outbound_passthrough_ipv4"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "outbound:passthrough:ipv4",
+        "trafficDirection": "OUTBOUND",
+        "useOriginalDst": true
+      },
+      "outbound:passthrough:ipv6": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15001
+          }
+        },
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "outbound:passthrough:ipv6",
+                  "statPrefix": "outbound_passthrough_ipv6"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "outbound:passthrough:ipv6",
+        "trafficDirection": "OUTBOUND",
+        "useOriginalDst": true
+      }
     }
-   },
-   "outbound:passthrough:ipv4": {
-    "name": "outbound:passthrough:ipv4",
-    "altStatName": "outbound_passthrough_ipv4",
-    "type": "ORIGINAL_DST",
-    "connectTimeout": "5s",
-    "lbPolicy": "CLUSTER_PROVIDED"
-   },
-   "outbound:passthrough:ipv6": {
-    "name": "outbound:passthrough:ipv6",
-    "altStatName": "outbound_passthrough_ipv6",
-    "type": "ORIGINAL_DST",
-    "connectTimeout": "5s",
-    "lbPolicy": "CLUSTER_PROVIDED"
-   }
-  },
-  "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment": {
-   "envoyconfig_demo-client__kuma-3_msvc_3000": {
-    "clusterName": "envoyconfig_demo-client__kuma-3_msvc_3000",
-    "endpoints": [
-     {
-      "locality": {
-       "zone": "kuma-3"
-      },
-      "lbEndpoints": [
-       {
-        "endpoint": {
-         "address": {
-          "socketAddress": {
-           "address": "IP_REDACTED",
-           "portValue": 3000
-          }
-         }
-        },
-        "metadata": {
-         "filterMetadata": {
-          "envoy.lb": {
-           "kuma.io/zone": "kuma-3",
-           "team": "client-owners"
-          },
-          "envoy.transport_socket_match": {
-           "kuma.io/zone": "kuma-3",
-           "team": "client-owners"
-          }
-         }
-        },
-        "loadBalancingWeight": 1
-       }
-      ]
-     }
-    ]
-   },
-   "envoyconfig_test-server__kuma-3_msvc_80": {
-    "clusterName": "envoyconfig_test-server__kuma-3_msvc_80",
-    "endpoints": [
-     {
-      "locality": {
-       "zone": "kuma-3"
-      },
-      "lbEndpoints": [
-       {
-        "endpoint": {
-         "address": {
-          "socketAddress": {
-           "address": "IP_REDACTED",
-           "portValue": 80
-          }
-         }
-        },
-        "metadata": {
-         "filterMetadata": {
-          "envoy.lb": {
-           "instance": "1",
-           "kuma.io/protocol": "http",
-           "kuma.io/zone": "kuma-3",
-           "team": "server-owners",
-           "version": "v1"
-          },
-          "envoy.transport_socket_match": {
-           "instance": "1",
-           "kuma.io/protocol": "http",
-           "kuma.io/zone": "kuma-3",
-           "team": "server-owners",
-           "version": "v1"
-          }
-         }
-        },
-        "loadBalancingWeight": 1
-       }
-      ]
-     }
-    ]
-   }
-  },
-  "type.googleapis.com/envoy.config.listener.v3.Listener": {
-   "inbound:IP_REDACTED:80": {
-    "name": "inbound:IP_REDACTED:80",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 80
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.http_connection_manager",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-         "statPrefix": "localhost_8080",
-         "routeConfig": {
-          "name": "inbound:test-server",
-          "virtualHosts": [
-           {
-            "name": "test-server",
-            "domains": [
-             "*"
-            ],
-            "routes": [
-             {
-              "match": {
-               "prefix": "/"
-              },
-              "route": {
-               "cluster": "localhost:8080",
-               "timeout": "52s",
-               "idleTimeout": "53s"
-              }
-             }
-            ]
-           }
-          ],
-          "requestHeadersToRemove": [
-           "x-kuma-tags"
-          ],
-          "validateClusters": false
-         },
-         "httpFilters": [
-          {
-           "name": "envoy.filters.http.router",
-           "typedConfig": {
-            "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
-           }
-          }
-         ],
-         "commonHttpProtocolOptions": {
-          "idleTimeout": "0s"
-         },
-         "streamIdleTimeout": "3600s",
-         "requestHeadersTimeout": "0s",
-         "forwardClientCertDetails": "SANITIZE_SET",
-         "setCurrentClientCertDetails": {
-          "uri": true
-         }
-        }
-       }
-      ]
-     }
-    ],
-    "metadata": {
-     "filterMetadata": {
-      "io.kuma.tags": {
-       "instance": "1",
-       "kuma.io/protocol": "http",
-       "kuma.io/service": "test-server",
-       "kuma.io/zone": "kuma-3",
-       "team": "server-owners",
-       "version": "v1"
-      }
-     }
-    },
-    "trafficDirection": "INBOUND",
-    "enableReusePort": false,
-    "bindToPort": false
-   },
-   "inbound:passthrough:ipv4": {
-    "name": "inbound:passthrough:ipv4",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 15006
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.tcp_proxy",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-         "statPrefix": "inbound_passthrough_ipv4",
-         "cluster": "inbound:passthrough:ipv4"
-        }
-       }
-      ]
-     }
-    ],
-    "useOriginalDst": true,
-    "trafficDirection": "INBOUND",
-    "enableReusePort": false
-   },
-   "inbound:passthrough:ipv6": {
-    "name": "inbound:passthrough:ipv6",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 15006
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.tcp_proxy",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-         "statPrefix": "inbound_passthrough_ipv6",
-         "cluster": "inbound:passthrough:ipv6"
-        }
-       }
-      ]
-     }
-    ],
-    "useOriginalDst": true,
-    "trafficDirection": "INBOUND",
-    "enableReusePort": false
-   },
-   "outbound:IP_REDACTED:3000": {
-    "name": "outbound:IP_REDACTED:3000",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 3000
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.tcp_proxy",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-         "statPrefix": "envoyconfig_demo-client__kuma-3_msvc_3000",
-         "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
-         "idleTimeout": "3600s"
-        }
-       }
-      ]
-     }
-    ],
-    "metadata": {
-     "filterMetadata": {
-      "io.kuma.tags": {}
-     }
-    },
-    "trafficDirection": "OUTBOUND",
-    "bindToPort": false
-   },
-   "outbound:IP_REDACTED:80": {
-    "name": "outbound:IP_REDACTED:80",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 80
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.http_connection_manager",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-         "statPrefix": "envoyconfig_test-server__kuma-3_msvc_80",
-         "routeConfig": {
-          "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
-          "virtualHosts": [
-           {
-            "name": "envoyconfig_test-server__kuma-3_msvc_80",
-            "domains": [
-             "*"
-            ],
-            "routes": [
-             {
-              "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
-              "match": {
-               "prefix": "/"
-              },
-              "route": {
-               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-               "timeout": "15s",
-               "idleTimeout": "5s"
-              }
-             }
-            ]
-           }
-          ],
-          "validateClusters": false
-         },
-         "httpFilters": [
-          {
-           "name": "envoy.filters.http.router",
-           "typedConfig": {
-            "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
-           }
-          }
-         ],
-         "commonHttpProtocolOptions": {
-          "idleTimeout": "0s"
-         },
-         "requestHeadersTimeout": "0s",
-         "normalizePath": true
-        }
-       }
-      ]
-     }
-    ],
-    "metadata": {
-     "filterMetadata": {
-      "io.kuma.tags": {}
-     }
-    },
-    "trafficDirection": "OUTBOUND",
-    "bindToPort": false
-   },
-   "outbound:passthrough:ipv4": {
-    "name": "outbound:passthrough:ipv4",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 15001
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.tcp_proxy",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-         "statPrefix": "outbound_passthrough_ipv4",
-         "cluster": "outbound:passthrough:ipv4"
-        }
-       }
-      ]
-     }
-    ],
-    "useOriginalDst": true,
-    "trafficDirection": "OUTBOUND"
-   },
-   "outbound:passthrough:ipv6": {
-    "name": "outbound:passthrough:ipv6",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 15001
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.tcp_proxy",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-         "statPrefix": "outbound_passthrough_ipv6",
-         "cluster": "outbound:passthrough:ipv6"
-        }
-       }
-      ]
-     }
-    ],
-    "useOriginalDst": true,
-    "trafficDirection": "OUTBOUND"
-   }
   }
- }
 }

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/no-policies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/no-policies.demo-client.golden.json
@@ -1,424 +1,424 @@
 {
- "diff": [],
- "xds": {
-  "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
-   "envoyconfig_demo-client__kuma-3_msvc_3000": {
-    "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
-    "type": "EDS",
-    "edsClusterConfig": {
-     "edsConfig": {
-      "ads": {},
-      "resourceApiVersion": "V3"
-     }
-    },
-    "typedExtensionProtocolOptions": {
-     "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
-      "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-      "explicitHttpConfig": {
-       "http2ProtocolOptions": {}
+  "diff": [],
+  "xds": {
+    "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
+      "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "edsClusterConfig": {
+          "edsConfig": {
+            "ads": {},
+            "resourceApiVersion": "V3"
+          }
+        },
+        "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "type": "EDS",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicitHttpConfig": {
+              "http2ProtocolOptions": {}
+            }
+          }
+        }
+      },
+      "envoyconfig_test-server__kuma-3_msvc_80": {
+        "edsClusterConfig": {
+          "edsConfig": {
+            "ads": {},
+            "resourceApiVersion": "V3"
+          }
+        },
+        "name": "envoyconfig_test-server__kuma-3_msvc_80",
+        "type": "EDS",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicitHttpConfig": {
+              "http2ProtocolOptions": {}
+            }
+          }
+        }
+      },
+      "inbound:passthrough:ipv4": {
+        "altStatName": "inbound_passthrough_ipv4",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "inbound:passthrough:ipv4",
+        "type": "ORIGINAL_DST",
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "inbound:passthrough:ipv6": {
+        "altStatName": "inbound_passthrough_ipv6",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "inbound:passthrough:ipv6",
+        "type": "ORIGINAL_DST",
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "localhost:3000": {
+        "altStatName": "localhost_3000",
+        "connectTimeout": "10s",
+        "loadAssignment": {
+          "clusterName": "localhost:3000",
+          "endpoints": [
+            {
+              "lbEndpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socketAddress": {
+                        "address": "IP_REDACTED",
+                        "portValue": 3000
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "name": "localhost:3000",
+        "type": "STATIC",
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "outbound:passthrough:ipv4": {
+        "altStatName": "outbound_passthrough_ipv4",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "outbound:passthrough:ipv4",
+        "type": "ORIGINAL_DST"
+      },
+      "outbound:passthrough:ipv6": {
+        "altStatName": "outbound_passthrough_ipv6",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "outbound:passthrough:ipv6",
+        "type": "ORIGINAL_DST"
       }
-     }
-    }
-   },
-   "envoyconfig_test-server__kuma-3_msvc_80": {
-    "name": "envoyconfig_test-server__kuma-3_msvc_80",
-    "type": "EDS",
-    "edsClusterConfig": {
-     "edsConfig": {
-      "ads": {},
-      "resourceApiVersion": "V3"
-     }
     },
-    "typedExtensionProtocolOptions": {
-     "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
-      "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-      "explicitHttpConfig": {
-       "http2ProtocolOptions": {}
+    "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment": {
+      "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "clusterName": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "IP_REDACTED",
+                      "portValue": 3000
+                    }
+                  }
+                },
+                "loadBalancingWeight": 1,
+                "metadata": {
+                  "filterMetadata": {
+                    "envoy.lb": {
+                      "kuma.io/zone": "kuma-3",
+                      "team": "client-owners"
+                    },
+                    "envoy.transport_socket_match": {
+                      "kuma.io/zone": "kuma-3",
+                      "team": "client-owners"
+                    }
+                  }
+                }
+              }
+            ],
+            "locality": {
+              "zone": "kuma-3"
+            }
+          }
+        ]
+      },
+      "envoyconfig_test-server__kuma-3_msvc_80": {
+        "clusterName": "envoyconfig_test-server__kuma-3_msvc_80",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "IP_REDACTED",
+                      "portValue": 80
+                    }
+                  }
+                },
+                "loadBalancingWeight": 1,
+                "metadata": {
+                  "filterMetadata": {
+                    "envoy.lb": {
+                      "instance": "1",
+                      "kuma.io/protocol": "http",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "server-owners",
+                      "version": "v1"
+                    },
+                    "envoy.transport_socket_match": {
+                      "instance": "1",
+                      "kuma.io/protocol": "http",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "server-owners",
+                      "version": "v1"
+                    }
+                  }
+                }
+              }
+            ],
+            "locality": {
+              "zone": "kuma-3"
+            }
+          }
+        ]
       }
-     }
-    }
-   },
-   "inbound:passthrough:ipv4": {
-    "name": "inbound:passthrough:ipv4",
-    "altStatName": "inbound_passthrough_ipv4",
-    "type": "ORIGINAL_DST",
-    "connectTimeout": "5s",
-    "lbPolicy": "CLUSTER_PROVIDED",
-    "upstreamBindConfig": {
-     "sourceAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 0
-     }
-    }
-   },
-   "inbound:passthrough:ipv6": {
-    "name": "inbound:passthrough:ipv6",
-    "altStatName": "inbound_passthrough_ipv6",
-    "type": "ORIGINAL_DST",
-    "connectTimeout": "5s",
-    "lbPolicy": "CLUSTER_PROVIDED",
-    "upstreamBindConfig": {
-     "sourceAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 0
-     }
-    }
-   },
-   "localhost:3000": {
-    "name": "localhost:3000",
-    "altStatName": "localhost_3000",
-    "type": "STATIC",
-    "connectTimeout": "10s",
-    "loadAssignment": {
-     "clusterName": "localhost:3000",
-     "endpoints": [
-      {
-       "lbEndpoints": [
-        {
-         "endpoint": {
-          "address": {
-           "socketAddress": {
+    },
+    "type.googleapis.com/envoy.config.listener.v3.Listener": {
+      "inbound:IP_REDACTED:3000": {
+        "address": {
+          "socketAddress": {
             "address": "IP_REDACTED",
             "portValue": 3000
-           }
           }
-         }
-        }
-       ]
-      }
-     ]
-    },
-    "upstreamBindConfig": {
-     "sourceAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 0
-     }
-    }
-   },
-   "outbound:passthrough:ipv4": {
-    "name": "outbound:passthrough:ipv4",
-    "altStatName": "outbound_passthrough_ipv4",
-    "type": "ORIGINAL_DST",
-    "connectTimeout": "5s",
-    "lbPolicy": "CLUSTER_PROVIDED"
-   },
-   "outbound:passthrough:ipv6": {
-    "name": "outbound:passthrough:ipv6",
-    "altStatName": "outbound_passthrough_ipv6",
-    "type": "ORIGINAL_DST",
-    "connectTimeout": "5s",
-    "lbPolicy": "CLUSTER_PROVIDED"
-   }
-  },
-  "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment": {
-   "envoyconfig_demo-client__kuma-3_msvc_3000": {
-    "clusterName": "envoyconfig_demo-client__kuma-3_msvc_3000",
-    "endpoints": [
-     {
-      "locality": {
-       "zone": "kuma-3"
-      },
-      "lbEndpoints": [
-       {
-        "endpoint": {
-         "address": {
-          "socketAddress": {
-           "address": "IP_REDACTED",
-           "portValue": 3000
-          }
-         }
         },
-        "metadata": {
-         "filterMetadata": {
-          "envoy.lb": {
-           "kuma.io/zone": "kuma-3",
-           "team": "client-owners"
-          },
-          "envoy.transport_socket_match": {
-           "kuma.io/zone": "kuma-3",
-           "team": "client-owners"
-          }
-         }
-        },
-        "loadBalancingWeight": 1
-       }
-      ]
-     }
-    ]
-   },
-   "envoyconfig_test-server__kuma-3_msvc_80": {
-    "clusterName": "envoyconfig_test-server__kuma-3_msvc_80",
-    "endpoints": [
-     {
-      "locality": {
-       "zone": "kuma-3"
-      },
-      "lbEndpoints": [
-       {
-        "endpoint": {
-         "address": {
-          "socketAddress": {
-           "address": "IP_REDACTED",
-           "portValue": 80
-          }
-         }
-        },
-        "metadata": {
-         "filterMetadata": {
-          "envoy.lb": {
-           "instance": "1",
-           "kuma.io/protocol": "http",
-           "kuma.io/zone": "kuma-3",
-           "team": "server-owners",
-           "version": "v1"
-          },
-          "envoy.transport_socket_match": {
-           "instance": "1",
-           "kuma.io/protocol": "http",
-           "kuma.io/zone": "kuma-3",
-           "team": "server-owners",
-           "version": "v1"
-          }
-         }
-        },
-        "loadBalancingWeight": 1
-       }
-      ]
-     }
-    ]
-   }
-  },
-  "type.googleapis.com/envoy.config.listener.v3.Listener": {
-   "inbound:IP_REDACTED:3000": {
-    "name": "inbound:IP_REDACTED:3000",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 3000
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.tcp_proxy",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-         "statPrefix": "localhost_3000",
-         "cluster": "localhost:3000",
-         "idleTimeout": "7200s"
-        }
-       }
-      ]
-     }
-    ],
-    "metadata": {
-     "filterMetadata": {
-      "io.kuma.tags": {
-       "kuma.io/service": "demo-client",
-       "kuma.io/zone": "kuma-3",
-       "team": "client-owners"
-      }
-     }
-    },
-    "trafficDirection": "INBOUND",
-    "enableReusePort": false,
-    "bindToPort": false
-   },
-   "inbound:passthrough:ipv4": {
-    "name": "inbound:passthrough:ipv4",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 15006
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.tcp_proxy",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-         "statPrefix": "inbound_passthrough_ipv4",
-         "cluster": "inbound:passthrough:ipv4"
-        }
-       }
-      ]
-     }
-    ],
-    "useOriginalDst": true,
-    "trafficDirection": "INBOUND",
-    "enableReusePort": false
-   },
-   "inbound:passthrough:ipv6": {
-    "name": "inbound:passthrough:ipv6",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 15006
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.tcp_proxy",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-         "statPrefix": "inbound_passthrough_ipv6",
-         "cluster": "inbound:passthrough:ipv6"
-        }
-       }
-      ]
-     }
-    ],
-    "useOriginalDst": true,
-    "trafficDirection": "INBOUND",
-    "enableReusePort": false
-   },
-   "outbound:IP_REDACTED:3000": {
-    "name": "outbound:IP_REDACTED:3000",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 3000
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.tcp_proxy",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-         "statPrefix": "envoyconfig_demo-client__kuma-3_msvc_3000",
-         "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000"
-        }
-       }
-      ]
-     }
-    ],
-    "metadata": {
-     "filterMetadata": {
-      "io.kuma.tags": {}
-     }
-    },
-    "trafficDirection": "OUTBOUND",
-    "bindToPort": false
-   },
-   "outbound:IP_REDACTED:80": {
-    "name": "outbound:IP_REDACTED:80",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 80
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.http_connection_manager",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-         "statPrefix": "envoyconfig_test-server__kuma-3_msvc_80",
-         "routeConfig": {
-          "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
-          "virtualHosts": [
-           {
-            "name": "envoyconfig_test-server__kuma-3_msvc_80",
-            "domains": [
-             "*"
-            ],
-            "routes": [
-             {
-              "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
-              "match": {
-               "prefix": "/"
-              },
-              "route": {
-               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-               "timeout": "0s"
-              }
-             }
-            ]
-           }
-          ],
-          "validateClusters": false
-         },
-         "httpFilters": [
+        "bindToPort": false,
+        "enableReusePort": false,
+        "filterChains": [
           {
-           "name": "envoy.filters.http.router",
-           "typedConfig": {
-            "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
-           }
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "localhost:3000",
+                  "idleTimeout": "7200s",
+                  "statPrefix": "localhost_3000"
+                }
+              }
+            ]
           }
-         ],
-         "normalizePath": true
-        }
-       }
-      ]
-     }
-    ],
-    "metadata": {
-     "filterMetadata": {
-      "io.kuma.tags": {}
-     }
-    },
-    "trafficDirection": "OUTBOUND",
-    "bindToPort": false
-   },
-   "outbound:passthrough:ipv4": {
-    "name": "outbound:passthrough:ipv4",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 15001
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.tcp_proxy",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-         "statPrefix": "outbound_passthrough_ipv4",
-         "cluster": "outbound:passthrough:ipv4"
-        }
-       }
-      ]
-     }
-    ],
-    "useOriginalDst": true,
-    "trafficDirection": "OUTBOUND"
-   },
-   "outbound:passthrough:ipv6": {
-    "name": "outbound:passthrough:ipv6",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 15001
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.tcp_proxy",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-         "statPrefix": "outbound_passthrough_ipv6",
-         "cluster": "outbound:passthrough:ipv6"
-        }
-       }
-      ]
-     }
-    ],
-    "useOriginalDst": true,
-    "trafficDirection": "OUTBOUND"
-   }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {
+              "kuma.io/service": "demo-client",
+              "kuma.io/zone": "kuma-3",
+              "team": "client-owners"
+            }
+          }
+        },
+        "name": "inbound:IP_REDACTED:3000",
+        "trafficDirection": "INBOUND"
+      },
+      "inbound:passthrough:ipv4": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15006
+          }
+        },
+        "enableReusePort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "inbound:passthrough:ipv4",
+                  "statPrefix": "inbound_passthrough_ipv4"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "inbound:passthrough:ipv4",
+        "trafficDirection": "INBOUND",
+        "useOriginalDst": true
+      },
+      "inbound:passthrough:ipv6": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15006
+          }
+        },
+        "enableReusePort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "inbound:passthrough:ipv6",
+                  "statPrefix": "inbound_passthrough_ipv6"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "inbound:passthrough:ipv6",
+        "trafficDirection": "INBOUND",
+        "useOriginalDst": true
+      },
+      "outbound:IP_REDACTED:3000": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 3000
+          }
+        },
+        "bindToPort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "statPrefix": "envoyconfig_demo-client__kuma-3_msvc_3000"
+                }
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {}
+          }
+        },
+        "name": "outbound:IP_REDACTED:3000",
+        "trafficDirection": "OUTBOUND"
+      },
+      "outbound:IP_REDACTED:80": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 80
+          }
+        },
+        "bindToPort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "httpFilters": [
+                    {
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
+                    }
+                  ],
+                  "normalizePath": true,
+                  "routeConfig": {
+                    "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
+                    "validateClusters": false,
+                    "virtualHosts": [
+                      {
+                        "domains": [
+                          "*"
+                        ],
+                        "name": "envoyconfig_test-server__kuma-3_msvc_80",
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/"
+                            },
+                            "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
+                            "route": {
+                              "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
+                              "timeout": "0s"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "statPrefix": "envoyconfig_test-server__kuma-3_msvc_80"
+                }
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {}
+          }
+        },
+        "name": "outbound:IP_REDACTED:80",
+        "trafficDirection": "OUTBOUND"
+      },
+      "outbound:passthrough:ipv4": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15001
+          }
+        },
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "outbound:passthrough:ipv4",
+                  "statPrefix": "outbound_passthrough_ipv4"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "outbound:passthrough:ipv4",
+        "trafficDirection": "OUTBOUND",
+        "useOriginalDst": true
+      },
+      "outbound:passthrough:ipv6": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15001
+          }
+        },
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "outbound:passthrough:ipv6",
+                  "statPrefix": "outbound_passthrough_ipv6"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "outbound:passthrough:ipv6",
+        "trafficDirection": "OUTBOUND",
+        "useOriginalDst": true
+      }
+    }
   }
- }
 }

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/no-policies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/no-policies.test-server.golden.json
@@ -1,478 +1,478 @@
 {
- "diff": [],
- "xds": {
-  "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
-   "envoyconfig_demo-client__kuma-3_msvc_3000": {
-    "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
-    "type": "EDS",
-    "edsClusterConfig": {
-     "edsConfig": {
-      "ads": {},
-      "resourceApiVersion": "V3"
-     }
-    },
-    "typedExtensionProtocolOptions": {
-     "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
-      "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-      "explicitHttpConfig": {
-       "http2ProtocolOptions": {}
-      }
-     }
-    }
-   },
-   "envoyconfig_test-server__kuma-3_msvc_80": {
-    "name": "envoyconfig_test-server__kuma-3_msvc_80",
-    "type": "EDS",
-    "edsClusterConfig": {
-     "edsConfig": {
-      "ads": {},
-      "resourceApiVersion": "V3"
-     }
-    },
-    "typedExtensionProtocolOptions": {
-     "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
-      "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-      "explicitHttpConfig": {
-       "http2ProtocolOptions": {}
-      }
-     }
-    }
-   },
-   "inbound:passthrough:ipv4": {
-    "name": "inbound:passthrough:ipv4",
-    "altStatName": "inbound_passthrough_ipv4",
-    "type": "ORIGINAL_DST",
-    "connectTimeout": "5s",
-    "lbPolicy": "CLUSTER_PROVIDED",
-    "upstreamBindConfig": {
-     "sourceAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 0
-     }
-    }
-   },
-   "inbound:passthrough:ipv6": {
-    "name": "inbound:passthrough:ipv6",
-    "altStatName": "inbound_passthrough_ipv6",
-    "type": "ORIGINAL_DST",
-    "connectTimeout": "5s",
-    "lbPolicy": "CLUSTER_PROVIDED",
-    "upstreamBindConfig": {
-     "sourceAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 0
-     }
-    }
-   },
-   "localhost:8080": {
-    "name": "localhost:8080",
-    "altStatName": "localhost_8080",
-    "type": "STATIC",
-    "connectTimeout": "10s",
-    "loadAssignment": {
-     "clusterName": "localhost:8080",
-     "endpoints": [
-      {
-       "lbEndpoints": [
-        {
-         "endpoint": {
-          "address": {
-           "socketAddress": {
+  "diff": [],
+  "xds": {
+    "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
+      "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "edsClusterConfig": {
+          "edsConfig": {
+            "ads": {},
+            "resourceApiVersion": "V3"
+          }
+        },
+        "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "type": "EDS",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicitHttpConfig": {
+              "http2ProtocolOptions": {}
+            }
+          }
+        }
+      },
+      "envoyconfig_test-server__kuma-3_msvc_80": {
+        "edsClusterConfig": {
+          "edsConfig": {
+            "ads": {},
+            "resourceApiVersion": "V3"
+          }
+        },
+        "name": "envoyconfig_test-server__kuma-3_msvc_80",
+        "type": "EDS",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicitHttpConfig": {
+              "http2ProtocolOptions": {}
+            }
+          }
+        }
+      },
+      "inbound:passthrough:ipv4": {
+        "altStatName": "inbound_passthrough_ipv4",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "inbound:passthrough:ipv4",
+        "type": "ORIGINAL_DST",
+        "upstreamBindConfig": {
+          "sourceAddress": {
             "address": "IP_REDACTED",
-            "portValue": 8080
-           }
+            "portValue": 0
           }
-         }
         }
-       ]
-      }
-     ]
-    },
-    "typedExtensionProtocolOptions": {
-     "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
-      "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-      "commonHttpProtocolOptions": {
-       "idleTimeout": "7200s"
       },
-      "explicitHttpConfig": {
-       "httpProtocolOptions": {}
+      "inbound:passthrough:ipv6": {
+        "altStatName": "inbound_passthrough_ipv6",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "inbound:passthrough:ipv6",
+        "type": "ORIGINAL_DST",
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "localhost:8080": {
+        "altStatName": "localhost_8080",
+        "connectTimeout": "10s",
+        "loadAssignment": {
+          "clusterName": "localhost:8080",
+          "endpoints": [
+            {
+              "lbEndpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socketAddress": {
+                        "address": "IP_REDACTED",
+                        "portValue": 8080
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "name": "localhost:8080",
+        "type": "STATIC",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "7200s"
+            },
+            "explicitHttpConfig": {
+              "httpProtocolOptions": {}
+            }
+          }
+        },
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "outbound:passthrough:ipv4": {
+        "altStatName": "outbound_passthrough_ipv4",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "outbound:passthrough:ipv4",
+        "type": "ORIGINAL_DST"
+      },
+      "outbound:passthrough:ipv6": {
+        "altStatName": "outbound_passthrough_ipv6",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "outbound:passthrough:ipv6",
+        "type": "ORIGINAL_DST"
       }
-     }
     },
-    "upstreamBindConfig": {
-     "sourceAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 0
-     }
+    "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment": {
+      "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "clusterName": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "IP_REDACTED",
+                      "portValue": 3000
+                    }
+                  }
+                },
+                "loadBalancingWeight": 1,
+                "metadata": {
+                  "filterMetadata": {
+                    "envoy.lb": {
+                      "kuma.io/zone": "kuma-3",
+                      "team": "client-owners"
+                    },
+                    "envoy.transport_socket_match": {
+                      "kuma.io/zone": "kuma-3",
+                      "team": "client-owners"
+                    }
+                  }
+                }
+              }
+            ],
+            "locality": {
+              "zone": "kuma-3"
+            }
+          }
+        ]
+      },
+      "envoyconfig_test-server__kuma-3_msvc_80": {
+        "clusterName": "envoyconfig_test-server__kuma-3_msvc_80",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "IP_REDACTED",
+                      "portValue": 80
+                    }
+                  }
+                },
+                "loadBalancingWeight": 1,
+                "metadata": {
+                  "filterMetadata": {
+                    "envoy.lb": {
+                      "instance": "1",
+                      "kuma.io/protocol": "http",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "server-owners",
+                      "version": "v1"
+                    },
+                    "envoy.transport_socket_match": {
+                      "instance": "1",
+                      "kuma.io/protocol": "http",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "server-owners",
+                      "version": "v1"
+                    }
+                  }
+                }
+              }
+            ],
+            "locality": {
+              "zone": "kuma-3"
+            }
+          }
+        ]
+      }
+    },
+    "type.googleapis.com/envoy.config.listener.v3.Listener": {
+      "inbound:IP_REDACTED:80": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 80
+          }
+        },
+        "bindToPort": false,
+        "enableReusePort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "7200s"
+                  },
+                  "forwardClientCertDetails": "SANITIZE_SET",
+                  "httpFilters": [
+                    {
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
+                    }
+                  ],
+                  "routeConfig": {
+                    "name": "inbound:test-server",
+                    "requestHeadersToRemove": [
+                      "x-kuma-tags"
+                    ],
+                    "validateClusters": false,
+                    "virtualHosts": [
+                      {
+                        "domains": [
+                          "*"
+                        ],
+                        "name": "test-server",
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/"
+                            },
+                            "route": {
+                              "cluster": "localhost:8080",
+                              "timeout": "0s"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "setCurrentClientCertDetails": {
+                    "uri": true
+                  },
+                  "statPrefix": "localhost_8080",
+                  "streamIdleTimeout": "3600s"
+                }
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {
+              "instance": "1",
+              "kuma.io/protocol": "http",
+              "kuma.io/service": "test-server",
+              "kuma.io/zone": "kuma-3",
+              "team": "server-owners",
+              "version": "v1"
+            }
+          }
+        },
+        "name": "inbound:IP_REDACTED:80",
+        "trafficDirection": "INBOUND"
+      },
+      "inbound:passthrough:ipv4": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15006
+          }
+        },
+        "enableReusePort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "inbound:passthrough:ipv4",
+                  "statPrefix": "inbound_passthrough_ipv4"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "inbound:passthrough:ipv4",
+        "trafficDirection": "INBOUND",
+        "useOriginalDst": true
+      },
+      "inbound:passthrough:ipv6": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15006
+          }
+        },
+        "enableReusePort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "inbound:passthrough:ipv6",
+                  "statPrefix": "inbound_passthrough_ipv6"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "inbound:passthrough:ipv6",
+        "trafficDirection": "INBOUND",
+        "useOriginalDst": true
+      },
+      "outbound:IP_REDACTED:3000": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 3000
+          }
+        },
+        "bindToPort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "statPrefix": "envoyconfig_demo-client__kuma-3_msvc_3000"
+                }
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {}
+          }
+        },
+        "name": "outbound:IP_REDACTED:3000",
+        "trafficDirection": "OUTBOUND"
+      },
+      "outbound:IP_REDACTED:80": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 80
+          }
+        },
+        "bindToPort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "httpFilters": [
+                    {
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
+                    }
+                  ],
+                  "normalizePath": true,
+                  "routeConfig": {
+                    "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
+                    "validateClusters": false,
+                    "virtualHosts": [
+                      {
+                        "domains": [
+                          "*"
+                        ],
+                        "name": "envoyconfig_test-server__kuma-3_msvc_80",
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/"
+                            },
+                            "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
+                            "route": {
+                              "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
+                              "timeout": "0s"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "statPrefix": "envoyconfig_test-server__kuma-3_msvc_80"
+                }
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {}
+          }
+        },
+        "name": "outbound:IP_REDACTED:80",
+        "trafficDirection": "OUTBOUND"
+      },
+      "outbound:passthrough:ipv4": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15001
+          }
+        },
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "outbound:passthrough:ipv4",
+                  "statPrefix": "outbound_passthrough_ipv4"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "outbound:passthrough:ipv4",
+        "trafficDirection": "OUTBOUND",
+        "useOriginalDst": true
+      },
+      "outbound:passthrough:ipv6": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15001
+          }
+        },
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "outbound:passthrough:ipv6",
+                  "statPrefix": "outbound_passthrough_ipv6"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "outbound:passthrough:ipv6",
+        "trafficDirection": "OUTBOUND",
+        "useOriginalDst": true
+      }
     }
-   },
-   "outbound:passthrough:ipv4": {
-    "name": "outbound:passthrough:ipv4",
-    "altStatName": "outbound_passthrough_ipv4",
-    "type": "ORIGINAL_DST",
-    "connectTimeout": "5s",
-    "lbPolicy": "CLUSTER_PROVIDED"
-   },
-   "outbound:passthrough:ipv6": {
-    "name": "outbound:passthrough:ipv6",
-    "altStatName": "outbound_passthrough_ipv6",
-    "type": "ORIGINAL_DST",
-    "connectTimeout": "5s",
-    "lbPolicy": "CLUSTER_PROVIDED"
-   }
-  },
-  "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment": {
-   "envoyconfig_demo-client__kuma-3_msvc_3000": {
-    "clusterName": "envoyconfig_demo-client__kuma-3_msvc_3000",
-    "endpoints": [
-     {
-      "locality": {
-       "zone": "kuma-3"
-      },
-      "lbEndpoints": [
-       {
-        "endpoint": {
-         "address": {
-          "socketAddress": {
-           "address": "IP_REDACTED",
-           "portValue": 3000
-          }
-         }
-        },
-        "metadata": {
-         "filterMetadata": {
-          "envoy.lb": {
-           "kuma.io/zone": "kuma-3",
-           "team": "client-owners"
-          },
-          "envoy.transport_socket_match": {
-           "kuma.io/zone": "kuma-3",
-           "team": "client-owners"
-          }
-         }
-        },
-        "loadBalancingWeight": 1
-       }
-      ]
-     }
-    ]
-   },
-   "envoyconfig_test-server__kuma-3_msvc_80": {
-    "clusterName": "envoyconfig_test-server__kuma-3_msvc_80",
-    "endpoints": [
-     {
-      "locality": {
-       "zone": "kuma-3"
-      },
-      "lbEndpoints": [
-       {
-        "endpoint": {
-         "address": {
-          "socketAddress": {
-           "address": "IP_REDACTED",
-           "portValue": 80
-          }
-         }
-        },
-        "metadata": {
-         "filterMetadata": {
-          "envoy.lb": {
-           "instance": "1",
-           "kuma.io/protocol": "http",
-           "kuma.io/zone": "kuma-3",
-           "team": "server-owners",
-           "version": "v1"
-          },
-          "envoy.transport_socket_match": {
-           "instance": "1",
-           "kuma.io/protocol": "http",
-           "kuma.io/zone": "kuma-3",
-           "team": "server-owners",
-           "version": "v1"
-          }
-         }
-        },
-        "loadBalancingWeight": 1
-       }
-      ]
-     }
-    ]
-   }
-  },
-  "type.googleapis.com/envoy.config.listener.v3.Listener": {
-   "inbound:IP_REDACTED:80": {
-    "name": "inbound:IP_REDACTED:80",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 80
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.http_connection_manager",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-         "statPrefix": "localhost_8080",
-         "routeConfig": {
-          "name": "inbound:test-server",
-          "virtualHosts": [
-           {
-            "name": "test-server",
-            "domains": [
-             "*"
-            ],
-            "routes": [
-             {
-              "match": {
-               "prefix": "/"
-              },
-              "route": {
-               "cluster": "localhost:8080",
-               "timeout": "0s"
-              }
-             }
-            ]
-           }
-          ],
-          "requestHeadersToRemove": [
-           "x-kuma-tags"
-          ],
-          "validateClusters": false
-         },
-         "httpFilters": [
-          {
-           "name": "envoy.filters.http.router",
-           "typedConfig": {
-            "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
-           }
-          }
-         ],
-         "commonHttpProtocolOptions": {
-          "idleTimeout": "7200s"
-         },
-         "streamIdleTimeout": "3600s",
-         "forwardClientCertDetails": "SANITIZE_SET",
-         "setCurrentClientCertDetails": {
-          "uri": true
-         }
-        }
-       }
-      ]
-     }
-    ],
-    "metadata": {
-     "filterMetadata": {
-      "io.kuma.tags": {
-       "instance": "1",
-       "kuma.io/protocol": "http",
-       "kuma.io/service": "test-server",
-       "kuma.io/zone": "kuma-3",
-       "team": "server-owners",
-       "version": "v1"
-      }
-     }
-    },
-    "trafficDirection": "INBOUND",
-    "enableReusePort": false,
-    "bindToPort": false
-   },
-   "inbound:passthrough:ipv4": {
-    "name": "inbound:passthrough:ipv4",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 15006
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.tcp_proxy",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-         "statPrefix": "inbound_passthrough_ipv4",
-         "cluster": "inbound:passthrough:ipv4"
-        }
-       }
-      ]
-     }
-    ],
-    "useOriginalDst": true,
-    "trafficDirection": "INBOUND",
-    "enableReusePort": false
-   },
-   "inbound:passthrough:ipv6": {
-    "name": "inbound:passthrough:ipv6",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 15006
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.tcp_proxy",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-         "statPrefix": "inbound_passthrough_ipv6",
-         "cluster": "inbound:passthrough:ipv6"
-        }
-       }
-      ]
-     }
-    ],
-    "useOriginalDst": true,
-    "trafficDirection": "INBOUND",
-    "enableReusePort": false
-   },
-   "outbound:IP_REDACTED:3000": {
-    "name": "outbound:IP_REDACTED:3000",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 3000
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.tcp_proxy",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-         "statPrefix": "envoyconfig_demo-client__kuma-3_msvc_3000",
-         "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000"
-        }
-       }
-      ]
-     }
-    ],
-    "metadata": {
-     "filterMetadata": {
-      "io.kuma.tags": {}
-     }
-    },
-    "trafficDirection": "OUTBOUND",
-    "bindToPort": false
-   },
-   "outbound:IP_REDACTED:80": {
-    "name": "outbound:IP_REDACTED:80",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 80
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.http_connection_manager",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-         "statPrefix": "envoyconfig_test-server__kuma-3_msvc_80",
-         "routeConfig": {
-          "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
-          "virtualHosts": [
-           {
-            "name": "envoyconfig_test-server__kuma-3_msvc_80",
-            "domains": [
-             "*"
-            ],
-            "routes": [
-             {
-              "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
-              "match": {
-               "prefix": "/"
-              },
-              "route": {
-               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-               "timeout": "0s"
-              }
-             }
-            ]
-           }
-          ],
-          "validateClusters": false
-         },
-         "httpFilters": [
-          {
-           "name": "envoy.filters.http.router",
-           "typedConfig": {
-            "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
-           }
-          }
-         ],
-         "normalizePath": true
-        }
-       }
-      ]
-     }
-    ],
-    "metadata": {
-     "filterMetadata": {
-      "io.kuma.tags": {}
-     }
-    },
-    "trafficDirection": "OUTBOUND",
-    "bindToPort": false
-   },
-   "outbound:passthrough:ipv4": {
-    "name": "outbound:passthrough:ipv4",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 15001
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.tcp_proxy",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-         "statPrefix": "outbound_passthrough_ipv4",
-         "cluster": "outbound:passthrough:ipv4"
-        }
-       }
-      ]
-     }
-    ],
-    "useOriginalDst": true,
-    "trafficDirection": "OUTBOUND"
-   },
-   "outbound:passthrough:ipv6": {
-    "name": "outbound:passthrough:ipv6",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 15001
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.tcp_proxy",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-         "statPrefix": "outbound_passthrough_ipv6",
-         "cluster": "outbound:passthrough:ipv6"
-        }
-       }
-      ]
-     }
-    ],
-    "useOriginalDst": true,
-    "trafficDirection": "OUTBOUND"
-   }
   }
- }
 }

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/outbound.demo-client.golden.json
@@ -1,494 +1,489 @@
 {
- "diff": [
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_demo-client__kuma-3_msvc_3000/connectTimeout",
-   "value": "5s"
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions",
-   "value": {
-    "idleTimeout": "50s",
-    "maxConnectionDuration": "55s",
-    "maxStreamDuration": "54s"
-   }
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/connectTimeout",
-   "value": "51s"
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:3000/filterChains/0/filters/0/typedConfig/idleTimeout",
-   "value": "3600s"
-  },
-  {
-   "op": "test",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
-   "value": "0s"
-  },
-  {
-   "op": "remove",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
-   "value": "0s"
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
-   "value": "52s"
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/idleTimeout",
-   "value": "53s"
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/commonHttpProtocolOptions",
-   "value": {
-    "idleTimeout": "0s"
-   }
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/requestHeadersTimeout",
-   "value": "0s"
-  }
- ],
- "xds": {
-  "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
-   "envoyconfig_demo-client__kuma-3_msvc_3000": {
-    "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
-    "type": "EDS",
-    "edsClusterConfig": {
-     "edsConfig": {
-      "ads": {},
-      "resourceApiVersion": "V3"
-     }
+  "diff": [
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_demo-client__kuma-3_msvc_3000/connectTimeout",
+      "value": "5s"
     },
-    "connectTimeout": "5s",
-    "typedExtensionProtocolOptions": {
-     "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
-      "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-      "explicitHttpConfig": {
-       "http2ProtocolOptions": {}
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/connectTimeout",
+      "value": "51s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions",
+      "value": {
+        "idleTimeout": "50s",
+        "maxConnectionDuration": "55s",
+        "maxStreamDuration": "54s"
       }
-     }
-    }
-   },
-   "envoyconfig_test-server__kuma-3_msvc_80": {
-    "name": "envoyconfig_test-server__kuma-3_msvc_80",
-    "type": "EDS",
-    "edsClusterConfig": {
-     "edsConfig": {
-      "ads": {},
-      "resourceApiVersion": "V3"
-     }
     },
-    "connectTimeout": "51s",
-    "typedExtensionProtocolOptions": {
-     "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
-      "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-      "commonHttpProtocolOptions": {
-       "idleTimeout": "50s",
-       "maxConnectionDuration": "55s",
-       "maxStreamDuration": "54s"
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:3000/filterChains/0/filters/0/typedConfig/idleTimeout",
+      "value": "3600s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/commonHttpProtocolOptions",
+      "value": {
+        "idleTimeout": "0s"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/requestHeadersTimeout",
+      "value": "0s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/idleTimeout",
+      "value": "53s"
+    },
+    {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
+      "value": "0s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
+      "value": "52s"
+    }
+  ],
+  "xds": {
+    "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
+      "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
+        "edsClusterConfig": {
+          "edsConfig": {
+            "ads": {},
+            "resourceApiVersion": "V3"
+          }
+        },
+        "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "type": "EDS",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicitHttpConfig": {
+              "http2ProtocolOptions": {}
+            }
+          }
+        }
       },
-      "explicitHttpConfig": {
-       "http2ProtocolOptions": {}
+      "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "51s",
+        "edsClusterConfig": {
+          "edsConfig": {
+            "ads": {},
+            "resourceApiVersion": "V3"
+          }
+        },
+        "name": "envoyconfig_test-server__kuma-3_msvc_80",
+        "type": "EDS",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "50s",
+              "maxConnectionDuration": "55s",
+              "maxStreamDuration": "54s"
+            },
+            "explicitHttpConfig": {
+              "http2ProtocolOptions": {}
+            }
+          }
+        }
+      },
+      "inbound:passthrough:ipv4": {
+        "altStatName": "inbound_passthrough_ipv4",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "inbound:passthrough:ipv4",
+        "type": "ORIGINAL_DST",
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "inbound:passthrough:ipv6": {
+        "altStatName": "inbound_passthrough_ipv6",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "inbound:passthrough:ipv6",
+        "type": "ORIGINAL_DST",
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "localhost:3000": {
+        "altStatName": "localhost_3000",
+        "connectTimeout": "10s",
+        "loadAssignment": {
+          "clusterName": "localhost:3000",
+          "endpoints": [
+            {
+              "lbEndpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socketAddress": {
+                        "address": "IP_REDACTED",
+                        "portValue": 3000
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "name": "localhost:3000",
+        "type": "STATIC",
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "outbound:passthrough:ipv4": {
+        "altStatName": "outbound_passthrough_ipv4",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "outbound:passthrough:ipv4",
+        "type": "ORIGINAL_DST"
+      },
+      "outbound:passthrough:ipv6": {
+        "altStatName": "outbound_passthrough_ipv6",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "outbound:passthrough:ipv6",
+        "type": "ORIGINAL_DST"
       }
-     }
-    }
-   },
-   "inbound:passthrough:ipv4": {
-    "name": "inbound:passthrough:ipv4",
-    "altStatName": "inbound_passthrough_ipv4",
-    "type": "ORIGINAL_DST",
-    "connectTimeout": "5s",
-    "lbPolicy": "CLUSTER_PROVIDED",
-    "upstreamBindConfig": {
-     "sourceAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 0
-     }
-    }
-   },
-   "inbound:passthrough:ipv6": {
-    "name": "inbound:passthrough:ipv6",
-    "altStatName": "inbound_passthrough_ipv6",
-    "type": "ORIGINAL_DST",
-    "connectTimeout": "5s",
-    "lbPolicy": "CLUSTER_PROVIDED",
-    "upstreamBindConfig": {
-     "sourceAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 0
-     }
-    }
-   },
-   "localhost:3000": {
-    "name": "localhost:3000",
-    "altStatName": "localhost_3000",
-    "type": "STATIC",
-    "connectTimeout": "10s",
-    "loadAssignment": {
-     "clusterName": "localhost:3000",
-     "endpoints": [
-      {
-       "lbEndpoints": [
-        {
-         "endpoint": {
-          "address": {
-           "socketAddress": {
+    },
+    "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment": {
+      "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "clusterName": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "IP_REDACTED",
+                      "portValue": 3000
+                    }
+                  }
+                },
+                "loadBalancingWeight": 1,
+                "metadata": {
+                  "filterMetadata": {
+                    "envoy.lb": {
+                      "kuma.io/zone": "kuma-3",
+                      "team": "client-owners"
+                    },
+                    "envoy.transport_socket_match": {
+                      "kuma.io/zone": "kuma-3",
+                      "team": "client-owners"
+                    }
+                  }
+                }
+              }
+            ],
+            "locality": {
+              "zone": "kuma-3"
+            }
+          }
+        ]
+      },
+      "envoyconfig_test-server__kuma-3_msvc_80": {
+        "clusterName": "envoyconfig_test-server__kuma-3_msvc_80",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "IP_REDACTED",
+                      "portValue": 80
+                    }
+                  }
+                },
+                "loadBalancingWeight": 1,
+                "metadata": {
+                  "filterMetadata": {
+                    "envoy.lb": {
+                      "instance": "1",
+                      "kuma.io/protocol": "http",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "server-owners",
+                      "version": "v1"
+                    },
+                    "envoy.transport_socket_match": {
+                      "instance": "1",
+                      "kuma.io/protocol": "http",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "server-owners",
+                      "version": "v1"
+                    }
+                  }
+                }
+              }
+            ],
+            "locality": {
+              "zone": "kuma-3"
+            }
+          }
+        ]
+      }
+    },
+    "type.googleapis.com/envoy.config.listener.v3.Listener": {
+      "inbound:IP_REDACTED:3000": {
+        "address": {
+          "socketAddress": {
             "address": "IP_REDACTED",
             "portValue": 3000
-           }
           }
-         }
-        }
-       ]
-      }
-     ]
-    },
-    "upstreamBindConfig": {
-     "sourceAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 0
-     }
-    }
-   },
-   "outbound:passthrough:ipv4": {
-    "name": "outbound:passthrough:ipv4",
-    "altStatName": "outbound_passthrough_ipv4",
-    "type": "ORIGINAL_DST",
-    "connectTimeout": "5s",
-    "lbPolicy": "CLUSTER_PROVIDED"
-   },
-   "outbound:passthrough:ipv6": {
-    "name": "outbound:passthrough:ipv6",
-    "altStatName": "outbound_passthrough_ipv6",
-    "type": "ORIGINAL_DST",
-    "connectTimeout": "5s",
-    "lbPolicy": "CLUSTER_PROVIDED"
-   }
-  },
-  "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment": {
-   "envoyconfig_demo-client__kuma-3_msvc_3000": {
-    "clusterName": "envoyconfig_demo-client__kuma-3_msvc_3000",
-    "endpoints": [
-     {
-      "locality": {
-       "zone": "kuma-3"
-      },
-      "lbEndpoints": [
-       {
-        "endpoint": {
-         "address": {
-          "socketAddress": {
-           "address": "IP_REDACTED",
-           "portValue": 3000
-          }
-         }
         },
-        "metadata": {
-         "filterMetadata": {
-          "envoy.lb": {
-           "kuma.io/zone": "kuma-3",
-           "team": "client-owners"
-          },
-          "envoy.transport_socket_match": {
-           "kuma.io/zone": "kuma-3",
-           "team": "client-owners"
-          }
-         }
-        },
-        "loadBalancingWeight": 1
-       }
-      ]
-     }
-    ]
-   },
-   "envoyconfig_test-server__kuma-3_msvc_80": {
-    "clusterName": "envoyconfig_test-server__kuma-3_msvc_80",
-    "endpoints": [
-     {
-      "locality": {
-       "zone": "kuma-3"
-      },
-      "lbEndpoints": [
-       {
-        "endpoint": {
-         "address": {
-          "socketAddress": {
-           "address": "IP_REDACTED",
-           "portValue": 80
-          }
-         }
-        },
-        "metadata": {
-         "filterMetadata": {
-          "envoy.lb": {
-           "instance": "1",
-           "kuma.io/protocol": "http",
-           "kuma.io/zone": "kuma-3",
-           "team": "server-owners",
-           "version": "v1"
-          },
-          "envoy.transport_socket_match": {
-           "instance": "1",
-           "kuma.io/protocol": "http",
-           "kuma.io/zone": "kuma-3",
-           "team": "server-owners",
-           "version": "v1"
-          }
-         }
-        },
-        "loadBalancingWeight": 1
-       }
-      ]
-     }
-    ]
-   }
-  },
-  "type.googleapis.com/envoy.config.listener.v3.Listener": {
-   "inbound:IP_REDACTED:3000": {
-    "name": "inbound:IP_REDACTED:3000",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 3000
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.tcp_proxy",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-         "statPrefix": "localhost_3000",
-         "cluster": "localhost:3000",
-         "idleTimeout": "7200s"
-        }
-       }
-      ]
-     }
-    ],
-    "metadata": {
-     "filterMetadata": {
-      "io.kuma.tags": {
-       "kuma.io/service": "demo-client",
-       "kuma.io/zone": "kuma-3",
-       "team": "client-owners"
-      }
-     }
-    },
-    "trafficDirection": "INBOUND",
-    "enableReusePort": false,
-    "bindToPort": false
-   },
-   "inbound:passthrough:ipv4": {
-    "name": "inbound:passthrough:ipv4",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 15006
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.tcp_proxy",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-         "statPrefix": "inbound_passthrough_ipv4",
-         "cluster": "inbound:passthrough:ipv4"
-        }
-       }
-      ]
-     }
-    ],
-    "useOriginalDst": true,
-    "trafficDirection": "INBOUND",
-    "enableReusePort": false
-   },
-   "inbound:passthrough:ipv6": {
-    "name": "inbound:passthrough:ipv6",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 15006
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.tcp_proxy",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-         "statPrefix": "inbound_passthrough_ipv6",
-         "cluster": "inbound:passthrough:ipv6"
-        }
-       }
-      ]
-     }
-    ],
-    "useOriginalDst": true,
-    "trafficDirection": "INBOUND",
-    "enableReusePort": false
-   },
-   "outbound:IP_REDACTED:3000": {
-    "name": "outbound:IP_REDACTED:3000",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 3000
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.tcp_proxy",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-         "statPrefix": "envoyconfig_demo-client__kuma-3_msvc_3000",
-         "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
-         "idleTimeout": "3600s"
-        }
-       }
-      ]
-     }
-    ],
-    "metadata": {
-     "filterMetadata": {
-      "io.kuma.tags": {}
-     }
-    },
-    "trafficDirection": "OUTBOUND",
-    "bindToPort": false
-   },
-   "outbound:IP_REDACTED:80": {
-    "name": "outbound:IP_REDACTED:80",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 80
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.http_connection_manager",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-         "statPrefix": "envoyconfig_test-server__kuma-3_msvc_80",
-         "routeConfig": {
-          "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
-          "virtualHosts": [
-           {
-            "name": "envoyconfig_test-server__kuma-3_msvc_80",
-            "domains": [
-             "*"
-            ],
-            "routes": [
-             {
-              "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
-              "match": {
-               "prefix": "/"
-              },
-              "route": {
-               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-               "timeout": "52s",
-               "idleTimeout": "53s"
-              }
-             }
-            ]
-           }
-          ],
-          "validateClusters": false
-         },
-         "httpFilters": [
+        "bindToPort": false,
+        "enableReusePort": false,
+        "filterChains": [
           {
-           "name": "envoy.filters.http.router",
-           "typedConfig": {
-            "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
-           }
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "localhost:3000",
+                  "idleTimeout": "7200s",
+                  "statPrefix": "localhost_3000"
+                }
+              }
+            ]
           }
-         ],
-         "commonHttpProtocolOptions": {
-          "idleTimeout": "0s"
-         },
-         "requestHeadersTimeout": "0s",
-         "normalizePath": true
-        }
-       }
-      ]
-     }
-    ],
-    "metadata": {
-     "filterMetadata": {
-      "io.kuma.tags": {}
-     }
-    },
-    "trafficDirection": "OUTBOUND",
-    "bindToPort": false
-   },
-   "outbound:passthrough:ipv4": {
-    "name": "outbound:passthrough:ipv4",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 15001
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.tcp_proxy",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-         "statPrefix": "outbound_passthrough_ipv4",
-         "cluster": "outbound:passthrough:ipv4"
-        }
-       }
-      ]
-     }
-    ],
-    "useOriginalDst": true,
-    "trafficDirection": "OUTBOUND"
-   },
-   "outbound:passthrough:ipv6": {
-    "name": "outbound:passthrough:ipv6",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 15001
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.tcp_proxy",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-         "statPrefix": "outbound_passthrough_ipv6",
-         "cluster": "outbound:passthrough:ipv6"
-        }
-       }
-      ]
-     }
-    ],
-    "useOriginalDst": true,
-    "trafficDirection": "OUTBOUND"
-   }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {
+              "kuma.io/service": "demo-client",
+              "kuma.io/zone": "kuma-3",
+              "team": "client-owners"
+            }
+          }
+        },
+        "name": "inbound:IP_REDACTED:3000",
+        "trafficDirection": "INBOUND"
+      },
+      "inbound:passthrough:ipv4": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15006
+          }
+        },
+        "enableReusePort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "inbound:passthrough:ipv4",
+                  "statPrefix": "inbound_passthrough_ipv4"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "inbound:passthrough:ipv4",
+        "trafficDirection": "INBOUND",
+        "useOriginalDst": true
+      },
+      "inbound:passthrough:ipv6": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15006
+          }
+        },
+        "enableReusePort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "inbound:passthrough:ipv6",
+                  "statPrefix": "inbound_passthrough_ipv6"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "inbound:passthrough:ipv6",
+        "trafficDirection": "INBOUND",
+        "useOriginalDst": true
+      },
+      "outbound:IP_REDACTED:3000": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 3000
+          }
+        },
+        "bindToPort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
+                  "statPrefix": "envoyconfig_demo-client__kuma-3_msvc_3000"
+                }
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {}
+          }
+        },
+        "name": "outbound:IP_REDACTED:3000",
+        "trafficDirection": "OUTBOUND"
+      },
+      "outbound:IP_REDACTED:80": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 80
+          }
+        },
+        "bindToPort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
+                  "httpFilters": [
+                    {
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
+                    }
+                  ],
+                  "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
+                  "routeConfig": {
+                    "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
+                    "validateClusters": false,
+                    "virtualHosts": [
+                      {
+                        "domains": [
+                          "*"
+                        ],
+                        "name": "envoyconfig_test-server__kuma-3_msvc_80",
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/"
+                            },
+                            "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
+                            "route": {
+                              "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
+                              "idleTimeout": "53s",
+                              "timeout": "52s"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "statPrefix": "envoyconfig_test-server__kuma-3_msvc_80"
+                }
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {}
+          }
+        },
+        "name": "outbound:IP_REDACTED:80",
+        "trafficDirection": "OUTBOUND"
+      },
+      "outbound:passthrough:ipv4": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15001
+          }
+        },
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "outbound:passthrough:ipv4",
+                  "statPrefix": "outbound_passthrough_ipv4"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "outbound:passthrough:ipv4",
+        "trafficDirection": "OUTBOUND",
+        "useOriginalDst": true
+      },
+      "outbound:passthrough:ipv6": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15001
+          }
+        },
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "outbound:passthrough:ipv6",
+                  "statPrefix": "outbound_passthrough_ipv6"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "outbound:passthrough:ipv6",
+        "trafficDirection": "OUTBOUND",
+        "useOriginalDst": true
+      }
+    }
   }
- }
 }

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/outbound.test-server.golden.json
@@ -1,548 +1,543 @@
 {
- "diff": [
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_demo-client__kuma-3_msvc_3000/connectTimeout",
-   "value": "5s"
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions",
-   "value": {
-    "idleTimeout": "50s",
-    "maxConnectionDuration": "55s",
-    "maxStreamDuration": "54s"
-   }
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/connectTimeout",
-   "value": "51s"
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:3000/filterChains/0/filters/0/typedConfig/idleTimeout",
-   "value": "3600s"
-  },
-  {
-   "op": "test",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
-   "value": "0s"
-  },
-  {
-   "op": "remove",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
-   "value": "0s"
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
-   "value": "52s"
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/idleTimeout",
-   "value": "53s"
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/commonHttpProtocolOptions",
-   "value": {
-    "idleTimeout": "0s"
-   }
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/requestHeadersTimeout",
-   "value": "0s"
-  }
- ],
- "xds": {
-  "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
-   "envoyconfig_demo-client__kuma-3_msvc_3000": {
-    "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
-    "type": "EDS",
-    "edsClusterConfig": {
-     "edsConfig": {
-      "ads": {},
-      "resourceApiVersion": "V3"
-     }
+  "diff": [
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_demo-client__kuma-3_msvc_3000/connectTimeout",
+      "value": "5s"
     },
-    "connectTimeout": "5s",
-    "typedExtensionProtocolOptions": {
-     "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
-      "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-      "explicitHttpConfig": {
-       "http2ProtocolOptions": {}
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/connectTimeout",
+      "value": "51s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions",
+      "value": {
+        "idleTimeout": "50s",
+        "maxConnectionDuration": "55s",
+        "maxStreamDuration": "54s"
       }
-     }
-    }
-   },
-   "envoyconfig_test-server__kuma-3_msvc_80": {
-    "name": "envoyconfig_test-server__kuma-3_msvc_80",
-    "type": "EDS",
-    "edsClusterConfig": {
-     "edsConfig": {
-      "ads": {},
-      "resourceApiVersion": "V3"
-     }
     },
-    "connectTimeout": "51s",
-    "typedExtensionProtocolOptions": {
-     "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
-      "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-      "commonHttpProtocolOptions": {
-       "idleTimeout": "50s",
-       "maxConnectionDuration": "55s",
-       "maxStreamDuration": "54s"
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:3000/filterChains/0/filters/0/typedConfig/idleTimeout",
+      "value": "3600s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/commonHttpProtocolOptions",
+      "value": {
+        "idleTimeout": "0s"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/requestHeadersTimeout",
+      "value": "0s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/idleTimeout",
+      "value": "53s"
+    },
+    {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
+      "value": "0s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
+      "value": "52s"
+    }
+  ],
+  "xds": {
+    "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
+      "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
+        "edsClusterConfig": {
+          "edsConfig": {
+            "ads": {},
+            "resourceApiVersion": "V3"
+          }
+        },
+        "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "type": "EDS",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicitHttpConfig": {
+              "http2ProtocolOptions": {}
+            }
+          }
+        }
       },
-      "explicitHttpConfig": {
-       "http2ProtocolOptions": {}
-      }
-     }
-    }
-   },
-   "inbound:passthrough:ipv4": {
-    "name": "inbound:passthrough:ipv4",
-    "altStatName": "inbound_passthrough_ipv4",
-    "type": "ORIGINAL_DST",
-    "connectTimeout": "5s",
-    "lbPolicy": "CLUSTER_PROVIDED",
-    "upstreamBindConfig": {
-     "sourceAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 0
-     }
-    }
-   },
-   "inbound:passthrough:ipv6": {
-    "name": "inbound:passthrough:ipv6",
-    "altStatName": "inbound_passthrough_ipv6",
-    "type": "ORIGINAL_DST",
-    "connectTimeout": "5s",
-    "lbPolicy": "CLUSTER_PROVIDED",
-    "upstreamBindConfig": {
-     "sourceAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 0
-     }
-    }
-   },
-   "localhost:8080": {
-    "name": "localhost:8080",
-    "altStatName": "localhost_8080",
-    "type": "STATIC",
-    "connectTimeout": "10s",
-    "loadAssignment": {
-     "clusterName": "localhost:8080",
-     "endpoints": [
-      {
-       "lbEndpoints": [
-        {
-         "endpoint": {
-          "address": {
-           "socketAddress": {
+      "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "51s",
+        "edsClusterConfig": {
+          "edsConfig": {
+            "ads": {},
+            "resourceApiVersion": "V3"
+          }
+        },
+        "name": "envoyconfig_test-server__kuma-3_msvc_80",
+        "type": "EDS",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "50s",
+              "maxConnectionDuration": "55s",
+              "maxStreamDuration": "54s"
+            },
+            "explicitHttpConfig": {
+              "http2ProtocolOptions": {}
+            }
+          }
+        }
+      },
+      "inbound:passthrough:ipv4": {
+        "altStatName": "inbound_passthrough_ipv4",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "inbound:passthrough:ipv4",
+        "type": "ORIGINAL_DST",
+        "upstreamBindConfig": {
+          "sourceAddress": {
             "address": "IP_REDACTED",
-            "portValue": 8080
-           }
+            "portValue": 0
           }
-         }
         }
-       ]
-      }
-     ]
-    },
-    "typedExtensionProtocolOptions": {
-     "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
-      "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-      "commonHttpProtocolOptions": {
-       "idleTimeout": "7200s"
       },
-      "explicitHttpConfig": {
-       "httpProtocolOptions": {}
+      "inbound:passthrough:ipv6": {
+        "altStatName": "inbound_passthrough_ipv6",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "inbound:passthrough:ipv6",
+        "type": "ORIGINAL_DST",
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "localhost:8080": {
+        "altStatName": "localhost_8080",
+        "connectTimeout": "10s",
+        "loadAssignment": {
+          "clusterName": "localhost:8080",
+          "endpoints": [
+            {
+              "lbEndpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socketAddress": {
+                        "address": "IP_REDACTED",
+                        "portValue": 8080
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "name": "localhost:8080",
+        "type": "STATIC",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "7200s"
+            },
+            "explicitHttpConfig": {
+              "httpProtocolOptions": {}
+            }
+          }
+        },
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "outbound:passthrough:ipv4": {
+        "altStatName": "outbound_passthrough_ipv4",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "outbound:passthrough:ipv4",
+        "type": "ORIGINAL_DST"
+      },
+      "outbound:passthrough:ipv6": {
+        "altStatName": "outbound_passthrough_ipv6",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "outbound:passthrough:ipv6",
+        "type": "ORIGINAL_DST"
       }
-     }
     },
-    "upstreamBindConfig": {
-     "sourceAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 0
-     }
+    "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment": {
+      "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "clusterName": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "IP_REDACTED",
+                      "portValue": 3000
+                    }
+                  }
+                },
+                "loadBalancingWeight": 1,
+                "metadata": {
+                  "filterMetadata": {
+                    "envoy.lb": {
+                      "kuma.io/zone": "kuma-3",
+                      "team": "client-owners"
+                    },
+                    "envoy.transport_socket_match": {
+                      "kuma.io/zone": "kuma-3",
+                      "team": "client-owners"
+                    }
+                  }
+                }
+              }
+            ],
+            "locality": {
+              "zone": "kuma-3"
+            }
+          }
+        ]
+      },
+      "envoyconfig_test-server__kuma-3_msvc_80": {
+        "clusterName": "envoyconfig_test-server__kuma-3_msvc_80",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "IP_REDACTED",
+                      "portValue": 80
+                    }
+                  }
+                },
+                "loadBalancingWeight": 1,
+                "metadata": {
+                  "filterMetadata": {
+                    "envoy.lb": {
+                      "instance": "1",
+                      "kuma.io/protocol": "http",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "server-owners",
+                      "version": "v1"
+                    },
+                    "envoy.transport_socket_match": {
+                      "instance": "1",
+                      "kuma.io/protocol": "http",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "server-owners",
+                      "version": "v1"
+                    }
+                  }
+                }
+              }
+            ],
+            "locality": {
+              "zone": "kuma-3"
+            }
+          }
+        ]
+      }
+    },
+    "type.googleapis.com/envoy.config.listener.v3.Listener": {
+      "inbound:IP_REDACTED:80": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 80
+          }
+        },
+        "bindToPort": false,
+        "enableReusePort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "7200s"
+                  },
+                  "forwardClientCertDetails": "SANITIZE_SET",
+                  "httpFilters": [
+                    {
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
+                    }
+                  ],
+                  "routeConfig": {
+                    "name": "inbound:test-server",
+                    "requestHeadersToRemove": [
+                      "x-kuma-tags"
+                    ],
+                    "validateClusters": false,
+                    "virtualHosts": [
+                      {
+                        "domains": [
+                          "*"
+                        ],
+                        "name": "test-server",
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/"
+                            },
+                            "route": {
+                              "cluster": "localhost:8080",
+                              "timeout": "0s"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "setCurrentClientCertDetails": {
+                    "uri": true
+                  },
+                  "statPrefix": "localhost_8080",
+                  "streamIdleTimeout": "3600s"
+                }
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {
+              "instance": "1",
+              "kuma.io/protocol": "http",
+              "kuma.io/service": "test-server",
+              "kuma.io/zone": "kuma-3",
+              "team": "server-owners",
+              "version": "v1"
+            }
+          }
+        },
+        "name": "inbound:IP_REDACTED:80",
+        "trafficDirection": "INBOUND"
+      },
+      "inbound:passthrough:ipv4": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15006
+          }
+        },
+        "enableReusePort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "inbound:passthrough:ipv4",
+                  "statPrefix": "inbound_passthrough_ipv4"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "inbound:passthrough:ipv4",
+        "trafficDirection": "INBOUND",
+        "useOriginalDst": true
+      },
+      "inbound:passthrough:ipv6": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15006
+          }
+        },
+        "enableReusePort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "inbound:passthrough:ipv6",
+                  "statPrefix": "inbound_passthrough_ipv6"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "inbound:passthrough:ipv6",
+        "trafficDirection": "INBOUND",
+        "useOriginalDst": true
+      },
+      "outbound:IP_REDACTED:3000": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 3000
+          }
+        },
+        "bindToPort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
+                  "statPrefix": "envoyconfig_demo-client__kuma-3_msvc_3000"
+                }
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {}
+          }
+        },
+        "name": "outbound:IP_REDACTED:3000",
+        "trafficDirection": "OUTBOUND"
+      },
+      "outbound:IP_REDACTED:80": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 80
+          }
+        },
+        "bindToPort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
+                  "httpFilters": [
+                    {
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
+                    }
+                  ],
+                  "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
+                  "routeConfig": {
+                    "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
+                    "validateClusters": false,
+                    "virtualHosts": [
+                      {
+                        "domains": [
+                          "*"
+                        ],
+                        "name": "envoyconfig_test-server__kuma-3_msvc_80",
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/"
+                            },
+                            "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
+                            "route": {
+                              "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
+                              "idleTimeout": "53s",
+                              "timeout": "52s"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "statPrefix": "envoyconfig_test-server__kuma-3_msvc_80"
+                }
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {}
+          }
+        },
+        "name": "outbound:IP_REDACTED:80",
+        "trafficDirection": "OUTBOUND"
+      },
+      "outbound:passthrough:ipv4": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15001
+          }
+        },
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "outbound:passthrough:ipv4",
+                  "statPrefix": "outbound_passthrough_ipv4"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "outbound:passthrough:ipv4",
+        "trafficDirection": "OUTBOUND",
+        "useOriginalDst": true
+      },
+      "outbound:passthrough:ipv6": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15001
+          }
+        },
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "outbound:passthrough:ipv6",
+                  "statPrefix": "outbound_passthrough_ipv6"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "outbound:passthrough:ipv6",
+        "trafficDirection": "OUTBOUND",
+        "useOriginalDst": true
+      }
     }
-   },
-   "outbound:passthrough:ipv4": {
-    "name": "outbound:passthrough:ipv4",
-    "altStatName": "outbound_passthrough_ipv4",
-    "type": "ORIGINAL_DST",
-    "connectTimeout": "5s",
-    "lbPolicy": "CLUSTER_PROVIDED"
-   },
-   "outbound:passthrough:ipv6": {
-    "name": "outbound:passthrough:ipv6",
-    "altStatName": "outbound_passthrough_ipv6",
-    "type": "ORIGINAL_DST",
-    "connectTimeout": "5s",
-    "lbPolicy": "CLUSTER_PROVIDED"
-   }
-  },
-  "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment": {
-   "envoyconfig_demo-client__kuma-3_msvc_3000": {
-    "clusterName": "envoyconfig_demo-client__kuma-3_msvc_3000",
-    "endpoints": [
-     {
-      "locality": {
-       "zone": "kuma-3"
-      },
-      "lbEndpoints": [
-       {
-        "endpoint": {
-         "address": {
-          "socketAddress": {
-           "address": "IP_REDACTED",
-           "portValue": 3000
-          }
-         }
-        },
-        "metadata": {
-         "filterMetadata": {
-          "envoy.lb": {
-           "kuma.io/zone": "kuma-3",
-           "team": "client-owners"
-          },
-          "envoy.transport_socket_match": {
-           "kuma.io/zone": "kuma-3",
-           "team": "client-owners"
-          }
-         }
-        },
-        "loadBalancingWeight": 1
-       }
-      ]
-     }
-    ]
-   },
-   "envoyconfig_test-server__kuma-3_msvc_80": {
-    "clusterName": "envoyconfig_test-server__kuma-3_msvc_80",
-    "endpoints": [
-     {
-      "locality": {
-       "zone": "kuma-3"
-      },
-      "lbEndpoints": [
-       {
-        "endpoint": {
-         "address": {
-          "socketAddress": {
-           "address": "IP_REDACTED",
-           "portValue": 80
-          }
-         }
-        },
-        "metadata": {
-         "filterMetadata": {
-          "envoy.lb": {
-           "instance": "1",
-           "kuma.io/protocol": "http",
-           "kuma.io/zone": "kuma-3",
-           "team": "server-owners",
-           "version": "v1"
-          },
-          "envoy.transport_socket_match": {
-           "instance": "1",
-           "kuma.io/protocol": "http",
-           "kuma.io/zone": "kuma-3",
-           "team": "server-owners",
-           "version": "v1"
-          }
-         }
-        },
-        "loadBalancingWeight": 1
-       }
-      ]
-     }
-    ]
-   }
-  },
-  "type.googleapis.com/envoy.config.listener.v3.Listener": {
-   "inbound:IP_REDACTED:80": {
-    "name": "inbound:IP_REDACTED:80",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 80
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.http_connection_manager",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-         "statPrefix": "localhost_8080",
-         "routeConfig": {
-          "name": "inbound:test-server",
-          "virtualHosts": [
-           {
-            "name": "test-server",
-            "domains": [
-             "*"
-            ],
-            "routes": [
-             {
-              "match": {
-               "prefix": "/"
-              },
-              "route": {
-               "cluster": "localhost:8080",
-               "timeout": "0s"
-              }
-             }
-            ]
-           }
-          ],
-          "requestHeadersToRemove": [
-           "x-kuma-tags"
-          ],
-          "validateClusters": false
-         },
-         "httpFilters": [
-          {
-           "name": "envoy.filters.http.router",
-           "typedConfig": {
-            "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
-           }
-          }
-         ],
-         "commonHttpProtocolOptions": {
-          "idleTimeout": "7200s"
-         },
-         "streamIdleTimeout": "3600s",
-         "forwardClientCertDetails": "SANITIZE_SET",
-         "setCurrentClientCertDetails": {
-          "uri": true
-         }
-        }
-       }
-      ]
-     }
-    ],
-    "metadata": {
-     "filterMetadata": {
-      "io.kuma.tags": {
-       "instance": "1",
-       "kuma.io/protocol": "http",
-       "kuma.io/service": "test-server",
-       "kuma.io/zone": "kuma-3",
-       "team": "server-owners",
-       "version": "v1"
-      }
-     }
-    },
-    "trafficDirection": "INBOUND",
-    "enableReusePort": false,
-    "bindToPort": false
-   },
-   "inbound:passthrough:ipv4": {
-    "name": "inbound:passthrough:ipv4",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 15006
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.tcp_proxy",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-         "statPrefix": "inbound_passthrough_ipv4",
-         "cluster": "inbound:passthrough:ipv4"
-        }
-       }
-      ]
-     }
-    ],
-    "useOriginalDst": true,
-    "trafficDirection": "INBOUND",
-    "enableReusePort": false
-   },
-   "inbound:passthrough:ipv6": {
-    "name": "inbound:passthrough:ipv6",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 15006
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.tcp_proxy",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-         "statPrefix": "inbound_passthrough_ipv6",
-         "cluster": "inbound:passthrough:ipv6"
-        }
-       }
-      ]
-     }
-    ],
-    "useOriginalDst": true,
-    "trafficDirection": "INBOUND",
-    "enableReusePort": false
-   },
-   "outbound:IP_REDACTED:3000": {
-    "name": "outbound:IP_REDACTED:3000",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 3000
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.tcp_proxy",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-         "statPrefix": "envoyconfig_demo-client__kuma-3_msvc_3000",
-         "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
-         "idleTimeout": "3600s"
-        }
-       }
-      ]
-     }
-    ],
-    "metadata": {
-     "filterMetadata": {
-      "io.kuma.tags": {}
-     }
-    },
-    "trafficDirection": "OUTBOUND",
-    "bindToPort": false
-   },
-   "outbound:IP_REDACTED:80": {
-    "name": "outbound:IP_REDACTED:80",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 80
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.http_connection_manager",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-         "statPrefix": "envoyconfig_test-server__kuma-3_msvc_80",
-         "routeConfig": {
-          "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
-          "virtualHosts": [
-           {
-            "name": "envoyconfig_test-server__kuma-3_msvc_80",
-            "domains": [
-             "*"
-            ],
-            "routes": [
-             {
-              "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
-              "match": {
-               "prefix": "/"
-              },
-              "route": {
-               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-               "timeout": "52s",
-               "idleTimeout": "53s"
-              }
-             }
-            ]
-           }
-          ],
-          "validateClusters": false
-         },
-         "httpFilters": [
-          {
-           "name": "envoy.filters.http.router",
-           "typedConfig": {
-            "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
-           }
-          }
-         ],
-         "commonHttpProtocolOptions": {
-          "idleTimeout": "0s"
-         },
-         "requestHeadersTimeout": "0s",
-         "normalizePath": true
-        }
-       }
-      ]
-     }
-    ],
-    "metadata": {
-     "filterMetadata": {
-      "io.kuma.tags": {}
-     }
-    },
-    "trafficDirection": "OUTBOUND",
-    "bindToPort": false
-   },
-   "outbound:passthrough:ipv4": {
-    "name": "outbound:passthrough:ipv4",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 15001
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.tcp_proxy",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-         "statPrefix": "outbound_passthrough_ipv4",
-         "cluster": "outbound:passthrough:ipv4"
-        }
-       }
-      ]
-     }
-    ],
-    "useOriginalDst": true,
-    "trafficDirection": "OUTBOUND"
-   },
-   "outbound:passthrough:ipv6": {
-    "name": "outbound:passthrough:ipv6",
-    "address": {
-     "socketAddress": {
-      "address": "IP_REDACTED",
-      "portValue": 15001
-     }
-    },
-    "filterChains": [
-     {
-      "filters": [
-       {
-        "name": "envoy.filters.network.tcp_proxy",
-        "typedConfig": {
-         "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-         "statPrefix": "outbound_passthrough_ipv6",
-         "cluster": "outbound:passthrough:ipv6"
-        }
-       }
-      ]
-     }
-    ],
-    "useOriginalDst": true,
-    "trafficDirection": "OUTBOUND"
-   }
   }
- }
 }


### PR DESCRIPTION
## Motivation

* The order of operations in `response.diff` depends on the listeners' and clusters' names that contain IP addresses. If we want this order to be stable, we have to sort it once again after redacting the IPs.
* compile regex once globally

