### PR TITLE
chore(MeshFaultInjection): add envoy config e2e test

### DIFF
--- a/test/e2e_env/universal/envoyconfig/envoyconfig.go
+++ b/test/e2e_env/universal/envoyconfig/envoyconfig.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kumahq/kuma/api/openapi/types"
 	api_common "github.com/kumahq/kuma/api/openapi/types/common"
 	meshaccesslog "github.com/kumahq/kuma/pkg/plugins/policies/meshaccesslog/api/v1alpha1"
+	meshfaultinjection "github.com/kumahq/kuma/pkg/plugins/policies/meshfaultinjection/api/v1alpha1"
 	meshratelimit "github.com/kumahq/kuma/pkg/plugins/policies/meshratelimit/api/v1alpha1"
 	meshtimeout "github.com/kumahq/kuma/pkg/plugins/policies/meshtimeout/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/test"
@@ -68,6 +69,7 @@ func EnvoyConfigTest() {
 			meshName,
 			meshtimeout.MeshTimeoutResourceTypeDescriptor,
 			meshaccesslog.MeshAccessLogResourceTypeDescriptor,
+			meshfaultinjection.MeshFaultInjectionResourceTypeDescriptor,
 			meshratelimit.MeshRateLimitResourceTypeDescriptor,
 		)).To(Succeed())
 	})
@@ -110,6 +112,7 @@ func EnvoyConfigTest() {
 		},
 		test.EntriesForFolder("meshtimeout", "envoyconfig"),
 		test.EntriesForFolder("meshaccesslog", "envoyconfig"),
+		test.EntriesForFolder("meshfaultinjection", "envoyconfig"),
 		test.EntriesForFolder("meshratelimit", "envoyconfig"),
 	)
 }

