### PR TITLE
fix(e2e): use eventually on envoy config comparison as some resources may not be present on first check

### DIFF
--- a/test/e2e_env/universal/envoyconfig/builtingateway.go
+++ b/test/e2e_env/universal/envoyconfig/builtingateway.go
@@ -132,7 +132,9 @@ spec:
 			}
 
 			// then
-			Expect(getConfig(mesh, "gateway-proxy")).To(matchers.MatchGoldenJSON(strings.Replace(inputFile, "input.yaml", "gateway-proxy.golden.json", 1)))
+			Eventually(func(g Gomega) {
+				g.Expect(getConfig(mesh, "gateway-proxy")).To(matchers.MatchGoldenJSON(strings.Replace(inputFile, "input.yaml", "gateway-proxy.golden.json", 1)))
+			}).Should(Succeed())
 		},
 		test.EntriesForFolder(filepath.Join("builtingateway", "meshaccesslog"), "envoyconfig"),
 		test.EntriesForFolder(filepath.Join("builtingateway", "meshtls"), "envoyconfig"),

--- a/test/e2e_env/universal/envoyconfig/sidecars.go
+++ b/test/e2e_env/universal/envoyconfig/sidecars.go
@@ -88,8 +88,10 @@ func Sidecars() {
 			}
 
 			// then
-			Expect(getConfig(meshName, "demo-client")).To(matchers.MatchGoldenJSON(strings.Replace(inputFile, "input.yaml", "demo-client.golden.json", 1)))
-			Expect(getConfig(meshName, "test-server")).To(matchers.MatchGoldenJSON(strings.Replace(inputFile, "input.yaml", "test-server.golden.json", 1)))
+			Eventually(func(g Gomega) {
+				g.Expect(getConfig(meshName, "demo-client")).To(matchers.MatchGoldenJSON(strings.Replace(inputFile, "input.yaml", "demo-client.golden.json", 1)))
+				g.Expect(getConfig(meshName, "test-server")).To(matchers.MatchGoldenJSON(strings.Replace(inputFile, "input.yaml", "test-server.golden.json", 1)))
+			}).Should(Succeed())
 		},
 		test.EntriesForFolder(filepath.Join("sidecars", "meshtimeout"), "envoyconfig"),
 		test.EntriesForFolder(filepath.Join("sidecars", "meshaccesslog"), "envoyconfig"),


### PR DESCRIPTION
## Motivation
This should fix flaky test where endpoints are missing in xds config

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
