### PR TITLE
chore(e2e): enable mTLS in envoy config tests

### DIFF
--- a/test/e2e_env/universal/envoyconfig/envoyconfig.go
+++ b/test/e2e_env/universal/envoyconfig/envoyconfig.go
@@ -36,9 +36,11 @@ func EnvoyConfigTest() {
 					builders.Mesh().
 						WithName(meshName).
 						WithoutInitialPolicies().
-						WithMeshServicesEnabled(mesh_proto.Mesh_MeshServices_Exclusive),
+						WithMeshServicesEnabled(mesh_proto.Mesh_MeshServices_Exclusive).
+						WithBuiltinMTLSBackend("ca-1").WithEnabledMTLSBackend("ca-1"),
 				),
 			).
+			Install(MeshTrafficPermissionAllowAllUniversal(meshName)).
 			Install(DemoClientUniversal("demo-client", meshName,
 				WithTransparentProxy(true)),
 			).

--- a/test/e2e_env/universal/envoyconfig/envoyconfig.go
+++ b/test/e2e_env/universal/envoyconfig/envoyconfig.go
@@ -80,7 +80,7 @@ func EnvoyConfigTest() {
 		output, err := universal.Cluster.GetKumactlOptions().
 			RunKumactlAndGetOutput("inspect", "dataplane", dpp, "--type", "config", "--mesh", meshName, "--shadow", "--include=diff")
 		Expect(err).ToNot(HaveOccurred())
-		redacted := redactIPs(output)
+		redacted := redactStatPrefixes(redactIPs(output))
 
 		response := types.InspectDataplanesConfig{}
 		Expect(json.Unmarshal([]byte(redacted), &response)).To(Succeed())
@@ -155,4 +155,11 @@ var ipRegex = regexp.MustCompile(ipv4Regex + "|" + ipv6Regex)
 
 func redactIPs(jsonStr string) string {
 	return ipRegex.ReplaceAllString(jsonStr, "IP_REDACTED")
+}
+
+// TODO this should be removed after fixing: https://github.com/kumahq/kuma/issues/12733
+var statsPrefixRegex = regexp.MustCompile("\"statPrefix\":\\s\".*\"")
+
+func redactStatPrefixes(jsonStr string) string {
+	return statsPrefixRegex.ReplaceAllString(jsonStr, "\"statPrefix\": \"\"")
 }

--- a/test/e2e_env/universal/envoyconfig/envoyconfig.go
+++ b/test/e2e_env/universal/envoyconfig/envoyconfig.go
@@ -161,5 +161,5 @@ func redactIPs(jsonStr string) string {
 var statsPrefixRegex = regexp.MustCompile("\"statPrefix\":\\s\".*\"")
 
 func redactStatPrefixes(jsonStr string) string {
-	return statsPrefixRegex.ReplaceAllString(jsonStr, "\"statPrefix\": \"\"")
+	return statsPrefixRegex.ReplaceAllString(jsonStr, "\"statPrefix\": \"STAT_PREFIX_REDACTED\"")
 }

--- a/test/e2e_env/universal/envoyconfig/testdata/meshaccesslog/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshaccesslog/inbound.demo-client.golden.json
@@ -320,7 +320,7 @@
                       }
                     }
                   },
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               },
               {
@@ -343,7 +343,7 @@
                   ],
                   "cluster": "localhost:3000",
                   "idleTimeout": "7200s",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ],
@@ -414,7 +414,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -440,7 +440,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -466,7 +466,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -528,7 +528,7 @@
                       }
                     ]
                   },
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -557,7 +557,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -582,7 +582,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshaccesslog/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshaccesslog/inbound.demo-client.golden.json
@@ -2,7 +2,7 @@
   "diff": [
     {
       "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:3000/filterChains/0/filters/0/typedConfig/accessLog",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:3000/filterChains/0/filters/1/typedConfig/accessLog",
       "value": [
         {
           "name": "envoy.access_loggers.file",
@@ -29,6 +29,46 @@
           }
         },
         "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/demo-client"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a65abe81bca1750d1.demo-client.3000.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -47,6 +87,46 @@
           }
         },
         "name": "envoyconfig_test-server__kuma-3_msvc_80",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/test-server"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a029781856823048e.test-server.80.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -221,6 +301,29 @@
           {
             "filters": [
               {
+                "name": "envoy.filters.network.rbac",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+                  "rules": {
+                    "policies": {
+                      "MeshTrafficPermission": {
+                        "permissions": [
+                          {
+                            "any": true
+                          }
+                        ],
+                        "principals": [
+                          {
+                            "any": true
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "statPrefix": "inbound_172_10_0_13_3000."
+                }
+              },
+              {
                 "name": "envoy.filters.network.tcp_proxy",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
@@ -243,7 +346,44 @@
                   "statPrefix": "localhost_3000"
                 }
               }
-            ]
+            ],
+            "transportSocket": {
+              "name": "envoy.transport_sockets.tls",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+                "commonTlsContext": {
+                  "combinedValidationContext": {
+                    "defaultValidationContext": {
+                      "matchTypedSubjectAltNames": [
+                        {
+                          "matcher": {
+                            "prefix": "spiffe://envoyconfig/"
+                          },
+                          "sanType": "URI"
+                        }
+                      ]
+                    },
+                    "validationContextSdsSecretConfig": {
+                      "name": "mesh_ca:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  },
+                  "tlsCertificateSdsSecretConfigs": [
+                    {
+                      "name": "identity_cert:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  ]
+                },
+                "requireClientCertificate": true
+              }
+            }
           }
         ],
         "metadata": {
@@ -451,6 +591,27 @@
         "name": "outbound:passthrough:ipv6",
         "trafficDirection": "OUTBOUND",
         "useOriginalDst": true
+      }
+    },
+    "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret": {
+      "identity_cert:secret:envoyconfig": {
+        "name": "identity_cert:secret:envoyconfig",
+        "tlsCertificate": {
+          "certificateChain": {
+            "inlineBytes": "Q0VSVA=="
+          },
+          "privateKey": {
+            "inlineBytes": "S0VZ"
+          }
+        }
+      },
+      "mesh_ca:secret:envoyconfig": {
+        "name": "mesh_ca:secret:envoyconfig",
+        "validationContext": {
+          "trustedCa": {
+            "inlineBytes": "Q0E="
+          }
+        }
       }
     }
   }

--- a/test/e2e_env/universal/envoyconfig/testdata/meshaccesslog/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshaccesslog/inbound.demo-client.golden.json
@@ -320,7 +320,7 @@
                       }
                     }
                   },
-                  "statPrefix": "inbound_172_10_0_13_3000."
+                  "statPrefix": ""
                 }
               },
               {
@@ -343,7 +343,7 @@
                   ],
                   "cluster": "localhost:3000",
                   "idleTimeout": "7200s",
-                  "statPrefix": "localhost_3000"
+                  "statPrefix": ""
                 }
               }
             ],
@@ -414,7 +414,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": "inbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -440,7 +440,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": "inbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -466,7 +466,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
-                  "statPrefix": "envoyconfig_demo-client__kuma-3_msvc_3000"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -528,7 +528,7 @@
                       }
                     ]
                   },
-                  "statPrefix": "envoyconfig_test-server__kuma-3_msvc_80"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -557,7 +557,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": "outbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -582,7 +582,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": "outbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshaccesslog/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshaccesslog/inbound.test-server.golden.json
@@ -29,6 +29,46 @@
           }
         },
         "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/demo-client"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a65abe81bca1750d1.demo-client.3000.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -47,6 +87,46 @@
           }
         },
         "name": "envoyconfig_test-server__kuma-3_msvc_80",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/test-server"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a029781856823048e.test-server.80.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -255,6 +335,28 @@
                   "forwardClientCertDetails": "SANITIZE_SET",
                   "httpFilters": [
                     {
+                      "name": "envoy.filters.http.rbac",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+                        "rules": {
+                          "policies": {
+                            "MeshTrafficPermission": {
+                              "permissions": [
+                                {
+                                  "any": true
+                                }
+                              ],
+                              "principals": [
+                                {
+                                  "any": true
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
                       "name": "envoy.filters.http.router",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
@@ -294,7 +396,44 @@
                   "streamIdleTimeout": "3600s"
                 }
               }
-            ]
+            ],
+            "transportSocket": {
+              "name": "envoy.transport_sockets.tls",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+                "commonTlsContext": {
+                  "combinedValidationContext": {
+                    "defaultValidationContext": {
+                      "matchTypedSubjectAltNames": [
+                        {
+                          "matcher": {
+                            "prefix": "spiffe://envoyconfig/"
+                          },
+                          "sanType": "URI"
+                        }
+                      ]
+                    },
+                    "validationContextSdsSecretConfig": {
+                      "name": "mesh_ca:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  },
+                  "tlsCertificateSdsSecretConfigs": [
+                    {
+                      "name": "identity_cert:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  ]
+                },
+                "requireClientCertificate": true
+              }
+            }
           }
         ],
         "metadata": {
@@ -505,6 +644,27 @@
         "name": "outbound:passthrough:ipv6",
         "trafficDirection": "OUTBOUND",
         "useOriginalDst": true
+      }
+    },
+    "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret": {
+      "identity_cert:secret:envoyconfig": {
+        "name": "identity_cert:secret:envoyconfig",
+        "tlsCertificate": {
+          "certificateChain": {
+            "inlineBytes": "Q0VSVA=="
+          },
+          "privateKey": {
+            "inlineBytes": "S0VZ"
+          }
+        }
+      },
+      "mesh_ca:secret:envoyconfig": {
+        "name": "mesh_ca:secret:envoyconfig",
+        "validationContext": {
+          "trustedCa": {
+            "inlineBytes": "Q0E="
+          }
+        }
       }
     }
   }

--- a/test/e2e_env/universal/envoyconfig/testdata/meshaccesslog/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshaccesslog/inbound.test-server.golden.json
@@ -392,7 +392,7 @@
                   "setCurrentClientCertDetails": {
                     "uri": true
                   },
-                  "statPrefix": "",
+                  "statPrefix": "STAT_PREFIX_REDACTED",
                   "streamIdleTimeout": "3600s"
                 }
               }
