### PR TITLE
fix(meshservice): use Protocol from the MeshService

### DIFF
--- a/pkg/plugins/policies/core/xds/meshroute/clusters.go
+++ b/pkg/plugins/policies/core/xds/meshroute/clusters.go
@@ -102,6 +102,9 @@ func GenerateClusters(
 								// we only check TLS status for local service
 								// services that are synced can be accessed only with TLS through ZoneIngress
 								tlsReady = !ms.IsLocalMeshService() || ms.Status.TLS.Status == meshservice_api.TLSReady
+								if port, found := ms.FindPortByName(realResourceRef.Resource.SectionName); found {
+									protocol = port.AppProtocol
+								}
 							}
 						}
 						edsClusterBuilder.Configure(envoy_clusters.ClientSideMultiIdentitiesMTLS(

--- a/pkg/plugins/policies/core/xds/meshroute/listeners.go
+++ b/pkg/plugins/policies/core/xds/meshroute/listeners.go
@@ -198,7 +198,7 @@ func GetServiceProtocolPortFromRef(
 		}
 		port := uint32(mes.Spec.Match.Port)
 		service := mes.DestinationName(port)
-		protocol := meshCtx.GetServiceProtocol(service)
+		protocol := mes.Spec.Match.Protocol
 		return service, protocol, port, true
 	case common_api.MeshMultiZoneService:
 		ms, ok := meshCtx.MeshMultiZoneServiceByIdentifier[pointer.Deref(ref.Resource).ResourceIdentifier]

--- a/test/e2e_env/kubernetes/gateway/gateway.go
+++ b/test/e2e_env/kubernetes/gateway/gateway.go
@@ -844,7 +844,7 @@ apiVersion: kuma.io/v1alpha1
 kind: MeshFaultInjection
 metadata:
   namespace: %s
-  name: mesh-fault-injecton
+  name: mesh-fault-injecton-gw
   labels:
     kuma.io/mesh: %s
 spec:

--- a/test/e2e_env/multizone/meshservice/policies.go
+++ b/test/e2e_env/multizone/meshservice/policies.go
@@ -310,8 +310,8 @@ spec:
 			)
 		}, "30s", "5s").Should(And(
 			HaveLen(100),
-			WithTransform(countResponseCodes(503), BeNumerically("~", 50, 10)),
-			WithTransform(countResponseCodes(200), BeNumerically("~", 50, 10)),
+			WithTransform(countResponseCodes(503), BeNumerically("~", 50, 15)),
+			WithTransform(countResponseCodes(200), BeNumerically("~", 50, 15)),
 		))
 
 		Eventually(func(g Gomega) {

--- a/test/e2e_env/multizone/meshtimeout/meshtimeout.go
+++ b/test/e2e_env/multizone/meshtimeout/meshtimeout.go
@@ -105,8 +105,8 @@ spec:
 		Expect(multizone.Global.DeleteMesh(mesh)).To(Succeed())
 	})
 
-	idleTimeoutCxStat := func(admin envoy_admin.Tunnel) *stats.Stats {
-		s, err := admin.GetStats("cluster.multizone-meshtimeout_test-server_multizone-meshtimeout-ns_kuma-2_msvc_80.upstream_cx_idle_timeout")
+	activeCxStat := func(admin envoy_admin.Tunnel) *stats.Stats {
+		s, err := admin.GetStats("cluster.multizone-meshtimeout_test-server_multizone-meshtimeout-ns_kuma-2_msvc_80.upstream_cx_active")
 		Expect(err).ToNot(HaveOccurred())
 		return s
 	}
@@ -286,7 +286,7 @@ spec:
 		}, "30s", "1s").MustPassRepeatedly(5).Should(Succeed())
 		// should have active connection
 		Consistently(func(g Gomega) {
-			g.Expect(idleTimeoutCxStat(tnl)).To(stats.BeEqualZero())
+			g.Expect(activeCxStat(tnl)).To(stats.BeGreaterThanZero())
 		}, "5s", "1s").Should(Succeed())
 
 		Expect(YamlUniversal(fmt.Sprintf(`
@@ -312,7 +312,7 @@ spec:
 		}, "30s", "1s").MustPassRepeatedly(5).Should(Succeed())
 		// should close the connection shortly after
 		Eventually(func(g Gomega) {
-			g.Expect(idleTimeoutCxStat(tnl)).To(stats.BeGreaterThanZero())
+			g.Expect(activeCxStat(tnl)).To(stats.BeEqualZero())
 		}, "30s", "1s").Should(Succeed())
 	})
 }

--- a/test/e2e_env/multizone/meshtimeout/meshtimeout.go
+++ b/test/e2e_env/multizone/meshtimeout/meshtimeout.go
@@ -270,7 +270,7 @@ spec:
 		}, "30s", "1s").Should(Succeed())
 	})
 
-	FIt("should apply MeshTimeout policy on MeshService from other zone", func() {
+	It("should apply MeshTimeout policy on MeshService from other zone", func() {
 		// given
 		// create a tunnel to test-client admin
 		Expect(multizone.KubeZone1.PortForwardService("test-client", k8sZoneNamespace, 9901)).To(Succeed())
@@ -309,10 +309,10 @@ spec:
 				framework_client.FromKubernetesPod(k8sZoneNamespace, "test-client"),
 			)
 			g.Expect(err).ToNot(HaveOccurred())
-		}, "30s", "1s").Should(Succeed())
+		}, "30s", "1s").MustPassRepeatedly(5).Should(Succeed())
 		// should close the connection shortly after
 		Eventually(func(g Gomega) {
 			g.Expect(idleTimeoutCxStat(tnl)).To(stats.BeGreaterThanZero())
-		}, "5s", "1s").Should(Succeed())
+		}, "30s", "1s").Should(Succeed())
 	})
 }


### PR DESCRIPTION
## Motivation

We were using an incorrect way to retrieve protocol for a MeshService, and that caused the configuration to not be applied

## Implementation information

Instead of using GetServiceProtocol, I changed the implementation to retrieve the port protocol directly from MeshService and use it. Additionally, I added an end-to-end (E2E) test to verify that `idleTimeout` is correctly set. The test ensures the connection is closed after 2 seconds, given that the default timeout is 1 hour.

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix https://github.com/kumahq/kuma/issues/12702

