### PR TITLE
chore(lint): fix api lint path

### DIFF
--- a/mk/check.mk
+++ b/mk/check.mk
@@ -68,7 +68,7 @@ lint: helm-lint golangci-lint shellcheck kube-lint hadolint ginkgo/lint api-lint
 .PHONY: api-lint
 api-lint:
 	go run $(TOOLS_DIR)/ci/api-linter/main.go $$(find ./pkg/plugins/policies/*/api/v1alpha1 -type d -maxdepth 0 | sed 's|^|$(GO_MODULE)/|')
-	go run tools/ci/api-linter/main.go github.com/kumahq/kuma/pkg/core/resources/apis/meshexternalservice/api/v1alpha1 github.com/kumahq/kuma/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1
+	go run $(TOOLS_DIR)/ci/api-linter/main.go github.com/kumahq/kuma/pkg/core/resources/apis/meshexternalservice/api/v1alpha1 github.com/kumahq/kuma/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1
 
 .PHONY: check
 check: format lint ## Dev: Run code checks (go fmt, go vet, ...)


### PR DESCRIPTION
## Motivation

Otherwise it fails in parent project.

## Implementation information

Add CI_TOOLS to the invocation.