@@ -467,7 +467,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -493,7 +493,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -519,7 +519,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -581,7 +581,7 @@
                       }
                     ]
                   },
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -610,7 +610,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -635,7 +635,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshaccesslog/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshaccesslog/inbound.test-server.golden.json
@@ -392,7 +392,7 @@
                   "setCurrentClientCertDetails": {
                     "uri": true
                   },
-                  "statPrefix": "localhost_8080",
+                  "statPrefix": "",
                   "streamIdleTimeout": "3600s"
                 }
               }
@@ -467,7 +467,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": "inbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -493,7 +493,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": "inbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -519,7 +519,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
-                  "statPrefix": "envoyconfig_demo-client__kuma-3_msvc_3000"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -581,7 +581,7 @@
                       }
                     ]
                   },
-                  "statPrefix": "envoyconfig_test-server__kuma-3_msvc_80"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -610,7 +610,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": "outbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -635,7 +635,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": "outbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshaccesslog/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshaccesslog/outbound.demo-client.golden.json
@@ -325,7 +325,7 @@
                       }
                     }
                   },
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               },
               {
@@ -334,7 +334,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
                   "idleTimeout": "7200s",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ],
@@ -405,7 +405,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -431,7 +431,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -457,7 +457,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -538,7 +538,7 @@
                       }
                     ]
                   },
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -567,7 +567,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -592,7 +592,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshaccesslog/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshaccesslog/outbound.demo-client.golden.json
@@ -34,6 +34,46 @@
           }
         },
         "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/demo-client"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a65abe81bca1750d1.demo-client.3000.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -52,6 +92,46 @@
           }
         },
         "name": "envoyconfig_test-server__kuma-3_msvc_80",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/test-server"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a029781856823048e.test-server.80.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -226,6 +306,29 @@
           {
             "filters": [
               {
+                "name": "envoy.filters.network.rbac",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+                  "rules": {
+                    "policies": {
+                      "MeshTrafficPermission": {
+                        "permissions": [
+                          {
+                            "any": true
+                          }
+                        ],
+                        "principals": [
+                          {
+                            "any": true
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "statPrefix": "inbound_172_10_0_13_3000."
+                }
+              },
+              {
                 "name": "envoy.filters.network.tcp_proxy",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
@@ -234,7 +337,44 @@
                   "statPrefix": "localhost_3000"
                 }
               }
-            ]
+            ],
+            "transportSocket": {
+              "name": "envoy.transport_sockets.tls",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+                "commonTlsContext": {
+                  "combinedValidationContext": {
+                    "defaultValidationContext": {
+                      "matchTypedSubjectAltNames": [
+                        {
+                          "matcher": {
+                            "prefix": "spiffe://envoyconfig/"
+                          },
+                          "sanType": "URI"
+                        }
+                      ]
+                    },
+                    "validationContextSdsSecretConfig": {
+                      "name": "mesh_ca:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  },
+                  "tlsCertificateSdsSecretConfigs": [
+                    {
+                      "name": "identity_cert:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  ]
+                },
+                "requireClientCertificate": true
+              }
+            }
           }
         ],
         "metadata": {
@@ -461,6 +601,27 @@
         "name": "outbound:passthrough:ipv6",
         "trafficDirection": "OUTBOUND",
         "useOriginalDst": true
+      }
+    },
+    "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret": {
+      "identity_cert:secret:envoyconfig": {
+        "name": "identity_cert:secret:envoyconfig",
+        "tlsCertificate": {
+          "certificateChain": {
+            "inlineBytes": "Q0VSVA=="
+          },
+          "privateKey": {
+            "inlineBytes": "S0VZ"
+          }
+        }
+      },
+      "mesh_ca:secret:envoyconfig": {
+        "name": "mesh_ca:secret:envoyconfig",
+        "validationContext": {
+          "trustedCa": {
+            "inlineBytes": "Q0E="
+          }
+        }
       }
     }
   }

--- a/test/e2e_env/universal/envoyconfig/testdata/meshaccesslog/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshaccesslog/outbound.demo-client.golden.json
@@ -325,7 +325,7 @@
                       }
                     }
                   },
-                  "statPrefix": "inbound_172_10_0_13_3000."
+                  "statPrefix": ""
                 }
               },
               {
@@ -334,7 +334,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
                   "idleTimeout": "7200s",
-                  "statPrefix": "localhost_3000"
+                  "statPrefix": ""
                 }
               }
             ],
@@ -405,7 +405,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": "inbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -431,7 +431,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": "inbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -457,7 +457,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
-                  "statPrefix": "envoyconfig_demo-client__kuma-3_msvc_3000"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -538,7 +538,7 @@
                       }
                     ]
                   },
-                  "statPrefix": "envoyconfig_test-server__kuma-3_msvc_80"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -567,7 +567,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": "outbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -592,7 +592,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": "outbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshaccesslog/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshaccesslog/outbound.test-server.golden.json
@@ -383,7 +383,7 @@
                   "setCurrentClientCertDetails": {
                     "uri": true
                   },
-                  "statPrefix": "localhost_8080",
+                  "statPrefix": "",
                   "streamIdleTimeout": "3600s"
                 }
               }
@@ -458,7 +458,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": "inbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -484,7 +484,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": "inbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -510,7 +510,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
-                  "statPrefix": "envoyconfig_demo-client__kuma-3_msvc_3000"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -591,7 +591,7 @@
                       }
                     ]
                   },
-                  "statPrefix": "envoyconfig_test-server__kuma-3_msvc_80"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -620,7 +620,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": "outbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -645,7 +645,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": "outbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshaccesslog/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshaccesslog/outbound.test-server.golden.json
@@ -383,7 +383,7 @@
                   "setCurrentClientCertDetails": {
                     "uri": true
                   },
-                  "statPrefix": "",
+                  "statPrefix": "STAT_PREFIX_REDACTED",
                   "streamIdleTimeout": "3600s"
                 }
               }
@@ -458,7 +458,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -484,7 +484,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -510,7 +510,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -591,7 +591,7 @@
                       }
                     ]
                   },
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -620,7 +620,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -645,7 +645,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshaccesslog/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshaccesslog/outbound.test-server.golden.json
@@ -34,6 +34,46 @@
           }
         },
         "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/demo-client"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a65abe81bca1750d1.demo-client.3000.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -52,6 +92,46 @@
           }
         },
         "name": "envoyconfig_test-server__kuma-3_msvc_80",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/test-server"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a029781856823048e.test-server.80.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -246,6 +326,28 @@
                   "forwardClientCertDetails": "SANITIZE_SET",
                   "httpFilters": [
                     {
+                      "name": "envoy.filters.http.rbac",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+                        "rules": {
+                          "policies": {
+                            "MeshTrafficPermission": {
+                              "permissions": [
+                                {
+                                  "any": true
+                                }
+                              ],
+                              "principals": [
+                                {
+                                  "any": true
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
                       "name": "envoy.filters.http.router",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
@@ -285,7 +387,44 @@
                   "streamIdleTimeout": "3600s"
                 }
               }
-            ]
+            ],
+            "transportSocket": {
+              "name": "envoy.transport_sockets.tls",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+                "commonTlsContext": {
+                  "combinedValidationContext": {
+                    "defaultValidationContext": {
+                      "matchTypedSubjectAltNames": [
+                        {
+                          "matcher": {
+                            "prefix": "spiffe://envoyconfig/"
+                          },
+                          "sanType": "URI"
+                        }
+                      ]
+                    },
+                    "validationContextSdsSecretConfig": {
+                      "name": "mesh_ca:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  },
+                  "tlsCertificateSdsSecretConfigs": [
+                    {
+                      "name": "identity_cert:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  ]
+                },
+                "requireClientCertificate": true
+              }
+            }
           }
         ],
         "metadata": {
@@ -515,6 +654,27 @@
         "name": "outbound:passthrough:ipv6",
         "trafficDirection": "OUTBOUND",
         "useOriginalDst": true
+      }
+    },
+    "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret": {
+      "identity_cert:secret:envoyconfig": {
+        "name": "identity_cert:secret:envoyconfig",
+        "tlsCertificate": {
+          "certificateChain": {
+            "inlineBytes": "Q0VSVA=="
+          },
+          "privateKey": {
+            "inlineBytes": "S0VZ"
+          }
+        }
+      },
+      "mesh_ca:secret:envoyconfig": {
+        "name": "mesh_ca:secret:envoyconfig",
+        "validationContext": {
+          "trustedCa": {
+            "inlineBytes": "Q0E="
+          }
+        }
       }
     }
   }

--- a/test/e2e_env/universal/envoyconfig/testdata/meshfaultinjection/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshfaultinjection/inbound.demo-client.golden.json
@@ -301,7 +301,7 @@
                       }
                     }
                   },
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               },
               {
@@ -310,7 +310,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
                   "idleTimeout": "7200s",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ],
@@ -381,7 +381,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -407,7 +407,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -433,7 +433,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -503,7 +503,7 @@
                       }
                     ]
                   },
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -532,7 +532,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -557,7 +557,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshfaultinjection/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshfaultinjection/inbound.demo-client.golden.json
@@ -301,7 +301,7 @@
                       }
                     }
                   },
