### PR TITLE
test(e2e): use manifest instead of operator to install calico

### DIFF
--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -158,7 +158,7 @@ k3d/start: ${KIND_KUBECONFIG_DIR} k3d/network/create k3d/setup-docker-credential
 k3d/configure/calico:
 ifeq ($(K3D_NETWORK_CNI),calico)
     # https://docs.tigera.io/calico/latest/getting-started/kubernetes/k3s/quickstart
-	@KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) apply -f kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.29.2/manifests/calico.yaml
+	@KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.29.2/manifests/calico.yaml
 endif
 
 .PHONY: k3d/configure/ebpf

--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -157,9 +157,8 @@ k3d/start: ${KIND_KUBECONFIG_DIR} k3d/network/create k3d/setup-docker-credential
 .PHONY: k3d/configure/calico
 k3d/configure/calico:
 ifeq ($(K3D_NETWORK_CNI),calico)
-	@KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) create -f https://raw.githubusercontent.com/projectcalico/calico/v3.29.0/manifests/tigera-operator.yaml
-	@KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) create -f https://raw.githubusercontent.com/projectcalico/calico/v3.29.0/manifests/custom-resources.yaml
-	@KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) patch installation default --type=merge --patch='{"spec":{"calicoNetwork":{"containerIPForwarding":"Enabled"}}}'
+    # https://docs.tigera.io/calico/latest/getting-started/kubernetes/k3s/quickstart
+	@KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) apply -f kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.29.2/manifests/calico.yaml
 endif
 
 .PHONY: k3d/configure/ebpf


### PR DESCRIPTION
## Motivation

We noticed it a bit flaky so maybe using manifest is more stable