### PR TITLE
feat(api-server): add support for label filters

### DIFF
--- a/api/mesh/v1alpha1/mesh/rest.yaml
+++ b/api/mesh/v1alpha1/mesh/rest.yaml
@@ -82,6 +82,20 @@ paths:
       operationId: getMeshList
       summary: Returns a list of Mesh in the mesh.
       tags: [ "Mesh" ]
+      parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
       responses:
         '200':
           $ref: "#/components/responses/MeshList"

--- a/api/mesh/v1alpha1/meshgateway/rest.yaml
+++ b/api/mesh/v1alpha1/meshgateway/rest.yaml
@@ -101,6 +101,19 @@ paths:
       summary: Returns a list of MeshGateway in the mesh.
       tags: [ "MeshGateway" ]
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -331,6 +331,19 @@ paths:
       tags:
         - MeshAccessLog
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:
@@ -438,6 +451,19 @@ paths:
       tags:
         - MeshCircuitBreaker
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:
@@ -545,6 +571,19 @@ paths:
       tags:
         - MeshFaultInjection
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:
@@ -652,6 +691,19 @@ paths:
       tags:
         - MeshHealthCheck
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:
@@ -759,6 +811,19 @@ paths:
       tags:
         - MeshHTTPRoute
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:
@@ -867,6 +932,19 @@ paths:
       tags:
         - MeshLoadBalancingStrategy
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:
@@ -972,6 +1050,19 @@ paths:
       tags:
         - MeshMetric
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:
@@ -1079,6 +1170,19 @@ paths:
       tags:
         - MeshPassthrough
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:
@@ -1186,6 +1290,19 @@ paths:
       tags:
         - MeshProxyPatch
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:
@@ -1293,6 +1410,19 @@ paths:
       tags:
         - MeshRateLimit
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:
@@ -1398,6 +1528,19 @@ paths:
       tags:
         - MeshRetry
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:
@@ -1503,6 +1646,19 @@ paths:
       tags:
         - MeshTCPRoute
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:
@@ -1608,6 +1764,19 @@ paths:
       tags:
         - MeshTimeout
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:
@@ -1713,6 +1882,19 @@ paths:
       tags:
         - MeshTLS
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:
@@ -1818,6 +2000,19 @@ paths:
       tags:
         - MeshTrace
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:
@@ -1926,6 +2121,19 @@ paths:
       tags:
         - MeshTrafficPermission
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:
@@ -2012,6 +2220,20 @@ paths:
       summary: Returns a list of Mesh in the mesh.
       tags:
         - Mesh
+      parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
       responses:
         '200':
           $ref: '#/components/responses/MeshList'
@@ -2111,6 +2333,19 @@ paths:
       tags:
         - MeshGateway
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:
@@ -2199,6 +2434,20 @@ paths:
       summary: Returns a list of HostnameGenerator in the mesh.
       tags:
         - HostnameGenerator
+      parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
       responses:
         '200':
           $ref: '#/components/responses/HostnameGeneratorList'
@@ -2300,6 +2549,19 @@ paths:
       tags:
         - MeshExternalService
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:
@@ -2407,6 +2669,19 @@ paths:
       tags:
         - MeshMultiZoneService
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:
@@ -2512,6 +2787,19 @@ paths:
       tags:
         - MeshService
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:

--- a/pkg/api-server/filters/filtering.go
+++ b/pkg/api-server/filters/filtering.go
@@ -13,12 +13,81 @@ import (
 	"github.com/kumahq/kuma/pkg/core/validators"
 )
 
