### PR TITLE
chore(MeshAccessLog): add envoyconfig e2e tests for MeshAccessLog selecting gateway

### DIFF
--- a/test/e2e_env/universal/envoyconfig/builtingateway.go
+++ b/test/e2e_env/universal/envoyconfig/builtingateway.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	meshaccesslog "github.com/kumahq/kuma/pkg/plugins/policies/meshaccesslog/api/v1alpha1"
 	meshtimeout "github.com/kumahq/kuma/pkg/plugins/policies/meshtimeout/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/test"
 	"github.com/kumahq/kuma/pkg/test/matchers"
@@ -112,6 +113,7 @@ spec:
 		Expect(DeleteMeshResources(
 			universal.Cluster,
 			mesh,
+			meshaccesslog.MeshAccessLogResourceTypeDescriptor,
 			meshtimeout.MeshTimeoutResourceTypeDescriptor,
 		)).To(Succeed())
 	})
@@ -130,6 +132,7 @@ spec:
 			// then
 			Expect(getConfig(mesh, "gateway-proxy")).To(matchers.MatchGoldenJSON(strings.Replace(inputFile, "input.yaml", "gateway-proxy.golden.json", 1)))
 		},
+		test.EntriesForFolder(filepath.Join("builtingateway", "meshaccesslog"), "envoyconfig"),
 		test.EntriesForFolder(filepath.Join("builtingateway", "meshtimeout"), "envoyconfig"),
 	)
 }

