### PR TITLE
fix(meshtimeout): remove if-condition that prevents plugin from running when there are no policies

### DIFF
--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/proxyconfig_shadow-false.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/proxyconfig_shadow-false.golden.json
@@ -5,7 +5,7 @@
     "name": "localhost:8080",
     "altStatName": "localhost_8080",
     "type": "STATIC",
-    "connectTimeout": "10s",
+    "connectTimeout": "5s",
     "loadAssignment": {
      "clusterName": "localhost:8080",
      "endpoints": [
@@ -45,7 +45,7 @@
          "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
          "statPrefix": "localhost_8080",
          "cluster": "localhost:8080",
-         "idleTimeout": "7200s"
+         "idleTimeout": "3600s"
         }
        }
       ]

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/proxyconfig_shadow-false_diff.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/proxyconfig_shadow-false_diff.golden.json
@@ -6,7 +6,7 @@
     "name": "localhost:8080",
     "altStatName": "localhost_8080",
     "type": "STATIC",
-    "connectTimeout": "10s",
+    "connectTimeout": "5s",
     "loadAssignment": {
      "clusterName": "localhost:8080",
      "endpoints": [
@@ -46,7 +46,7 @@
          "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
          "statPrefix": "localhost_8080",
          "cluster": "localhost:8080",
-         "idleTimeout": "7200s"
+         "idleTimeout": "3600s"
         }
        }
       ]

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/proxyconfig_shadow-true_diff.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/proxyconfig_shadow-true_diff.golden.json
@@ -2,28 +2,13 @@
  "diff": [
   {
    "op": "test",
-   "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/connectTimeout",
-   "value": "10s"
-  },
-  {
-   "op": "remove",
-   "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/connectTimeout",
-   "value": "10s"
-  },
-  {
-   "op": "add",
-   "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/connectTimeout",
-   "value": "5s"
-  },
-  {
-   "op": "test",
    "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:127.0.0.1:8080/filterChains/0/filters/0/typedConfig/idleTimeout",
-   "value": "7200s"
+   "value": "3600s"
   },
   {
    "op": "remove",
    "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:127.0.0.1:8080/filterChains/0/filters/0/typedConfig/idleTimeout",
-   "value": "7200s"
+   "value": "3600s"
   },
   {
    "op": "add",

--- a/pkg/core/xds/inspect/testdata/diff.json
+++ b/pkg/core/xds/inspect/testdata/diff.json
@@ -1,21 +1,6 @@
 [
   {
     "op": "test",
-    "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/connectTimeout",
-    "value": "5s"
-  },
-  {
-    "op": "remove",
-    "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/connectTimeout",
-    "value": "5s"
-  },
-  {
-    "op": "add",
-    "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/connectTimeout",
-    "value": "10s"
-  },
-  {
-    "op": "test",
     "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:192.168.0.1:80/filterChains/0/filters/0/typedConfig/idleTimeout",
     "value": "123s"
   },
@@ -27,6 +12,6 @@
   {
     "op": "add",
     "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:192.168.0.1:80/filterChains/0/filters/0/typedConfig/idleTimeout",
-    "value": "7200s"
+    "value": "3600s"
   }
 ]

--- a/pkg/core/xds/inspect/testdata/with-shadow-policies.get.json
+++ b/pkg/core/xds/inspect/testdata/with-shadow-policies.get.json
@@ -4,7 +4,7 @@
       "name": "localhost:8080",
       "altStatName": "localhost_8080",
       "type": "STATIC",
-      "connectTimeout": "10s",
+      "connectTimeout": "5s",
       "loadAssignment": {
         "clusterName": "localhost:8080",
         "endpoints": [
@@ -44,7 +44,7 @@
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                 "statPrefix": "localhost_8080",
                 "cluster": "localhost:8080",
-                "idleTimeout": "7200s"
+                "idleTimeout": "3600s"
               }
             }
           ]

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/original_inbound_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/original_inbound_cluster.golden.yaml
@@ -1,1 +1,9 @@
+connectTimeout: 5s
 name: localhost:8080
+typedExtensionProtocolOptions:
+  envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+    '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+    commonHttpProtocolOptions:
+      idleTimeout: 3600s
+      maxConnectionDuration: 0s
+      maxStreamDuration: 0s

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/original_inbound_listener.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/original_inbound_listener.golden.yaml
@@ -8,10 +8,13 @@ filterChains:
   - name: envoy.filters.network.http_connection_manager
     typedConfig:
       '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+      commonHttpProtocolOptions:
+        idleTimeout: 0s
       httpFilters:
       - name: envoy.filters.http.router
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+      requestHeadersTimeout: 0s
       routeConfig:
         name: inbound:backend
         requestHeadersToRemove:
@@ -26,7 +29,8 @@ filterChains:
               prefix: /
             route:
               cluster: backend
-              timeout: 0s
+              idleTimeout: 1800s
+              timeout: 15s
       statPrefix: inbound_127_0_0_1_80
 name: inbound:127.0.0.1:80
 trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/original_outbound_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/original_outbound_cluster.golden.yaml
@@ -1,1 +1,9 @@
+connectTimeout: 5s
 name: other-service
+typedExtensionProtocolOptions:
+  envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+    '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+    commonHttpProtocolOptions:
+      idleTimeout: 3600s
+      maxConnectionDuration: 0s
+      maxStreamDuration: 0s

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/original_outbound_listener.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/original_outbound_listener.golden.yaml
@@ -7,10 +7,13 @@ filterChains:
   - name: envoy.filters.network.http_connection_manager
     typedConfig:
       '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+      commonHttpProtocolOptions:
+        idleTimeout: 0s
       httpFilters:
       - name: envoy.filters.http.router
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+      requestHeadersTimeout: 0s
       routeConfig:
         name: outbound:backend
         requestHeadersToAdd:
@@ -28,7 +31,8 @@ filterChains:
             name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
             route:
               cluster: backend
-              timeout: 0s
+              idleTimeout: 1800s
+              timeout: 15s
       statPrefix: outbound_127_0_0_1_10001
 name: outbound:127.0.0.1:10001
 trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/route-level-timeouts.gateway.cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/route-level-timeouts.gateway.cluster.golden.yaml
@@ -10,6 +10,8 @@ typedExtensionProtocolOptions:
   envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
     '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
     commonHttpProtocolOptions:
-      idleTimeout: 0s
+      idleTimeout: 3600s
+      maxConnectionDuration: 0s
+      maxStreamDuration: 0s
     explicitHttpConfig:
       httpProtocolOptions: {}

--- a/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
@@ -42,9 +42,6 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 	if !ok {
 		return nil
 	}
-	if len(policies.ToRules.Rules) == 0 && len(policies.FromRules.Rules) == 0 && len(policies.GatewayRules.ToRules.ByListener) == 0 && len(policies.ToRules.ResourceRules) == 0 {
-		return nil
-	}
 
 	listeners := xds.GatherListeners(rs)
 	clusters := xds.GatherClusters(rs)

--- a/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
@@ -229,8 +229,6 @@ func applyToGateway(
 					}
 
 					serviceName := dest.Destination[mesh_proto.ServiceTag]
-
-					conf, _ = getConf(toRules.Rules, subsetutils.MeshServiceElement(serviceName))
 					if err := applyToClusters(
 						toRules.Rules,
 						serviceName,

--- a/pkg/plugins/runtime/gateway/testdata/tcp/tcp-route-no-egress.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/tcp/tcp-route-no-egress.yaml
@@ -114,6 +114,7 @@ Listeners:
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
             cluster: external-no-protocol-httpbin-6a3325e78573377c
+            idleTimeout: 300s
             maxConnectAttempts: 5
             statPrefix: gateway-default
       listenerFilters:

--- a/pkg/plugins/runtime/gateway/testdata/tcp/tcp-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/tcp/tcp-route.yaml
@@ -169,6 +169,7 @@ Listeners:
         - name: envoy.filters.network.tcp_proxy
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+            idleTimeout: 300s
             maxConnectAttempts: 5
             statPrefix: gateway-default
             weightedClusters:

--- a/pkg/plugins/runtime/gateway/testdata/tls/tcp-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/tls/tcp-route.yaml
@@ -173,6 +173,7 @@ Listeners:
         - name: envoy.filters.network.tcp_proxy
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+            idleTimeout: 300s
             maxConnectAttempts: 5
             statPrefix: gateway-default
             weightedClusters:
@@ -202,6 +203,7 @@ Listeners:
         - name: envoy.filters.network.tcp_proxy
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+            idleTimeout: 300s
             maxConnectAttempts: 5
             statPrefix: gateway-default
             weightedClusters:

--- a/pkg/xds/server/v3/testdata/hook-before-pt.golden.yaml
+++ b/pkg/xds/server/v3/testdata/hook-before-pt.golden.yaml
@@ -15,7 +15,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: localhost_8080
-    connectTimeout: 10s
+    connectTimeout: 5s
     loadAssignment:
       clusterName: localhost:8080
       endpoints:
@@ -35,7 +35,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: localhost_8443
-    connectTimeout: 10s
+    connectTimeout: 5s
     loadAssignment:
       clusterName: localhost:8443
       endpoints:
@@ -79,7 +79,7 @@ resources:
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
           cluster: localhost:8443
-          idleTimeout: 7200s
+          idleTimeout: 3600s
           statPrefix: localhost_8443
       transportSocket:
         name: envoy.transport_sockets.tls
@@ -129,7 +129,7 @@ resources:
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
           cluster: localhost:8080
-          idleTimeout: 7200s
+          idleTimeout: 3600s
           statPrefix: localhost_8080
       transportSocket:
         name: envoy.transport_sockets.tls
@@ -179,7 +179,7 @@ resources:
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
           cluster: localhost:8443
-          idleTimeout: 7200s
+          idleTimeout: 3600s
           statPrefix: localhost_8443
       transportSocket:
         name: envoy.transport_sockets.tls
@@ -229,7 +229,7 @@ resources:
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
           cluster: localhost:8080
-          idleTimeout: 7200s
+          idleTimeout: 3600s
           statPrefix: localhost_8080
       transportSocket:
         name: envoy.transport_sockets.tls

--- a/pkg/xds/server/v3/testdata/stable-es.golden.yaml
+++ b/pkg/xds/server/v3/testdata/stable-es.golden.yaml
@@ -134,7 +134,9 @@ resources:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         commonHttpProtocolOptions:
-          idleTimeout: 0s
+          idleTimeout: 3600s
+          maxConnectionDuration: 0s
+          maxStreamDuration: 0s
         explicitHttpConfig:
           httpProtocolOptions: {}
 - name: inbound:passthrough:ipv4
@@ -153,7 +155,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: localhost_8080
-    connectTimeout: 10s
+    connectTimeout: 5s
     loadAssignment:
       clusterName: localhost:8080
       endpoints:
@@ -173,7 +175,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: localhost_8443
-    connectTimeout: 10s
+    connectTimeout: 5s
     loadAssignment:
       clusterName: localhost:8443
       endpoints:
@@ -223,7 +225,7 @@ resources:
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
           cluster: localhost:8443
-          idleTimeout: 7200s
+          idleTimeout: 3600s
           statPrefix: localhost_8443
       transportSocket:
         name: envoy.transport_sockets.tls
@@ -279,7 +281,7 @@ resources:
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
           cluster: localhost:8080
-          idleTimeout: 7200s
+          idleTimeout: 3600s
           statPrefix: localhost_8080
       transportSocket:
         name: envoy.transport_sockets.tls
@@ -335,7 +337,7 @@ resources:
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
           cluster: localhost:8443
-          idleTimeout: 7200s
+          idleTimeout: 3600s
           statPrefix: localhost_8443
       transportSocket:
         name: envoy.transport_sockets.tls
@@ -391,7 +393,7 @@ resources:
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
           cluster: localhost:8080
-          idleTimeout: 7200s
+          idleTimeout: 3600s
           statPrefix: localhost_8080
       transportSocket:
         name: envoy.transport_sockets.tls

--- a/test/e2e_env/universal/envoyconfig/testdata/builtingateway/meshaccesslog/mal-with-from.gateway-proxy.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/builtingateway/meshaccesslog/mal-with-from.gateway-proxy.golden.json
@@ -22,6 +22,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig-builtingateway_echo-service__kuma-3_msvc_80-3e607e0fbdf6b9a2": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -74,6 +75,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "httpProtocolOptions": {}
             }

--- a/test/e2e_env/universal/envoyconfig/testdata/builtingateway/meshaccesslog/mal-with-rules.gateway-proxy.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/builtingateway/meshaccesslog/mal-with-rules.gateway-proxy.golden.json
@@ -22,6 +22,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig-builtingateway_echo-service__kuma-3_msvc_80-3e607e0fbdf6b9a2": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -74,6 +75,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "httpProtocolOptions": {}
             }

