### PR TITLE
fix(kds): add all valid resources and skip only not valid (backport #12776)

### DIFF
--- a/pkg/core/resources/model/resource.go
+++ b/pkg/core/resources/model/resource.go
@@ -561,3 +561,20 @@ type PolicyWithSingleItem interface {
 	Policy
 	GetPolicyItem() PolicyItem
 }
+
+func IndexByKey[T Resource](resources []T) map[ResourceKey]T {
+	indexedResources := make(map[ResourceKey]T)
+	for _, resource := range resources {
+		key := MetaToResourceKey(resource.GetMeta())
+		indexedResources[key] = resource
+	}
+	return indexedResources
+}
+
+func IndexKeys(keys []ResourceKey) map[ResourceKey]struct{} {
+	indexedKeys := make(map[ResourceKey]struct{})
+	for _, key := range keys {
+		indexedKeys[key] = struct{}{}
+	}
+	return indexedKeys
+}

--- a/pkg/kds/v2/client/kds_client.go
+++ b/pkg/kds/v2/client/kds_client.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	std_errors "errors"
 	"io"
 	"time"
 
@@ -15,6 +16,7 @@ type UpstreamResponse struct {
 	ControlPlaneId      string
 	Type                model.ResourceType
 	AddedResources      model.ResourceList
+	InvalidResourcesKey []model.ResourceKey
 	RemovedResourcesKey []model.ResourceKey
 	IsInitialRequest    bool
 }
@@ -23,12 +25,14 @@ func (u *UpstreamResponse) Validate() error {
 	if u.AddedResources == nil {
 		return nil
 	}
+	var err error
 	for _, res := range u.AddedResources.GetItems() {
-		if err := model.Validate(res); err != nil {
-			return err
+		if validationErr := model.Validate(res); validationErr != nil {
+			err = std_errors.Join(err, validationErr)
+			u.InvalidResourcesKey = append(u.InvalidResourcesKey, core_model.MetaToResourceKey(res.GetMeta()))
 		}
 	}
-	return nil
+	return err
 }
 
 type Callbacks struct {
@@ -88,19 +92,19 @@ func (s *kdsSyncClient) Receive() error {
 			return errors.Wrap(err, "failed to receive a discovery response")
 		}
 		s.log.V(1).Info("DeltaDiscoveryResponse received", "response", received)
-
-		if err := received.Validate(); err != nil {
-			s.log.Info("received resource is invalid, sending NACK", "err", err)
-			if err := s.kdsStream.NACK(received.Type, err); err != nil {
-				if err == io.EOF {
-					return nil
-				}
-				return errors.Wrap(err, "failed to NACK a discovery response")
-			}
-			continue
-		}
+		validationErrors := received.Validate()
 
 		if s.callbacks == nil {
+			if validationErrors != nil {
+				s.log.Info("received resource is invalid, sending NACK", "err", validationErrors)
+				if err := s.kdsStream.NACK(received.Type, validationErrors); err != nil {
+					if err == io.EOF {
+						return nil
+					}
+					return errors.Wrap(err, "failed to NACK a discovery response")
+				}
+				continue
+			}
 			s.log.Info("no callback set, sending ACK", "type", string(received.Type))
 			if err := s.kdsStream.ACK(received.Type); err != nil {
 				if err == io.EOF {
@@ -113,6 +117,16 @@ func (s *kdsSyncClient) Receive() error {
 		err = s.callbacks.OnResourcesReceived(received)
 		if err != nil {
 			return errors.Wrapf(err, "failed to store %s resources", received.Type)
+		}
+		if validationErrors != nil {
+			s.log.Info("received resource is invalid, sending NACK", "err", validationErrors)
+			if err := s.kdsStream.NACK(received.Type, validationErrors); err != nil {
+				if err == io.EOF {
+					return nil
+				}
+				return errors.Wrap(err, "failed to NACK a discovery response")
+			}
+			continue
 		}
 		if !received.IsInitialRequest {
 			// Execute backoff only on subsequent request.

--- a/pkg/kds/v2/client/stream.go
+++ b/pkg/kds/v2/client/stream.go
@@ -27,12 +27,12 @@ type latestReceived struct {
 }
 
 type stream struct {
-	streamClient   KDSSyncServiceStream
-	latestACKed    map[core_model.ResourceType]string
-	latestReceived map[core_model.ResourceType]*latestReceived
-	clientId       string
-	cpConfig       string
-	runtimeInfo    core_runtime.RuntimeInfo
+	streamClient       KDSSyncServiceStream
+	initialRequestDone map[core_model.ResourceType]bool
+	latestReceived     map[core_model.ResourceType]*latestReceived
+	clientId           string
+	cpConfig           string
+	runtimeInfo        core_runtime.RuntimeInfo
 }
 
 type KDSSyncServiceStream interface {
@@ -42,12 +42,12 @@ type KDSSyncServiceStream interface {
 
 func NewDeltaKDSStream(s KDSSyncServiceStream, clientId string, runtimeInfo core_runtime.RuntimeInfo, cpConfig string) DeltaKDSStream {
 	return &stream{
-		streamClient:   s,
-		runtimeInfo:    runtimeInfo,
-		latestACKed:    make(map[core_model.ResourceType]string),
-		latestReceived: make(map[core_model.ResourceType]*latestReceived),
-		clientId:       clientId,
-		cpConfig:       cpConfig,
+		streamClient:       s,
+		runtimeInfo:        runtimeInfo,
+		initialRequestDone: make(map[core_model.ResourceType]bool),
+		latestReceived:     make(map[core_model.ResourceType]*latestReceived),
+		clientId:           clientId,
+		cpConfig:           cpConfig,
 	}
 }
 
@@ -98,10 +98,7 @@ func (s *stream) Receive() (UpstreamResponse, error) {
 		return UpstreamResponse{}, err
 	}
 	// when there isn't nonce it means it's the first request
-	isInitialRequest := true
-	if _, found := s.latestACKed[rs.GetItemType()]; found {
-		isInitialRequest = false
-	}
+	isInitialRequest := !s.initialRequestDone[rs.GetItemType()]
 	s.latestReceived[rs.GetItemType()] = &latestReceived{
 		nonce:         resp.Nonce,
 		nameToVersion: nameToVersion,
@@ -112,6 +109,7 @@ func (s *stream) Receive() (UpstreamResponse, error) {
 		AddedResources:      rs,
 		RemovedResourcesKey: s.mapRemovedResources(resp.RemovedResources),
 		IsInitialRequest:    isInitialRequest,
+		InvalidResourcesKey: []core_model.ResourceKey{},
 	}, err
 }
 
@@ -128,7 +126,7 @@ func (s *stream) ACK(resourceType core_model.ResourceType) error {
 		TypeUrl: string(resourceType),
 	})
 	if err == nil {
-		s.latestACKed[resourceType] = latestReceived.nonce
+		s.initialRequestDone[resourceType] = true
 	}
 	return err
 }
@@ -138,6 +136,7 @@ func (s *stream) NACK(resourceType core_model.ResourceType, err error) error {
 	if !found {
 		return nil
 	}
+	s.initialRequestDone[resourceType] = true
 	return s.streamClient.Send(&envoy_sd.DeltaDiscoveryRequest{
 		ResponseNonce:          latestReceived.nonce,
 		ResourceNamesSubscribe: []string{"*"},

--- a/pkg/util/xds/logging_callbacks.go
+++ b/pkg/util/xds/logging_callbacks.go
@@ -2,6 +2,7 @@ package xds
 
 import (
 	"context"
+	"errors"
 
 	"github.com/go-logr/logr"
 )
@@ -51,7 +52,11 @@ func (cb LoggingCallbacks) OnDeltaStreamClosed(streamID int64) {
 // OnStreamDeltaRequest is called once a request is received on a stream.
 // Returning an error will end processing and close the stream. OnStreamDeltaRequest will still be called.
 func (cb LoggingCallbacks) OnStreamDeltaRequest(streamID int64, req DeltaDiscoveryRequest) error {
-	cb.Log.V(1).Info("OnStreamDeltaRequest", "streamid", streamID, "req", req)
+	if req.ErrorMsg() != "" {
+		cb.Log.Error(errors.New(req.ErrorMsg()), "OnStreamDeltaRequest: resource was rejected", "streamid", streamID, "req", req)
+	} else {
+		cb.Log.V(1).Info("OnStreamDeltaRequest", "streamid", streamID, "req", req)
+	}
 	return nil
 }
 


### PR DESCRIPTION
While working on
[kumahq/kuma#12719](https://github.com/kumahq/kuma/issues/12719), I noticed some strange behavior. If there are X resources and one is invalid, none of the valid resources are added. Once the invalid resource is fixed, the previously valid resources are still not added.

We send a NACK for the invalid resource type, but there's no way to reject only a single resource of that type—[we have to NACK the entire resource type](https://github.com/envoyproxy/envoy/issues/5739). Additionally, since the hash in the cache remains unchanged for valid resources, they are not resent (this is how Delta xDS works), and only the last changed resource is sent again.

* Changed the logic to mark IsInitialRequest when there is a NACK, since Delta XDS, on the second request, sends only the diff and not all resources, even if the first request was NACKed.
* Added an error log to display NACK, making it easier to identify incorrect resources.
* Filtered out invalid resources and stored valid ones, while still sending a NACK with the invalid resources so the user is aware that some are incorrect.

backport #12776