### PR TITLE
test(e2e): configure kic to watch specific namespace

### DIFF
--- a/test/framework/deployments/kic/kubernetes.go
+++ b/test/framework/deployments/kic/kubernetes.go
@@ -37,7 +37,7 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 	_, err = helm.RunHelmCommandAndGetStdOutE(cluster.GetTesting(), &opts, "install", t.name,
 		"--namespace", t.ingressNamespace,
 		"--repo", "https://charts.konghq.com",
-		"--set", "controller.ingressController.watchNamespaces="+t.ingressNamespace,
+		"--set", "controller.ingressController.watchNamespaces={"+t.ingressNamespace+"}",
 		"--set", "controller.ingressController.ingressClass="+t.name,
 		"--set", "controller.podAnnotations.kuma\\.io/mesh="+t.mesh,
 		"--set", "gateway.podAnnotations.kuma\\.io/mesh="+t.mesh,

--- a/test/framework/deployments/kic/kubernetes.go
+++ b/test/framework/deployments/kic/kubernetes.go
@@ -37,7 +37,7 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 	_, err = helm.RunHelmCommandAndGetStdOutE(cluster.GetTesting(), &opts, "install", t.name,
 		"--namespace", t.ingressNamespace,
 		"--repo", "https://charts.konghq.com",
-		"--set", "controller.ingressController.watchNamespace="+t.ingressNamespace,
+		"--set", "controller.ingressController.watchNamespaces="+t.ingressNamespace,
 		"--set", "controller.ingressController.ingressClass="+t.name,
 		"--set", "controller.podAnnotations.kuma\\.io/mesh="+t.mesh,
 		"--set", "gateway.podAnnotations.kuma\\.io/mesh="+t.mesh,

--- a/test/framework/deployments/kic/kubernetes.go
+++ b/test/framework/deployments/kic/kubernetes.go
@@ -37,6 +37,7 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 	_, err = helm.RunHelmCommandAndGetStdOutE(cluster.GetTesting(), &opts, "install", t.name,
 		"--namespace", t.ingressNamespace,
 		"--repo", "https://charts.konghq.com",
+		"--set", "controller.ingressController.watchNamespace="+t.ingressNamespace,
 		"--set", "controller.ingressController.ingressClass="+t.name,
 		"--set", "controller.podAnnotations.kuma\\.io/mesh="+t.mesh,
 		"--set", "gateway.podAnnotations.kuma\\.io/mesh="+t.mesh,


### PR DESCRIPTION
## Motivation

Noticed a flake https://github.com/kumahq/kuma/actions/runs/13278477384/job/37072625102

## Implementation information

While investigating a debug package, I noticed the following error:
```
2025-02-12T05:36:51Z	error	controllers.Gateway	Reconciler error	{"reconcileID": "0c64b565-7733-4f48-b2ca-976f28c2cbad", "error": "publish service reference \"kic/kic-gateway-proxy\" from Gateway's annotations did not match configured controller manager's publish services (\"delegated-gateway-ms/delegated-gateway-ms-gateway-proxy\")"}
```
This indicated that changes from another test case were affecting the results of a different test. Upon investigation, I found that we had not configured the `watchNamespaces` parameter, causing KIC to react to changes from all namespaces. I added a configuration to restrict it to the ingress namespace, as we run and apply resources only within this namespace.
