### PR TITLE
test(e2e): make connections shorter when using MLBS

### DIFF
--- a/test/e2e_env/kubernetes/gateway/gateway.go
+++ b/test/e2e_env/kubernetes/gateway/gateway.go
@@ -555,7 +555,6 @@ spec:
   - targetRef:
       kind: Mesh
     default:
-      idleTimeout: 10s
       http:
         maxConnectionDuration: 10s`, Config.KumaNamespace, meshName)
 		mlbs := fmt.Sprintf(`


### PR DESCRIPTION
## Motivation

Noticed a flake: Once Envoy establishes a connection, it might continue routing traffic to the same instance, which is not expected by our MLBS. This happens because connections are persisted and reused. They can be closed by a timeout or a cluster reload. In the test, I observed that the test eventually passes, but initially, it takes time to start using the policy strategy.

## Implementation Information

I introduced a timeout policy to shorten connection durations. This should ensure that routing aligns with our strategy sooner.
