### PR TITLE
fix(api): mark warnings as read-only

### DIFF
--- a/api/mesh/v1alpha1/mesh/rest.yaml
+++ b/api/mesh/v1alpha1/mesh/rest.yaml
@@ -95,6 +95,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: |
             warnings is a list of warning messages to return to the requesting Kuma API clients.
             Warning messages describe a problem the client making the API request should correct or be aware of.

--- a/api/mesh/v1alpha1/meshgateway/rest.yaml
+++ b/api/mesh/v1alpha1/meshgateway/rest.yaml
@@ -120,6 +120,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: |
             warnings is a list of warning messages to return to the requesting Kuma API clients.
             Warning messages describe a problem the client making the API request should correct or be aware of.

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -3826,6 +3826,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: >
             warnings is a list of warning messages to return to the requesting
             Kuma API clients.
@@ -5053,6 +5054,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: >
             warnings is a list of warning messages to return to the requesting
             Kuma API clients.
@@ -5574,6 +5576,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: >
             warnings is a list of warning messages to return to the requesting
             Kuma API clients.
@@ -6068,6 +6071,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: >
             warnings is a list of warning messages to return to the requesting
             Kuma API clients.
@@ -6881,6 +6885,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: >
             warnings is a list of warning messages to return to the requesting
             Kuma API clients.
@@ -7651,6 +7656,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: >
             warnings is a list of warning messages to return to the requesting
             Kuma API clients.
@@ -7989,6 +7995,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: >
             warnings is a list of warning messages to return to the requesting
             Kuma API clients.
@@ -8180,6 +8187,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: >
             warnings is a list of warning messages to return to the requesting
             Kuma API clients.
@@ -8903,6 +8911,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: >
             warnings is a list of warning messages to return to the requesting
             Kuma API clients.
@@ -9498,6 +9507,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: >
             warnings is a list of warning messages to return to the requesting
             Kuma API clients.
@@ -10151,6 +10161,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: >
             warnings is a list of warning messages to return to the requesting
             Kuma API clients.
@@ -10499,6 +10510,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: >
             warnings is a list of warning messages to return to the requesting
             Kuma API clients.
@@ -11077,6 +11089,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: >
             warnings is a list of warning messages to return to the requesting
             Kuma API clients.
@@ -11364,6 +11377,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: >
             warnings is a list of warning messages to return to the requesting
             Kuma API clients.
@@ -11720,6 +11734,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: >
             warnings is a list of warning messages to return to the requesting
             Kuma API clients.
@@ -11968,6 +11983,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: >
             warnings is a list of warning messages to return to the requesting
             Kuma API clients.
@@ -12353,6 +12369,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: >
             warnings is a list of warning messages to return to the requesting
             Kuma API clients.
@@ -12712,6 +12729,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: >
             warnings is a list of warning messages to return to the requesting
             Kuma API clients.
@@ -12790,6 +12808,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: >
             warnings is a list of warning messages to return to the requesting
             Kuma API clients.
@@ -13153,6 +13172,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: >
             warnings is a list of warning messages to return to the requesting
             Kuma API clients.
@@ -13372,6 +13392,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: >
             warnings is a list of warning messages to return to the requesting
             Kuma API clients.
@@ -13617,6 +13638,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: >
             warnings is a list of warning messages to return to the requesting
             Kuma API clients.

--- a/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/rest.yaml
@@ -95,6 +95,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: |
             warnings is a list of warning messages to return to the requesting Kuma API clients.
             Warning messages describe a problem the client making the API request should correct or be aware of.

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/rest.yaml
@@ -120,6 +120,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: |
             warnings is a list of warning messages to return to the requesting Kuma API clients.
             Warning messages describe a problem the client making the API request should correct or be aware of.