--- a/test/e2e_env/universal/envoyconfig/testdata/builtingateway/meshaccesslog/mal-with-from.gateway-proxy.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/builtingateway/meshaccesslog/mal-with-from.gateway-proxy.golden.json
@@ -1,0 +1,330 @@
+{
+  "diff": [
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/gateway-proxy:HTTP:8080/filterChains/0/filters/0/typedConfig/accessLog",
+      "value": [
+        {
+          "name": "envoy.access_loggers.file",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+            "logFormat": {
+              "textFormatSource": {
+                "inlineString": "[%START_TIME%]\n"
+              }
+            },
+            "path": "/dev/stdout"
+          }
+        }
+      ]
+    }
+  ],
+  "xds": {
+    "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
+      "envoyconfig-builtingateway_echo-service__kuma-3_msvc_80-3e607e0fbdf6b9a2": {
+        "edsClusterConfig": {
+          "edsConfig": {
+            "ads": {},
+            "resourceApiVersion": "V3"
+          }
+        },
+        "name": "envoyconfig-builtingateway_echo-service__kuma-3_msvc_80-3e607e0fbdf6b9a2",
+        "perConnectionBufferLimitBytes": 32768,
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig-builtingateway/echo-service"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig-builtingateway",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig-builtingateway",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "aecb4981e52fda985.echo-service.80.envoyconfig-builtingateway.ms"
+          }
+        },
+        "type": "EDS",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicitHttpConfig": {
+              "httpProtocolOptions": {}
+            }
+          }
+        }
+      }
+    },
+    "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment": {
+      "envoyconfig-builtingateway_echo-service__kuma-3_msvc_80-3e607e0fbdf6b9a2": {
+        "clusterName": "envoyconfig-builtingateway_echo-service__kuma-3_msvc_80-3e607e0fbdf6b9a2",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "IP_REDACTED",
+                      "portValue": 80
+                    }
+                  }
+                },
+                "loadBalancingWeight": 1,
+                "metadata": {
+                  "filterMetadata": {
+                    "envoy.lb": {
+                      "instance": "1",
+                      "kuma.io/protocol": "http",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "server-owners",
+                      "version": "v1"
+                    },
+                    "envoy.transport_socket_match": {
+                      "instance": "1",
+                      "kuma.io/protocol": "http",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "server-owners",
+                      "version": "v1"
+                    }
+                  }
+                }
+              }
+            ],
+            "locality": {
+              "zone": "kuma-3"
+            }
+          }
+        ]
+      }
+    },
+    "type.googleapis.com/envoy.config.listener.v3.Listener": {
+      "gateway-proxy:HTTP:8080": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 8080
+          }
+        },
+        "enableReusePort": true,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "accessLog": [
+                    {
+                      "name": "envoy.access_loggers.file",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+                        "logFormat": {
+                          "textFormatSource": {
+                            "inlineString": "[%START_TIME%]\n"
+                          }
+                        },
+                        "path": "/dev/stdout"
+                      }
+                    }
+                  ],
+                  "commonHttpProtocolOptions": {
+                    "headersWithUnderscoresAction": "REJECT_REQUEST",
+                    "idleTimeout": "300s"
+                  },
+                  "http2ProtocolOptions": {
+                    "allowConnect": true,
+                    "initialConnectionWindowSize": 1048576,
+                    "initialStreamWindowSize": 65536,
+                    "maxConcurrentStreams": 100
+                  },
+                  "httpFilters": [
+                    {
+                      "name": "envoy.filters.http.local_ratelimit",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit",
+                        "statPrefix": "STAT_PREFIX_REDACTED"
+                      }
+                    },
+                    {
+                      "name": "gzip-compress",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor",
+                        "compressorLibrary": {
+                          "name": "gzip",
+                          "typedConfig": {
+                            "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
+                          }
+                        },
+                        "responseDirectionConfig": {
+                          "disableOnEtagHeader": true
+                        }
+                      }
+                    },
+                    {
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
+                    }
+                  ],
+                  "mergeSlashes": true,
+                  "normalizePath": true,
+                  "pathWithEscapedSlashesAction": "UNESCAPE_AND_REDIRECT",
+                  "rds": {
+                    "configSource": {
+                      "ads": {},
+                      "resourceApiVersion": "V3"
+                    },
+                    "routeConfigName": "gateway-proxy:HTTP:8080:*"
+                  },
+                  "requestHeadersTimeout": "0.500s",
+                  "serverName": "Kuma Gateway",
+                  "statPrefix": "STAT_PREFIX_REDACTED",
+                  "streamIdleTimeout": "5s",
+                  "useRemoteAddress": true
+                }
+              }
+            ]
+          }
+        ],
+        "listenerFilters": [
+          {
+            "name": "envoy.filters.listener.tls_inspector",
+            "typedConfig": {
+              "@type": "type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector"
+            }
+          }
+        ],
+        "name": "gateway-proxy:HTTP:8080",
+        "perConnectionBufferLimitBytes": 32768,
+        "trafficDirection": "INBOUND"
+      }
+    },
+    "type.googleapis.com/envoy.config.route.v3.RouteConfiguration": {
+      "gateway-proxy:HTTP:8080:*": {
+        "ignorePortInHostMatching": true,
+        "name": "gateway-proxy:HTTP:8080:*",
+        "requestHeadersToRemove": [
+          "x-kuma-tags"
+        ],
+        "validateClusters": false,
+        "virtualHosts": [
+          {
+            "domains": [
+              "example.kuma.io"
+            ],
+            "name": "example.kuma.io",
+            "routes": [
+              {
+                "match": {
+                  "path": "/"
+                },
+                "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
+                "route": {
+                  "clusterNotFoundResponseCode": "INTERNAL_SERVER_ERROR",
+                  "idleTimeout": "5s",
+                  "weightedClusters": {
+                    "clusters": [
+                      {
+                        "name": "envoyconfig-builtingateway_echo-service__kuma-3_msvc_80-3e607e0fbdf6b9a2",
+                        "requestHeadersToAdd": [
+                          {
+                            "header": {
+                              "key": "x-kuma-tags",
+                              "value": "\u0026kuma.io/service=gateway-proxy\u0026\u0026kuma.io/zone=kuma-3\u0026"
+                            }
+                          }
+                        ],
+                        "weight": 1
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "match": {
+                  "prefix": "/"
+                },
+                "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
+                "route": {
+                  "clusterNotFoundResponseCode": "INTERNAL_SERVER_ERROR",
+                  "idleTimeout": "5s",
+                  "weightedClusters": {
+                    "clusters": [
+                      {
+                        "name": "envoyconfig-builtingateway_echo-service__kuma-3_msvc_80-3e607e0fbdf6b9a2",
+                        "requestHeadersToAdd": [
+                          {
+                            "header": {
+                              "key": "x-kuma-tags",
+                              "value": "\u0026kuma.io/service=gateway-proxy\u0026\u0026kuma.io/zone=kuma-3\u0026"
+                            }
+                          }
+                        ],
+                        "weight": 1
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret": {
+      "identity_cert:secret:envoyconfig-builtingateway": {
+        "name": "identity_cert:secret:envoyconfig-builtingateway",
+        "tlsCertificate": {
+          "certificateChain": {
+            "inlineBytes": "Q0VSVA=="
+          },
+          "privateKey": {
+            "inlineBytes": "S0VZ"
+          }
+        }
+      },
+      "mesh_ca:secret:envoyconfig-builtingateway": {
+        "name": "mesh_ca:secret:envoyconfig-builtingateway",
+        "validationContext": {
+          "trustedCa": {
+            "inlineBytes": "Q0E="
+          }
+        }
+      }
+    },
+    "type.googleapis.com/envoy.service.runtime.v3.Runtime": {
+      "gateway.listeners": {
+        "layer": {},
+        "name": "gateway.listeners"
+      }
+    }
+  }
+}

--- a/test/e2e_env/universal/envoyconfig/testdata/builtingateway/meshaccesslog/mal-with-from.input.yaml
+++ b/test/e2e_env/universal/envoyconfig/testdata/builtingateway/meshaccesslog/mal-with-from.input.yaml
@@ -1,0 +1,21 @@
+type: MeshAccessLog
+name: mt-1
+mesh: envoyconfig-builtingateway
+labels:
+  kuma.io/effect: shadow
+spec:
+  targetRef:
+    kind: Mesh
+    proxyTypes:
+      - Gateway
+  from:
+    - targetRef:
+        kind: Mesh
+      default:
+        backends:
+          - type: File
+            file:
+              path: "/dev/stdout"
+              format:
+                type: Plain
+                plain: "[%START_TIME%]"

--- a/test/e2e_env/universal/envoyconfig/testdata/builtingateway/meshaccesslog/mt-with-to.gateway-proxy.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/builtingateway/meshaccesslog/mt-with-to.gateway-proxy.golden.json
@@ -1,0 +1,340 @@
+{
+  "diff": [
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/gateway-proxy:HTTP:8080/filterChains/0/filters/0/typedConfig/accessLog",
+      "value": [
+        {
+          "name": "envoy.access_loggers.file",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+            "logFormat": {
+              "jsonFormat": {
+                "Destination": "%*%",
+                "HeaderCamel": "%%REQ(X-Test)%%",
+                "HeaderCrazy": "%%REQ(X-TeSt)%%",
+                "HeaderLower": "%%REQ(x-test)%%",
+                "Source": "%gateway-proxy%",
+                "Start": "%%START_TIME(%%s)%%"
+              }
+            },
+            "path": "/dev/stdout"
+          }
+        }
+      ]
+    }
+  ],
+  "xds": {
+    "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
+      "envoyconfig-builtingateway_echo-service__kuma-3_msvc_80-3e607e0fbdf6b9a2": {
+        "edsClusterConfig": {
+          "edsConfig": {
+            "ads": {},
+            "resourceApiVersion": "V3"
+          }
+        },
+        "name": "envoyconfig-builtingateway_echo-service__kuma-3_msvc_80-3e607e0fbdf6b9a2",
+        "perConnectionBufferLimitBytes": 32768,
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig-builtingateway/echo-service"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig-builtingateway",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig-builtingateway",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "aecb4981e52fda985.echo-service.80.envoyconfig-builtingateway.ms"
+          }
+        },
+        "type": "EDS",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicitHttpConfig": {
+              "httpProtocolOptions": {}
+            }
+          }
+        }
+      }
+    },
+    "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment": {
+      "envoyconfig-builtingateway_echo-service__kuma-3_msvc_80-3e607e0fbdf6b9a2": {
+        "clusterName": "envoyconfig-builtingateway_echo-service__kuma-3_msvc_80-3e607e0fbdf6b9a2",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "IP_REDACTED",
+                      "portValue": 80
+                    }
+                  }
+                },
+                "loadBalancingWeight": 1,
+                "metadata": {
+                  "filterMetadata": {
+                    "envoy.lb": {
+                      "instance": "1",
+                      "kuma.io/protocol": "http",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "server-owners",
+                      "version": "v1"
+                    },
+                    "envoy.transport_socket_match": {
+                      "instance": "1",
+                      "kuma.io/protocol": "http",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "server-owners",
+                      "version": "v1"
+                    }
+                  }
+                }
+              }
+            ],
+            "locality": {
+              "zone": "kuma-3"
+            }
+          }
+        ]
+      }
+    },
+    "type.googleapis.com/envoy.config.listener.v3.Listener": {
+      "gateway-proxy:HTTP:8080": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 8080
+          }
+        },
+        "enableReusePort": true,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "accessLog": [
+                    {
+                      "name": "envoy.access_loggers.file",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+                        "logFormat": {
+                          "jsonFormat": {
+                            "Destination": "%*%",
+                            "HeaderCamel": "%%REQ(X-Test)%%",
+                            "HeaderCrazy": "%%REQ(X-TeSt)%%",
+                            "HeaderLower": "%%REQ(x-test)%%",
+                            "Source": "%gateway-proxy%",
+                            "Start": "%%START_TIME(%%s)%%"
+                          }
+                        },
+                        "path": "/dev/stdout"
+                      }
+                    }
+                  ],
+                  "commonHttpProtocolOptions": {
+                    "headersWithUnderscoresAction": "REJECT_REQUEST",
+                    "idleTimeout": "300s"
+                  },
+                  "http2ProtocolOptions": {
+                    "allowConnect": true,
+                    "initialConnectionWindowSize": 1048576,
+                    "initialStreamWindowSize": 65536,
+                    "maxConcurrentStreams": 100
+                  },
+                  "httpFilters": [
+                    {
+                      "name": "envoy.filters.http.local_ratelimit",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit",
+                        "statPrefix": "STAT_PREFIX_REDACTED"
+                      }
+                    },
+                    {
+                      "name": "gzip-compress",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor",
+                        "compressorLibrary": {
+                          "name": "gzip",
+                          "typedConfig": {
+                            "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
+                          }
+                        },
+                        "responseDirectionConfig": {
+                          "disableOnEtagHeader": true
+                        }
+                      }
+                    },
+                    {
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
+                    }
+                  ],
+                  "mergeSlashes": true,
+                  "normalizePath": true,
+                  "pathWithEscapedSlashesAction": "UNESCAPE_AND_REDIRECT",
+                  "rds": {
+                    "configSource": {
+                      "ads": {},
+                      "resourceApiVersion": "V3"
+                    },
+                    "routeConfigName": "gateway-proxy:HTTP:8080:*"
+                  },
+                  "requestHeadersTimeout": "0.500s",
+                  "serverName": "Kuma Gateway",
+                  "statPrefix": "STAT_PREFIX_REDACTED",
+                  "streamIdleTimeout": "5s",
+                  "useRemoteAddress": true
+                }
+              }
+            ]
+          }
+        ],
+        "listenerFilters": [
+          {
+            "name": "envoy.filters.listener.tls_inspector",
+            "typedConfig": {
+              "@type": "type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector"
+            }
+          }
+        ],
+        "name": "gateway-proxy:HTTP:8080",
+        "perConnectionBufferLimitBytes": 32768,
+        "trafficDirection": "INBOUND"
+      }
+    },
+    "type.googleapis.com/envoy.config.route.v3.RouteConfiguration": {
+      "gateway-proxy:HTTP:8080:*": {
+        "ignorePortInHostMatching": true,
+        "name": "gateway-proxy:HTTP:8080:*",
+        "requestHeadersToRemove": [
+          "x-kuma-tags"
+        ],
+        "validateClusters": false,
+        "virtualHosts": [
+          {
+            "domains": [
+              "example.kuma.io"
+            ],
+            "name": "example.kuma.io",
+            "routes": [
+              {
+                "match": {
+                  "path": "/"
+                },
+                "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
+                "route": {
+                  "clusterNotFoundResponseCode": "INTERNAL_SERVER_ERROR",
+                  "idleTimeout": "5s",
+                  "weightedClusters": {
+                    "clusters": [
+                      {
+                        "name": "envoyconfig-builtingateway_echo-service__kuma-3_msvc_80-3e607e0fbdf6b9a2",
+                        "requestHeadersToAdd": [
+                          {
+                            "header": {
+                              "key": "x-kuma-tags",
+                              "value": "\u0026kuma.io/service=gateway-proxy\u0026\u0026kuma.io/zone=kuma-3\u0026"
+                            }
+                          }
+                        ],
+                        "weight": 1
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "match": {
+                  "prefix": "/"
+                },
+                "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
+                "route": {
+                  "clusterNotFoundResponseCode": "INTERNAL_SERVER_ERROR",
+                  "idleTimeout": "5s",
+                  "weightedClusters": {
+                    "clusters": [
+                      {
+                        "name": "envoyconfig-builtingateway_echo-service__kuma-3_msvc_80-3e607e0fbdf6b9a2",
+                        "requestHeadersToAdd": [
+                          {
+                            "header": {
+                              "key": "x-kuma-tags",
+                              "value": "\u0026kuma.io/service=gateway-proxy\u0026\u0026kuma.io/zone=kuma-3\u0026"
+                            }
+                          }
+                        ],
+                        "weight": 1
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret": {
+      "identity_cert:secret:envoyconfig-builtingateway": {
+        "name": "identity_cert:secret:envoyconfig-builtingateway",
+        "tlsCertificate": {
+          "certificateChain": {
+            "inlineBytes": "Q0VSVA=="
+          },
+          "privateKey": {
+            "inlineBytes": "S0VZ"
+          }
+        }
+      },
+      "mesh_ca:secret:envoyconfig-builtingateway": {
+        "name": "mesh_ca:secret:envoyconfig-builtingateway",
+        "validationContext": {
+          "trustedCa": {
+            "inlineBytes": "Q0E="
+          }
+        }
+      }
+    },
+    "type.googleapis.com/envoy.service.runtime.v3.Runtime": {
+      "gateway.listeners": {
+        "layer": {},
+        "name": "gateway.listeners"
+      }
+    }
+  }
+}

--- a/test/e2e_env/universal/envoyconfig/testdata/builtingateway/meshaccesslog/mt-with-to.input.yaml
+++ b/test/e2e_env/universal/envoyconfig/testdata/builtingateway/meshaccesslog/mt-with-to.input.yaml
@@ -1,0 +1,33 @@
+type: MeshAccessLog
+name: mt-1
+mesh: envoyconfig-builtingateway
+labels:
+  kuma.io/effect: shadow
+spec:
+  targetRef:
+    kind: Mesh
+    proxyTypes:
+      - Gateway
+  to:
+    - targetRef:
+        kind: Mesh
+      default:
+        backends:
+          - type: File
+            file:
+              path: "/dev/stdout"
+              format:
+                type: Json
+                json:
+                  - key: Source
+                    value: '%%KUMA_SOURCE_SERVICE%%'
+                  - key: Destination
+                    value: '%%KUMA_DESTINATION_SERVICE%%'
+                  - key: Start
+                    value: '%%START_TIME(%%s)%%'
+                  - key: HeaderCamel
+                    value: '%%REQ(X-Test)%%'
+                  - key: HeaderLower
+                    value: '%%REQ(x-test)%%'
+                  - key: HeaderCrazy
+                    value: '%%REQ(X-TeSt)%%'


### PR DESCRIPTION
## Motivation
We need more tests before we add rules api to MeshAccessLog selecting gateway

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
