### PR TITLE
fix(xds): fix token expiration issue caused by inappropriate cache in kuma-cp

### DIFF
--- a/pkg/xds/auth/callbacks.go
+++ b/pkg/xds/auth/callbacks.go
@@ -59,7 +59,8 @@ type stream struct {
 	// Dataplane / ZoneIngress / ZoneEgress associated with this XDS stream.
 	resource model.Resource
 	// nodeID of the stream. Has to be the same for the whole life of a stream.
-	nodeID string
+	nodeID        string
+	authenticated bool
 }
 
 var _ util_xds.Callbacks = &authCallbacks{}
@@ -87,12 +88,16 @@ func (a *authCallbacks) OnStreamRequest(streamID core_xds.StreamID, req util_xds
 		return err
 	}
 
-	credential, err := ExtractCredential(s.ctx)
-	if err != nil {
-		return errors.Wrap(err, "could not extract credential from DiscoveryRequest")
-	}
-	if err := a.authenticator.Authenticate(user.Ctx(s.ctx, user.ControlPlane), s.resource, credential); err != nil {
-		return errors.Wrap(err, "authentication failed")
+	// If the gRPC stream is already authenticated, we don't need to authenticate it again.
+	if !s.authenticated {
+		credential, err := ExtractCredential(s.ctx)
+		if err != nil {
+			return errors.Wrap(err, "could not extract credential from DiscoveryRequest")
+		}
+		if err := a.authenticator.Authenticate(user.Ctx(s.ctx, user.ControlPlane), s.resource, credential); err != nil {
+			return errors.Wrap(err, "authentication failed")
+		}
+		s.authenticated = true
 	}
 	a.Lock()
 	a.streams[streamID] = s

--- a/pkg/xds/auth/k8s/authenticator.go
+++ b/pkg/xds/auth/k8s/authenticator.go
@@ -45,7 +45,8 @@ type kubeAuthenticator struct {
 var _ auth.Authenticator = &kubeAuthenticator{}
 
 func (k *kubeAuthenticator) Authenticate(ctx context.Context, resource model.Resource, credential auth.Credential) error {
-	if _, authenticated := k.authenticated.GetIfPresent(credential); authenticated {
+	cacheKey := resource.GetMeta().GetName() + credential
+	if _, authenticated := k.authenticated.GetIfPresent(cacheKey); authenticated {
 		return nil
 	}
 
@@ -61,7 +62,7 @@ func (k *kubeAuthenticator) Authenticate(ctx context.Context, resource model.Res
 		return err
 	}
 
-	k.authenticated.Put(credential, struct{}{})
+	k.authenticated.Put(cacheKey, struct{}{})
 	return nil
 }
 


### PR DESCRIPTION
## Motivation

An inappropriate cache of the auth result may cause incorrect auth result between DP and CP.

## Implementation information

Only auth once per gRPC stream.

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