-                  "statPrefix": "inbound_172_10_0_13_3000."
+                  "statPrefix": ""
                 }
               },
               {
@@ -310,7 +310,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
                   "idleTimeout": "7200s",
-                  "statPrefix": "localhost_3000"
+                  "statPrefix": ""
                 }
               }
             ],
@@ -381,7 +381,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": "inbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -407,7 +407,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": "inbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -433,7 +433,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
-                  "statPrefix": "envoyconfig_demo-client__kuma-3_msvc_3000"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -503,7 +503,7 @@
                       }
                     ]
                   },
-                  "statPrefix": "envoyconfig_test-server__kuma-3_msvc_80"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -532,7 +532,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": "outbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -557,7 +557,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": "outbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshfaultinjection/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshfaultinjection/inbound.demo-client.golden.json
@@ -10,6 +10,46 @@
           }
         },
         "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/demo-client"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a65abe81bca1750d1.demo-client.3000.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -28,6 +68,46 @@
           }
         },
         "name": "envoyconfig_test-server__kuma-3_msvc_80",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/test-server"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a029781856823048e.test-server.80.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -202,6 +282,29 @@
           {
             "filters": [
               {
+                "name": "envoy.filters.network.rbac",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+                  "rules": {
+                    "policies": {
+                      "MeshTrafficPermission": {
+                        "permissions": [
+                          {
+                            "any": true
+                          }
+                        ],
+                        "principals": [
+                          {
+                            "any": true
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "statPrefix": "inbound_172_10_0_13_3000."
+                }
+              },
+              {
                 "name": "envoy.filters.network.tcp_proxy",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
@@ -210,7 +313,44 @@
                   "statPrefix": "localhost_3000"
                 }
               }
-            ]
+            ],
+            "transportSocket": {
+              "name": "envoy.transport_sockets.tls",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+                "commonTlsContext": {
+                  "combinedValidationContext": {
+                    "defaultValidationContext": {
+                      "matchTypedSubjectAltNames": [
+                        {
+                          "matcher": {
+                            "prefix": "spiffe://envoyconfig/"
+                          },
+                          "sanType": "URI"
+                        }
+                      ]
+                    },
+                    "validationContextSdsSecretConfig": {
+                      "name": "mesh_ca:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  },
+                  "tlsCertificateSdsSecretConfigs": [
+                    {
+                      "name": "identity_cert:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  ]
+                },
+                "requireClientCertificate": true
+              }
+            }
           }
         ],
         "metadata": {
@@ -426,6 +566,27 @@
         "name": "outbound:passthrough:ipv6",
         "trafficDirection": "OUTBOUND",
         "useOriginalDst": true
+      }
+    },
+    "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret": {
+      "identity_cert:secret:envoyconfig": {
+        "name": "identity_cert:secret:envoyconfig",
+        "tlsCertificate": {
+          "certificateChain": {
+            "inlineBytes": "Q0VSVA=="
+          },
+          "privateKey": {
+            "inlineBytes": "S0VZ"
+          }
+        }
+      },
+      "mesh_ca:secret:envoyconfig": {
+        "name": "mesh_ca:secret:envoyconfig",
+        "validationContext": {
+          "trustedCa": {
+            "inlineBytes": "Q0E="
+          }
+        }
       }
     }
   }

--- a/test/e2e_env/universal/envoyconfig/testdata/meshfaultinjection/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshfaultinjection/inbound.test-server.golden.json
@@ -446,7 +446,7 @@
                   "setCurrentClientCertDetails": {
                     "uri": true
                   },
-                  "statPrefix": "localhost_8080",
+                  "statPrefix": "",
                   "streamIdleTimeout": "3600s"
                 }
               }
@@ -521,7 +521,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": "inbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -547,7 +547,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": "inbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -573,7 +573,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
-                  "statPrefix": "envoyconfig_demo-client__kuma-3_msvc_3000"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -643,7 +643,7 @@
                       }
                     ]
                   },
-                  "statPrefix": "envoyconfig_test-server__kuma-3_msvc_80"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -672,7 +672,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": "outbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -697,7 +697,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": "outbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshfaultinjection/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshfaultinjection/inbound.test-server.golden.json
@@ -2,7 +2,7 @@
   "diff": [
     {
       "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/httpFilters/0",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/httpFilters/1",
       "value": {
         "name": "envoy.filters.http.fault",
         "typedConfig": {
@@ -18,7 +18,7 @@
     },
     {
       "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/httpFilters/0",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/httpFilters/1",
       "value": {
         "name": "envoy.filters.http.fault",
         "typedConfig": {
@@ -34,7 +34,7 @@
     },
     {
       "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/httpFilters/0",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/httpFilters/1",
       "value": {
         "name": "envoy.filters.http.fault",
         "typedConfig": {
@@ -60,6 +60,46 @@
           }
         },
         "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/demo-client"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a65abe81bca1750d1.demo-client.3000.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -78,6 +118,46 @@
           }
         },
         "name": "envoyconfig_test-server__kuma-3_msvc_80",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/test-server"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a029781856823048e.test-server.80.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -272,6 +352,28 @@
                   "forwardClientCertDetails": "SANITIZE_SET",
                   "httpFilters": [
                     {
+                      "name": "envoy.filters.http.rbac",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+                        "rules": {
+                          "policies": {
+                            "MeshTrafficPermission": {
+                              "permissions": [
+                                {
+                                  "any": true
+                                }
+                              ],
+                              "principals": [
+                                {
+                                  "any": true
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
                       "name": "envoy.filters.http.fault",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault",
@@ -348,7 +450,44 @@
                   "streamIdleTimeout": "3600s"
                 }
               }
-            ]
+            ],
+            "transportSocket": {
+              "name": "envoy.transport_sockets.tls",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+                "commonTlsContext": {
+                  "combinedValidationContext": {
+                    "defaultValidationContext": {
+                      "matchTypedSubjectAltNames": [
+                        {
+                          "matcher": {
+                            "prefix": "spiffe://envoyconfig/"
+                          },
+                          "sanType": "URI"
+                        }
+                      ]
+                    },
+                    "validationContextSdsSecretConfig": {
+                      "name": "mesh_ca:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  },
+                  "tlsCertificateSdsSecretConfigs": [
+                    {
+                      "name": "identity_cert:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  ]
+                },
+                "requireClientCertificate": true
+              }
+            }
           }
         ],
         "metadata": {
@@ -567,6 +706,27 @@
         "name": "outbound:passthrough:ipv6",
         "trafficDirection": "OUTBOUND",
         "useOriginalDst": true
+      }
+    },
+    "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret": {
+      "identity_cert:secret:envoyconfig": {
+        "name": "identity_cert:secret:envoyconfig",
+        "tlsCertificate": {
+          "certificateChain": {
+            "inlineBytes": "Q0VSVA=="
+          },
+          "privateKey": {
+            "inlineBytes": "S0VZ"
+          }
+        }
+      },
+      "mesh_ca:secret:envoyconfig": {
+        "name": "mesh_ca:secret:envoyconfig",
+        "validationContext": {
+          "trustedCa": {
+            "inlineBytes": "Q0E="
+          }
+        }
       }
     }
   }

--- a/test/e2e_env/universal/envoyconfig/testdata/meshfaultinjection/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshfaultinjection/inbound.test-server.golden.json
@@ -446,7 +446,7 @@
                   "setCurrentClientCertDetails": {
                     "uri": true
                   },
-                  "statPrefix": "",
+                  "statPrefix": "STAT_PREFIX_REDACTED",
                   "streamIdleTimeout": "3600s"
                 }
               }
@@ -521,7 +521,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -547,7 +547,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -573,7 +573,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -643,7 +643,7 @@
                       }
                     ]
                   },
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -672,7 +672,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -697,7 +697,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshratelimit/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshratelimit/inbound.demo-client.golden.json
@@ -301,7 +301,7 @@
                       }
                     }
                   },
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               },
               {
@@ -310,7 +310,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
                   "idleTimeout": "7200s",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ],
@@ -381,7 +381,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -407,7 +407,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -433,7 +433,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -495,7 +495,7 @@
                       }
                     ]
                   },
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -524,7 +524,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -549,7 +549,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshratelimit/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshratelimit/inbound.demo-client.golden.json
@@ -301,7 +301,7 @@
                       }
                     }
                   },
-                  "statPrefix": "inbound_172_10_0_13_3000."
+                  "statPrefix": ""
                 }
               },
               {
@@ -310,7 +310,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
                   "idleTimeout": "7200s",
-                  "statPrefix": "localhost_3000"
+                  "statPrefix": ""
                 }
               }
             ],
@@ -381,7 +381,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": "inbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -407,7 +407,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": "inbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -433,7 +433,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
-                  "statPrefix": "envoyconfig_demo-client__kuma-3_msvc_3000"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -495,7 +495,7 @@
                       }
                     ]
                   },
