### PR TITLE
feat(oapi): parse comments to set defaults on pb resources

### DIFF
--- a/api/mesh/v1alpha1/datadogtracingbackendconfig/schema.yaml
+++ b/api/mesh/v1alpha1/datadogtracingbackendconfig/schema.yaml
@@ -15,6 +15,7 @@ components:
             `backend` service that communicates with a couple of databases, you would
             get service names like `backend_INBOUND`, `backend_OUTBOUND_db1`, and
             `backend_OUTBOUND_db2` in Datadog. Default: false
+            Default: false
           type: boolean
       type: object
 info:

--- a/api/mesh/v1alpha1/mesh.pb.go
+++ b/api/mesh/v1alpha1/mesh.pb.go
@@ -559,6 +559,7 @@ type DatadogTracingBackendConfig struct {
 	// `backend` service that communicates with a couple of databases, you would
 	// get service names like `backend_INBOUND`, `backend_OUTBOUND_db1`, and
 	// `backend_OUTBOUND_db2` in Datadog. Default: false
+	// Default: false
 	SplitService bool `protobuf:"varint,3,opt,name=splitService,proto3" json:"splitService,omitempty"`
 }
 
@@ -623,6 +624,7 @@ type ZipkinTracingBackendConfig struct {
 	// Address of Zipkin collector.
 	Url string `protobuf:"bytes,1,opt,name=url,proto3" json:"url,omitempty"`
 	// Generate 128bit traces. Default: false
+	// Default: false
 	TraceId128Bit bool `protobuf:"varint,2,opt,name=traceId128bit,proto3" json:"traceId128bit,omitempty"`
 	// Version of the API. values: httpJson, httpJsonV1, httpProto. Default:
 	// httpJson see
@@ -631,6 +633,7 @@ type ZipkinTracingBackendConfig struct {
 	// Determines whether client and server spans will share the same span
 	// context. Default: true.
 	// https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/trace/v3/zipkin.proto#config-trace-v3-zipkinconfig
+	// Default: false
 	SharedSpanContext *wrapperspb.BoolValue `protobuf:"bytes,4,opt,name=sharedSpanContext,proto3" json:"sharedSpanContext,omitempty"`
 }
 
@@ -935,6 +938,7 @@ type Routing struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Enable the Locality Aware Load Balancing
+	// Default: false
 	LocalityAwareLoadBalancing bool `protobuf:"varint,1,opt,name=localityAwareLoadBalancing,proto3" json:"localityAwareLoadBalancing,omitempty"`
 	// Enable routing traffic to services in other zone or external services
 	// through ZoneEgress. Default: false
@@ -1008,6 +1012,7 @@ type Mesh_Mtls struct {
 	// List of available Certificate Authority backends
 	Backends []*CertificateAuthorityBackend `protobuf:"bytes,2,rep,name=backends,proto3" json:"backends,omitempty"`
 	// If enabled, skips CA validation.
+	// Default: false
 	SkipValidation bool `protobuf:"varint,3,opt,name=skipValidation,proto3" json:"skipValidation,omitempty"`
 }
 
@@ -1439,6 +1444,7 @@ type Networking_Outbound struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Control the passthrough cluster
+	// Default: false
 	Passthrough *wrapperspb.BoolValue `protobuf:"bytes,1,opt,name=passthrough,proto3" json:"passthrough,omitempty"`
 }
 

--- a/api/mesh/v1alpha1/mesh.proto
+++ b/api/mesh/v1alpha1/mesh.proto
@@ -32,6 +32,7 @@ message Mesh {
     repeated CertificateAuthorityBackend backends = 2;
 
     // If enabled, skips CA validation.
+    // Default: false
     bool skipValidation = 3;
   }
 