--- a/test/e2e_env/universal/envoyconfig/testdata/builtingateway/meshaccesslog/mt-with-to.gateway-proxy.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/builtingateway/meshaccesslog/mt-with-to.gateway-proxy.golden.json
@@ -27,6 +27,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig-builtingateway_echo-service__kuma-3_msvc_80-3e607e0fbdf6b9a2": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -79,6 +80,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "httpProtocolOptions": {}
             }

--- a/test/e2e_env/universal/envoyconfig/testdata/builtingateway/meshtimeout/mt-with-from.gateway-proxy.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/builtingateway/meshtimeout/mt-with-from.gateway-proxy.golden.json
@@ -1,20 +1,6 @@
 {
   "diff": [
     {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig-builtingateway_echo-service__kuma-3_msvc_80-3e607e0fbdf6b9a2/connectTimeout",
-      "value": "5s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig-builtingateway_echo-service__kuma-3_msvc_80-3e607e0fbdf6b9a2/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions",
-      "value": {
-        "idleTimeout": "3600s",
-        "maxConnectionDuration": "0s",
-        "maxStreamDuration": "0s"
-      }
-    },
-    {
       "op": "remove",
       "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/gateway-proxy:HTTP:8080/filterChains/0/filters/0/typedConfig/commonHttpProtocolOptions/idleTimeout",
       "value": "300s"

--- a/test/e2e_env/universal/envoyconfig/testdata/builtingateway/meshtimeout/mt-with-rules.gateway-proxy.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/builtingateway/meshtimeout/mt-with-rules.gateway-proxy.golden.json
@@ -1,20 +1,6 @@
 {
   "diff": [
     {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig-builtingateway_echo-service__kuma-3_msvc_80-3e607e0fbdf6b9a2/connectTimeout",
-      "value": "5s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig-builtingateway_echo-service__kuma-3_msvc_80-3e607e0fbdf6b9a2/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions",
-      "value": {
-        "idleTimeout": "3600s",
-        "maxConnectionDuration": "0s",
-        "maxStreamDuration": "0s"
-      }
-    },
-    {
       "op": "remove",
       "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/gateway-proxy:HTTP:8080/filterChains/0/filters/0/typedConfig/commonHttpProtocolOptions/idleTimeout",
       "value": "300s"

--- a/test/e2e_env/universal/envoyconfig/testdata/builtingateway/meshtimeout/mt-with-to.gateway-proxy.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/builtingateway/meshtimeout/mt-with-to.gateway-proxy.golden.json
@@ -1,18 +1,44 @@
 {
   "diff": [
     {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig-builtingateway_echo-service__kuma-3_msvc_80-3e607e0fbdf6b9a2/connectTimeout",
+      "value": "5s"
+    },
+    {
       "op": "add",
       "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig-builtingateway_echo-service__kuma-3_msvc_80-3e607e0fbdf6b9a2/connectTimeout",
       "value": "51s"
     },
     {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig-builtingateway_echo-service__kuma-3_msvc_80-3e607e0fbdf6b9a2/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/idleTimeout",
+      "value": "3600s"
+    },
+    {
       "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig-builtingateway_echo-service__kuma-3_msvc_80-3e607e0fbdf6b9a2/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions",
-      "value": {
-        "idleTimeout": "50s",
-        "maxConnectionDuration": "55s",
-        "maxStreamDuration": "54s"
-      }
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig-builtingateway_echo-service__kuma-3_msvc_80-3e607e0fbdf6b9a2/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/idleTimeout",
+      "value": "50s"
+    },
+    {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig-builtingateway_echo-service__kuma-3_msvc_80-3e607e0fbdf6b9a2/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/maxConnectionDuration",
+      "value": "0s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig-builtingateway_echo-service__kuma-3_msvc_80-3e607e0fbdf6b9a2/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/maxConnectionDuration",
+      "value": "55s"
+    },
+    {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig-builtingateway_echo-service__kuma-3_msvc_80-3e607e0fbdf6b9a2/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/maxStreamDuration",
+      "value": "0s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig-builtingateway_echo-service__kuma-3_msvc_80-3e607e0fbdf6b9a2/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/maxStreamDuration",
+      "value": "54s"
     },
     {
       "op": "remove",

--- a/test/e2e_env/universal/envoyconfig/testdata/builtingateway/meshtimeout/no-policies.gateway-proxy.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/builtingateway/meshtimeout/no-policies.gateway-proxy.golden.json
@@ -3,6 +3,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig-builtingateway_echo-service__kuma-3_msvc_80-3e607e0fbdf6b9a2": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -55,6 +56,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "httpProtocolOptions": {}
             }

--- a/test/e2e_env/universal/envoyconfig/testdata/builtingateway/meshtls/inbound-permissive.gateway-proxy.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/builtingateway/meshtls/inbound-permissive.gateway-proxy.golden.json
@@ -3,6 +3,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig-builtingateway_echo-service__kuma-3_msvc_80-3e607e0fbdf6b9a2": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -55,6 +56,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "httpProtocolOptions": {}
             }

--- a/test/e2e_env/universal/envoyconfig/testdata/builtingateway/meshtls/inbound.gateway-proxy.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/builtingateway/meshtls/inbound.gateway-proxy.golden.json
@@ -15,6 +15,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig-builtingateway_echo-service__kuma-3_msvc_80-3e607e0fbdf6b9a2": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -74,6 +75,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "httpProtocolOptions": {}
             }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules-dpp.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules-dpp.demo-client.golden.json
@@ -3,6 +3,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -61,6 +62,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -112,6 +114,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -146,7 +153,7 @@
       },
       "localhost:3000": {
         "altStatName": "localhost_3000",
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:3000",
           "endpoints": [
@@ -309,7 +316,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
-                  "idleTimeout": "7200s",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -433,6 +440,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -462,6 +470,9 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -471,6 +482,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
@@ -488,7 +500,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules-dpp.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules-dpp.test-server.golden.json
@@ -22,6 +22,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -80,6 +81,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -131,6 +133,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -165,7 +172,7 @@
       },
       "localhost:8080": {
         "altStatName": "localhost_8080",
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:8080",
           "endpoints": [
@@ -191,7 +198,9 @@
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
             "commonHttpProtocolOptions": {
-              "idleTimeout": "7200s"
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
             },
             "explicitHttpConfig": {
               "httpProtocolOptions": {}
@@ -330,7 +339,7 @@
                     }
                   ],
                   "commonHttpProtocolOptions": {
-                    "idleTimeout": "7200s"
+                    "idleTimeout": "0s"
                   },
                   "forwardClientCertDetails": "SANITIZE_SET",
                   "httpFilters": [
@@ -363,6 +372,7 @@
                       }
                     }
                   ],
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "inbound:test-server",
                     "requestHeadersToRemove": [
@@ -382,7 +392,8 @@
                             },
                             "route": {
                               "cluster": "localhost:8080",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]
@@ -519,6 +530,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -548,6 +560,9 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -557,6 +572,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
@@ -574,7 +590,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules.demo-client.golden.json
@@ -22,6 +22,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -80,6 +81,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -131,6 +133,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -165,7 +172,7 @@
       },
       "localhost:3000": {
         "altStatName": "localhost_3000",
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:3000",
           "endpoints": [
@@ -342,7 +349,7 @@
                     }
                   ],
                   "cluster": "localhost:3000",
-                  "idleTimeout": "7200s",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -466,6 +473,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -495,6 +503,9 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -504,6 +515,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
@@ -521,7 +533,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules.test-server.golden.json
@@ -22,6 +22,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -80,6 +81,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -131,6 +133,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -165,7 +172,7 @@
       },
       "localhost:8080": {
         "altStatName": "localhost_8080",
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:8080",
           "endpoints": [
@@ -191,7 +198,9 @@
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
             "commonHttpProtocolOptions": {
-              "idleTimeout": "7200s"
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
             },
             "explicitHttpConfig": {
               "httpProtocolOptions": {}
@@ -330,7 +339,7 @@
                     }
                   ],
                   "commonHttpProtocolOptions": {
-                    "idleTimeout": "7200s"
+                    "idleTimeout": "0s"
                   },
                   "forwardClientCertDetails": "SANITIZE_SET",
                   "httpFilters": [
@@ -363,6 +372,7 @@
                       }
                     }
                   ],
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "inbound:test-server",
                     "requestHeadersToRemove": [
@@ -382,7 +392,8 @@
                             },
                             "route": {
                               "cluster": "localhost:8080",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]
@@ -519,6 +530,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -548,6 +560,9 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -557,6 +572,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
@@ -574,7 +590,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound.demo-client.golden.json
@@ -22,6 +22,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -80,6 +81,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -131,6 +133,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -165,7 +172,7 @@
       },
       "localhost:3000": {
         "altStatName": "localhost_3000",
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:3000",
           "endpoints": [
@@ -342,7 +349,7 @@
                     }
                   ],
                   "cluster": "localhost:3000",
-                  "idleTimeout": "7200s",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -466,6 +473,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -495,6 +503,9 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -504,6 +515,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
@@ -521,7 +533,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound.test-server.golden.json
@@ -22,6 +22,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -80,6 +81,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -131,6 +133,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -165,7 +172,7 @@
       },
       "localhost:8080": {
         "altStatName": "localhost_8080",
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:8080",
           "endpoints": [
@@ -191,7 +198,9 @@
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
             "commonHttpProtocolOptions": {
-              "idleTimeout": "7200s"
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
             },
             "explicitHttpConfig": {
               "httpProtocolOptions": {}
@@ -330,7 +339,7 @@
                     }
                   ],
                   "commonHttpProtocolOptions": {
-                    "idleTimeout": "7200s"
+                    "idleTimeout": "0s"
                   },
                   "forwardClientCertDetails": "SANITIZE_SET",
                   "httpFilters": [
@@ -363,6 +372,7 @@
                       }
                     }
                   ],
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "inbound:test-server",
                     "requestHeadersToRemove": [
@@ -382,7 +392,8 @@
                             },
                             "route": {
                               "cluster": "localhost:8080",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]