-                  "statPrefix": "envoyconfig_test-server__kuma-3_msvc_80"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -524,7 +524,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": "outbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -549,7 +549,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": "outbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshratelimit/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshratelimit/inbound.demo-client.golden.json
@@ -10,6 +10,46 @@
           }
         },
         "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/demo-client"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a65abe81bca1750d1.demo-client.3000.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -28,6 +68,46 @@
           }
         },
         "name": "envoyconfig_test-server__kuma-3_msvc_80",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/test-server"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a029781856823048e.test-server.80.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -202,6 +282,29 @@
           {
             "filters": [
               {
+                "name": "envoy.filters.network.rbac",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+                  "rules": {
+                    "policies": {
+                      "MeshTrafficPermission": {
+                        "permissions": [
+                          {
+                            "any": true
+                          }
+                        ],
+                        "principals": [
+                          {
+                            "any": true
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "statPrefix": "inbound_172_10_0_13_3000."
+                }
+              },
+              {
                 "name": "envoy.filters.network.tcp_proxy",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
@@ -210,7 +313,44 @@
                   "statPrefix": "localhost_3000"
                 }
               }
-            ]
+            ],
+            "transportSocket": {
+              "name": "envoy.transport_sockets.tls",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+                "commonTlsContext": {
+                  "combinedValidationContext": {
+                    "defaultValidationContext": {
+                      "matchTypedSubjectAltNames": [
+                        {
+                          "matcher": {
+                            "prefix": "spiffe://envoyconfig/"
+                          },
+                          "sanType": "URI"
+                        }
+                      ]
+                    },
+                    "validationContextSdsSecretConfig": {
+                      "name": "mesh_ca:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  },
+                  "tlsCertificateSdsSecretConfigs": [
+                    {
+                      "name": "identity_cert:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  ]
+                },
+                "requireClientCertificate": true
+              }
+            }
           }
         ],
         "metadata": {
@@ -418,6 +558,27 @@
         "name": "outbound:passthrough:ipv6",
         "trafficDirection": "OUTBOUND",
         "useOriginalDst": true
+      }
+    },
+    "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret": {
+      "identity_cert:secret:envoyconfig": {
+        "name": "identity_cert:secret:envoyconfig",
+        "tlsCertificate": {
+          "certificateChain": {
+            "inlineBytes": "Q0VSVA=="
+          },
+          "privateKey": {
+            "inlineBytes": "S0VZ"
+          }
+        }
+      },
+      "mesh_ca:secret:envoyconfig": {
+        "name": "mesh_ca:secret:envoyconfig",
+        "validationContext": {
+          "trustedCa": {
+            "inlineBytes": "Q0E="
+          }
+        }
       }
     }
   }

--- a/test/e2e_env/universal/envoyconfig/testdata/meshratelimit/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshratelimit/inbound.test-server.golden.json
@@ -2,7 +2,7 @@
   "diff": [
     {
       "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/httpFilters/0",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/httpFilters/1",
       "value": {
         "name": "envoy.filters.http.local_ratelimit",
         "typedConfig": {
@@ -61,6 +61,46 @@
           }
         },
         "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/demo-client"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a65abe81bca1750d1.demo-client.3000.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -79,6 +119,46 @@
           }
         },
         "name": "envoyconfig_test-server__kuma-3_msvc_80",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/test-server"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a029781856823048e.test-server.80.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -273,6 +353,28 @@
                   "forwardClientCertDetails": "SANITIZE_SET",
                   "httpFilters": [
                     {
+                      "name": "envoy.filters.http.rbac",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+                        "rules": {
+                          "policies": {
+                            "MeshTrafficPermission": {
+                              "permissions": [
+                                {
+                                  "any": true
+                                }
+                              ],
+                              "principals": [
+                                {
+                                  "any": true
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
                       "name": "envoy.filters.http.local_ratelimit",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit",
@@ -354,7 +456,44 @@
                   "streamIdleTimeout": "3600s"
                 }
               }
-            ]
+            ],
+            "transportSocket": {
+              "name": "envoy.transport_sockets.tls",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+                "commonTlsContext": {
+                  "combinedValidationContext": {
+                    "defaultValidationContext": {
+                      "matchTypedSubjectAltNames": [
+                        {
+                          "matcher": {
+                            "prefix": "spiffe://envoyconfig/"
+                          },
+                          "sanType": "URI"
+                        }
+                      ]
+                    },
+                    "validationContextSdsSecretConfig": {
+                      "name": "mesh_ca:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  },
+                  "tlsCertificateSdsSecretConfigs": [
+                    {
+                      "name": "identity_cert:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  ]
+                },
+                "requireClientCertificate": true
+              }
+            }
           }
         ],
         "metadata": {
@@ -565,6 +704,27 @@
         "name": "outbound:passthrough:ipv6",
         "trafficDirection": "OUTBOUND",
         "useOriginalDst": true
+      }
+    },
+    "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret": {
+      "identity_cert:secret:envoyconfig": {
+        "name": "identity_cert:secret:envoyconfig",
+        "tlsCertificate": {
+          "certificateChain": {
+            "inlineBytes": "Q0VSVA=="
+          },
+          "privateKey": {
+            "inlineBytes": "S0VZ"
+          }
+        }
+      },
+      "mesh_ca:secret:envoyconfig": {
+        "name": "mesh_ca:secret:envoyconfig",
+        "validationContext": {
+          "trustedCa": {
+            "inlineBytes": "Q0E="
+          }
+        }
       }
     }
   }

--- a/test/e2e_env/universal/envoyconfig/testdata/meshratelimit/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshratelimit/inbound.test-server.golden.json
@@ -7,7 +7,7 @@
         "name": "envoy.filters.http.local_ratelimit",
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit",
-          "statPrefix": "rate_limit"
+          "statPrefix": ""
         }
       }
     },
@@ -38,7 +38,7 @@
               }
             }
           ],
-          "statPrefix": "rate_limit",
+          "statPrefix": "",
           "status": {
             "code": "Locked"
           },
@@ -378,7 +378,7 @@
                       "name": "envoy.filters.http.local_ratelimit",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit",
-                        "statPrefix": "rate_limit"
+                        "statPrefix": ""
                       }
                     },
                     {
@@ -433,7 +433,7 @@
                                     }
                                   }
                                 ],
-                                "statPrefix": "rate_limit",
+                                "statPrefix": "",
                                 "status": {
                                   "code": "Locked"
                                 },
@@ -452,7 +452,7 @@
                   "setCurrentClientCertDetails": {
                     "uri": true
                   },
-                  "statPrefix": "localhost_8080",
+                  "statPrefix": "",
                   "streamIdleTimeout": "3600s"
                 }
               }
@@ -527,7 +527,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": "inbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -553,7 +553,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": "inbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -579,7 +579,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
-                  "statPrefix": "envoyconfig_demo-client__kuma-3_msvc_3000"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -641,7 +641,7 @@
                       }
                     ]
                   },
-                  "statPrefix": "envoyconfig_test-server__kuma-3_msvc_80"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -670,7 +670,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": "outbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -695,7 +695,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": "outbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshratelimit/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshratelimit/inbound.test-server.golden.json
@@ -7,7 +7,7 @@
         "name": "envoy.filters.http.local_ratelimit",
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit",
-          "statPrefix": ""
+          "statPrefix": "STAT_PREFIX_REDACTED"
         }
       }
     },
@@ -38,7 +38,7 @@
               }
             }
           ],
-          "statPrefix": "",
+          "statPrefix": "STAT_PREFIX_REDACTED",
           "status": {
             "code": "Locked"
           },
@@ -378,7 +378,7 @@
                       "name": "envoy.filters.http.local_ratelimit",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit",
-                        "statPrefix": ""
+                        "statPrefix": "STAT_PREFIX_REDACTED"
                       }
                     },
                     {
@@ -433,7 +433,7 @@
                                     }
                                   }
                                 ],
-                                "statPrefix": "",
+                                "statPrefix": "STAT_PREFIX_REDACTED",
                                 "status": {
                                   "code": "Locked"
                                 },
@@ -452,7 +452,7 @@
                   "setCurrentClientCertDetails": {
                     "uri": true
                   },
-                  "statPrefix": "",
+                  "statPrefix": "STAT_PREFIX_REDACTED",
                   "streamIdleTimeout": "3600s"
                 }
               }
@@ -527,7 +527,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -553,7 +553,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -579,7 +579,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -641,7 +641,7 @@
                       }
                     ]
                   },
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -670,7 +670,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -695,7 +695,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound-rules-dpp.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound-rules-dpp.demo-client.golden.json
@@ -81,7 +81,7 @@
                   "matchTypedSubjectAltNames": [
                     {
                       "matcher": {
-                        "prefix": "spiffe://envoyconfig/"
+                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }
@@ -301,7 +301,7 @@
                       }
                     }
                   },
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               },
               {
@@ -310,7 +310,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
                   "idleTimeout": "7200s",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ],
@@ -381,7 +381,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -407,7 +407,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -433,7 +433,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -495,7 +495,7 @@
                       }
                     ]
                   },
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -524,7 +524,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -549,7 +549,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound-rules-dpp.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound-rules-dpp.demo-client.golden.json
@@ -10,6 +10,46 @@
           }
         },
         "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/demo-client"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a65abe81bca1750d1.demo-client.3000.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -28,6 +68,46 @@
           }
         },
         "name": "envoyconfig_test-server__kuma-3_msvc_80",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/test-server"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a029781856823048e.test-server.80.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -202,6 +282,29 @@
           {
             "filters": [
               {
+                "name": "envoy.filters.network.rbac",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+                  "rules": {
+                    "policies": {
+                      "MeshTrafficPermission": {
+                        "permissions": [
+                          {
+                            "any": true
+                          }
+                        ],
+                        "principals": [
+                          {
+                            "any": true
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "statPrefix": "inbound_172_10_0_13_3000."
+                }
+              },
+              {
                 "name": "envoy.filters.network.tcp_proxy",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
@@ -210,7 +313,44 @@
                   "statPrefix": "localhost_3000"
                 }
               }
-            ]
+            ],
+            "transportSocket": {
+              "name": "envoy.transport_sockets.tls",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+                "commonTlsContext": {
+                  "combinedValidationContext": {
+                    "defaultValidationContext": {
+                      "matchTypedSubjectAltNames": [
+                        {
+                          "matcher": {
+                            "prefix": "spiffe://envoyconfig/"
+                          },
+                          "sanType": "URI"
+                        }
+                      ]
+                    },
+                    "validationContextSdsSecretConfig": {
+                      "name": "mesh_ca:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  },
+                  "tlsCertificateSdsSecretConfigs": [
+                    {
+                      "name": "identity_cert:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  ]
+                },
+                "requireClientCertificate": true
+              }
+            }
           }
         ],
         "metadata": {
@@ -418,6 +558,27 @@
         "name": "outbound:passthrough:ipv6",
         "trafficDirection": "OUTBOUND",
         "useOriginalDst": true
+      }
+    },
+    "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret": {
+      "identity_cert:secret:envoyconfig": {
+        "name": "identity_cert:secret:envoyconfig",
+        "tlsCertificate": {
+          "certificateChain": {
+            "inlineBytes": "Q0VSVA=="
+          },
+          "privateKey": {
+            "inlineBytes": "S0VZ"
+          }
+        }
+      },
+      "mesh_ca:secret:envoyconfig": {
+        "name": "mesh_ca:secret:envoyconfig",
+        "validationContext": {
+          "trustedCa": {
+            "inlineBytes": "Q0E="
+          }
+        }
       }
     }
   }

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound-rules-dpp.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound-rules-dpp.demo-client.golden.json
@@ -81,7 +81,7 @@
                   "matchTypedSubjectAltNames": [
                     {
                       "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
+                        "prefix": "spiffe://envoyconfig/"
                       },
                       "sanType": "URI"
                     }
@@ -301,7 +301,7 @@
                       }
                     }
                   },