@@ -180,6 +181,7 @@ message Networking {
   // Outbound describes the common mesh outbound settings
   message Outbound {
     // Control the passthrough cluster
+    // Default: false
     google.protobuf.BoolValue passthrough = 1;
   }
 
@@ -227,6 +229,7 @@ message DatadogTracingBackendConfig {
   // `backend` service that communicates with a couple of databases, you would
   // get service names like `backend_INBOUND`, `backend_OUTBOUND_db1`, and
   // `backend_OUTBOUND_db2` in Datadog. Default: false
+  // Default: false
   bool splitService = 3;
 }
 
@@ -235,6 +238,7 @@ message ZipkinTracingBackendConfig {
   string url = 1;
 
   // Generate 128bit traces. Default: false
+  // Default: false
   bool traceId128bit = 2;
 
   // Version of the API. values: httpJson, httpJsonV1, httpProto. Default:
@@ -245,6 +249,7 @@ message ZipkinTracingBackendConfig {
   // Determines whether client and server spans will share the same span
   // context. Default: true.
   // https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/trace/v3/zipkin.proto#config-trace-v3-zipkinconfig
+  // Default: false
   google.protobuf.BoolValue sharedSpanContext = 4;
 }
 
@@ -290,6 +295,7 @@ message TcpLoggingBackendConfig {
 // Routing defines configuration for the routing in the mesh
 message Routing {
   // Enable the Locality Aware Load Balancing
+  // Default: false
   bool localityAwareLoadBalancing = 1;
 
   // Enable routing traffic to services in other zone or external services

--- a/api/mesh/v1alpha1/mesh/schema.yaml
+++ b/api/mesh/v1alpha1/mesh/schema.yaml
@@ -192,7 +192,9 @@ properties:
         description: Name of the enabled backend
         type: string
       skipValidation:
-        description: If enabled, skips CA validation.
+        description: |-
+          If enabled, skips CA validation.
+          Default: false
         type: boolean
     type: object
   name:
@@ -204,7 +206,9 @@ properties:
         description: Outbound settings
         properties:
           passthrough:
-            description: Control the passthrough cluster
+            description: |-
+              Control the passthrough cluster
+              Default: false
             type: boolean
         type: object
     type: object
@@ -212,14 +216,19 @@ properties:
     description: Routing settings of the mesh
     properties:
       defaultForbidMeshExternalServiceAccess:
+        default: false
         description: |-
           If true, blocks traffic to MeshExternalServices.
           Default: false
         type: boolean
       localityAwareLoadBalancing:
-        description: Enable the Locality Aware Load Balancing
+        default: false
+        description: |-
+          Enable the Locality Aware Load Balancing
+          Default: false
         type: boolean
       zoneEgress:
+        default: false
         description: |-
           Enable routing traffic to services in other zone or external services
           through ZoneEgress. Default: false

--- a/api/mesh/v1alpha1/zipkintracingbackendconfig/schema.yaml
+++ b/api/mesh/v1alpha1/zipkintracingbackendconfig/schema.yaml
@@ -13,9 +13,12 @@ components:
             Determines whether client and server spans will share the same span
             context. Default: true.
             https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/trace/v3/zipkin.proto#config-trace-v3-zipkinconfig
+            Default: false
           type: boolean
         traceId128bit:
-          description: 'Generate 128bit traces. Default: false'
+          description: |-
+            Generate 128bit traces. Default: false
+            Default: false
           type: boolean
         url:
           description: Address of Zipkin collector.

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -12203,6 +12203,8 @@ components:
             and
 
             `backend_OUTBOUND_db2` in Datadog. Default: false
+
+            Default: false
           type: boolean
       type: object
     FileLoggingBackendConfig:
@@ -12448,7 +12450,9 @@ components:
               description: Name of the enabled backend
               type: string
             skipValidation:
-              description: If enabled, skips CA validation.
+              description: |-
+                If enabled, skips CA validation.
+                Default: false
               type: boolean
           type: object
         name:
@@ -12460,7 +12464,9 @@ components:
               description: Outbound settings
               properties:
                 passthrough:
-                  description: Control the passthrough cluster
+                  description: |-
+                    Control the passthrough cluster
+                    Default: false
                   type: boolean
               type: object
           type: object
@@ -12468,14 +12474,19 @@ components:
           description: Routing settings of the mesh
           properties:
             defaultForbidMeshExternalServiceAccess:
+              default: false
               description: |-
                 If true, blocks traffic to MeshExternalServices.
                 Default: false
               type: boolean
             localityAwareLoadBalancing:
-              description: Enable the Locality Aware Load Balancing
+              default: false
+              description: |-
+                Enable the Locality Aware Load Balancing
+                Default: false
               type: boolean
             zoneEgress:
+              default: false
               description: >-
                 Enable routing traffic to services in other zone or external
                 services
@@ -12706,9 +12717,13 @@ components:
             context. Default: true.
 
             https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/trace/v3/zipkin.proto#config-trace-v3-zipkinconfig
+
+            Default: false
           type: boolean
         traceId128bit:
-          description: 'Generate 128bit traces. Default: false'
+          description: |-
+            Generate 128bit traces. Default: false
+            Default: false
           type: boolean
         url:
           description: Address of Zipkin collector.

--- a/docs/generated/raw/protos/DatadogTracingBackendConfig.json
+++ b/docs/generated/raw/protos/DatadogTracingBackendConfig.json
@@ -14,7 +14,7 @@
                 },
                 "splitService": {
                     "type": "boolean",
-                    "description": "Determines if datadog service name should be split based on traffic direction and destination. For example, with `splitService: true` and a `backend` service that communicates with a couple of databases, you would get service names like `backend_INBOUND`, `backend_OUTBOUND_db1`, and `backend_OUTBOUND_db2` in Datadog. Default: false"
+                    "description": "Determines if datadog service name should be split based on traffic direction and destination. For example, with `splitService: true` and a `backend` service that communicates with a couple of databases, you would get service names like `backend_INBOUND`, `backend_OUTBOUND_db1`, and `backend_OUTBOUND_db2` in Datadog. Default: false Default: false"
                 }
             },
             "additionalProperties": true,

--- a/docs/generated/raw/protos/Mesh.json
+++ b/docs/generated/raw/protos/Mesh.json
@@ -283,7 +283,7 @@
                 },
                 "skipValidation": {
                     "type": "boolean",
-                    "description": "If enabled, skips CA validation."
+                    "description": "If enabled, skips CA validation. Default: false"
                 }
             },
             "additionalProperties": true,
