### PR TITLE
feat(MeshTLS): meshTLS should configure gateway when rules api is used

### DIFF
--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin.go
@@ -18,7 +18,6 @@ import (
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/matchers"
 	core_rules "github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
 	rules_inbound "github.com/kumahq/kuma/pkg/plugins/policies/core/rules/inbound"
-	"github.com/kumahq/kuma/pkg/plugins/policies/core/rules/subsetutils"
 	policies_xds "github.com/kumahq/kuma/pkg/plugins/policies/core/xds"
 	api "github.com/kumahq/kuma/pkg/plugins/policies/meshtls/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/util/pointer"
@@ -160,15 +159,12 @@ func applyToGateways(
 			continue
 		}
 		// there is only one rule always because we're in `Mesh/Mesh`
-		var conf *api.Conf
-		for _, r := range gatewayRules.FromRules {
-			conf = core_rules.ComputeConf[api.Conf](r, subsetutils.MeshElement())
+		var conf api.Conf
+		for _, r := range gatewayRules.InboundRules {
+			conf = rules_inbound.MatchesAllIncomingTraffic[api.Conf](r)
 			break
 		}
-		if conf == nil {
-			continue
-		}
-		if err := configureParams(*conf, cluster); err != nil {
+		if err := configureParams(conf, cluster); err != nil {
 			return err
 		}
 	}

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin_test.go
@@ -415,24 +415,24 @@ func getFromRules(froms []api.From) core_rules.FromRules {
 
 func getGatewayRules(froms []api.From) core_rules.GatewayRules {
 	var rules []*core_rules.Rule
+	var confs []interface{}
 
 	for _, from := range froms {
 		rules = append(rules, &core_rules.Rule{
 			Subset: subsetutils.Subset{},
 			Conf:   from.Default,
 		})
+		confs = append(confs, from.Default)
 	}
 
 	return core_rules.GatewayRules{
 		FromRules: map[core_rules.InboundListener]core_rules.Rules{
-			{
-				Address: "127.0.0.1",
-				Port:    17777,
-			}: rules,
-			{
-				Address: "127.0.0.1",
-				Port:    17778,
-			}: rules,
+			{Address: "127.0.0.1", Port: 17777}: rules,
+			{Address: "127.0.0.1", Port: 17778}: rules,
+		},
+		InboundRules: map[core_rules.InboundListener][]*inbound.Rule{
+			{Address: "127.0.0.1", Port: 17777}: {{Conf: confs}},
+			{Address: "127.0.0.1", Port: 17778}: {{Conf: confs}},
 		},
 	}
 }


### PR DESCRIPTION
## Motivation

We need to properly configure gateway when MeshTLS with new rules api is used

Fix #12819

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
