### PR TITLE
test(e2e): use unique name of the resource

### DIFF
--- a/test/e2e_env/kubernetes/meshcircuitbreaker/meshcircuitbreaker.go
+++ b/test/e2e_env/kubernetes/meshcircuitbreaker/meshcircuitbreaker.go
@@ -206,6 +206,7 @@ spec:
           maxConnections: 1
           maxPendingRequests: 1
           maxRequests: 1
+          maxRetries: 1
         outlierDetection:
           interval: 1s
           baseEjectionTime: 30s

--- a/test/e2e_env/kubernetes/meshcircuitbreaker/meshcircuitbreaker.go
+++ b/test/e2e_env/kubernetes/meshcircuitbreaker/meshcircuitbreaker.go
@@ -190,7 +190,7 @@ spec:
 apiVersion: kuma.io/v1alpha1
 kind: MeshCircuitBreaker
 metadata:
-  name: mcb-outbound
+  name: mcb-outbound-ms
   namespace: %s
   labels:
     kuma.io/mesh: %s

--- a/test/e2e_env/kubernetes/meshcircuitbreaker/meshcircuitbreaker.go
+++ b/test/e2e_env/kubernetes/meshcircuitbreaker/meshcircuitbreaker.go
@@ -206,7 +206,6 @@ spec:
           maxConnections: 1
           maxPendingRequests: 1
           maxRequests: 1
-          maxRetries: 1
         outlierDetection:
           interval: 1s
           baseEjectionTime: 30s


### PR DESCRIPTION
## Motivation

We were using the same name as other policy. Let's see if it helps