### PR TITLE
fix(rules): a bug in ResolveTargetRef that caused creating excessive entries in ResourceRules

### DIFF
--- a/pkg/core/resources/apis/core/interfaces.go
+++ b/pkg/core/resources/apis/core/interfaces.go
@@ -1,0 +1,6 @@
+package core
+
+type Port interface {
+	GetName() string
+	GetValue() uint32
+}

--- a/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/helpers.go
+++ b/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/helpers.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	"fmt"
 
+	"github.com/kumahq/kuma/pkg/core/resources/apis/core"
 	core_vip "github.com/kumahq/kuma/pkg/core/resources/apis/core/vip"
 	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
@@ -37,7 +38,7 @@ func (m *MeshMultiZoneServiceResource) findPort(port uint32) (Port, bool) {
 
 func (m *MeshMultiZoneServiceResource) FindSectionNameByPort(port uint32) (string, bool) {
 	if port, found := m.findPort(port); found {
-		return port.GetName(), true
+		return port.GetNameOrStringifyPort(), true
 	}
 	return "", false
 }
@@ -66,7 +67,7 @@ func (m *MeshMultiZoneServiceResource) AsOutbounds() xds_types.Outbounds {
 			outbounds = append(outbounds, &xds_types.Outbound{
 				Address:  vip.IP,
 				Port:     port.Port,
-				Resource: pointer.To(model.NewTypedResourceIdentifier(m, model.WithSectionName(port.GetName()))),
+				Resource: pointer.To(model.NewTypedResourceIdentifier(m, model.WithSectionName(port.GetNameOrStringifyPort()))),
 			})
 		}
 	}
@@ -85,4 +86,27 @@ func (t *MeshMultiZoneServiceResource) Domains() *xds_types.VIPDomains {
 		}
 	}
 	return nil
+}
+
+func (t *MeshMultiZoneServiceResource) GetPorts() []core.Port {
+	var ports []core.Port
+	for _, port := range t.Spec.Ports {
+		ports = append(ports, core.Port(port))
+	}
+	return ports
+}
+
+func (p Port) GetNameOrStringifyPort() string {
+	if p.Name != "" {
+		return p.Name
+	}
+	return fmt.Sprintf("%d", p.Port)
+}
+
+func (p Port) GetName() string {
+	return p.Name
+}
+
+func (p Port) GetValue() uint32 {
+	return p.Port
 }

--- a/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/meshmultizoneservice.go
+++ b/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/meshmultizoneservice.go
@@ -31,13 +31,6 @@ type Port struct {
 	AppProtocol core_mesh.Protocol `json:"appProtocol,omitempty"`
 }
 
