### PR TITLE
fix(kds): add all valid resources and skip only not valid (backport #12776)

### DIFF
--- a/pkg/core/resources/model/resource.go
+++ b/pkg/core/resources/model/resource.go
@@ -750,6 +750,14 @@ func IndexByKey[T Resource](resources []T) map[ResourceKey]T {
 	return indexedResources
 }
 
+func IndexKeys(keys []ResourceKey) map[ResourceKey]struct{} {
+	indexedKeys := make(map[ResourceKey]struct{})
+	for _, key := range keys {
+		indexedKeys[key] = struct{}{}
+	}
+	return indexedKeys
+}
+
 // Resource can implement defaulter to provide static default fields.
 // Kubernetes Webhook and Resource Manager will make sure that Default() is called before Create/Update
 type Defaulter interface {

--- a/pkg/kds/v2/client/kds_client.go
+++ b/pkg/kds/v2/client/kds_client.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	std_errors "errors"
 	"io"
 	"time"
 
@@ -15,6 +16,7 @@ type UpstreamResponse struct {
 	ControlPlaneId      string
 	Type                model.ResourceType
 	AddedResources      model.ResourceList
+	InvalidResourcesKey []model.ResourceKey
 	RemovedResourcesKey []model.ResourceKey
 	IsInitialRequest    bool
 }
@@ -23,12 +25,14 @@ func (u *UpstreamResponse) Validate() error {
 	if u.AddedResources == nil {
 		return nil
 	}
+	var err error
 	for _, res := range u.AddedResources.GetItems() {
-		if err := model.Validate(res); err != nil {
-			return err
+		if validationErr := model.Validate(res); validationErr != nil {
+			err = std_errors.Join(err, validationErr)
+			u.InvalidResourcesKey = append(u.InvalidResourcesKey, core_model.MetaToResourceKey(res.GetMeta()))
 		}
 	}
-	return nil
+	return err
 }
 
 type Callbacks struct {
@@ -88,19 +92,19 @@ func (s *kdsSyncClient) Receive() error {
 			return errors.Wrap(err, "failed to receive a discovery response")
 		}
 		s.log.V(1).Info("DeltaDiscoveryResponse received", "response", received)
-
-		if err := received.Validate(); err != nil {
-			s.log.Info("received resource is invalid, sending NACK", "err", err)
-			if err := s.kdsStream.NACK(received.Type, err); err != nil {
-				if err == io.EOF {
-					return nil
-				}
-				return errors.Wrap(err, "failed to NACK a discovery response")
-			}
-			continue
-		}
+		validationErrors := received.Validate()
 
 		if s.callbacks == nil {
+			if validationErrors != nil {
+				s.log.Info("received resource is invalid, sending NACK", "err", validationErrors)
+				if err := s.kdsStream.NACK(received.Type, validationErrors); err != nil {
+					if err == io.EOF {
+						return nil
+					}
+					return errors.Wrap(err, "failed to NACK a discovery response")
+				}
+				continue
+			}
 			s.log.Info("no callback set, sending ACK", "type", string(received.Type))
 			if err := s.kdsStream.ACK(received.Type); err != nil {
 				if err == io.EOF {
@@ -113,6 +117,16 @@ func (s *kdsSyncClient) Receive() error {
 		err = s.callbacks.OnResourcesReceived(received)
 		if err != nil {
 			return errors.Wrapf(err, "failed to store %s resources", received.Type)
+		}
+		if validationErrors != nil {
+			s.log.Info("received resource is invalid, sending NACK", "err", validationErrors)
+			if err := s.kdsStream.NACK(received.Type, validationErrors); err != nil {
+				if err == io.EOF {
+					return nil
+				}
+				return errors.Wrap(err, "failed to NACK a discovery response")
+			}
+			continue
 		}
 		if !received.IsInitialRequest {
 			// Execute backoff only on subsequent request.

--- a/pkg/kds/v2/store/sync.go
+++ b/pkg/kds/v2/store/sync.go
@@ -118,6 +118,7 @@ func (s *syncResourceStore) Sync(syncCtx context.Context, upstreamResponse clien
 	log = kuma_log.AddFieldsFromCtx(log, ctx, s.extensions)
 	upstream := upstreamResponse.AddedResources
 	downstream, err := registry.Global().NewList(upstreamResponse.Type)
+	indexedInvalidResources := model.IndexKeys(upstreamResponse.InvalidResourcesKey)
 	if err != nil {
 		return err
 	}
@@ -131,24 +132,40 @@ func (s *syncResourceStore) Sync(syncCtx context.Context, upstreamResponse clien
 			return err
 		}
 	}
+
+	filterResources := func(resources core_model.ResourceList, predicates []func(core_model.Resource) bool) (core_model.ResourceList, error) {
+		return filter(resources, func(r core_model.Resource) bool {
+			includeResource := true
+			for _, predicate := range predicates {
+				includeResource = includeResource && predicate(r)
+			}
+			return includeResource
+		})
+	}
+
+	isValidResource := func(r core_model.Resource) bool {
+		_, exists := indexedInvalidResources[model.MetaToResourceKey(r.GetMeta())]
+		return !exists
+	}
+
+	predicate := []func(r core_model.Resource) bool{isValidResource}
+	if opts.Predicate != nil {
+		predicate = append(predicate, opts.Predicate)
+	}
+
 	log.V(1).Info("before filtering", "downstream", downstream, "upstream", upstream)
 
-	if opts.Predicate != nil {
-		if filtered, err := filter(downstream, opts.Predicate); err != nil {
-			return err
-		} else {
-			downstream = filtered
-		}
-		if filtered, err := filter(upstream, opts.Predicate); err != nil {
-			return err
-		} else {
-			upstream = filtered
-		}
+	if downstream, err = filterResources(downstream, predicate); err != nil {
+		return err
 	}
+	if upstream, err = filterResources(upstream, predicate); err != nil {
+		return err
+	}
+
 	log.V(1).Info("after filtering", "downstream", downstream, "upstream", upstream)
 
-	indexedDownstream := newIndexed(downstream)
-	indexedUpstream := newIndexed(upstream)
+	indexedDownstream := model.IndexByKey(downstream.GetItems())
+	indexedUpstream := model.IndexByKey(upstream.GetItems())
 
 	onDelete := []core_model.Resource{}
 	// 1. delete resources which were removed from the upstream
@@ -159,18 +176,18 @@ func (s *syncResourceStore) Sync(syncCtx context.Context, upstreamResponse clien
 	// so we don't want to remove resources haven't changed.
 	if upstreamResponse.IsInitialRequest {
 		for _, r := range downstream.GetItems() {
-			if indexedUpstream.get(core_model.MetaToResourceKey(r.GetMeta())) == nil {
+			if indexedUpstream[core_model.MetaToResourceKey(r.GetMeta())] == nil {
 				onDelete = append(onDelete, r)
 			}
 		}
 	} else {
 		for _, rk := range upstreamResponse.RemovedResourcesKey {
 			// check if we are adding and removing the resource at the same time
-			if r := indexedUpstream.get(rk); r != nil {
+			if r := indexedUpstream[rk]; r != nil {
 				// it isn't remove but update
 				continue
 			}
-			if r := indexedDownstream.get(rk); r != nil {
+			if r := indexedDownstream[rk]; r != nil {
 				onDelete = append(onDelete, r)
 			}
 		}
@@ -180,7 +197,7 @@ func (s *syncResourceStore) Sync(syncCtx context.Context, upstreamResponse clien
 	onCreate := []core_model.Resource{}
 	onUpdate := []OnUpdate{}
 	for _, r := range upstream.GetItems() {
-		existing := indexedDownstream.get(core_model.MetaToResourceKey(r.GetMeta()))
+		existing := indexedDownstream[core_model.MetaToResourceKey(r.GetMeta())]
 		if existing == nil {
 			onCreate = append(onCreate, r)
 			continue
@@ -202,7 +219,6 @@ func (s *syncResourceStore) Sync(syncCtx context.Context, upstreamResponse clien
 			return err
 		}
 	}
-
 	return store.InTx(ctx, s.transactions, func(ctx context.Context) error {
 		for _, r := range onCreate {
 			rk := core_model.MetaToResourceKey(r.GetMeta())
@@ -260,22 +276,6 @@ func filter(rs core_model.ResourceList, predicate func(r core_model.Resource) bo
 		}
 	}
 	return rv, nil
-}
-
-type indexed struct {
-	indexByResourceKey map[core_model.ResourceKey]core_model.Resource
-}
-
-func (i *indexed) get(rk core_model.ResourceKey) core_model.Resource {
-	return i.indexByResourceKey[rk]
-}
-
-func newIndexed(rs core_model.ResourceList) *indexed {
-	idxByRk := map[core_model.ResourceKey]core_model.Resource{}
-	for _, r := range rs.GetItems() {
-		idxByRk[core_model.MetaToResourceKey(r.GetMeta())] = r
-	}
-	return &indexed{indexByResourceKey: idxByRk}
 }
 
 func ZoneSyncCallback(ctx context.Context, configToSync map[string]bool, syncer ResourceSyncer, k8sStore bool, localZone string, kubeFactory resources_k8s.KubeFactory, systemNamespace string) *client_v2.Callbacks {
@@ -338,6 +338,7 @@ func GlobalSyncCallback(
 			if !supportsHashSuffixes {
 				// todo: remove in 2 releases after 2.6.x
 				upstream.RemovedResourcesKey = util.AddPrefixToResourceKeyNames(upstream.RemovedResourcesKey, upstream.ControlPlaneId)
+				upstream.InvalidResourcesKey = util.AddPrefixToResourceKeyNames(upstream.InvalidResourcesKey, upstream.ControlPlaneId)
 				util.AddPrefixToNames(upstream.AddedResources.GetItems(), upstream.ControlPlaneId)
 			}
 
@@ -390,6 +391,7 @@ func addNamespaceSuffix(kubeFactory resources_k8s.KubeFactory, upstream client_v
 	if kubeObject.Scope() == k8s_model.ScopeNamespace {
 		util.AddSuffixToNames(upstream.AddedResources.GetItems(), ns)
 		upstream.RemovedResourcesKey = util.AddSuffixToResourceKeyNames(upstream.RemovedResourcesKey, ns)
+		upstream.InvalidResourcesKey = util.AddSuffixToResourceKeyNames(upstream.InvalidResourcesKey, ns)
 	}
 	return nil
 }

--- a/pkg/util/xds/logging_callbacks.go
+++ b/pkg/util/xds/logging_callbacks.go
@@ -2,6 +2,7 @@ package xds
 
 import (
 	"context"
+	"errors"
 
 	"github.com/go-logr/logr"
 )
@@ -51,7 +52,11 @@ func (cb LoggingCallbacks) OnDeltaStreamClosed(streamID int64) {
 // OnStreamDeltaRequest is called once a request is received on a stream.
 // Returning an error will end processing and close the stream. OnStreamDeltaRequest will still be called.
 func (cb LoggingCallbacks) OnStreamDeltaRequest(streamID int64, req DeltaDiscoveryRequest) error {
-	cb.Log.V(1).Info("OnStreamDeltaRequest", "streamid", streamID, "req", req)
+	if req.ErrorMsg() != "" {
+		cb.Log.Error(errors.New(req.ErrorMsg()), "OnStreamDeltaRequest: resource was rejected", "streamid", streamID, "req", req)
+	} else {
+		cb.Log.V(1).Info("OnStreamDeltaRequest", "streamid", streamID, "req", req)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Motivation

While working on
[kumahq/kuma#12719](https://github.com/kumahq/kuma/issues/12719), I noticed some strange behavior. If there are X resources and one is invalid, none of the valid resources are added. Once the invalid resource is fixed, the previously valid resources are still not added.

We send a NACK for the invalid resource type, but there's no way to reject only a single resource of that type—[we have to NACK the entire resource type](https://github.com/envoyproxy/envoy/issues/5739). Additionally, since the hash in the cache remains unchanged for valid resources, they are not resent (this is how Delta xDS works), and only the last changed resource is sent again.

## Implementation information
* Changed the logic to mark IsInitialRequest when there is a NACK, since Delta XDS, on the second request, sends only the diff and not all resources, even if the first request was NACKed.
* Added an error log to display NACK, making it easier to identify incorrect resources.
* Filtered out invalid resources and stored valid ones, while still sending a NACK with the invalid resources so the user is aware that some are incorrect.

backport #12776
