### PR TITLE
feat(kuma-cp): deprecate from section in policies with rules api implemented

### DIFF
--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/deprecated.go
@@ -5,5 +5,9 @@ import (
 )
 
 func (t *MeshAccessLogResource) Deprecations() []string {
-	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
+	var deprecations []string
+	if len(t.Spec.From) > 0 {
+		deprecations = append(deprecations, "'from' field is deprecated, use 'rules' instead")
+	}
+	return append(deprecations, validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)...)
 }

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/deprecated.go
@@ -5,5 +5,9 @@ import (
 )
 
 func (t *MeshCircuitBreakerResource) Deprecations() []string {
-	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
+	var deprecations []string
+	if len(t.Spec.From) > 0 {
+		deprecations = append(deprecations, "'from' field is deprecated, use 'rules' instead")
+	}
+	return append(deprecations, validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)...)
 }

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/deprecated.go
@@ -5,5 +5,9 @@ import (
 )
 
 func (t *MeshRateLimitResource) Deprecations() []string {
-	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
+	var deprecations []string
+	if len(t.Spec.From) > 0 {
+		deprecations = append(deprecations, "'from' field is deprecated, use 'rules' instead")
+	}
+	return append(deprecations, validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)...)
 }

--- a/pkg/plugins/policies/meshtls/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshtls/api/v1alpha1/deprecated.go
@@ -4,7 +4,7 @@ import (
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/jsonpatch/validators"
 )
 
-func (t *MeshTimeoutResource) Deprecations() []string {
+func (t *MeshTLSResource) Deprecations() []string {
 	var deprecations []string
 	if len(t.Spec.From) > 0 {
 		deprecations = append(deprecations, "'from' field is deprecated, use 'rules' instead")


### PR DESCRIPTION
## Motivation
We have added new `rules` api to inbound policies. We can now safely deprecate `from` section in these policies


<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