-                  "statPrefix": "inbound_172_10_0_13_3000."
+                  "statPrefix": ""
                 }
               },
               {
@@ -310,7 +310,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
                   "idleTimeout": "7200s",
-                  "statPrefix": "localhost_3000"
+                  "statPrefix": ""
                 }
               }
             ],
@@ -381,7 +381,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": "inbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -407,7 +407,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": "inbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -433,7 +433,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
-                  "statPrefix": "envoyconfig_demo-client__kuma-3_msvc_3000"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -495,7 +495,7 @@
                       }
                     ]
                   },
-                  "statPrefix": "envoyconfig_test-server__kuma-3_msvc_80"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -524,7 +524,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": "outbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -549,7 +549,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": "outbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound-rules-dpp.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound-rules-dpp.test-server.golden.json
@@ -195,7 +195,7 @@
                   "matchTypedSubjectAltNames": [
                     {
                       "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
+                        "prefix": "spiffe://envoyconfig/"
                       },
                       "sanType": "URI"
                     }
@@ -482,7 +482,7 @@
                   "setCurrentClientCertDetails": {
                     "uri": true
                   },
-                  "statPrefix": "localhost_8080",
+                  "statPrefix": "",
                   "streamIdleTimeout": "3600s"
                 }
               }
@@ -557,7 +557,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": "inbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -583,7 +583,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": "inbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -610,7 +610,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
                   "idleTimeout": "3600s",
-                  "statPrefix": "envoyconfig_demo-client__kuma-3_msvc_3000"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -677,7 +677,7 @@
                       }
                     ]
                   },
-                  "statPrefix": "envoyconfig_test-server__kuma-3_msvc_80"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -706,7 +706,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": "outbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -731,7 +731,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": "outbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound-rules-dpp.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound-rules-dpp.test-server.golden.json
@@ -123,6 +123,46 @@
           }
         },
         "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/demo-client"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a65abe81bca1750d1.demo-client.3000.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -142,6 +182,46 @@
           }
         },
         "name": "envoyconfig_test-server__kuma-3_msvc_80",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/test-server"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a029781856823048e.test-server.80.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -343,6 +423,28 @@
                   "forwardClientCertDetails": "SANITIZE_SET",
                   "httpFilters": [
                     {
+                      "name": "envoy.filters.http.rbac",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+                        "rules": {
+                          "policies": {
+                            "MeshTrafficPermission": {
+                              "permissions": [
+                                {
+                                  "any": true
+                                }
+                              ],
+                              "principals": [
+                                {
+                                  "any": true
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
                       "name": "envoy.filters.http.router",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
@@ -384,7 +486,44 @@
                   "streamIdleTimeout": "3600s"
                 }
               }
-            ]
+            ],
+            "transportSocket": {
+              "name": "envoy.transport_sockets.tls",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+                "commonTlsContext": {
+                  "combinedValidationContext": {
+                    "defaultValidationContext": {
+                      "matchTypedSubjectAltNames": [
+                        {
+                          "matcher": {
+                            "prefix": "spiffe://envoyconfig/"
+                          },
+                          "sanType": "URI"
+                        }
+                      ]
+                    },
+                    "validationContextSdsSecretConfig": {
+                      "name": "mesh_ca:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  },
+                  "tlsCertificateSdsSecretConfigs": [
+                    {
+                      "name": "identity_cert:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  ]
+                },
+                "requireClientCertificate": true
+              }
+            }
           }
         ],
         "metadata": {
@@ -601,6 +740,27 @@
         "name": "outbound:passthrough:ipv6",
         "trafficDirection": "OUTBOUND",
         "useOriginalDst": true
+      }
+    },
+    "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret": {
+      "identity_cert:secret:envoyconfig": {
+        "name": "identity_cert:secret:envoyconfig",
+        "tlsCertificate": {
+          "certificateChain": {
+            "inlineBytes": "Q0VSVA=="
+          },
+          "privateKey": {
+            "inlineBytes": "S0VZ"
+          }
+        }
+      },
+      "mesh_ca:secret:envoyconfig": {
+        "name": "mesh_ca:secret:envoyconfig",
+        "validationContext": {
+          "trustedCa": {
+            "inlineBytes": "Q0E="
+          }
+        }
       }
     }
   }

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound-rules-dpp.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound-rules-dpp.test-server.golden.json
@@ -195,7 +195,7 @@
                   "matchTypedSubjectAltNames": [
                     {
                       "matcher": {
-                        "prefix": "spiffe://envoyconfig/"
+                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }
@@ -482,7 +482,7 @@
                   "setCurrentClientCertDetails": {
                     "uri": true
                   },
-                  "statPrefix": "",
+                  "statPrefix": "STAT_PREFIX_REDACTED",
                   "streamIdleTimeout": "3600s"
                 }
               }
@@ -557,7 +557,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -583,7 +583,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -610,7 +610,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
                   "idleTimeout": "3600s",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -677,7 +677,7 @@
                       }
                     ]
                   },
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -706,7 +706,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -731,7 +731,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound-rules.demo-client.golden.json
@@ -155,7 +155,7 @@
                   "matchTypedSubjectAltNames": [
                     {
                       "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
+                        "prefix": "spiffe://envoyconfig/"
                       },
                       "sanType": "URI"
                     }
@@ -380,7 +380,7 @@
                       }
                     }
                   },
-                  "statPrefix": "inbound_172_10_0_13_3000."
+                  "statPrefix": ""
                 }
               },
               {
@@ -389,7 +389,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
                   "idleTimeout": "50s",
-                  "statPrefix": "localhost_3000"
+                  "statPrefix": ""
                 }
               }
             ],
@@ -460,7 +460,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": "inbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -486,7 +486,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": "inbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -513,7 +513,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
                   "idleTimeout": "3600s",
-                  "statPrefix": "envoyconfig_demo-client__kuma-3_msvc_3000"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -580,7 +580,7 @@
                       }
                     ]
                   },
-                  "statPrefix": "envoyconfig_test-server__kuma-3_msvc_80"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -609,7 +609,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": "outbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -634,7 +634,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": "outbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound-rules.demo-client.golden.json
@@ -155,7 +155,7 @@
                   "matchTypedSubjectAltNames": [
                     {
                       "matcher": {
-                        "prefix": "spiffe://envoyconfig/"
+                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }
@@ -380,7 +380,7 @@
                       }
                     }
                   },
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               },
               {
@@ -389,7 +389,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
                   "idleTimeout": "50s",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ],
@@ -460,7 +460,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -486,7 +486,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -513,7 +513,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
                   "idleTimeout": "3600s",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -580,7 +580,7 @@
                       }
                     ]
                   },
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -609,7 +609,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -634,7 +634,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound-rules.demo-client.golden.json
@@ -31,12 +31,12 @@
     },
     {
       "op": "remove",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:3000/filterChains/0/filters/0/typedConfig/idleTimeout",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:3000/filterChains/0/filters/1/typedConfig/idleTimeout",
       "value": "7200s"
     },
     {
       "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:3000/filterChains/0/filters/0/typedConfig/idleTimeout",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:3000/filterChains/0/filters/1/typedConfig/idleTimeout",
       "value": "50s"
     },
     {
@@ -83,6 +83,46 @@
           }
         },
         "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/demo-client"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a65abe81bca1750d1.demo-client.3000.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -102,6 +142,46 @@
           }
         },
         "name": "envoyconfig_test-server__kuma-3_msvc_80",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/test-server"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a029781856823048e.test-server.80.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -281,6 +361,29 @@
           {
             "filters": [
               {
+                "name": "envoy.filters.network.rbac",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+                  "rules": {
+                    "policies": {
+                      "MeshTrafficPermission": {
+                        "permissions": [
+                          {
+                            "any": true
+                          }
+                        ],
+                        "principals": [
+                          {
+                            "any": true
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "statPrefix": "inbound_172_10_0_13_3000."
+                }
+              },
+              {
                 "name": "envoy.filters.network.tcp_proxy",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
@@ -289,7 +392,44 @@
                   "statPrefix": "localhost_3000"
                 }
               }
-            ]
+            ],
+            "transportSocket": {
+              "name": "envoy.transport_sockets.tls",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+                "commonTlsContext": {
+                  "combinedValidationContext": {
+                    "defaultValidationContext": {
+                      "matchTypedSubjectAltNames": [
+                        {
+                          "matcher": {
+                            "prefix": "spiffe://envoyconfig/"
+                          },
+                          "sanType": "URI"
+                        }
+                      ]
+                    },
+                    "validationContextSdsSecretConfig": {
+                      "name": "mesh_ca:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  },
+                  "tlsCertificateSdsSecretConfigs": [
+                    {
+                      "name": "identity_cert:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  ]
+                },
+                "requireClientCertificate": true
+              }
+            }
           }
         ],
         "metadata": {
@@ -503,6 +643,27 @@
         "name": "outbound:passthrough:ipv6",
         "trafficDirection": "OUTBOUND",
         "useOriginalDst": true
+      }
+    },
+    "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret": {
+      "identity_cert:secret:envoyconfig": {
+        "name": "identity_cert:secret:envoyconfig",
+        "tlsCertificate": {
+          "certificateChain": {
+            "inlineBytes": "Q0VSVA=="
+          },
+          "privateKey": {
+            "inlineBytes": "S0VZ"
+          }
+        }
+      },
+      "mesh_ca:secret:envoyconfig": {
+        "name": "mesh_ca:secret:envoyconfig",
+        "validationContext": {
+          "trustedCa": {
+            "inlineBytes": "Q0E="
+          }
+        }
       }
     }
   }

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound-rules.test-server.golden.json
@@ -195,7 +195,7 @@
                   "matchTypedSubjectAltNames": [
                     {
                       "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
+                        "prefix": "spiffe://envoyconfig/"
                       },
                       "sanType": "URI"
                     }
@@ -482,7 +482,7 @@
                   "setCurrentClientCertDetails": {
                     "uri": true
                   },
-                  "statPrefix": "localhost_8080",
+                  "statPrefix": "",
                   "streamIdleTimeout": "3600s"
                 }
               }
