### PR TITLE
fix(kuma-dp): prevent watchers from being cleaned up unexpectedly

### DIFF
--- a/pkg/util/xds/v3/watchdog_callbacks.go
+++ b/pkg/util/xds/v3/watchdog_callbacks.go
@@ -14,6 +14,12 @@ type Watchdog interface {
 	Start(ctx context.Context)
 }
 
+// SingletonWatchdog can check if there is an existing state
+type SingletonWatchdog interface {
+	Watchdog
+	ExistsStaleState() bool
+}
+
 type NewNodeWatchdogFunc func(ctx context.Context, node *envoy_core.Node, streamId int64) (Watchdog, error)
 
 func NewWatchdogCallbacks(newNodeWatchdog NewNodeWatchdogFunc) envoy_xds.Callbacks {

--- a/pkg/xds/server/callbacks/dataplane_sync_tracker.go
+++ b/pkg/xds/server/callbacks/dataplane_sync_tracker.go
@@ -2,11 +2,9 @@ package callbacks
 
 import (
 	"context"
-	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	envoy_cache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
-	"github.com/pkg/errors"
 	stdsync "sync"
-	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/core"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
@@ -16,13 +14,11 @@ import (
 
 var dataplaneSyncTrackerLog = core.Log.WithName("xds").WithName("dataplane-sync-tracker")
 
-type NewDataplaneWatchdogFunc func(key core_model.ResourceKey) util_xds_v3.Watchdog
+type NewDataplaneWatchdogFunc func(key core_model.ResourceKey) util_xds_v3.SingletonWatchdog
 
-func NewDataplaneSyncTracker(factoryFunc NewDataplaneWatchdogFunc, hasher envoy_cache.NodeHash, cache envoy_cache.SnapshotCache) DataplaneCallbacks {
+func NewDataplaneSyncTracker(factoryFunc NewDataplaneWatchdogFunc) DataplaneCallbacks {
 	return &dataplaneSyncTracker{
 		newDataplaneWatchdog: factoryFunc,
-		nodeHasher:           hasher,
-		snapshotCache:        cache,
 		watchdogs:            map[core_model.ResourceKey]context.CancelFunc{},
 	}
 }
@@ -42,19 +38,12 @@ type dataplaneSyncTracker struct {
 
 	stdsync.RWMutex // protects access to the fields below
 	watchdogs       map[core_model.ResourceKey]context.CancelFunc
-	nodeHasher      envoy_cache.NodeHash
-	snapshotCache   envoy_cache.SnapshotCache
 }
 
-func (t *dataplaneSyncTracker) OnProxyConnected(streamID core_xds.StreamID, dpKey core_model.ResourceKey, ctx context.Context, _ core_xds.DataplaneMetadata) error {
+func (t *dataplaneSyncTracker) OnProxyConnected(streamID core_xds.StreamID, dpKey core_model.ResourceKey, connCtx context.Context, _ core_xds.DataplaneMetadata) error {
 	// We use OnProxyConnected because there should be only one watchdog for given dataplane.
 	t.Lock()
 	defer t.Unlock()
-
-	// when there is an existing cache to be cleaned up, we wait for it to be removed
-	if err := t.waitForCleaningUpExisting(dpKey, ctx, 3*time.Second); err != nil {
-		return err
-	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.watchdogs[dpKey] = func() {
@@ -62,8 +51,13 @@ func (t *dataplaneSyncTracker) OnProxyConnected(streamID core_xds.StreamID, dpKe
 		cancel()
 	}
 	dataplaneSyncTrackerLog.V(1).Info("starting Watchdog for a Dataplane", "dpKey", dpKey, "streamID", streamID)
+	dataplaneWatchdog := t.newDataplaneWatchdog(dpKey)
+	if dataplaneWatchdog.ExistsStaleState() {
+		dataplaneSyncTrackerLog.Info("[WARNING] rejected a Dataplane connect attempt when it's previous state is still being cleaned up", "dpKey", dpKey, "streamID", streamID)
+		return errors.Errorf("an existing state of the Dataplane is being removed")
+	}
 	//nolint:contextcheck // it's not clear how the parent go-control-plane context lives
-	go t.newDataplaneWatchdog(dpKey).Start(ctx)
+	go dataplaneWatchdog.Start(ctx)
 	return nil
 }
 
@@ -74,43 +68,4 @@ func (t *dataplaneSyncTracker) OnProxyDisconnected(_ context.Context, _ core_xds
 		cancelFn()
 	}
 	delete(t.watchdogs, dpKey)
-}
-
-func (t *dataplaneSyncTracker) waitForCleaningUpExisting(dpKey core_model.ResourceKey, ctx context.Context, maxWait time.Duration) error {
-	timeout := time.After(maxWait)
-	timer := time.NewTicker(50 * time.Millisecond)
-	defer timer.Stop()
-
-	if t.nodeHasher == nil || t.snapshotCache == nil {
-		return nil
-	}
-
-	proxyId := core_xds.FromResourceKey(dpKey)
-	nodeCacheKey := t.nodeHasher.ID(&envoy_core.Node{Id: proxyId.String()})
-	cacheExists := func() error {
-		snapshot, err := t.snapshotCache.GetSnapshot(nodeCacheKey)
-		if err != nil || snapshot == nil {
-			return nil
-		}
-		return errors.New("dataplane is still in the cache")
-	}
-
-	if cacheExists() == nil {
-		return nil
-	}
-
-	for {
-		select {
-		case <-timer.C:
-			if cacheExists() == nil {
-				return nil
-			}
-		case <-timeout:
-			// if the cache is still there, this means there is a performance issue on the CP
-			// in this case, we kick out the connection and the DPP will reconnect later
-			return errors.Errorf("timeout while waiting for dataplane %s to be removed from the cache", proxyId)
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-	}
 }

--- a/pkg/xds/server/callbacks/dataplane_sync_tracker_test.go
+++ b/pkg/xds/server/callbacks/dataplane_sync_tracker_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Sync", func() {
 	Describe("dataplaneSyncTracker", func() {
 		It("should not fail when ADS stream is closed before Watchdog is even created", func() {
 			// setup
-			tracker := DataplaneCallbacksToXdsCallbacks(NewDataplaneSyncTracker(nil))
+			tracker := DataplaneCallbacksToXdsCallbacks(NewDataplaneSyncTracker(nil, nil, nil))
 
 			// given
 			ctx := context.Background()
@@ -43,7 +43,7 @@ var _ = Describe("Sync", func() {
 
 		It("should not fail when Envoy presents invalid Node ID", func() {
 			// setup
-			tracker := NewDataplaneSyncTracker(nil)
+			tracker := NewDataplaneSyncTracker(nil, nil, nil)
 			callbacks := util_xds_v3.AdaptCallbacks(DataplaneCallbacksToXdsCallbacks(tracker))
 
 			// given
@@ -82,7 +82,7 @@ var _ = Describe("Sync", func() {
 					<-ctx.Done()
 					close(watchdogCh)
 				})
-			})
+			}, nil, nil)
 			callbacks := util_xds_v3.AdaptCallbacks(DataplaneCallbacksToXdsCallbacks(tracker))
 
 			// given
@@ -136,7 +136,7 @@ var _ = Describe("Sync", func() {
 					<-ctx.Done()
 					atomic.AddInt32(&activeWatchdogs, -1)
 				})
-			})
+			}, nil, nil)
 			callbacks := util_xds_v3.AdaptCallbacks(DataplaneCallbacksToXdsCallbacks(tracker))
 
 			// when one stream for backend-01 is connected and request is sent

--- a/pkg/xds/server/v3/components.go
+++ b/pkg/xds/server/v3/components.go
@@ -56,7 +56,7 @@ func RegisterXDS(
 		util_xds_v3.AdaptCallbacks(xds_callbacks.DataplaneCallbacksToXdsCallbacks(
 			xds_callbacks.NewDataplaneLifecycle(rt.AppContext(), rt.ResourceManager(), authenticator, rt.Config().XdsServer.DataplaneDeregistrationDelay.Duration, rt.GetInstanceId(), rt.Config().Store.Cache.ExpirationTime.Duration)),
 		),
-		util_xds_v3.AdaptCallbacks(xds_callbacks.DataplaneCallbacksToXdsCallbacks(xds_callbacks.NewDataplaneSyncTracker(watchdogFactory.New, xdsContext.Hasher(), xdsContext.Cache()))),
+		util_xds_v3.AdaptCallbacks(xds_callbacks.DataplaneCallbacksToXdsCallbacks(xds_callbacks.NewDataplaneSyncTracker(watchdogFactory.New))),
 		util_xds_v3.AdaptCallbacks(DefaultDataplaneStatusTracker(rt, envoyCpCtx.Secrets)),
 		util_xds_v3.AdaptCallbacks(xds_callbacks.NewNackBackoff(rt.Config().XdsServer.NACKBackoff.Duration)),
 	}

--- a/pkg/xds/server/v3/components.go
+++ b/pkg/xds/server/v3/components.go
@@ -56,7 +56,7 @@ func RegisterXDS(
 		util_xds_v3.AdaptCallbacks(xds_callbacks.DataplaneCallbacksToXdsCallbacks(
 			xds_callbacks.NewDataplaneLifecycle(rt.AppContext(), rt.ResourceManager(), authenticator, rt.Config().XdsServer.DataplaneDeregistrationDelay.Duration, rt.GetInstanceId(), rt.Config().Store.Cache.ExpirationTime.Duration)),
 		),
-		util_xds_v3.AdaptCallbacks(xds_callbacks.DataplaneCallbacksToXdsCallbacks(xds_callbacks.NewDataplaneSyncTracker(watchdogFactory.New))),
+		util_xds_v3.AdaptCallbacks(xds_callbacks.DataplaneCallbacksToXdsCallbacks(xds_callbacks.NewDataplaneSyncTracker(watchdogFactory.New, xdsContext.Hasher(), xdsContext.Cache()))),
 		util_xds_v3.AdaptCallbacks(DefaultDataplaneStatusTracker(rt, envoyCpCtx.Secrets)),
 		util_xds_v3.AdaptCallbacks(xds_callbacks.NewNackBackoff(rt.Config().XdsServer.NACKBackoff.Duration)),
 	}

--- a/pkg/xds/server/v3/reconcile.go
+++ b/pkg/xds/server/v3/reconcile.go
@@ -38,6 +38,12 @@ func (r *reconciler) Clear(proxyId *model.ProxyId) error {
 	return nil
 }
 
+func (r *reconciler) CacheExists(proxyId *model.ProxyId) bool {
+	nodeId := &envoy_core.Node{Id: proxyId.String()}
+	snap, err := r.cacher.Get(nodeId)
+	return err == nil && snap != nil
+}
+
 func (r *reconciler) clearUndeliveredConfigStats(nodeId *envoy_core.Node) {
 	snap, err := r.cacher.Get(nodeId)
 	if err != nil {

--- a/pkg/xds/sync/dataplane_watchdog_factory.go
+++ b/pkg/xds/sync/dataplane_watchdog_factory.go
@@ -31,33 +31,45 @@ func NewDataplaneWatchdogFactory(
 	}, nil
 }
 
-func (d *dataplaneWatchdogFactory) New(dpKey model.ResourceKey) util_xds_v3.Watchdog {
+type singletonWatchdogWrapper struct {
+	*util_watchdog.SimpleWatchdog
+	stateChecker func() bool
+}
+
+func (w *singletonWatchdogWrapper) ExistsStaleState() bool {
+	return w.stateChecker()
+}
+
+func (d *dataplaneWatchdogFactory) New(dpKey model.ResourceKey) util_xds_v3.SingletonWatchdog {
 	log := xdsServerLog.WithName("dataplane-sync-watchdog").WithValues("dataplaneKey", dpKey)
 	dataplaneWatchdog := NewDataplaneWatchdog(d.deps, dpKey)
-	return &util_watchdog.SimpleWatchdog{
-		NewTicker: func() *time.Ticker {
-			return time.NewTicker(d.refreshInterval)
-		},
-		OnTick: func(ctx context.Context) error {
-			ctx = user.Ctx(ctx, user.ControlPlane)
-			start := core.Now()
-			result, err := dataplaneWatchdog.Sync(ctx)
-			if err != nil {
-				return err
-			}
-			d.xdsMetrics.XdsGenerations.
-				WithLabelValues(string(result.ProxyType), string(result.Status)).
-				Observe(float64(core.Now().Sub(start).Milliseconds()))
-			return nil
-		},
-		OnError: func(err error) {
-			d.xdsMetrics.XdsGenerationsErrors.Inc()
-			log.Error(err, "OnTick() failed")
-		},
-		OnStop: func() {
-			if err := dataplaneWatchdog.Cleanup(); err != nil {
+	return &singletonWatchdogWrapper{
+		SimpleWatchdog: &util_watchdog.SimpleWatchdog{
+			NewTicker: func() *time.Ticker {
+				return time.NewTicker(d.refreshInterval)
+			},
+			OnTick: func(ctx context.Context) error {
+				ctx = user.Ctx(ctx, user.ControlPlane)
+				start := core.Now()
+				result, err := dataplaneWatchdog.Sync(ctx)
+				if err != nil {
+					return err
+				}
+				d.xdsMetrics.XdsGenerations.
+					WithLabelValues(string(result.ProxyType), string(result.Status)).
+					Observe(float64(core.Now().Sub(start).Milliseconds()))
+				return nil
+			},
+			OnError: func(err error) {
+				d.xdsMetrics.XdsGenerationsErrors.Inc()
 				log.Error(err, "OnTick() failed")
-			}
+			},
+			OnStop: func() {
+				if err := dataplaneWatchdog.Cleanup(); err != nil {
+					log.Error(err, "OnTick() failed")
+				}
+			},
 		},
+		stateChecker: dataplaneWatchdog.DataplaneStateExists,
 	}
 }

--- a/pkg/xds/sync/dataplane_watchdog_test.go
+++ b/pkg/xds/sync/dataplane_watchdog_test.go
@@ -51,6 +51,10 @@ func (s *staticSnapshotReconciler) Clear(proxyId *core_xds.ProxyId) error {
 	return nil
 }
 
+func (s *staticSnapshotReconciler) CacheExists(proxyId *core_xds.ProxyId) bool {
+	return false
+}
+
 var _ sync.SnapshotReconciler = &staticSnapshotReconciler{}
 
 var _ = Describe("Dataplane Watchdog", func() {

--- a/pkg/xds/sync/interfaces.go
+++ b/pkg/xds/sync/interfaces.go
@@ -21,9 +21,10 @@ type ConnectionInfoTracker interface {
 type SnapshotReconciler interface {
 	Reconcile(context.Context, xds_context.Context, *core_xds.Proxy) (bool, error)
 	Clear(proxyId *core_xds.ProxyId) error
+	CacheExists(proxyId *core_xds.ProxyId) bool
 }
 
 // DataplaneWatchdogFactory returns a Watchdog that creates a new XdsContext and Proxy and executes SnapshotReconciler if there is any change
 type DataplaneWatchdogFactory interface {
-	New(dpKey core_model.ResourceKey) util_xds_v3.Watchdog
+	New(dpKey core_model.ResourceKey) util_xds_v3.SingletonWatchdog
 }


### PR DESCRIPTION
## Motivation

fixing potential xDS update lost by unexpected watcher cleanups

## Implementation information

Only allow a single active connection between a DP and the CP:
* __[this change]__ In the `pkg/xds/server/callbacks/dataplane_sync_tracker.go`, check if there is existing/stale and pending-removing state for a dataplane: if there is, reject this connect attempt
* __[existing behaviour]__ the DP will then retry connecting in a loop-backoff manner
* __[known fact]__ the DP may reach other CP instances which do not have this stale state

This does not change the behaviour of current CP XDS server as we never supported multiple xDS streams from a DP.

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

fixes https://github.com/kumahq/kuma/issues/12885

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
