### PR TITLE
chore(api-server): improve types and docs for /dataplanes/_config

### DIFF
--- a/api/openapi/specs/api.yaml
+++ b/api/openapi/specs/api.yaml
@@ -81,9 +81,9 @@ paths:
           $ref: '#/components/responses/Internal'
   /meshes/{mesh}/dataplanes/{name}/_config:
     get:
-      operationId: get-meshes-mesh-dataplanes-name-config
-      summary: Get a proxy XDS config on a CP
-      description: Returns the configuration of the proxy ([xds](https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol) configuration).
+      operationId: get-dataplanes-xds-config
+      summary: Get a proxy XDS config on a CP, this endpoint is only available on zone CPs.
+      description: Returns the [xds](https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol) configuration of the proxy.
       parameters:
         - in: path
           name: mesh
@@ -100,7 +100,7 @@ paths:
         - in: query
           name: shadow
           description: |
-            When computing XDS config the CP takes into account policies with 'kuma.io/effect: shadow' label
+            When computing XDS config the CP take into account policies with 'kuma.io/effect: shadow' label
           schema:
             type: boolean
             default: false
@@ -116,7 +116,7 @@ paths:
               enum: [diff]
       responses:
         '200':
-          $ref: '#/components/responses/InspectDataplanesConfigResponse'
+          $ref: '#/components/responses/GetDataplaneXDSConfigResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
         '500':
@@ -265,9 +265,9 @@ components:
           type: array
           items:
             $ref: './common/resource.yaml#/components/schemas/Meta'
-    InspectDataplanesConfig:
+    DataplaneXDSConfig:
       type: object
-      title: InspectDataplanesConfig
+      title: DataplaneXDSConfig
       required: [ xds ]
       properties:
         xds:
@@ -543,12 +543,12 @@ components:
           examples:
             ResponseForDataplane:
               $ref: '#/components/examples/InspectDataplanesForPolicyExample'
-    InspectDataplanesConfigResponse:
+    GetDataplaneXDSConfigResponse:
       description: Successfully retrieved proxy XDS config.
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/InspectDataplanesConfig'
+            $ref: '#/components/schemas/DataplaneXDSConfig'
     InspectRulesResponse:
       description: A response containing policies that match a resource
       content:

--- a/api/openapi/types/zz_generated.api.go
+++ b/api/openapi/types/zz_generated.api.go
@@ -9,9 +9,9 @@ import (
 	externalRef0 "github.com/kumahq/kuma/api/openapi/types/common"
 )
 
-// Defines values for GetMeshesMeshDataplanesNameConfigParamsInclude.
+// Defines values for GetDataplanesXdsConfigParamsInclude.
 const (
-	Diff GetMeshesMeshDataplanesNameConfigParamsInclude = "diff"
+	Diff GetDataplanesXdsConfigParamsInclude = "diff"
 )
 
 // Defines values for InspectDataplanesRulesParamsResourceType.
