### PR TITLE
fix(inspectapi): inspect api flake because of inbound ordering

### DIFF
--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -974,6 +974,9 @@ func (r *resourceEndpoints) rulesForResource() restful.RouteFunction {
 						Rules: fromRulesForInbound,
 					})
 				}
+				sort.SliceStable(fromRules, func(i, j int) bool {
+					return pointer.Deref(fromRules[i].Inbound.Name) < pointer.Deref(fromRules[j].Inbound.Name)
+				})
 			}
 			toResourceRules := []api_common.ResourceRule{}
 			for itemIdentifier, resourceRuleItem := range res.ToRules.ResourceRules {

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/dataplane_kind_meshtimeout_section_name.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/dataplane_kind_meshtimeout_section_name.golden.json
@@ -13,6 +13,35 @@
    "fromRules": [
     {
      "inbound": {
+      "name": "main-port",
+      "port": 8080,
+      "tags": {
+       "kuma.io/service": "foo"
+      }
+     },
+     "rules": [
+      {
+       "conf": {
+        "connectionTimeout": "7s",
+        "idleTimeout": "7s",
+        "http": {
+         "requestTimeout": "7s"
+        }
+       },
+       "matchers": [],
+       "origin": [
+        {
+         "labels": {},
+         "mesh": "mesh-1",
+         "name": "select-whole-dpp",
+         "type": "MeshTimeout"
+        }
+       ]
+      }
+     ]
+    },
+    {
+     "inbound": {
       "name": "secondary-port",
       "port": 9090,
       "tags": {
@@ -40,35 +69,6 @@
          "labels": {},
          "mesh": "mesh-1",
          "name": "select-single-inbound",
-         "type": "MeshTimeout"
-        }
-       ]
-      }
-     ]
-    },
-    {
-     "inbound": {
-      "name": "main-port",
-      "port": 8080,
-      "tags": {
-       "kuma.io/service": "foo"
-      }
-     },
-     "rules": [
-      {
-       "conf": {
-        "connectionTimeout": "7s",
-        "idleTimeout": "7s",
-        "http": {
-         "requestTimeout": "7s"
-        }
-       },
-       "matchers": [],
-       "origin": [
-        {
-         "labels": {},
-         "mesh": "mesh-1",
-         "name": "select-whole-dpp",
          "type": "MeshTimeout"
         }
        ]


### PR DESCRIPTION
## Motivation

Fixing flake when inbounds were reordered in inspectapi

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
