### PR TITLE
feat(meshfaultinjection): support GRPC protocol

### DIFF
--- a/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin.go
@@ -181,7 +181,7 @@ func configure(
 	protocol core_mesh.Protocol,
 ) error {
 	switch protocol {
-	case core_mesh.ProtocolHTTP, core_mesh.ProtocolHTTP2:
+	case core_mesh.ProtocolHTTP, core_mesh.ProtocolHTTP2, core_mesh.ProtocolGRPC:
 		for _, rule := range fromRules {
 			conf := rule.Conf.(api.Conf)
 			from := rule.Subset


### PR DESCRIPTION
## Motivation

GRPC is an HTTP2 protocol and the difference in configuration is only additional grpc stats. We can enable it for GRPC.

## Implementation information

Configure MeshFaultInjection for GRPC protocol