@@ -557,7 +557,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": "inbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -583,7 +583,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": "inbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -610,7 +610,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
                   "idleTimeout": "3600s",
-                  "statPrefix": "envoyconfig_demo-client__kuma-3_msvc_3000"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -677,7 +677,7 @@
                       }
                     ]
                   },
-                  "statPrefix": "envoyconfig_test-server__kuma-3_msvc_80"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -706,7 +706,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": "outbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -731,7 +731,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": "outbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound-rules.test-server.golden.json
@@ -123,6 +123,46 @@
           }
         },
         "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/demo-client"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a65abe81bca1750d1.demo-client.3000.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -142,6 +182,46 @@
           }
         },
         "name": "envoyconfig_test-server__kuma-3_msvc_80",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/test-server"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a029781856823048e.test-server.80.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -343,6 +423,28 @@
                   "forwardClientCertDetails": "SANITIZE_SET",
                   "httpFilters": [
                     {
+                      "name": "envoy.filters.http.rbac",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+                        "rules": {
+                          "policies": {
+                            "MeshTrafficPermission": {
+                              "permissions": [
+                                {
+                                  "any": true
+                                }
+                              ],
+                              "principals": [
+                                {
+                                  "any": true
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
                       "name": "envoy.filters.http.router",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
@@ -384,7 +486,44 @@
                   "streamIdleTimeout": "3600s"
                 }
               }
-            ]
+            ],
+            "transportSocket": {
+              "name": "envoy.transport_sockets.tls",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+                "commonTlsContext": {
+                  "combinedValidationContext": {
+                    "defaultValidationContext": {
+                      "matchTypedSubjectAltNames": [
+                        {
+                          "matcher": {
+                            "prefix": "spiffe://envoyconfig/"
+                          },
+                          "sanType": "URI"
+                        }
+                      ]
+                    },
+                    "validationContextSdsSecretConfig": {
+                      "name": "mesh_ca:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  },
+                  "tlsCertificateSdsSecretConfigs": [
+                    {
+                      "name": "identity_cert:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  ]
+                },
+                "requireClientCertificate": true
+              }
+            }
           }
         ],
         "metadata": {
@@ -601,6 +740,27 @@
         "name": "outbound:passthrough:ipv6",
         "trafficDirection": "OUTBOUND",
         "useOriginalDst": true
+      }
+    },
+    "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret": {
+      "identity_cert:secret:envoyconfig": {
+        "name": "identity_cert:secret:envoyconfig",
+        "tlsCertificate": {
+          "certificateChain": {
+            "inlineBytes": "Q0VSVA=="
+          },
+          "privateKey": {
+            "inlineBytes": "S0VZ"
+          }
+        }
+      },
+      "mesh_ca:secret:envoyconfig": {
+        "name": "mesh_ca:secret:envoyconfig",
+        "validationContext": {
+          "trustedCa": {
+            "inlineBytes": "Q0E="
+          }
+        }
       }
     }
   }

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound-rules.test-server.golden.json
@@ -195,7 +195,7 @@
                   "matchTypedSubjectAltNames": [
                     {
                       "matcher": {
-                        "prefix": "spiffe://envoyconfig/"
+                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }
@@ -482,7 +482,7 @@
                   "setCurrentClientCertDetails": {
                     "uri": true
                   },
-                  "statPrefix": "",
+                  "statPrefix": "STAT_PREFIX_REDACTED",
                   "streamIdleTimeout": "3600s"
                 }
               }
@@ -557,7 +557,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -583,7 +583,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -610,7 +610,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
                   "idleTimeout": "3600s",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -677,7 +677,7 @@
                       }
                     ]
                   },
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -706,7 +706,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -731,7 +731,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound.demo-client.golden.json
@@ -380,7 +380,7 @@
                       }
                     }
                   },
-                  "statPrefix": "inbound_172_10_0_13_3000."
+                  "statPrefix": ""
                 }
               },
               {
@@ -389,7 +389,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
                   "idleTimeout": "50s",
-                  "statPrefix": "localhost_3000"
+                  "statPrefix": ""
                 }
               }
             ],
@@ -460,7 +460,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": "inbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -486,7 +486,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": "inbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -513,7 +513,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
                   "idleTimeout": "3600s",
-                  "statPrefix": "envoyconfig_demo-client__kuma-3_msvc_3000"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -580,7 +580,7 @@
                       }
                     ]
                   },
-                  "statPrefix": "envoyconfig_test-server__kuma-3_msvc_80"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -609,7 +609,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": "outbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -634,7 +634,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": "outbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound.demo-client.golden.json
@@ -380,7 +380,7 @@
                       }
                     }
                   },
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               },
               {
@@ -389,7 +389,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
                   "idleTimeout": "50s",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ],
@@ -460,7 +460,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -486,7 +486,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -513,7 +513,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
                   "idleTimeout": "3600s",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -580,7 +580,7 @@
                       }
                     ]
                   },
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -609,7 +609,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -634,7 +634,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound.demo-client.golden.json
@@ -31,12 +31,12 @@
     },
     {
       "op": "remove",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:3000/filterChains/0/filters/0/typedConfig/idleTimeout",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:3000/filterChains/0/filters/1/typedConfig/idleTimeout",
       "value": "7200s"
     },
     {
       "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:3000/filterChains/0/filters/0/typedConfig/idleTimeout",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:3000/filterChains/0/filters/1/typedConfig/idleTimeout",
       "value": "50s"
     },
     {
@@ -83,6 +83,46 @@
           }
         },
         "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/demo-client"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a65abe81bca1750d1.demo-client.3000.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -102,6 +142,46 @@
           }
         },
         "name": "envoyconfig_test-server__kuma-3_msvc_80",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/test-server"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a029781856823048e.test-server.80.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -281,6 +361,29 @@
           {
             "filters": [
               {
+                "name": "envoy.filters.network.rbac",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+                  "rules": {
+                    "policies": {
+                      "MeshTrafficPermission": {
+                        "permissions": [
+                          {
+                            "any": true
+                          }
+                        ],
+                        "principals": [
+                          {
+                            "any": true
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "statPrefix": "inbound_172_10_0_13_3000."
+                }
+              },
+              {
                 "name": "envoy.filters.network.tcp_proxy",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
@@ -289,7 +392,44 @@
                   "statPrefix": "localhost_3000"
                 }
               }
-            ]
+            ],
+            "transportSocket": {
+              "name": "envoy.transport_sockets.tls",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+                "commonTlsContext": {
+                  "combinedValidationContext": {
+                    "defaultValidationContext": {
+                      "matchTypedSubjectAltNames": [
+                        {
+                          "matcher": {
+                            "prefix": "spiffe://envoyconfig/"
+                          },
+                          "sanType": "URI"
+                        }
+                      ]
+                    },
+                    "validationContextSdsSecretConfig": {
+                      "name": "mesh_ca:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  },
+                  "tlsCertificateSdsSecretConfigs": [
+                    {
+                      "name": "identity_cert:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  ]
+                },
+                "requireClientCertificate": true
+              }
+            }
           }
         ],
         "metadata": {
@@ -503,6 +643,27 @@
         "name": "outbound:passthrough:ipv6",
         "trafficDirection": "OUTBOUND",
         "useOriginalDst": true
+      }
+    },
+    "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret": {
+      "identity_cert:secret:envoyconfig": {
+        "name": "identity_cert:secret:envoyconfig",
+        "tlsCertificate": {
+          "certificateChain": {
+            "inlineBytes": "Q0VSVA=="
+          },
+          "privateKey": {
+            "inlineBytes": "S0VZ"
+          }
+        }
+      },
+      "mesh_ca:secret:envoyconfig": {
+        "name": "mesh_ca:secret:envoyconfig",
+        "validationContext": {
+          "trustedCa": {
+            "inlineBytes": "Q0E="
+          }
+        }
       }
     }
   }

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound.test-server.golden.json
@@ -482,7 +482,7 @@
                   "setCurrentClientCertDetails": {
                     "uri": true
                   },
-                  "statPrefix": "localhost_8080",
+                  "statPrefix": "",
                   "streamIdleTimeout": "3600s"
                 }
               }
