### PR TITLE
fix(kuma-cp): clone labels

### DIFF
--- a/pkg/core/resources/model/resource.go
+++ b/pkg/core/resources/model/resource.go
@@ -3,6 +3,7 @@ package model
 import (
 	"fmt"
 	"hash/fnv"
+	"maps"
 	"reflect"
 	"strings"
 	"time"
@@ -526,7 +527,7 @@ func ComputeLabels(
 ) (map[string]string, error) {
 	labels := map[string]string{}
 	if len(existingLabels) > 0 {
-		labels = existingLabels
+		labels = maps.Clone(existingLabels)
 	}
 
 	setIfNotExist := func(k, v string) {


### PR DESCRIPTION
## Motivation

I was investigating a test fail https://github.com/kumahq/kuma/actions/runs/13448107702/job/37578543976 and noticed there was a panic

```
fatal error: concurrent map read and map write

goroutine 5374 [running]:
github.com/kumahq/kuma/pkg/plugins/policies/core/matchers.dppSelectedByZone({0x40d65f0, 0xc00275c120}, 0xc002aca5e8, 0x0)
	github.com/kumahq/kuma/pkg/plugins/policies/core/matchers/dataplane.go:299 +0xb1
```

## Implementation information

I reviewed another goroutine and noticed that we perform an update. I suspect this happens because we didn't clone the labels in ComputeLabels.
```
github.com/kumahq/kuma/pkg/hds/tracker.(*tracker).updateDataplane(0xc00048e700, 0x20, 0xc0018317a0, 0x1)
	github.com/kumahq/kuma/pkg/hds/tracker/callbacks.go:228 +0x7c4
```

