### PR TITLE
test(unit): check correctly active watchdogs

### DIFF
--- a/pkg/xds/server/callbacks/dataplane_sync_tracker_test.go
+++ b/pkg/xds/server/callbacks/dataplane_sync_tracker_test.go
@@ -127,7 +127,7 @@ var _ = Describe("Sync", func() {
 			Expect(watchdogIsRunning).To(BeFalse())
 		}))
 
-		It("should start only one watchdog per dataplane", func() {
+		FIt("should start only one watchdog per dataplane", func() {
 			// setup
 			var activeWatchdogs int32
 			var cleanupDone atomic.Bool
@@ -152,7 +152,9 @@ var _ = Describe("Sync", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// then a watchdog is active
-			Expect(atomic.LoadInt32(&activeWatchdogs)).To(Equal(int32(0)))
+			Eventually(func() int32 {
+				return atomic.LoadInt32(&activeWatchdogs)
+			}, "5s", "10ms").Should(Equal(int32(1)))
 
 			// and when new stream from backend-01 is connected  and request is sent
 			err = callbacks.OnStreamOpen(context.Background(), streamID2, "")


### PR DESCRIPTION
## Motivation

Noticed a flake of the test.

## Implementation information

I was reviewing the test and noticed that we have an active watchdog, but our assertion was incorrectly checking that we didn't. Since this happens asynchronously, there's a potential race condition where the value increases right before the assertion. I updated it to use `Eventually` to verify that the watchdog is active.