### PR TITLE
fix(e2e): add flake attempt on new meshtimeout test as we do on older tests

### DIFF
--- a/test/e2e_env/kubernetes/meshtimeout/meshtimeout.go
+++ b/test/e2e_env/kubernetes/meshtimeout/meshtimeout.go
@@ -186,7 +186,7 @@ spec:
 			}(),
 		)
 
-		It("should configure timeout for single inbound", func() {
+		It("should configure timeout for single inbound", FlakeAttempts(3), func() {
 			policy := fmt.Sprintf(`
 apiVersion: kuma.io/v1alpha1
 kind: MeshTimeout


### PR DESCRIPTION


<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