--- a/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/rest.yaml
@@ -120,6 +120,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: |
             warnings is a list of warning messages to return to the requesting Kuma API clients.
             Warning messages describe a problem the client making the API request should correct or be aware of.

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/rest.yaml
@@ -120,6 +120,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: |
             warnings is a list of warning messages to return to the requesting Kuma API clients.
             Warning messages describe a problem the client making the API request should correct or be aware of.

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/rest.yaml
@@ -120,6 +120,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: |
             warnings is a list of warning messages to return to the requesting Kuma API clients.
             Warning messages describe a problem the client making the API request should correct or be aware of.

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/rest.yaml
@@ -120,6 +120,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: |
             warnings is a list of warning messages to return to the requesting Kuma API clients.
             Warning messages describe a problem the client making the API request should correct or be aware of.

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/rest.yaml
@@ -120,6 +120,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: |
             warnings is a list of warning messages to return to the requesting Kuma API clients.
             Warning messages describe a problem the client making the API request should correct or be aware of.

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/rest.yaml
@@ -120,6 +120,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: |
             warnings is a list of warning messages to return to the requesting Kuma API clients.
             Warning messages describe a problem the client making the API request should correct or be aware of.

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/rest.yaml
@@ -120,6 +120,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: |
             warnings is a list of warning messages to return to the requesting Kuma API clients.
             Warning messages describe a problem the client making the API request should correct or be aware of.

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/rest.yaml
@@ -120,6 +120,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: |
             warnings is a list of warning messages to return to the requesting Kuma API clients.
             Warning messages describe a problem the client making the API request should correct or be aware of.

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/rest.yaml
@@ -120,6 +120,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: |
             warnings is a list of warning messages to return to the requesting Kuma API clients.
             Warning messages describe a problem the client making the API request should correct or be aware of.

--- a/pkg/plugins/policies/meshpassthrough/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshpassthrough/api/v1alpha1/rest.yaml
@@ -120,6 +120,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: |
             warnings is a list of warning messages to return to the requesting Kuma API clients.
             Warning messages describe a problem the client making the API request should correct or be aware of.

--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/rest.yaml
@@ -120,6 +120,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: |
             warnings is a list of warning messages to return to the requesting Kuma API clients.
             Warning messages describe a problem the client making the API request should correct or be aware of.

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/rest.yaml
@@ -120,6 +120,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: |
             warnings is a list of warning messages to return to the requesting Kuma API clients.
             Warning messages describe a problem the client making the API request should correct or be aware of.

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/rest.yaml
@@ -120,6 +120,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: |
             warnings is a list of warning messages to return to the requesting Kuma API clients.
             Warning messages describe a problem the client making the API request should correct or be aware of.

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/rest.yaml
@@ -120,6 +120,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: |
             warnings is a list of warning messages to return to the requesting Kuma API clients.
             Warning messages describe a problem the client making the API request should correct or be aware of.

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/rest.yaml
@@ -120,6 +120,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: |
             warnings is a list of warning messages to return to the requesting Kuma API clients.
             Warning messages describe a problem the client making the API request should correct or be aware of.

--- a/pkg/plugins/policies/meshtls/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtls/api/v1alpha1/rest.yaml
@@ -120,6 +120,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: |
             warnings is a list of warning messages to return to the requesting Kuma API clients.
             Warning messages describe a problem the client making the API request should correct or be aware of.

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/rest.yaml
@@ -120,6 +120,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: |
             warnings is a list of warning messages to return to the requesting Kuma API clients.
             Warning messages describe a problem the client making the API request should correct or be aware of.

--- a/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/rest.yaml
@@ -120,6 +120,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: |
             warnings is a list of warning messages to return to the requesting Kuma API clients.
             Warning messages describe a problem the client making the API request should correct or be aware of.

--- a/tools/openapi/templates/endpoints.yaml
+++ b/tools/openapi/templates/endpoints.yaml
@@ -128,6 +128,7 @@ components:
       properties:
         warnings:
           type: array
+          readOnly: true
           description: |
             warnings is a list of warning messages to return to the requesting Kuma API clients.
             Warning messages describe a problem the client making the API request should correct or be aware of.


### PR DESCRIPTION
## Motivation

Because they are readOnly, you shouldn't update "warnings" yourself. Pretty much the same as https://github.com/kumahq/kuma/pull/12742.

## Implementation information

Add "readOnly" in template.

## Supporting documentation

xrel https://github.com/kumahq/kuma/issues/12734
