### PR TITLE
fix(meshservice): prevent reconciling all namespaces on label change

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/meshservice_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/meshservice_controller.go
@@ -461,7 +461,7 @@ func NamespaceToServiceMapper(l logr.Logger, client kube_client.Client) kube_han
 	l = l.WithName("namespace-to-service-mapper")
 	return func(ctx context.Context, obj kube_client.Object) []kube_reconcile.Request {
 		services := &kube_core.ServiceList{}
-		if err := client.List(ctx, services, kube_client.InNamespace(obj.GetNamespace())); err != nil {
+		if err := client.List(ctx, services, kube_client.InNamespace(obj.GetName())); err != nil {
 			l.WithValues("namespace", obj.GetName()).Error(err, "failed to fetch Services")
 			return nil
 		}


### PR DESCRIPTION
## Motivation & Implementation information

Fixes an issue in `MeshService` controller where `GetNamespace()` was used on a Namespace object, causing it to list all services in the cluster. Replaced with `GetName()` to correctly scope label changes. This significantly improves performance in large deployments.