### PR TITLE
feat(kuma-cp): inbound name should be taken from pod instead of service

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
@@ -32,7 +32,7 @@ func inboundForService(zone string, pod *kube_core.Pod, service *kube_core.Servi
 			// ignore non-TCP ports
 			continue
 		}
-		containerPort, container, err := util_k8s.FindPort(pod, &svcPort)
+		containerPort, portName, container, err := util_k8s.FindPort(pod, &svcPort)
 		if err != nil {
 			converterLog.Error(err, "failed to find a container port in a given Pod that would match a given Service port", "namespace", pod.Namespace, "podName", pod.Name, "serviceName", service.Name, "servicePortName", svcPort.Name)
 			// ignore those cases where a Pod doesn't have all the ports a Service has
@@ -77,7 +77,7 @@ func inboundForService(zone string, pod *kube_core.Pod, service *kube_core.Servi
 
 		ifaces = append(ifaces, &mesh_proto.Dataplane_Networking_Inbound{
 			Port:   uint32(containerPort),
-			Name:   svcPort.Name,
+			Name:   portName,
 			Tags:   tags,
 			State:  state,
 			Health: &health, // write health for backwards compatibility with Kuma 2.5 and older

--- a/pkg/plugins/runtime/k8s/controllers/pod_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller_test.go
@@ -674,6 +674,7 @@ var _ = Describe("PodReconciler", func() {
             - state: NotReady
               health: {}
               port: 6060
+              name: metrics
               tags:
                 app: sample
                 kuma.io/service: example_demo_svc_6061
@@ -775,6 +776,7 @@ var _ = Describe("PodReconciler", func() {
             - state: NotReady
               health: {}
               port: 6060
+              name: metrics
               tags:
                 app: sample
                 kuma.io/service: example_demo_svc_6061

--- a/pkg/plugins/runtime/k8s/controllers/testdata/01.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/01.dataplane.yaml
@@ -50,6 +50,7 @@ spec:
         version: "0.1"
     - health:
         ready: true
+      name: metrics
       port: 6060
       tags:
         app: example

--- a/pkg/plugins/runtime/k8s/util/util.go
+++ b/pkg/plugins/runtime/k8s/util/util.go
@@ -70,7 +70,7 @@ func MatchService(svc *kube_core.Service, predicates ...ServicePredicate) bool {
 // targetPort is a number, use that.  If the targetPort is a string, look that
 // string up in all named ports in all containers in the target pod.  If no
 // match is found, fail.
-func FindPort(pod *kube_core.Pod, svcPort *kube_core.ServicePort) (int, *kube_core.Container, error) {
+func FindPort(pod *kube_core.Pod, svcPort *kube_core.ServicePort) (int, string, *kube_core.Container, error) {
 	givenOrDefault := func(value kube_core.Protocol) kube_core.Protocol {
 		if value != "" {
 			return value
@@ -85,7 +85,7 @@ func FindPort(pod *kube_core.Pod, svcPort *kube_core.ServicePort) (int, *kube_co
 		for _, container := range pod.Spec.Containers {
 			for _, port := range container.Ports {
 				if port.Name == name && givenOrDefault(port.Protocol) == givenOrDefault(svcPort.Protocol) {
-					return int(port.ContainerPort), &container, nil
+					return int(port.ContainerPort), port.Name, &container, nil
 				}
 			}
 		}
@@ -98,14 +98,14 @@ func FindPort(pod *kube_core.Pod, svcPort *kube_core.ServicePort) (int, *kube_co
 		for _, container := range pod.Spec.Containers {
 			for _, port := range container.Ports {
 				if port.ContainerPort == portName.IntVal && givenOrDefault(port.Protocol) == givenOrDefault(svcPort.Protocol) {
-					return int(port.ContainerPort), &container, nil
+					return int(port.ContainerPort), port.Name, &container, nil
 				}
 			}
 		}
-		return portName.IntValue(), nil, nil
+		return portName.IntValue(), "", nil, nil
 	}
 
-	return 0, nil, fmt.Errorf("no suitable port for manifest: %s", pod.UID)
+	return 0, "", nil, fmt.Errorf("no suitable port for manifest: %s", pod.UID)
 }
 
 func findContainerStatus(containerName string, status []kube_core.ContainerStatus, initStatus []kube_core.ContainerStatus) *kube_core.ContainerStatus {

--- a/pkg/plugins/runtime/k8s/util/util_test.go
+++ b/pkg/plugins/runtime/k8s/util/util_test.go
@@ -357,9 +357,10 @@ var _ = Describe("Util", func() {
 	Describe("FindPort()", func() {
 		Describe("should return a correct port number", func() {
 			type testCase struct {
-				pod      string
-				svcPort  string
-				expected int
+				pod              string
+				svcPort          string
+				expectedPort     int
+				expectedPortName string
 			}
 
 			DescribeTable("should correctly find a matching port in a given Pod",
@@ -379,11 +380,12 @@ var _ = Describe("Util", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					// when
-					actual, _, err := util.FindPort(&pod, &svcPort)
+					actualPort, actualPortName, _, err := util.FindPort(&pod, &svcPort)
 					// then
 					Expect(err).ToNot(HaveOccurred())
 					// and
-					Expect(actual).To(Equal(given.expected))
+					Expect(actualPort).To(Equal(given.expectedPort))
+					Expect(actualPortName).To(Equal(given.expectedPortName))
 				},
 				Entry("Service with `targetPort` as a number (TCP)", testCase{
 					pod: `
@@ -398,7 +400,7 @@ var _ = Describe("Util", func() {
                     protocol: TCP
                     targetPort: 8080
 `,
-					expected: 8080,
+					expectedPort: 8080,
 				}),
 				Entry("Service with `targetPort` as a number (UDP)", testCase{
 					pod: `
@@ -413,7 +415,7 @@ var _ = Describe("Util", func() {
                     protocol: UDP
                     targetPort: 53
 `,
-					expected: 53,
+					expectedPort: 53,
 				}),
 				Entry("Service with `targetPort` as a name (container port protocol is omitted)", testCase{
 					pod: `
@@ -437,7 +439,8 @@ var _ = Describe("Util", func() {
                     protocol: TCP
                     targetPort: http-api
 `,
-					expected: 7070,
+					expectedPort:     7070,
+					expectedPortName: "http-api",
 				}),
 				Entry("Service with `targetPort` as a name (container port protocol is set to TCP)", testCase{
 					pod: `
@@ -461,7 +464,8 @@ var _ = Describe("Util", func() {
                     protocol: TCP
                     targetPort: http-api
 `,
-					expected: 7070,
+					expectedPort:     7070,
+					expectedPortName: "http-api",
 				}),
 				Entry("Service with `targetPort` as a name (container port protocol is set to UDP)", testCase{
 					pod: `
@@ -485,7 +489,8 @@ var _ = Describe("Util", func() {
                     protocol: UDP
                     targetPort: dns-port
 `,
-					expected: 1053,
+					expectedPort:     1053,
+					expectedPortName: "dns-port",
 				}),
 				Entry("Service with `targetPort` as a name (service port protocol is omitted and container port protocol is omitted)", testCase{
 					pod: `
@@ -508,7 +513,8 @@ var _ = Describe("Util", func() {
                     port: 8080
                     targetPort: http-api
 `,
-					expected: 7070,
+					expectedPort:     7070,
+					expectedPortName: "http-api",
 				}),
 				Entry("Service with `targetPort` as a name (service port protocol is omitted while container port protocol set to TCP)", testCase{
 					pod: `
@@ -531,7 +537,8 @@ var _ = Describe("Util", func() {
                     port: 8080
                     targetPort: http-api
 `,
-					expected: 7070,
+					expectedPort:     7070,
+					expectedPortName: "http-api",
 				}),
 			)
 		})
@@ -560,7 +567,7 @@ var _ = Describe("Util", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					// when
-					actual, _, err := util.FindPort(&pod, &svcPort)
+					actual, _, _, err := util.FindPort(&pod, &svcPort)
 					// then
 					Expect(err).To(HaveOccurred())
 					// and


### PR DESCRIPTION
## Motivation

At this moment we are taking inbound name from service port name. In order to get rid of kuma.io/service we need to take name from pod port name. Since we are not using name at the moment, it is safe to switch this.

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