--- a/test/e2e_env/universal/envoyconfig/testdata/meshfaultinjection/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshfaultinjection/inbound.demo-client.golden.json
@@ -1,0 +1,432 @@
+{
+  "diff": [],
+  "xds": {
+    "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
+      "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "edsClusterConfig": {
+          "edsConfig": {
+            "ads": {},
+            "resourceApiVersion": "V3"
+          }
+        },
+        "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "type": "EDS",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicitHttpConfig": {
+              "http2ProtocolOptions": {}
+            }
+          }
+        }
+      },
+      "envoyconfig_test-server__kuma-3_msvc_80": {
+        "edsClusterConfig": {
+          "edsConfig": {
+            "ads": {},
+            "resourceApiVersion": "V3"
+          }
+        },
+        "name": "envoyconfig_test-server__kuma-3_msvc_80",
+        "type": "EDS",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicitHttpConfig": {
+              "http2ProtocolOptions": {}
+            }
+          }
+        }
+      },
+      "inbound:passthrough:ipv4": {
+        "altStatName": "inbound_passthrough_ipv4",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "inbound:passthrough:ipv4",
+        "type": "ORIGINAL_DST",
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "inbound:passthrough:ipv6": {
+        "altStatName": "inbound_passthrough_ipv6",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "inbound:passthrough:ipv6",
+        "type": "ORIGINAL_DST",
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "localhost:3000": {
+        "altStatName": "localhost_3000",
+        "connectTimeout": "10s",
+        "loadAssignment": {
+          "clusterName": "localhost:3000",
+          "endpoints": [
+            {
+              "lbEndpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socketAddress": {
+                        "address": "IP_REDACTED",
+                        "portValue": 3000
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "name": "localhost:3000",
+        "type": "STATIC",
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "outbound:passthrough:ipv4": {
+        "altStatName": "outbound_passthrough_ipv4",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "outbound:passthrough:ipv4",
+        "type": "ORIGINAL_DST"
+      },
+      "outbound:passthrough:ipv6": {
+        "altStatName": "outbound_passthrough_ipv6",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "outbound:passthrough:ipv6",
+        "type": "ORIGINAL_DST"
+      }
+    },
+    "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment": {
+      "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "clusterName": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "IP_REDACTED",
+                      "portValue": 3000
+                    }
+                  }
+                },
+                "loadBalancingWeight": 1,
+                "metadata": {
+                  "filterMetadata": {
+                    "envoy.lb": {
+                      "kuma.io/zone": "kuma-3",
+                      "team": "client-owners"
+                    },
+                    "envoy.transport_socket_match": {
+                      "kuma.io/zone": "kuma-3",
+                      "team": "client-owners"
+                    }
+                  }
+                }
+              }
+            ],
+            "locality": {
+              "zone": "kuma-3"
+            }
+          }
+        ]
+      },
+      "envoyconfig_test-server__kuma-3_msvc_80": {
+        "clusterName": "envoyconfig_test-server__kuma-3_msvc_80",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "IP_REDACTED",
+                      "portValue": 80
+                    }
+                  }
+                },
+                "loadBalancingWeight": 1,
+                "metadata": {
+                  "filterMetadata": {
+                    "envoy.lb": {
+                      "instance": "1",
+                      "kuma.io/protocol": "http",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "server-owners",
+                      "version": "v1"
+                    },
+                    "envoy.transport_socket_match": {
+                      "instance": "1",
+                      "kuma.io/protocol": "http",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "server-owners",
+                      "version": "v1"
+                    }
+                  }
+                }
+              }
+            ],
+            "locality": {
+              "zone": "kuma-3"
+            }
+          }
+        ]
+      }
+    },
+    "type.googleapis.com/envoy.config.listener.v3.Listener": {
+      "inbound:IP_REDACTED:3000": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 3000
+          }
+        },
+        "bindToPort": false,
+        "enableReusePort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "localhost:3000",
+                  "idleTimeout": "7200s",
+                  "statPrefix": "localhost_3000"
+                }
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {
+              "kuma.io/service": "demo-client",
+              "kuma.io/zone": "kuma-3",
+              "team": "client-owners"
+            }
+          }
+        },
+        "name": "inbound:IP_REDACTED:3000",
+        "trafficDirection": "INBOUND"
+      },
+      "inbound:passthrough:ipv4": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15006
+          }
+        },
+        "enableReusePort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "inbound:passthrough:ipv4",
+                  "statPrefix": "inbound_passthrough_ipv4"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "inbound:passthrough:ipv4",
+        "trafficDirection": "INBOUND",
+        "useOriginalDst": true
+      },
+      "inbound:passthrough:ipv6": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15006
+          }
+        },
+        "enableReusePort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "inbound:passthrough:ipv6",
+                  "statPrefix": "inbound_passthrough_ipv6"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "inbound:passthrough:ipv6",
+        "trafficDirection": "INBOUND",
+        "useOriginalDst": true
+      },
+      "outbound:IP_REDACTED:3000": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 3000
+          }
+        },
+        "bindToPort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "statPrefix": "envoyconfig_demo-client__kuma-3_msvc_3000"
+                }
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {}
+          }
+        },
+        "name": "outbound:IP_REDACTED:3000",
+        "trafficDirection": "OUTBOUND"
+      },
+      "outbound:IP_REDACTED:80": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 80
+          }
+        },
+        "bindToPort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "httpFilters": [
+                    {
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
+                    }
+                  ],
+                  "normalizePath": true,
+                  "routeConfig": {
+                    "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
+                    "requestHeadersToAdd": [
+                      {
+                        "header": {
+                          "key": "x-kuma-tags",
+                          "value": "\u0026kuma.io/service=demo-client\u0026\u0026kuma.io/zone=kuma-3\u0026\u0026team=client-owners\u0026"
+                        }
+                      }
+                    ],
+                    "validateClusters": false,
+                    "virtualHosts": [
+                      {
+                        "domains": [
+                          "*"
+                        ],
+                        "name": "envoyconfig_test-server__kuma-3_msvc_80",
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/"
+                            },
+                            "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
+                            "route": {
+                              "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
+                              "timeout": "0s"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "statPrefix": "envoyconfig_test-server__kuma-3_msvc_80"
+                }
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {}
+          }
+        },
+        "name": "outbound:IP_REDACTED:80",
+        "trafficDirection": "OUTBOUND"
+      },
+      "outbound:passthrough:ipv4": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15001
+          }
+        },
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "outbound:passthrough:ipv4",
+                  "statPrefix": "outbound_passthrough_ipv4"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "outbound:passthrough:ipv4",
+        "trafficDirection": "OUTBOUND",
+        "useOriginalDst": true
+      },
+      "outbound:passthrough:ipv6": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15001
+          }
+        },
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "outbound:passthrough:ipv6",
+                  "statPrefix": "outbound_passthrough_ipv6"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "outbound:passthrough:ipv6",
+        "trafficDirection": "OUTBOUND",
+        "useOriginalDst": true
+      }
+    }
+  }
+}

--- a/test/e2e_env/universal/envoyconfig/testdata/meshfaultinjection/inbound.input.yaml
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshfaultinjection/inbound.input.yaml
@@ -1,0 +1,23 @@
+type: MeshFaultInjection
+name: mfi-1
+mesh: envoyconfig
+labels:
+  kuma.io/effect: shadow
+spec:
+  targetRef:
+    kind: Mesh
+    proxyTypes: [Sidecar]
+  from:
+    - targetRef:
+        kind: Mesh
+      default:
+        http:
+          - abort:
+              httpStatus: 500
+              percentage: '2.5'
+          - abort:
+              httpStatus: 500
+              percentage: 10
+          - delay:
+              value: 5s
+              percentage: 5

