### PR TITLE
chore(oapi): add default empty arrays

### DIFF
--- a/api/common/v1alpha1/ref.go
+++ b/api/common/v1alpha1/ref.go
@@ -100,6 +100,7 @@ type TargetRef struct {
 	// ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
 	// all data plane types are targeted by the policy.
 	// +kubebuilder:validation:MinItems=1
+	// +kubebuilder:default={}
 	ProxyTypes []TargetRefProxyType `json:"proxyTypes,omitempty"`
 	// Namespace specifies the namespace of target resource. If empty only resources in policy namespace
 	// will be targeted.

--- a/api/common/v1alpha1/ref.go
+++ b/api/common/v1alpha1/ref.go
@@ -100,7 +100,7 @@ type TargetRef struct {
 	// ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
 	// all data plane types are targeted by the policy.
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:default={}
+	// +kubebuilder:default={Sidecar,Gateway}
 	ProxyTypes []TargetRefProxyType `json:"proxyTypes,omitempty"`
 	// Namespace specifies the namespace of target resource. If empty only resources in policy namespace
 	// will be targeted.

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -297,6 +297,7 @@ spec:
               resource.
             properties:
               endpoints:
+                default: []
                 description: Endpoints defines a list of destinations to send traffic
                   to.
                 items:
@@ -440,6 +441,7 @@ spec:
                           Indicator set by Kuma.
                         type: string
                       subjectAltNames:
+                        default: []
                         description: SubjectAltNames list of names to verify in the
                           certificate.
                         items:
@@ -635,6 +637,7 @@ spec:
               resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -645,6 +648,7 @@ spec:
                         'targetRef'
                       properties:
                         http:
+                          default: []
                           description: Http allows to define list of Http faults between
                             dataplanes.
                           items:
@@ -759,6 +763,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -827,6 +834,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -851,6 +861,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between clients and corresponding
                   configurations
                 items:
@@ -861,6 +872,7 @@ spec:
                         'targetRef'
                       properties:
                         http:
+                          default: []
                           description: Http allows to define list of Http faults between
                             dataplanes.
                           items:
@@ -975,6 +987,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -1784,6 +1799,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -1808,6 +1826,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between the consumed services and
                   corresponding configurations
                 items:
@@ -1877,6 +1896,7 @@ spec:
                               description: If true the HttpHealthCheck is disabled
                               type: boolean
                             expectedStatuses:
+                              default: []
                               description: List of HTTP response statuses which are
                                 considered healthy
                               items:
@@ -1895,6 +1915,7 @@ spec:
                                 request
                               properties:
                                 add:
+                                  default: []
                                   items:
                                     properties:
                                       name:
@@ -1914,6 +1935,7 @@ spec:
                                   - name
                                   x-kubernetes-list-type: map
                                 set:
+                                  default: []
                                   items:
                                     properties:
                                       name:
@@ -1981,6 +2003,7 @@ spec:
                               description: If true the TcpHealthCheck is disabled
                               type: boolean
                             receive:
+                              default: []
                               description: |-
                                 List of Base64 encoded blocks of strings expected as a response. When checking the response,
                                 "fuzzy" matching is performed such that each block must be found, and
@@ -2046,6 +2069,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -2170,6 +2196,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -2194,11 +2223,13 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To matches destination services of requests and holds
                   configuration.
                 items:
                   properties:
                     hostnames:
+                      default: []
                       description: |-
                         Hostnames is only valid when targeting MeshGateway and limits the
                         effects of the rules to requests to this hostname.
@@ -2208,6 +2239,7 @@ spec:
                         type: string
                       type: array
                     rules:
+                      default: []
                       description: |-
                         Rules contains the routing rules applies to a combination of top-level
                         targetRef and the targetRef in this entry.
@@ -2219,6 +2251,7 @@ spec:
                               policies.
                             properties:
                               backendRefs:
+                                default: []
                                 items:
                                   description: BackendRef defines where to forward
                                     traffic.
@@ -2263,6 +2296,9 @@ spec:
                                       format: int32
                                       type: integer
                                     proxyTypes:
+                                      default:
+                                      - Sidecar
+                                      - Gateway
                                       description: |-
                                         ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                         all data plane types are targeted by the policy.
@@ -2292,6 +2328,7 @@ spec:
                                   type: object
                                 type: array
                               filters:
+                                default: []
                                 items:
                                   properties:
                                     requestHeaderModifier:
@@ -2301,6 +2338,7 @@ spec:
                                         header value formatting, separating each value with a comma.
                                       properties:
                                         add:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -2320,11 +2358,13 @@ spec:
                                           - name
                                           x-kubernetes-list-type: map
                                         remove:
+                                          default: []
                                           items:
                                             type: string
                                           maxItems: 16
                                           type: array
                                         set:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -2392,6 +2432,9 @@ spec:
                                               format: int32
                                               type: integer
                                             proxyTypes:
+                                              default:
+                                              - Sidecar
+                                              - Gateway
                                               description: |-
                                                 ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                                 all data plane types are targeted by the policy.
@@ -2496,6 +2539,7 @@ spec:
                                         header value formatting, separating each value with a comma.
                                       properties:
                                         add:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -2515,11 +2559,13 @@ spec:
                                           - name
                                           x-kubernetes-list-type: map
                                         remove:
+                                          default: []
                                           items:
                                             type: string
                                           maxItems: 16
                                           type: array
                                         set:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -2590,6 +2636,7 @@ spec:
                             items:
                               properties:
                                 headers:
+                                  default: []
                                   items:
                                     description: |-
                                       HeaderMatch describes how to select an HTTP route by matching HTTP request
@@ -2653,6 +2700,7 @@ spec:
                                   - value
                                   type: object
                                 queryParams:
+                                  default: []
                                   description: |-
                                     QueryParams matches based on HTTP URL query parameters. Multiple matches
                                     are ANDed together such that all listed matches must succeed.
@@ -2722,6 +2770,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -2945,6 +2996,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -3014,6 +3068,7 @@ spec:
                                 consistent hashing is desired.
                               properties:
                                 hashPolicies:
+                                  default: []
                                   description: |-
                                     HashPolicies specify a list of request/connection properties that are used to calculate a hash.
                                     These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
@@ -3136,6 +3191,7 @@ spec:
                                   - MurmurHash2
                                   type: string
                                 hashPolicies:
+                                  default: []
                                   description: |-
                                     HashPolicies specify a list of request/connection properties that are used to calculate a hash.
                                     These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
@@ -3267,6 +3323,7 @@ spec:
                                 are unavailable
                               properties:
                                 failover:
+                                  default: []
                                   description: Failover defines list of load balancing
                                     rules in order of priority
                                   items:
@@ -3276,6 +3333,7 @@ spec:
                                           to which the rule applies
                                         properties:
                                           zones:
+                                            default: []
                                             items:
                                               type: string
                                             type: array
@@ -3296,6 +3354,7 @@ spec:
                                             - AnyExcept
                                             type: string
                                           zones:
+                                            default: []
                                             items:
                                               type: string
                                             type: array
@@ -3333,6 +3392,7 @@ spec:
                                 priorities between dataplane proxies inside a zone
                               properties:
                                 affinityTags:
+                                  default: []
                                   description: AffinityTags list of tags for local
                                     zone load balancing.
                                   items:
@@ -3398,6 +3458,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -3424,6 +3487,7 @@ spec:
                   required:
                   - targetRef
                   type: object
+                minItems: 1
                 type: array
             type: object
         type: object
@@ -3485,6 +3549,7 @@ spec:
                 description: MeshMetric configuration.
                 properties:
                   applications:
+                    default: []
                     description: Applications is a list of application that Dataplane
                       Proxy will scrape
                     items:
@@ -3510,6 +3575,7 @@ spec:
                       type: object
                     type: array
                   backends:
+                    default: []
                     description: Backends list that will be used to collect metrics.
                     items:
                       properties:
@@ -3589,6 +3655,7 @@ spec:
                           published.
                         properties:
                           appendProfiles:
+                            default: []
                             description: AppendProfiles allows to combine the metrics
                               from multiple predefined profiles.
                             items:
@@ -3606,6 +3673,7 @@ spec:
                               type: object
                             type: array
                           exclude:
+                            default: []
                             description: |-
                               Exclude makes it possible to exclude groups of metrics from a resulting profile.
                               Exclude is subordinate to Include.
@@ -3630,6 +3698,7 @@ spec:
                               type: object
                             type: array
                           include:
+                            default: []
                             description: |-
                               Include makes it possible to include additional metrics in a selected profiles.
                               Include takes precedence over Exclude.
@@ -3697,6 +3766,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -3981,6 +4053,7 @@ spec:
                 description: MeshPassthrough configuration.
                 properties:
                   appendMatch:
+                    default: []
                     description: AppendMatch is a list of destinations that should
                       be allowed through the sidecar.
                     items:
@@ -4066,6 +4139,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -4151,6 +4227,7 @@ spec:
                   referenced in 'targetRef'.
                 properties:
                   appendModifications:
+                    default: []
                     description: AppendModifications is a list of modifications applied
                       on the selected proxy.
                     items:
@@ -4160,6 +4237,7 @@ spec:
                             resource.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy's Cluster
                                 resource
@@ -4237,6 +4315,7 @@ spec:
                             available in HTTP Connection Manager in a Listener resource.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy's
                                 HTTP Filter available in HTTP Connection Manager in a Listener resource.
@@ -4325,6 +4404,7 @@ spec:
                             resource.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy's Listener
                                 resource
@@ -4406,6 +4486,7 @@ spec:
                             filter.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy Listener's
                                 filter.
@@ -4495,6 +4576,7 @@ spec:
                             referenced in HTTP Connection Manager in a Listener resource.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy's
                                 VirtualHost resource
@@ -4617,6 +4699,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -4699,6 +4784,7 @@ spec:
             description: Spec is the specification of the Kuma MeshRateLimit resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -4729,6 +4815,7 @@ spec:
                                         HTTP response on a rate limit event
                                       properties:
                                         add:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -4748,6 +4835,7 @@ spec:
                                           - name
                                           x-kubernetes-list-type: map
                                         set:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -4863,6 +4951,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -4931,6 +5022,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -4955,6 +5049,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between clients and corresponding
                   configurations
                 items:
@@ -4985,6 +5080,7 @@ spec:
                                         HTTP response on a rate limit event
                                       properties:
                                         add:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -5004,6 +5100,7 @@ spec:
                                           - name
                                           x-kubernetes-list-type: map
                                         set:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -5119,6 +5216,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -5243,6 +5343,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -5267,6 +5370,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between the consumed services and
                   corresponding configurations
                 items:
@@ -5320,6 +5424,7 @@ spec:
                                     time which will be taken between retries.
                                   type: string
                                 resetHeaders:
+                                  default: []
                                   description: |-
                                     ResetHeaders specifies the list of headers (like Retry-After or X-RateLimit-Reset)
                                     to match against the response. Headers are tried in order, and matched
@@ -5346,6 +5451,7 @@ spec:
                                   type: array
                               type: object
                             retryOn:
+                              default: []
                               description: RetryOn is a list of conditions which will
                                 cause a retry.
                               example:
@@ -5386,6 +5492,7 @@ spec:
                                   type: string
                               type: object
                             hostSelection:
+                              default: []
                               description: |-
                                 HostSelection is a list of predicates that dictate how hosts should be selected
                                 when requests are retried.
@@ -5448,6 +5555,7 @@ spec:
                                     time which will be taken between retries.
                                   type: string
                                 resetHeaders:
+                                  default: []
                                   description: |-
                                     ResetHeaders specifies the list of headers (like Retry-After or X-RateLimit-Reset)
                                     to match against the response. Headers are tried in order, and matched
@@ -5474,6 +5582,7 @@ spec:
                                   type: array
                               type: object
                             retriableRequestHeaders:
+                              default: []
                               description: |-
                                 RetriableRequestHeaders is an HTTP headers which must be present in the request
                                 for retries to be attempted.
@@ -5510,6 +5619,7 @@ spec:
                                 type: object
                               type: array
                             retriableResponseHeaders:
+                              default: []
                               description: |-
                                 RetriableResponseHeaders is an HTTP response headers that trigger a retry
                                 if present in the response. A retry will be triggered if any of the header
@@ -5547,6 +5657,7 @@ spec:
                                 type: object
                               type: array
                             retryOn:
+                              default: []
                               description: |-
                                 RetryOn is a list of conditions which will cause a retry. Available values are:
                                 [5XX, GatewayError, Reset, Retriable4xx, ConnectFailure, EnvoyRatelimited,
@@ -5630,6 +5741,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -5711,6 +5825,7 @@ spec:
             description: Spec is the specification of the Kuma MeshService resource.
             properties:
               identities:
+                default: []
                 items:
                   properties:
                     type:
@@ -5725,6 +5840,7 @@ spec:
                   type: object
                 type: array
               ports:
+                default: []
                 items:
                   properties:
                     appProtocol:
@@ -5974,6 +6090,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -6004,6 +6123,7 @@ spec:
                 items:
                   properties:
                     rules:
+                      default: []
                       description: |-
                         Rules contains the routing rules applies to a combination of top-level
                         targetRef and the targetRef in this entry.
@@ -6015,6 +6135,7 @@ spec:
                               policies.
                             properties:
                               backendRefs:
+                                default: []
                                 items:
                                   description: BackendRef defines where to forward
                                     traffic.
@@ -6059,6 +6180,9 @@ spec:
                                       format: int32
                                       type: integer
                                     proxyTypes:
+                                      default:
+                                      - Sidecar
+                                      - Gateway
                                       description: |-
                                         ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                         all data plane types are targeted by the policy.
@@ -6136,6 +6260,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -6221,6 +6348,7 @@ spec:
             description: Spec is the specification of the Kuma MeshTimeout resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -6317,6 +6445,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -6345,6 +6476,7 @@ spec:
                   type: object
                 type: array
               rules:
+                default: []
                 description: |-
                   Rules defines inbound timeout configurations. Currently limited to exactly one rule containing
                   default timeouts that apply to all inbound traffic, as L7 matching is not yet implemented.
@@ -6443,6 +6575,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -6467,6 +6602,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between the consumed services and
                   corresponding configurations
                 items:
@@ -6563,6 +6699,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -6814,6 +6953,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -6882,6 +7024,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -6965,6 +7110,7 @@ spec:
                 description: MeshTrace configuration.
                 properties:
                   backends:
+                    default: []
                     description: |-
                       A one element array of backend definition.
                       Envoy allows configuring only 1 backend, so the natural way of
@@ -7093,6 +7239,7 @@ spec:
                         x-kubernetes-int-or-string: true
                     type: object
                   tags:
+                    default: []
                     description: |-
                       Custom tags configuration. You can add custom tags to traces based on
                       headers or literal values.
@@ -7168,6 +7315,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -7307,6 +7457,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -7375,6 +7528,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -8496,6 +8652,7 @@ spec:
             description: Spec is the specification of the Kuma MeshAccessLog resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -8506,6 +8663,7 @@ spec:
                         'targetRef'
                       properties:
                         backends:
+                          default: []
                           items:
                             properties:
                               file:
@@ -8518,6 +8676,7 @@ spec:
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        default: []
                                         example:
                                         - key: start_time
                                           value: '%START_TIME%'
@@ -8558,6 +8717,7 @@ spec:
                                 description: Defines an OpenTelemetry logging backend.
                                 properties:
                                   attributes:
+                                    default: []
                                     description: |-
                                       Attributes can contain placeholders available on
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
@@ -8608,6 +8768,7 @@ spec:
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        default: []
                                         example:
                                         - key: start_time
                                           value: '%START_TIME%'
@@ -8689,6 +8850,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -8757,6 +8921,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -8781,6 +8948,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between the consumed services and
                   corresponding configurations
                 items:
@@ -8791,6 +8959,7 @@ spec:
                         'targetRef'
                       properties:
                         backends:
+                          default: []
                           items:
                             properties:
                               file:
@@ -8803,6 +8972,7 @@ spec:
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        default: []
                                         example:
                                         - key: start_time
                                           value: '%START_TIME%'
@@ -8843,6 +9013,7 @@ spec:
                                 description: Defines an OpenTelemetry logging backend.
                                 properties:
                                   attributes:
+                                    default: []
                                     description: |-
                                       Attributes can contain placeholders available on
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
@@ -8893,6 +9064,7 @@ spec:
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        default: []
                                         example:
                                         - key: start_time
                                           value: '%START_TIME%'
@@ -8974,6 +9146,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -9059,6 +9234,7 @@ spec:
               resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -9342,6 +9518,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -9410,6 +9589,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -9434,6 +9616,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: |-
                   To list makes a match between the consumed services and corresponding
                   configurations
@@ -9718,6 +9901,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -297,6 +297,7 @@ spec:
               resource.
             properties:
               endpoints:
+                default: []
                 description: Endpoints defines a list of destinations to send traffic
                   to.
                 items:
@@ -440,6 +441,7 @@ spec:
                           Indicator set by Kuma.
                         type: string
                       subjectAltNames:
+                        default: []
                         description: SubjectAltNames list of names to verify in the
                           certificate.
                         items:
@@ -635,6 +637,7 @@ spec:
               resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -645,6 +648,7 @@ spec:
                         'targetRef'
                       properties:
                         http:
+                          default: []
                           description: Http allows to define list of Http faults between
                             dataplanes.
                           items:
@@ -759,6 +763,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -827,6 +834,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -851,6 +861,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between clients and corresponding
                   configurations
                 items:
@@ -861,6 +872,7 @@ spec:
                         'targetRef'
                       properties:
                         http:
+                          default: []
                           description: Http allows to define list of Http faults between
                             dataplanes.
                           items:
@@ -975,6 +987,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -1784,6 +1799,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -1808,6 +1826,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between the consumed services and
                   corresponding configurations
                 items:
@@ -1877,6 +1896,7 @@ spec:
                               description: If true the HttpHealthCheck is disabled
                               type: boolean
                             expectedStatuses:
+                              default: []
                               description: List of HTTP response statuses which are
                                 considered healthy
                               items:
@@ -1895,6 +1915,7 @@ spec:
                                 request
                               properties:
                                 add:
+                                  default: []
                                   items:
                                     properties:
                                       name:
@@ -1914,6 +1935,7 @@ spec:
                                   - name
                                   x-kubernetes-list-type: map
                                 set:
+                                  default: []
                                   items:
                                     properties:
                                       name:
@@ -1981,6 +2003,7 @@ spec:
                               description: If true the TcpHealthCheck is disabled
                               type: boolean
                             receive:
+                              default: []
                               description: |-
                                 List of Base64 encoded blocks of strings expected as a response. When checking the response,
                                 "fuzzy" matching is performed such that each block must be found, and
@@ -2046,6 +2069,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -2170,6 +2196,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -2194,11 +2223,13 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To matches destination services of requests and holds
                   configuration.
                 items:
                   properties:
                     hostnames:
+                      default: []
                       description: |-
                         Hostnames is only valid when targeting MeshGateway and limits the
                         effects of the rules to requests to this hostname.
@@ -2208,6 +2239,7 @@ spec:
                         type: string
                       type: array
                     rules:
+                      default: []
                       description: |-
                         Rules contains the routing rules applies to a combination of top-level
                         targetRef and the targetRef in this entry.
@@ -2219,6 +2251,7 @@ spec:
                               policies.
                             properties:
                               backendRefs:
+                                default: []
                                 items:
                                   description: BackendRef defines where to forward
                                     traffic.
@@ -2263,6 +2296,9 @@ spec:
                                       format: int32
                                       type: integer
                                     proxyTypes:
+                                      default:
+                                      - Sidecar
+                                      - Gateway
                                       description: |-
                                         ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                         all data plane types are targeted by the policy.
@@ -2292,6 +2328,7 @@ spec:
                                   type: object
                                 type: array
                               filters:
+                                default: []
                                 items:
                                   properties:
                                     requestHeaderModifier:
@@ -2301,6 +2338,7 @@ spec:
                                         header value formatting, separating each value with a comma.
                                       properties:
                                         add:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -2320,11 +2358,13 @@ spec:
                                           - name
                                           x-kubernetes-list-type: map
                                         remove:
+                                          default: []
                                           items:
                                             type: string
                                           maxItems: 16
                                           type: array
                                         set:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -2392,6 +2432,9 @@ spec:
                                               format: int32
                                               type: integer
                                             proxyTypes:
+                                              default:
+                                              - Sidecar
+                                              - Gateway
                                               description: |-
                                                 ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                                 all data plane types are targeted by the policy.
@@ -2496,6 +2539,7 @@ spec:
                                         header value formatting, separating each value with a comma.
                                       properties:
                                         add:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -2515,11 +2559,13 @@ spec:
                                           - name
                                           x-kubernetes-list-type: map
                                         remove:
+                                          default: []
                                           items:
                                             type: string
                                           maxItems: 16
                                           type: array
                                         set:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -2590,6 +2636,7 @@ spec:
                             items:
                               properties:
                                 headers:
+                                  default: []
                                   items:
                                     description: |-
                                       HeaderMatch describes how to select an HTTP route by matching HTTP request
@@ -2653,6 +2700,7 @@ spec:
                                   - value
                                   type: object
                                 queryParams:
+                                  default: []
                                   description: |-
                                     QueryParams matches based on HTTP URL query parameters. Multiple matches
                                     are ANDed together such that all listed matches must succeed.
@@ -2722,6 +2770,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -2945,6 +2996,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -3014,6 +3068,7 @@ spec:
                                 consistent hashing is desired.
                               properties:
                                 hashPolicies:
+                                  default: []
                                   description: |-
                                     HashPolicies specify a list of request/connection properties that are used to calculate a hash.
                                     These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
@@ -3136,6 +3191,7 @@ spec:
                                   - MurmurHash2
                                   type: string
                                 hashPolicies:
+                                  default: []
                                   description: |-
                                     HashPolicies specify a list of request/connection properties that are used to calculate a hash.
                                     These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
@@ -3267,6 +3323,7 @@ spec:
                                 are unavailable
                               properties:
                                 failover:
+                                  default: []
                                   description: Failover defines list of load balancing
                                     rules in order of priority
                                   items:
@@ -3276,6 +3333,7 @@ spec:
                                           to which the rule applies
                                         properties:
                                           zones:
+                                            default: []
                                             items:
                                               type: string
                                             type: array
@@ -3296,6 +3354,7 @@ spec:
                                             - AnyExcept
                                             type: string
                                           zones:
+                                            default: []
                                             items:
                                               type: string
                                             type: array
@@ -3333,6 +3392,7 @@ spec:
                                 priorities between dataplane proxies inside a zone
                               properties:
                                 affinityTags:
+                                  default: []
                                   description: AffinityTags list of tags for local
                                     zone load balancing.
                                   items:
@@ -3398,6 +3458,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -3424,6 +3487,7 @@ spec:
                   required:
                   - targetRef
                   type: object
+                minItems: 1
                 type: array
             type: object
         type: object
@@ -3485,6 +3549,7 @@ spec:
                 description: MeshMetric configuration.
                 properties:
                   applications:
+                    default: []
                     description: Applications is a list of application that Dataplane
                       Proxy will scrape
                     items:
@@ -3510,6 +3575,7 @@ spec:
                       type: object
                     type: array
                   backends:
+                    default: []
                     description: Backends list that will be used to collect metrics.
                     items:
                       properties:
@@ -3589,6 +3655,7 @@ spec:
                           published.
                         properties:
                           appendProfiles:
+                            default: []
                             description: AppendProfiles allows to combine the metrics
                               from multiple predefined profiles.
                             items:
@@ -3606,6 +3673,7 @@ spec:
                               type: object
                             type: array
                           exclude:
+                            default: []
                             description: |-
                               Exclude makes it possible to exclude groups of metrics from a resulting profile.
                               Exclude is subordinate to Include.
@@ -3630,6 +3698,7 @@ spec:
                               type: object
                             type: array
                           include:
+                            default: []
                             description: |-
                               Include makes it possible to include additional metrics in a selected profiles.
                               Include takes precedence over Exclude.
@@ -3697,6 +3766,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -3981,6 +4053,7 @@ spec:
                 description: MeshPassthrough configuration.
                 properties:
                   appendMatch:
+                    default: []
                     description: AppendMatch is a list of destinations that should
                       be allowed through the sidecar.
                     items:
@@ -4066,6 +4139,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -4151,6 +4227,7 @@ spec:
                   referenced in 'targetRef'.
                 properties:
                   appendModifications:
+                    default: []
                     description: AppendModifications is a list of modifications applied
                       on the selected proxy.
                     items:
@@ -4160,6 +4237,7 @@ spec:
                             resource.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy's Cluster
                                 resource
@@ -4237,6 +4315,7 @@ spec:
                             available in HTTP Connection Manager in a Listener resource.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy's
                                 HTTP Filter available in HTTP Connection Manager in a Listener resource.
@@ -4325,6 +4404,7 @@ spec:
                             resource.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy's Listener
                                 resource
@@ -4406,6 +4486,7 @@ spec:
                             filter.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy Listener's
                                 filter.
@@ -4495,6 +4576,7 @@ spec:
                             referenced in HTTP Connection Manager in a Listener resource.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy's
                                 VirtualHost resource
@@ -4617,6 +4699,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -4699,6 +4784,7 @@ spec:
             description: Spec is the specification of the Kuma MeshRateLimit resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -4729,6 +4815,7 @@ spec:
                                         HTTP response on a rate limit event
                                       properties:
                                         add:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -4748,6 +4835,7 @@ spec:
                                           - name
                                           x-kubernetes-list-type: map
                                         set:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -4863,6 +4951,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -4931,6 +5022,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -4955,6 +5049,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between clients and corresponding
                   configurations
                 items:
@@ -4985,6 +5080,7 @@ spec:
                                         HTTP response on a rate limit event
                                       properties:
                                         add:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -5004,6 +5100,7 @@ spec:
                                           - name
                                           x-kubernetes-list-type: map
                                         set:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -5119,6 +5216,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -5243,6 +5343,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -5267,6 +5370,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between the consumed services and
                   corresponding configurations
                 items:
@@ -5320,6 +5424,7 @@ spec:
                                     time which will be taken between retries.
                                   type: string
                                 resetHeaders:
+                                  default: []
                                   description: |-
                                     ResetHeaders specifies the list of headers (like Retry-After or X-RateLimit-Reset)
                                     to match against the response. Headers are tried in order, and matched
@@ -5346,6 +5451,7 @@ spec:
                                   type: array
                               type: object
                             retryOn:
+                              default: []
                               description: RetryOn is a list of conditions which will
                                 cause a retry.
                               example:
@@ -5386,6 +5492,7 @@ spec:
                                   type: string
                               type: object
                             hostSelection:
+                              default: []
                               description: |-
                                 HostSelection is a list of predicates that dictate how hosts should be selected
                                 when requests are retried.
@@ -5448,6 +5555,7 @@ spec:
                                     time which will be taken between retries.
                                   type: string
                                 resetHeaders:
+                                  default: []
                                   description: |-
                                     ResetHeaders specifies the list of headers (like Retry-After or X-RateLimit-Reset)
                                     to match against the response. Headers are tried in order, and matched
@@ -5474,6 +5582,7 @@ spec:
                                   type: array
                               type: object
                             retriableRequestHeaders:
+                              default: []
                               description: |-
                                 RetriableRequestHeaders is an HTTP headers which must be present in the request
                                 for retries to be attempted.
@@ -5510,6 +5619,7 @@ spec:
                                 type: object
                               type: array
                             retriableResponseHeaders:
+                              default: []
                               description: |-
                                 RetriableResponseHeaders is an HTTP response headers that trigger a retry
                                 if present in the response. A retry will be triggered if any of the header
@@ -5547,6 +5657,7 @@ spec:
                                 type: object
                               type: array
                             retryOn:
+                              default: []
                               description: |-
                                 RetryOn is a list of conditions which will cause a retry. Available values are:
                                 [5XX, GatewayError, Reset, Retriable4xx, ConnectFailure, EnvoyRatelimited,
@@ -5630,6 +5741,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -5711,6 +5825,7 @@ spec:
             description: Spec is the specification of the Kuma MeshService resource.
             properties:
               identities:
+                default: []
                 items:
                   properties:
                     type:
@@ -5725,6 +5840,7 @@ spec:
                   type: object
                 type: array
               ports:
+                default: []
                 items:
                   properties:
                     appProtocol:
@@ -5974,6 +6090,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -6004,6 +6123,7 @@ spec:
                 items:
                   properties:
                     rules:
+                      default: []
                       description: |-
                         Rules contains the routing rules applies to a combination of top-level
                         targetRef and the targetRef in this entry.
@@ -6015,6 +6135,7 @@ spec:
                               policies.
                             properties:
                               backendRefs:
+                                default: []
                                 items:
                                   description: BackendRef defines where to forward
                                     traffic.
@@ -6059,6 +6180,9 @@ spec:
                                       format: int32
                                       type: integer
                                     proxyTypes:
+                                      default:
+                                      - Sidecar
+                                      - Gateway
                                       description: |-
                                         ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                         all data plane types are targeted by the policy.
@@ -6136,6 +6260,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -6221,6 +6348,7 @@ spec:
             description: Spec is the specification of the Kuma MeshTimeout resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -6317,6 +6445,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -6345,6 +6476,7 @@ spec:
                   type: object
                 type: array
               rules:
+                default: []
                 description: |-
                   Rules defines inbound timeout configurations. Currently limited to exactly one rule containing
                   default timeouts that apply to all inbound traffic, as L7 matching is not yet implemented.
@@ -6443,6 +6575,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -6467,6 +6602,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between the consumed services and
                   corresponding configurations
                 items:
@@ -6563,6 +6699,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -6814,6 +6953,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -6882,6 +7024,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -6965,6 +7110,7 @@ spec:
                 description: MeshTrace configuration.
                 properties:
                   backends:
+                    default: []
                     description: |-
                       A one element array of backend definition.
                       Envoy allows configuring only 1 backend, so the natural way of
@@ -7093,6 +7239,7 @@ spec:
                         x-kubernetes-int-or-string: true
                     type: object
                   tags:
+                    default: []
                     description: |-
                       Custom tags configuration. You can add custom tags to traces based on
                       headers or literal values.
@@ -7168,6 +7315,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -7307,6 +7457,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -7375,6 +7528,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -8496,6 +8652,7 @@ spec:
             description: Spec is the specification of the Kuma MeshAccessLog resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -8506,6 +8663,7 @@ spec:
                         'targetRef'
                       properties:
                         backends:
+                          default: []
                           items:
                             properties:
                               file:
@@ -8518,6 +8676,7 @@ spec:
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        default: []
                                         example:
                                         - key: start_time
                                           value: '%START_TIME%'
@@ -8558,6 +8717,7 @@ spec:
                                 description: Defines an OpenTelemetry logging backend.
                                 properties:
                                   attributes:
+                                    default: []
                                     description: |-
                                       Attributes can contain placeholders available on
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
@@ -8608,6 +8768,7 @@ spec:
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        default: []
                                         example:
                                         - key: start_time
                                           value: '%START_TIME%'
@@ -8689,6 +8850,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -8757,6 +8921,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -8781,6 +8948,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between the consumed services and
                   corresponding configurations
                 items:
@@ -8791,6 +8959,7 @@ spec:
                         'targetRef'
                       properties:
                         backends:
+                          default: []
                           items:
                             properties:
                               file:
@@ -8803,6 +8972,7 @@ spec:
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        default: []
                                         example:
                                         - key: start_time
                                           value: '%START_TIME%'
@@ -8843,6 +9013,7 @@ spec:
                                 description: Defines an OpenTelemetry logging backend.
                                 properties:
                                   attributes:
+                                    default: []
                                     description: |-
                                       Attributes can contain placeholders available on
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
@@ -8893,6 +9064,7 @@ spec:
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        default: []
                                         example:
                                         - key: start_time
                                           value: '%START_TIME%'
@@ -8974,6 +9146,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -9059,6 +9234,7 @@ spec:
               resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -9342,6 +9518,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -9410,6 +9589,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -9434,6 +9616,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: |-
                   To list makes a match between the consumed services and corresponding
                   configurations
@@ -9718,6 +9901,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -317,6 +317,7 @@ spec:
               resource.
             properties:
               endpoints:
+                default: []
                 description: Endpoints defines a list of destinations to send traffic
                   to.
                 items:
@@ -460,6 +461,7 @@ spec:
                           Indicator set by Kuma.
                         type: string
                       subjectAltNames:
+                        default: []
                         description: SubjectAltNames list of names to verify in the
                           certificate.
                         items:
@@ -655,6 +657,7 @@ spec:
               resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -665,6 +668,7 @@ spec:
                         'targetRef'
                       properties:
                         http:
+                          default: []
                           description: Http allows to define list of Http faults between
                             dataplanes.
                           items:
@@ -779,6 +783,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -847,6 +854,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -871,6 +881,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between clients and corresponding
                   configurations
                 items:
@@ -881,6 +892,7 @@ spec:
                         'targetRef'
                       properties:
                         http:
+                          default: []
                           description: Http allows to define list of Http faults between
                             dataplanes.
                           items:
@@ -995,6 +1007,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -1804,6 +1819,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -1828,6 +1846,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between the consumed services and
                   corresponding configurations
                 items:
@@ -1897,6 +1916,7 @@ spec:
                               description: If true the HttpHealthCheck is disabled
                               type: boolean
                             expectedStatuses:
+                              default: []
                               description: List of HTTP response statuses which are
                                 considered healthy
                               items:
@@ -1915,6 +1935,7 @@ spec:
                                 request
                               properties:
                                 add:
+                                  default: []
                                   items:
                                     properties:
                                       name:
@@ -1934,6 +1955,7 @@ spec:
                                   - name
                                   x-kubernetes-list-type: map
                                 set:
+                                  default: []
                                   items:
                                     properties:
                                       name:
@@ -2001,6 +2023,7 @@ spec:
                               description: If true the TcpHealthCheck is disabled
                               type: boolean
                             receive:
+                              default: []
                               description: |-
                                 List of Base64 encoded blocks of strings expected as a response. When checking the response,
                                 "fuzzy" matching is performed such that each block must be found, and
@@ -2066,6 +2089,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -2190,6 +2216,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -2214,11 +2243,13 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To matches destination services of requests and holds
                   configuration.
                 items:
                   properties:
                     hostnames:
+                      default: []
                       description: |-
                         Hostnames is only valid when targeting MeshGateway and limits the
                         effects of the rules to requests to this hostname.
@@ -2228,6 +2259,7 @@ spec:
                         type: string
                       type: array
                     rules:
+                      default: []
                       description: |-
                         Rules contains the routing rules applies to a combination of top-level
                         targetRef and the targetRef in this entry.
@@ -2239,6 +2271,7 @@ spec:
                               policies.
                             properties:
                               backendRefs:
+                                default: []
                                 items:
                                   description: BackendRef defines where to forward
                                     traffic.
@@ -2283,6 +2316,9 @@ spec:
                                       format: int32
                                       type: integer
                                     proxyTypes:
+                                      default:
+                                      - Sidecar
+                                      - Gateway
                                       description: |-
                                         ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                         all data plane types are targeted by the policy.
@@ -2312,6 +2348,7 @@ spec:
                                   type: object
                                 type: array
                               filters:
+                                default: []
                                 items:
                                   properties:
                                     requestHeaderModifier:
@@ -2321,6 +2358,7 @@ spec:
                                         header value formatting, separating each value with a comma.
                                       properties:
                                         add:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -2340,11 +2378,13 @@ spec:
                                           - name
                                           x-kubernetes-list-type: map
                                         remove:
+                                          default: []
                                           items:
                                             type: string
                                           maxItems: 16
                                           type: array
                                         set:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -2412,6 +2452,9 @@ spec:
                                               format: int32
                                               type: integer
                                             proxyTypes:
+                                              default:
+                                              - Sidecar
+                                              - Gateway
                                               description: |-
                                                 ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                                 all data plane types are targeted by the policy.
@@ -2516,6 +2559,7 @@ spec:
                                         header value formatting, separating each value with a comma.
                                       properties:
                                         add:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -2535,11 +2579,13 @@ spec:
                                           - name
                                           x-kubernetes-list-type: map
                                         remove:
+                                          default: []
                                           items:
                                             type: string
                                           maxItems: 16
                                           type: array
                                         set:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -2610,6 +2656,7 @@ spec:
                             items:
                               properties:
                                 headers:
+                                  default: []
                                   items:
                                     description: |-
                                       HeaderMatch describes how to select an HTTP route by matching HTTP request
@@ -2673,6 +2720,7 @@ spec:
                                   - value
                                   type: object
                                 queryParams:
+                                  default: []
                                   description: |-
                                     QueryParams matches based on HTTP URL query parameters. Multiple matches
                                     are ANDed together such that all listed matches must succeed.
@@ -2742,6 +2790,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -2965,6 +3016,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -3034,6 +3088,7 @@ spec:
                                 consistent hashing is desired.
                               properties:
                                 hashPolicies:
+                                  default: []
                                   description: |-
                                     HashPolicies specify a list of request/connection properties that are used to calculate a hash.
                                     These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
@@ -3156,6 +3211,7 @@ spec:
                                   - MurmurHash2
                                   type: string
                                 hashPolicies:
+                                  default: []
                                   description: |-
                                     HashPolicies specify a list of request/connection properties that are used to calculate a hash.
                                     These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
@@ -3287,6 +3343,7 @@ spec:
                                 are unavailable
                               properties:
                                 failover:
+                                  default: []
                                   description: Failover defines list of load balancing
                                     rules in order of priority
                                   items:
@@ -3296,6 +3353,7 @@ spec:
                                           to which the rule applies
                                         properties:
                                           zones:
+                                            default: []
                                             items:
                                               type: string
                                             type: array
@@ -3316,6 +3374,7 @@ spec:
                                             - AnyExcept
                                             type: string
                                           zones:
+                                            default: []
                                             items:
                                               type: string
                                             type: array
@@ -3353,6 +3412,7 @@ spec:
                                 priorities between dataplane proxies inside a zone
                               properties:
                                 affinityTags:
+                                  default: []
                                   description: AffinityTags list of tags for local
                                     zone load balancing.
                                   items:
@@ -3418,6 +3478,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -3444,6 +3507,7 @@ spec:
                   required:
                   - targetRef
                   type: object
+                minItems: 1
                 type: array
             type: object
         type: object
@@ -3505,6 +3569,7 @@ spec:
                 description: MeshMetric configuration.
                 properties:
                   applications:
+                    default: []
                     description: Applications is a list of application that Dataplane
                       Proxy will scrape
                     items:
@@ -3530,6 +3595,7 @@ spec:
                       type: object
                     type: array
                   backends:
+                    default: []
                     description: Backends list that will be used to collect metrics.
                     items:
                       properties:
@@ -3609,6 +3675,7 @@ spec:
                           published.
                         properties:
                           appendProfiles:
+                            default: []
                             description: AppendProfiles allows to combine the metrics
                               from multiple predefined profiles.
                             items:
@@ -3626,6 +3693,7 @@ spec:
                               type: object
                             type: array
                           exclude:
+                            default: []
                             description: |-
                               Exclude makes it possible to exclude groups of metrics from a resulting profile.
                               Exclude is subordinate to Include.
@@ -3650,6 +3718,7 @@ spec:
                               type: object
                             type: array
                           include:
+                            default: []
                             description: |-
                               Include makes it possible to include additional metrics in a selected profiles.
                               Include takes precedence over Exclude.
@@ -3717,6 +3786,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -4001,6 +4073,7 @@ spec:
                 description: MeshPassthrough configuration.
                 properties:
                   appendMatch:
+                    default: []
                     description: AppendMatch is a list of destinations that should
                       be allowed through the sidecar.
                     items:
@@ -4086,6 +4159,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -4171,6 +4247,7 @@ spec:
                   referenced in 'targetRef'.
                 properties:
                   appendModifications:
+                    default: []
                     description: AppendModifications is a list of modifications applied
                       on the selected proxy.
                     items:
@@ -4180,6 +4257,7 @@ spec:
                             resource.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy's Cluster
                                 resource
@@ -4257,6 +4335,7 @@ spec:
                             available in HTTP Connection Manager in a Listener resource.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy's
                                 HTTP Filter available in HTTP Connection Manager in a Listener resource.
@@ -4345,6 +4424,7 @@ spec:
                             resource.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy's Listener
                                 resource
@@ -4426,6 +4506,7 @@ spec:
                             filter.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy Listener's
                                 filter.
@@ -4515,6 +4596,7 @@ spec:
                             referenced in HTTP Connection Manager in a Listener resource.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy's
                                 VirtualHost resource
@@ -4637,6 +4719,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -4719,6 +4804,7 @@ spec:
             description: Spec is the specification of the Kuma MeshRateLimit resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -4749,6 +4835,7 @@ spec:
                                         HTTP response on a rate limit event
                                       properties:
                                         add:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -4768,6 +4855,7 @@ spec:
                                           - name
                                           x-kubernetes-list-type: map
                                         set:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -4883,6 +4971,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -4951,6 +5042,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -4975,6 +5069,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between clients and corresponding
                   configurations
                 items:
@@ -5005,6 +5100,7 @@ spec:
                                         HTTP response on a rate limit event
                                       properties:
                                         add:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -5024,6 +5120,7 @@ spec:
                                           - name
                                           x-kubernetes-list-type: map
                                         set:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -5139,6 +5236,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -5263,6 +5363,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -5287,6 +5390,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between the consumed services and
                   corresponding configurations
                 items:
@@ -5340,6 +5444,7 @@ spec:
                                     time which will be taken between retries.
                                   type: string
                                 resetHeaders:
+                                  default: []
                                   description: |-
                                     ResetHeaders specifies the list of headers (like Retry-After or X-RateLimit-Reset)
                                     to match against the response. Headers are tried in order, and matched
@@ -5366,6 +5471,7 @@ spec:
                                   type: array
                               type: object
                             retryOn:
+                              default: []
                               description: RetryOn is a list of conditions which will
                                 cause a retry.
                               example:
@@ -5406,6 +5512,7 @@ spec:
                                   type: string
                               type: object
                             hostSelection:
+                              default: []
                               description: |-
                                 HostSelection is a list of predicates that dictate how hosts should be selected
                                 when requests are retried.
@@ -5468,6 +5575,7 @@ spec:
                                     time which will be taken between retries.
                                   type: string
                                 resetHeaders:
+                                  default: []
                                   description: |-
                                     ResetHeaders specifies the list of headers (like Retry-After or X-RateLimit-Reset)
                                     to match against the response. Headers are tried in order, and matched
@@ -5494,6 +5602,7 @@ spec:
                                   type: array
                               type: object
                             retriableRequestHeaders:
+                              default: []
                               description: |-
                                 RetriableRequestHeaders is an HTTP headers which must be present in the request
                                 for retries to be attempted.
@@ -5530,6 +5639,7 @@ spec:
                                 type: object
                               type: array
                             retriableResponseHeaders:
+                              default: []
                               description: |-
                                 RetriableResponseHeaders is an HTTP response headers that trigger a retry
                                 if present in the response. A retry will be triggered if any of the header
@@ -5567,6 +5677,7 @@ spec:
                                 type: object
                               type: array
                             retryOn:
+                              default: []
                               description: |-
                                 RetryOn is a list of conditions which will cause a retry. Available values are:
                                 [5XX, GatewayError, Reset, Retriable4xx, ConnectFailure, EnvoyRatelimited,
@@ -5650,6 +5761,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -5731,6 +5845,7 @@ spec:
             description: Spec is the specification of the Kuma MeshService resource.
             properties:
               identities:
+                default: []
                 items:
                   properties:
                     type:
@@ -5745,6 +5860,7 @@ spec:
                   type: object
                 type: array
               ports:
+                default: []
                 items:
                   properties:
                     appProtocol:
@@ -5994,6 +6110,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -6024,6 +6143,7 @@ spec:
                 items:
                   properties:
                     rules:
+                      default: []
                       description: |-
                         Rules contains the routing rules applies to a combination of top-level
                         targetRef and the targetRef in this entry.
@@ -6035,6 +6155,7 @@ spec:
                               policies.
                             properties:
                               backendRefs:
+                                default: []
                                 items:
                                   description: BackendRef defines where to forward
                                     traffic.
@@ -6079,6 +6200,9 @@ spec:
                                       format: int32
                                       type: integer
                                     proxyTypes:
+                                      default:
+                                      - Sidecar
+                                      - Gateway
                                       description: |-
                                         ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                         all data plane types are targeted by the policy.
@@ -6156,6 +6280,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -6241,6 +6368,7 @@ spec:
             description: Spec is the specification of the Kuma MeshTimeout resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -6337,6 +6465,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -6365,6 +6496,7 @@ spec:
                   type: object
                 type: array
               rules:
+                default: []
                 description: |-
                   Rules defines inbound timeout configurations. Currently limited to exactly one rule containing
                   default timeouts that apply to all inbound traffic, as L7 matching is not yet implemented.
@@ -6463,6 +6595,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -6487,6 +6622,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between the consumed services and
                   corresponding configurations
                 items:
@@ -6583,6 +6719,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -6834,6 +6973,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -6902,6 +7044,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -6985,6 +7130,7 @@ spec:
                 description: MeshTrace configuration.
                 properties:
                   backends:
+                    default: []
                     description: |-
                       A one element array of backend definition.
                       Envoy allows configuring only 1 backend, so the natural way of
@@ -7113,6 +7259,7 @@ spec:
                         x-kubernetes-int-or-string: true
                     type: object
                   tags:
+                    default: []
                     description: |-
                       Custom tags configuration. You can add custom tags to traces based on
                       headers or literal values.
@@ -7188,6 +7335,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -7327,6 +7477,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -7395,6 +7548,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -8516,6 +8672,7 @@ spec:
             description: Spec is the specification of the Kuma MeshAccessLog resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -8526,6 +8683,7 @@ spec:
                         'targetRef'
                       properties:
                         backends:
+                          default: []
                           items:
                             properties:
                               file:
@@ -8538,6 +8696,7 @@ spec:
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        default: []
                                         example:
                                         - key: start_time
                                           value: '%START_TIME%'
@@ -8578,6 +8737,7 @@ spec:
                                 description: Defines an OpenTelemetry logging backend.
                                 properties:
                                   attributes:
+                                    default: []
                                     description: |-
                                       Attributes can contain placeholders available on
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
@@ -8628,6 +8788,7 @@ spec:
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        default: []
                                         example:
                                         - key: start_time
                                           value: '%START_TIME%'
@@ -8709,6 +8870,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -8777,6 +8941,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -8801,6 +8968,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between the consumed services and
                   corresponding configurations
                 items:
@@ -8811,6 +8979,7 @@ spec:
                         'targetRef'
                       properties:
                         backends:
+                          default: []
                           items:
                             properties:
                               file:
@@ -8823,6 +8992,7 @@ spec:
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        default: []
                                         example:
                                         - key: start_time
                                           value: '%START_TIME%'
@@ -8863,6 +9033,7 @@ spec:
                                 description: Defines an OpenTelemetry logging backend.
                                 properties:
                                   attributes:
+                                    default: []
                                     description: |-
                                       Attributes can contain placeholders available on
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
@@ -8913,6 +9084,7 @@ spec:
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        default: []
                                         example:
                                         - key: start_time
                                           value: '%START_TIME%'
@@ -8994,6 +9166,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -9079,6 +9254,7 @@ spec:
               resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -9362,6 +9538,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -9430,6 +9609,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -9454,6 +9636,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: |-
                   To list makes a match between the consumed services and corresponding
                   configurations
@@ -9738,6 +9921,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -561,6 +561,7 @@ spec:
             description: Spec is the specification of the Kuma MeshAccessLog resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -571,6 +572,7 @@ spec:
                         'targetRef'
                       properties:
                         backends:
+                          default: []
                           items:
                             properties:
                               file:
@@ -583,6 +585,7 @@ spec:
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        default: []
                                         example:
                                         - key: start_time
                                           value: '%START_TIME%'
@@ -623,6 +626,7 @@ spec:
                                 description: Defines an OpenTelemetry logging backend.
                                 properties:
                                   attributes:
+                                    default: []
                                     description: |-
                                       Attributes can contain placeholders available on
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
@@ -673,6 +677,7 @@ spec:
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        default: []
                                         example:
                                         - key: start_time
                                           value: '%START_TIME%'
@@ -754,6 +759,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -822,6 +830,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -846,6 +857,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between the consumed services and
                   corresponding configurations
                 items:
@@ -856,6 +868,7 @@ spec:
                         'targetRef'
                       properties:
                         backends:
+                          default: []
                           items:
                             properties:
                               file:
@@ -868,6 +881,7 @@ spec:
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        default: []
                                         example:
                                         - key: start_time
                                           value: '%START_TIME%'
@@ -908,6 +922,7 @@ spec:
                                 description: Defines an OpenTelemetry logging backend.
                                 properties:
                                   attributes:
+                                    default: []
                                     description: |-
                                       Attributes can contain placeholders available on
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
@@ -958,6 +973,7 @@ spec:
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        default: []
                                         example:
                                         - key: start_time
                                           value: '%START_TIME%'
@@ -1039,6 +1055,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -1124,6 +1143,7 @@ spec:
               resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -1407,6 +1427,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -1475,6 +1498,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -1499,6 +1525,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: |-
                   To list makes a match between the consumed services and corresponding
                   configurations
@@ -1783,6 +1810,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -1917,6 +1947,7 @@ spec:
               resource.
             properties:
               endpoints:
+                default: []
                 description: Endpoints defines a list of destinations to send traffic
                   to.
                 items:
@@ -2060,6 +2091,7 @@ spec:
                           Indicator set by Kuma.
                         type: string
                       subjectAltNames:
+                        default: []
                         description: SubjectAltNames list of names to verify in the
                           certificate.
                         items:
@@ -2255,6 +2287,7 @@ spec:
               resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -2265,6 +2298,7 @@ spec:
                         'targetRef'
                       properties:
                         http:
+                          default: []
                           description: Http allows to define list of Http faults between
                             dataplanes.
                           items:
@@ -2379,6 +2413,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -2447,6 +2484,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -2471,6 +2511,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between clients and corresponding
                   configurations
                 items:
@@ -2481,6 +2522,7 @@ spec:
                         'targetRef'
                       properties:
                         http:
+                          default: []
                           description: Http allows to define list of Http faults between
                             dataplanes.
                           items:
@@ -2595,6 +2637,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -3404,6 +3449,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -3428,6 +3476,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between the consumed services and
                   corresponding configurations
                 items:
@@ -3497,6 +3546,7 @@ spec:
                               description: If true the HttpHealthCheck is disabled
                               type: boolean
                             expectedStatuses:
+                              default: []
                               description: List of HTTP response statuses which are
                                 considered healthy
                               items:
@@ -3515,6 +3565,7 @@ spec:
                                 request
                               properties:
                                 add:
+                                  default: []
                                   items:
                                     properties:
                                       name:
@@ -3534,6 +3585,7 @@ spec:
                                   - name
                                   x-kubernetes-list-type: map
                                 set:
+                                  default: []
                                   items:
                                     properties:
                                       name:
@@ -3601,6 +3653,7 @@ spec:
                               description: If true the TcpHealthCheck is disabled
                               type: boolean
                             receive:
+                              default: []
                               description: |-
                                 List of Base64 encoded blocks of strings expected as a response. When checking the response,
                                 "fuzzy" matching is performed such that each block must be found, and
@@ -3666,6 +3719,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -3790,6 +3846,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -3814,11 +3873,13 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To matches destination services of requests and holds
                   configuration.
                 items:
                   properties:
                     hostnames:
+                      default: []
                       description: |-
                         Hostnames is only valid when targeting MeshGateway and limits the
                         effects of the rules to requests to this hostname.
@@ -3828,6 +3889,7 @@ spec:
                         type: string
                       type: array
                     rules:
+                      default: []
                       description: |-
                         Rules contains the routing rules applies to a combination of top-level
                         targetRef and the targetRef in this entry.
@@ -3839,6 +3901,7 @@ spec:
                               policies.
                             properties:
                               backendRefs:
+                                default: []
                                 items:
                                   description: BackendRef defines where to forward
                                     traffic.
@@ -3883,6 +3946,9 @@ spec:
                                       format: int32
                                       type: integer
                                     proxyTypes:
+                                      default:
+                                      - Sidecar
+                                      - Gateway
                                       description: |-
                                         ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                         all data plane types are targeted by the policy.
@@ -3912,6 +3978,7 @@ spec:
                                   type: object
                                 type: array
                               filters:
+                                default: []
                                 items:
                                   properties:
                                     requestHeaderModifier:
@@ -3921,6 +3988,7 @@ spec:
                                         header value formatting, separating each value with a comma.
                                       properties:
                                         add:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -3940,11 +4008,13 @@ spec:
                                           - name
                                           x-kubernetes-list-type: map
                                         remove:
+                                          default: []
                                           items:
                                             type: string
                                           maxItems: 16
                                           type: array
                                         set:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -4012,6 +4082,9 @@ spec:
                                               format: int32
                                               type: integer
                                             proxyTypes:
+                                              default:
+                                              - Sidecar
+                                              - Gateway
                                               description: |-
                                                 ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                                 all data plane types are targeted by the policy.
@@ -4116,6 +4189,7 @@ spec:
                                         header value formatting, separating each value with a comma.
                                       properties:
                                         add:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -4135,11 +4209,13 @@ spec:
                                           - name
                                           x-kubernetes-list-type: map
                                         remove:
+                                          default: []
                                           items:
                                             type: string
                                           maxItems: 16
                                           type: array
                                         set:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -4210,6 +4286,7 @@ spec:
                             items:
                               properties:
                                 headers:
+                                  default: []
                                   items:
                                     description: |-
                                       HeaderMatch describes how to select an HTTP route by matching HTTP request
@@ -4273,6 +4350,7 @@ spec:
                                   - value
                                   type: object
                                 queryParams:
+                                  default: []
                                   description: |-
                                     QueryParams matches based on HTTP URL query parameters. Multiple matches
                                     are ANDed together such that all listed matches must succeed.
@@ -4342,6 +4420,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -4515,6 +4596,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -4584,6 +4668,7 @@ spec:
                                 consistent hashing is desired.
                               properties:
                                 hashPolicies:
+                                  default: []
                                   description: |-
                                     HashPolicies specify a list of request/connection properties that are used to calculate a hash.
                                     These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
@@ -4706,6 +4791,7 @@ spec:
                                   - MurmurHash2
                                   type: string
                                 hashPolicies:
+                                  default: []
                                   description: |-
                                     HashPolicies specify a list of request/connection properties that are used to calculate a hash.
                                     These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
@@ -4837,6 +4923,7 @@ spec:
                                 are unavailable
                               properties:
                                 failover:
+                                  default: []
                                   description: Failover defines list of load balancing
                                     rules in order of priority
                                   items:
@@ -4846,6 +4933,7 @@ spec:
                                           to which the rule applies
                                         properties:
                                           zones:
+                                            default: []
                                             items:
                                               type: string
                                             type: array
@@ -4866,6 +4954,7 @@ spec:
                                             - AnyExcept
                                             type: string
                                           zones:
+                                            default: []
                                             items:
                                               type: string
                                             type: array
@@ -4903,6 +4992,7 @@ spec:
                                 priorities between dataplane proxies inside a zone
                               properties:
                                 affinityTags:
+                                  default: []
                                   description: AffinityTags list of tags for local
                                     zone load balancing.
                                   items:
@@ -4968,6 +5058,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -4994,6 +5087,7 @@ spec:
                   required:
                   - targetRef
                   type: object
+                minItems: 1
                 type: array
             type: object
         type: object
@@ -5055,6 +5149,7 @@ spec:
                 description: MeshMetric configuration.
                 properties:
                   applications:
+                    default: []
                     description: Applications is a list of application that Dataplane
                       Proxy will scrape
                     items:
@@ -5080,6 +5175,7 @@ spec:
                       type: object
                     type: array
                   backends:
+                    default: []
                     description: Backends list that will be used to collect metrics.
                     items:
                       properties:
@@ -5159,6 +5255,7 @@ spec:
                           published.
                         properties:
                           appendProfiles:
+                            default: []
                             description: AppendProfiles allows to combine the metrics
                               from multiple predefined profiles.
                             items:
@@ -5176,6 +5273,7 @@ spec:
                               type: object
                             type: array
                           exclude:
+                            default: []
                             description: |-
                               Exclude makes it possible to exclude groups of metrics from a resulting profile.
                               Exclude is subordinate to Include.
@@ -5200,6 +5298,7 @@ spec:
                               type: object
                             type: array
                           include:
+                            default: []
                             description: |-
                               Include makes it possible to include additional metrics in a selected profiles.
                               Include takes precedence over Exclude.
@@ -5267,6 +5366,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -5551,6 +5653,7 @@ spec:
                 description: MeshPassthrough configuration.
                 properties:
                   appendMatch:
+                    default: []
                     description: AppendMatch is a list of destinations that should
                       be allowed through the sidecar.
                     items:
@@ -5636,6 +5739,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -5721,6 +5827,7 @@ spec:
                   referenced in 'targetRef'.
                 properties:
                   appendModifications:
+                    default: []
                     description: AppendModifications is a list of modifications applied
                       on the selected proxy.
                     items:
@@ -5730,6 +5837,7 @@ spec:
                             resource.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy's Cluster
                                 resource
@@ -5807,6 +5915,7 @@ spec:
                             available in HTTP Connection Manager in a Listener resource.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy's
                                 HTTP Filter available in HTTP Connection Manager in a Listener resource.
@@ -5895,6 +6004,7 @@ spec:
                             resource.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy's Listener
                                 resource
@@ -5976,6 +6086,7 @@ spec:
                             filter.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy Listener's
                                 filter.
@@ -6065,6 +6176,7 @@ spec:
                             referenced in HTTP Connection Manager in a Listener resource.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy's
                                 VirtualHost resource
@@ -6187,6 +6299,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -6269,6 +6384,7 @@ spec:
             description: Spec is the specification of the Kuma MeshRateLimit resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -6299,6 +6415,7 @@ spec:
                                         HTTP response on a rate limit event
                                       properties:
                                         add:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -6318,6 +6435,7 @@ spec:
                                           - name
                                           x-kubernetes-list-type: map
                                         set:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -6433,6 +6551,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -6501,6 +6622,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -6525,6 +6649,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between clients and corresponding
                   configurations
                 items:
@@ -6555,6 +6680,7 @@ spec:
                                         HTTP response on a rate limit event
                                       properties:
                                         add:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -6574,6 +6700,7 @@ spec:
                                           - name
                                           x-kubernetes-list-type: map
                                         set:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -6689,6 +6816,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -6813,6 +6943,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -6837,6 +6970,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between the consumed services and
                   corresponding configurations
                 items:
@@ -6890,6 +7024,7 @@ spec:
                                     time which will be taken between retries.
                                   type: string
                                 resetHeaders:
+                                  default: []
                                   description: |-
                                     ResetHeaders specifies the list of headers (like Retry-After or X-RateLimit-Reset)
                                     to match against the response. Headers are tried in order, and matched
@@ -6916,6 +7051,7 @@ spec:
                                   type: array
                               type: object
                             retryOn:
+                              default: []
                               description: RetryOn is a list of conditions which will
                                 cause a retry.
                               example:
@@ -6956,6 +7092,7 @@ spec:
                                   type: string
                               type: object
                             hostSelection:
+                              default: []
                               description: |-
                                 HostSelection is a list of predicates that dictate how hosts should be selected
                                 when requests are retried.
@@ -7018,6 +7155,7 @@ spec:
                                     time which will be taken between retries.
                                   type: string
                                 resetHeaders:
+                                  default: []
                                   description: |-
                                     ResetHeaders specifies the list of headers (like Retry-After or X-RateLimit-Reset)
                                     to match against the response. Headers are tried in order, and matched
@@ -7044,6 +7182,7 @@ spec:
                                   type: array
                               type: object
                             retriableRequestHeaders:
+                              default: []
                               description: |-
                                 RetriableRequestHeaders is an HTTP headers which must be present in the request
                                 for retries to be attempted.
@@ -7080,6 +7219,7 @@ spec:
                                 type: object
                               type: array
                             retriableResponseHeaders:
+                              default: []
                               description: |-
                                 RetriableResponseHeaders is an HTTP response headers that trigger a retry
                                 if present in the response. A retry will be triggered if any of the header
@@ -7117,6 +7257,7 @@ spec:
                                 type: object
                               type: array
                             retryOn:
+                              default: []
                               description: |-
                                 RetryOn is a list of conditions which will cause a retry. Available values are:
                                 [5XX, GatewayError, Reset, Retriable4xx, ConnectFailure, EnvoyRatelimited,
@@ -7200,6 +7341,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -7281,6 +7425,7 @@ spec:
             description: Spec is the specification of the Kuma MeshService resource.
             properties:
               identities:
+                default: []
                 items:
                   properties:
                     type:
@@ -7295,6 +7440,7 @@ spec:
                   type: object
                 type: array
               ports:
+                default: []
                 items:
                   properties:
                     appProtocol:
@@ -7544,6 +7690,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -7574,6 +7723,7 @@ spec:
                 items:
                   properties:
                     rules:
+                      default: []
                       description: |-
                         Rules contains the routing rules applies to a combination of top-level
                         targetRef and the targetRef in this entry.
@@ -7585,6 +7735,7 @@ spec:
                               policies.
                             properties:
                               backendRefs:
+                                default: []
                                 items:
                                   description: BackendRef defines where to forward
                                     traffic.
@@ -7629,6 +7780,9 @@ spec:
                                       format: int32
                                       type: integer
                                     proxyTypes:
+                                      default:
+                                      - Sidecar
+                                      - Gateway
                                       description: |-
                                         ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                         all data plane types are targeted by the policy.
@@ -7706,6 +7860,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -7791,6 +7948,7 @@ spec:
             description: Spec is the specification of the Kuma MeshTimeout resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -7887,6 +8045,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -7915,6 +8076,7 @@ spec:
                   type: object
                 type: array
               rules:
+                default: []
                 description: |-
                   Rules defines inbound timeout configurations. Currently limited to exactly one rule containing
                   default timeouts that apply to all inbound traffic, as L7 matching is not yet implemented.
@@ -8013,6 +8175,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -8037,6 +8202,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between the consumed services and
                   corresponding configurations
                 items:
@@ -8133,6 +8299,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -8312,6 +8481,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -8380,6 +8552,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -8463,6 +8638,7 @@ spec:
                 description: MeshTrace configuration.
                 properties:
                   backends:
+                    default: []
                     description: |-
                       A one element array of backend definition.
                       Envoy allows configuring only 1 backend, so the natural way of
@@ -8591,6 +8767,7 @@ spec:
                         x-kubernetes-int-or-string: true
                     type: object
                   tags:
+                    default: []
                     description: |-
                       Custom tags configuration. You can add custom tags to traces based on
                       headers or literal values.
@@ -8666,6 +8843,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -8805,6 +8985,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -8873,6 +9056,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/deployments/charts/kuma/crds/kuma.io_meshaccesslogs.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshaccesslogs.yaml
@@ -50,6 +50,7 @@ spec:
             description: Spec is the specification of the Kuma MeshAccessLog resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -60,6 +61,7 @@ spec:
                         'targetRef'
                       properties:
                         backends:
+                          default: []
                           items:
                             properties:
                               file:
@@ -72,6 +74,7 @@ spec:
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        default: []
                                         example:
                                         - key: start_time
                                           value: '%START_TIME%'
@@ -112,6 +115,7 @@ spec:
                                 description: Defines an OpenTelemetry logging backend.
                                 properties:
                                   attributes:
+                                    default: []
                                     description: |-
                                       Attributes can contain placeholders available on
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
@@ -162,6 +166,7 @@ spec:
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        default: []
                                         example:
                                         - key: start_time
                                           value: '%START_TIME%'
@@ -243,6 +248,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -311,6 +317,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -335,6 +342,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between the consumed services and
                   corresponding configurations
                 items:
@@ -345,6 +353,7 @@ spec:
                         'targetRef'
                       properties:
                         backends:
+                          default: []
                           items:
                             properties:
                               file:
@@ -357,6 +366,7 @@ spec:
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        default: []
                                         example:
                                         - key: start_time
                                           value: '%START_TIME%'
@@ -397,6 +407,7 @@ spec:
                                 description: Defines an OpenTelemetry logging backend.
                                 properties:
                                   attributes:
+                                    default: []
                                     description: |-
                                       Attributes can contain placeholders available on
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
@@ -447,6 +458,7 @@ spec:
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        default: []
                                         example:
                                         - key: start_time
                                           value: '%START_TIME%'
@@ -528,6 +540,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/deployments/charts/kuma/crds/kuma.io_meshaccesslogs.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshaccesslogs.yaml
@@ -248,7 +248,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -317,7 +319,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -540,7 +544,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/deployments/charts/kuma/crds/kuma.io_meshcircuitbreakers.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshcircuitbreakers.yaml
@@ -51,6 +51,7 @@ spec:
               resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -334,6 +335,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -402,6 +404,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -426,6 +429,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: |-
                   To list makes a match between the consumed services and corresponding
                   configurations
@@ -710,6 +714,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/deployments/charts/kuma/crds/kuma.io_meshcircuitbreakers.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshcircuitbreakers.yaml
@@ -335,7 +335,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -404,7 +406,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -714,7 +718,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/deployments/charts/kuma/crds/kuma.io_meshexternalservices.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshexternalservices.yaml
@@ -48,6 +48,7 @@ spec:
               resource.
             properties:
               endpoints:
+                default: []
                 description: Endpoints defines a list of destinations to send traffic
                   to.
                 items:
@@ -191,6 +192,7 @@ spec:
                           Indicator set by Kuma.
                         type: string
                       subjectAltNames:
+                        default: []
                         description: SubjectAltNames list of names to verify in the
                           certificate.
                         items:

--- a/deployments/charts/kuma/crds/kuma.io_meshfaultinjections.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshfaultinjections.yaml
@@ -177,7 +177,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -246,7 +248,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -397,7 +401,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/deployments/charts/kuma/crds/kuma.io_meshfaultinjections.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshfaultinjections.yaml
@@ -51,6 +51,7 @@ spec:
               resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -61,6 +62,7 @@ spec:
                         'targetRef'
                       properties:
                         http:
+                          default: []
                           description: Http allows to define list of Http faults between
                             dataplanes.
                           items:
@@ -175,6 +177,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -243,6 +246,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -267,6 +271,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between clients and corresponding
                   configurations
                 items:
@@ -277,6 +282,7 @@ spec:
                         'targetRef'
                       properties:
                         http:
+                          default: []
                           description: Http allows to define list of Http faults between
                             dataplanes.
                           items:
@@ -391,6 +397,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/deployments/charts/kuma/crds/kuma.io_meshhealthchecks.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshhealthchecks.yaml
@@ -90,6 +90,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -114,6 +115,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between the consumed services and
                   corresponding configurations
                 items:
@@ -183,6 +185,7 @@ spec:
                               description: If true the HttpHealthCheck is disabled
                               type: boolean
                             expectedStatuses:
+                              default: []
                               description: List of HTTP response statuses which are
                                 considered healthy
                               items:
@@ -201,6 +204,7 @@ spec:
                                 request
                               properties:
                                 add:
+                                  default: []
                                   items:
                                     properties:
                                       name:
@@ -220,6 +224,7 @@ spec:
                                   - name
                                   x-kubernetes-list-type: map
                                 set:
+                                  default: []
                                   items:
                                     properties:
                                       name:
@@ -287,6 +292,7 @@ spec:
                               description: If true the TcpHealthCheck is disabled
                               type: boolean
                             receive:
+                              default: []
                               description: |-
                                 List of Base64 encoded blocks of strings expected as a response. When checking the response,
                                 "fuzzy" matching is performed such that each block must be found, and
@@ -352,6 +358,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/deployments/charts/kuma/crds/kuma.io_meshhealthchecks.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshhealthchecks.yaml
@@ -90,7 +90,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -358,7 +360,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/deployments/charts/kuma/crds/kuma.io_meshhttproutes.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshhttproutes.yaml
@@ -90,7 +90,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -188,7 +190,9 @@ spec:
                                       format: int32
                                       type: integer
                                     proxyTypes:
-                                      default: []
+                                      default:
+                                      - Sidecar
+                                      - Gateway
                                       description: |-
                                         ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                         all data plane types are targeted by the policy.
@@ -322,7 +326,9 @@ spec:
                                               format: int32
                                               type: integer
                                             proxyTypes:
-                                              default: []
+                                              default:
+                                              - Sidecar
+                                              - Gateway
                                               description: |-
                                                 ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                                 all data plane types are targeted by the policy.
@@ -658,7 +664,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/deployments/charts/kuma/crds/kuma.io_meshhttproutes.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshhttproutes.yaml
@@ -90,6 +90,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -114,11 +115,13 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To matches destination services of requests and holds
                   configuration.
                 items:
                   properties:
                     hostnames:
+                      default: []
                       description: |-
                         Hostnames is only valid when targeting MeshGateway and limits the
                         effects of the rules to requests to this hostname.
@@ -128,6 +131,7 @@ spec:
                         type: string
                       type: array
                     rules:
+                      default: []
                       description: |-
                         Rules contains the routing rules applies to a combination of top-level
                         targetRef and the targetRef in this entry.
@@ -139,6 +143,7 @@ spec:
                               policies.
                             properties:
                               backendRefs:
+                                default: []
                                 items:
                                   description: BackendRef defines where to forward
                                     traffic.
@@ -183,6 +188,7 @@ spec:
                                       format: int32
                                       type: integer
                                     proxyTypes:
+                                      default: []
                                       description: |-
                                         ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                         all data plane types are targeted by the policy.
@@ -212,6 +218,7 @@ spec:
                                   type: object
                                 type: array
                               filters:
+                                default: []
                                 items:
                                   properties:
                                     requestHeaderModifier:
@@ -221,6 +228,7 @@ spec:
                                         header value formatting, separating each value with a comma.
                                       properties:
                                         add:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -240,11 +248,13 @@ spec:
                                           - name
                                           x-kubernetes-list-type: map
                                         remove:
+                                          default: []
                                           items:
                                             type: string
                                           maxItems: 16
                                           type: array
                                         set:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -312,6 +322,7 @@ spec:
                                               format: int32
                                               type: integer
                                             proxyTypes:
+                                              default: []
                                               description: |-
                                                 ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                                 all data plane types are targeted by the policy.
@@ -416,6 +427,7 @@ spec:
                                         header value formatting, separating each value with a comma.
                                       properties:
                                         add:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -435,11 +447,13 @@ spec:
                                           - name
                                           x-kubernetes-list-type: map
                                         remove:
+                                          default: []
                                           items:
                                             type: string
                                           maxItems: 16
                                           type: array
                                         set:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -510,6 +524,7 @@ spec:
                             items:
                               properties:
                                 headers:
+                                  default: []
                                   items:
                                     description: |-
                                       HeaderMatch describes how to select an HTTP route by matching HTTP request
@@ -573,6 +588,7 @@ spec:
                                   - value
                                   type: object
                                 queryParams:
+                                  default: []
                                   description: |-
                                     QueryParams matches based on HTTP URL query parameters. Multiple matches
                                     are ANDed together such that all listed matches must succeed.
@@ -642,6 +658,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/deployments/charts/kuma/crds/kuma.io_meshloadbalancingstrategies.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshloadbalancingstrategies.yaml
@@ -91,6 +91,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -160,6 +161,7 @@ spec:
                                 consistent hashing is desired.
                               properties:
                                 hashPolicies:
+                                  default: []
                                   description: |-
                                     HashPolicies specify a list of request/connection properties that are used to calculate a hash.
                                     These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
@@ -282,6 +284,7 @@ spec:
                                   - MurmurHash2
                                   type: string
                                 hashPolicies:
+                                  default: []
                                   description: |-
                                     HashPolicies specify a list of request/connection properties that are used to calculate a hash.
                                     These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
@@ -413,6 +416,7 @@ spec:
                                 are unavailable
                               properties:
                                 failover:
+                                  default: []
                                   description: Failover defines list of load balancing
                                     rules in order of priority
                                   items:
@@ -422,6 +426,7 @@ spec:
                                           to which the rule applies
                                         properties:
                                           zones:
+                                            default: []
                                             items:
                                               type: string
                                             type: array
@@ -442,6 +447,7 @@ spec:
                                             - AnyExcept
                                             type: string
                                           zones:
+                                            default: []
                                             items:
                                               type: string
                                             type: array
@@ -479,6 +485,7 @@ spec:
                                 priorities between dataplane proxies inside a zone
                               properties:
                                 affinityTags:
+                                  default: []
                                   description: AffinityTags list of tags for local
                                     zone load balancing.
                                   items:
@@ -544,6 +551,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -570,6 +578,7 @@ spec:
                   required:
                   - targetRef
                   type: object
+                minItems: 1
                 type: array
             type: object
         type: object

--- a/deployments/charts/kuma/crds/kuma.io_meshloadbalancingstrategies.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshloadbalancingstrategies.yaml
@@ -91,7 +91,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -551,7 +553,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/deployments/charts/kuma/crds/kuma.io_meshmetrics.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshmetrics.yaml
@@ -270,7 +270,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/deployments/charts/kuma/crds/kuma.io_meshmetrics.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshmetrics.yaml
@@ -53,6 +53,7 @@ spec:
                 description: MeshMetric configuration.
                 properties:
                   applications:
+                    default: []
                     description: Applications is a list of application that Dataplane
                       Proxy will scrape
                     items:
@@ -78,6 +79,7 @@ spec:
                       type: object
                     type: array
                   backends:
+                    default: []
                     description: Backends list that will be used to collect metrics.
                     items:
                       properties:
@@ -157,6 +159,7 @@ spec:
                           published.
                         properties:
                           appendProfiles:
+                            default: []
                             description: AppendProfiles allows to combine the metrics
                               from multiple predefined profiles.
                             items:
@@ -174,6 +177,7 @@ spec:
                               type: object
                             type: array
                           exclude:
+                            default: []
                             description: |-
                               Exclude makes it possible to exclude groups of metrics from a resulting profile.
                               Exclude is subordinate to Include.
@@ -198,6 +202,7 @@ spec:
                               type: object
                             type: array
                           include:
+                            default: []
                             description: |-
                               Include makes it possible to include additional metrics in a selected profiles.
                               Include takes precedence over Exclude.
@@ -265,6 +270,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/deployments/charts/kuma/crds/kuma.io_meshpassthroughs.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshpassthroughs.yaml
@@ -53,6 +53,7 @@ spec:
                 description: MeshPassthrough configuration.
                 properties:
                   appendMatch:
+                    default: []
                     description: AppendMatch is a list of destinations that should
                       be allowed through the sidecar.
                     items:
@@ -138,6 +139,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/deployments/charts/kuma/crds/kuma.io_meshpassthroughs.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshpassthroughs.yaml
@@ -139,7 +139,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/deployments/charts/kuma/crds/kuma.io_meshproxypatches.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshproxypatches.yaml
@@ -527,7 +527,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/deployments/charts/kuma/crds/kuma.io_meshproxypatches.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshproxypatches.yaml
@@ -55,6 +55,7 @@ spec:
                   referenced in 'targetRef'.
                 properties:
                   appendModifications:
+                    default: []
                     description: AppendModifications is a list of modifications applied
                       on the selected proxy.
                     items:
@@ -64,6 +65,7 @@ spec:
                             resource.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy's Cluster
                                 resource
@@ -141,6 +143,7 @@ spec:
                             available in HTTP Connection Manager in a Listener resource.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy's
                                 HTTP Filter available in HTTP Connection Manager in a Listener resource.
@@ -229,6 +232,7 @@ spec:
                             resource.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy's Listener
                                 resource
@@ -310,6 +314,7 @@ spec:
                             filter.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy Listener's
                                 filter.
@@ -399,6 +404,7 @@ spec:
                             referenced in HTTP Connection Manager in a Listener resource.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy's
                                 VirtualHost resource
@@ -521,6 +527,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/deployments/charts/kuma/crds/kuma.io_meshratelimits.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshratelimits.yaml
@@ -217,7 +217,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -286,7 +288,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -478,7 +482,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/deployments/charts/kuma/crds/kuma.io_meshratelimits.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshratelimits.yaml
@@ -50,6 +50,7 @@ spec:
             description: Spec is the specification of the Kuma MeshRateLimit resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -80,6 +81,7 @@ spec:
                                         HTTP response on a rate limit event
                                       properties:
                                         add:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -99,6 +101,7 @@ spec:
                                           - name
                                           x-kubernetes-list-type: map
                                         set:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -214,6 +217,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -282,6 +286,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -306,6 +311,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between clients and corresponding
                   configurations
                 items:
@@ -336,6 +342,7 @@ spec:
                                         HTTP response on a rate limit event
                                       properties:
                                         add:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -355,6 +362,7 @@ spec:
                                           - name
                                           x-kubernetes-list-type: map
                                         set:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -470,6 +478,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/deployments/charts/kuma/crds/kuma.io_meshretries.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshretries.yaml
@@ -90,6 +90,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -114,6 +115,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between the consumed services and
                   corresponding configurations
                 items:
@@ -167,6 +169,7 @@ spec:
                                     time which will be taken between retries.
                                   type: string
                                 resetHeaders:
+                                  default: []
                                   description: |-
                                     ResetHeaders specifies the list of headers (like Retry-After or X-RateLimit-Reset)
                                     to match against the response. Headers are tried in order, and matched
@@ -193,6 +196,7 @@ spec:
                                   type: array
                               type: object
                             retryOn:
+                              default: []
                               description: RetryOn is a list of conditions which will
                                 cause a retry.
                               example:
@@ -233,6 +237,7 @@ spec:
                                   type: string
                               type: object
                             hostSelection:
+                              default: []
                               description: |-
                                 HostSelection is a list of predicates that dictate how hosts should be selected
                                 when requests are retried.
@@ -295,6 +300,7 @@ spec:
                                     time which will be taken between retries.
                                   type: string
                                 resetHeaders:
+                                  default: []
                                   description: |-
                                     ResetHeaders specifies the list of headers (like Retry-After or X-RateLimit-Reset)
                                     to match against the response. Headers are tried in order, and matched
@@ -321,6 +327,7 @@ spec:
                                   type: array
                               type: object
                             retriableRequestHeaders:
+                              default: []
                               description: |-
                                 RetriableRequestHeaders is an HTTP headers which must be present in the request
                                 for retries to be attempted.
@@ -357,6 +364,7 @@ spec:
                                 type: object
                               type: array
                             retriableResponseHeaders:
+                              default: []
                               description: |-
                                 RetriableResponseHeaders is an HTTP response headers that trigger a retry
                                 if present in the response. A retry will be triggered if any of the header
@@ -394,6 +402,7 @@ spec:
                                 type: object
                               type: array
                             retryOn:
+                              default: []
                               description: |-
                                 RetryOn is a list of conditions which will cause a retry. Available values are:
                                 [5XX, GatewayError, Reset, Retriable4xx, ConnectFailure, EnvoyRatelimited,
@@ -477,6 +486,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/deployments/charts/kuma/crds/kuma.io_meshretries.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshretries.yaml
@@ -90,7 +90,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -486,7 +488,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/deployments/charts/kuma/crds/kuma.io_meshservices.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshservices.yaml
@@ -47,6 +47,7 @@ spec:
             description: Spec is the specification of the Kuma MeshService resource.
             properties:
               identities:
+                default: []
                 items:
                   properties:
                     type:
@@ -61,6 +62,7 @@ spec:
                   type: object
                 type: array
               ports:
+                default: []
                 items:
                   properties:
                     appProtocol:

--- a/deployments/charts/kuma/crds/kuma.io_meshtcproutes.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtcproutes.yaml
@@ -90,6 +90,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -120,6 +121,7 @@ spec:
                 items:
                   properties:
                     rules:
+                      default: []
                       description: |-
                         Rules contains the routing rules applies to a combination of top-level
                         targetRef and the targetRef in this entry.
@@ -131,6 +133,7 @@ spec:
                               policies.
                             properties:
                               backendRefs:
+                                default: []
                                 items:
                                   description: BackendRef defines where to forward
                                     traffic.
@@ -175,6 +178,7 @@ spec:
                                       format: int32
                                       type: integer
                                     proxyTypes:
+                                      default: []
                                       description: |-
                                         ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                         all data plane types are targeted by the policy.
@@ -252,6 +256,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/deployments/charts/kuma/crds/kuma.io_meshtcproutes.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtcproutes.yaml
@@ -90,7 +90,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -178,7 +180,9 @@ spec:
                                       format: int32
                                       type: integer
                                     proxyTypes:
-                                      default: []
+                                      default:
+                                      - Sidecar
+                                      - Gateway
                                       description: |-
                                         ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                         all data plane types are targeted by the policy.
@@ -256,7 +260,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/deployments/charts/kuma/crds/kuma.io_meshtimeouts.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtimeouts.yaml
@@ -147,7 +147,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -275,7 +277,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -397,7 +401,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/deployments/charts/kuma/crds/kuma.io_meshtimeouts.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtimeouts.yaml
@@ -50,6 +50,7 @@ spec:
             description: Spec is the specification of the Kuma MeshTimeout resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -146,6 +147,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -174,6 +176,7 @@ spec:
                   type: object
                 type: array
               rules:
+                default: []
                 description: |-
                   Rules defines inbound timeout configurations. Currently limited to exactly one rule containing
                   default timeouts that apply to all inbound traffic, as L7 matching is not yet implemented.
@@ -272,6 +275,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -296,6 +300,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between the consumed services and
                   corresponding configurations
                 items:
@@ -392,6 +397,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/deployments/charts/kuma/crds/kuma.io_meshtlses.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtlses.yaml
@@ -145,7 +145,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -214,7 +216,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/deployments/charts/kuma/crds/kuma.io_meshtlses.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtlses.yaml
@@ -145,6 +145,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -213,6 +214,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/deployments/charts/kuma/crds/kuma.io_meshtraces.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtraces.yaml
@@ -258,7 +258,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/deployments/charts/kuma/crds/kuma.io_meshtraces.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtraces.yaml
@@ -53,6 +53,7 @@ spec:
                 description: MeshTrace configuration.
                 properties:
                   backends:
+                    default: []
                     description: |-
                       A one element array of backend definition.
                       Envoy allows configuring only 1 backend, so the natural way of
@@ -181,6 +182,7 @@ spec:
                         x-kubernetes-int-or-string: true
                     type: object
                   tags:
+                    default: []
                     description: |-
                       Custom tags configuration. You can add custom tags to traces based on
                       headers or literal values.
@@ -256,6 +258,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/deployments/charts/kuma/crds/kuma.io_meshtrafficpermissions.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtrafficpermissions.yaml
@@ -109,6 +109,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -177,6 +178,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/deployments/charts/kuma/crds/kuma.io_meshtrafficpermissions.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtrafficpermissions.yaml
@@ -109,7 +109,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -178,7 +180,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -3441,7 +3441,9 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
-                        default: []
+                        default:
+                          - Sidecar
+                          - Gateway
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -3529,7 +3531,9 @@ components:
                     will be targeted.
                   type: string
                 proxyTypes:
-                  default: []
+                  default:
+                    - Sidecar
+                    - Gateway
                   description: >-
                     ProxyTypes specifies the data plane types that are subject
                     to the policy. When not specified,
@@ -3785,7 +3789,9 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
-                        default: []
+                        default:
+                          - Sidecar
+                          - Gateway
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -4389,7 +4395,9 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
-                        default: []
+                        default:
+                          - Sidecar
+                          - Gateway
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -4477,7 +4485,9 @@ components:
                     will be targeted.
                   type: string
                 proxyTypes:
-                  default: []
+                  default:
+                    - Sidecar
+                    - Gateway
                   description: >-
                     ProxyTypes specifies the data plane types that are subject
                     to the policy. When not specified,
@@ -5018,7 +5028,9 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
-                        default: []
+                        default:
+                          - Sidecar
+                          - Gateway
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -5271,7 +5283,9 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
-                        default: []
+                        default:
+                          - Sidecar
+                          - Gateway
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -5359,7 +5373,9 @@ components:
                     will be targeted.
                   type: string
                 proxyTypes:
-                  default: []
+                  default:
+                    - Sidecar
+                    - Gateway
                   description: >-
                     ProxyTypes specifies the data plane types that are subject
                     to the policy. When not specified,
@@ -5547,7 +5563,9 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
-                        default: []
+                        default:
+                          - Sidecar
+                          - Gateway
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -5694,7 +5712,9 @@ components:
                     will be targeted.
                   type: string
                 proxyTypes:
-                  default: []
+                  default:
+                    - Sidecar
+                    - Gateway
                   description: >-
                     ProxyTypes specifies the data plane types that are subject
                     to the policy. When not specified,
@@ -6049,7 +6069,9 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
-                        default: []
+                        default:
+                          - Sidecar
+                          - Gateway
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -6196,7 +6218,9 @@ components:
                     will be targeted.
                   type: string
                 proxyTypes:
-                  default: []
+                  default:
+                    - Sidecar
+                    - Gateway
                   description: >-
                     ProxyTypes specifies the data plane types that are subject
                     to the policy. When not specified,
@@ -6319,7 +6343,9 @@ components:
                                     format: int32
                                     type: integer
                                   proxyTypes:
-                                    default: []
+                                    default:
+                                      - Sidecar
+                                      - Gateway
                                     description: >-
                                       ProxyTypes specifies the data plane types
                                       that are subject to the policy. When not
@@ -6478,7 +6504,9 @@ components:
                                             format: int32
                                             type: integer
                                           proxyTypes:
-                                            default: []
+                                            default:
+                                              - Sidecar
+                                              - Gateway
                                             description: >-
                                               ProxyTypes specifies the data plane
                                               types that are subject to the policy.
@@ -6882,7 +6910,9 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
-                        default: []
+                        default:
+                          - Sidecar
+                          - Gateway
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -7029,7 +7059,9 @@ components:
                     will be targeted.
                   type: string
                 proxyTypes:
-                  default: []
+                  default:
+                    - Sidecar
+                    - Gateway
                   description: >-
                     ProxyTypes specifies the data plane types that are subject
                     to the policy. When not specified,
@@ -7659,7 +7691,9 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
-                        default: []
+                        default:
+                          - Sidecar
+                          - Gateway
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -8011,7 +8045,9 @@ components:
                     will be targeted.
                   type: string
                 proxyTypes:
-                  default: []
+                  default:
+                    - Sidecar
+                    - Gateway
                   description: >-
                     ProxyTypes specifies the data plane types that are subject
                     to the policy. When not specified,
@@ -8205,7 +8241,9 @@ components:
                     will be targeted.
                   type: string
                 proxyTypes:
-                  default: []
+                  default:
+                    - Sidecar
+                    - Gateway
                   description: >-
                     ProxyTypes specifies the data plane types that are subject
                     to the policy. When not specified,
@@ -8934,7 +8972,9 @@ components:
                     will be targeted.
                   type: string
                 proxyTypes:
-                  default: []
+                  default:
+                    - Sidecar
+                    - Gateway
                   description: >-
                     ProxyTypes specifies the data plane types that are subject
                     to the policy. When not specified,
@@ -9221,7 +9261,9 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
-                        default: []
+                        default:
+                          - Sidecar
+                          - Gateway
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -9309,7 +9351,9 @@ components:
                     will be targeted.
                   type: string
                 proxyTypes:
-                  default: []
+                  default:
+                    - Sidecar
+                    - Gateway
                   description: >-
                     ProxyTypes specifies the data plane types that are subject
                     to the policy. When not specified,
@@ -9535,7 +9579,9 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
-                        default: []
+                        default:
+                          - Sidecar
+                          - Gateway
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -9682,7 +9728,9 @@ components:
                     will be targeted.
                   type: string
                 proxyTypes:
-                  default: []
+                  default:
+                    - Sidecar
+                    - Gateway
                   description: >-
                     ProxyTypes specifies the data plane types that are subject
                     to the policy. When not specified,
@@ -10199,7 +10247,9 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
-                        default: []
+                        default:
+                          - Sidecar
+                          - Gateway
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -10346,7 +10396,9 @@ components:
                     will be targeted.
                   type: string
                 proxyTypes:
-                  default: []
+                  default:
+                    - Sidecar
+                    - Gateway
                   description: >-
                     ProxyTypes specifies the data plane types that are subject
                     to the policy. When not specified,
@@ -10455,7 +10507,9 @@ components:
                                     format: int32
                                     type: integer
                                   proxyTypes:
-                                    default: []
+                                    default:
+                                      - Sidecar
+                                      - Gateway
                                     description: >-
                                       ProxyTypes specifies the data plane types
                                       that are subject to the policy. When not
@@ -10552,7 +10606,9 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
-                        default: []
+                        default:
+                          - Sidecar
+                          - Gateway
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -10788,7 +10844,9 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
-                        default: []
+                        default:
+                          - Sidecar
+                          - Gateway
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -10968,7 +11026,9 @@ components:
                     will be targeted.
                   type: string
                 proxyTypes:
-                  default: []
+                  default:
+                    - Sidecar
+                    - Gateway
                   description: >-
                     ProxyTypes specifies the data plane types that are subject
                     to the policy. When not specified,
@@ -11138,7 +11198,9 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
-                        default: []
+                        default:
+                          - Sidecar
+                          - Gateway
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -11346,7 +11408,9 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
-                        default: []
+                        default:
+                          - Sidecar
+                          - Gateway
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -11434,7 +11498,9 @@ components:
                     will be targeted.
                   type: string
                 proxyTypes:
-                  default: []
+                  default:
+                    - Sidecar
+                    - Gateway
                   description: >-
                     ProxyTypes specifies the data plane types that are subject
                     to the policy. When not specified,
@@ -11794,7 +11860,9 @@ components:
                     will be targeted.
                   type: string
                 proxyTypes:
-                  default: []
+                  default:
+                    - Sidecar
+                    - Gateway
                   description: >-
                     ProxyTypes specifies the data plane types that are subject
                     to the policy. When not specified,
@@ -11957,7 +12025,9 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
-                        default: []
+                        default:
+                          - Sidecar
+                          - Gateway
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -12045,7 +12115,9 @@ components:
                     will be targeted.
                   type: string
                 proxyTypes:
-                  default: []
+                  default:
+                    - Sidecar
+                    - Gateway
                   description: >-
                     ProxyTypes specifies the data plane types that are subject
                     to the policy. When not specified,

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -3216,6 +3216,7 @@ components:
           description: Spec is the specification of the Kuma MeshAccessLog resource.
           properties:
             from:
+              default: []
               description: >-
                 From list makes a match between clients and corresponding
                 configurations
@@ -3229,6 +3230,7 @@ components:
                       'targetRef'
                     properties:
                       backends:
+                        default: []
                         items:
                           properties:
                             file:
@@ -3244,6 +3246,7 @@ components:
                                     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                   properties:
                                     json:
+                                      default: []
                                       example:
                                         - key: start_time
                                           value: '%START_TIME%'
@@ -3285,6 +3288,7 @@ components:
                               description: Defines an OpenTelemetry logging backend.
                               properties:
                                 attributes:
+                                  default: []
                                   description: >-
                                     Attributes can contain placeholders
                                     available on
@@ -3344,6 +3348,7 @@ components:
                                     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                   properties:
                                     json:
+                                      default: []
                                       example:
                                         - key: start_time
                                           value: '%START_TIME%'
@@ -3436,6 +3441,7 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
+                        default: []
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -3523,6 +3529,7 @@ components:
                     will be targeted.
                   type: string
                 proxyTypes:
+                  default: []
                   description: >-
                     ProxyTypes specifies the data plane types that are subject
                     to the policy. When not specified,
@@ -3553,6 +3560,7 @@ components:
                   type: object
               type: object
             to:
+              default: []
               description: >-
                 To list makes a match between the consumed services and
                 corresponding configurations
@@ -3566,6 +3574,7 @@ components:
                       'targetRef'
                     properties:
                       backends:
+                        default: []
                         items:
                           properties:
                             file:
@@ -3581,6 +3590,7 @@ components:
                                     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                   properties:
                                     json:
+                                      default: []
                                       example:
                                         - key: start_time
                                           value: '%START_TIME%'
@@ -3622,6 +3632,7 @@ components:
                               description: Defines an OpenTelemetry logging backend.
                               properties:
                                 attributes:
+                                  default: []
                                   description: >-
                                     Attributes can contain placeholders
                                     available on
@@ -3681,6 +3692,7 @@ components:
                                     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                   properties:
                                     json:
+                                      default: []
                                       example:
                                         - key: start_time
                                           value: '%START_TIME%'
@@ -3773,6 +3785,7 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
+                        default: []
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -3868,6 +3881,7 @@ components:
           description: Spec is the specification of the Kuma MeshCircuitBreaker resource.
           properties:
             from:
+              default: []
               description: >-
                 From list makes a match between clients and corresponding
                 configurations
@@ -4375,6 +4389,7 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
+                        default: []
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -4462,6 +4477,7 @@ components:
                     will be targeted.
                   type: string
                 proxyTypes:
+                  default: []
                   description: >-
                     ProxyTypes specifies the data plane types that are subject
                     to the policy. When not specified,
@@ -4492,6 +4508,7 @@ components:
                   type: object
               type: object
             to:
+              default: []
               description: >-
                 To list makes a match between the consumed services and
                 corresponding
@@ -5001,6 +5018,7 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
+                        default: []
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -5096,6 +5114,7 @@ components:
           description: Spec is the specification of the Kuma MeshFaultInjection resource.
           properties:
             from:
+              default: []
               description: >-
                 From list makes a match between clients and corresponding
                 configurations
@@ -5109,6 +5128,7 @@ components:
                       'targetRef'
                     properties:
                       http:
+                        default: []
                         description: >-
                           Http allows to define list of Http faults between
                           dataplanes.
@@ -5251,6 +5271,7 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
+                        default: []
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -5338,6 +5359,7 @@ components:
                     will be targeted.
                   type: string
                 proxyTypes:
+                  default: []
                   description: >-
                     ProxyTypes specifies the data plane types that are subject
                     to the policy. When not specified,
@@ -5368,6 +5390,7 @@ components:
                   type: object
               type: object
             to:
+              default: []
               description: >-
                 To list makes a match between clients and corresponding
                 configurations
@@ -5381,6 +5404,7 @@ components:
                       'targetRef'
                     properties:
                       http:
+                        default: []
                         description: >-
                           Http allows to define list of Http faults between
                           dataplanes.
@@ -5523,6 +5547,7 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
+                        default: []
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -5669,6 +5694,7 @@ components:
                     will be targeted.
                   type: string
                 proxyTypes:
+                  default: []
                   description: >-
                     ProxyTypes specifies the data plane types that are subject
                     to the policy. When not specified,
@@ -5699,6 +5725,7 @@ components:
                   type: object
               type: object
             to:
+              default: []
               description: >-
                 To list makes a match between the consumed services and
                 corresponding configurations
@@ -5795,6 +5822,7 @@ components:
                             description: If true the HttpHealthCheck is disabled
                             type: boolean
                           expectedStatuses:
+                            default: []
                             description: >-
                               List of HTTP response statuses which are
                               considered healthy
@@ -5818,6 +5846,7 @@ components:
                               request
                             properties:
                               add:
+                                default: []
                                 items:
                                   properties:
                                     name:
@@ -5837,6 +5866,7 @@ components:
                                   - name
                                 x-kubernetes-list-type: map
                               set:
+                                default: []
                                 items:
                                   properties:
                                     name:
@@ -5933,6 +5963,7 @@ components:
                             description: If true the TcpHealthCheck is disabled
                             type: boolean
                           receive:
+                            default: []
                             description: >-
                               List of Base64 encoded blocks of strings expected
                               as a response. When checking the response,
@@ -6018,6 +6049,7 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
+                        default: []
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -6164,6 +6196,7 @@ components:
                     will be targeted.
                   type: string
                 proxyTypes:
+                  default: []
                   description: >-
                     ProxyTypes specifies the data plane types that are subject
                     to the policy. When not specified,
@@ -6194,12 +6227,14 @@ components:
                   type: object
               type: object
             to:
+              default: []
               description: >-
                 To matches destination services of requests and holds
                 configuration.
               items:
                 properties:
                   hostnames:
+                    default: []
                     description: >-
                       Hostnames is only valid when targeting MeshGateway and
                       limits the
@@ -6214,6 +6249,7 @@ components:
                       type: string
                     type: array
                   rules:
+                    default: []
                     description: >-
                       Rules contains the routing rules applies to a combination
                       of top-level
@@ -6229,6 +6265,7 @@ components:
                             policies.
                           properties:
                             backendRefs:
+                              default: []
                               items:
                                 description: BackendRef defines where to forward traffic.
                                 properties:
@@ -6282,6 +6319,7 @@ components:
                                     format: int32
                                     type: integer
                                   proxyTypes:
+                                    default: []
                                     description: >-
                                       ProxyTypes specifies the data plane types
                                       that are subject to the policy. When not
@@ -6321,6 +6359,7 @@ components:
                                 type: object
                               type: array
                             filters:
+                              default: []
                               items:
                                 properties:
                                   requestHeaderModifier:
@@ -6335,6 +6374,7 @@ components:
                                       value with a comma.
                                     properties:
                                       add:
+                                        default: []
                                         items:
                                           properties:
                                             name:
@@ -6354,11 +6394,13 @@ components:
                                           - name
                                         x-kubernetes-list-type: map
                                       remove:
+                                        default: []
                                         items:
                                           type: string
                                         maxItems: 16
                                         type: array
                                       set:
+                                        default: []
                                         items:
                                           properties:
                                             name:
@@ -6436,6 +6478,7 @@ components:
                                             format: int32
                                             type: integer
                                           proxyTypes:
+                                            default: []
                                             description: >-
                                               ProxyTypes specifies the data plane
                                               types that are subject to the policy.
@@ -6578,6 +6621,7 @@ components:
                                       value with a comma.
                                     properties:
                                       add:
+                                        default: []
                                         items:
                                           properties:
                                             name:
@@ -6597,11 +6641,13 @@ components:
                                           - name
                                         x-kubernetes-list-type: map
                                       remove:
+                                        default: []
                                         items:
                                           type: string
                                         maxItems: 16
                                         type: array
                                       set:
+                                        default: []
                                         items:
                                           properties:
                                             name:
@@ -6679,6 +6725,7 @@ components:
                           items:
                             properties:
                               headers:
+                                default: []
                                 items:
                                   description: >-
                                     HeaderMatch describes how to select an HTTP
@@ -6753,6 +6800,7 @@ components:
                                   - value
                                 type: object
                               queryParams:
+                                default: []
                                 description: >-
                                   QueryParams matches based on HTTP URL query
                                   parameters. Multiple matches
@@ -6834,6 +6882,7 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
+                        default: []
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -6980,6 +7029,7 @@ components:
                     will be targeted.
                   type: string
                 proxyTypes:
+                  default: []
                   description: >-
                     ProxyTypes specifies the data plane types that are subject
                     to the policy. When not specified,
@@ -7078,6 +7128,7 @@ components:
                               consistent hashing is desired.
                             properties:
                               hashPolicies:
+                                default: []
                                 description: >-
                                   HashPolicies specify a list of
                                   request/connection properties that are used to
@@ -7251,6 +7302,7 @@ components:
                                   - MurmurHash2
                                 type: string
                               hashPolicies:
+                                default: []
                                 description: >-
                                   HashPolicies specify a list of
                                   request/connection properties that are used to
@@ -7424,6 +7476,7 @@ components:
                               are unavailable
                             properties:
                               failover:
+                                default: []
                                 description: >-
                                   Failover defines list of load balancing rules
                                   in order of priority
@@ -7435,6 +7488,7 @@ components:
                                         the rule applies
                                       properties:
                                         zones:
+                                          default: []
                                           items:
                                             type: string
                                           type: array
@@ -7457,6 +7511,7 @@ components:
                                             - AnyExcept
                                           type: string
                                         zones:
+                                          default: []
                                           items:
                                             type: string
                                           type: array
@@ -7508,6 +7563,7 @@ components:
                               priorities between dataplane proxies inside a zone
                             properties:
                               affinityTags:
+                                default: []
                                 description: >-
                                   AffinityTags list of tags for local zone load
                                   balancing.
@@ -7603,6 +7659,7 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
+                        default: []
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -7637,6 +7694,7 @@ components:
                 required:
                   - targetRef
                 type: object
+              minItems: 1
               type: array
           type: object
         creationTime:
@@ -7701,6 +7759,7 @@ components:
               description: MeshMetric configuration.
               properties:
                 applications:
+                  default: []
                   description: >-
                     Applications is a list of application that Dataplane Proxy
                     will scrape
@@ -7729,6 +7788,7 @@ components:
                     type: object
                   type: array
                 backends:
+                  default: []
                   description: Backends list that will be used to collect metrics.
                   items:
                     properties:
@@ -7819,6 +7879,7 @@ components:
                         published.
                       properties:
                         appendProfiles:
+                          default: []
                           description: >-
                             AppendProfiles allows to combine the metrics from
                             multiple predefined profiles.
@@ -7838,6 +7899,7 @@ components:
                             type: object
                           type: array
                         exclude:
+                          default: []
                           description: >-
                             Exclude makes it possible to exclude groups of
                             metrics from a resulting profile.
@@ -7866,6 +7928,7 @@ components:
                             type: object
                           type: array
                         include:
+                          default: []
                           description: >-
                             Include makes it possible to include additional
                             metrics in a selected profiles.
@@ -7948,6 +8011,7 @@ components:
                     will be targeted.
                   type: string
                 proxyTypes:
+                  default: []
                   description: >-
                     ProxyTypes specifies the data plane types that are subject
                     to the policy. When not specified,
@@ -8040,6 +8104,7 @@ components:
               description: MeshPassthrough configuration.
               properties:
                 appendMatch:
+                  default: []
                   description: >-
                     AppendMatch is a list of destinations that should be allowed
                     through the sidecar.
@@ -8140,6 +8205,7 @@ components:
                     will be targeted.
                   type: string
                 proxyTypes:
+                  default: []
                   description: >-
                     ProxyTypes specifies the data plane types that are subject
                     to the policy. When not specified,
@@ -8234,6 +8300,7 @@ components:
                 referenced in 'targetRef'.
               properties:
                 appendModifications:
+                  default: []
                   description: >-
                     AppendModifications is a list of modifications applied on
                     the selected proxy.
@@ -8243,6 +8310,7 @@ components:
                         description: Cluster is a modification of Envoy's Cluster resource.
                         properties:
                           jsonPatches:
+                            default: []
                             description: >-
                               JsonPatches specifies list of jsonpatches to apply
                               to on Envoy's Cluster
@@ -8349,6 +8417,7 @@ components:
                           resource.
                         properties:
                           jsonPatches:
+                            default: []
                             description: >-
                               JsonPatches specifies list of jsonpatches to apply
                               to on Envoy's
@@ -8469,6 +8538,7 @@ components:
                           resource.
                         properties:
                           jsonPatches:
+                            default: []
                             description: >-
                               JsonPatches specifies list of jsonpatches to apply
                               to on Envoy's Listener
@@ -8580,6 +8650,7 @@ components:
                           filter.
                         properties:
                           jsonPatches:
+                            default: []
                             description: >-
                               JsonPatches specifies list of jsonpatches to apply
                               to on Envoy Listener's
@@ -8701,6 +8772,7 @@ components:
                           resource.
                         properties:
                           jsonPatches:
+                            default: []
                             description: >-
                               JsonPatches specifies list of jsonpatches to apply
                               to on Envoy's
@@ -8862,6 +8934,7 @@ components:
                     will be targeted.
                   type: string
                 proxyTypes:
+                  default: []
                   description: >-
                     ProxyTypes specifies the data plane types that are subject
                     to the policy. When not specified,
@@ -8953,6 +9026,7 @@ components:
           description: Spec is the specification of the Kuma MeshRateLimit resource.
           properties:
             from:
+              default: []
               description: >-
                 From list makes a match between clients and corresponding
                 configurations
@@ -8991,6 +9065,7 @@ components:
                                       response on a rate limit event
                                     properties:
                                       add:
+                                        default: []
                                         items:
                                           properties:
                                             name:
@@ -9010,6 +9085,7 @@ components:
                                           - name
                                         x-kubernetes-list-type: map
                                       set:
+                                        default: []
                                         items:
                                           properties:
                                             name:
@@ -9145,6 +9221,7 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
+                        default: []
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -9232,6 +9309,7 @@ components:
                     will be targeted.
                   type: string
                 proxyTypes:
+                  default: []
                   description: >-
                     ProxyTypes specifies the data plane types that are subject
                     to the policy. When not specified,
@@ -9262,6 +9340,7 @@ components:
                   type: object
               type: object
             to:
+              default: []
               description: >-
                 To list makes a match between clients and corresponding
                 configurations
@@ -9300,6 +9379,7 @@ components:
                                       response on a rate limit event
                                     properties:
                                       add:
+                                        default: []
                                         items:
                                           properties:
                                             name:
@@ -9319,6 +9399,7 @@ components:
                                           - name
                                         x-kubernetes-list-type: map
                                       set:
+                                        default: []
                                         items:
                                           properties:
                                             name:
@@ -9454,6 +9535,7 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
+                        default: []
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -9600,6 +9682,7 @@ components:
                     will be targeted.
                   type: string
                 proxyTypes:
+                  default: []
                   description: >-
                     ProxyTypes specifies the data plane types that are subject
                     to the policy. When not specified,
@@ -9630,6 +9713,7 @@ components:
                   type: object
               type: object
             to:
+              default: []
               description: >-
                 To list makes a match between the consumed services and
                 corresponding configurations
@@ -9706,6 +9790,7 @@ components:
                                   will be taken between retries.
                                 type: string
                               resetHeaders:
+                                default: []
                                 description: >-
                                   ResetHeaders specifies the list of headers
                                   (like Retry-After or X-RateLimit-Reset)
@@ -9739,6 +9824,7 @@ components:
                                 type: array
                             type: object
                           retryOn:
+                            default: []
                             description: >-
                               RetryOn is a list of conditions which will cause a
                               retry.
@@ -9788,6 +9874,7 @@ components:
                                 type: string
                             type: object
                           hostSelection:
+                            default: []
                             description: >-
                               HostSelection is a list of predicates that dictate
                               how hosts should be selected
@@ -9878,6 +9965,7 @@ components:
                                   will be taken between retries.
                                 type: string
                               resetHeaders:
+                                default: []
                                 description: >-
                                   ResetHeaders specifies the list of headers
                                   (like Retry-After or X-RateLimit-Reset)
@@ -9911,6 +9999,7 @@ components:
                                 type: array
                             type: object
                           retriableRequestHeaders:
+                            default: []
                             description: >-
                               RetriableRequestHeaders is an HTTP headers which
                               must be present in the request
@@ -9957,6 +10046,7 @@ components:
                               type: object
                             type: array
                           retriableResponseHeaders:
+                            default: []
                             description: >-
                               RetriableResponseHeaders is an HTTP response
                               headers that trigger a retry
@@ -10006,6 +10096,7 @@ components:
                               type: object
                             type: array
                           retryOn:
+                            default: []
                             description: >-
                               RetryOn is a list of conditions which will cause a
                               retry. Available values are:
@@ -10108,6 +10199,7 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
+                        default: []
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -10254,6 +10346,7 @@ components:
                     will be targeted.
                   type: string
                 proxyTypes:
+                  default: []
                   description: >-
                     ProxyTypes specifies the data plane types that are subject
                     to the policy. When not specified,
@@ -10292,6 +10385,7 @@ components:
               items:
                 properties:
                   rules:
+                    default: []
                     description: >-
                       Rules contains the routing rules applies to a combination
                       of top-level
@@ -10307,6 +10401,7 @@ components:
                             policies.
                           properties:
                             backendRefs:
+                              default: []
                               items:
                                 description: BackendRef defines where to forward traffic.
                                 properties:
@@ -10360,6 +10455,7 @@ components:
                                     format: int32
                                     type: integer
                                   proxyTypes:
+                                    default: []
                                     description: >-
                                       ProxyTypes specifies the data plane types
                                       that are subject to the policy. When not
@@ -10456,6 +10552,7 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
+                        default: []
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -10552,6 +10649,7 @@ components:
           description: Spec is the specification of the Kuma MeshTimeout resource.
           properties:
             from:
+              default: []
               description: >-
                 From list makes a match between clients and corresponding
                 configurations
@@ -10690,6 +10788,7 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
+                        default: []
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -10726,6 +10825,7 @@ components:
                 type: object
               type: array
             rules:
+              default: []
               description: >-
                 Rules defines inbound timeout configurations. Currently limited
                 to exactly one rule containing
@@ -10868,6 +10968,7 @@ components:
                     will be targeted.
                   type: string
                 proxyTypes:
+                  default: []
                   description: >-
                     ProxyTypes specifies the data plane types that are subject
                     to the policy. When not specified,
@@ -10898,6 +10999,7 @@ components:
                   type: object
               type: object
             to:
+              default: []
               description: >-
                 To list makes a match between the consumed services and
                 corresponding configurations
@@ -11036,6 +11138,7 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
+                        default: []
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -11243,6 +11346,7 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
+                        default: []
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -11330,6 +11434,7 @@ components:
                     will be targeted.
                   type: string
                 proxyTypes:
+                  default: []
                   description: >-
                     ProxyTypes specifies the data plane types that are subject
                     to the policy. When not specified,
@@ -11422,6 +11527,7 @@ components:
               description: MeshTrace configuration.
               properties:
                 backends:
+                  default: []
                   description: >-
                     A one element array of backend definition.
 
@@ -11596,6 +11702,7 @@ components:
                       x-kubernetes-int-or-string: true
                   type: object
                 tags:
+                  default: []
                   description: >-
                     Custom tags configuration. You can add custom tags to traces
                     based on
@@ -11687,6 +11794,7 @@ components:
                     will be targeted.
                   type: string
                 proxyTypes:
+                  default: []
                   description: >-
                     ProxyTypes specifies the data plane types that are subject
                     to the policy. When not specified,
@@ -11849,6 +11957,7 @@ components:
                           will be targeted.
                         type: string
                       proxyTypes:
+                        default: []
                         description: >-
                           ProxyTypes specifies the data plane types that are
                           subject to the policy. When not specified,
@@ -11936,6 +12045,7 @@ components:
                     will be targeted.
                   type: string
                 proxyTypes:
+                  default: []
                   description: >-
                     ProxyTypes specifies the data plane types that are subject
                     to the policy. When not specified,
@@ -12850,6 +12960,7 @@ components:
           description: Spec is the specification of the Kuma MeshExternalService resource.
           properties:
             endpoints:
+              default: []
               description: Endpoints defines a list of destinations to send traffic to.
               items:
                 properties:
@@ -12997,6 +13108,7 @@ components:
                         set by Kuma.
                       type: string
                     subjectAltNames:
+                      default: []
                       description: >-
                         SubjectAltNames list of names to verify in the
                         certificate.
@@ -13434,6 +13546,7 @@ components:
           description: Spec is the specification of the Kuma MeshService resource.
           properties:
             identities:
+              default: []
               items:
                 properties:
                   type:
@@ -13448,6 +13561,7 @@ components:
                 type: object
               type: array
             ports:
+              default: []
               items:
                 properties:
                   appProtocol:

--- a/docs/generated/raw/crds/kuma.io_meshaccesslogs.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshaccesslogs.yaml
@@ -50,6 +50,7 @@ spec:
             description: Spec is the specification of the Kuma MeshAccessLog resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -60,6 +61,7 @@ spec:
                         'targetRef'
                       properties:
                         backends:
+                          default: []
                           items:
                             properties:
                               file:
@@ -72,6 +74,7 @@ spec:
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        default: []
                                         example:
                                         - key: start_time
                                           value: '%START_TIME%'
@@ -112,6 +115,7 @@ spec:
                                 description: Defines an OpenTelemetry logging backend.
                                 properties:
                                   attributes:
+                                    default: []
                                     description: |-
                                       Attributes can contain placeholders available on
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
@@ -162,6 +166,7 @@ spec:
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        default: []
                                         example:
                                         - key: start_time
                                           value: '%START_TIME%'
@@ -243,6 +248,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -311,6 +317,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -335,6 +342,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between the consumed services and
                   corresponding configurations
                 items:
@@ -345,6 +353,7 @@ spec:
                         'targetRef'
                       properties:
                         backends:
+                          default: []
                           items:
                             properties:
                               file:
@@ -357,6 +366,7 @@ spec:
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        default: []
                                         example:
                                         - key: start_time
                                           value: '%START_TIME%'
@@ -397,6 +407,7 @@ spec:
                                 description: Defines an OpenTelemetry logging backend.
                                 properties:
                                   attributes:
+                                    default: []
                                     description: |-
                                       Attributes can contain placeholders available on
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
@@ -447,6 +458,7 @@ spec:
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        default: []
                                         example:
                                         - key: start_time
                                           value: '%START_TIME%'
@@ -528,6 +540,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/docs/generated/raw/crds/kuma.io_meshaccesslogs.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshaccesslogs.yaml
@@ -248,7 +248,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -317,7 +319,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -540,7 +544,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/docs/generated/raw/crds/kuma.io_meshcircuitbreakers.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshcircuitbreakers.yaml
@@ -51,6 +51,7 @@ spec:
               resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -334,6 +335,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -402,6 +404,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -426,6 +429,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: |-
                   To list makes a match between the consumed services and corresponding
                   configurations
@@ -710,6 +714,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/docs/generated/raw/crds/kuma.io_meshcircuitbreakers.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshcircuitbreakers.yaml
@@ -335,7 +335,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -404,7 +406,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -714,7 +718,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/docs/generated/raw/crds/kuma.io_meshexternalservices.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshexternalservices.yaml
@@ -48,6 +48,7 @@ spec:
               resource.
             properties:
               endpoints:
+                default: []
                 description: Endpoints defines a list of destinations to send traffic
                   to.
                 items:
@@ -191,6 +192,7 @@ spec:
                           Indicator set by Kuma.
                         type: string
                       subjectAltNames:
+                        default: []
                         description: SubjectAltNames list of names to verify in the
                           certificate.
                         items:

--- a/docs/generated/raw/crds/kuma.io_meshfaultinjections.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshfaultinjections.yaml
@@ -177,7 +177,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -246,7 +248,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -397,7 +401,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/docs/generated/raw/crds/kuma.io_meshfaultinjections.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshfaultinjections.yaml
@@ -51,6 +51,7 @@ spec:
               resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -61,6 +62,7 @@ spec:
                         'targetRef'
                       properties:
                         http:
+                          default: []
                           description: Http allows to define list of Http faults between
                             dataplanes.
                           items:
@@ -175,6 +177,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -243,6 +246,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -267,6 +271,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between clients and corresponding
                   configurations
                 items:
@@ -277,6 +282,7 @@ spec:
                         'targetRef'
                       properties:
                         http:
+                          default: []
                           description: Http allows to define list of Http faults between
                             dataplanes.
                           items:
@@ -391,6 +397,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/docs/generated/raw/crds/kuma.io_meshhealthchecks.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshhealthchecks.yaml
@@ -90,6 +90,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -114,6 +115,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between the consumed services and
                   corresponding configurations
                 items:
@@ -183,6 +185,7 @@ spec:
                               description: If true the HttpHealthCheck is disabled
                               type: boolean
                             expectedStatuses:
+                              default: []
                               description: List of HTTP response statuses which are
                                 considered healthy
                               items:
@@ -201,6 +204,7 @@ spec:
                                 request
                               properties:
                                 add:
+                                  default: []
                                   items:
                                     properties:
                                       name:
@@ -220,6 +224,7 @@ spec:
                                   - name
                                   x-kubernetes-list-type: map
                                 set:
+                                  default: []
                                   items:
                                     properties:
                                       name:
@@ -287,6 +292,7 @@ spec:
                               description: If true the TcpHealthCheck is disabled
                               type: boolean
                             receive:
+                              default: []
                               description: |-
                                 List of Base64 encoded blocks of strings expected as a response. When checking the response,
                                 "fuzzy" matching is performed such that each block must be found, and
@@ -352,6 +358,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/docs/generated/raw/crds/kuma.io_meshhealthchecks.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshhealthchecks.yaml
@@ -90,7 +90,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -358,7 +360,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/docs/generated/raw/crds/kuma.io_meshhttproutes.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshhttproutes.yaml
@@ -90,7 +90,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -188,7 +190,9 @@ spec:
                                       format: int32
                                       type: integer
                                     proxyTypes:
-                                      default: []
+                                      default:
+                                      - Sidecar
+                                      - Gateway
                                       description: |-
                                         ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                         all data plane types are targeted by the policy.
@@ -322,7 +326,9 @@ spec:
                                               format: int32
                                               type: integer
                                             proxyTypes:
-                                              default: []
+                                              default:
+                                              - Sidecar
+                                              - Gateway
                                               description: |-
                                                 ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                                 all data plane types are targeted by the policy.
@@ -658,7 +664,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/docs/generated/raw/crds/kuma.io_meshhttproutes.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshhttproutes.yaml
@@ -90,6 +90,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -114,11 +115,13 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To matches destination services of requests and holds
                   configuration.
                 items:
                   properties:
                     hostnames:
+                      default: []
                       description: |-
                         Hostnames is only valid when targeting MeshGateway and limits the
                         effects of the rules to requests to this hostname.
@@ -128,6 +131,7 @@ spec:
                         type: string
                       type: array
                     rules:
+                      default: []
                       description: |-
                         Rules contains the routing rules applies to a combination of top-level
                         targetRef and the targetRef in this entry.
@@ -139,6 +143,7 @@ spec:
                               policies.
                             properties:
                               backendRefs:
+                                default: []
                                 items:
                                   description: BackendRef defines where to forward
                                     traffic.
@@ -183,6 +188,7 @@ spec:
                                       format: int32
                                       type: integer
                                     proxyTypes:
+                                      default: []
                                       description: |-
                                         ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                         all data plane types are targeted by the policy.
@@ -212,6 +218,7 @@ spec:
                                   type: object
                                 type: array
                               filters:
+                                default: []
                                 items:
                                   properties:
                                     requestHeaderModifier:
@@ -221,6 +228,7 @@ spec:
                                         header value formatting, separating each value with a comma.
                                       properties:
                                         add:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -240,11 +248,13 @@ spec:
                                           - name
                                           x-kubernetes-list-type: map
                                         remove:
+                                          default: []
                                           items:
                                             type: string
                                           maxItems: 16
                                           type: array
                                         set:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -312,6 +322,7 @@ spec:
                                               format: int32
                                               type: integer
                                             proxyTypes:
+                                              default: []
                                               description: |-
                                                 ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                                 all data plane types are targeted by the policy.
@@ -416,6 +427,7 @@ spec:
                                         header value formatting, separating each value with a comma.
                                       properties:
                                         add:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -435,11 +447,13 @@ spec:
                                           - name
                                           x-kubernetes-list-type: map
                                         remove:
+                                          default: []
                                           items:
                                             type: string
                                           maxItems: 16
                                           type: array
                                         set:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -510,6 +524,7 @@ spec:
                             items:
                               properties:
                                 headers:
+                                  default: []
                                   items:
                                     description: |-
                                       HeaderMatch describes how to select an HTTP route by matching HTTP request
@@ -573,6 +588,7 @@ spec:
                                   - value
                                   type: object
                                 queryParams:
+                                  default: []
                                   description: |-
                                     QueryParams matches based on HTTP URL query parameters. Multiple matches
                                     are ANDed together such that all listed matches must succeed.
@@ -642,6 +658,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/docs/generated/raw/crds/kuma.io_meshloadbalancingstrategies.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshloadbalancingstrategies.yaml
@@ -91,6 +91,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -160,6 +161,7 @@ spec:
                                 consistent hashing is desired.
                               properties:
                                 hashPolicies:
+                                  default: []
                                   description: |-
                                     HashPolicies specify a list of request/connection properties that are used to calculate a hash.
                                     These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
@@ -282,6 +284,7 @@ spec:
                                   - MurmurHash2
                                   type: string
                                 hashPolicies:
+                                  default: []
                                   description: |-
                                     HashPolicies specify a list of request/connection properties that are used to calculate a hash.
                                     These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
@@ -413,6 +416,7 @@ spec:
                                 are unavailable
                               properties:
                                 failover:
+                                  default: []
                                   description: Failover defines list of load balancing
                                     rules in order of priority
                                   items:
@@ -422,6 +426,7 @@ spec:
                                           to which the rule applies
                                         properties:
                                           zones:
+                                            default: []
                                             items:
                                               type: string
                                             type: array
@@ -442,6 +447,7 @@ spec:
                                             - AnyExcept
                                             type: string
                                           zones:
+                                            default: []
                                             items:
                                               type: string
                                             type: array
@@ -479,6 +485,7 @@ spec:
                                 priorities between dataplane proxies inside a zone
                               properties:
                                 affinityTags:
+                                  default: []
                                   description: AffinityTags list of tags for local
                                     zone load balancing.
                                   items:
@@ -544,6 +551,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -570,6 +578,7 @@ spec:
                   required:
                   - targetRef
                   type: object
+                minItems: 1
                 type: array
             type: object
         type: object

--- a/docs/generated/raw/crds/kuma.io_meshloadbalancingstrategies.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshloadbalancingstrategies.yaml
@@ -91,7 +91,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -551,7 +553,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/docs/generated/raw/crds/kuma.io_meshmetrics.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshmetrics.yaml
@@ -270,7 +270,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/docs/generated/raw/crds/kuma.io_meshmetrics.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshmetrics.yaml
@@ -53,6 +53,7 @@ spec:
                 description: MeshMetric configuration.
                 properties:
                   applications:
+                    default: []
                     description: Applications is a list of application that Dataplane
                       Proxy will scrape
                     items:
@@ -78,6 +79,7 @@ spec:
                       type: object
                     type: array
                   backends:
+                    default: []
                     description: Backends list that will be used to collect metrics.
                     items:
                       properties:
@@ -157,6 +159,7 @@ spec:
                           published.
                         properties:
                           appendProfiles:
+                            default: []
                             description: AppendProfiles allows to combine the metrics
                               from multiple predefined profiles.
                             items:
@@ -174,6 +177,7 @@ spec:
                               type: object
                             type: array
                           exclude:
+                            default: []
                             description: |-
                               Exclude makes it possible to exclude groups of metrics from a resulting profile.
                               Exclude is subordinate to Include.
@@ -198,6 +202,7 @@ spec:
                               type: object
                             type: array
                           include:
+                            default: []
                             description: |-
                               Include makes it possible to include additional metrics in a selected profiles.
                               Include takes precedence over Exclude.
@@ -265,6 +270,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/docs/generated/raw/crds/kuma.io_meshpassthroughs.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshpassthroughs.yaml
@@ -53,6 +53,7 @@ spec:
                 description: MeshPassthrough configuration.
                 properties:
                   appendMatch:
+                    default: []
                     description: AppendMatch is a list of destinations that should
                       be allowed through the sidecar.
                     items:
@@ -138,6 +139,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/docs/generated/raw/crds/kuma.io_meshpassthroughs.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshpassthroughs.yaml
@@ -139,7 +139,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/docs/generated/raw/crds/kuma.io_meshproxypatches.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshproxypatches.yaml
@@ -527,7 +527,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/docs/generated/raw/crds/kuma.io_meshproxypatches.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshproxypatches.yaml
@@ -55,6 +55,7 @@ spec:
                   referenced in 'targetRef'.
                 properties:
                   appendModifications:
+                    default: []
                     description: AppendModifications is a list of modifications applied
                       on the selected proxy.
                     items:
@@ -64,6 +65,7 @@ spec:
                             resource.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy's Cluster
                                 resource
@@ -141,6 +143,7 @@ spec:
                             available in HTTP Connection Manager in a Listener resource.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy's
                                 HTTP Filter available in HTTP Connection Manager in a Listener resource.
@@ -229,6 +232,7 @@ spec:
                             resource.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy's Listener
                                 resource
@@ -310,6 +314,7 @@ spec:
                             filter.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy Listener's
                                 filter.
@@ -399,6 +404,7 @@ spec:
                             referenced in HTTP Connection Manager in a Listener resource.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy's
                                 VirtualHost resource
@@ -521,6 +527,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/docs/generated/raw/crds/kuma.io_meshratelimits.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshratelimits.yaml
@@ -217,7 +217,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -286,7 +288,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -478,7 +482,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/docs/generated/raw/crds/kuma.io_meshratelimits.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshratelimits.yaml
@@ -50,6 +50,7 @@ spec:
             description: Spec is the specification of the Kuma MeshRateLimit resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -80,6 +81,7 @@ spec:
                                         HTTP response on a rate limit event
                                       properties:
                                         add:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -99,6 +101,7 @@ spec:
                                           - name
                                           x-kubernetes-list-type: map
                                         set:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -214,6 +217,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -282,6 +286,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -306,6 +311,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between clients and corresponding
                   configurations
                 items:
@@ -336,6 +342,7 @@ spec:
                                         HTTP response on a rate limit event
                                       properties:
                                         add:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -355,6 +362,7 @@ spec:
                                           - name
                                           x-kubernetes-list-type: map
                                         set:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -470,6 +478,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/docs/generated/raw/crds/kuma.io_meshretries.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshretries.yaml
@@ -90,6 +90,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -114,6 +115,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between the consumed services and
                   corresponding configurations
                 items:
@@ -167,6 +169,7 @@ spec:
                                     time which will be taken between retries.
                                   type: string
                                 resetHeaders:
+                                  default: []
                                   description: |-
                                     ResetHeaders specifies the list of headers (like Retry-After or X-RateLimit-Reset)
                                     to match against the response. Headers are tried in order, and matched
@@ -193,6 +196,7 @@ spec:
                                   type: array
                               type: object
                             retryOn:
+                              default: []
                               description: RetryOn is a list of conditions which will
                                 cause a retry.
                               example:
@@ -233,6 +237,7 @@ spec:
                                   type: string
                               type: object
                             hostSelection:
+                              default: []
                               description: |-
                                 HostSelection is a list of predicates that dictate how hosts should be selected
                                 when requests are retried.
@@ -295,6 +300,7 @@ spec:
                                     time which will be taken between retries.
                                   type: string
                                 resetHeaders:
+                                  default: []
                                   description: |-
                                     ResetHeaders specifies the list of headers (like Retry-After or X-RateLimit-Reset)
                                     to match against the response. Headers are tried in order, and matched
@@ -321,6 +327,7 @@ spec:
                                   type: array
                               type: object
                             retriableRequestHeaders:
+                              default: []
                               description: |-
                                 RetriableRequestHeaders is an HTTP headers which must be present in the request
                                 for retries to be attempted.
@@ -357,6 +364,7 @@ spec:
                                 type: object
                               type: array
                             retriableResponseHeaders:
+                              default: []
                               description: |-
                                 RetriableResponseHeaders is an HTTP response headers that trigger a retry
                                 if present in the response. A retry will be triggered if any of the header
@@ -394,6 +402,7 @@ spec:
                                 type: object
                               type: array
                             retryOn:
+                              default: []
                               description: |-
                                 RetryOn is a list of conditions which will cause a retry. Available values are:
                                 [5XX, GatewayError, Reset, Retriable4xx, ConnectFailure, EnvoyRatelimited,
@@ -477,6 +486,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/docs/generated/raw/crds/kuma.io_meshretries.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshretries.yaml
@@ -90,7 +90,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -486,7 +488,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/docs/generated/raw/crds/kuma.io_meshservices.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshservices.yaml
@@ -47,6 +47,7 @@ spec:
             description: Spec is the specification of the Kuma MeshService resource.
             properties:
               identities:
+                default: []
                 items:
                   properties:
                     type:
@@ -61,6 +62,7 @@ spec:
                   type: object
                 type: array
               ports:
+                default: []
                 items:
                   properties:
                     appProtocol:

--- a/docs/generated/raw/crds/kuma.io_meshtcproutes.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshtcproutes.yaml
@@ -90,6 +90,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -120,6 +121,7 @@ spec:
                 items:
                   properties:
                     rules:
+                      default: []
                       description: |-
                         Rules contains the routing rules applies to a combination of top-level
                         targetRef and the targetRef in this entry.
@@ -131,6 +133,7 @@ spec:
                               policies.
                             properties:
                               backendRefs:
+                                default: []
                                 items:
                                   description: BackendRef defines where to forward
                                     traffic.
@@ -175,6 +178,7 @@ spec:
                                       format: int32
                                       type: integer
                                     proxyTypes:
+                                      default: []
                                       description: |-
                                         ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                         all data plane types are targeted by the policy.
@@ -252,6 +256,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/docs/generated/raw/crds/kuma.io_meshtcproutes.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshtcproutes.yaml
@@ -90,7 +90,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -178,7 +180,9 @@ spec:
                                       format: int32
                                       type: integer
                                     proxyTypes:
-                                      default: []
+                                      default:
+                                      - Sidecar
+                                      - Gateway
                                       description: |-
                                         ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                         all data plane types are targeted by the policy.
@@ -256,7 +260,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/docs/generated/raw/crds/kuma.io_meshtimeouts.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshtimeouts.yaml
@@ -147,7 +147,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -275,7 +277,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -397,7 +401,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/docs/generated/raw/crds/kuma.io_meshtimeouts.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshtimeouts.yaml
@@ -50,6 +50,7 @@ spec:
             description: Spec is the specification of the Kuma MeshTimeout resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -146,6 +147,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -174,6 +176,7 @@ spec:
                   type: object
                 type: array
               rules:
+                default: []
                 description: |-
                   Rules defines inbound timeout configurations. Currently limited to exactly one rule containing
                   default timeouts that apply to all inbound traffic, as L7 matching is not yet implemented.
@@ -272,6 +275,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -296,6 +300,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between the consumed services and
                   corresponding configurations
                 items:
@@ -392,6 +397,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/docs/generated/raw/crds/kuma.io_meshtlses.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshtlses.yaml
@@ -145,7 +145,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -214,7 +216,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/docs/generated/raw/crds/kuma.io_meshtlses.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshtlses.yaml
@@ -145,6 +145,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -213,6 +214,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/docs/generated/raw/crds/kuma.io_meshtraces.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshtraces.yaml
@@ -258,7 +258,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/docs/generated/raw/crds/kuma.io_meshtraces.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshtraces.yaml
@@ -53,6 +53,7 @@ spec:
                 description: MeshTrace configuration.
                 properties:
                   backends:
+                    default: []
                     description: |-
                       A one element array of backend definition.
                       Envoy allows configuring only 1 backend, so the natural way of
@@ -181,6 +182,7 @@ spec:
                         x-kubernetes-int-or-string: true
                     type: object
                   tags:
+                    default: []
                     description: |-
                       Custom tags configuration. You can add custom tags to traces based on
                       headers or literal values.
@@ -256,6 +258,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/docs/generated/raw/crds/kuma.io_meshtrafficpermissions.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshtrafficpermissions.yaml
@@ -109,6 +109,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -177,6 +178,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/docs/generated/raw/crds/kuma.io_meshtrafficpermissions.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshtrafficpermissions.yaml
@@ -109,7 +109,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -178,7 +180,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/meshexternalservice.go
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/meshexternalservice.go
@@ -23,6 +23,7 @@ type MeshExternalService struct {
 	// Extension struct for a plugin configuration, in the presence of an extension `endpoints` and `tls` are not required anymore - it's up to the extension to validate them independently.
 	Extension *Extension `json:"extension,omitempty"`
 	// Endpoints defines a list of destinations to send traffic to.
+	// +kubebuilder:default={}
 	Endpoints []Endpoint `json:"endpoints,omitempty"`
 	// Tls provides a TLS configuration when proxy is resposible for a TLS origination
 	Tls *Tls `json:"tls,omitempty"`
@@ -99,6 +100,7 @@ type Verification struct {
 	// ServerName overrides the default Server Name Indicator set by Kuma.
 	ServerName *string `json:"serverName,omitempty"`
 	// SubjectAltNames list of names to verify in the certificate.
+	// +kubebuilder:default={}
 	SubjectAltNames *[]SANMatch `json:"subjectAltNames,omitempty"`
 	// CaCert defines a certificate of CA.
 	CaCert *v1alpha1.DataSource `json:"caCert,omitempty"`

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/schema.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/schema.yaml
@@ -22,6 +22,7 @@ properties:
     description: Spec is the specification of the Kuma MeshExternalService resource.
     properties:
       endpoints:
+        default: []
         description: Endpoints defines a list of destinations to send traffic to.
         items:
           properties:
@@ -150,6 +151,7 @@ properties:
                 description: ServerName overrides the default Server Name Indicator set by Kuma.
                 type: string
               subjectAltNames:
+                default: []
                 description: SubjectAltNames list of names to verify in the certificate.
                 items:
                   properties:

--- a/pkg/core/resources/apis/meshexternalservice/k8s/crd/kuma.io_meshexternalservices.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/k8s/crd/kuma.io_meshexternalservices.yaml
@@ -48,6 +48,7 @@ spec:
               resource.
             properties:
               endpoints:
+                default: []
                 description: Endpoints defines a list of destinations to send traffic
                   to.
                 items:
@@ -191,6 +192,7 @@ spec:
                           Indicator set by Kuma.
                         type: string
                       subjectAltNames:
+                        default: []
                         description: SubjectAltNames list of names to verify in the
                           certificate.
                         items:

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/meshservice.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/meshservice.go
@@ -46,7 +46,9 @@ type MeshService struct {
 	// +listType=map
 	// +listMapKey=port
 	// +listMapKey=appProtocol
+	// +kubebuilder:default={}
 	Ports      []Port                `json:"ports,omitempty"`
+	// +kubebuilder:default={}
 	Identities []MeshServiceIdentity `json:"identities,omitempty"`
 }
 

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/meshservice.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/meshservice.go
@@ -47,7 +47,7 @@ type MeshService struct {
 	// +listMapKey=port
 	// +listMapKey=appProtocol
 	// +kubebuilder:default={}
-	Ports      []Port                `json:"ports,omitempty"`
+	Ports []Port `json:"ports,omitempty"`
 	// +kubebuilder:default={}
 	Identities []MeshServiceIdentity `json:"identities,omitempty"`
 }

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/schema.yaml
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/schema.yaml
@@ -22,6 +22,7 @@ properties:
     description: Spec is the specification of the Kuma MeshService resource.
     properties:
       identities:
+        default: []
         items:
           properties:
             type:
@@ -36,6 +37,7 @@ properties:
           type: object
         type: array
       ports:
+        default: []
         items:
           properties:
             appProtocol:

--- a/pkg/core/resources/apis/meshservice/k8s/crd/kuma.io_meshservices.yaml
+++ b/pkg/core/resources/apis/meshservice/k8s/crd/kuma.io_meshservices.yaml
@@ -47,6 +47,7 @@ spec:
             description: Spec is the specification of the Kuma MeshService resource.
             properties:
               identities:
+                default: []
                 items:
                   properties:
                     type:
@@ -61,6 +62,7 @@ spec:
                   type: object
                 type: array
               ports:
+                default: []
                 items:
                   properties:
                     appProtocol:

--- a/pkg/plugins/policies/donothingpolicy/api/v1alpha1/donothingpolicy.go
+++ b/pkg/plugins/policies/donothingpolicy/api/v1alpha1/donothingpolicy.go
@@ -13,8 +13,10 @@ type DoNothingPolicy struct {
 	// defined inplace.
 	TargetRef *common_api.TargetRef `json:"targetRef,omitempty"`
 	// To list makes a match between the consumed services and corresponding configurations
+	// +kubebuilder:default={}
 	To []To `json:"to,omitempty"`
 	// From list makes a match between clients and corresponding configurations
+	// +kubebuilder:default={}
 	From []From `json:"from,omitempty"`
 }
 

--- a/pkg/plugins/policies/donothingpolicy/k8s/crd/kuma.io_donothingpolicies.yaml
+++ b/pkg/plugins/policies/donothingpolicy/k8s/crd/kuma.io_donothingpolicies.yaml
@@ -50,6 +50,7 @@ spec:
             description: Spec is the specification of the Kuma DoNothingPolicy resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -105,6 +106,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -173,6 +175,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -197,6 +200,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between the consumed services and
                   corresponding configurations
                 items:
@@ -252,6 +256,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/donothingpolicy/k8s/crd/kuma.io_donothingpolicies.yaml
+++ b/pkg/plugins/policies/donothingpolicy/k8s/crd/kuma.io_donothingpolicies.yaml
@@ -106,7 +106,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -175,7 +177,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -256,7 +260,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/meshaccesslog.go
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/meshaccesslog.go
@@ -15,8 +15,10 @@ type MeshAccessLog struct {
 	// defined in-place.
 	TargetRef *common_api.TargetRef `json:"targetRef,omitempty"`
 	// To list makes a match between the consumed services and corresponding configurations
+	// +kubebuilder:default={}
 	To []To `json:"to,omitempty"`
 	// From list makes a match between clients and corresponding configurations
+	// +kubebuilder:default={}
 	From []From `json:"from,omitempty"`
 }
 
@@ -39,6 +41,7 @@ type From struct {
 }
 
 type Conf struct {
+	// +kubebuilder:default={}
 	Backends *[]Backend `json:"backends,omitempty"`
 }
 
@@ -74,6 +77,7 @@ type OtelBackend struct {
 	// Attributes can contain placeholders available on
 	// https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
 	// +kubebuilder:example={{key: "mesh", value: "%KUMA_MESH%"}}
+	// +kubebuilder:default={}
 	Attributes []JsonValue `json:"attributes,omitempty"`
 	// Body is a raw string or an OTLP any value as described at
 	// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
@@ -111,6 +115,7 @@ type Format struct {
 	// +kubebuilder:example="[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%"
 	Plain *string `json:"plain,omitempty"`
 	// +kubebuilder:example={{key: "start_time", value: "%START_TIME%"},{key: "bytes_received", value: "%BYTES_RECEIVED%"}}
+	// +kubebuilder:default={}
 	Json *[]JsonValue `json:"json,omitempty"`
 	// +kubebuilder:default=false
 	OmitEmptyValues *bool `json:"omitEmptyValues,omitempty"`

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/schema.yaml
@@ -215,7 +215,9 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
-                  default: []
+                  default:
+                    - Sidecar
+                    - Gateway
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.
@@ -283,7 +285,9 @@ properties:
               will be targeted.
             type: string
           proxyTypes:
-            default: []
+            default:
+              - Sidecar
+              - Gateway
             description: |-
               ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
               all data plane types are targeted by the policy.
@@ -501,7 +505,9 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
-                  default: []
+                  default:
+                    - Sidecar
+                    - Gateway
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/schema.yaml
@@ -22,6 +22,7 @@ properties:
     description: Spec is the specification of the Kuma MeshAccessLog resource.
     properties:
       from:
+        default: []
         description: From list makes a match between clients and corresponding configurations
         items:
           properties:
@@ -31,6 +32,7 @@ properties:
                 'targetRef'
               properties:
                 backends:
+                  default: []
                   items:
                     properties:
                       file:
@@ -42,6 +44,7 @@ properties:
                               https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                             properties:
                               json:
+                                default: []
                                 example:
                                   - key: start_time
                                     value: '%START_TIME%'
@@ -81,6 +84,7 @@ properties:
                         description: Defines an OpenTelemetry logging backend.
                         properties:
                           attributes:
+                            default: []
                             description: |-
                               Attributes can contain placeholders available on
                               https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
@@ -130,6 +134,7 @@ properties:
                               https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                             properties:
                               json:
+                                default: []
                                 example:
                                   - key: start_time
                                     value: '%START_TIME%'
@@ -210,6 +215,7 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
+                  default: []
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.
@@ -277,6 +283,7 @@ properties:
               will be targeted.
             type: string
           proxyTypes:
+            default: []
             description: |-
               ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
               all data plane types are targeted by the policy.
@@ -301,6 +308,7 @@ properties:
             type: object
         type: object
       to:
+        default: []
         description: To list makes a match between the consumed services and corresponding configurations
         items:
           properties:
@@ -310,6 +318,7 @@ properties:
                 'targetRef'
               properties:
                 backends:
+                  default: []
                   items:
                     properties:
                       file:
@@ -321,6 +330,7 @@ properties:
                               https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                             properties:
                               json:
+                                default: []
                                 example:
                                   - key: start_time
                                     value: '%START_TIME%'
@@ -360,6 +370,7 @@ properties:
                         description: Defines an OpenTelemetry logging backend.
                         properties:
                           attributes:
+                            default: []
                             description: |-
                               Attributes can contain placeholders available on
                               https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
@@ -409,6 +420,7 @@ properties:
                               https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                             properties:
                               json:
+                                default: []
                                 example:
                                   - key: start_time
                                     value: '%START_TIME%'
@@ -489,6 +501,7 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
+                  default: []
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshaccesslog/k8s/crd/kuma.io_meshaccesslogs.yaml
+++ b/pkg/plugins/policies/meshaccesslog/k8s/crd/kuma.io_meshaccesslogs.yaml
@@ -50,6 +50,7 @@ spec:
             description: Spec is the specification of the Kuma MeshAccessLog resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -60,6 +61,7 @@ spec:
                         'targetRef'
                       properties:
                         backends:
+                          default: []
                           items:
                             properties:
                               file:
@@ -72,6 +74,7 @@ spec:
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        default: []
                                         example:
                                         - key: start_time
                                           value: '%START_TIME%'
@@ -112,6 +115,7 @@ spec:
                                 description: Defines an OpenTelemetry logging backend.
                                 properties:
                                   attributes:
+                                    default: []
                                     description: |-
                                       Attributes can contain placeholders available on
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
@@ -162,6 +166,7 @@ spec:
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        default: []
                                         example:
                                         - key: start_time
                                           value: '%START_TIME%'
@@ -243,6 +248,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -311,6 +317,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -335,6 +342,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between the consumed services and
                   corresponding configurations
                 items:
@@ -345,6 +353,7 @@ spec:
                         'targetRef'
                       properties:
                         backends:
+                          default: []
                           items:
                             properties:
                               file:
@@ -357,6 +366,7 @@ spec:
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        default: []
                                         example:
                                         - key: start_time
                                           value: '%START_TIME%'
@@ -397,6 +407,7 @@ spec:
                                 description: Defines an OpenTelemetry logging backend.
                                 properties:
                                   attributes:
+                                    default: []
                                     description: |-
                                       Attributes can contain placeholders available on
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
@@ -447,6 +458,7 @@ spec:
                                       https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        default: []
                                         example:
                                         - key: start_time
                                           value: '%START_TIME%'
@@ -528,6 +540,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshaccesslog/k8s/crd/kuma.io_meshaccesslogs.yaml
+++ b/pkg/plugins/policies/meshaccesslog/k8s/crd/kuma.io_meshaccesslogs.yaml
@@ -248,7 +248,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -317,7 +319,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -540,7 +544,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/meshcircuitbreaker.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/meshcircuitbreaker.go
@@ -17,9 +17,11 @@ type MeshCircuitBreaker struct {
 
 	// To list makes a match between the consumed services and corresponding
 	// configurations
+	// +kubebuilder:default={}
 	To []To `json:"to,omitempty"`
 
 	// From list makes a match between clients and corresponding configurations
+	// +kubebuilder:default={}
 	From []From `json:"from,omitempty"`
 }
 

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/schema.yaml
@@ -302,7 +302,9 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
-                  default: []
+                  default:
+                    - Sidecar
+                    - Gateway
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.
@@ -370,7 +372,9 @@ properties:
               will be targeted.
             type: string
           proxyTypes:
-            default: []
+            default:
+              - Sidecar
+              - Gateway
             description: |-
               ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
               all data plane types are targeted by the policy.
@@ -677,7 +681,9 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
-                  default: []
+                  default:
+                    - Sidecar
+                    - Gateway
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/schema.yaml
@@ -22,6 +22,7 @@ properties:
     description: Spec is the specification of the Kuma MeshCircuitBreaker resource.
     properties:
       from:
+        default: []
         description: From list makes a match between clients and corresponding configurations
         items:
           properties:
@@ -301,6 +302,7 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
+                  default: []
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.
@@ -368,6 +370,7 @@ properties:
               will be targeted.
             type: string
           proxyTypes:
+            default: []
             description: |-
               ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
               all data plane types are targeted by the policy.
@@ -392,6 +395,7 @@ properties:
             type: object
         type: object
       to:
+        default: []
         description: |-
           To list makes a match between the consumed services and corresponding
           configurations
@@ -673,6 +677,7 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
+                  default: []
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshcircuitbreaker/k8s/crd/kuma.io_meshcircuitbreakers.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/k8s/crd/kuma.io_meshcircuitbreakers.yaml
@@ -51,6 +51,7 @@ spec:
               resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -334,6 +335,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -402,6 +404,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -426,6 +429,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: |-
                   To list makes a match between the consumed services and corresponding
                   configurations
@@ -710,6 +714,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshcircuitbreaker/k8s/crd/kuma.io_meshcircuitbreakers.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/k8s/crd/kuma.io_meshcircuitbreakers.yaml
@@ -335,7 +335,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -404,7 +406,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -714,7 +718,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/meshfaultinjection.go
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/meshfaultinjection.go
@@ -16,9 +16,11 @@ type MeshFaultInjection struct {
 	TargetRef *common_api.TargetRef `json:"targetRef,omitempty"`
 
 	// From list makes a match between clients and corresponding configurations
+	// +kubebuilder:default={}
 	From []From `json:"from,omitempty"`
 
 	// To list makes a match between clients and corresponding configurations
+	// +kubebuilder:default={}
 	To []To `json:"to,omitempty"`
 }
 
@@ -42,6 +44,7 @@ type To struct {
 
 type Conf struct {
 	// Http allows to define list of Http faults between dataplanes.
+	// +kubebuilder:default={}
 	Http *[]FaultInjectionConf `json:"http,omitempty"`
 }
 

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/schema.yaml
@@ -22,6 +22,7 @@ properties:
     description: Spec is the specification of the Kuma MeshFaultInjection resource.
     properties:
       from:
+        default: []
         description: From list makes a match between clients and corresponding configurations
         items:
           properties:
@@ -31,6 +32,7 @@ properties:
                 'targetRef'
               properties:
                 http:
+                  default: []
                   description: Http allows to define list of Http faults between dataplanes.
                   items:
                     description: FaultInjection defines the configuration of faults between dataplanes.
@@ -139,6 +141,7 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
+                  default: []
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.
@@ -206,6 +209,7 @@ properties:
               will be targeted.
             type: string
           proxyTypes:
+            default: []
             description: |-
               ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
               all data plane types are targeted by the policy.
@@ -230,6 +234,7 @@ properties:
             type: object
         type: object
       to:
+        default: []
         description: To list makes a match between clients and corresponding configurations
         items:
           properties:
@@ -239,6 +244,7 @@ properties:
                 'targetRef'
               properties:
                 http:
+                  default: []
                   description: Http allows to define list of Http faults between dataplanes.
                   items:
                     description: FaultInjection defines the configuration of faults between dataplanes.
@@ -347,6 +353,7 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
+                  default: []
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/schema.yaml
@@ -141,7 +141,9 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
-                  default: []
+                  default:
+                    - Sidecar
+                    - Gateway
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.
@@ -209,7 +211,9 @@ properties:
               will be targeted.
             type: string
           proxyTypes:
-            default: []
+            default:
+              - Sidecar
+              - Gateway
             description: |-
               ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
               all data plane types are targeted by the policy.
@@ -353,7 +357,9 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
-                  default: []
+                  default:
+                    - Sidecar
+                    - Gateway
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshfaultinjection/k8s/crd/kuma.io_meshfaultinjections.yaml
+++ b/pkg/plugins/policies/meshfaultinjection/k8s/crd/kuma.io_meshfaultinjections.yaml
@@ -177,7 +177,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -246,7 +248,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -397,7 +401,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshfaultinjection/k8s/crd/kuma.io_meshfaultinjections.yaml
+++ b/pkg/plugins/policies/meshfaultinjection/k8s/crd/kuma.io_meshfaultinjections.yaml
@@ -51,6 +51,7 @@ spec:
               resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -61,6 +62,7 @@ spec:
                         'targetRef'
                       properties:
                         http:
+                          default: []
                           description: Http allows to define list of Http faults between
                             dataplanes.
                           items:
@@ -175,6 +177,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -243,6 +246,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -267,6 +271,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between clients and corresponding
                   configurations
                 items:
@@ -277,6 +282,7 @@ spec:
                         'targetRef'
                       properties:
                         http:
+                          default: []
                           description: Http allows to define list of Http faults between
                             dataplanes.
                           items:
@@ -391,6 +397,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/meshhealthcheck.go
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/meshhealthcheck.go
@@ -17,6 +17,7 @@ type MeshHealthCheck struct {
 	TargetRef *common_api.TargetRef `json:"targetRef,omitempty"`
 
 	// To list makes a match between the consumed services and corresponding configurations
+	// +kubebuilder:default={}
 	To []To `json:"to,omitempty"`
 }
 
@@ -98,6 +99,7 @@ type TcpHealthCheck struct {
 	// "fuzzy" matching is performed such that each block must be found, and
 	// in the order specified, but not necessarily contiguous.
 	// If not provided or empty, checks will be performed as "connect only" and be marked as successful when TCP connection is successfully established.
+	// +kubebuilder:default={}
 	Receive *[]string `json:"receive,omitempty"`
 }
 
@@ -114,6 +116,7 @@ type HttpHealthCheck struct {
 	// request
 	RequestHeadersToAdd *HeaderModifier `json:"requestHeadersToAdd,omitempty"`
 	// List of HTTP response statuses which are considered healthy
+	// +kubebuilder:default={}
 	ExpectedStatuses *[]int32 `json:"expectedStatuses,omitempty"`
 }
 
@@ -140,9 +143,11 @@ type HeaderModifier struct {
 	// +listType=map
 	// +listMapKey=name
 	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:default={}
 	Set []HeaderKeyValue `json:"set,omitempty"`
 	// +listType=map
 	// +listMapKey=name
 	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:default={}
 	Add []HeaderKeyValue `json:"add,omitempty"`
 }

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/schema.yaml
@@ -61,7 +61,9 @@ properties:
               will be targeted.
             type: string
           proxyTypes:
-            default: []
+            default:
+              - Sidecar
+              - Gateway
             description: |-
               ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
               all data plane types are targeted by the policy.
@@ -322,7 +324,9 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
-                  default: []
+                  default:
+                    - Sidecar
+                    - Gateway
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/schema.yaml
@@ -61,6 +61,7 @@ properties:
               will be targeted.
             type: string
           proxyTypes:
+            default: []
             description: |-
               ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
               all data plane types are targeted by the policy.
@@ -85,6 +86,7 @@ properties:
             type: object
         type: object
       to:
+        default: []
         description: To list makes a match between the consumed services and corresponding configurations
         items:
           properties:
@@ -151,6 +153,7 @@ properties:
                       description: If true the HttpHealthCheck is disabled
                       type: boolean
                     expectedStatuses:
+                      default: []
                       description: List of HTTP response statuses which are considered healthy
                       items:
                         format: int32
@@ -168,6 +171,7 @@ properties:
                         request
                       properties:
                         add:
+                          default: []
                           items:
                             properties:
                               name:
@@ -187,6 +191,7 @@ properties:
                             - name
                           x-kubernetes-list-type: map
                         set:
+                          default: []
                           items:
                             properties:
                               name:
@@ -253,6 +258,7 @@ properties:
                       description: If true the TcpHealthCheck is disabled
                       type: boolean
                     receive:
+                      default: []
                       description: |-
                         List of Base64 encoded blocks of strings expected as a response. When checking the response,
                         "fuzzy" matching is performed such that each block must be found, and
@@ -316,6 +322,7 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
+                  default: []
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshhealthcheck/k8s/crd/kuma.io_meshhealthchecks.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/k8s/crd/kuma.io_meshhealthchecks.yaml
@@ -90,6 +90,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -114,6 +115,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between the consumed services and
                   corresponding configurations
                 items:
@@ -183,6 +185,7 @@ spec:
                               description: If true the HttpHealthCheck is disabled
                               type: boolean
                             expectedStatuses:
+                              default: []
                               description: List of HTTP response statuses which are
                                 considered healthy
                               items:
@@ -201,6 +204,7 @@ spec:
                                 request
                               properties:
                                 add:
+                                  default: []
                                   items:
                                     properties:
                                       name:
@@ -220,6 +224,7 @@ spec:
                                   - name
                                   x-kubernetes-list-type: map
                                 set:
+                                  default: []
                                   items:
                                     properties:
                                       name:
@@ -287,6 +292,7 @@ spec:
                               description: If true the TcpHealthCheck is disabled
                               type: boolean
                             receive:
+                              default: []
                               description: |-
                                 List of Base64 encoded blocks of strings expected as a response. When checking the response,
                                 "fuzzy" matching is performed such that each block must be found, and
@@ -352,6 +358,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshhealthcheck/k8s/crd/kuma.io_meshhealthchecks.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/k8s/crd/kuma.io_meshhealthchecks.yaml
@@ -90,7 +90,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -358,7 +360,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/meshhttproute.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/meshhttproute.go
@@ -25,6 +25,7 @@ type MeshHTTPRoute struct {
 	TargetRef *common_api.TargetRef `json:"targetRef,omitempty"`
 
 	// To matches destination services of requests and holds configuration.
+	// +kubebuilder:default={}
 	To []To `json:"to,omitempty"`
 }
 
@@ -33,12 +34,14 @@ type To struct {
 	// effects of the rules to requests to this hostname.
 	// Given hostnames must intersect with the hostname of the listeners the
 	// route attaches to.
+	// +kubebuilder:default={}
 	Hostnames []string `json:"hostnames,omitempty"`
 	// TargetRef is a reference to the resource that represents a group of
 	// request destinations.
 	TargetRef common_api.TargetRef `json:"targetRef,omitempty"`
 	// Rules contains the routing rules applies to a combination of top-level
 	// targetRef and the targetRef in this entry.
+	// +kubebuilder:default={}
 	Rules []Rule `json:"rules,omitempty"`
 }
 
@@ -63,7 +66,9 @@ type Match struct {
 	Method *Method    `json:"method,omitempty"`
 	// QueryParams matches based on HTTP URL query parameters. Multiple matches
 	// are ANDed together such that all listed matches must succeed.
+	// +kubebuilder:default={}
 	QueryParams []QueryParamsMatch       `json:"queryParams,omitempty"`
+	// +kubebuilder:default={}
 	Headers     []common_api.HeaderMatch `json:"headers,omitempty"`
 }
 
@@ -103,7 +108,9 @@ type QueryParamsMatch struct {
 }
 
 type RuleConf struct {
+	// +kubebuilder:default={}
 	Filters     *[]Filter                `json:"filters,omitempty"`
+	// +kubebuilder:default={}
 	BackendRefs *[]common_api.BackendRef `json:"backendRefs,omitempty"`
 }
 
@@ -130,12 +137,15 @@ type HeaderModifier struct {
 	// +listType=map
 	// +listMapKey=name
 	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:default={}
 	Set []HeaderKeyValue `json:"set,omitempty"`
 	// +listType=map
 	// +listMapKey=name
 	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:default={}
 	Add []HeaderKeyValue `json:"add,omitempty"`
 	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:default={}
 	Remove []string `json:"remove,omitempty"`
 }
 

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/meshhttproute.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/meshhttproute.go
@@ -67,9 +67,9 @@ type Match struct {
 	// QueryParams matches based on HTTP URL query parameters. Multiple matches
 	// are ANDed together such that all listed matches must succeed.
 	// +kubebuilder:default={}
-	QueryParams []QueryParamsMatch       `json:"queryParams,omitempty"`
+	QueryParams []QueryParamsMatch `json:"queryParams,omitempty"`
 	// +kubebuilder:default={}
-	Headers     []common_api.HeaderMatch `json:"headers,omitempty"`
+	Headers []common_api.HeaderMatch `json:"headers,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=Exact;PathPrefix;RegularExpression
@@ -109,7 +109,7 @@ type QueryParamsMatch struct {
 
 type RuleConf struct {
 	// +kubebuilder:default={}
-	Filters     *[]Filter                `json:"filters,omitempty"`
+	Filters *[]Filter `json:"filters,omitempty"`
 	// +kubebuilder:default={}
 	BackendRefs *[]common_api.BackendRef `json:"backendRefs,omitempty"`
 }

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/schema.yaml
@@ -61,7 +61,9 @@ properties:
               will be targeted.
             type: string
           proxyTypes:
-            default: []
+            default:
+              - Sidecar
+              - Gateway
             description: |-
               ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
               all data plane types are targeted by the policy.
@@ -155,7 +157,9 @@ properties:
                               format: int32
                               type: integer
                             proxyTypes:
-                              default: []
+                              default:
+                                - Sidecar
+                                - Gateway
                               description: |-
                                 ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                 all data plane types are targeted by the policy.
@@ -284,7 +288,9 @@ properties:
                                       format: int32
                                       type: integer
                                     proxyTypes:
-                                      default: []
+                                      default:
+                                        - Sidecar
+                                        - Gateway
                                       description: |-
                                         ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                         all data plane types are targeted by the policy.
@@ -614,7 +620,9 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
-                  default: []
+                  default:
+                    - Sidecar
+                    - Gateway
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/schema.yaml
@@ -61,6 +61,7 @@ properties:
               will be targeted.
             type: string
           proxyTypes:
+            default: []
             description: |-
               ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
               all data plane types are targeted by the policy.
@@ -85,10 +86,12 @@ properties:
             type: object
         type: object
       to:
+        default: []
         description: To matches destination services of requests and holds configuration.
         items:
           properties:
             hostnames:
+              default: []
               description: |-
                 Hostnames is only valid when targeting MeshGateway and limits the
                 effects of the rules to requests to this hostname.
@@ -98,6 +101,7 @@ properties:
                 type: string
               type: array
             rules:
+              default: []
               description: |-
                 Rules contains the routing rules applies to a combination of top-level
                 targetRef and the targetRef in this entry.
@@ -109,6 +113,7 @@ properties:
                       policies.
                     properties:
                       backendRefs:
+                        default: []
                         items:
                           description: BackendRef defines where to forward traffic.
                           properties:
@@ -150,6 +155,7 @@ properties:
                               format: int32
                               type: integer
                             proxyTypes:
+                              default: []
                               description: |-
                                 ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                 all data plane types are targeted by the policy.
@@ -179,6 +185,7 @@ properties:
                           type: object
                         type: array
                       filters:
+                        default: []
                         items:
                           properties:
                             requestHeaderModifier:
@@ -188,6 +195,7 @@ properties:
                                 header value formatting, separating each value with a comma.
                               properties:
                                 add:
+                                  default: []
                                   items:
                                     properties:
                                       name:
@@ -207,11 +215,13 @@ properties:
                                     - name
                                   x-kubernetes-list-type: map
                                 remove:
+                                  default: []
                                   items:
                                     type: string
                                   maxItems: 16
                                   type: array
                                 set:
+                                  default: []
                                   items:
                                     properties:
                                       name:
@@ -274,6 +284,7 @@ properties:
                                       format: int32
                                       type: integer
                                     proxyTypes:
+                                      default: []
                                       description: |-
                                         ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                         all data plane types are targeted by the policy.
@@ -377,6 +388,7 @@ properties:
                                 header value formatting, separating each value with a comma.
                               properties:
                                 add:
+                                  default: []
                                   items:
                                     properties:
                                       name:
@@ -396,11 +408,13 @@ properties:
                                     - name
                                   x-kubernetes-list-type: map
                                 remove:
+                                  default: []
                                   items:
                                     type: string
                                   maxItems: 16
                                   type: array
                                 set:
+                                  default: []
                                   items:
                                     properties:
                                       name:
@@ -469,6 +483,7 @@ properties:
                     items:
                       properties:
                         headers:
+                          default: []
                           items:
                             description: |-
                               HeaderMatch describes how to select an HTTP route by matching HTTP request
@@ -530,6 +545,7 @@ properties:
                             - value
                           type: object
                         queryParams:
+                          default: []
                           description: |-
                             QueryParams matches based on HTTP URL query parameters. Multiple matches
                             are ANDed together such that all listed matches must succeed.
@@ -598,6 +614,7 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
+                  default: []
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshhttproute/k8s/crd/kuma.io_meshhttproutes.yaml
+++ b/pkg/plugins/policies/meshhttproute/k8s/crd/kuma.io_meshhttproutes.yaml
@@ -90,7 +90,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -188,7 +190,9 @@ spec:
                                       format: int32
                                       type: integer
                                     proxyTypes:
-                                      default: []
+                                      default:
+                                      - Sidecar
+                                      - Gateway
                                       description: |-
                                         ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                         all data plane types are targeted by the policy.
@@ -322,7 +326,9 @@ spec:
                                               format: int32
                                               type: integer
                                             proxyTypes:
-                                              default: []
+                                              default:
+                                              - Sidecar
+                                              - Gateway
                                               description: |-
                                                 ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                                 all data plane types are targeted by the policy.
@@ -658,7 +664,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshhttproute/k8s/crd/kuma.io_meshhttproutes.yaml
+++ b/pkg/plugins/policies/meshhttproute/k8s/crd/kuma.io_meshhttproutes.yaml
@@ -90,6 +90,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -114,11 +115,13 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To matches destination services of requests and holds
                   configuration.
                 items:
                   properties:
                     hostnames:
+                      default: []
                       description: |-
                         Hostnames is only valid when targeting MeshGateway and limits the
                         effects of the rules to requests to this hostname.
@@ -128,6 +131,7 @@ spec:
                         type: string
                       type: array
                     rules:
+                      default: []
                       description: |-
                         Rules contains the routing rules applies to a combination of top-level
                         targetRef and the targetRef in this entry.
@@ -139,6 +143,7 @@ spec:
                               policies.
                             properties:
                               backendRefs:
+                                default: []
                                 items:
                                   description: BackendRef defines where to forward
                                     traffic.
@@ -183,6 +188,7 @@ spec:
                                       format: int32
                                       type: integer
                                     proxyTypes:
+                                      default: []
                                       description: |-
                                         ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                         all data plane types are targeted by the policy.
@@ -212,6 +218,7 @@ spec:
                                   type: object
                                 type: array
                               filters:
+                                default: []
                                 items:
                                   properties:
                                     requestHeaderModifier:
@@ -221,6 +228,7 @@ spec:
                                         header value formatting, separating each value with a comma.
                                       properties:
                                         add:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -240,11 +248,13 @@ spec:
                                           - name
                                           x-kubernetes-list-type: map
                                         remove:
+                                          default: []
                                           items:
                                             type: string
                                           maxItems: 16
                                           type: array
                                         set:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -312,6 +322,7 @@ spec:
                                               format: int32
                                               type: integer
                                             proxyTypes:
+                                              default: []
                                               description: |-
                                                 ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                                 all data plane types are targeted by the policy.
@@ -416,6 +427,7 @@ spec:
                                         header value formatting, separating each value with a comma.
                                       properties:
                                         add:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -435,11 +447,13 @@ spec:
                                           - name
                                           x-kubernetes-list-type: map
                                         remove:
+                                          default: []
                                           items:
                                             type: string
                                           maxItems: 16
                                           type: array
                                         set:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -510,6 +524,7 @@ spec:
                             items:
                               properties:
                                 headers:
+                                  default: []
                                   items:
                                     description: |-
                                       HeaderMatch describes how to select an HTTP route by matching HTTP request
@@ -573,6 +588,7 @@ spec:
                                   - value
                                   type: object
                                 queryParams:
+                                  default: []
                                   description: |-
                                     QueryParams matches based on HTTP URL query parameters. Multiple matches
                                     are ANDed together such that all listed matches must succeed.
@@ -642,6 +658,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/meshloadbalancingstrategy.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/meshloadbalancingstrategy.go
@@ -16,6 +16,7 @@ type MeshLoadBalancingStrategy struct {
 	// defined inplace.
 	TargetRef *common_api.TargetRef `json:"targetRef,omitempty"`
 	// To list makes a match between the consumed services and corresponding configurations
+	// +kubebuilder:validation:MinItems=1
 	To []To `json:"to,omitempty"`
 }
 
@@ -48,6 +49,7 @@ type LocalityAwareness struct {
 
 type LocalZone struct {
 	// AffinityTags list of tags for local zone load balancing.
+	// +kubebuilder:default={}
 	AffinityTags *[]AffinityTag `json:"affinityTags,omitempty"`
 }
 
@@ -65,6 +67,7 @@ type AffinityTag struct {
 
 type CrossZone struct {
 	// Failover defines list of load balancing rules in order of priority
+	// +kubebuilder:default={}
 	Failover []Failover `json:"failover,omitempty"`
 	// FailoverThreshold defines the percentage of live destination dataplane proxies below which load balancing to the
 	// next priority starts.
@@ -82,12 +85,14 @@ type Failover struct {
 }
 
 type FromZone struct {
+	// +kubebuilder:default={}
 	Zones []string `json:"zones"`
 }
 
 type ToZone struct {
 	// Type defines how target zones will be picked from available zones
 	Type  ToZoneType `json:"type"`
+	// +kubebuilder:default={}
 	Zones *[]string  `json:"zones,omitempty"`
 }
 
@@ -194,6 +199,7 @@ type RingHash struct {
 	// These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
 	// set to true, and there is already a hash generated, the hash is returned immediately,
 	// ignoring the rest of the hash policy list.
+	// +kubebuilder:default={}
 	HashPolicies *[]HashPolicy `json:"hashPolicies,omitempty"`
 }
 
@@ -279,5 +285,6 @@ type Maglev struct {
 	// These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
 	// set to true, and there is already a hash generated, the hash is returned immediately,
 	// ignoring the rest of the hash policy list.
+	// +kubebuilder:default={}
 	HashPolicies *[]HashPolicy `json:"hashPolicies,omitempty"`
 }

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/meshloadbalancingstrategy.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/meshloadbalancingstrategy.go
@@ -91,9 +91,9 @@ type FromZone struct {
 
 type ToZone struct {
 	// Type defines how target zones will be picked from available zones
-	Type  ToZoneType `json:"type"`
+	Type ToZoneType `json:"type"`
 	// +kubebuilder:default={}
-	Zones *[]string  `json:"zones,omitempty"`
+	Zones *[]string `json:"zones,omitempty"`
 }
 
 type FailoverThreshold struct {

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/schema.yaml
@@ -61,7 +61,9 @@ properties:
               will be targeted.
             type: string
           proxyTypes:
-            default: []
+            default:
+              - Sidecar
+              - Gateway
             description: |-
               ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
               all data plane types are targeted by the policy.
@@ -498,7 +500,9 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
-                  default: []
+                  default:
+                    - Sidecar
+                    - Gateway
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/schema.yaml
@@ -61,6 +61,7 @@ properties:
               will be targeted.
             type: string
           proxyTypes:
+            default: []
             description: |-
               ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
               all data plane types are targeted by the policy.
@@ -128,6 +129,7 @@ properties:
                         consistent hashing is desired.
                       properties:
                         hashPolicies:
+                          default: []
                           description: |-
                             HashPolicies specify a list of request/connection properties that are used to calculate a hash.
                             These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
@@ -244,6 +246,7 @@ properties:
                             - MurmurHash2
                           type: string
                         hashPolicies:
+                          default: []
                           description: |-
                             HashPolicies specify a list of request/connection properties that are used to calculate a hash.
                             These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
@@ -368,6 +371,7 @@ properties:
                         are unavailable
                       properties:
                         failover:
+                          default: []
                           description: Failover defines list of load balancing rules in order of priority
                           items:
                             properties:
@@ -375,6 +379,7 @@ properties:
                                 description: From defines the list of zones to which the rule applies
                                 properties:
                                   zones:
+                                    default: []
                                     items:
                                       type: string
                                     type: array
@@ -393,6 +398,7 @@ properties:
                                       - AnyExcept
                                     type: string
                                   zones:
+                                    default: []
                                     items:
                                       type: string
                                     type: array
@@ -429,6 +435,7 @@ properties:
                       description: LocalZone defines locality aware load balancing priorities between dataplane proxies inside a zone
                       properties:
                         affinityTags:
+                          default: []
                           description: AffinityTags list of tags for local zone load balancing.
                           items:
                             properties:
@@ -491,6 +498,7 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
+                  default: []
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.
@@ -517,6 +525,7 @@ properties:
           required:
             - targetRef
           type: object
+        minItems: 1
         type: array
     type: object
   creationTime:

--- a/pkg/plugins/policies/meshloadbalancingstrategy/k8s/crd/kuma.io_meshloadbalancingstrategies.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/k8s/crd/kuma.io_meshloadbalancingstrategies.yaml
@@ -91,6 +91,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -160,6 +161,7 @@ spec:
                                 consistent hashing is desired.
                               properties:
                                 hashPolicies:
+                                  default: []
                                   description: |-
                                     HashPolicies specify a list of request/connection properties that are used to calculate a hash.
                                     These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
@@ -282,6 +284,7 @@ spec:
                                   - MurmurHash2
                                   type: string
                                 hashPolicies:
+                                  default: []
                                   description: |-
                                     HashPolicies specify a list of request/connection properties that are used to calculate a hash.
                                     These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
@@ -413,6 +416,7 @@ spec:
                                 are unavailable
                               properties:
                                 failover:
+                                  default: []
                                   description: Failover defines list of load balancing
                                     rules in order of priority
                                   items:
@@ -422,6 +426,7 @@ spec:
                                           to which the rule applies
                                         properties:
                                           zones:
+                                            default: []
                                             items:
                                               type: string
                                             type: array
@@ -442,6 +447,7 @@ spec:
                                             - AnyExcept
                                             type: string
                                           zones:
+                                            default: []
                                             items:
                                               type: string
                                             type: array
@@ -479,6 +485,7 @@ spec:
                                 priorities between dataplane proxies inside a zone
                               properties:
                                 affinityTags:
+                                  default: []
                                   description: AffinityTags list of tags for local
                                     zone load balancing.
                                   items:
@@ -544,6 +551,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -570,6 +578,7 @@ spec:
                   required:
                   - targetRef
                   type: object
+                minItems: 1
                 type: array
             type: object
         type: object

--- a/pkg/plugins/policies/meshloadbalancingstrategy/k8s/crd/kuma.io_meshloadbalancingstrategies.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/k8s/crd/kuma.io_meshloadbalancingstrategies.yaml
@@ -91,7 +91,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -551,7 +553,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/meshmetric.go
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/meshmetric.go
@@ -21,8 +21,10 @@ type Conf struct {
 	// Sidecar metrics collection configuration
 	Sidecar *Sidecar `json:"sidecar,omitempty"`
 	// Applications is a list of application that Dataplane Proxy will scrape
+	// +kubebuilder:default={}
 	Applications *[]Application `json:"applications,omitempty"`
 	// Backends list that will be used to collect metrics.
+	// +kubebuilder:default={}
 	Backends *[]Backend `json:"backends,omitempty"`
 }
 
@@ -38,12 +40,15 @@ type Sidecar struct {
 
 type Profiles struct {
 	// AppendProfiles allows to combine the metrics from multiple predefined profiles.
+	// +kubebuilder:default={}
 	AppendProfiles *[]Profile `json:"appendProfiles,omitempty"`
 	// Exclude makes it possible to exclude groups of metrics from a resulting profile.
 	// Exclude is subordinate to Include.
+	// +kubebuilder:default={}
 	Exclude *[]Selector `json:"exclude,omitempty"`
 	// Include makes it possible to include additional metrics in a selected profiles.
 	// Include takes precedence over Exclude.
+	// +kubebuilder:default={}
 	Include *[]Selector `json:"include,omitempty"`
 }
 

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/schema.yaml
@@ -25,6 +25,7 @@ properties:
         description: MeshMetric configuration.
         properties:
           applications:
+            default: []
             description: Applications is a list of application that Dataplane Proxy will scrape
             items:
               properties:
@@ -47,6 +48,7 @@ properties:
               type: object
             type: array
           backends:
+            default: []
             description: Backends list that will be used to collect metrics.
             items:
               properties:
@@ -119,6 +121,7 @@ properties:
                 description: Profiles allows to customize which metrics are published.
                 properties:
                   appendProfiles:
+                    default: []
                     description: AppendProfiles allows to combine the metrics from multiple predefined profiles.
                     items:
                       properties:
@@ -134,6 +137,7 @@ properties:
                       type: object
                     type: array
                   exclude:
+                    default: []
                     description: |-
                       Exclude makes it possible to exclude groups of metrics from a resulting profile.
                       Exclude is subordinate to Include.
@@ -156,6 +160,7 @@ properties:
                       type: object
                     type: array
                   include:
+                    default: []
                     description: |-
                       Include makes it possible to include additional metrics in a selected profiles.
                       Include takes precedence over Exclude.
@@ -220,6 +225,7 @@ properties:
               will be targeted.
             type: string
           proxyTypes:
+            default: []
             description: |-
               ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
               all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/schema.yaml
@@ -225,7 +225,9 @@ properties:
               will be targeted.
             type: string
           proxyTypes:
-            default: []
+            default:
+              - Sidecar
+              - Gateway
             description: |-
               ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
               all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshmetric/k8s/crd/kuma.io_meshmetrics.yaml
+++ b/pkg/plugins/policies/meshmetric/k8s/crd/kuma.io_meshmetrics.yaml
@@ -270,7 +270,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshmetric/k8s/crd/kuma.io_meshmetrics.yaml
+++ b/pkg/plugins/policies/meshmetric/k8s/crd/kuma.io_meshmetrics.yaml
@@ -53,6 +53,7 @@ spec:
                 description: MeshMetric configuration.
                 properties:
                   applications:
+                    default: []
                     description: Applications is a list of application that Dataplane
                       Proxy will scrape
                     items:
@@ -78,6 +79,7 @@ spec:
                       type: object
                     type: array
                   backends:
+                    default: []
                     description: Backends list that will be used to collect metrics.
                     items:
                       properties:
@@ -157,6 +159,7 @@ spec:
                           published.
                         properties:
                           appendProfiles:
+                            default: []
                             description: AppendProfiles allows to combine the metrics
                               from multiple predefined profiles.
                             items:
@@ -174,6 +177,7 @@ spec:
                               type: object
                             type: array
                           exclude:
+                            default: []
                             description: |-
                               Exclude makes it possible to exclude groups of metrics from a resulting profile.
                               Exclude is subordinate to Include.
@@ -198,6 +202,7 @@ spec:
                               type: object
                             type: array
                           include:
+                            default: []
                             description: |-
                               Include makes it possible to include additional metrics in a selected profiles.
                               Include takes precedence over Exclude.
@@ -265,6 +270,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshpassthrough/api/v1alpha1/meshpassthrough.go
+++ b/pkg/plugins/policies/meshpassthrough/api/v1alpha1/meshpassthrough.go
@@ -21,6 +21,7 @@ type Conf struct {
 	// +kubebuilder:default=None
 	PassthroughMode *PassthroughMode `json:"passthroughMode,omitempty"`
 	// AppendMatch is a list of destinations that should be allowed through the sidecar.
+	// +kubebuilder:default={}
 	AppendMatch []Match `json:"appendMatch,omitempty"`
 }
 

--- a/pkg/plugins/policies/meshpassthrough/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshpassthrough/api/v1alpha1/schema.yaml
@@ -25,6 +25,7 @@ properties:
         description: MeshPassthrough configuration.
         properties:
           appendMatch:
+            default: []
             description: AppendMatch is a list of destinations that should be allowed through the sidecar.
             items:
               properties:
@@ -105,6 +106,7 @@ properties:
               will be targeted.
             type: string
           proxyTypes:
+            default: []
             description: |-
               ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
               all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshpassthrough/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshpassthrough/api/v1alpha1/schema.yaml
@@ -106,7 +106,9 @@ properties:
               will be targeted.
             type: string
           proxyTypes:
-            default: []
+            default:
+              - Sidecar
+              - Gateway
             description: |-
               ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
               all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshpassthrough/k8s/crd/kuma.io_meshpassthroughs.yaml
+++ b/pkg/plugins/policies/meshpassthrough/k8s/crd/kuma.io_meshpassthroughs.yaml
@@ -53,6 +53,7 @@ spec:
                 description: MeshPassthrough configuration.
                 properties:
                   appendMatch:
+                    default: []
                     description: AppendMatch is a list of destinations that should
                       be allowed through the sidecar.
                     items:
@@ -138,6 +139,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshpassthrough/k8s/crd/kuma.io_meshpassthroughs.yaml
+++ b/pkg/plugins/policies/meshpassthrough/k8s/crd/kuma.io_meshpassthroughs.yaml
@@ -139,7 +139,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/meshproxypatch.go
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/meshproxypatch.go
@@ -20,6 +20,7 @@ type MeshProxyPatch struct {
 
 type Conf struct {
 	// AppendModifications is a list of modifications applied on the selected proxy.
+	// +kubebuilder:default={}
 	AppendModifications []Modification `json:"appendModifications"`
 }
 
@@ -75,6 +76,7 @@ type ClusterMod struct {
 	Value *string `json:"value,omitempty"`
 	// JsonPatches specifies list of jsonpatches to apply to on Envoy's Cluster
 	// resource
+	// +kubebuilder:default={}
 	JsonPatches []common_api.JsonPatchBlock `json:"jsonPatches,omitempty"`
 }
 
@@ -110,6 +112,7 @@ type ListenerMod struct {
 	Value *string `json:"value,omitempty"`
 	// JsonPatches specifies list of jsonpatches to apply to on Envoy's Listener
 	// resource
+	// +kubebuilder:default={}
 	JsonPatches []common_api.JsonPatchBlock `json:"jsonPatches,omitempty"`
 }
 
@@ -147,6 +150,7 @@ type NetworkFilterMod struct {
 	Value *string `json:"value,omitempty"`
 	// JsonPatches specifies list of jsonpatches to apply to on Envoy Listener's
 	// filter.
+	// +kubebuilder:default={}
 	JsonPatches []common_api.JsonPatchBlock `json:"jsonPatches,omitempty"`
 }
 
@@ -187,6 +191,7 @@ type HTTPFilterMod struct {
 	Value *string `json:"value,omitempty"`
 	// JsonPatches specifies list of jsonpatches to apply to on Envoy's
 	// HTTP Filter available in HTTP Connection Manager in a Listener resource.
+	// +kubebuilder:default={}
 	JsonPatches []common_api.JsonPatchBlock `json:"jsonPatches,omitempty"`
 }
 
@@ -227,6 +232,7 @@ type VirtualHostMod struct {
 	Value *string `json:"value,omitempty"`
 	// JsonPatches specifies list of jsonpatches to apply to on Envoy's
 	// VirtualHost resource
+	// +kubebuilder:default={}
 	JsonPatches []common_api.JsonPatchBlock `json:"jsonPatches,omitempty"`
 }
 

--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/schema.yaml
@@ -466,7 +466,9 @@ properties:
               will be targeted.
             type: string
           proxyTypes:
-            default: []
+            default:
+              - Sidecar
+              - Gateway
             description: |-
               ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
               all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/schema.yaml
@@ -27,6 +27,7 @@ properties:
           referenced in 'targetRef'.
         properties:
           appendModifications:
+            default: []
             description: AppendModifications is a list of modifications applied on the selected proxy.
             items:
               properties:
@@ -34,6 +35,7 @@ properties:
                   description: Cluster is a modification of Envoy's Cluster resource.
                   properties:
                     jsonPatches:
+                      default: []
                       description: |-
                         JsonPatches specifies list of jsonpatches to apply to on Envoy's Cluster
                         resource
@@ -106,6 +108,7 @@ properties:
                     available in HTTP Connection Manager in a Listener resource.
                   properties:
                     jsonPatches:
+                      default: []
                       description: |-
                         JsonPatches specifies list of jsonpatches to apply to on Envoy's
                         HTTP Filter available in HTTP Connection Manager in a Listener resource.
@@ -187,6 +190,7 @@ properties:
                   description: Listener is a modification of Envoy's Listener resource.
                   properties:
                     jsonPatches:
+                      default: []
                       description: |-
                         JsonPatches specifies list of jsonpatches to apply to on Envoy's Listener
                         resource
@@ -262,6 +266,7 @@ properties:
                   description: NetworkFilter is a modification of Envoy Listener's filter.
                   properties:
                     jsonPatches:
+                      default: []
                       description: |-
                         JsonPatches specifies list of jsonpatches to apply to on Envoy Listener's
                         filter.
@@ -345,6 +350,7 @@ properties:
                     referenced in HTTP Connection Manager in a Listener resource.
                   properties:
                     jsonPatches:
+                      default: []
                       description: |-
                         JsonPatches specifies list of jsonpatches to apply to on Envoy's
                         VirtualHost resource
@@ -460,6 +466,7 @@ properties:
               will be targeted.
             type: string
           proxyTypes:
+            default: []
             description: |-
               ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
               all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshproxypatch/k8s/crd/kuma.io_meshproxypatches.yaml
+++ b/pkg/plugins/policies/meshproxypatch/k8s/crd/kuma.io_meshproxypatches.yaml
@@ -527,7 +527,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshproxypatch/k8s/crd/kuma.io_meshproxypatches.yaml
+++ b/pkg/plugins/policies/meshproxypatch/k8s/crd/kuma.io_meshproxypatches.yaml
@@ -55,6 +55,7 @@ spec:
                   referenced in 'targetRef'.
                 properties:
                   appendModifications:
+                    default: []
                     description: AppendModifications is a list of modifications applied
                       on the selected proxy.
                     items:
@@ -64,6 +65,7 @@ spec:
                             resource.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy's Cluster
                                 resource
@@ -141,6 +143,7 @@ spec:
                             available in HTTP Connection Manager in a Listener resource.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy's
                                 HTTP Filter available in HTTP Connection Manager in a Listener resource.
@@ -229,6 +232,7 @@ spec:
                             resource.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy's Listener
                                 resource
@@ -310,6 +314,7 @@ spec:
                             filter.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy Listener's
                                 filter.
@@ -399,6 +404,7 @@ spec:
                             referenced in HTTP Connection Manager in a Listener resource.
                           properties:
                             jsonPatches:
+                              default: []
                               description: |-
                                 JsonPatches specifies list of jsonpatches to apply to on Envoy's
                                 VirtualHost resource
@@ -521,6 +527,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/meshratelimit.go
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/meshratelimit.go
@@ -14,8 +14,10 @@ type MeshRateLimit struct {
 	// defined inplace.
 	TargetRef *common_api.TargetRef `json:"targetRef,omitempty"`
 	// From list makes a match between clients and corresponding configurations
+	// +kubebuilder:default={}
 	From []From `json:"from,omitempty"`
 	// To list makes a match between clients and corresponding configurations
+	// +kubebuilder:default={}
 	To []To `json:"to,omitempty"`
 }
 
@@ -76,10 +78,12 @@ type HeaderModifier struct {
 	// +listType=map
 	// +listMapKey=name
 	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:default={}
 	Set []HeaderKeyValue `json:"set,omitempty"`
 	// +listType=map
 	// +listMapKey=name
 	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:default={}
 	Add []HeaderKeyValue `json:"add,omitempty"`
 }
 

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/schema.yaml
@@ -179,7 +179,9 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
-                  default: []
+                  default:
+                    - Sidecar
+                    - Gateway
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.
@@ -247,7 +249,9 @@ properties:
               will be targeted.
             type: string
           proxyTypes:
-            default: []
+            default:
+              - Sidecar
+              - Gateway
             description: |-
               ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
               all data plane types are targeted by the policy.
@@ -429,7 +433,9 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
-                  default: []
+                  default:
+                    - Sidecar
+                    - Gateway
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/schema.yaml
@@ -22,6 +22,7 @@ properties:
     description: Spec is the specification of the Kuma MeshRateLimit resource.
     properties:
       from:
+        default: []
         description: From list makes a match between clients and corresponding configurations
         items:
           properties:
@@ -48,6 +49,7 @@ properties:
                               description: The Headers to be added to the HTTP response on a rate limit event
                               properties:
                                 add:
+                                  default: []
                                   items:
                                     properties:
                                       name:
@@ -67,6 +69,7 @@ properties:
                                     - name
                                   x-kubernetes-list-type: map
                                 set:
+                                  default: []
                                   items:
                                     properties:
                                       name:
@@ -176,6 +179,7 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
+                  default: []
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.
@@ -243,6 +247,7 @@ properties:
               will be targeted.
             type: string
           proxyTypes:
+            default: []
             description: |-
               ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
               all data plane types are targeted by the policy.
@@ -267,6 +272,7 @@ properties:
             type: object
         type: object
       to:
+        default: []
         description: To list makes a match between clients and corresponding configurations
         items:
           properties:
@@ -293,6 +299,7 @@ properties:
                               description: The Headers to be added to the HTTP response on a rate limit event
                               properties:
                                 add:
+                                  default: []
                                   items:
                                     properties:
                                       name:
@@ -312,6 +319,7 @@ properties:
                                     - name
                                   x-kubernetes-list-type: map
                                 set:
+                                  default: []
                                   items:
                                     properties:
                                       name:
@@ -421,6 +429,7 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
+                  default: []
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshratelimit/k8s/crd/kuma.io_meshratelimits.yaml
+++ b/pkg/plugins/policies/meshratelimit/k8s/crd/kuma.io_meshratelimits.yaml
@@ -217,7 +217,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -286,7 +288,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -478,7 +482,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshratelimit/k8s/crd/kuma.io_meshratelimits.yaml
+++ b/pkg/plugins/policies/meshratelimit/k8s/crd/kuma.io_meshratelimits.yaml
@@ -50,6 +50,7 @@ spec:
             description: Spec is the specification of the Kuma MeshRateLimit resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -80,6 +81,7 @@ spec:
                                         HTTP response on a rate limit event
                                       properties:
                                         add:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -99,6 +101,7 @@ spec:
                                           - name
                                           x-kubernetes-list-type: map
                                         set:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -214,6 +217,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -282,6 +286,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -306,6 +311,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between clients and corresponding
                   configurations
                 items:
@@ -336,6 +342,7 @@ spec:
                                         HTTP response on a rate limit event
                                       properties:
                                         add:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -355,6 +362,7 @@ spec:
                                           - name
                                           x-kubernetes-list-type: map
                                         set:
+                                          default: []
                                           items:
                                             properties:
                                               name:
@@ -470,6 +478,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/meshretry.go
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/meshretry.go
@@ -15,6 +15,7 @@ type MeshRetry struct {
 	// defined inplace.
 	TargetRef *common_api.TargetRef `json:"targetRef,omitempty"`
 	// To list makes a match between the consumed services and corresponding configurations
+	// +kubebuilder:default={}
 	To []To `json:"to,omitempty"`
 }
 
@@ -151,16 +152,20 @@ type HTTP struct {
 	// HttpMethodPost, HttpMethodPut, HttpMethodTrace].
 	// Also, any HTTP status code (500, 503, etc.).
 	// +kubebuilder:example={"5XX","GatewayError","Reset","Retriable4xx","ConnectFailure","EnvoyRatelimited","RefusedStream","Http3PostConnectFailure","HttpMethodConnect","HttpMethodDelete","HttpMethodGet","HttpMethodHead","HttpMethodOptions","HttpMethodPatch","HttpMethodPost","HttpMethodPut","HttpMethodTrace","500","503"}
+	// +kubebuilder:default={}
 	RetryOn *[]HTTPRetryOn `json:"retryOn,omitempty"`
 	// RetriableResponseHeaders is an HTTP response headers that trigger a retry
 	// if present in the response. A retry will be triggered if any of the header
 	// matches the upstream response headers.
+	// +kubebuilder:default={}
 	RetriableResponseHeaders *[]common_api.HeaderMatch `json:"retriableResponseHeaders,omitempty"`
 	// RetriableRequestHeaders is an HTTP headers which must be present in the request
 	// for retries to be attempted.
+	// +kubebuilder:default={}
 	RetriableRequestHeaders *[]common_api.HeaderMatch `json:"retriableRequestHeaders,omitempty"`
 	// HostSelection is a list of predicates that dictate how hosts should be selected
 	// when requests are retried.
+	// +kubebuilder:default={}
 	HostSelection *[]Predicate `json:"hostSelection,omitempty"`
 	// HostSelectionMaxAttempts is the maximum number of times host selection will be
 	// reattempted before giving up, at which point the host that was last selected will
@@ -217,6 +222,7 @@ type GRPC struct {
 	RateLimitedBackOff *RateLimitedBackOff `json:"rateLimitedBackOff,omitempty"`
 	// RetryOn is a list of conditions which will cause a retry.
 	// +kubebuilder:example={Canceled,DeadlineExceeded,Internal,ResourceExhausted,Unavailable}
+	// +kubebuilder:default={}
 	RetryOn *[]GRPCRetryOn `json:"retryOn,omitempty"`
 }
 
@@ -235,6 +241,7 @@ type RateLimitedBackOff struct {
 	// to match against the response. Headers are tried in order, and matched
 	// case-insensitive. The first header to be parsed successfully is used.
 	// If no headers match the default exponential BackOff is used instead.
+	// +kubebuilder:default={}
 	ResetHeaders *[]ResetHeader `json:"resetHeaders,omitempty"`
 	// MaxInterval is a maximal amount of time which will be taken between retries.
 	// +kubebuilder:default="300s"

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/schema.yaml
@@ -61,6 +61,7 @@ properties:
               will be targeted.
             type: string
           proxyTypes:
+            default: []
             description: |-
               ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
               all data plane types are targeted by the policy.
@@ -85,6 +86,7 @@ properties:
             type: object
         type: object
       to:
+        default: []
         description: To list makes a match between the consumed services and corresponding configurations
         items:
           properties:
@@ -135,6 +137,7 @@ properties:
                           description: MaxInterval is a maximal amount of time which will be taken between retries.
                           type: string
                         resetHeaders:
+                          default: []
                           description: |-
                             ResetHeaders specifies the list of headers (like Retry-After or X-RateLimit-Reset)
                             to match against the response. Headers are tried in order, and matched
@@ -161,6 +164,7 @@ properties:
                           type: array
                       type: object
                     retryOn:
+                      default: []
                       description: RetryOn is a list of conditions which will cause a retry.
                       example:
                         - Canceled
@@ -199,6 +203,7 @@ properties:
                           type: string
                       type: object
                     hostSelection:
+                      default: []
                       description: |-
                         HostSelection is a list of predicates that dictate how hosts should be selected
                         when requests are retried.
@@ -260,6 +265,7 @@ properties:
                           description: MaxInterval is a maximal amount of time which will be taken between retries.
                           type: string
                         resetHeaders:
+                          default: []
                           description: |-
                             ResetHeaders specifies the list of headers (like Retry-After or X-RateLimit-Reset)
                             to match against the response. Headers are tried in order, and matched
@@ -286,6 +292,7 @@ properties:
                           type: array
                       type: object
                     retriableRequestHeaders:
+                      default: []
                       description: |-
                         RetriableRequestHeaders is an HTTP headers which must be present in the request
                         for retries to be attempted.
@@ -320,6 +327,7 @@ properties:
                         type: object
                       type: array
                     retriableResponseHeaders:
+                      default: []
                       description: |-
                         RetriableResponseHeaders is an HTTP response headers that trigger a retry
                         if present in the response. A retry will be triggered if any of the header
@@ -355,6 +363,7 @@ properties:
                         type: object
                       type: array
                     retryOn:
+                      default: []
                       description: |-
                         RetryOn is a list of conditions which will cause a retry. Available values are:
                         [5XX, GatewayError, Reset, Retriable4xx, ConnectFailure, EnvoyRatelimited,
@@ -436,6 +445,7 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
+                  default: []
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/schema.yaml
@@ -61,7 +61,9 @@ properties:
               will be targeted.
             type: string
           proxyTypes:
-            default: []
+            default:
+              - Sidecar
+              - Gateway
             description: |-
               ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
               all data plane types are targeted by the policy.
@@ -445,7 +447,9 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
-                  default: []
+                  default:
+                    - Sidecar
+                    - Gateway
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshretry/k8s/crd/kuma.io_meshretries.yaml
+++ b/pkg/plugins/policies/meshretry/k8s/crd/kuma.io_meshretries.yaml
@@ -90,6 +90,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -114,6 +115,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between the consumed services and
                   corresponding configurations
                 items:
@@ -167,6 +169,7 @@ spec:
                                     time which will be taken between retries.
                                   type: string
                                 resetHeaders:
+                                  default: []
                                   description: |-
                                     ResetHeaders specifies the list of headers (like Retry-After or X-RateLimit-Reset)
                                     to match against the response. Headers are tried in order, and matched
@@ -193,6 +196,7 @@ spec:
                                   type: array
                               type: object
                             retryOn:
+                              default: []
                               description: RetryOn is a list of conditions which will
                                 cause a retry.
                               example:
@@ -233,6 +237,7 @@ spec:
                                   type: string
                               type: object
                             hostSelection:
+                              default: []
                               description: |-
                                 HostSelection is a list of predicates that dictate how hosts should be selected
                                 when requests are retried.
@@ -295,6 +300,7 @@ spec:
                                     time which will be taken between retries.
                                   type: string
                                 resetHeaders:
+                                  default: []
                                   description: |-
                                     ResetHeaders specifies the list of headers (like Retry-After or X-RateLimit-Reset)
                                     to match against the response. Headers are tried in order, and matched
@@ -321,6 +327,7 @@ spec:
                                   type: array
                               type: object
                             retriableRequestHeaders:
+                              default: []
                               description: |-
                                 RetriableRequestHeaders is an HTTP headers which must be present in the request
                                 for retries to be attempted.
@@ -357,6 +364,7 @@ spec:
                                 type: object
                               type: array
                             retriableResponseHeaders:
+                              default: []
                               description: |-
                                 RetriableResponseHeaders is an HTTP response headers that trigger a retry
                                 if present in the response. A retry will be triggered if any of the header
@@ -394,6 +402,7 @@ spec:
                                 type: object
                               type: array
                             retryOn:
+                              default: []
                               description: |-
                                 RetryOn is a list of conditions which will cause a retry. Available values are:
                                 [5XX, GatewayError, Reset, Retriable4xx, ConnectFailure, EnvoyRatelimited,
@@ -477,6 +486,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshretry/k8s/crd/kuma.io_meshretries.yaml
+++ b/pkg/plugins/policies/meshretry/k8s/crd/kuma.io_meshretries.yaml
@@ -90,7 +90,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -486,7 +488,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/meshtcproute.go
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/meshtcproute.go
@@ -48,6 +48,7 @@ type To struct {
 	// Rules contains the routing rules applies to a combination of top-level
 	// targetRef and the targetRef in this entry.
 	// +kubebuilder:validation:MaxItems=1
+	// +kubebuilder:default={}
 	Rules []Rule `json:"rules,omitempty"`
 }
 
@@ -59,5 +60,6 @@ type Rule struct {
 
 type RuleConf struct {
 	// +kubebuilder:validation:MinItems=1
+	// +kubebuilder:default={}
 	BackendRefs []common_api.BackendRef `json:"backendRefs"`
 }

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/schema.yaml
@@ -61,6 +61,7 @@ properties:
               will be targeted.
             type: string
           proxyTypes:
+            default: []
             description: |-
               ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
               all data plane types are targeted by the policy.
@@ -91,6 +92,7 @@ properties:
         items:
           properties:
             rules:
+              default: []
               description: |-
                 Rules contains the routing rules applies to a combination of top-level
                 targetRef and the targetRef in this entry.
@@ -102,6 +104,7 @@ properties:
                       policies.
                     properties:
                       backendRefs:
+                        default: []
                         items:
                           description: BackendRef defines where to forward traffic.
                           properties:
@@ -143,6 +146,7 @@ properties:
                               format: int32
                               type: integer
                             proxyTypes:
+                              default: []
                               description: |-
                                 ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                 all data plane types are targeted by the policy.
@@ -219,6 +223,7 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
+                  default: []
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/schema.yaml
@@ -61,7 +61,9 @@ properties:
               will be targeted.
             type: string
           proxyTypes:
-            default: []
+            default:
+              - Sidecar
+              - Gateway
             description: |-
               ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
               all data plane types are targeted by the policy.
@@ -146,7 +148,9 @@ properties:
                               format: int32
                               type: integer
                             proxyTypes:
-                              default: []
+                              default:
+                                - Sidecar
+                                - Gateway
                               description: |-
                                 ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                 all data plane types are targeted by the policy.
@@ -223,7 +227,9 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
-                  default: []
+                  default:
+                    - Sidecar
+                    - Gateway
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshtcproute/k8s/crd/kuma.io_meshtcproutes.yaml
+++ b/pkg/plugins/policies/meshtcproute/k8s/crd/kuma.io_meshtcproutes.yaml
@@ -90,6 +90,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -120,6 +121,7 @@ spec:
                 items:
                   properties:
                     rules:
+                      default: []
                       description: |-
                         Rules contains the routing rules applies to a combination of top-level
                         targetRef and the targetRef in this entry.
@@ -131,6 +133,7 @@ spec:
                               policies.
                             properties:
                               backendRefs:
+                                default: []
                                 items:
                                   description: BackendRef defines where to forward
                                     traffic.
@@ -175,6 +178,7 @@ spec:
                                       format: int32
                                       type: integer
                                     proxyTypes:
+                                      default: []
                                       description: |-
                                         ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                         all data plane types are targeted by the policy.
@@ -252,6 +256,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshtcproute/k8s/crd/kuma.io_meshtcproutes.yaml
+++ b/pkg/plugins/policies/meshtcproute/k8s/crd/kuma.io_meshtcproutes.yaml
@@ -90,7 +90,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -178,7 +180,9 @@ spec:
                                       format: int32
                                       type: integer
                                     proxyTypes:
-                                      default: []
+                                      default:
+                                      - Sidecar
+                                      - Gateway
                                       description: |-
                                         ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                                         all data plane types are targeted by the policy.
@@ -256,7 +260,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/meshtimeout.go
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/meshtimeout.go
@@ -15,11 +15,14 @@ type MeshTimeout struct {
 	// defined inplace.
 	TargetRef *common_api.TargetRef `json:"targetRef,omitempty"`
 	// To list makes a match between the consumed services and corresponding configurations
+	// +kubebuilder:default={}
 	To []To `json:"to,omitempty"`
 	// From list makes a match between clients and corresponding configurations
+	// +kubebuilder:default={}
 	From []From `json:"from,omitempty"`
 	// Rules defines inbound timeout configurations. Currently limited to exactly one rule containing
 	// default timeouts that apply to all inbound traffic, as L7 matching is not yet implemented.
+	// +kubebuilder:default={}
 	Rules []Rule `json:"rules,omitempty"`
 }
 

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/schema.yaml
@@ -116,7 +116,9 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
-                  default: []
+                  default:
+                    - Sidecar
+                    - Gateway
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.
@@ -242,7 +244,9 @@ properties:
               will be targeted.
             type: string
           proxyTypes:
-            default: []
+            default:
+              - Sidecar
+              - Gateway
             description: |-
               ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
               all data plane types are targeted by the policy.
@@ -361,7 +365,9 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
-                  default: []
+                  default:
+                    - Sidecar
+                    - Gateway
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/schema.yaml
@@ -22,6 +22,7 @@ properties:
     description: Spec is the specification of the Kuma MeshTimeout resource.
     properties:
       from:
+        default: []
         description: From list makes a match between clients and corresponding configurations
         items:
           properties:
@@ -115,6 +116,7 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
+                  default: []
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.
@@ -143,6 +145,7 @@ properties:
           type: object
         type: array
       rules:
+        default: []
         description: |-
           Rules defines inbound timeout configurations. Currently limited to exactly one rule containing
           default timeouts that apply to all inbound traffic, as L7 matching is not yet implemented.
@@ -239,6 +242,7 @@ properties:
               will be targeted.
             type: string
           proxyTypes:
+            default: []
             description: |-
               ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
               all data plane types are targeted by the policy.
@@ -263,6 +267,7 @@ properties:
             type: object
         type: object
       to:
+        default: []
         description: To list makes a match between the consumed services and corresponding configurations
         items:
           properties:
@@ -356,6 +361,7 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
+                  default: []
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshtimeout/k8s/crd/kuma.io_meshtimeouts.yaml
+++ b/pkg/plugins/policies/meshtimeout/k8s/crd/kuma.io_meshtimeouts.yaml
@@ -147,7 +147,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -275,7 +277,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -397,7 +401,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshtimeout/k8s/crd/kuma.io_meshtimeouts.yaml
+++ b/pkg/plugins/policies/meshtimeout/k8s/crd/kuma.io_meshtimeouts.yaml
@@ -50,6 +50,7 @@ spec:
             description: Spec is the specification of the Kuma MeshTimeout resource.
             properties:
               from:
+                default: []
                 description: From list makes a match between clients and corresponding
                   configurations
                 items:
@@ -146,6 +147,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -174,6 +176,7 @@ spec:
                   type: object
                 type: array
               rules:
+                default: []
                 description: |-
                   Rules defines inbound timeout configurations. Currently limited to exactly one rule containing
                   default timeouts that apply to all inbound traffic, as L7 matching is not yet implemented.
@@ -272,6 +275,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.
@@ -296,6 +300,7 @@ spec:
                     type: object
                 type: object
               to:
+                default: []
                 description: To list makes a match between the consumed services and
                   corresponding configurations
                 items:
@@ -392,6 +397,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshtls/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtls/api/v1alpha1/schema.yaml
@@ -112,7 +112,9 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
-                  default: []
+                  default:
+                    - Sidecar
+                    - Gateway
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.
@@ -180,7 +182,9 @@ properties:
               will be targeted.
             type: string
           proxyTypes:
-            default: []
+            default:
+              - Sidecar
+              - Gateway
             description: |-
               ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
               all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshtls/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtls/api/v1alpha1/schema.yaml
@@ -112,6 +112,7 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
+                  default: []
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.
@@ -179,6 +180,7 @@ properties:
               will be targeted.
             type: string
           proxyTypes:
+            default: []
             description: |-
               ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
               all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshtls/api/v1alpha1/testdata/invalid-top-level-sectionName.output.yaml
+++ b/pkg/plugins/policies/meshtls/api/v1alpha1/testdata/invalid-top-level-sectionName.output.yaml
@@ -1,3 +1,3 @@
 violations:
-  - field: spec.targetRef.sectionName
-    message: can only be used with inbound policies
+- field: spec.targetRef.sectionName
+  message: can only be used with inbound policies

--- a/pkg/plugins/policies/meshtls/k8s/crd/kuma.io_meshtlses.yaml
+++ b/pkg/plugins/policies/meshtls/k8s/crd/kuma.io_meshtlses.yaml
@@ -145,7 +145,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -214,7 +216,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshtls/k8s/crd/kuma.io_meshtlses.yaml
+++ b/pkg/plugins/policies/meshtls/k8s/crd/kuma.io_meshtlses.yaml
@@ -145,6 +145,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -213,6 +214,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/meshtrace.go
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/meshtrace.go
@@ -26,6 +26,7 @@ type Conf struct {
 	// reasons explained in MADR 009-tracing-policy this has to be a one element
 	// array for now.
 	// +kubebuilder:validation:MaxItems=1
+	// +kubebuilder:default={}
 	Backends *[]Backend `json:"backends,omitempty"`
 	// Sampling configuration.
 	// Sampling is the process by which a decision is made on whether to
@@ -33,6 +34,7 @@ type Conf struct {
 	Sampling *Sampling `json:"sampling,omitempty"`
 	// Custom tags configuration. You can add custom tags to traces based on
 	// headers or literal values.
+	// +kubebuilder:default={}
 	Tags *[]Tag `json:"tags,omitempty"`
 }
 

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/schema.yaml
@@ -228,7 +228,9 @@ properties:
               will be targeted.
             type: string
           proxyTypes:
-            default: []
+            default:
+              - Sidecar
+              - Gateway
             description: |-
               ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
               all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/schema.yaml
@@ -25,6 +25,7 @@ properties:
         description: MeshTrace configuration.
         properties:
           backends:
+            default: []
             description: |-
               A one element array of backend definition.
               Envoy allows configuring only 1 backend, so the natural way of
@@ -152,6 +153,7 @@ properties:
                 x-kubernetes-int-or-string: true
             type: object
           tags:
+            default: []
             description: |-
               Custom tags configuration. You can add custom tags to traces based on
               headers or literal values.
@@ -226,6 +228,7 @@ properties:
               will be targeted.
             type: string
           proxyTypes:
+            default: []
             description: |-
               ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
               all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshtrace/k8s/crd/kuma.io_meshtraces.yaml
+++ b/pkg/plugins/policies/meshtrace/k8s/crd/kuma.io_meshtraces.yaml
@@ -258,7 +258,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshtrace/k8s/crd/kuma.io_meshtraces.yaml
+++ b/pkg/plugins/policies/meshtrace/k8s/crd/kuma.io_meshtraces.yaml
@@ -53,6 +53,7 @@ spec:
                 description: MeshTrace configuration.
                 properties:
                   backends:
+                    default: []
                     description: |-
                       A one element array of backend definition.
                       Envoy allows configuring only 1 backend, so the natural way of
@@ -181,6 +182,7 @@ spec:
                         x-kubernetes-int-or-string: true
                     type: object
                   tags:
+                    default: []
                     description: |-
                       Custom tags configuration. You can add custom tags to traces based on
                       headers or literal values.
@@ -256,6 +258,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/schema.yaml
@@ -77,7 +77,9 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
-                  default: []
+                  default:
+                    - Sidecar
+                    - Gateway
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.
@@ -145,7 +147,9 @@ properties:
               will be targeted.
             type: string
           proxyTypes:
-            default: []
+            default:
+              - Sidecar
+              - Gateway
             description: |-
               ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
               all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/schema.yaml
@@ -77,6 +77,7 @@ properties:
                     will be targeted.
                   type: string
                 proxyTypes:
+                  default: []
                   description: |-
                     ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                     all data plane types are targeted by the policy.
@@ -144,6 +145,7 @@ properties:
               will be targeted.
             type: string
           proxyTypes:
+            default: []
             description: |-
               ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
               all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshtrafficpermission/k8s/crd/kuma.io_meshtrafficpermissions.yaml
+++ b/pkg/plugins/policies/meshtrafficpermission/k8s/crd/kuma.io_meshtrafficpermissions.yaml
@@ -109,6 +109,7 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
+                          default: []
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -177,6 +178,7 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
+                    default: []
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.

--- a/pkg/plugins/policies/meshtrafficpermission/k8s/crd/kuma.io_meshtrafficpermissions.yaml
+++ b/pkg/plugins/policies/meshtrafficpermission/k8s/crd/kuma.io_meshtrafficpermissions.yaml
@@ -109,7 +109,9 @@ spec:
                             will be targeted.
                           type: string
                         proxyTypes:
-                          default: []
+                          default:
+                          - Sidecar
+                          - Gateway
                           description: |-
                             ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                             all data plane types are targeted by the policy.
@@ -178,7 +180,9 @@ spec:
                       will be targeted.
                     type: string
                   proxyTypes:
-                    default: []
+                    default:
+                    - Sidecar
+                    - Gateway
                     description: |-
                       ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
                       all data plane types are targeted by the policy.


### PR DESCRIPTION
## Motivation

Empty arrays in terraform are serialized as "[]" in the file but as "null" in the state. This creates an artificial diff which will never be resolved. E.g.

```
                          ~ {
                              ~ tcp  = {
                                  ~ format  = {
                                      - json              = [] -> null
                                        # (3 unchanged attributes hidden)
                                    }
                                    # (1 unchanged attribute hidden)
                                }
                                # (1 unchanged attribute hidden)
                            },
                        ]
                    }
                  ~ target_ref = {
                      - proxy_types = [] -> null
                        # (1 unchanged attribute hidden)
                    }
```

If we tell it that the default is "[]" it won't detect the diff. 

## Implementation information

Add kubebuilder default to all arrays that don't have requirements on the number of elements. I found one place in MeshLoadBalancingStrategy where we require 1 element so I added `minElements` there. 

**This shouldn't impact the behaviour but let's see if e2e tests pass**.

## Supporting documentation

xrel https://github.com/Kong/kong-mesh/issues/7201
