### PR TITLE
docs(upgrade): add info about apiVersion

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -40,23 +40,28 @@ New rule:
 
 ### MeshTrace
 
+#### Unifying defaults for `apiVersion`
+
+Due to misconfiguration, a default for `apiVersion` for traces on Universal could have been missing.
+If you're using Universal mode, and you did not specify `tracing.backends[].conf.apiVersion` value in your `MeshTrace` resource, you have to explicitly set it to "httpJson".
+
 #### Unifying defaults for `sharedSpanContext`
 
-Due to misconfiguration a default `sharedSpanContext` for metrics on Universal ("false") was different from on Kubernetes ("true").
+Due to misconfiguration, a default `sharedSpanContext` for traces on Universal ("false") was different from on Kubernetes ("true").
 If you're using Universal mode, and you did not specify `tracing.backends[].conf.sharedSpanContext` value in your `MeshTrace` resource, you have to explicitly set it to "false" to continue using that value.
 
 ### MeshMetric
 
 #### Unifying defaults for `path`
 
-Due to misconfiguration a default `path` for metrics on Universal ("/metrics") was different from on Kubernetes ("/metrics/prometheus").
+Due to misconfiguration, a default `path` for metrics on Universal ("/metrics") was different from on Kubernetes ("/metrics/prometheus").
 If you're using Universal mode, and you did not specify `default.applications[].path` value in your `MeshMetric` resource, you have to explicitly set it to "/metrics" to continue using that value.
 
 ### MeshPassthrough
 
 #### Unifying defaults for `passthroughMode`
 
-Due to misconfiguration a default `passthroughMode` for `MeshPasstrhough` on Universal ("Matched") was different from on Kubernetes ("None").
+Due to misconfiguration, a default `passthroughMode` for `MeshPasstrhough` on Universal ("Matched") was different from on Kubernetes ("None").
 If you're using Kubernetes mode, and you did not specify `default.passthroughMode` value in your `MeshPasstrhough` resource, you have to explicitly set it to "None" to continue using that value.
 
 ### MeshLoadBalancingStrategy


### PR DESCRIPTION
## Motivation

In https://github.com/kumahq/kuma/pull/12844#issuecomment-2662510181 we missed `enums` that could be problematic.

## Implementation information

Add upgrade.md entry.