--- a/test/e2e_env/universal/envoyconfig/testdata/meshfaultinjection/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshfaultinjection/inbound.test-server.golden.json
@@ -1,0 +1,573 @@
+{
+  "diff": [
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/httpFilters/0",
+      "value": {
+        "name": "envoy.filters.http.fault",
+        "typedConfig": {
+          "@type": "type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault",
+          "delay": {
+            "fixedDelay": "5s",
+            "percentage": {
+              "numerator": 5
+            }
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/httpFilters/0",
+      "value": {
+        "name": "envoy.filters.http.fault",
+        "typedConfig": {
+          "@type": "type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault",
+          "abort": {
+            "httpStatus": 500,
+            "percentage": {
+              "numerator": 10
+            }
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/httpFilters/0",
+      "value": {
+        "name": "envoy.filters.http.fault",
+        "typedConfig": {
+          "@type": "type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault",
+          "abort": {
+            "httpStatus": 500,
+            "percentage": {
+              "denominator": "TEN_THOUSAND",
+              "numerator": 250
+            }
+          }
+        }
+      }
+    }
+  ],
+  "xds": {
+    "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
+      "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "edsClusterConfig": {
+          "edsConfig": {
+            "ads": {},
+            "resourceApiVersion": "V3"
+          }
+        },
+        "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "type": "EDS",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicitHttpConfig": {
+              "http2ProtocolOptions": {}
+            }
+          }
+        }
+      },
+      "envoyconfig_test-server__kuma-3_msvc_80": {
+        "edsClusterConfig": {
+          "edsConfig": {
+            "ads": {},
+            "resourceApiVersion": "V3"
+          }
+        },
+        "name": "envoyconfig_test-server__kuma-3_msvc_80",
+        "type": "EDS",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicitHttpConfig": {
+              "http2ProtocolOptions": {}
+            }
+          }
+        }
+      },
+      "inbound:passthrough:ipv4": {
+        "altStatName": "inbound_passthrough_ipv4",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "inbound:passthrough:ipv4",
+        "type": "ORIGINAL_DST",
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "inbound:passthrough:ipv6": {
+        "altStatName": "inbound_passthrough_ipv6",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "inbound:passthrough:ipv6",
+        "type": "ORIGINAL_DST",
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "localhost:8080": {
+        "altStatName": "localhost_8080",
+        "connectTimeout": "10s",
+        "loadAssignment": {
+          "clusterName": "localhost:8080",
+          "endpoints": [
+            {
+              "lbEndpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socketAddress": {
+                        "address": "IP_REDACTED",
+                        "portValue": 8080
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "name": "localhost:8080",
+        "type": "STATIC",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "7200s"
+            },
+            "explicitHttpConfig": {
+              "httpProtocolOptions": {}
+            }
+          }
+        },
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "outbound:passthrough:ipv4": {
+        "altStatName": "outbound_passthrough_ipv4",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "outbound:passthrough:ipv4",
+        "type": "ORIGINAL_DST"
+      },
+      "outbound:passthrough:ipv6": {
+        "altStatName": "outbound_passthrough_ipv6",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "outbound:passthrough:ipv6",
+        "type": "ORIGINAL_DST"
+      }
+    },
+    "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment": {
+      "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "clusterName": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "IP_REDACTED",
+                      "portValue": 3000
+                    }
+                  }
+                },
+                "loadBalancingWeight": 1,
+                "metadata": {
+                  "filterMetadata": {
+                    "envoy.lb": {
+                      "kuma.io/zone": "kuma-3",
+                      "team": "client-owners"
+                    },
+                    "envoy.transport_socket_match": {
+                      "kuma.io/zone": "kuma-3",
+                      "team": "client-owners"
+                    }
+                  }
+                }
+              }
+            ],
+            "locality": {
+              "zone": "kuma-3"
+            }
+          }
+        ]
+      },
+      "envoyconfig_test-server__kuma-3_msvc_80": {
+        "clusterName": "envoyconfig_test-server__kuma-3_msvc_80",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "IP_REDACTED",
+                      "portValue": 80
+                    }
+                  }
+                },
+                "loadBalancingWeight": 1,
+                "metadata": {
+                  "filterMetadata": {
+                    "envoy.lb": {
+                      "instance": "1",
+                      "kuma.io/protocol": "http",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "server-owners",
+                      "version": "v1"
+                    },
+                    "envoy.transport_socket_match": {
+                      "instance": "1",
+                      "kuma.io/protocol": "http",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "server-owners",
+                      "version": "v1"
+                    }
+                  }
+                }
+              }
+            ],
+            "locality": {
+              "zone": "kuma-3"
+            }
+          }
+        ]
+      }
+    },
+    "type.googleapis.com/envoy.config.listener.v3.Listener": {
+      "inbound:IP_REDACTED:80": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 80
+          }
+        },
+        "bindToPort": false,
+        "enableReusePort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "7200s"
+                  },
+                  "forwardClientCertDetails": "SANITIZE_SET",
+                  "httpFilters": [
+                    {
+                      "name": "envoy.filters.http.fault",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault",
+                        "abort": {
+                          "httpStatus": 500,
+                          "percentage": {
+                            "denominator": "TEN_THOUSAND",
+                            "numerator": 250
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "name": "envoy.filters.http.fault",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault",
+                        "abort": {
+                          "httpStatus": 500,
+                          "percentage": {
+                            "numerator": 10
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "name": "envoy.filters.http.fault",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault",
+                        "delay": {
+                          "fixedDelay": "5s",
+                          "percentage": {
+                            "numerator": 5
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
+                    }
+                  ],
+                  "routeConfig": {
+                    "name": "inbound:test-server",
+                    "requestHeadersToRemove": [
+                      "x-kuma-tags"
+                    ],
+                    "validateClusters": false,
+                    "virtualHosts": [
+                      {
+                        "domains": [
+                          "*"
+                        ],
+                        "name": "test-server",
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/"
+                            },
+                            "route": {
+                              "cluster": "localhost:8080",
+                              "timeout": "0s"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "setCurrentClientCertDetails": {
+                    "uri": true
+                  },
+                  "statPrefix": "localhost_8080",
+                  "streamIdleTimeout": "3600s"
+                }
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {
+              "instance": "1",
+              "kuma.io/protocol": "http",
+              "kuma.io/service": "test-server",
+              "kuma.io/zone": "kuma-3",
+              "team": "server-owners",
+              "version": "v1"
+            }
+          }
+        },
+        "name": "inbound:IP_REDACTED:80",
+        "trafficDirection": "INBOUND"
+      },
+      "inbound:passthrough:ipv4": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15006
+          }
+        },
+        "enableReusePort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "inbound:passthrough:ipv4",
+                  "statPrefix": "inbound_passthrough_ipv4"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "inbound:passthrough:ipv4",
+        "trafficDirection": "INBOUND",
+        "useOriginalDst": true
+      },
+      "inbound:passthrough:ipv6": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15006
+          }
+        },
+        "enableReusePort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "inbound:passthrough:ipv6",
+                  "statPrefix": "inbound_passthrough_ipv6"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "inbound:passthrough:ipv6",
+        "trafficDirection": "INBOUND",
+        "useOriginalDst": true
+      },
+      "outbound:IP_REDACTED:3000": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 3000
+          }
+        },
+        "bindToPort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "statPrefix": "envoyconfig_demo-client__kuma-3_msvc_3000"
+                }
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {}
+          }
+        },
+        "name": "outbound:IP_REDACTED:3000",
+        "trafficDirection": "OUTBOUND"
+      },
+      "outbound:IP_REDACTED:80": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 80
+          }
+        },
+        "bindToPort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "httpFilters": [
+                    {
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
+                    }
+                  ],
+                  "normalizePath": true,
+                  "routeConfig": {
+                    "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
+                    "requestHeadersToAdd": [
+                      {
+                        "header": {
+                          "key": "x-kuma-tags",
+                          "value": "\u0026instance=1\u0026\u0026kuma.io/protocol=http\u0026\u0026kuma.io/service=test-server\u0026\u0026kuma.io/zone=kuma-3\u0026\u0026team=server-owners\u0026\u0026version=v1\u0026"
+                        }
+                      }
+                    ],
+                    "validateClusters": false,
+                    "virtualHosts": [
+                      {
+                        "domains": [
+                          "*"
+                        ],
+                        "name": "envoyconfig_test-server__kuma-3_msvc_80",
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/"
+                            },
+                            "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
+                            "route": {
+                              "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
+                              "timeout": "0s"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "statPrefix": "envoyconfig_test-server__kuma-3_msvc_80"
+                }
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {}
+          }
+        },
+        "name": "outbound:IP_REDACTED:80",
+        "trafficDirection": "OUTBOUND"
+      },
+      "outbound:passthrough:ipv4": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15001
+          }
+        },
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "outbound:passthrough:ipv4",
+                  "statPrefix": "outbound_passthrough_ipv4"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "outbound:passthrough:ipv4",
+        "trafficDirection": "OUTBOUND",
+        "useOriginalDst": true
+      },
+      "outbound:passthrough:ipv6": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15001
+          }
+        },
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "outbound:passthrough:ipv6",
+                  "statPrefix": "outbound_passthrough_ipv6"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "outbound:passthrough:ipv6",
+        "trafficDirection": "OUTBOUND",
+        "useOriginalDst": true
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Motivation

We need to add more e2e tests before we implement rules api for MeshFaultIjection

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
