### PR TITLE
test(e2e): provide kubeconfig on kind cluster removal

### DIFF
--- a/mk/kind.mk
+++ b/mk/kind.mk
@@ -65,7 +65,7 @@ kind/wait:
 
 .PHONY: kind/stop
 kind/stop: kind/cleanup-docker-credentials
-	@$(KIND) delete cluster --name $(KIND_CLUSTER_NAME)
+	@$(KIND) delete cluster --kubeconfig $(KIND_KUBECONFIG) --name $(KIND_CLUSTER_NAME)
 	@rm -f $(KUBECONFIG_DIR)/$(KIND_KUBECONFIG)
 
 .PHONY: kind/stop/all


### PR DESCRIPTION
## Motivation

We observed that during multizone tests, while all tests succeeded, the job occasionally failed with the following error:
```
failed to update kubeconfig: failed to lock config file: open /home/ubuntu/.kube/config.lock: file exists
```
After investigating the issue and reviewing similar cases, I came across a suggestion to provide a kubeconfig file. Reusing a specific kubeconfig file could help prevent this issue from occurring.

## Implementation information

Provide kubeconfig file location on removal

## Supporting documentation

xref: https://github.com/kubernetes-sigs/kind/issues/2008
