### PR TITLE
fix(oapi): fix default in size query parameter

### DIFF
--- a/api/mesh/v1alpha1/mesh/rest.yaml
+++ b/api/mesh/v1alpha1/mesh/rest.yaml
@@ -94,9 +94,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query

--- a/api/mesh/v1alpha1/meshgateway/rest.yaml
+++ b/api/mesh/v1alpha1/meshgateway/rest.yaml
@@ -112,9 +112,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -344,9 +344,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query
@@ -480,9 +480,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query
@@ -616,9 +616,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query
@@ -752,9 +752,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query
@@ -888,9 +888,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query
@@ -1025,9 +1025,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query
@@ -1159,9 +1159,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query
@@ -1295,9 +1295,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query
@@ -1431,9 +1431,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query
@@ -1567,9 +1567,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query
@@ -1701,9 +1701,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query
@@ -1835,9 +1835,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query
@@ -1969,9 +1969,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query
@@ -2103,9 +2103,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query
@@ -2237,9 +2237,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query
@@ -2374,9 +2374,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query
@@ -2490,9 +2490,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query
@@ -2618,9 +2618,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query
@@ -2736,9 +2736,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query
@@ -2866,9 +2866,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query
@@ -3002,9 +3002,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query
@@ -3136,9 +3136,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query

--- a/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/rest.yaml
@@ -94,9 +94,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/rest.yaml
@@ -112,9 +112,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query

--- a/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/rest.yaml
@@ -112,9 +112,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/rest.yaml
@@ -112,9 +112,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/rest.yaml
@@ -112,9 +112,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/rest.yaml
@@ -112,9 +112,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/rest.yaml
@@ -112,9 +112,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/rest.yaml
@@ -112,9 +112,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/rest.yaml
@@ -112,9 +112,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/rest.yaml
@@ -112,9 +112,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/rest.yaml
@@ -112,9 +112,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query

--- a/pkg/plugins/policies/meshpassthrough/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshpassthrough/api/v1alpha1/rest.yaml
@@ -112,9 +112,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query

--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/rest.yaml
@@ -112,9 +112,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/rest.yaml
@@ -112,9 +112,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/rest.yaml
@@ -112,9 +112,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/rest.yaml
@@ -112,9 +112,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/rest.yaml
@@ -112,9 +112,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query

--- a/pkg/plugins/policies/meshtls/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtls/api/v1alpha1/rest.yaml
@@ -112,9 +112,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/rest.yaml
@@ -112,9 +112,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query

--- a/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/rest.yaml
@@ -112,9 +112,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query

--- a/tools/openapi/templates/endpoints.yaml
+++ b/tools/openapi/templates/endpoints.yaml
@@ -118,9 +118,9 @@ paths:
           name: size
           description: the number of items per page
           required: false
-          default: 100
           schema:
             type: integer
+            default: 100
             maximum: 1000
             minimum: 1
         - in: query


### PR DESCRIPTION
## Motivation

It's just wrong and causes failures upstream.

## Implementation information

Put it in the right place - https://swagger.io/docs/specification/v3_0/describing-parameters/#default-parameter-values

xrel: https://github.com/kumahq/kuma/issues/12935