### PR TITLE
refactor(tokens): move token constants to core/resources/apis/system

### DIFF
--- a/app/kumactl/cmd/export/export.go
+++ b/app/kumactl/cmd/export/export.go
@@ -18,9 +18,6 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/model/rest/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
-	admin_tls "github.com/kumahq/kuma/pkg/envoy/admin/tls"
-	intercp_tls "github.com/kumahq/kuma/pkg/intercp/tls"
-	"github.com/kumahq/kuma/pkg/plugins/authn/api-server/tokens/issuer"
 )
 
 type exportContext struct {
@@ -129,9 +126,9 @@ $ kumactl export --profile federation --format universal > policies.yaml
 			var userTokenSigningKeys []model.Resource
 			// filter out envoy-admin-ca and inter-cp-ca otherwise it will cause TLS handshake errors
 			for _, res := range allResources {
-				isUserTokenSigningKey := strings.HasPrefix(res.GetMeta().GetName(), issuer.UserTokenSigningKeyPrefix)
-				if res.GetMeta().GetName() != admin_tls.GlobalSecretKey.Name &&
-					res.GetMeta().GetName() != intercp_tls.GlobalSecretKey.Name &&
+				isUserTokenSigningKey := strings.HasPrefix(res.GetMeta().GetName(), core_system.UserTokenSigningKeyPrefix)
+				if res.GetMeta().GetName() != core_system.EnvoyAdminCA &&
+					res.GetMeta().GetName() != core_system.InterCpCA &&
 					!isUserTokenSigningKey {
 					resources = append(resources, res)
 				}

--- a/pkg/core/managers/apis/mesh/mesh_manager_test.go
+++ b/pkg/core/managers/apis/mesh/mesh_manager_test.go
@@ -28,7 +28,6 @@ import (
 	test_resources "github.com/kumahq/kuma/pkg/test/resources"
 	"github.com/kumahq/kuma/pkg/test/resources/builders"
 	"github.com/kumahq/kuma/pkg/test/resources/samples"
-	"github.com/kumahq/kuma/pkg/tokens/builtin/issuer"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 )
 
@@ -119,7 +118,7 @@ var _ = Describe("Mesh Manager", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// and Dataplane Token Signing Key for the mesh exists
-			key := tokens.SigningKeyResourceKey(issuer.DataplaneTokenSigningKeyPrefix(meshName), tokens.DefaultKeyID, meshName)
+			key := tokens.SigningKeyResourceKey(system.DataplaneTokenSigningKey(meshName), tokens.DefaultKeyID, meshName)
 			err = secretManager.Get(context.Background(), system.NewSecretResource(), store.GetBy(key))
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/pkg/core/resources/apis/system/constants.go
+++ b/pkg/core/resources/apis/system/constants.go
@@ -1,0 +1,34 @@
+package system
+
+const (
+	// AdminUserToken is the name of the global secret holding the token for the admin user
+	AdminUserToken = "admin-user-token"
+	// EnvoyAdminCA is the name of the global secret holding the CA for the Envoy Admin
+	EnvoyAdminCA = "envoy-admin-ca"
+	// InterCpCA is the name of the global secret holding the CA for the inter control plane communication
+	InterCpCA = "inter-cp-ca"
+	// ZoneTokenSigningKeyPrefix is the prefix for the global secret holding the zone ingress token signing key
+	ZoneTokenSigningKeyPrefix = "zone-token-signing-key"
+	// ZoneTokenSigningPublicKeyPrefix is the prefix for the global secret holding the zone ingress token signing public key
+	ZoneTokenSigningPublicKeyPrefix = "zone-token-signing-public-key"
+	// ZoneTokenRevocations is the name of the global secret holding the zone token revocations
+	ZoneTokenRevocations = "zone-token-revocations" // #nosec G101 -- this is not a credential
+
+	// UserTokenSigningKeyPrefix is the prefix for the global secret holding the user token signing key
+	UserTokenSigningKeyPrefix = "user-token-signing-key"
+	// UserTokenRevocations is the name of the global secret holding the user token revocations
+	UserTokenRevocations = "user-token-revocations" // #nosec G101 -- this is not a credential
+
+	// DataplaneTokenSigningKeyPrefix is the prefix for the secret holding the dataplane token signing key
+	DataplaneTokenSigningKeyPrefix = "dataplane-token-signing-key-"
+	// DataplaneTokenRevolationsPrefix is the prefix for the secret holding the dataplane token revocations
+	DataplaneTokenRevocationsPrefix = "dataplane-token-revocations-"
+)
+
+func DataplaneTokenSigningKey(mesh string) string {
+	return DataplaneTokenSigningKeyPrefix + mesh
+}
+
+func DataplaneTokenRevocations(mesh string) string {
+	return DataplaneTokenRevocationsPrefix + mesh
+}

--- a/pkg/defaults/components.go
+++ b/pkg/defaults/components.go
@@ -9,13 +9,13 @@ import (
 
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
 	"github.com/kumahq/kuma/pkg/core"
+	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/runtime"
 	"github.com/kumahq/kuma/pkg/core/runtime/component"
 	"github.com/kumahq/kuma/pkg/core/tokens"
 	"github.com/kumahq/kuma/pkg/core/user"
 	kuma_log "github.com/kumahq/kuma/pkg/log"
-	"github.com/kumahq/kuma/pkg/tokens/builtin/zone"
 )
 
 var log = core.Log.WithName("defaults")
@@ -85,5 +85,5 @@ func EnsureZoneTokenSigningKeyExists(ctx context.Context, resManager core_manage
 	if cfg.IsFederatedZoneCP() {
 		return nil
 	}
-	return tokens.EnsureDefaultSigningKeyExist(zone.SigningKeyPrefix, ctx, resManager, logger)
+	return tokens.EnsureDefaultSigningKeyExist(system.ZoneTokenSigningKeyPrefix, ctx, resManager, logger)
 }

--- a/pkg/defaults/envoy_admin_ca_test.go
+++ b/pkg/defaults/envoy_admin_ca_test.go
@@ -10,9 +10,9 @@ import (
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
 	core_system "github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 	"github.com/kumahq/kuma/pkg/defaults"
-	envoy_admin_tls "github.com/kumahq/kuma/pkg/envoy/admin/tls"
 	resources_memory "github.com/kumahq/kuma/pkg/plugins/resources/memory"
 )
 
@@ -27,7 +27,7 @@ var _ = Describe("Envoy Admin CA defaults", func() {
 
 		// then
 		Expect(err).ToNot(HaveOccurred())
-		err = manager.Get(context.Background(), core_system.NewGlobalSecretResource(), core_store.GetBy(envoy_admin_tls.GlobalSecretKey))
+		err = manager.Get(context.Background(), core_system.NewGlobalSecretResource(), core_store.GetBy(core_model.ResourceKey{Name: core_system.EnvoyAdminCA}))
 		Expect(err).ToNot(HaveOccurred())
 	})
 })

--- a/pkg/defaults/mesh/mesh.go
+++ b/pkg/defaults/mesh/mesh.go
@@ -10,12 +10,12 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/core"
+	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	"github.com/kumahq/kuma/pkg/core/tokens"
 	kuma_log "github.com/kumahq/kuma/pkg/log"
-	"github.com/kumahq/kuma/pkg/tokens/builtin/issuer"
 )
 
 var log = core.Log.WithName("defaults").WithName("mesh")
