### PR TITLE
fix(watchdog): wait for the first tick

### DIFF
--- a/pkg/util/watchdog/watchdog.go
+++ b/pkg/util/watchdog/watchdog.go
@@ -48,12 +48,12 @@ func (w *SimpleWatchdog) Start(ctx context.Context) {
 				w.OnError(err)
 			}
 		}
-		if w.hasTickedChan != nil && !channels.IsClosed(w.hasTickedChan) { // On the first tick we close the channel
-			close(w.hasTickedChan)
-		}
 		select {
 		case <-ctx.Done():
 		case <-ticker.C:
+		}
+		if w.hasTickedChan != nil && !channels.IsClosed(w.hasTickedChan) { // On the first tick we close the channel
+			close(w.hasTickedChan)
 		}
 		// cases are non prioritized so we first check is the context is done
 		select {

--- a/pkg/util/watchdog/watchdog.go
+++ b/pkg/util/watchdog/watchdog.go
@@ -48,12 +48,12 @@ func (w *SimpleWatchdog) Start(ctx context.Context) {
 				w.OnError(err)
 			}
 		}
+		if w.hasTickedChan != nil && !channels.IsClosed(w.hasTickedChan) { // On the first tick we close the channel
+			close(w.hasTickedChan)
+		}
 		select {
 		case <-ctx.Done():
 		case <-ticker.C:
-		}
-		if w.hasTickedChan != nil && !channels.IsClosed(w.hasTickedChan) { // On the first tick we close the channel
-			close(w.hasTickedChan)
 		}
 		// cases are non prioritized so we first check is the context is done
 		select {

--- a/pkg/util/watchdog/watchdog_test.go
+++ b/pkg/util/watchdog/watchdog_test.go
@@ -216,12 +216,16 @@ var _ = Describe("SimpleWatchdog", func() {
 			close(doneCh)
 		}()
 		Expect(watchdog.HasTicked(false)).Should(BeFalse())
-		Consistently(hasTicked).ShouldNot(Receive())
+		Consistently(func(g Gomega) {
+			g.Expect(hasTicked).ShouldNot(Receive())
+		}, "100ms", "10ms").Should(Succeed())
 
 		By("simulating 1st tick")
 		// when
 		timeTicks <- time.Time{}
-		Expect(watchdog.HasTicked(false)).Should(BeTrue())
+		Eventually(func(g Gomega) {
+			g.Expect(watchdog.HasTicked(false)).Should(BeTrue())
+		}, "100ms", "10ms").Should(Succeed())
 		Expect(hasTicked).Should(BeClosed())
 
 		By("simulating 2nd tick")

--- a/pkg/util/watchdog/watchdog_test.go
+++ b/pkg/util/watchdog/watchdog_test.go
@@ -215,15 +215,16 @@ var _ = Describe("SimpleWatchdog", func() {
 			watchdog.Start(ctx)
 			close(doneCh)
 		}()
-		Expect(watchdog.HasTicked(false)).Should(BeFalse())
-		Consistently(hasTicked, "100ms", "10ms").ShouldNot(Receive())
+		// first onTick call
+		Eventually(func(g Gomega) {
+			g.Expect(watchdog.HasTicked(false)).Should(BeTrue())
+		}, "100ms", "10ms").Should(Succeed())
+		Expect(hasTicked).Should(BeClosed())
 
 		By("simulating 1st tick")
 		// when
 		timeTicks <- time.Time{}
-		Eventually(func(g Gomega) {
-			g.Expect(watchdog.HasTicked(false)).Should(BeTrue())
-		}, "100ms", "10ms").Should(Succeed())
+		Expect(watchdog.HasTicked(false)).Should(BeTrue())
 		Expect(hasTicked).Should(BeClosed())
 
 		By("simulating 2nd tick")

--- a/pkg/util/watchdog/watchdog_test.go
+++ b/pkg/util/watchdog/watchdog_test.go
@@ -190,6 +190,7 @@ var _ = Describe("SimpleWatchdog", func() {
 	}))
 
 	It("should wait for the first tick to happen on WaitForFirstTick", func() {
+		onTickBlockCh := make(chan struct{})
 		watchdog := &SimpleWatchdog{
 			NewTicker: func() *time.Ticker {
 				return &time.Ticker{
@@ -197,6 +198,7 @@ var _ = Describe("SimpleWatchdog", func() {
 				}
 			},
 			OnTick: func(ctx context.Context) error {
+				<-onTickBlockCh
 				return nil
 			},
 			OnError: func(err error) {
@@ -215,9 +217,13 @@ var _ = Describe("SimpleWatchdog", func() {
 			watchdog.Start(ctx)
 			close(doneCh)
 		}()
-		// first onTick call
+		// before the first OnTick returns false
+		Expect(watchdog.HasTicked(false)).Should(BeFalse())
+		// unblock OnTick
+		close(onTickBlockCh)
+		// after the first tick returns true
 		Eventually(func(g Gomega) {
-			g.Expect(watchdog.HasTicked(false)).Should(BeTrue())
+			g.Expect(watchdog.HasTicked(false)).To(BeTrue())
 		}, "100ms", "10ms").Should(Succeed())
 		Expect(hasTicked).Should(BeClosed())
 

--- a/pkg/util/watchdog/watchdog_test.go
+++ b/pkg/util/watchdog/watchdog_test.go
@@ -216,9 +216,7 @@ var _ = Describe("SimpleWatchdog", func() {
 			close(doneCh)
 		}()
 		Expect(watchdog.HasTicked(false)).Should(BeFalse())
-		Consistently(func(g Gomega) {
-			g.Expect(hasTicked).ShouldNot(Receive())
-		}, "100ms", "10ms").Should(Succeed())
+		Consistently(hasTicked, "100ms", "10ms").ShouldNot(Receive())
 
 		By("simulating 1st tick")
 		// when


### PR DESCRIPTION
## Motivation

Issue: https://github.com/kumahq/kuma/issues/12657


## Implementation information

Changed to wait for the `HasTicked` to be called before first Ticker event, since there was a race and sometimes on ticked happened before the assertion 

fix: https://github.com/kumahq/kuma/issues/12657