-func (p *Port) GetName() string {
-	if p.Name != "" {
-		return p.Name
-	}
-	return fmt.Sprintf("%d", p.Port)
-}
-
 type Selector struct {
 	// MeshService selects MeshServices
 	MeshService MeshServiceSelector `json:"meshService"`

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/helpers.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/helpers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/pkg/core/resources/apis/core"
 	core_vip "github.com/kumahq/kuma/pkg/core/resources/apis/core/vip"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
@@ -26,7 +27,7 @@ func (m *MeshServiceResource) findPort(port uint32) (Port, bool) {
 
 func (m *MeshServiceResource) FindSectionNameByPort(port uint32) (string, bool) {
 	if port, found := m.findPort(port); found {
-		return port.GetName(), true
+		return port.GetNameOrStringifyPort(), true
 	}
 	return "", false
 }
@@ -107,7 +108,7 @@ func (t *MeshServiceResource) AsOutbounds() xds_types.Outbounds {
 			outbounds = append(outbounds, &xds_types.Outbound{
 				Address:  vip.IP,
 				Port:     port.Port,
-				Resource: pointer.To(model.NewTypedResourceIdentifier(t, model.WithSectionName(port.GetName()))),
+				Resource: pointer.To(model.NewTypedResourceIdentifier(t, model.WithSectionName(port.GetNameOrStringifyPort()))),
 			})
 		}
 	}
@@ -128,9 +129,25 @@ func (t *MeshServiceResource) Domains() *xds_types.VIPDomains {
 	return nil
 }
 
-func (p *Port) GetName() string {
+func (t *MeshServiceResource) GetPorts() []core.Port {
+	var ports []core.Port
+	for _, port := range t.Spec.Ports {
+		ports = append(ports, core.Port(port))
+	}
+	return ports
+}
+
+func (p Port) GetNameOrStringifyPort() string {
 	if p.Name != "" {
 		return p.Name
 	}
 	return fmt.Sprintf("%d", p.Port)
+}
+
+func (p Port) GetName() string {
+	return p.Name
+}
+
+func (p Port) GetValue() uint32 {
+	return p.Port
 }

--- a/pkg/plugins/policies/core/rules/common/resolvetargetref_test.go
+++ b/pkg/plugins/policies/core/rules/common/resolvetargetref_test.go
@@ -1,0 +1,315 @@
+package common_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/core/resources/registry"
+	"github.com/kumahq/kuma/pkg/plugins/policies/core/rules/common"
+	"github.com/kumahq/kuma/pkg/test/resources/builders"
+	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
+	"github.com/kumahq/kuma/pkg/xds/context"
+)
+
+var _ = Describe("ResolveTargetRef", func() {
+
+	var resources context.Resources
+	BeforeEach(func() {
+		resources = context.NewResources()
+	})
+
+	addResource := func(resource core_model.Resource) {
+		if _, ok := resources.MeshLocalResources[resource.Descriptor().Name]; !ok {
+			list, err := registry.Global().NewList(resource.Descriptor().Name)
+			Expect(err).ToNot(HaveOccurred())
+			resources.MeshLocalResources[resource.Descriptor().Name] = list
+		}
+		Expect(resources.MeshLocalResources[resource.Descriptor().Name].AddItem(resource)).To(Succeed())
+	}
+
+	It("should resolve MeshService targetRef", func() {
+		// given 'policy-1' with targetRef (somewhere in its spec) to 'backend'
+		policyMeta := &test_model.ResourceMeta{
+			Name: "policy-1",
+			Mesh: "mesh-1",
+		}
+		targetRef := common_api.TargetRef{
+			Kind:      common_api.MeshService,
+			Name:      "backend",
+			Namespace: "kuma-demo",
+		}
+		// given actual MeshService 'backend' in 'kuma-demo' namespace with port 8080
+		addResource(builders.MeshService().
+			WithName("backend").
+			WithMesh("mesh-1").
+			WithLabels(map[string]string{
+				"k8s.kuma.io/namespace": "kuma-demo",
+				"kuma.io/display-name":  "backend",
+			}).
+			AddIntPortWithName(8080, 8081, mesh.ProtocolTCP, "tcp-port").
+			Build(),
+		)
+
+		// when
+		resolved := common.ResolveTargetRef(targetRef, policyMeta, resources)
+
+		// then
+		Expect(resolved).To(HaveLen(1))
+		Expect(resolved[0].Identifier().String()).To(Equal("meshservice:mesh/mesh-1:namespace/kuma-demo:name/backend"))
+	})
+
+	It("should resolve MeshService targetRef with section name", func() {
+		// given 'policy-1' with targetRef (somewhere in its spec) to 'backend'
+		policyMeta := &test_model.ResourceMeta{
+			Name: "policy-1",
+			Mesh: "mesh-1",
+		}
+		targetRef := common_api.TargetRef{
+			Kind:        common_api.MeshService,
+			Name:        "backend",
+			Namespace:   "kuma-demo",
+			SectionName: "tcp-port",
+		}
+		// given actual MeshService 'backend' in 'kuma-demo' namespace with port 8080
+		addResource(builders.MeshService().
+			WithName("backend").
+			WithMesh("mesh-1").
+			WithLabels(map[string]string{
+				"k8s.kuma.io/namespace": "kuma-demo",
+				"kuma.io/display-name":  "backend",
+			}).
+			AddIntPortWithName(8080, 8081, mesh.ProtocolTCP, "tcp-port").
+			Build(),
+		)
+
+		// when
+		resolved := common.ResolveTargetRef(targetRef, policyMeta, resources)
+
+		// then
+		Expect(resolved).To(HaveLen(1))
+		Expect(resolved[0].Identifier().String()).To(Equal("meshservice:mesh/mesh-1:namespace/kuma-demo:name/backend:section/tcp-port"))
+	})
+
+	It("should not resolve MeshService targetRef with section name that doesn't exist", func() {
+		// given 'policy-1' with targetRef (somewhere in its spec) to 'backend'
+		policyMeta := &test_model.ResourceMeta{
+			Name: "policy-1",
+			Mesh: "mesh-1",
+		}
+		targetRef := common_api.TargetRef{
+			Kind:        common_api.MeshService,
+			Name:        "backend",
+			Namespace:   "kuma-demo",
+			SectionName: "tcp-port",
+		}
+		// given actual MeshService 'backend' in 'kuma-demo' namespace with port 8080
+		addResource(builders.MeshService().
+			WithName("backend").
+			WithMesh("mesh-1").
+			WithLabels(map[string]string{
+				"k8s.kuma.io/namespace": "kuma-demo",
+				"kuma.io/display-name":  "backend",
+			}).
+			AddIntPort(8080, 8081, mesh.ProtocolTCP).
+			Build(),
+		)
+
+		// when
+		resolved := common.ResolveTargetRef(targetRef, policyMeta, resources)
+
+		// then
+		Expect(resolved).To(BeEmpty())
+	})
+
+	It("should not resolve MeshService targetRef with section name being a port value and MeshService's port name is set", func() {
+		// given 'policy-1' with targetRef (somewhere in its spec) to 'backend'
+		policyMeta := &test_model.ResourceMeta{
+			Name: "policy-1",
+			Mesh: "mesh-1",
+		}
+		targetRef := common_api.TargetRef{
+			Kind:        common_api.MeshService,
+			Name:        "backend",
+			Namespace:   "kuma-demo",
+			SectionName: "8080",
+		}
+		// given actual MeshService 'backend' in 'kuma-demo' namespace with port 8080
+		addResource(builders.MeshService().
+			WithName("backend").
+			WithMesh("mesh-1").
+			WithLabels(map[string]string{
+				"k8s.kuma.io/namespace": "kuma-demo",
+				"kuma.io/display-name":  "backend",
+			}).
+			AddIntPortWithName(8080, 8081, mesh.ProtocolTCP, "tcp-port").
+			Build(),
+		)
+
+		// when
+		resolved := common.ResolveTargetRef(targetRef, policyMeta, resources)
+
+		// then
+		Expect(resolved).To(BeEmpty())
+	})
+
+	It("should resolve MeshService targetRef with section name being a port value and MeshService's port name is unset", func() {
+		// given 'policy-1' with targetRef (somewhere in its spec) to 'backend'
+		policyMeta := &test_model.ResourceMeta{
+			Name: "policy-1",
+			Mesh: "mesh-1",
+		}
+		targetRef := common_api.TargetRef{
+			Kind:        common_api.MeshService,
+			Name:        "backend",
+			Namespace:   "kuma-demo",
+			SectionName: "8080",
+		}
+		// given actual MeshService 'backend' in 'kuma-demo' namespace with port 8080
+		addResource(builders.MeshService().
+			WithName("backend").
+			WithMesh("mesh-1").
+			WithLabels(map[string]string{
+				"k8s.kuma.io/namespace": "kuma-demo",
+				"kuma.io/display-name":  "backend",
+			}).
+			AddIntPort(8080, 8081, mesh.ProtocolTCP).
+			Build(),
+		)
+
+		// when
+		resolved := common.ResolveTargetRef(targetRef, policyMeta, resources)
+
+		// then
+		Expect(resolved).To(HaveLen(1))
+		Expect(resolved[0].Identifier().String()).To(Equal("meshservice:mesh/mesh-1:namespace/kuma-demo:name/backend:section/8080"))
+	})
+
+	It("should resolve legacy MeshService targetRef", func() {
+		// given 'policy-1' with targetRef (somewhere in its spec) to 'backend_kuma-demo_svc_8080'
+		policyMeta := &test_model.ResourceMeta{
+			Name: "policy-1",
+			Mesh: "mesh-1",
+		}
+		targetRef := common_api.TargetRef{
+			Kind: common_api.MeshService,
+			Name: "backend_kuma-demo_svc_8080",
+		}
+		// given actual MeshService 'backend' in 'kuma-demo' namespace with port 8080
+		addResource(builders.MeshService().
+			WithName("backend").
+			WithMesh("mesh-1").
+			WithLabels(map[string]string{
+				"k8s.kuma.io/namespace": "kuma-demo",
+				"kuma.io/display-name":  "backend",
+			}).
+			AddIntPortWithName(8080, 8081, mesh.ProtocolTCP, "tcp-port").
+			Build(),
+		)
+
+		// when
+		resolved := common.ResolveTargetRef(targetRef, policyMeta, resources)
+
+		// then
+		Expect(resolved).To(HaveLen(1))
+		Expect(resolved[0].Identifier().String()).To(Equal("meshservice:mesh/mesh-1:namespace/kuma-demo:name/backend:section/tcp-port"))
+	})
+
+	It("should resolve legacy MeshService targetRef, MeshService's port without name", func() {
+		// given 'policy-1' with targetRef (somewhere in its spec) to 'backend_kuma-demo_svc_8080'
+		policyMeta := &test_model.ResourceMeta{
+			Name: "policy-1",
+			Mesh: "mesh-1",
+		}
+		targetRef := common_api.TargetRef{
+			Kind: common_api.MeshService,
+			Name: "backend_kuma-demo_svc_8080",
+		}
+		// given actual MeshService 'backend' in 'kuma-demo' namespace with port 8080
+		addResource(builders.MeshService().
+			WithName("backend").
+			WithMesh("mesh-1").
+			WithLabels(map[string]string{
+				"k8s.kuma.io/namespace": "kuma-demo",
+				"kuma.io/display-name":  "backend",
+			}).
+			AddIntPort(8080, 8081, mesh.ProtocolTCP).
+			Build(),
+		)
+
+		// when
+		resolved := common.ResolveTargetRef(targetRef, policyMeta, resources)
+
+		// then
+		Expect(resolved).To(HaveLen(1))
+		Expect(resolved[0].Identifier().String()).To(Equal("meshservice:mesh/mesh-1:namespace/kuma-demo:name/backend"))
+	})
+
+	It("should resolve legacy MeshService targetRef for service less", func() {
+		// given 'policy-1' with targetRef (somewhere in its spec) to 'backend_kuma-demo_svc'
+		policyMeta := &test_model.ResourceMeta{
+			Name: "policy-1",
+			Mesh: "mesh-1",
+		}
+		targetRef := common_api.TargetRef{
+			Kind: common_api.MeshService,
+			Name: "backend_kuma-demo_svc",
+		}
+		// given actual MeshService 'backend' in 'kuma-demo' namespace with port 8080
+		addResource(builders.MeshService().
+			WithName("backend").
+			WithMesh("mesh-1").
+			WithLabels(map[string]string{
+				"k8s.kuma.io/namespace": "kuma-demo",
+				"kuma.io/display-name":  "backend",
+			}).
+			AddIntPort(8080, 8081, mesh.ProtocolTCP).
+			Build(),
+		)
+
+		// when
+		resolved := common.ResolveTargetRef(targetRef, policyMeta, resources)
+
+		// then
+		Expect(resolved).To(HaveLen(1))
+		Expect(resolved[0].Identifier().String()).To(Equal("meshservice:mesh/mesh-1:namespace/kuma-demo:name/backend"))
+	})
+
+	It("should resolve MeshMultiZoneService targetRef with section name", func() {
+		// given 'policy-1' with targetRef (somewhere in its spec) to 'backend-mzsvc'
+		policyMeta := &test_model.ResourceMeta{
+			Name: "policy-1",
+			Mesh: "mesh-1",
+		}
+		targetRef := common_api.TargetRef{
+			Kind:        common_api.MeshMultiZoneService,
+			Name:        "backend-mzsvc",
+			Namespace:   "kuma-demo",
+			SectionName: "tcp-port",
+		}
+		// given actual MeshService 'backend' in 'kuma-demo' namespace with port 8080
+		addResource(builders.MeshMultiZoneService().
+			WithName("backend-mzsvc").
+			WithMesh("mesh-1").
+			WithLabels(map[string]string{
+				"k8s.kuma.io/namespace": "kuma-demo",
+				"kuma.io/display-name":  "backend-mzsvc",
+			}).
+			WithServiceLabelSelector(map[string]string{
+				mesh_proto.DisplayName: "backend",
+			}).
+			AddIntPortWithName(8080, mesh.ProtocolTCP, "tcp-port").
+			Build(),
+		)
+
+		// when
+		resolved := common.ResolveTargetRef(targetRef, policyMeta, resources)
+
+		// then
+		Expect(resolved).To(HaveLen(1))
+		Expect(resolved[0].Identifier().String()).To(Equal("meshmultizoneservice:mesh/mesh-1:namespace/kuma-demo:name/backend-mzsvc:section/tcp-port"))
+	})
+})

--- a/pkg/plugins/policies/core/rules/common/resolvetargetref_test.go
+++ b/pkg/plugins/policies/core/rules/common/resolvetargetref_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 var _ = Describe("ResolveTargetRef", func() {
-
 	var resources context.Resources
 	BeforeEach(func() {
 		resources = context.NewResources()

--- a/pkg/plugins/policies/core/rules/common/suite_test.go
+++ b/pkg/plugins/policies/core/rules/common/suite_test.go
@@ -1,0 +1,11 @@
+package common_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/pkg/test"
+)
+
+func TestRulesCommon(t *testing.T) {
+	test.RunSpecs(t, "Rules Common Suite")
+}

--- a/pkg/plugins/policies/core/rules/outbound/resourcerules.go
+++ b/pkg/plugins/policies/core/rules/outbound/resourcerules.go
@@ -169,7 +169,7 @@ type withResolvedResource[T any] struct {
 	rs    *common.ResourceSection
 }
 
-// isRelevant returns true if the resolvedWrapper's resource is relevant to the other resource or section of the resource
+// isRelevant returns true if the rs.resource is relevant to the other resource or section of the resource
 func (rw *withResolvedResource[T]) isRelevant(other core_model.Resource, sectionName string) bool {
 	switch itemDescriptorName := rw.rs.Resource.Descriptor().Name; itemDescriptorName {
 	case core_mesh.MeshType:

--- a/pkg/test/resources/builders/meshmultizoneservice_builder.go
+++ b/pkg/test/resources/builders/meshmultizoneservice_builder.go
@@ -70,6 +70,15 @@ func (m *MeshMultiZoneServiceBuilder) AddIntPort(port uint32, protocol core_mesh
 	return m
 }
 
+func (m *MeshMultiZoneServiceBuilder) AddIntPortWithName(port uint32, protocol core_mesh.Protocol, name string) *MeshMultiZoneServiceBuilder {
+	m.res.Spec.Ports = append(m.res.Spec.Ports, meshmzservice_api.Port{
+		Port:        port,
+		AppProtocol: protocol,
+		Name:        name,
+	})
+	return m
+}
+
 func (m *MeshMultiZoneServiceBuilder) Build() *meshmzservice_api.MeshMultiZoneServiceResource {
 	if err := m.res.Validate(); err != nil {
 		panic(err)

--- a/pkg/test/resources/builders/meshservice_builder.go
+++ b/pkg/test/resources/builders/meshservice_builder.go
@@ -76,6 +76,19 @@ func (m *MeshServiceBuilder) AddIntPort(port, target uint32, protocol core_mesh.
 	return m
 }
 
+func (m *MeshServiceBuilder) AddIntPortWithName(port, target uint32, protocol core_mesh.Protocol, name string) *MeshServiceBuilder {
+	m.res.Spec.Ports = append(m.res.Spec.Ports, v1alpha1.Port{
+		Port: port,
+		TargetPort: intstr.IntOrString{
+			Type:   intstr.Int,
+			IntVal: int32(target),
+		},
+		AppProtocol: protocol,
+		Name:        name,
+	})
+	return m
+}
+
 func (m *MeshServiceBuilder) AddServiceTagIdentity(identity string) *MeshServiceBuilder {
 	m.res.Spec.Identities = append(m.res.Spec.Identities, v1alpha1.MeshServiceIdentity{
 		Type:  v1alpha1.MeshServiceIdentityServiceTagType,


### PR DESCRIPTION
## Motivation

It's a minor bug, I noticed it while covering `ResolveTargetRef` function with unit tests. It resulted in creating extra entities in `ResourceRules` map, i.e if policy has:
```yaml
to:
  - targetRef:
      kind: MeshService
      name: backend
      namespace: kuma-demo
      sectionName: non-existent-section-name
    default: $conf1
```

we're going to produce entry

```json
{
  "..."
  "meshservice:mesh/mesh-1:namespace/kuma-demo:name/backend:section/non-existent-section-name": $conf1,
  "..."
}
```

but it won't be used by the actual policy plugins because `MeshService` doesn't have `non-existent-section-name`.

## Implementation information

* properly handle section names in `ResolveTargetRef` function
* add unit tests
* common interface for ports to avoid depending on specific types like MeshService or MeshMutliZoneService

