### PR TITLE
feat(config): combine default switches into mode

### DIFF
--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -32,17 +32,31 @@ var _ config.Config = &Config{}
 
 var _ config.Config = &Defaults{}
 
+const (
+	ModeNone DefaultsMode = "none"
+	ModeDemo DefaultsMode = "demo"
+)
+
+type DefaultsMode string
+
 type Defaults struct {
 	config.BaseConfig
 
+	// Mode for defining default resources. Possible values: "none", "demo".
+	// None - no default resources will be created. This is best suited for IaC and production use cases where you want to precisely control what's created.
+	// Demo - default resources will be created. This is best suited for demoing and testing use cases where you want to quickly get started.
+	Mode DefaultsMode `json:"mode" envconfig:"kuma_defaults_mode"`
 	// If true, it skips creating the default Mesh
+	// Deprecated: use mode instead.
 	SkipMeshCreation bool `json:"skipMeshCreation" envconfig:"kuma_defaults_skip_mesh_creation"`
 	// If true, it skips creating the default tenant resources
+	// Deprecated: use mode instead.
 	SkipTenantResources bool `json:"skipTenantResources" envconfig:"kuma_defaults_skip_tenant_resources"`
 	// If true, automatically create the default routing (TrafficPermission and TrafficRoute) resources for a new Mesh.
 	// These policies are essential for traffic to flow correctly when operating a global control plane with zones running older (<2.6.0) versions of Kuma.
 	CreateMeshRoutingResources bool `json:"createMeshRoutingResources" envconfig:"kuma_defaults_create_mesh_routing_resources"`
 	// If true, it skips creating default hostname generators
+	// Deprecated: use mode instead.
 	SkipHostnameGenerators bool `json:"SkipHostnameGenerators" envconfig:"kuma_defaults_skip_hostname_generators"`
 }
 
@@ -427,6 +441,7 @@ func DefaultGeneralConfig() *GeneralConfig {
 
 func DefaultDefaultsConfig() *Defaults {
 	return &Defaults{
+		Mode:                       ModeDemo,
 		SkipMeshCreation:           false,
 		SkipTenantResources:        false,
 		CreateMeshRoutingResources: false,

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -280,6 +280,7 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.Multizone.Zone.KDS.TlsSkipVerify).To(BeTrue())
 			Expect(cfg.Multizone.Zone.KDS.Labels.SkipPrefixes).To(Equal([]string{"argocd.argoproj.io"}))
 
+			Expect(cfg.Defaults.Mode).To(Equal(kuma_cp.ModeNone))
 			Expect(cfg.Defaults.SkipMeshCreation).To(BeTrue())
 			Expect(cfg.Defaults.SkipTenantResources).To(BeTrue())
 			Expect(cfg.Defaults.CreateMeshRoutingResources).To(BeTrue())
@@ -649,6 +650,7 @@ dnsServer:
   serviceVipEnabled: false
   serviceVipPort: 9090
 defaults:
+  skipMeshCreation: None
   skipMeshCreation: true
   skipHostnameGenerators: true
   skipTenantResources: true

--- a/pkg/defaults/components.go
+++ b/pkg/defaults/components.go
@@ -31,6 +31,11 @@ var EnsureDefaultFuncs = []EnsureDefaultFunc{
 }
 
 func Setup(runtime runtime.Runtime) error {
+	if runtime.Config().Defaults.Mode == kuma_cp.ModeNone {
+		log.V(1).Info("skipping default tenant resources because KUMA_DEFAULTS_MODE is set to none")
+		return nil
+	}
+
 	if runtime.Config().Defaults.SkipTenantResources {
 		log.V(1).Info("skipping default tenant resources because KUMA_DEFAULTS_SKIP_TENANT_RESOURCES is set to true")
 		return nil

--- a/pkg/defaults/components_test.go
+++ b/pkg/defaults/components_test.go
@@ -102,4 +102,32 @@ var _ = Describe("Defaults Component", func() {
 			Expect(core_store.IsResourceNotFound(err)).To(BeTrue())
 		})
 	})
+
+	Describe("when mode is set to none", func() {
+		var component core_component.Component
+		var manager core_manager.ResourceManager
+
+		BeforeEach(func() {
+			cfg := kuma_cp.DefaultConfig()
+			cfg.Defaults.Mode = kuma_cp.ModeNone
+			store := resources_memory.NewStore()
+			manager = core_manager.NewResourceManager(store)
+			component = &defaults.DefaultComponent{
+				Extensions: context.Background(),
+				Funcs:      []defaults.EnsureDefaultFunc{defaults.EnsureDefaultMeshExists},
+				ResManager: manager,
+				CpConfig:   cfg,
+			}
+		})
+
+		It("should not create default mesh", func() {
+			// when
+			err := component.Start(nil)
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			err = manager.Get(context.Background(), core_mesh.NewMeshResource(), core_store.GetByKey("default", "default"))
+			Expect(core_store.IsResourceNotFound(err)).To(BeTrue())
+		})
+	})
 })

--- a/pkg/defaults/hostname_generator.go
+++ b/pkg/defaults/hostname_generator.go
@@ -18,6 +18,10 @@ import (
 )
 
 func EnsureHostnameGeneratorExists(ctx context.Context, resManager core_manager.ResourceManager, logger logr.Logger, cfg kuma_cp.Config) error {
+	if cfg.Defaults.Mode == kuma_cp.ModeNone {
+		log.V(1).Info("skipping default hostname generators because KUMA_DEFAULTS_MODE is set to none")
+		return nil
+	}
 	if cfg.Defaults.SkipHostnameGenerators {
 		log.V(1).Info("skip ensuring default hostname generators because SkipHostnameGenerators is set to true")
 		return nil

--- a/pkg/defaults/hostname_generator_test.go
+++ b/pkg/defaults/hostname_generator_test.go
@@ -60,6 +60,14 @@ var _ = Describe("Ensure Hostname Generators", func() {
 			},
 			expectedGenNames: nil,
 		}),
+		Entry("skip defaults via mode", testCase{
+			cpConfig: kuma_cp.Config{
+				Defaults: &kuma_cp.Defaults{
+					Mode: kuma_cp.ModeNone,
+				},
+			},
+			expectedGenNames: nil,
+		}),
 		Entry("global universal", testCase{
 			cpConfig: kuma_cp.Config{
 				Defaults:    &kuma_cp.Defaults{},

--- a/pkg/defaults/mesh.go
+++ b/pkg/defaults/mesh.go
@@ -22,6 +22,10 @@ func EnsureDefaultMeshExists(
 	logger logr.Logger,
 	cfg kuma_cp.Config,
 ) error {
+	if cfg.Defaults.Mode == kuma_cp.ModeNone {
+		log.V(1).Info("skipping default Mesh creation because KUMA_DEFAULTS_MODE is set to none")
+		return nil
+	}
 	if cfg.Defaults.SkipMeshCreation {
 		log.V(1).Info("skipping default Mesh creation because KUMA_DEFAULTS_SKIP_MESH_CREATION is set to true")
 		return nil


### PR DESCRIPTION
combine SkipMeshCreation SkipTenantResources and SkipHostnameGenerators into Mode

## Motivation

<!-- Why are we doing this change -->

## Implementation information

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Closes https://github.com/kumahq/kuma/issues/12413

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
