### PR TITLE
fix(MeshTLS): fix shadow policy effect for MeshTLS

### DIFF
--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin.go
@@ -42,7 +42,7 @@ func NewPlugin() core_plugins.Plugin {
 }
 
 func (p plugin) MatchedPolicies(dataplane *core_mesh.DataplaneResource, resources xds_context.Resources, opts ...core_plugins.MatchedPoliciesOption) (core_xds.TypedMatchingPolicies, error) {
-	return matchers.MatchedPolicies(api.MeshTLSType, dataplane, resources)
+	return matchers.MatchedPolicies(api.MeshTLSType, dataplane, resources, opts...)
 }
 
 func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *core_xds.Proxy) error {

--- a/tools/policy-gen/bootstrap/root.go
+++ b/tools/policy-gen/bootstrap/root.go
@@ -265,7 +265,7 @@ func NewPlugin() core_plugins.Plugin {
 func (p plugin) MatchedPolicies(dataplane *core_mesh.DataplaneResource, resources xds_context.Resources, opts ...core_plugins.MatchedPoliciesOption) (core_xds.TypedMatchingPolicies, error) {	{{- if not .generateTargetRef }}
 	panic("implement me")
 	{{- else }}
-	return matchers.MatchedPolicies(api.{{ .name }}Type, dataplane, resources)
+	return matchers.MatchedPolicies(api.{{ .name }}Type, dataplane, resources, opts...), nil
 	{{- end }}
 }
 


### PR DESCRIPTION
## Motivation

We were not passing options for MeshTLS policy matching, because of this shadow effect didn't work for it. I've also updated policy-gen tool to prevent this from happening in the future.

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
