### PR TITLE
fix(api-server): return when there is error on delete

### DIFF
--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -515,6 +515,7 @@ func (r *resourceEndpoints) deleteResource(request *restful.Request, response *r
 
 	if err := r.resManager.Delete(request.Request.Context(), resource, store.DeleteByKey(name, meshName)); err != nil {
 		rest_errors.HandleError(request.Request.Context(), response, err, "Could not delete a resource")
+		return
 	}
 
 	resp := api_server_types.DeleteSuccessResponse{}


### PR DESCRIPTION
## Motivation
In the logs I noticed an error

```
http: superfluous response.WriteHeader call from github.com/emicklei/go-restful/v3.(*Response).WriteHeader (response.go:224)
```

After checking the code, I noticed that we don't return on error, which causes execution to continue to the next step, `WriteHeaderAndJson`. Since we call it a second time and it internally calls `WriteHeader`, we encounter the following error.

## Implementation information

Changed the logic to return earlier