@@ -557,7 +557,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": "inbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -583,7 +583,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": "inbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -610,7 +610,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
                   "idleTimeout": "3600s",
-                  "statPrefix": "envoyconfig_demo-client__kuma-3_msvc_3000"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -677,7 +677,7 @@
                       }
                     ]
                   },
-                  "statPrefix": "envoyconfig_test-server__kuma-3_msvc_80"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -706,7 +706,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": "outbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -731,7 +731,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": "outbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound.test-server.golden.json
@@ -123,6 +123,46 @@
           }
         },
         "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/demo-client"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a65abe81bca1750d1.demo-client.3000.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -142,6 +182,46 @@
           }
         },
         "name": "envoyconfig_test-server__kuma-3_msvc_80",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/test-server"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a029781856823048e.test-server.80.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -343,6 +423,28 @@
                   "forwardClientCertDetails": "SANITIZE_SET",
                   "httpFilters": [
                     {
+                      "name": "envoy.filters.http.rbac",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+                        "rules": {
+                          "policies": {
+                            "MeshTrafficPermission": {
+                              "permissions": [
+                                {
+                                  "any": true
+                                }
+                              ],
+                              "principals": [
+                                {
+                                  "any": true
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
                       "name": "envoy.filters.http.router",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
@@ -384,7 +486,44 @@
                   "streamIdleTimeout": "3600s"
                 }
               }
-            ]
+            ],
+            "transportSocket": {
+              "name": "envoy.transport_sockets.tls",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+                "commonTlsContext": {
+                  "combinedValidationContext": {
+                    "defaultValidationContext": {
+                      "matchTypedSubjectAltNames": [
+                        {
+                          "matcher": {
+                            "prefix": "spiffe://envoyconfig/"
+                          },
+                          "sanType": "URI"
+                        }
+                      ]
+                    },
+                    "validationContextSdsSecretConfig": {
+                      "name": "mesh_ca:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  },
+                  "tlsCertificateSdsSecretConfigs": [
+                    {
+                      "name": "identity_cert:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  ]
+                },
+                "requireClientCertificate": true
+              }
+            }
           }
         ],
         "metadata": {
@@ -601,6 +740,27 @@
         "name": "outbound:passthrough:ipv6",
         "trafficDirection": "OUTBOUND",
         "useOriginalDst": true
+      }
+    },
+    "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret": {
+      "identity_cert:secret:envoyconfig": {
+        "name": "identity_cert:secret:envoyconfig",
+        "tlsCertificate": {
+          "certificateChain": {
+            "inlineBytes": "Q0VSVA=="
+          },
+          "privateKey": {
+            "inlineBytes": "S0VZ"
+          }
+        }
+      },
+      "mesh_ca:secret:envoyconfig": {
+        "name": "mesh_ca:secret:envoyconfig",
+        "validationContext": {
+          "trustedCa": {
+            "inlineBytes": "Q0E="
+          }
+        }
       }
     }
   }

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/inbound.test-server.golden.json
@@ -482,7 +482,7 @@
                   "setCurrentClientCertDetails": {
                     "uri": true
                   },
-                  "statPrefix": "",
+                  "statPrefix": "STAT_PREFIX_REDACTED",
                   "streamIdleTimeout": "3600s"
                 }
               }
@@ -557,7 +557,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -583,7 +583,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -610,7 +610,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
                   "idleTimeout": "3600s",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -677,7 +677,7 @@
                       }
                     ]
                   },
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -706,7 +706,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -731,7 +731,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/no-policies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/no-policies.demo-client.golden.json
@@ -301,7 +301,7 @@
                       }
                     }
                   },
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               },
               {
@@ -310,7 +310,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
                   "idleTimeout": "7200s",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ],
@@ -381,7 +381,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -407,7 +407,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -433,7 +433,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -495,7 +495,7 @@
                       }
                     ]
                   },
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -524,7 +524,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -549,7 +549,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/no-policies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/no-policies.demo-client.golden.json
@@ -301,7 +301,7 @@
                       }
                     }
                   },
-                  "statPrefix": "inbound_172_10_0_13_3000."
+                  "statPrefix": ""
                 }
               },
               {
@@ -310,7 +310,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
                   "idleTimeout": "7200s",
-                  "statPrefix": "localhost_3000"
+                  "statPrefix": ""
                 }
               }
             ],
@@ -381,7 +381,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": "inbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -407,7 +407,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": "inbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -433,7 +433,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
-                  "statPrefix": "envoyconfig_demo-client__kuma-3_msvc_3000"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -495,7 +495,7 @@
                       }
                     ]
                   },
-                  "statPrefix": "envoyconfig_test-server__kuma-3_msvc_80"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -524,7 +524,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": "outbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -549,7 +549,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": "outbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/no-policies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/no-policies.demo-client.golden.json
@@ -10,6 +10,46 @@
           }
         },
         "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/demo-client"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a65abe81bca1750d1.demo-client.3000.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -28,6 +68,46 @@
           }
         },
         "name": "envoyconfig_test-server__kuma-3_msvc_80",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/test-server"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a029781856823048e.test-server.80.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -202,6 +282,29 @@
           {
             "filters": [
               {
+                "name": "envoy.filters.network.rbac",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+                  "rules": {
+                    "policies": {
+                      "MeshTrafficPermission": {
+                        "permissions": [
+                          {
+                            "any": true
+                          }
+                        ],
+                        "principals": [
+                          {
+                            "any": true
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "statPrefix": "inbound_172_10_0_13_3000."
+                }
+              },
+              {
                 "name": "envoy.filters.network.tcp_proxy",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
@@ -210,7 +313,44 @@
                   "statPrefix": "localhost_3000"
                 }
               }
-            ]
+            ],
+            "transportSocket": {
+              "name": "envoy.transport_sockets.tls",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+                "commonTlsContext": {
+                  "combinedValidationContext": {
+                    "defaultValidationContext": {
+                      "matchTypedSubjectAltNames": [
+                        {
+                          "matcher": {
+                            "prefix": "spiffe://envoyconfig/"
+                          },
+                          "sanType": "URI"
+                        }
+                      ]
+                    },
+                    "validationContextSdsSecretConfig": {
+                      "name": "mesh_ca:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  },
+                  "tlsCertificateSdsSecretConfigs": [
+                    {
+                      "name": "identity_cert:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  ]
+                },
+                "requireClientCertificate": true
+              }
+            }
           }
         ],
         "metadata": {
@@ -418,6 +558,27 @@
         "name": "outbound:passthrough:ipv6",
         "trafficDirection": "OUTBOUND",
         "useOriginalDst": true
+      }
+    },
+    "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret": {
+      "identity_cert:secret:envoyconfig": {
+        "name": "identity_cert:secret:envoyconfig",
+        "tlsCertificate": {
+          "certificateChain": {
+            "inlineBytes": "Q0VSVA=="
+          },
+          "privateKey": {
+            "inlineBytes": "S0VZ"
+          }
+        }
+      },
+      "mesh_ca:secret:envoyconfig": {
+        "name": "mesh_ca:secret:envoyconfig",
+        "validationContext": {
+          "trustedCa": {
+            "inlineBytes": "Q0E="
+          }
+        }
       }
     }
   }

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/no-policies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/no-policies.test-server.golden.json
@@ -10,6 +10,46 @@
           }
         },
         "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/demo-client"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a65abe81bca1750d1.demo-client.3000.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -28,6 +68,46 @@
           }
         },
         "name": "envoyconfig_test-server__kuma-3_msvc_80",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/test-server"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a029781856823048e.test-server.80.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -222,6 +302,28 @@
                   "forwardClientCertDetails": "SANITIZE_SET",
                   "httpFilters": [
                     {
+                      "name": "envoy.filters.http.rbac",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+                        "rules": {
+                          "policies": {
+                            "MeshTrafficPermission": {
+                              "permissions": [
+                                {
+                                  "any": true
+                                }
+                              ],
+                              "principals": [
+                                {
+                                  "any": true
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
                       "name": "envoy.filters.http.router",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
@@ -261,7 +363,44 @@
                   "streamIdleTimeout": "3600s"
                 }
               }
-            ]
+            ],
+            "transportSocket": {
+              "name": "envoy.transport_sockets.tls",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+                "commonTlsContext": {
+                  "combinedValidationContext": {
+                    "defaultValidationContext": {
+                      "matchTypedSubjectAltNames": [
+                        {
+                          "matcher": {
+                            "prefix": "spiffe://envoyconfig/"
+                          },
+                          "sanType": "URI"
+                        }
+                      ]
+                    },
+                    "validationContextSdsSecretConfig": {
+                      "name": "mesh_ca:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  },
+                  "tlsCertificateSdsSecretConfigs": [
+                    {
+                      "name": "identity_cert:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  ]
+                },
+                "requireClientCertificate": true
+              }
+            }
           }
         ],
         "metadata": {
@@ -472,6 +611,27 @@
         "name": "outbound:passthrough:ipv6",
         "trafficDirection": "OUTBOUND",
         "useOriginalDst": true
+      }
+    },
+    "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret": {
+      "identity_cert:secret:envoyconfig": {
+        "name": "identity_cert:secret:envoyconfig",
+        "tlsCertificate": {
+          "certificateChain": {
+            "inlineBytes": "Q0VSVA=="
+          },
+          "privateKey": {
+            "inlineBytes": "S0VZ"
+          }
+        }
+      },
+      "mesh_ca:secret:envoyconfig": {
+        "name": "mesh_ca:secret:envoyconfig",
+        "validationContext": {
+          "trustedCa": {
+            "inlineBytes": "Q0E="
+          }
+        }
       }
     }
   }

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/no-policies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/no-policies.test-server.golden.json
@@ -359,7 +359,7 @@
                   "setCurrentClientCertDetails": {
                     "uri": true
                   },
-                  "statPrefix": "localhost_8080",
+                  "statPrefix": "",
                   "streamIdleTimeout": "3600s"
                 }
               }