@@ -50,7 +50,7 @@ func EnsureDefaultMeshResources(
 		return errors.Wrap(err, "could not create default Dataplane Token Signing Key")
 	}
 	if created {
-		resKey := tokens.SigningKeyResourceKey(issuer.DataplaneTokenSigningKeyPrefix(meshName), tokens.DefaultKeyID, meshName)
+		resKey := tokens.SigningKeyResourceKey(system.DataplaneTokenSigningKey(meshName), tokens.DefaultKeyID, meshName)
 		logger.Info("default Dataplane Token Signing Key created", "name", resKey.Name)
 	} else {
 		logger.Info("Dataplane Token Signing Key already exists")

--- a/pkg/defaults/mesh/mesh_test.go
+++ b/pkg/defaults/mesh/mesh_test.go
@@ -17,7 +17,6 @@ import (
 	meshretry "github.com/kumahq/kuma/pkg/plugins/policies/meshretry/api/v1alpha1"
 	meshtimeout "github.com/kumahq/kuma/pkg/plugins/policies/meshtimeout/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/resources/memory"
-	"github.com/kumahq/kuma/pkg/tokens/builtin/issuer"
 )
 
 var _ = Describe("EnsureDefaultMeshResources", func() {
@@ -39,7 +38,7 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// then Dataplane Token Signing Key for the mesh exists
-			err = resManager.Get(context.Background(), system.NewSecretResource(), core_store.GetBy(tokens.SigningKeyResourceKey(issuer.DataplaneTokenSigningKeyPrefix(model.DefaultMesh), tokens.DefaultKeyID, model.DefaultMesh)))
+			err = resManager.Get(context.Background(), system.NewSecretResource(), core_store.GetBy(tokens.SigningKeyResourceKey(system.DataplaneTokenSigningKey(model.DefaultMesh), tokens.DefaultKeyID, model.DefaultMesh)))
 			Expect(err).ToNot(HaveOccurred())
 
 			// and default TrafficPermission for the mesh doesn't exists
@@ -85,7 +84,7 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 			Expect(err).ToNot(HaveOccurred())
 			err = resManager.Get(context.Background(), meshcircuitbreaker.NewMeshCircuitBreakerResource(), core_store.GetByKey("mesh-circuit-breaker-all-default", model.DefaultMesh))
 			Expect(err).ToNot(HaveOccurred())
-			err = resManager.Get(context.Background(), system.NewSecretResource(), core_store.GetBy(tokens.SigningKeyResourceKey(issuer.DataplaneTokenSigningKeyPrefix(model.DefaultMesh), tokens.DefaultKeyID, model.DefaultMesh)))
+			err = resManager.Get(context.Background(), system.NewSecretResource(), core_store.GetBy(tokens.SigningKeyResourceKey(system.DataplaneTokenSigningKey(model.DefaultMesh), tokens.DefaultKeyID, model.DefaultMesh)))
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -111,7 +110,7 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 			Expect(core_store.IsResourceNotFound(err)).To(BeTrue())
 
 			// and Dataplane Token Signing Key for the mesh exists
-			err = resManager.Get(context.Background(), system.NewSecretResource(), core_store.GetBy(tokens.SigningKeyResourceKey(issuer.DataplaneTokenSigningKeyPrefix(model.DefaultMesh), tokens.DefaultKeyID, model.DefaultMesh)))
+			err = resManager.Get(context.Background(), system.NewSecretResource(), core_store.GetBy(tokens.SigningKeyResourceKey(system.DataplaneTokenSigningKey(model.DefaultMesh), tokens.DefaultKeyID, model.DefaultMesh)))
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -137,7 +136,7 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// and Dataplane Token Signing Key for the mesh exists
-			err = resManager.Get(context.Background(), system.NewSecretResource(), core_store.GetBy(tokens.SigningKeyResourceKey(issuer.DataplaneTokenSigningKeyPrefix(model.DefaultMesh), tokens.DefaultKeyID, model.DefaultMesh)))
+			err = resManager.Get(context.Background(), system.NewSecretResource(), core_store.GetBy(tokens.SigningKeyResourceKey(system.DataplaneTokenSigningKey(model.DefaultMesh), tokens.DefaultKeyID, model.DefaultMesh)))
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
@@ -173,7 +172,7 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// and Dataplane Token Signing Key for the mesh exists
-			err = resManager.Get(context.Background(), system.NewSecretResource(), core_store.GetBy(tokens.SigningKeyResourceKey(issuer.DataplaneTokenSigningKeyPrefix(model.DefaultMesh), tokens.DefaultKeyID, model.DefaultMesh)))
+			err = resManager.Get(context.Background(), system.NewSecretResource(), core_store.GetBy(tokens.SigningKeyResourceKey(system.DataplaneTokenSigningKey(model.DefaultMesh), tokens.DefaultKeyID, model.DefaultMesh)))
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -199,7 +198,7 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 			Expect(err).ToNot(HaveOccurred())
 			err = resManager.Get(context.Background(), meshcircuitbreaker.NewMeshCircuitBreakerResource(), core_store.GetByKey("mesh-circuit-breaker-all-default", model.DefaultMesh))
 			Expect(err).ToNot(HaveOccurred())
-			err = resManager.Get(context.Background(), system.NewSecretResource(), core_store.GetBy(tokens.SigningKeyResourceKey(issuer.DataplaneTokenSigningKeyPrefix(model.DefaultMesh), tokens.DefaultKeyID, model.DefaultMesh)))
+			err = resManager.Get(context.Background(), system.NewSecretResource(), core_store.GetBy(tokens.SigningKeyResourceKey(system.DataplaneTokenSigningKey(model.DefaultMesh), tokens.DefaultKeyID, model.DefaultMesh)))
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -233,7 +232,7 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 			Expect(core_store.IsResourceNotFound(err)).To(BeTrue())
 
 			// and Dataplane Token Signing Key for the mesh exists
-			err = resManager.Get(context.Background(), system.NewSecretResource(), core_store.GetBy(tokens.SigningKeyResourceKey(issuer.DataplaneTokenSigningKeyPrefix(model.DefaultMesh), tokens.DefaultKeyID, model.DefaultMesh)))
+			err = resManager.Get(context.Background(), system.NewSecretResource(), core_store.GetBy(tokens.SigningKeyResourceKey(system.DataplaneTokenSigningKey(model.DefaultMesh), tokens.DefaultKeyID, model.DefaultMesh)))
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -267,7 +266,7 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// and Dataplane Token Signing Key for the mesh exists
-			err = resManager.Get(context.Background(), system.NewSecretResource(), core_store.GetBy(tokens.SigningKeyResourceKey(issuer.DataplaneTokenSigningKeyPrefix(model.DefaultMesh), tokens.DefaultKeyID, model.DefaultMesh)))
+			err = resManager.Get(context.Background(), system.NewSecretResource(), core_store.GetBy(tokens.SigningKeyResourceKey(system.DataplaneTokenSigningKey(model.DefaultMesh), tokens.DefaultKeyID, model.DefaultMesh)))
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})

--- a/pkg/defaults/mesh/signing_key.go
+++ b/pkg/defaults/mesh/signing_key.go
@@ -3,15 +3,15 @@ package mesh
 import (
 	"context"
 
+	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/tokens"
-	"github.com/kumahq/kuma/pkg/tokens/builtin/issuer"
 )
 
 func ensureDataplaneTokenSigningKey(ctx context.Context, resManager manager.ResourceManager, mesh model.Resource) (bool, error) {
 	meshName := mesh.GetMeta().GetName()
-	signingKeyManager := tokens.NewMeshedSigningKeyManager(resManager, issuer.DataplaneTokenSigningKeyPrefix(meshName), meshName)
+	signingKeyManager := tokens.NewMeshedSigningKeyManager(resManager, system.DataplaneTokenSigningKey(meshName), meshName)
 	_, _, err := signingKeyManager.GetLatestSigningKey(ctx)
 	if err == nil {
 		return false, nil

--- a/pkg/envoy/admin/tls/pki.go
+++ b/pkg/envoy/admin/tls/pki.go
@@ -3,7 +3,7 @@ package tls
 import (
 	"context"
 	"crypto/rsa"
-	tls "crypto/tls"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -21,8 +21,8 @@ const (
 	ClientCertSAN = "kuma-cp"
 )
 
-var GlobalSecretKey = model.ResourceKey{
-	Name: "envoy-admin-ca",
+var globalSecretKey = model.ResourceKey{
+	Name: system.EnvoyAdminCA,
 }
 
 // GenerateCA generates CA for Envoy Admin communication (CP sending requests to Envoy Admin).
@@ -47,7 +47,7 @@ func GenerateCA() (*util_tls.KeyPair, error) {
 
 func LoadCA(ctx context.Context, resManager manager.ReadOnlyResourceManager) (tls.Certificate, error) {
 	globalSecret := system.NewGlobalSecretResource()
-	if err := resManager.Get(ctx, globalSecret, store.GetBy(GlobalSecretKey)); err != nil {
+	if err := resManager.Get(ctx, globalSecret, store.GetBy(globalSecretKey)); err != nil {
 		return tls.Certificate{}, err
 	}
 	bytes := globalSecret.Spec.GetData().GetValue()
@@ -62,7 +62,7 @@ func CreateCA(ctx context.Context, keyPair util_tls.KeyPair, resManager manager.
 	globalSecret.Spec.Data = &wrapperspb.BytesValue{
 		Value: bytes,
 	}
-	return resManager.Create(ctx, globalSecret, store.CreateBy(GlobalSecretKey))
+	return resManager.Create(ctx, globalSecret, store.CreateBy(globalSecretKey))
 }
 
 func GenerateClientCert(ca tls.Certificate) (util_tls.KeyPair, error) {

--- a/pkg/intercp/tls/pki.go
+++ b/pkg/intercp/tls/pki.go
@@ -3,7 +3,7 @@ package tls
 import (
 	"context"
 	"crypto/rsa"
-	tls "crypto/tls"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -17,8 +17,8 @@ import (
 	util_tls "github.com/kumahq/kuma/pkg/tls"
 )
 
-var GlobalSecretKey = model.ResourceKey{
-	Name: "inter-cp-ca",
+var globalSecretKey = model.ResourceKey{
+	Name: system.InterCpCA,
 }
 
 func GenerateCA() (*util_tls.KeyPair, error) {
@@ -32,7 +32,7 @@ func GenerateCA() (*util_tls.KeyPair, error) {
 
 func LoadCA(ctx context.Context, resManager manager.ReadOnlyResourceManager) (tls.Certificate, error) {
 	globalSecret := system.NewGlobalSecretResource()
-	if err := resManager.Get(ctx, globalSecret, store.GetBy(GlobalSecretKey)); err != nil {
+	if err := resManager.Get(ctx, globalSecret, store.GetBy(globalSecretKey)); err != nil {
 		return tls.Certificate{}, err
 	}
 	bytes := globalSecret.Spec.GetData().GetValue()
@@ -47,7 +47,7 @@ func CreateCA(ctx context.Context, keyPair util_tls.KeyPair, resManager manager.
 	globalSecret.Spec.Data = &wrapperspb.BytesValue{
 		Value: bytes,
 	}
-	return resManager.Create(ctx, globalSecret, store.CreateBy(GlobalSecretKey))
+	return resManager.Create(ctx, globalSecret, store.CreateBy(globalSecretKey))
 }
 
 func GenerateClientCert(ca tls.Certificate, ip string) (tls.Certificate, error) {

--- a/pkg/kds/context/context.go
+++ b/pkg/kds/context/context.go
@@ -33,7 +33,6 @@ import (
 	"github.com/kumahq/kuma/pkg/kds/service"
 	"github.com/kumahq/kuma/pkg/kds/util"
 	reconcile_v2 "github.com/kumahq/kuma/pkg/kds/v2/reconcile"
-	zone_tokens "github.com/kumahq/kuma/pkg/tokens/builtin/zone"
 	"github.com/kumahq/kuma/pkg/util/rsa"
 	"github.com/kumahq/kuma/pkg/version"
 )
@@ -76,7 +75,7 @@ func DefaultContext(
 		reconcile_v2.If(
 			reconcile_v2.And(
 				reconcile_v2.TypeIs(system.GlobalSecretType),
-				reconcile_v2.NameHasPrefix(zone_tokens.SigningKeyPrefix),
+				reconcile_v2.NameHasPrefix(system.ZoneTokenSigningKeyPrefix),
 			),
 			MapZoneTokenSigningKeyGlobalToPublicKey),
 		reconcile_v2.If(
@@ -203,8 +202,8 @@ func MapZoneTokenSigningKeyGlobalToPublicKey(_ kds.Features, r core_model.Resour
 	publicSigningKeyResource := system.NewGlobalSecretResource()
 	newResName := strings.ReplaceAll(
 		r.GetMeta().GetName(),
-		zone_tokens.SigningKeyPrefix,
-		zone_tokens.SigningPublicKeyPrefix,
+		system.ZoneTokenSigningKeyPrefix,
+		system.ZoneTokenSigningPublicKeyPrefix,
 	)
 	publicSigningKeyResource.SetMeta(util.CloneResourceMeta(r.GetMeta(), util.WithName(newResName)))
 
@@ -270,7 +269,7 @@ func GlobalProvidedFilter(rm manager.ResourceManager, configs map[string]bool) r
 			return configs[resName]
 		case r.Descriptor().Name == system.GlobalSecretType:
 			return util.ResourceNameHasAtLeastOneOfPrefixes(resName, []string{
-				zone_tokens.SigningKeyPrefix,
+				system.ZoneTokenSigningKeyPrefix,
 			}...)
 		}
 

--- a/pkg/kds/context/context_test.go
+++ b/pkg/kds/context/context_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/kumahq/kuma/pkg/plugins/resources/memory"
 	"github.com/kumahq/kuma/pkg/test/matchers"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
-	zone_tokens "github.com/kumahq/kuma/pkg/tokens/builtin/zone"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 )
 
@@ -309,7 +308,7 @@ var _ = Describe("Context", func() {
 			Entry("should not filter out zone token signing key", testCase{
 				resource: &core_system.GlobalSecretResource{
 					Meta: &test_model.ResourceMeta{
-						Name: zone_tokens.SigningKeyPrefix + "-1",
+						Name: core_system.ZoneTokenSigningKeyPrefix + "-1",
 					},
 				},
 				expect: true,

--- a/pkg/kds/v2/store/sync.go
+++ b/pkg/kds/v2/store/sync.go
@@ -29,7 +29,6 @@ import (
 	core_metrics "github.com/kumahq/kuma/pkg/metrics"
 	resources_k8s "github.com/kumahq/kuma/pkg/plugins/resources/k8s"
 	k8s_model "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/model"
-	zone_tokens "github.com/kumahq/kuma/pkg/tokens/builtin/zone"
 )
 
 // ResourceSyncer allows to synchronize resources in Store
@@ -318,7 +317,7 @@ func ZoneSyncCallback(ctx context.Context, configToSync map[string]bool, syncer 
 				return syncer.Sync(ctx, upstream, PrefilterBy(func(r core_model.Resource) bool {
 					return util.ResourceNameHasAtLeastOneOfPrefixes(
 						r.GetMeta().GetName(),
-						zone_tokens.SigningPublicKeyPrefix,
+						system.ZoneTokenSigningPublicKeyPrefix,
 					)
 				}))
 

--- a/pkg/plugins/authn/api-server/tokens/issuer/token.go
+++ b/pkg/plugins/authn/api-server/tokens/issuer/token.go
@@ -3,17 +3,9 @@ package issuer
 import (
 	"github.com/golang-jwt/jwt/v4"
 
-	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/tokens"
 	"github.com/kumahq/kuma/pkg/core/user"
 )
-
-const UserTokenSigningKeyPrefix = "user-token-signing-key"
-
-var UserTokenRevocationsGlobalSecretKey = core_model.ResourceKey{
-	Name: "user-token-revocations",
-	Mesh: core_model.NoMesh,
-}
 
 type UserClaims struct {
 	user.User

--- a/pkg/plugins/authn/api-server/tokens/ws/ws_test.go
+++ b/pkg/plugins/authn/api-server/tokens/ws/ws_test.go
@@ -17,7 +17,9 @@ import (
 
 	store_config "github.com/kumahq/kuma/pkg/config/core/resources/store"
 	"github.com/kumahq/kuma/pkg/core"
+	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_tokens "github.com/kumahq/kuma/pkg/core/tokens"
 	"github.com/kumahq/kuma/pkg/core/user"
 	"github.com/kumahq/kuma/pkg/plugins/authn/api-server/tokens/issuer"
@@ -41,15 +43,15 @@ var _ = Describe("Auth Tokens WS", func() {
 
 	BeforeEach(func() {
 		resManager := manager.NewResourceManager(memory.NewStore())
-		signingKeyManager := core_tokens.NewSigningKeyManager(resManager, issuer.UserTokenSigningKeyPrefix)
+		signingKeyManager := core_tokens.NewSigningKeyManager(resManager, system.UserTokenSigningKeyPrefix)
 		tokenIssuer := issuer.NewUserTokenIssuer(core_tokens.NewTokenIssuer(signingKeyManager))
 		userTokenValidator = issuer.NewUserTokenValidator(
 			core_tokens.NewValidator(
 				core.Log.WithName("test"),
 				[]core_tokens.SigningKeyAccessor{
-					core_tokens.NewSigningKeyAccessor(resManager, issuer.UserTokenSigningKeyPrefix),
+					core_tokens.NewSigningKeyAccessor(resManager, system.UserTokenSigningKeyPrefix),
 				},
-				core_tokens.NewRevocations(resManager, issuer.UserTokenRevocationsGlobalSecretKey),
+				core_tokens.NewRevocations(resManager, core_model.ResourceKey{Name: system.UserTokenRevocations}),
 				store_config.MemoryStore,
 			),
 		)

--- a/pkg/test/resources/samples/global_secret_samples.go
+++ b/pkg/test/resources/samples/global_secret_samples.go
@@ -36,7 +36,7 @@ zk0CWhRmtI7HMSnFTQOz9421MiMO8CnLZLqxRBxro/Hr5kb7FqmI4/ItURKbJReK
 
 func SampleSigningKeyGlobalSecretBuilder() *builders.GlobalSecretBuilder {
 	return builders.GlobalSecret().
-		WithName("user-token-signing-key-1").
+		WithName(system.UserTokenSigningKeyPrefix + "-1").
 		WithStringValue(SampleSigningKeyValue)
 }
 

--- a/pkg/test/resources/samples/secret_samples.go
+++ b/pkg/test/resources/samples/secret_samples.go
@@ -4,7 +4,6 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
-	"github.com/kumahq/kuma/pkg/envoy/admin/tls"
 	"github.com/kumahq/kuma/pkg/test/resources/builders"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
 )
@@ -25,8 +24,7 @@ func SampleGlobalSecretAdminCa() *system.GlobalSecretResource {
 		Value: []byte{},
 	}
 	globalSecret.SetMeta(&test_model.ResourceMeta{
-		Name: tls.GlobalSecretKey.Name,
-		Mesh: tls.GlobalSecretKey.Mesh,
+		Name: system.EnvoyAdminCA,
 	})
 	return globalSecret
 }

--- a/pkg/tokens/builtin/issuer/token.go
+++ b/pkg/tokens/builtin/issuer/token.go
@@ -4,20 +4,8 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/tokens"
 )
-
-func DataplaneTokenSigningKeyPrefix(mesh string) string {
-	return "dataplane-token-signing-key-" + mesh
-}
-
-func DataplaneTokenRevocationsSecretKey(mesh string) core_model.ResourceKey {
-	return core_model.ResourceKey{
-		Name: "dataplane-token-revocations-" + mesh,
-		Mesh: mesh,
-	}
-}
 
 type DataplaneIdentity struct {
 	Name string

--- a/pkg/tokens/builtin/zone/token.go
+++ b/pkg/tokens/builtin/zone/token.go
@@ -3,19 +3,8 @@ package zone
 import (
 	"github.com/golang-jwt/jwt/v4"
 
-	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_tokens "github.com/kumahq/kuma/pkg/core/tokens"
 )
-
-const (
-	SigningKeyPrefix       = "zone-token-signing-key"
-	SigningPublicKeyPrefix = "zone-token-signing-public-key"
-)
-
-var TokenRevocationsGlobalSecretKey = core_model.ResourceKey{
-	Name: "zone-token-revocations",
-	Mesh: core_model.NoMesh,
-}
 
 type ZoneClaims struct {
 	Zone  string

--- a/pkg/xds/auth/universal/auth_test.go
+++ b/pkg/xds/auth/universal/auth_test.go
@@ -57,9 +57,9 @@ var _ = Describe("Authentication flow", func() {
 		Expect(err).ToNot(HaveOccurred())
 		authenticator = universal.NewAuthenticator(dataplaneValidator, zoneTokenValidator, "zone-1")
 
-		signingKeyManager := tokens.NewMeshedSigningKeyManager(resManager, builtin_issuer.DataplaneTokenSigningKeyPrefix("default"), "default")
+		signingKeyManager := tokens.NewMeshedSigningKeyManager(resManager, system.DataplaneTokenSigningKey("default"), "default")
 		Expect(signingKeyManager.CreateDefaultSigningKey(ctx)).To(Succeed())
-		signingKeyManager = tokens.NewMeshedSigningKeyManager(resManager, builtin_issuer.DataplaneTokenSigningKeyPrefix("demo"), "demo")
+		signingKeyManager = tokens.NewMeshedSigningKeyManager(resManager, system.DataplaneTokenSigningKey("demo"), "demo")
 		Expect(signingKeyManager.CreateDefaultSigningKey(ctx)).To(Succeed())
 
 		err = resStore.Create(ctx, &dpRes, core_store.CreateByKey("dp-1", "default"))
@@ -200,7 +200,7 @@ var _ = Describe("Authentication flow", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// and new signing key
-		signingKeyManager := tokens.NewMeshedSigningKeyManager(resManager, builtin_issuer.DataplaneTokenSigningKeyPrefix("default"), "default")
+		signingKeyManager := tokens.NewMeshedSigningKeyManager(resManager, system.DataplaneTokenSigningKey("default"), "default")
 		Expect(resManager.DeleteAll(ctx, &system.SecretResourceList{})).To(Succeed())
 		Expect(signingKeyManager.CreateDefaultSigningKey(ctx)).To(Succeed())
 
@@ -240,7 +240,7 @@ var _ = Describe("Authentication flow", func() {
 			err := resStore.Create(ctx, &ziRes, core_store.CreateByKey("zi-1", model.NoMesh))
 			Expect(err).ToNot(HaveOccurred())
 
-			zoneKeyManager := tokens.NewSigningKeyManager(resManager, zone.SigningKeyPrefix)
+			zoneKeyManager := tokens.NewSigningKeyManager(resManager, system.ZoneTokenSigningKeyPrefix)
 			Expect(zoneKeyManager.CreateDefaultSigningKey(ctx)).To(Succeed())
 			zoneTokenIssuer = builtin.NewZoneTokenIssuer(resManager)
 		})


### PR DESCRIPTION
They are used all over the place and make more sense in this more generic package