@@ -519,6 +530,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -548,6 +560,9 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -557,6 +572,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
@@ -574,7 +590,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound.demo-client.golden.json
@@ -27,6 +27,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -85,6 +86,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -136,6 +138,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -170,7 +177,7 @@
       },
       "localhost:3000": {
         "altStatName": "localhost_3000",
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:3000",
           "endpoints": [
@@ -333,7 +340,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
-                  "idleTimeout": "7200s",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -457,6 +464,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -505,6 +513,9 @@
                       }
                     }
                   ],
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -514,6 +525,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
@@ -531,7 +543,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound.test-server.golden.json
@@ -27,6 +27,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -85,6 +86,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -136,6 +138,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -170,7 +177,7 @@
       },
       "localhost:8080": {
         "altStatName": "localhost_8080",
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:8080",
           "endpoints": [
@@ -196,7 +203,9 @@
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
             "commonHttpProtocolOptions": {
-              "idleTimeout": "7200s"
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
             },
             "explicitHttpConfig": {
               "httpProtocolOptions": {}
@@ -321,7 +330,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
                   "commonHttpProtocolOptions": {
-                    "idleTimeout": "7200s"
+                    "idleTimeout": "0s"
                   },
                   "forwardClientCertDetails": "SANITIZE_SET",
                   "httpFilters": [
@@ -354,6 +363,7 @@
                       }
                     }
                   ],
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "inbound:test-server",
                     "requestHeadersToRemove": [
@@ -373,7 +383,8 @@
                             },
                             "route": {
                               "cluster": "localhost:8080",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]
@@ -510,6 +521,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -558,6 +570,9 @@
                       }
                     }
                   ],
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -567,6 +582,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
@@ -584,7 +600,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules-dpp.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules-dpp.demo-client.golden.json
@@ -3,6 +3,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -61,6 +62,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -112,6 +114,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -146,7 +153,7 @@
       },
       "localhost:3000": {
         "altStatName": "localhost_3000",
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:3000",
           "endpoints": [
@@ -309,7 +316,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
-                  "idleTimeout": "7200s",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -433,6 +440,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -462,6 +470,9 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -471,6 +482,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
@@ -488,7 +500,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules-dpp.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules-dpp.test-server.golden.json
@@ -3,6 +3,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -61,6 +62,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -112,6 +114,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -146,7 +153,7 @@
       },
       "localhost:8080": {
         "altStatName": "localhost_8080",
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:8080",
           "endpoints": [
@@ -172,7 +179,9 @@
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
             "commonHttpProtocolOptions": {
-              "idleTimeout": "7200s"
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
             },
             "explicitHttpConfig": {
               "httpProtocolOptions": {}
@@ -297,7 +306,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
                   "commonHttpProtocolOptions": {
-                    "idleTimeout": "7200s"
+                    "idleTimeout": "0s"
                   },
                   "forwardClientCertDetails": "SANITIZE_SET",
                   "httpFilters": [
@@ -330,6 +339,7 @@
                       }
                     }
                   ],
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "inbound:test-server",
                     "requestHeadersToRemove": [
@@ -349,7 +359,8 @@
                             },
                             "route": {
                               "cluster": "localhost:8080",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]
@@ -486,6 +497,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -515,6 +527,9 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -524,6 +539,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
@@ -541,7 +557,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules.demo-client.golden.json
@@ -20,6 +20,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -78,6 +79,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -129,6 +131,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -175,7 +182,7 @@
             }
           ]
         },
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:3000",
           "endpoints": [
@@ -338,7 +345,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
-                  "idleTimeout": "7200s",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -462,6 +469,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -491,6 +499,9 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -500,6 +511,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
@@ -517,7 +529,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules.test-server.golden.json
@@ -3,6 +3,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -61,6 +62,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -112,6 +114,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -146,7 +153,7 @@
       },
       "localhost:8080": {
         "altStatName": "localhost_8080",
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:8080",
           "endpoints": [
@@ -172,7 +179,9 @@
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
             "commonHttpProtocolOptions": {
-              "idleTimeout": "7200s"
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
             },
             "explicitHttpConfig": {
               "httpProtocolOptions": {}
@@ -297,7 +306,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
                   "commonHttpProtocolOptions": {
-                    "idleTimeout": "7200s"
+                    "idleTimeout": "0s"
                   },
                   "forwardClientCertDetails": "SANITIZE_SET",
                   "httpFilters": [
@@ -330,6 +339,7 @@
                       }
                     }
                   ],
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "inbound:test-server",
                     "requestHeadersToRemove": [
@@ -349,7 +359,8 @@
                             },
                             "route": {
                               "cluster": "localhost:8080",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]
@@ -486,6 +497,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -515,6 +527,9 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -524,6 +539,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
@@ -541,7 +557,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound.demo-client.golden.json
@@ -20,6 +20,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -78,6 +79,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -129,6 +131,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -175,7 +182,7 @@
             }
           ]
         },
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:3000",
           "endpoints": [
@@ -338,7 +345,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
-                  "idleTimeout": "7200s",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -462,6 +469,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -491,6 +499,9 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -500,6 +511,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
@@ -517,7 +529,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound.test-server.golden.json
@@ -3,6 +3,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -61,6 +62,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -112,6 +114,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -146,7 +153,7 @@
       },
       "localhost:8080": {
         "altStatName": "localhost_8080",
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:8080",
           "endpoints": [
@@ -172,7 +179,9 @@
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
             "commonHttpProtocolOptions": {
-              "idleTimeout": "7200s"
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
             },
             "explicitHttpConfig": {
               "httpProtocolOptions": {}
@@ -297,7 +306,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
                   "commonHttpProtocolOptions": {
-                    "idleTimeout": "7200s"
+                    "idleTimeout": "0s"
                   },
                   "forwardClientCertDetails": "SANITIZE_SET",
                   "httpFilters": [
@@ -330,6 +339,7 @@
                       }
                     }
                   ],
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "inbound:test-server",
                     "requestHeadersToRemove": [
@@ -349,7 +359,8 @@
                             },
                             "route": {
                               "cluster": "localhost:8080",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]
@@ -486,6 +497,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -515,6 +527,9 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -524,6 +539,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
@@ -541,7 +557,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound.demo-client.golden.json
@@ -30,6 +30,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -88,6 +89,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -161,6 +163,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -195,7 +202,7 @@
       },
       "localhost:3000": {
         "altStatName": "localhost_3000",
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:3000",
           "endpoints": [
@@ -358,7 +365,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
-                  "idleTimeout": "7200s",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -482,6 +489,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -511,6 +519,9 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -520,6 +531,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
@@ -537,7 +549,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound.test-server.golden.json
@@ -30,6 +30,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -88,6 +89,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -161,6 +163,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -195,7 +202,7 @@
       },
       "localhost:8080": {
         "altStatName": "localhost_8080",
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:8080",
           "endpoints": [
@@ -221,7 +228,9 @@
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
             "commonHttpProtocolOptions": {
-              "idleTimeout": "7200s"
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
             },
             "explicitHttpConfig": {
               "httpProtocolOptions": {}
@@ -346,7 +355,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
                   "commonHttpProtocolOptions": {
-                    "idleTimeout": "7200s"
+                    "idleTimeout": "0s"
                   },
                   "forwardClientCertDetails": "SANITIZE_SET",
                   "httpFilters": [
@@ -379,6 +388,7 @@
                       }
                     }
                   ],
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "inbound:test-server",
                     "requestHeadersToRemove": [
@@ -398,7 +408,8 @@
                             },
                             "route": {
                               "cluster": "localhost:8080",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]
@@ -535,6 +546,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -564,6 +576,9 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -573,6 +588,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
@@ -590,7 +606,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound.demo-client.golden.json
@@ -3,6 +3,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -61,6 +62,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -112,6 +114,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -146,7 +153,7 @@
       },
       "localhost:3000": {
         "altStatName": "localhost_3000",
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:3000",
           "endpoints": [
@@ -309,7 +316,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
-                  "idleTimeout": "7200s",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -433,6 +440,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -462,6 +470,9 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -471,6 +482,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "requestHeadersToAdd": [
@@ -496,7 +508,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound.test-server.golden.json
@@ -53,6 +53,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -111,6 +112,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -162,6 +164,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -196,7 +203,7 @@
       },
       "localhost:8080": {
         "altStatName": "localhost_8080",
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:8080",
           "endpoints": [
@@ -222,7 +229,9 @@
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
             "commonHttpProtocolOptions": {
-              "idleTimeout": "7200s"
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
             },
             "explicitHttpConfig": {
               "httpProtocolOptions": {}
@@ -347,7 +356,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
                   "commonHttpProtocolOptions": {
-                    "idleTimeout": "7200s"
+                    "idleTimeout": "0s"
                   },
                   "forwardClientCertDetails": "SANITIZE_SET",
                   "httpFilters": [
@@ -417,6 +426,7 @@
                       }
                     }
                   ],
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "inbound:test-server",
                     "requestHeadersToRemove": [
@@ -436,7 +446,8 @@
                             },
                             "route": {
                               "cluster": "localhost:8080",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]
@@ -573,6 +584,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -602,6 +614,9 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -611,6 +626,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "requestHeadersToAdd": [
@@ -636,7 +652,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules-dpp.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules-dpp.demo-client.golden.json
@@ -3,6 +3,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -61,6 +62,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -112,6 +114,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -146,7 +153,7 @@
       },
       "localhost:3000": {
         "altStatName": "localhost_3000",
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:3000",
           "endpoints": [
@@ -309,7 +316,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
-                  "idleTimeout": "7200s",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -433,6 +440,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -462,6 +470,9 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -471,6 +482,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
@@ -488,7 +500,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules-dpp.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules-dpp.test-server.golden.json
@@ -54,6 +54,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -112,6 +113,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -163,6 +165,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -197,7 +204,7 @@
       },
       "localhost:8080": {
         "altStatName": "localhost_8080",
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:8080",
           "endpoints": [
@@ -223,7 +230,9 @@
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
             "commonHttpProtocolOptions": {
-              "idleTimeout": "7200s"
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
             },
             "explicitHttpConfig": {
               "httpProtocolOptions": {}
@@ -348,7 +357,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
                   "commonHttpProtocolOptions": {
-                    "idleTimeout": "7200s"
+                    "idleTimeout": "0s"
                   },
                   "forwardClientCertDetails": "SANITIZE_SET",
                   "httpFilters": [
@@ -388,6 +397,7 @@
                       }
                     }
                   ],
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "inbound:test-server",
                     "requestHeadersToRemove": [
@@ -407,7 +417,8 @@
                             },
                             "route": {
                               "cluster": "localhost:8080",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             },
                             "typedPerFilterConfig": {
                               "envoy.filters.http.local_ratelimit": {
@@ -579,6 +590,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -608,6 +620,9 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -617,6 +632,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
@@ -634,7 +650,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.demo-client.golden.json
@@ -3,6 +3,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -61,6 +62,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -112,6 +114,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -146,7 +153,7 @@
       },
       "localhost:3000": {
         "altStatName": "localhost_3000",
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:3000",
           "endpoints": [
@@ -309,7 +316,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
-                  "idleTimeout": "7200s",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -433,6 +440,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -462,6 +470,9 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -471,6 +482,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
@@ -488,7 +500,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.test-server.golden.json
@@ -54,6 +54,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -112,6 +113,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -163,6 +165,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -197,7 +204,7 @@
       },
       "localhost:8080": {
         "altStatName": "localhost_8080",
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:8080",
           "endpoints": [
@@ -223,7 +230,9 @@
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
             "commonHttpProtocolOptions": {
-              "idleTimeout": "7200s"
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
             },
             "explicitHttpConfig": {
               "httpProtocolOptions": {}
@@ -348,7 +357,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
                   "commonHttpProtocolOptions": {
-                    "idleTimeout": "7200s"
+                    "idleTimeout": "0s"
                   },
                   "forwardClientCertDetails": "SANITIZE_SET",
                   "httpFilters": [
@@ -388,6 +397,7 @@
                       }
                     }
                   ],
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "inbound:test-server",
                     "requestHeadersToRemove": [
@@ -407,7 +417,8 @@
                             },
                             "route": {
                               "cluster": "localhost:8080",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             },
                             "typedPerFilterConfig": {
                               "envoy.filters.http.local_ratelimit": {
@@ -579,6 +590,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -608,6 +620,9 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -617,6 +632,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
@@ -634,7 +650,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.demo-client.golden.json
@@ -3,6 +3,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -61,6 +62,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -112,6 +114,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -146,7 +153,7 @@
       },
       "localhost:3000": {
         "altStatName": "localhost_3000",
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:3000",
           "endpoints": [
@@ -309,7 +316,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
-                  "idleTimeout": "7200s",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -433,6 +440,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -462,6 +470,9 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -471,6 +482,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
@@ -488,7 +500,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.test-server.golden.json
@@ -54,6 +54,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -112,6 +113,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -163,6 +165,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -197,7 +204,7 @@
       },
       "localhost:8080": {
         "altStatName": "localhost_8080",
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:8080",
           "endpoints": [
@@ -223,7 +230,9 @@
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
             "commonHttpProtocolOptions": {
-              "idleTimeout": "7200s"
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
             },
             "explicitHttpConfig": {
               "httpProtocolOptions": {}
@@ -348,7 +357,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
                   "commonHttpProtocolOptions": {
-                    "idleTimeout": "7200s"
+                    "idleTimeout": "0s"
                   },
                   "forwardClientCertDetails": "SANITIZE_SET",
                   "httpFilters": [
@@ -388,6 +397,7 @@
                       }
                     }
                   ],
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "inbound:test-server",
                     "requestHeadersToRemove": [
@@ -407,7 +417,8 @@
                             },
                             "route": {
                               "cluster": "localhost:8080",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             },
                             "typedPerFilterConfig": {
                               "envoy.filters.http.local_ratelimit": {
@@ -579,6 +590,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -608,6 +620,9 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -617,6 +632,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
@@ -634,7 +650,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules-dpp.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules-dpp.demo-client.golden.json
@@ -3,6 +3,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -61,6 +62,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -112,6 +114,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -146,7 +153,7 @@
       },
       "localhost:3000": {
         "altStatName": "localhost_3000",
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:3000",
           "endpoints": [
@@ -309,7 +316,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
-                  "idleTimeout": "7200s",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -433,6 +440,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -462,6 +470,9 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -471,6 +482,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
@@ -488,7 +500,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules-dpp.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules-dpp.test-server.golden.json
@@ -1,28 +1,9 @@
 {
   "diff": [
     {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_demo-client__kuma-3_msvc_3000/connectTimeout",
-      "value": "5s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/connectTimeout",
-      "value": "5s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions",
-      "value": {
-        "idleTimeout": "3600s",
-        "maxConnectionDuration": "0s",
-        "maxStreamDuration": "0s"
-      }
-    },
-    {
       "op": "remove",
       "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/connectTimeout",
-      "value": "10s"
+      "value": "5s"
     },
     {
       "op": "add",
@@ -32,7 +13,7 @@
     {
       "op": "remove",
       "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/idleTimeout",
-      "value": "7200s"
+      "value": "3600s"
     },
     {
       "op": "add",
@@ -40,9 +21,19 @@
       "value": "50s"
     },
     {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/maxConnectionDuration",
+      "value": "0s"
+    },
+    {
       "op": "add",
       "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/maxConnectionDuration",
       "value": "55s"
+    },
+    {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/maxStreamDuration",
+      "value": "0s"
     },
     {
       "op": "add",
@@ -51,18 +42,8 @@
     },
     {
       "op": "remove",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/commonHttpProtocolOptions/idleTimeout",
-      "value": "7200s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/commonHttpProtocolOptions/idleTimeout",
-      "value": "0s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/requestHeadersTimeout",
-      "value": "0s"
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/idleTimeout",
+      "value": "1800s"
     },
     {
       "op": "add",
@@ -72,44 +53,12 @@
     {
       "op": "remove",
       "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
-      "value": "0s"
+      "value": "15s"
     },
     {
       "op": "add",
       "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
       "value": "52s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:3000/filterChains/0/filters/0/typedConfig/idleTimeout",
-      "value": "3600s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/commonHttpProtocolOptions",
-      "value": {
-        "idleTimeout": "0s"
-      }
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/requestHeadersTimeout",
-      "value": "0s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/idleTimeout",
-      "value": "1800s"
-    },
-    {
-      "op": "remove",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
-      "value": "0s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
-      "value": "15s"
     }
   ],
   "xds": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules.demo-client.golden.json
@@ -1,28 +1,9 @@
 {
   "diff": [
     {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_demo-client__kuma-3_msvc_3000/connectTimeout",
-      "value": "5s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/connectTimeout",
-      "value": "5s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions",
-      "value": {
-        "idleTimeout": "3600s",
-        "maxConnectionDuration": "0s",
-        "maxStreamDuration": "0s"
-      }
-    },
-    {
       "op": "remove",
       "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:3000/connectTimeout",
-      "value": "10s"
+      "value": "5s"
     },
     {
       "op": "add",
@@ -32,44 +13,12 @@
     {
       "op": "remove",
       "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:3000/filterChains/0/filters/1/typedConfig/idleTimeout",
-      "value": "7200s"
+      "value": "3600s"
     },
     {
       "op": "add",
       "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:3000/filterChains/0/filters/1/typedConfig/idleTimeout",
       "value": "50s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:3000/filterChains/0/filters/0/typedConfig/idleTimeout",
-      "value": "3600s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/commonHttpProtocolOptions",
-      "value": {
-        "idleTimeout": "0s"
-      }
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/requestHeadersTimeout",
-      "value": "0s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/idleTimeout",
-      "value": "1800s"
-    },
-    {
-      "op": "remove",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
-      "value": "0s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
-      "value": "15s"
     }
   ],
   "xds": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules.test-server.golden.json
@@ -1,28 +1,9 @@
 {
   "diff": [
     {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_demo-client__kuma-3_msvc_3000/connectTimeout",
-      "value": "5s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/connectTimeout",
-      "value": "5s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions",
-      "value": {
-        "idleTimeout": "3600s",
-        "maxConnectionDuration": "0s",
-        "maxStreamDuration": "0s"
-      }
-    },
-    {
       "op": "remove",
       "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/connectTimeout",
-      "value": "10s"
+      "value": "5s"
     },
     {
       "op": "add",
@@ -32,7 +13,7 @@
     {
       "op": "remove",
       "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/idleTimeout",
-      "value": "7200s"
+      "value": "3600s"
     },
     {
       "op": "add",
@@ -40,9 +21,19 @@
       "value": "50s"
     },
     {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/maxConnectionDuration",
+      "value": "0s"
+    },
+    {
       "op": "add",
       "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/maxConnectionDuration",
       "value": "55s"
+    },
+    {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/maxStreamDuration",
+      "value": "0s"
     },
     {
       "op": "add",
@@ -51,18 +42,8 @@
     },
     {
       "op": "remove",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/commonHttpProtocolOptions/idleTimeout",
-      "value": "7200s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/commonHttpProtocolOptions/idleTimeout",
-      "value": "0s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/requestHeadersTimeout",
-      "value": "0s"
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/idleTimeout",
+      "value": "1800s"
     },
     {
       "op": "add",
@@ -72,44 +53,12 @@
     {
       "op": "remove",
       "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
-      "value": "0s"
+      "value": "15s"
     },
     {
       "op": "add",
       "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
       "value": "52s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:3000/filterChains/0/filters/0/typedConfig/idleTimeout",
-      "value": "3600s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/commonHttpProtocolOptions",
-      "value": {
-        "idleTimeout": "0s"
-      }
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/requestHeadersTimeout",
-      "value": "0s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/idleTimeout",
-      "value": "1800s"
-    },
-    {
-      "op": "remove",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
-      "value": "0s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
-      "value": "15s"
     }
   ],
   "xds": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound.demo-client.golden.json
@@ -1,28 +1,9 @@
 {
   "diff": [
     {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_demo-client__kuma-3_msvc_3000/connectTimeout",
-      "value": "5s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/connectTimeout",
-      "value": "5s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions",
-      "value": {
-        "idleTimeout": "3600s",
-        "maxConnectionDuration": "0s",
-        "maxStreamDuration": "0s"
-      }
-    },
-    {
       "op": "remove",
       "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:3000/connectTimeout",
-      "value": "10s"
+      "value": "5s"
     },
     {
       "op": "add",
@@ -32,44 +13,12 @@
     {
       "op": "remove",
       "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:3000/filterChains/0/filters/1/typedConfig/idleTimeout",
-      "value": "7200s"
+      "value": "3600s"
     },
     {
       "op": "add",
       "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:3000/filterChains/0/filters/1/typedConfig/idleTimeout",
       "value": "50s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:3000/filterChains/0/filters/0/typedConfig/idleTimeout",
-      "value": "3600s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/commonHttpProtocolOptions",
-      "value": {
-        "idleTimeout": "0s"
-      }
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/requestHeadersTimeout",
-      "value": "0s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/idleTimeout",
-      "value": "1800s"
-    },
-    {
-      "op": "remove",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
-      "value": "0s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
-      "value": "15s"
     }
   ],
   "xds": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound.test-server.golden.json
@@ -1,28 +1,9 @@
 {
   "diff": [
     {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_demo-client__kuma-3_msvc_3000/connectTimeout",
-      "value": "5s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/connectTimeout",
-      "value": "5s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions",
-      "value": {
-        "idleTimeout": "3600s",
-        "maxConnectionDuration": "0s",
-        "maxStreamDuration": "0s"
-      }
-    },
-    {
       "op": "remove",
       "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/connectTimeout",
-      "value": "10s"
+      "value": "5s"
     },
     {
       "op": "add",
@@ -32,7 +13,7 @@
     {
       "op": "remove",
       "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/idleTimeout",
-      "value": "7200s"
+      "value": "3600s"
     },
     {
       "op": "add",
@@ -40,9 +21,19 @@
       "value": "50s"
     },
     {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/maxConnectionDuration",
+      "value": "0s"
+    },
+    {
       "op": "add",
       "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/maxConnectionDuration",
       "value": "55s"
+    },
+    {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/maxStreamDuration",
+      "value": "0s"
     },
     {
       "op": "add",
@@ -51,18 +42,8 @@
     },
     {
       "op": "remove",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/commonHttpProtocolOptions/idleTimeout",
-      "value": "7200s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/commonHttpProtocolOptions/idleTimeout",
-      "value": "0s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/requestHeadersTimeout",
-      "value": "0s"
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/idleTimeout",
+      "value": "1800s"
     },
     {
       "op": "add",
@@ -72,44 +53,12 @@
     {
       "op": "remove",
       "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
-      "value": "0s"
+      "value": "15s"
     },
     {
       "op": "add",
       "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
       "value": "52s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:3000/filterChains/0/filters/0/typedConfig/idleTimeout",
-      "value": "3600s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/commonHttpProtocolOptions",
-      "value": {
-        "idleTimeout": "0s"
-      }
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/requestHeadersTimeout",
-      "value": "0s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/idleTimeout",
-      "value": "1800s"
-    },
-    {
-      "op": "remove",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
-      "value": "0s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
-      "value": "15s"
     }
   ],
   "xds": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/no-policies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/no-policies.demo-client.golden.json
@@ -3,6 +3,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -61,6 +62,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -112,6 +114,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -146,7 +153,7 @@
       },
       "localhost:3000": {
         "altStatName": "localhost_3000",
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:3000",
           "endpoints": [
@@ -309,7 +316,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
-                  "idleTimeout": "7200s",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -433,6 +440,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -462,6 +470,9 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -471,6 +482,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
@@ -488,7 +500,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/no-policies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/no-policies.test-server.golden.json
@@ -3,6 +3,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -61,6 +62,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -112,6 +114,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -146,7 +153,7 @@
       },
       "localhost:8080": {
         "altStatName": "localhost_8080",
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:8080",
           "endpoints": [
@@ -172,7 +179,9 @@
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
             "commonHttpProtocolOptions": {
-              "idleTimeout": "7200s"
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
             },
             "explicitHttpConfig": {
               "httpProtocolOptions": {}
@@ -297,7 +306,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
                   "commonHttpProtocolOptions": {
-                    "idleTimeout": "7200s"
+                    "idleTimeout": "0s"
                   },
                   "forwardClientCertDetails": "SANITIZE_SET",
                   "httpFilters": [
@@ -330,6 +339,7 @@
                       }
                     }
                   ],
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "inbound:test-server",
                     "requestHeadersToRemove": [
@@ -349,7 +359,8 @@
                             },
                             "route": {
                               "cluster": "localhost:8080",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]
@@ -486,6 +497,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -515,6 +527,9 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -524,6 +539,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
@@ -541,7 +557,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound.demo-client.golden.json
@@ -1,8 +1,8 @@
 {
   "diff": [
     {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_demo-client__kuma-3_msvc_3000/connectTimeout",
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/connectTimeout",
       "value": "5s"
     },
     {
@@ -11,50 +11,39 @@
       "value": "51s"
     },
     {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions",
-      "value": {
-        "idleTimeout": "50s",
-        "maxConnectionDuration": "55s",
-        "maxStreamDuration": "54s"
-      }
-    },
-    {
       "op": "remove",
-      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:3000/connectTimeout",
-      "value": "10s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:3000/connectTimeout",
-      "value": "5s"
-    },
-    {
-      "op": "remove",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:3000/filterChains/0/filters/1/typedConfig/idleTimeout",
-      "value": "7200s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:3000/filterChains/0/filters/1/typedConfig/idleTimeout",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/idleTimeout",
       "value": "3600s"
     },
     {
       "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:3000/filterChains/0/filters/0/typedConfig/idleTimeout",
-      "value": "3600s"
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/idleTimeout",
+      "value": "50s"
     },
     {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/commonHttpProtocolOptions",
-      "value": {
-        "idleTimeout": "0s"
-      }
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/requestHeadersTimeout",
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/maxConnectionDuration",
       "value": "0s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/maxConnectionDuration",
+      "value": "55s"
+    },
+    {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/maxStreamDuration",
+      "value": "0s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/maxStreamDuration",
+      "value": "54s"
+    },
+    {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/idleTimeout",
+      "value": "1800s"
     },
     {
       "op": "add",
@@ -64,7 +53,7 @@
     {
       "op": "remove",
       "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
-      "value": "0s"
+      "value": "15s"
     },
     {
       "op": "add",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound.test-server.golden.json
@@ -1,8 +1,8 @@
 {
   "diff": [
     {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_demo-client__kuma-3_msvc_3000/connectTimeout",
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/connectTimeout",
       "value": "5s"
     },
     {
@@ -11,90 +11,39 @@
       "value": "51s"
     },
     {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions",
-      "value": {
-        "idleTimeout": "50s",
-        "maxConnectionDuration": "55s",
-        "maxStreamDuration": "54s"
-      }
-    },
-    {
       "op": "remove",
-      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/connectTimeout",
-      "value": "10s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/connectTimeout",
-      "value": "5s"
-    },
-    {
-      "op": "remove",
-      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/idleTimeout",
-      "value": "7200s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/idleTimeout",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/idleTimeout",
       "value": "3600s"
     },
     {
       "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/maxConnectionDuration",
-      "value": "0s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/localhost:8080/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/maxStreamDuration",
-      "value": "0s"
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/idleTimeout",
+      "value": "50s"
     },
     {
       "op": "remove",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/commonHttpProtocolOptions/idleTimeout",
-      "value": "7200s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/commonHttpProtocolOptions/idleTimeout",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/maxConnectionDuration",
       "value": "0s"
     },
     {
       "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/requestHeadersTimeout",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/maxConnectionDuration",
+      "value": "55s"
+    },
+    {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/maxStreamDuration",
       "value": "0s"
     },
     {
       "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/idleTimeout",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/typedExtensionProtocolOptions/envoy.extensions.upstreams.http.v3.HttpProtocolOptions/commonHttpProtocolOptions/maxStreamDuration",
+      "value": "54s"
+    },
+    {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/idleTimeout",
       "value": "1800s"
-    },
-    {
-      "op": "remove",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
-      "value": "0s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
-      "value": "15s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:3000/filterChains/0/filters/0/typedConfig/idleTimeout",
-      "value": "3600s"
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/commonHttpProtocolOptions",
-      "value": {
-        "idleTimeout": "0s"
-      }
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/requestHeadersTimeout",
-      "value": "0s"
     },
     {
       "op": "add",
@@ -104,7 +53,7 @@
     {
       "op": "remove",
       "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
-      "value": "0s"
+      "value": "15s"
     },
     {
       "op": "add",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive-rules.demo-client.golden.json
@@ -114,7 +114,7 @@
             "typedConfig": {
               "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
               "cluster": "localhost:3000",
-              "idleTimeout": "7200s",
+              "idleTimeout": "3600s",
               "statPrefix": "STAT_PREFIX_REDACTED"
             }
           }
@@ -171,7 +171,7 @@
             "typedConfig": {
               "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
               "cluster": "localhost:3000",
-              "idleTimeout": "7200s",
+              "idleTimeout": "3600s",
               "statPrefix": "STAT_PREFIX_REDACTED"
             }
           }
@@ -194,6 +194,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -252,6 +253,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -303,6 +305,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -337,7 +344,7 @@
       },
       "localhost:3000": {
         "altStatName": "localhost_3000",
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:3000",
           "endpoints": [
@@ -480,7 +487,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
-                  "idleTimeout": "7200s",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -496,7 +503,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
-                  "idleTimeout": "7200s",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -538,7 +545,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
-                  "idleTimeout": "7200s",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -670,6 +677,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -699,6 +707,9 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -708,6 +719,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
@@ -725,7 +737,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive-rules.test-server.golden.json
@@ -90,7 +90,7 @@
             "typedConfig": {
               "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
               "commonHttpProtocolOptions": {
-                "idleTimeout": "7200s"
+                "idleTimeout": "0s"
               },
               "forwardClientCertDetails": "SANITIZE_SET",
               "httpFilters": [
@@ -123,6 +123,7 @@
                   }
                 }
               ],
+              "requestHeadersTimeout": "0s",
               "routeConfig": {
                 "name": "inbound:test-server",
                 "requestHeadersToRemove": [
@@ -142,7 +143,8 @@
                         },
                         "route": {
                           "cluster": "localhost:8080",
-                          "timeout": "0s"
+                          "idleTimeout": "1800s",
+                          "timeout": "15s"
                         }
                       }
                     ]
@@ -209,7 +211,7 @@
             "typedConfig": {
               "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
               "commonHttpProtocolOptions": {
-                "idleTimeout": "7200s"
+                "idleTimeout": "0s"
               },
               "forwardClientCertDetails": "SANITIZE_SET",
               "httpFilters": [
@@ -220,6 +222,7 @@
                   }
                 }
               ],
+              "requestHeadersTimeout": "0s",
               "routeConfig": {
                 "name": "inbound:test-server",
                 "requestHeadersToRemove": [
@@ -239,7 +242,8 @@
                         },
                         "route": {
                           "cluster": "localhost:8080",
-                          "timeout": "0s"
+                          "idleTimeout": "1800s",
+                          "timeout": "15s"
                         }
                       }
                     ]
@@ -272,6 +276,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -330,6 +335,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -381,6 +387,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -415,7 +426,7 @@
       },
       "localhost:8080": {
         "altStatName": "localhost_8080",
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:8080",
           "endpoints": [
@@ -441,7 +452,9 @@
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
             "commonHttpProtocolOptions": {
-              "idleTimeout": "7200s"
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
             },
             "explicitHttpConfig": {
               "httpProtocolOptions": {}
@@ -569,7 +582,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
                   "commonHttpProtocolOptions": {
-                    "idleTimeout": "7200s"
+                    "idleTimeout": "0s"
                   },
                   "forwardClientCertDetails": "SANITIZE_SET",
                   "httpFilters": [
@@ -580,6 +593,7 @@
                       }
                     }
                   ],
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "inbound:test-server",
                     "requestHeadersToRemove": [
@@ -599,7 +613,8 @@
                             },
                             "route": {
                               "cluster": "localhost:8080",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]
@@ -625,7 +640,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
                   "commonHttpProtocolOptions": {
-                    "idleTimeout": "7200s"
+                    "idleTimeout": "0s"
                   },
                   "forwardClientCertDetails": "SANITIZE_SET",
                   "httpFilters": [
@@ -636,6 +651,7 @@
                       }
                     }
                   ],
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "inbound:test-server",
                     "requestHeadersToRemove": [
@@ -655,7 +671,8 @@
                             },
                             "route": {
                               "cluster": "localhost:8080",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]
@@ -684,7 +701,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
                   "commonHttpProtocolOptions": {
-                    "idleTimeout": "7200s"
+                    "idleTimeout": "0s"
                   },
                   "forwardClientCertDetails": "SANITIZE_SET",
                   "httpFilters": [
@@ -717,6 +734,7 @@
                       }
                     }
                   ],
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "inbound:test-server",
                     "requestHeadersToRemove": [
@@ -736,7 +754,8 @@
                             },
                             "route": {
                               "cluster": "localhost:8080",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]
@@ -881,6 +900,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -910,6 +930,9 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -919,6 +942,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
@@ -936,7 +960,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive.demo-client.golden.json
@@ -114,7 +114,7 @@
             "typedConfig": {
               "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
               "cluster": "localhost:3000",
-              "idleTimeout": "7200s",
+              "idleTimeout": "3600s",
               "statPrefix": "STAT_PREFIX_REDACTED"
             }
           }
@@ -171,7 +171,7 @@
             "typedConfig": {
               "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
               "cluster": "localhost:3000",
-              "idleTimeout": "7200s",
+              "idleTimeout": "3600s",
               "statPrefix": "STAT_PREFIX_REDACTED"
             }
           }
@@ -194,6 +194,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -252,6 +253,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -303,6 +305,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -337,7 +344,7 @@
       },
       "localhost:3000": {
         "altStatName": "localhost_3000",
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:3000",
           "endpoints": [
@@ -480,7 +487,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
-                  "idleTimeout": "7200s",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -496,7 +503,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
-                  "idleTimeout": "7200s",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -538,7 +545,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
-                  "idleTimeout": "7200s",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -670,6 +677,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -699,6 +707,9 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -708,6 +719,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
@@ -725,7 +737,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive.test-server.golden.json
@@ -90,7 +90,7 @@
             "typedConfig": {
               "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
               "commonHttpProtocolOptions": {
-                "idleTimeout": "7200s"
+                "idleTimeout": "0s"
               },
               "forwardClientCertDetails": "SANITIZE_SET",
               "httpFilters": [
@@ -123,6 +123,7 @@
                   }
                 }
               ],
+              "requestHeadersTimeout": "0s",
               "routeConfig": {
                 "name": "inbound:test-server",
                 "requestHeadersToRemove": [
@@ -142,7 +143,8 @@
                         },
                         "route": {
                           "cluster": "localhost:8080",
-                          "timeout": "0s"
+                          "idleTimeout": "1800s",
+                          "timeout": "15s"
                         }
                       }
                     ]
@@ -209,7 +211,7 @@
             "typedConfig": {
               "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
               "commonHttpProtocolOptions": {
-                "idleTimeout": "7200s"
+                "idleTimeout": "0s"
               },
               "forwardClientCertDetails": "SANITIZE_SET",
               "httpFilters": [
@@ -220,6 +222,7 @@
                   }
                 }
               ],
+              "requestHeadersTimeout": "0s",
               "routeConfig": {
                 "name": "inbound:test-server",
                 "requestHeadersToRemove": [
@@ -239,7 +242,8 @@
                         },
                         "route": {
                           "cluster": "localhost:8080",
-                          "timeout": "0s"
+                          "idleTimeout": "1800s",
+                          "timeout": "15s"
                         }
                       }
                     ]
@@ -272,6 +276,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -330,6 +335,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -381,6 +387,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -415,7 +426,7 @@
       },
       "localhost:8080": {
         "altStatName": "localhost_8080",
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:8080",
           "endpoints": [
@@ -441,7 +452,9 @@
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
             "commonHttpProtocolOptions": {
-              "idleTimeout": "7200s"
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
             },
             "explicitHttpConfig": {
               "httpProtocolOptions": {}
@@ -569,7 +582,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
                   "commonHttpProtocolOptions": {
-                    "idleTimeout": "7200s"
+                    "idleTimeout": "0s"
                   },
                   "forwardClientCertDetails": "SANITIZE_SET",
                   "httpFilters": [
@@ -580,6 +593,7 @@
                       }
                     }
                   ],
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "inbound:test-server",
                     "requestHeadersToRemove": [
@@ -599,7 +613,8 @@
                             },
                             "route": {
                               "cluster": "localhost:8080",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]
@@ -625,7 +640,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
                   "commonHttpProtocolOptions": {
-                    "idleTimeout": "7200s"
+                    "idleTimeout": "0s"
                   },
                   "forwardClientCertDetails": "SANITIZE_SET",
                   "httpFilters": [
@@ -636,6 +651,7 @@
                       }
                     }
                   ],
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "inbound:test-server",
                     "requestHeadersToRemove": [
@@ -655,7 +671,8 @@
                             },
                             "route": {
                               "cluster": "localhost:8080",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]
@@ -684,7 +701,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
                   "commonHttpProtocolOptions": {
-                    "idleTimeout": "7200s"
+                    "idleTimeout": "0s"
                   },
                   "forwardClientCertDetails": "SANITIZE_SET",
                   "httpFilters": [
@@ -717,6 +734,7 @@
                       }
                     }
                   ],
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "inbound:test-server",
                     "requestHeadersToRemove": [
@@ -736,7 +754,8 @@
                             },
                             "route": {
                               "cluster": "localhost:8080",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]
@@ -881,6 +900,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -910,6 +930,9 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -919,6 +942,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
@@ -936,7 +960,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-rules.demo-client.golden.json
@@ -37,6 +37,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -102,6 +103,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -160,6 +162,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -194,7 +201,7 @@
       },
       "localhost:3000": {
         "altStatName": "localhost_3000",
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:3000",
           "endpoints": [
@@ -357,7 +364,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
-                  "idleTimeout": "7200s",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -488,6 +495,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -517,6 +525,9 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -526,6 +537,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
@@ -543,7 +555,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-rules.test-server.golden.json
@@ -37,6 +37,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -102,6 +103,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -160,6 +162,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -194,7 +201,7 @@
       },
       "localhost:8080": {
         "altStatName": "localhost_8080",
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:8080",
           "endpoints": [
@@ -220,7 +227,9 @@
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
             "commonHttpProtocolOptions": {
-              "idleTimeout": "7200s"
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
             },
             "explicitHttpConfig": {
               "httpProtocolOptions": {}
@@ -345,7 +354,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
                   "commonHttpProtocolOptions": {
-                    "idleTimeout": "7200s"
+                    "idleTimeout": "0s"
                   },
                   "forwardClientCertDetails": "SANITIZE_SET",
                   "httpFilters": [
@@ -378,6 +387,7 @@
                       }
                     }
                   ],
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "inbound:test-server",
                     "requestHeadersToRemove": [
@@ -397,7 +407,8 @@
                             },
                             "route": {
                               "cluster": "localhost:8080",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]
@@ -541,6 +552,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -570,6 +582,9 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -579,6 +594,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
@@ -596,7 +612,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound.demo-client.golden.json
@@ -37,6 +37,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -102,6 +103,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -160,6 +162,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -194,7 +201,7 @@
       },
       "localhost:3000": {
         "altStatName": "localhost_3000",
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:3000",
           "endpoints": [
@@ -357,7 +364,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "localhost:3000",
-                  "idleTimeout": "7200s",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -488,6 +495,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -517,6 +525,9 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -526,6 +537,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
@@ -543,7 +555,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound.test-server.golden.json
@@ -37,6 +37,7 @@
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -102,6 +103,7 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
             "ads": {},
@@ -160,6 +162,11 @@
         "typedExtensionProtocolOptions": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
             "explicitHttpConfig": {
               "http2ProtocolOptions": {}
             }
@@ -194,7 +201,7 @@
       },
       "localhost:8080": {
         "altStatName": "localhost_8080",
-        "connectTimeout": "10s",
+        "connectTimeout": "5s",
         "loadAssignment": {
           "clusterName": "localhost:8080",
           "endpoints": [
@@ -220,7 +227,9 @@
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
             "commonHttpProtocolOptions": {
-              "idleTimeout": "7200s"
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
             },
             "explicitHttpConfig": {
               "httpProtocolOptions": {}
@@ -345,7 +354,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
                   "commonHttpProtocolOptions": {
-                    "idleTimeout": "7200s"
+                    "idleTimeout": "0s"
                   },
                   "forwardClientCertDetails": "SANITIZE_SET",
                   "httpFilters": [
@@ -378,6 +387,7 @@
                       }
                     }
                   ],
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "inbound:test-server",
                     "requestHeadersToRemove": [
@@ -397,7 +407,8 @@
                             },
                             "route": {
                               "cluster": "localhost:8080",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]
@@ -541,6 +552,7 @@
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                   "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
                   "statPrefix": "STAT_PREFIX_REDACTED"
                 }
               }
@@ -570,6 +582,9 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
                   "httpFilters": [
                     {
                       "name": "envoy.filters.http.router",
@@ -579,6 +594,7 @@
                     }
                   ],
                   "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
                   "routeConfig": {
                     "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
@@ -596,7 +612,8 @@
                             "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
                             "route": {
                               "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
-                              "timeout": "0s"
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
                             }
                           }
                         ]


### PR DESCRIPTION
## Motivation

This if-condition at the beginning of the plugin
```go
if len(policies.ToRules.Rules) == 0 && len(policies.FromRules.Rules) == 0 && len(policies.GatewayRules.ToRules.ByListener) == 0 && len(policies.ToRules.ResourceRules) == 0 {
    return nil
}
```
causes inconsistent default values. For example, the default outbound timeouts should be the same regardless of the presence of MeshTimeout policies with `from`. 

## Implementation information

Depends on https://github.com/kumahq/kuma/pull/12766

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix https://github.com/kumahq/kuma/issues/12649