@@ -434,7 +434,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": "inbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -460,7 +460,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": "inbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -486,7 +486,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
-                  "statPrefix": "envoyconfig_demo-client__kuma-3_msvc_3000"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -548,7 +548,7 @@
                       }
                     ]
                   },
-                  "statPrefix": "envoyconfig_test-server__kuma-3_msvc_80"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -577,7 +577,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": "outbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -602,7 +602,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": "outbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/no-policies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/no-policies.test-server.golden.json
@@ -359,7 +359,7 @@
                   "setCurrentClientCertDetails": {
                     "uri": true
                   },
-                  "statPrefix": "",
+                  "statPrefix": "STAT_PREFIX_REDACTED",
                   "streamIdleTimeout": "3600s"
                 }
               }
@@ -434,7 +434,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -460,7 +460,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -486,7 +486,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -548,7 +548,7 @@
                       }
                     ]
                   },
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -577,7 +577,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -602,7 +602,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/outbound.demo-client.golden.json
@@ -380,7 +380,7 @@
                       }
                     }
                   },
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               },
               {
@@ -389,7 +389,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
                   "idleTimeout": "3600s",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ],
@@ -460,7 +460,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -486,7 +486,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -513,7 +513,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
                   "idleTimeout": "3600s",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -580,7 +580,7 @@
                       }
                     ]
                   },
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -609,7 +609,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -634,7 +634,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/outbound.demo-client.golden.json
@@ -31,12 +31,12 @@
     },
     {
       "op": "remove",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:3000/filterChains/0/filters/0/typedConfig/idleTimeout",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:3000/filterChains/0/filters/1/typedConfig/idleTimeout",
       "value": "7200s"
     },
     {
       "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:3000/filterChains/0/filters/0/typedConfig/idleTimeout",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:3000/filterChains/0/filters/1/typedConfig/idleTimeout",
       "value": "3600s"
     },
     {
@@ -83,6 +83,46 @@
           }
         },
         "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/demo-client"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a65abe81bca1750d1.demo-client.3000.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -102,6 +142,46 @@
           }
         },
         "name": "envoyconfig_test-server__kuma-3_msvc_80",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/test-server"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a029781856823048e.test-server.80.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -281,6 +361,29 @@
           {
             "filters": [
               {
+                "name": "envoy.filters.network.rbac",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+                  "rules": {
+                    "policies": {
+                      "MeshTrafficPermission": {
+                        "permissions": [
+                          {
+                            "any": true
+                          }
+                        ],
+                        "principals": [
+                          {
+                            "any": true
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "statPrefix": "inbound_172_10_0_13_3000."
+                }
+              },
+              {
                 "name": "envoy.filters.network.tcp_proxy",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
@@ -289,7 +392,44 @@
                   "statPrefix": "localhost_3000"
                 }
               }
-            ]
+            ],
+            "transportSocket": {
+              "name": "envoy.transport_sockets.tls",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+                "commonTlsContext": {
+                  "combinedValidationContext": {
+                    "defaultValidationContext": {
+                      "matchTypedSubjectAltNames": [
+                        {
+                          "matcher": {
+                            "prefix": "spiffe://envoyconfig/"
+                          },
+                          "sanType": "URI"
+                        }
+                      ]
+                    },
+                    "validationContextSdsSecretConfig": {
+                      "name": "mesh_ca:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  },
+                  "tlsCertificateSdsSecretConfigs": [
+                    {
+                      "name": "identity_cert:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  ]
+                },
+                "requireClientCertificate": true
+              }
+            }
           }
         ],
         "metadata": {
@@ -503,6 +643,27 @@
         "name": "outbound:passthrough:ipv6",
         "trafficDirection": "OUTBOUND",
         "useOriginalDst": true
+      }
+    },
+    "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret": {
+      "identity_cert:secret:envoyconfig": {
+        "name": "identity_cert:secret:envoyconfig",
+        "tlsCertificate": {
+          "certificateChain": {
+            "inlineBytes": "Q0VSVA=="
+          },
+          "privateKey": {
+            "inlineBytes": "S0VZ"
+          }
+        }
+      },
+      "mesh_ca:secret:envoyconfig": {
+        "name": "mesh_ca:secret:envoyconfig",
+        "validationContext": {
+          "trustedCa": {
+            "inlineBytes": "Q0E="
+          }
+        }
       }
     }
   }

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/outbound.demo-client.golden.json
@@ -380,7 +380,7 @@
                       }
                     }
                   },
-                  "statPrefix": "inbound_172_10_0_13_3000."
+                  "statPrefix": ""
                 }
               },
               {
@@ -389,7 +389,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
                   "idleTimeout": "3600s",
-                  "statPrefix": "localhost_3000"
+                  "statPrefix": ""
                 }
               }
             ],
@@ -460,7 +460,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": "inbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -486,7 +486,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": "inbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -513,7 +513,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
                   "idleTimeout": "3600s",
-                  "statPrefix": "envoyconfig_demo-client__kuma-3_msvc_3000"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -580,7 +580,7 @@
                       }
                     ]
                   },
-                  "statPrefix": "envoyconfig_test-server__kuma-3_msvc_80"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -609,7 +609,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": "outbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -634,7 +634,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": "outbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/outbound.test-server.golden.json
@@ -482,7 +482,7 @@
                   "setCurrentClientCertDetails": {
                     "uri": true
                   },
-                  "statPrefix": "localhost_8080",
+                  "statPrefix": "",
                   "streamIdleTimeout": "3600s"
                 }
               }
@@ -557,7 +557,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": "inbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -583,7 +583,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": "inbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -610,7 +610,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
                   "idleTimeout": "3600s",
-                  "statPrefix": "envoyconfig_demo-client__kuma-3_msvc_3000"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -677,7 +677,7 @@
                       }
                     ]
                   },
-                  "statPrefix": "envoyconfig_test-server__kuma-3_msvc_80"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -706,7 +706,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": "outbound_passthrough_ipv4"
+                  "statPrefix": ""
                 }
               }
             ]
@@ -731,7 +731,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": "outbound_passthrough_ipv6"
+                  "statPrefix": ""
                 }
               }
             ]

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/outbound.test-server.golden.json
@@ -123,6 +123,46 @@
           }
         },
         "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/demo-client"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a65abe81bca1750d1.demo-client.3000.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -142,6 +182,46 @@
           }
         },
         "name": "envoyconfig_test-server__kuma-3_msvc_80",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/test-server"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a029781856823048e.test-server.80.envoyconfig.ms"
+          }
+        },
         "type": "EDS",
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -343,6 +423,28 @@
                   "forwardClientCertDetails": "SANITIZE_SET",
                   "httpFilters": [
                     {
+                      "name": "envoy.filters.http.rbac",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+                        "rules": {
+                          "policies": {
+                            "MeshTrafficPermission": {
+                              "permissions": [
+                                {
+                                  "any": true
+                                }
+                              ],
+                              "principals": [
+                                {
+                                  "any": true
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
                       "name": "envoy.filters.http.router",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
@@ -384,7 +486,44 @@
                   "streamIdleTimeout": "3600s"
                 }
               }
-            ]
+            ],
+            "transportSocket": {
+              "name": "envoy.transport_sockets.tls",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+                "commonTlsContext": {
+                  "combinedValidationContext": {
+                    "defaultValidationContext": {
+                      "matchTypedSubjectAltNames": [
+                        {
+                          "matcher": {
+                            "prefix": "spiffe://envoyconfig/"
+                          },
+                          "sanType": "URI"
+                        }
+                      ]
+                    },
+                    "validationContextSdsSecretConfig": {
+                      "name": "mesh_ca:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  },
+                  "tlsCertificateSdsSecretConfigs": [
+                    {
+                      "name": "identity_cert:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  ]
+                },
+                "requireClientCertificate": true
+              }
+            }
           }
         ],
         "metadata": {
@@ -601,6 +740,27 @@
         "name": "outbound:passthrough:ipv6",
         "trafficDirection": "OUTBOUND",
         "useOriginalDst": true
+      }
+    },
+    "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret": {
+      "identity_cert:secret:envoyconfig": {
+        "name": "identity_cert:secret:envoyconfig",
+        "tlsCertificate": {
+          "certificateChain": {
+            "inlineBytes": "Q0VSVA=="
+          },
+          "privateKey": {
+            "inlineBytes": "S0VZ"
+          }
+        }
+      },
+      "mesh_ca:secret:envoyconfig": {
+        "name": "mesh_ca:secret:envoyconfig",
+        "validationContext": {
+          "trustedCa": {
+            "inlineBytes": "Q0E="
+          }
+        }
       }
     }
   }

--- a/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/meshtimeout/outbound.test-server.golden.json
@@ -482,7 +482,7 @@
                   "setCurrentClientCertDetails": {
                     "uri": true
                   },
-                  "statPrefix": "",
+                  "statPrefix": "STAT_PREFIX_REDACTED",
                   "streamIdleTimeout": "3600s"
                 }
               }
@@ -557,7 +557,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -583,7 +583,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "inbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -610,7 +610,7 @@
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
                   "idleTimeout": "3600s",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -677,7 +677,7 @@
                       }
                     ]
                   },
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -706,7 +706,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv4",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]
@@ -731,7 +731,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "outbound:passthrough:ipv6",
-                  "statPrefix": ""
+                  "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
             ]


### PR DESCRIPTION
## Motivation

We will need this to test MeshTLS policy

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
