### PR TITLE
test(e2e): changed MeshGatewayRoute to MeshHTTPRoute

### DIFF
--- a/test/e2e_env/universal/gateway/cross-mesh.go
+++ b/test/e2e_env/universal/gateway/cross-mesh.go
@@ -48,9 +48,9 @@ func CrossMeshGatewayOnUniversal() {
 	)
 	crossMeshGatewayDataplane := mkGatewayDataplane(crossMeshGatewayName, gatewayMesh, crossMeshGatewayName)
 	edgeGatewayYaml := MkGateway(
-		edgeGatewayName, gatewayOtherMesh, crossMeshGatewayName, false, "", echoServerName(gatewayOtherMesh), edgeGatewayPort,
+		edgeGatewayName, gatewayOtherMesh, edgeGatewayName, false, "", echoServerName(gatewayOtherMesh), edgeGatewayPort,
 	)
-	edgeGatewayDataplane := mkGatewayDataplane(edgeGatewayName, gatewayOtherMesh, crossMeshGatewayName)
+	edgeGatewayDataplane := mkGatewayDataplane(edgeGatewayName, gatewayOtherMesh, edgeGatewayName)
 
 	BeforeAll(func() {
 		By("installing one cross-mesh gateway and one non-cross-mesh gateway")

--- a/test/e2e_env/universal/gateway/gateway.go
+++ b/test/e2e_env/universal/gateway/gateway.go
@@ -97,22 +97,26 @@ networking:
 			Expect(universal.Cluster.Install(TrafficPermissionUniversal(mesh))).To(Succeed())
 			Expect(
 				universal.Cluster.Install(YamlUniversal(fmt.Sprintf(`
-type: MeshGatewayRoute
-mesh: %s
+type: MeshHTTPRoute
 name: external-routes
-selectors:
-- match:
-    kuma.io/service: gateway-proxy
-conf:
-  http:
+mesh: %s
+spec:
+  targetRef:
+    kind: MeshGateway
+    name: gateway-proxy
+  to:
+  - targetRef:
+      kind: Mesh
     rules:
     - matches:
       - path:
-          match: PREFIX
-          value: /external
-      backends:
-      - destination:
-          kuma.io/service: external-echo
+          type: PathPrefix
+          value: "/external"
+      default:
+        backendRefs:
+        - kind: MeshService
+          name: external-echo
+          weight: 100
 `, mesh))),
 			).To(Succeed())
 		})

--- a/test/e2e_env/universal/gateway/utils.go
+++ b/test/e2e_env/universal/gateway/utils.go
@@ -101,23 +101,27 @@ conf:
 `, name, mesh, serviceName, port, crossMesh, hostname)
 
 	route := fmt.Sprintf(`
-type: MeshGatewayRoute
+type: MeshHTTPRoute
 name: %s
 mesh: %s
-selectors:
-- match:
-    kuma.io/service: %s
-conf:
-  http:
+spec:
+  targetRef:
+    kind: MeshGateway
+    name: %s
+  to:
+  - targetRef:
+      kind: Mesh
     rules:
     - matches:
       - path:
-          match: PREFIX
-          value: /
-      backends:
-      - destination:
-          kuma.io/service: %s
-`, name, mesh, serviceName, backendService)
+          type: PathPrefix
+          value: "/"
+      default:
+        backendRefs:
+        - kind: MeshService
+          name: %s
+          weight: 100
+`, name, mesh, name, backendService)
 
 	return strings.Join([]string{meshGateway, route}, "\n---\n")
 }

--- a/test/e2e_env/universal/observability/meshtrace.go
+++ b/test/e2e_env/universal/observability/meshtrace.go
@@ -50,8 +50,8 @@ func PluginTest() {
 			Install(MeshUniversal(mesh)).
 			Install(TestServerUniversal("test-server", mesh, WithArgs([]string{"echo", "--instance", "universal1"}))).
 			Install(DemoClientUniversal(AppModeDemoClient, mesh, WithTransparentProxy(true))).
-			Install(GatewayProxyUniversal(mesh, "edge-gateway")).
-			Install(YamlUniversal(gateway.MkGateway("edge-gateway", mesh, "edge-gateway", false, "example.kuma.io", "test-server", 8080))).
+			Install(GatewayProxyUniversal(mesh, "trace-edge-gateway")).
+			Install(YamlUniversal(gateway.MkGateway("trace-edge-gateway", mesh, "trace-edge-gateway", false, "example.kuma.io", "test-server", 8080))).
 			Install(gateway.GatewayClientAppUniversal("gateway-client")).
 			Setup(universal.Cluster)
 		obsClient = obs.From(obsDeployment, universal.Cluster)
@@ -97,9 +97,9 @@ func PluginTest() {
 
 		Eventually(func(g Gomega) {
 			gateway.ProxySimpleRequests(universal.Cluster, "universal1",
-				GatewayAddressPort("edge-gateway", 8080), "example.kuma.io")(g)
+				GatewayAddressPort("trace-edge-gateway", 8080), "example.kuma.io")(g)
 			g.Expect(obsClient.TracedServices()).Should(ContainElements([]string{
-				"edge-gateway",
+				"trace-edge-gateway",
 				"jaeger-query",
 				"test-server",
 			}))


### PR DESCRIPTION
## Motivation

MeshGatewayRoute is deprecated in favor of MeshHTTPRoute.

Fix: https://github.com/kumahq/kuma/issues/12763