+type FilterOp string
+
+const (
+	FilterOpEq FilterOp = "eq"
+)
+
+type filterEntry struct {
+	Op    FilterOp
+	Key   string
+	Value string
+}
+
+// labelFilter returns a store filter that filters resources based on their labels.
+// the end goal is to support https://kong-aip.netlify.app/aip/160/ which is a standard for filtering resources
+// but atm we only support eq operation with exact match
+func labelFilter(request *restful.Request) (store.ListFilterFunc, error) {
+	verr := &validators.ValidationError{}
+	filters := make([]filterEntry, 0)
+	for k, v := range request.Request.URL.Query() {
+		if !strings.HasPrefix(k, "filter[") {
+			continue
+		}
+		if !strings.HasPrefix(k, "filter[labels.") {
+			verr.AddViolationAt(
+				validators.RootedAt(request.SelectedRoutePath()).Field(k), "filters are only supported on labels")
+			continue
+		}
+		closingBracket := strings.Index(k, "]")
+		key := k[len("filter[labels."):closingBracket]
+		if closingBracket != len(k)-1 {
+			verr.AddViolationAt(
+				validators.RootedAt(request.SelectedRoutePath()).Field(k), "advanced filters are not supported")
+			continue
+		}
+		op := FilterOpEq
+		filters = append(filters, filterEntry{
+			Op:    op,
+			Key:   key,
+			Value: v[len(v)-1],
+		})
+	}
+	if verr.HasViolations() {
+		return nil, verr
+	}
+	if len(filters) == 0 {
+		return nil, nil
+	}
+	return func(rs core_model.Resource) bool {
+		labels := rs.GetMeta().GetLabels()
+		for _, filter := range filters {
+			v, ok := labels[filter.Key]
+			switch filter.Op {
+			case FilterOpEq:
+				if !ok || v != filter.Value {
+					return false
+				}
+			}
+			if !ok || v != filter.Value {
+				return false
+			}
+		}
+		return true
+	}, nil
+}
+
 // Resource return a store filter depending on the resource. We take a descriptor so that we can do advance filtering options
 // For example we could make a filter that works on top level targetRef by looking at the descriptor info
 func Resource(resDescriptor core_model.ResourceTypeDescriptor) func(request *restful.Request) (store.ListFilterFunc, error) {
-	switch resDescriptor.Name {
-	case mesh.DataplaneType:
-		return func(request *restful.Request) (store.ListFilterFunc, error) {
+	return func(request *restful.Request) (store.ListFilterFunc, error) {
+		genericFilter, err := labelFilter(request)
+		if err != nil {
+			return nil, err
+		}
+		switch resDescriptor.Name {
+		case mesh.DataplaneType:
 			gatewayFilter, err := gatewayModeFilterFromParameter(request)
 			if err != nil {
 				return nil, err
@@ -27,6 +96,9 @@ func Resource(resDescriptor core_model.ResourceTypeDescriptor) func(request *res
 			tags := parseTags(request.QueryParameters("tag"))
 
 			return func(rs core_model.Resource) bool {
+				if genericFilter != nil && !genericFilter(rs) {
+					return false
+				}
 				dataplane, ok := rs.(*mesh.DataplaneResource)
 				if !ok { // Sometimes this is going to return insights for example which will not match
 					return true
@@ -41,18 +113,17 @@ func Resource(resDescriptor core_model.ResourceTypeDescriptor) func(request *res
 
 				return true
 			}, nil
-		}
-	case mesh.ExternalServiceType:
-		return func(request *restful.Request) (store.ListFilterFunc, error) {
+		case mesh.ExternalServiceType:
 			tags := parseTags(request.QueryParameters("tag"))
 
 			return func(rs core_model.Resource) bool {
+				if genericFilter != nil && !genericFilter(rs) {
+					return false
+				}
 				return rs.(*mesh.ExternalServiceResource).Spec.MatchTagsFuzzy(tags)
 			}, nil
-		}
-	default:
-		return func(request *restful.Request) (store.ListFilterFunc, error) {
-			return nil, nil
+		default:
+			return genericFilter, nil
 		}
 	}
 }

--- a/pkg/api-server/testdata/resources/crud/list_dp_with_label_filter.golden.json
+++ b/pkg/api-server/testdata/resources/crud/list_dp_with_label_filter.golden.json
@@ -1,0 +1,27 @@
+{
+ "total": 1,
+ "items": [
+  {
+   "type": "Dataplane",
+   "mesh": "default",
+   "name": "dp-1",
+   "creationTime": "0001-01-01T00:00:00Z",
+   "modificationTime": "0001-01-01T00:00:00Z",
+   "labels": {
+    "k8s.kuma.io/namespace": "ns1"
+   },
+   "networking": {
+    "address": "10.1.2.1",
+    "inbound": [
+     {
+      "port": 1234,
+      "tags": {
+       "kuma.io/service": "my-svc"
+      }
+     }
+    ]
+   }
+  }
+ ],
+ "next": null
+}

--- a/pkg/api-server/testdata/resources/crud/list_dp_with_label_filter.input.yaml
+++ b/pkg/api-server/testdata/resources/crud/list_dp_with_label_filter.input.yaml
@@ -1,0 +1,40 @@
+#/meshes/default/dataplanes?filter[labels.k8s.kuma.io/namespace]=ns1 200
+type: Mesh
+name: default
+---
+type: Dataplane
+mesh: default
+name: dp-1
+labels:
+    k8s.kuma.io/namespace: ns1
+networking:
+  address: 10.1.2.1
+  inbound:
+    - port: 1234
+      tags:
+        kuma.io/service: my-svc
+---
+type: Dataplane
+mesh: default
+name: dp-2
+labels:
+  k8s.kuma.io/namespace: ns2
+networking:
+  address: 10.1.2.2
+  inbound:
+    - port: 1232
+      tags:
+        kuma.io/service: other-svc
+    - port: 1234
+      tags:
+        kuma.io/service: my-svc
+---
+type: Dataplane
+mesh: default
+name: dp-3
+networking:
+  address: 10.1.2.3
+  inbound:
+    - port: 1234
+      tags:
+        kuma.io/service: other-svc

--- a/pkg/api-server/testdata/resources/crud/list_dp_with_label_filter_bad.golden.json
+++ b/pkg/api-server/testdata/resources/crud/list_dp_with_label_filter_bad.golden.json
@@ -1,0 +1,19 @@
+{
+ "type": "/std-errors",
+ "status": 400,
+ "title": "Could not retrieve resources",
+ "detail": "Resource is not valid",
+ "invalid_parameters": [
+  {
+   "field": "/meshes/{mesh}/dataplanes.filter[labelds.k8s.kuma.io/namespace]",
+   "reason": "filters are only supported on labels"
+  }
+ ],
+ "details": "Resource is not valid",
+ "causes": [
+  {
+   "field": "/meshes/{mesh}/dataplanes.filter[labelds.k8s.kuma.io/namespace]",
+   "message": "filters are only supported on labels"
+  }
+ ]
+}

--- a/pkg/api-server/testdata/resources/crud/list_dp_with_label_filter_bad.input.yaml
+++ b/pkg/api-server/testdata/resources/crud/list_dp_with_label_filter_bad.input.yaml
@@ -1,0 +1,3 @@
+#/meshes/default/dataplanes?filter[labelds.k8s.kuma.io/namespace]=ns1 400
+type: Mesh
+name: default

--- a/pkg/api-server/testdata/resources/crud/list_dp_with_label_filter_op_unsupported.golden.json
+++ b/pkg/api-server/testdata/resources/crud/list_dp_with_label_filter_op_unsupported.golden.json
@@ -1,0 +1,19 @@
+{
+ "type": "/std-errors",
+ "status": 400,
+ "title": "Could not retrieve resources",
+ "detail": "Resource is not valid",
+ "invalid_parameters": [
+  {
+   "field": "/meshes/{mesh}/dataplanes.filter[labels.k8s.kuma.io/namespace][eq]",
+   "reason": "advanced filters are not supported"
+  }
+ ],
+ "details": "Resource is not valid",
+ "causes": [
+  {
+   "field": "/meshes/{mesh}/dataplanes.filter[labels.k8s.kuma.io/namespace][eq]",
+   "message": "advanced filters are not supported"
+  }
+ ]
+}

--- a/pkg/api-server/testdata/resources/crud/list_dp_with_label_filter_op_unsupported.input.yaml
+++ b/pkg/api-server/testdata/resources/crud/list_dp_with_label_filter_op_unsupported.input.yaml
@@ -1,0 +1,3 @@
+#/meshes/default/dataplanes?filter[labels.k8s.kuma.io/namespace][eq]=ns1 400
+type: Mesh
+name: default

--- a/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/rest.yaml
@@ -82,6 +82,20 @@ paths:
       operationId: getHostnameGeneratorList
       summary: Returns a list of HostnameGenerator in the mesh.
       tags: [ "HostnameGenerator" ]
+      parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
       responses:
         '200':
           $ref: "#/components/responses/HostnameGeneratorList"

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/rest.yaml
@@ -101,6 +101,19 @@ paths:
       summary: Returns a list of MeshExternalService in the mesh.
       tags: [ "MeshExternalService" ]
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:

--- a/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/rest.yaml
@@ -101,6 +101,19 @@ paths:
       summary: Returns a list of MeshMultiZoneService in the mesh.
       tags: [ "MeshMultiZoneService" ]
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/rest.yaml
@@ -101,6 +101,19 @@ paths:
       summary: Returns a list of MeshService in the mesh.
       tags: [ "MeshService" ]
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:

--- a/pkg/core/resources/store/options.go
+++ b/pkg/core/resources/store/options.go
@@ -175,6 +175,7 @@ func (g *GetOptions) HashCode() string {
 }
 
 type (
+	// ListFilterFunc returns true if the item passes the filtering criteria
 	ListFilterFunc func(rs core_model.Resource) bool
 )
 

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/rest.yaml
@@ -101,6 +101,19 @@ paths:
       summary: Returns a list of MeshAccessLog in the mesh.
       tags: [ "MeshAccessLog" ]
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/rest.yaml
@@ -101,6 +101,19 @@ paths:
       summary: Returns a list of MeshCircuitBreaker in the mesh.
       tags: [ "MeshCircuitBreaker" ]
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/rest.yaml
@@ -101,6 +101,19 @@ paths:
       summary: Returns a list of MeshFaultInjection in the mesh.
       tags: [ "MeshFaultInjection" ]
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/rest.yaml
@@ -101,6 +101,19 @@ paths:
       summary: Returns a list of MeshHealthCheck in the mesh.
       tags: [ "MeshHealthCheck" ]
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/rest.yaml
@@ -101,6 +101,19 @@ paths:
       summary: Returns a list of MeshHTTPRoute in the mesh.
       tags: [ "MeshHTTPRoute" ]
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/rest.yaml
@@ -101,6 +101,19 @@ paths:
       summary: Returns a list of MeshLoadBalancingStrategy in the mesh.
       tags: [ "MeshLoadBalancingStrategy" ]
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/rest.yaml
@@ -101,6 +101,19 @@ paths:
       summary: Returns a list of MeshMetric in the mesh.
       tags: [ "MeshMetric" ]
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:

--- a/pkg/plugins/policies/meshpassthrough/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshpassthrough/api/v1alpha1/rest.yaml
@@ -101,6 +101,19 @@ paths:
       summary: Returns a list of MeshPassthrough in the mesh.
       tags: [ "MeshPassthrough" ]
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:

--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/rest.yaml
@@ -101,6 +101,19 @@ paths:
       summary: Returns a list of MeshProxyPatch in the mesh.
       tags: [ "MeshProxyPatch" ]
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/rest.yaml
@@ -101,6 +101,19 @@ paths:
       summary: Returns a list of MeshRateLimit in the mesh.
       tags: [ "MeshRateLimit" ]
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/rest.yaml
@@ -101,6 +101,19 @@ paths:
       summary: Returns a list of MeshRetry in the mesh.
       tags: [ "MeshRetry" ]
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/rest.yaml
@@ -101,6 +101,19 @@ paths:
       summary: Returns a list of MeshTCPRoute in the mesh.
       tags: [ "MeshTCPRoute" ]
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/rest.yaml
@@ -101,6 +101,19 @@ paths:
       summary: Returns a list of MeshTimeout in the mesh.
       tags: [ "MeshTimeout" ]
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:

--- a/pkg/plugins/policies/meshtls/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtls/api/v1alpha1/rest.yaml
@@ -101,6 +101,19 @@ paths:
       summary: Returns a list of MeshTLS in the mesh.
       tags: [ "MeshTLS" ]
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/rest.yaml
@@ -101,6 +101,19 @@ paths:
       summary: Returns a list of MeshTrace in the mesh.
       tags: [ "MeshTrace" ]
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:

--- a/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/rest.yaml
@@ -101,6 +101,19 @@ paths:
       summary: Returns a list of MeshTrafficPermission in the mesh.
       tags: [ "MeshTrafficPermission" ]
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
         - in: path
           name: mesh
           schema:

--- a/tools/openapi/templates/endpoints.yaml
+++ b/tools/openapi/templates/endpoints.yaml
@@ -106,8 +106,21 @@ paths:
       operationId: get{{ .Name }}List
       summary: Returns a list of {{ .Name }} in the mesh.
       tags: [ "{{ .Name }}" ]
-      {{- if eq .Scope "Mesh"}}
       parameters:
+        - in: query
+          name: filter
+          description: filter by labels when multiple filters are present, they are ANDed
+          required: false
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+          example:
+            label.k8s.kuma.io/namespace: my-ns
+      {{- if eq .Scope "Mesh"}}
         - in: path
           name: mesh
           schema:


### PR DESCRIPTION
## Motivation

We now have labels on all our entities. Some of these labels are very useful (kuma.io/zone for example).
We should be able to use it when filtering api responses.

## Implementation information

Support a basic subset of https://kong-aip.netlify.app/aip/160/ only for labels.

This works for all resource types and while a little costly it should suffice for GUI and kumactl use cases

## Supporting documentation

Fix #12809