### PR TITLE
test(e2e): change some assertions to reduce time

### DIFF
--- a/test/e2e_env/kubernetes/gateway/cross-mesh.go
+++ b/test/e2e_env/kubernetes/gateway/cross-mesh.go
@@ -138,7 +138,7 @@ func CrossMeshGatewayOnKubernetes() {
 				kubernetes.Cluster,
 				gatewayAddr,
 				gatewayClientOutsideMesh,
-			), "1m", "1s").Should(Succeed())
+			), "1m", "1s").MustPassRepeatedly(5).Should(Succeed())
 		})
 
 		It("HTTP requests to a non-crossMesh gateway should still be proxied", func() {

--- a/test/e2e_env/kubernetes/gateway/cross-mesh.go
+++ b/test/e2e_env/kubernetes/gateway/cross-mesh.go
@@ -138,7 +138,7 @@ func CrossMeshGatewayOnKubernetes() {
 				kubernetes.Cluster,
 				gatewayAddr,
 				gatewayClientOutsideMesh,
-			), "1m", "1s").MustPassRepeatedly(5).Should(Succeed())
+			), "10s", "1s").Should(Succeed())
 		})
 
 		It("HTTP requests to a non-crossMesh gateway should still be proxied", func() {

--- a/test/e2e_env/kubernetes/gateway/delegated/meshpassthrough.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshpassthrough.go
@@ -137,7 +137,7 @@ spec:
 				)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(resp.ResponseCode).To(Equal(502))
-			}, "30s", "1s", MustPassRepeatedly(3)).Should(Succeed())
+			}, "30s", "1s").MustPassRepeatedly(3).Should(Succeed())
 		})
 	}
 }

--- a/test/e2e_env/kubernetes/gateway/delegated/meshpassthrough.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshpassthrough.go
@@ -137,7 +137,7 @@ spec:
 				)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(resp.ResponseCode).To(Equal(502))
-			}, "30s", "1s").MustPassRepeatedly(3).Should(Succeed())
+			}, "10s", "1s").Should(Succeed())
 		})
 	}
 }

--- a/test/e2e_env/kubernetes/gateway/gateway.go
+++ b/test/e2e_env/kubernetes/gateway/gateway.go
@@ -470,7 +470,7 @@ spec:
 
 					g.Expect(err).ToNot(HaveOccurred())
 					g.Expect(status.ResponseCode).To(Equal(404))
-				}, "30s", "1s").Should(Succeed())
+				}, "30s", "1s").MustPassRepeatedly(5).Should(Succeed())
 			})
 		})
 	}
@@ -730,7 +730,7 @@ spec:
 					client.FromKubernetesPod(clientNamespace, "demo-client"),
 				)
 				g.Expect(err).ToNot(HaveOccurred())
-			}, "30s", "1s", MustPassRepeatedly(5)).Should(Succeed())
+			}, "30s", "1s"). MustPassRepeatedly(5).Should(Succeed())
 		})
 	})
 

--- a/test/e2e_env/kubernetes/gateway/gateway.go
+++ b/test/e2e_env/kubernetes/gateway/gateway.go
@@ -730,7 +730,7 @@ spec:
 					client.FromKubernetesPod(clientNamespace, "demo-client"),
 				)
 				g.Expect(err).ToNot(HaveOccurred())
-			}, "30s", "1s"). MustPassRepeatedly(5).Should(Succeed())
+			}, "30s", "1s").MustPassRepeatedly(5).Should(Succeed())
 		})
 	})
 

--- a/test/e2e_env/kubernetes/gateway/gateway.go
+++ b/test/e2e_env/kubernetes/gateway/gateway.go
@@ -470,7 +470,7 @@ spec:
 
 					g.Expect(err).ToNot(HaveOccurred())
 					g.Expect(status.ResponseCode).To(Equal(404))
-				}, "30s", "1s").MustPassRepeatedly(5).Should(Succeed())
+				}, "10s", "1s").Should(Succeed())
 			})
 		})
 	}
@@ -730,7 +730,7 @@ spec:
 					client.FromKubernetesPod(clientNamespace, "demo-client"),
 				)
 				g.Expect(err).ToNot(HaveOccurred())
-			}, "30s", "1s").MustPassRepeatedly(5).Should(Succeed())
+			}, "10s", "1s").Should(Succeed())
 		})
 	})
 

--- a/test/e2e_env/kubernetes/meshmetric/meshmetric.go
+++ b/test/e2e_env/kubernetes/meshmetric/meshmetric.go
@@ -357,28 +357,29 @@ func MeshMetric() {
 					otelcollector.WithIPv6(Config.IPV6),
 				),
 				democlient.Install(democlient.WithNamespace(secondaryOpenTelemetryCollectorNamespace)),
+				testserver.Install(
+					testserver.WithName("test-server-0"),
+					testserver.WithMesh(mainMesh),
+					testserver.WithNamespace(namespace),
+				),
+				testserver.Install(
+					testserver.WithName("test-server-1"),
+					testserver.WithMesh(mainMesh),
+					testserver.WithNamespace(namespace),
+				),
+				testserver.Install(
+					testserver.WithName("test-server-2"),
+					testserver.WithMesh(secondaryMesh),
+					testserver.WithNamespace(namespace),
+				),
+				testserver.Install(
+					testserver.WithName("test-server-3"),
+					testserver.WithMesh(secondaryMesh),
+					testserver.WithNamespace(namespace),
+				),
 			)).
 			Setup(kubernetes.Cluster)
 		Expect(err).To(Succeed())
-
-		for i := 0; i < 2; i++ {
-			Expect(
-				kubernetes.Cluster.Install(testserver.Install(
-					testserver.WithName(fmt.Sprintf("test-server-%d", i)),
-					testserver.WithMesh(mainMesh),
-					testserver.WithNamespace(namespace),
-				)),
-			).To(Succeed())
-		}
-		for i := 2; i < 4; i++ {
-			Expect(
-				kubernetes.Cluster.Install(testserver.Install(
-					testserver.WithName(fmt.Sprintf("test-server-%d", i)),
-					testserver.WithMesh(secondaryMesh),
-					testserver.WithNamespace(namespace),
-				)),
-			).To(Succeed())
-		}
 	})
 
 	AfterEachFailure(func() {


### PR DESCRIPTION
## Motivation

We want to speed up tests execution

## Implementation information

* added parallel for MeshMetrics setup to speedup setting up a cluster
* Added `MustPassRepeatedly` for Consistently to avoid waiting for a minute

time reduced from 20-22min -> 18-20min

