### PR TITLE
fix(api): only mark readonly when status exists

### DIFF
--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -3821,8 +3821,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-        status:
-          readOnly: true
     MeshAccessLogCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -5050,8 +5048,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-        status:
-          readOnly: true
     MeshCircuitBreakerCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -5573,8 +5569,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-        status:
-          readOnly: true
     MeshFaultInjectionCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -6069,8 +6063,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-        status:
-          readOnly: true
     MeshHealthCheckCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -6884,8 +6876,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-        status:
-          readOnly: true
     MeshHTTPRouteCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -7656,8 +7646,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-        status:
-          readOnly: true
     MeshLoadBalancingStrategyCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -7996,8 +7984,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-        status:
-          readOnly: true
     MeshMetricCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -8189,8 +8175,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-        status:
-          readOnly: true
     MeshPassthroughCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -8914,8 +8898,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-        status:
-          readOnly: true
     MeshProxyPatchCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -9511,8 +9493,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-        status:
-          readOnly: true
     MeshRateLimitCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -10166,8 +10146,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-        status:
-          readOnly: true
     MeshRetryCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -10516,8 +10494,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-        status:
-          readOnly: true
     MeshTCPRouteCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -11096,8 +11072,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-        status:
-          readOnly: true
     MeshTimeoutCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -11385,8 +11359,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-        status:
-          readOnly: true
     MeshTLSCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -11743,8 +11715,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-        status:
-          readOnly: true
     MeshTraceCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -11993,8 +11963,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-        status:
-          readOnly: true
     MeshTrafficPermissionCreateOrUpdateSuccessResponse:
       type: object
       properties:
@@ -12817,8 +12785,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-        status:
-          readOnly: true
     HostnameGeneratorCreateOrUpdateSuccessResponse:
       type: object
       properties:

--- a/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/schema.yaml
+++ b/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/schema.yaml
@@ -56,5 +56,3 @@ properties:
     description: 'Time at which the resource was updated'
     format: date-time
     example: '0001-01-01T00:00:00Z'
-  status:
-    readOnly: true

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/schema.yaml
@@ -529,5 +529,3 @@ properties:
     description: 'Time at which the resource was updated'
     format: date-time
     example: '0001-01-01T00:00:00Z'
-  status:
-    readOnly: true

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/schema.yaml
@@ -713,5 +713,3 @@ properties:
     description: 'Time at which the resource was updated'
     format: date-time
     example: '0001-01-01T00:00:00Z'
-  status:
-    readOnly: true

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/schema.yaml
@@ -387,5 +387,3 @@ properties:
     description: 'Time at which the resource was updated'
     format: date-time
     example: '0001-01-01T00:00:00Z'
-  status:
-    readOnly: true

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/schema.yaml
@@ -356,5 +356,3 @@ properties:
     description: 'Time at which the resource was updated'
     format: date-time
     example: '0001-01-01T00:00:00Z'
-  status:
-    readOnly: true

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/schema.yaml
@@ -636,5 +636,3 @@ properties:
     description: 'Time at which the resource was updated'
     format: date-time
     example: '0001-01-01T00:00:00Z'
-  status:
-    readOnly: true

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/schema.yaml
@@ -531,5 +531,3 @@ properties:
     description: 'Time at which the resource was updated'
     format: date-time
     example: '0001-01-01T00:00:00Z'
-  status:
-    readOnly: true

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/schema.yaml
@@ -256,5 +256,3 @@ properties:
     description: 'Time at which the resource was updated'
     format: date-time
     example: '0001-01-01T00:00:00Z'
-  status:
-    readOnly: true

--- a/pkg/plugins/policies/meshpassthrough/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshpassthrough/api/v1alpha1/schema.yaml
@@ -141,5 +141,3 @@ properties:
     description: 'Time at which the resource was updated'
     format: date-time
     example: '0001-01-01T00:00:00Z'
-  status:
-    readOnly: true

--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/schema.yaml
@@ -498,5 +498,3 @@ properties:
     description: 'Time at which the resource was updated'
     format: date-time
     example: '0001-01-01T00:00:00Z'
-  status:
-    readOnly: true

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/schema.yaml
@@ -461,5 +461,3 @@ properties:
     description: 'Time at which the resource was updated'
     format: date-time
     example: '0001-01-01T00:00:00Z'
-  status:
-    readOnly: true

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/schema.yaml
@@ -476,5 +476,3 @@ properties:
     description: 'Time at which the resource was updated'
     format: date-time
     example: '0001-01-01T00:00:00Z'
-  status:
-    readOnly: true

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/schema.yaml
@@ -260,5 +260,3 @@ properties:
     description: 'Time at which the resource was updated'
     format: date-time
     example: '0001-01-01T00:00:00Z'
-  status:
-    readOnly: true

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/schema.yaml
@@ -396,5 +396,3 @@ properties:
     description: 'Time at which the resource was updated'
     format: date-time
     example: '0001-01-01T00:00:00Z'
-  status:
-    readOnly: true

--- a/pkg/plugins/policies/meshtls/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtls/api/v1alpha1/schema.yaml
@@ -215,5 +215,3 @@ properties:
     description: 'Time at which the resource was updated'
     format: date-time
     example: '0001-01-01T00:00:00Z'
-  status:
-    readOnly: true

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/schema.yaml
@@ -262,5 +262,3 @@ properties:
     description: 'Time at which the resource was updated'
     format: date-time
     example: '0001-01-01T00:00:00Z'
-  status:
-    readOnly: true

--- a/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/schema.yaml
@@ -180,5 +180,3 @@ properties:
     description: 'Time at which the resource was updated'
     format: date-time
     example: '0001-01-01T00:00:00Z'
-  status:
-    readOnly: true

--- a/tools/policy-gen/generator/cmd/openapi.go
+++ b/tools/policy-gen/generator/cmd/openapi.go
@@ -72,7 +72,7 @@ func newOpenAPI(rootArgs *args) *cobra.Command {
         | del(.kind)
       ) * {"type": {"enum": [.spec.names.kind]}}
   )
-  | (.properties.status? ) |= . + {"readOnly": true}`, crdPath),
+  | (.properties | select(has("status")).status) |= . + {"readOnly": true}`, crdPath),
 				schemaOutPath,
 			)
 			yqExec.Stderr = cmd.ErrOrStderr()


### PR DESCRIPTION
## Motivation

In https://github.com/kumahq/kuma/pull/12735 I mistakenly added `status.readonly: true` to properties that did not have `status` in the first place.

## Implementation information

Use `select` to filter this out

## Supporting documentation

> Changelog: fix(api): mark read-only fields as readOnly