@@ -31,6 +31,16 @@ const (
 type BaseStatus struct {
 	Online int `json:"online"`
 	Total  int `json:"total"`
+}
+
+// DataplaneXDSConfig defines model for DataplaneXDSConfig.
+type DataplaneXDSConfig struct {
+	// Diff Contains a diff in a JSONPatch format between the XDS config returned in 'xds' and the current proxy XDS config.
+	// By default, the field is empty. To include the diff in the response, use the `include=diff` query parameter.
+	Diff *[]externalRef0.JsonPatchItem `json:"diff,omitempty"`
+
+	// Xds The raw XDS config as an inline JSON object
+	Xds map[string]interface{} `json:"xds"`
 }
 
 // DataplanesStats Dataplanes statistics
@@ -76,16 +86,6 @@ type Index struct {
 
 	// Version The semantic version of the server running
 	Version string `json:"version"`
-}
-
-// InspectDataplanesConfig defines model for InspectDataplanesConfig.
-type InspectDataplanesConfig struct {
-	// Diff Contains a diff in a JSONPatch format between the XDS config returned in 'xds' and the current proxy XDS config.
-	// By default, the field is empty. To include the diff in the response, use the `include=diff` query parameter.
-	Diff *[]externalRef0.JsonPatchItem `json:"diff,omitempty"`
-
-	// Xds The raw XDS config as an inline JSON object
-	Xds map[string]interface{} `json:"xds"`
 }
 
 // InspectDataplanesForPolicy A list of proxies
@@ -199,14 +199,14 @@ type SchemasGlobalInsight struct {
 // BadRequest standard error
 type BadRequest = externalRef0.Error
 
+// GetDataplaneXDSConfigResponse defines model for GetDataplaneXDSConfigResponse.
+type GetDataplaneXDSConfigResponse = DataplaneXDSConfig
+
 // GlobalInsightResponse defines model for GlobalInsightResponse.
 type GlobalInsightResponse = GlobalInsight
 
 // IndexResponse Some metadata about the service
 type IndexResponse = Index
-
-// InspectDataplanesConfigResponse defines model for InspectDataplanesConfigResponse.
-type InspectDataplanesConfigResponse = InspectDataplanesConfig
 
 // InspectDataplanesForPolicyResponse A list of proxies
 type InspectDataplanesForPolicyResponse = InspectDataplanesForPolicy
@@ -223,18 +223,18 @@ type Internal = externalRef0.Error
 // ResourceTypeDescriptionListResponse A list of all resources install
 type ResourceTypeDescriptionListResponse = ResourceTypeDescriptionList
 
-// GetMeshesMeshDataplanesNameConfigParams defines parameters for GetMeshesMeshDataplanesNameConfig.
-type GetMeshesMeshDataplanesNameConfigParams struct {
-	// Shadow When computing XDS config the CP takes into account policies with 'kuma.io/effect: shadow' label
+// GetDataplanesXdsConfigParams defines parameters for GetDataplanesXdsConfig.
+type GetDataplanesXdsConfigParams struct {
+	// Shadow When computing XDS config the CP take into account policies with 'kuma.io/effect: shadow' label
 	Shadow *bool `form:"shadow,omitempty" json:"shadow,omitempty"`
 
 	// Include An array of extra fields to include in the response. When `include=diff` the server computes a diff in JSONPatch format
 	// between the current proxy XDS config and the config returned in the 'xds' field.
-	Include *[]GetMeshesMeshDataplanesNameConfigParamsInclude `form:"include,omitempty" json:"include,omitempty"`
+	Include *[]GetDataplanesXdsConfigParamsInclude `form:"include,omitempty" json:"include,omitempty"`
 }
 
-// GetMeshesMeshDataplanesNameConfigParamsInclude defines parameters for GetMeshesMeshDataplanesNameConfig.
-type GetMeshesMeshDataplanesNameConfigParamsInclude string
+// GetDataplanesXdsConfigParamsInclude defines parameters for GetDataplanesXdsConfig.
+type GetDataplanesXdsConfigParamsInclude string
 
 // InspectResourcesParams defines parameters for InspectResources.
 type InspectResourcesParams struct {

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -87,12 +87,14 @@ paths:
           $ref: '#/components/responses/Internal'
   /meshes/{mesh}/dataplanes/{name}/_config:
     get:
-      operationId: get-meshes-mesh-dataplanes-name-config
-      summary: Get a proxy XDS config on a CP
+      operationId: get-dataplanes-xds-config
+      summary: >-
+        Get a proxy XDS config on a CP, this endpoint is only available on zone
+        CPs.
       description: >-
-        Returns the configuration of the proxy
-        ([xds](https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol)
-        configuration).
+        Returns the
+        [xds](https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol)
+        configuration of the proxy.
       parameters:
         - in: path
           name: mesh
@@ -109,7 +111,7 @@ paths:
         - in: query
           name: shadow
           description: >
-            When computing XDS config the CP takes into account policies with
+            When computing XDS config the CP take into account policies with
             'kuma.io/effect: shadow' label
           schema:
             type: boolean
@@ -130,7 +132,7 @@ paths:
                 - diff
       responses:
         '200':
-          $ref: '#/components/responses/InspectDataplanesConfigResponse'
+          $ref: '#/components/responses/GetDataplaneXDSConfigResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
         '500':
@@ -3225,9 +3227,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Meta'
-    InspectDataplanesConfig:
+    DataplaneXDSConfig:
       type: object
-      title: InspectDataplanesConfig
+      title: DataplaneXDSConfig
       required:
         - xds
       properties:
@@ -15214,12 +15216,12 @@ components:
           examples:
             ResponseForDataplane:
               $ref: '#/components/examples/InspectDataplanesForPolicyExample'
-    InspectDataplanesConfigResponse:
+    GetDataplaneXDSConfigResponse:
       description: Successfully retrieved proxy XDS config.
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/InspectDataplanesConfig'
+            $ref: '#/components/schemas/DataplaneXDSConfig'
     InspectRulesResponse:
       description: A response containing policies that match a resource
       content:

--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -788,7 +788,7 @@ func (r *resourceEndpoints) configForProxy() restful.RouteFunction {
 			return
 		}
 
-		out := &api_types.InspectDataplanesConfig{
+		out := &api_types.GetDataplaneXDSConfigResponse{
 			Xds: config,
 		}
 
@@ -812,10 +812,10 @@ func (r *resourceEndpoints) configForProxy() restful.RouteFunction {
 	}
 }
 
-func (r *resourceEndpoints) configForProxyParams(request *restful.Request) (*api_types.GetMeshesMeshDataplanesNameConfigParams, error) {
-	params := &api_types.GetMeshesMeshDataplanesNameConfigParams{
+func (r *resourceEndpoints) configForProxyParams(request *restful.Request) (*api_types.GetDataplanesXdsConfigParams, error) {
+	params := &api_types.GetDataplanesXdsConfigParams{
 		Shadow:  pointer.To(false),
-		Include: &[]api_types.GetMeshesMeshDataplanesNameConfigParamsInclude{},
+		Include: &[]api_types.GetDataplanesXdsConfigParamsInclude{},
 	}
 
 	if shadow := request.QueryParameter("shadow"); shadow != "" {
@@ -828,12 +828,12 @@ func (r *resourceEndpoints) configForProxyParams(request *restful.Request) (*api
 
 	if include := request.QueryParameter("include"); include != "" {
 		for _, v := range strings.Split(include, ",") {
-			switch api_types.GetMeshesMeshDataplanesNameConfigParamsInclude(v) {
+			switch api_types.GetDataplanesXdsConfigParamsInclude(v) {
 			case api_types.Diff:
 			default:
 				return nil, rest_errors.NewBadRequestError("unsupported value for query parameter 'include'")
 			}
-			*params.Include = append(*params.Include, api_types.GetMeshesMeshDataplanesNameConfigParamsInclude(v))
+			*params.Include = append(*params.Include, api_types.GetDataplanesXdsConfigParamsInclude(v))
 		}
 	}
 

--- a/test/e2e_env/universal/envoyconfig/utils.go
+++ b/test/e2e_env/universal/envoyconfig/utils.go
@@ -36,7 +36,7 @@ func getConfig(mesh, dpp string) string {
 	Expect(err).ToNot(HaveOccurred())
 	redacted := redactStatPrefixes(redactIPs(output))
 
-	response := types.InspectDataplanesConfig{}
+	response := types.GetDataplaneXDSConfigResponse{}
 	Expect(json.Unmarshal([]byte(redacted), &response)).To(Succeed())
 	Expect(response.Diff).ToNot(BeNil())
 	response.Diff = pointer.To(slices.DeleteFunc(*response.Diff, func(item api_common.JsonPatchItem) bool {


### PR DESCRIPTION
## Motivation

The docs were not very clear and the entities were using the already overloaded "inspect" word.