@@ -349,7 +349,7 @@
                 "passthrough": {
                     "additionalProperties": true,
                     "type": "boolean",
-                    "description": "Control the passthrough cluster"
+                    "description": "Control the passthrough cluster Default: false"
                 }
             },
             "additionalProperties": true,
@@ -361,7 +361,7 @@
             "properties": {
                 "localityAwareLoadBalancing": {
                     "type": "boolean",
-                    "description": "Enable the Locality Aware Load Balancing"
+                    "description": "Enable the Locality Aware Load Balancing Default: false"
                 },
                 "zoneEgress": {
                     "type": "boolean",

--- a/docs/generated/raw/protos/Networking.json
+++ b/docs/generated/raw/protos/Networking.json
@@ -20,7 +20,7 @@
                 "passthrough": {
                     "additionalProperties": true,
                     "type": "boolean",
-                    "description": "Control the passthrough cluster"
+                    "description": "Control the passthrough cluster Default: false"
                 }
             },
             "additionalProperties": true,

--- a/docs/generated/raw/protos/Routing.json
+++ b/docs/generated/raw/protos/Routing.json
@@ -6,7 +6,7 @@
             "properties": {
                 "localityAwareLoadBalancing": {
                     "type": "boolean",
-                    "description": "Enable the Locality Aware Load Balancing"
+                    "description": "Enable the Locality Aware Load Balancing Default: false"
                 },
                 "zoneEgress": {
                     "type": "boolean",

--- a/docs/generated/raw/protos/ZipkinTracingBackendConfig.json
+++ b/docs/generated/raw/protos/ZipkinTracingBackendConfig.json
@@ -10,7 +10,7 @@
                 },
                 "traceId128bit": {
                     "type": "boolean",
-                    "description": "Generate 128bit traces. Default: false"
+                    "description": "Generate 128bit traces. Default: false Default: false"
                 },
                 "apiVersion": {
                     "type": "string",
@@ -19,7 +19,7 @@
                 "sharedSpanContext": {
                     "additionalProperties": true,
                     "type": "boolean",
-                    "description": "Determines whether client and server spans will share the same span context. Default: true. https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/trace/v3/zipkin.proto#config-trace-v3-zipkinconfig"
+                    "description": "Determines whether client and server spans will share the same span context. Default: true. https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/trace/v3/zipkin.proto#config-trace-v3-zipkinconfig Default: false"
                 }
             },
             "additionalProperties": true,

--- a/tools/resource-gen/pkg/generator/main.go
+++ b/tools/resource-gen/pkg/generator/main.go
@@ -495,7 +495,7 @@ func openApiGenerator(pkg string, resources []ResourceInfo) error {
 		}
 
 		modifySchema(&schema, "", func(path string, s *jsonschema.Schema) {
-			comment, ok := reflector.CommentMap[base + "api/mesh/v1alpha1." + path]
+			comment, ok := reflector.CommentMap[base+"api/mesh/v1alpha1."+path]
 
 			if ok && strings.Contains(comment, "Default:") {
 				s.Default = extractDefaultValue(comment)


### PR DESCRIPTION
## Motivation

TF distinguishes between null and zero type value so without this we get:

```
      ~ routing                        = {
          + default_forbid_mesh_external_service_access = false
          + zone_egress                                 = false
            # (1 unchanged attribute hidden)
        }
```

## Implementation information

I extract default value from "Default: " in comments and put it in "default" field.

## Supporting documentation

xrel https://github.com/Kong/kong-mesh/issues/7201
