### PR TITLE
fix(xds): only auth once per xds gRPC stream in kuma-cp

### DIFF
--- a/pkg/xds/auth/callbacks.go
+++ b/pkg/xds/auth/callbacks.go
@@ -88,7 +88,6 @@ func (a *authCallbacks) OnStreamRequest(streamID core_xds.StreamID, req util_xds
 		return err
 	}
 
-	// If the gRPC stream is already authenticated, we don't need to authenticate it again.
 	if !s.authenticated {
 		credential, err := ExtractCredential(s.ctx)
 		if err != nil {

--- a/pkg/xds/auth/callbacks.go
+++ b/pkg/xds/auth/callbacks.go
@@ -59,7 +59,8 @@ type stream struct {
 	// Dataplane / ZoneIngress / ZoneEgress associated with this XDS stream.
 	resource model.Resource
 	// nodeID of the stream. Has to be the same for the whole life of a stream.
-	nodeID string
+	nodeID        string
+	authenticated bool
 }
 
 var _ util_xds.Callbacks = &authCallbacks{}
@@ -87,12 +88,16 @@ func (a *authCallbacks) OnStreamRequest(streamID core_xds.StreamID, req util_xds
 		return err
 	}
 
-	credential, err := ExtractCredential(s.ctx)
-	if err != nil {
-		return errors.Wrap(err, "could not extract credential from DiscoveryRequest")
-	}
-	if err := a.authenticator.Authenticate(user.Ctx(s.ctx, user.ControlPlane), s.resource, credential); err != nil {
-		return errors.Wrap(err, "authentication failed")
+	// If the gRPC stream is already authenticated, we don't need to authenticate it again.
+	if !s.authenticated {
+		credential, err := ExtractCredential(s.ctx)
+		if err != nil {
+			return errors.Wrap(err, "could not extract credential from DiscoveryRequest")
+		}
+		if err := a.authenticator.Authenticate(user.Ctx(s.ctx, user.ControlPlane), s.resource, credential); err != nil {
+			return errors.Wrap(err, "authentication failed")
+		}
+		s.authenticated = true
 	}
 	a.Lock()
 	a.streams[streamID] = s

--- a/pkg/xds/auth/k8s/authenticator.go
+++ b/pkg/xds/auth/k8s/authenticator.go
@@ -45,7 +45,8 @@ type kubeAuthenticator struct {
 var _ auth.Authenticator = &kubeAuthenticator{}
 
 func (k *kubeAuthenticator) Authenticate(ctx context.Context, resource model.Resource, credential auth.Credential) error {
-	if _, authenticated := k.authenticated.GetIfPresent(credential); authenticated {
+	cacheKey := resource.GetMeta().GetName() + credential
+	if _, authenticated := k.authenticated.GetIfPresent(cacheKey); authenticated {
 		return nil
 	}
 
@@ -61,7 +62,7 @@ func (k *kubeAuthenticator) Authenticate(ctx context.Context, resource model.Res
 		return err
 	}
 
-	k.authenticated.Put(credential, struct{}{})
+	k.authenticated.Put(cacheKey, struct{}{})
 	return nil
 }
 

--- a/pkg/xds/auth/k8s/authenticator.go
+++ b/pkg/xds/auth/k8s/authenticator.go
@@ -73,14 +73,13 @@ func (k *kubeAuthenticator) verifyToken(ctx context.Context, credential auth.Cre
 		},
 	}
 
-	log.V(1).Info("verifying token", "proxy", resourceName, "serviceAccountName", serviceAccountName)
 	if err := k.client.Create(ctx, tokenReview); err != nil {
-		log.Info("[WARNING] fail to call Kubernetes API Server to verify token", "error", err, "proxy", resourceName, "serviceAccountName", serviceAccountName)
+		log.Info("[WARNING] fail to call Kubernetes API Server to verify dataplane token", "error", err, "proxy", resourceName, "serviceAccountName", serviceAccountName)
 		return errors.New("call to TokenReview API failed")
 	}
 	if !tokenReview.Status.Authenticated {
-		log.V(1).Info("fail to verify token", "error", tokenReview.Status.Error, "credential", credential)
-		return errors.Errorf("token doesn't belong to a valid user")
+		log.Info("[WARNING] fail to verify dataplane token", "error", tokenReview.Status.Error)
+		return errors.Errorf("token verification failed")
 	}
 	userInfo := strings.Split(tokenReview.Status.User.Username, ":")
 	if len(userInfo) != 4 {

--- a/pkg/xds/auth/k8s/authenticator.go
+++ b/pkg/xds/auth/k8s/authenticator.go
@@ -55,7 +55,7 @@ func (k *kubeAuthenticator) verifyToken(ctx context.Context, credential auth.Cre
 	}
 
 	if err := k.client.Create(ctx, tokenReview); err != nil {
-		log.Info("[WARNING] fail to call Kubernetes API Server to verify dataplane token", "error", err, "proxy", resourceName, "serviceAccountName", serviceAccountName)
+		log.Error(err, "fail to call Kubernetes API Server to verify dataplane token", "proxy", resourceName, "serviceAccountName", serviceAccountName)
 		return errors.New("call to TokenReview API failed")
 	}
 	if !tokenReview.Status.Authenticated {

--- a/pkg/xds/auth/k8s/authenticator.go
+++ b/pkg/xds/auth/k8s/authenticator.go
@@ -2,14 +2,15 @@ package k8s
 
 import (
 	"context"
-	"github.com/kumahq/kuma/pkg/core"
+	"strings"
+
 	"github.com/pkg/errors"
 	kube_auth "k8s.io/api/authentication/v1"
 	kube_core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
 
+	"github.com/kumahq/kuma/pkg/core"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	util_k8s "github.com/kumahq/kuma/pkg/util/k8s"

--- a/test/e2e_env/universal/auth/dp_auth.go
+++ b/test/e2e_env/universal/auth/dp_auth.go
@@ -1,11 +1,6 @@
 package auth
 
 import (
-	"encoding/base64"
-	"fmt"
-	"math/rand"
-
-	"github.com/golang-jwt/jwt/v4"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -69,67 +64,5 @@ func DpAuth() {
 		Eventually(func() (string, error) {
 			return universal.Cluster.GetKumactlOptions().RunKumactlAndGetOutput("get", "dataplanes", "-oyaml")
 		}, "30s", "1s").ShouldNot(ContainSubstring("192.168.0.2"))
-	})
-
-	It("should revoke token and kick out dataplane proxy out of the mesh", func() {
-		// given
-		serviceName := "test-server-to-be-revoked"
-		token, err := universal.Cluster.GetKuma().GenerateDpToken(meshName, serviceName)
-		Expect(err).ToNot(HaveOccurred())
-
-		err = universal.Cluster.Install(TestServerUniversal(serviceName, meshName, WithServiceName(serviceName), WithToken(token)))
-		Expect(err).ToNot(HaveOccurred())
-
-		Eventually(func(g Gomega) {
-			online, found, err := IsDataplaneOnline(universal.Cluster, meshName, serviceName)
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(found).To(BeTrue())
-			g.Expect(online).To(BeTrue())
-		}).Should(Succeed())
-
-		// when token ID is added to revocation list
-		claims := &jwt.RegisteredClaims{}
-		_, _, err = jwt.NewParser().ParseUnverified(token, claims)
-		Expect(err).ToNot(HaveOccurred())
-
-		yaml := fmt.Sprintf(`
-type: Secret
-mesh: dp-auth
-name: dataplane-token-revocations-dp-auth
-data: %s`, base64.StdEncoding.EncodeToString([]byte(claims.ID)))
-		Expect(universal.Cluster.Install(YamlUniversal(yaml))).To(Succeed())
-
-		// then DPP is disconnected
-		Eventually(func(g Gomega) {
-			// we need to trigger XDS config change for this DP to disconnect it
-			// this limitation may be lifted in the future
-			randomRetries := rand.Int()%100 + 1 // #nosec G404 -- this is for tests no need to use secure rand
-			yaml = fmt.Sprintf(`
-type: MeshRetry
-name: retry-policy
-mesh: dp-auth
-spec:
-  targetRef:
-    kind: MeshService
-    name: test-server-to-be-revoked
-  to:
-    - targetRef:
-        kind: MeshService
-        name: test-server-to-be-revoked
-      default:
-        http:
-          numRetries: %d
-          backOff:
-            baseInterval: 15s
-            maxInterval: 20m
-          retryOn:
-            - "5xx"
-`, randomRetries)
-			g.Expect(universal.Cluster.Install(YamlUniversal(yaml))).To(Succeed())
-
-			online, _, err := IsDataplaneOnline(universal.Cluster, meshName, serviceName)
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(online).To(BeFalse()) // either online or not found
-		}).Should(Succeed())
 	})
 }


### PR DESCRIPTION
## Motivation

Right now, we are authenticating the DP on every `OnStreamRequest` event in `auth.Callback`, and [the authenticator has a cache](https://github.com/kumahq/kuma/blob/5359d941bf6a7fab22cb177cd94de1112b9b4ad7/pkg/xds/auth/k8s/authenticator.go#L48-L64) which caches the successful verification results. The Kubernetes API Server is only called when it is not hitting the cache, and the cache can last long: when the cache expires, the token is already expired from Kube's point of view.

In a cluster with bound service account token enabled and "extend-token-expiration" disabled, service account tokens expire once an hour by default.

## Implementation information

* Only auth once per gRPC stream.

* Remove auth cache as it's not required when it's only auth once during a gRPC stream/connection.


## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

fixes https://github.com/kumahq/kuma/issues/12784
fixes  https://github.com/kumahq/kuma/issues/12785

replaces https://github.com/kumahq/kuma/pull/12782


<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
