### PR TITLE
fix(kuma-dp): prevent watchers from being cleaned up unexpectedly (backport of #12886) (backport of #12941)

### DIFF
--- a/pkg/xds/server/callbacks/dataplane_lifecycle.go
+++ b/pkg/xds/server/callbacks/dataplane_lifecycle.go
@@ -76,16 +76,6 @@ func (d *DataplaneLifecycle) OnProxyConnected(streamID core_xds.StreamID, proxyK
 	return d.register(ctx, streamID, proxyKey, md)
 }
 
-func (d *DataplaneLifecycle) OnProxyReconnected(streamID core_xds.StreamID, proxyKey core_model.ResourceKey, ctx context.Context, md core_xds.DataplaneMetadata) error {
-	if md.Resource == nil {
-		return nil
-	}
-	if err := d.validateProxyKey(proxyKey, md.Resource); err != nil {
-		return err
-	}
-	return d.register(ctx, streamID, proxyKey, md)
-}
-
 func (d *DataplaneLifecycle) OnProxyDisconnected(ctx context.Context, streamID core_xds.StreamID, proxyKey core_model.ResourceKey) {
 	// OnStreamClosed method could be called either in case data plane proxy is down or
 	// Kuma CP is gracefully shutting down. If Kuma CP is gracefully shutting down we

--- a/pkg/xds/server/callbacks/dataplane_metadata_tracker.go
+++ b/pkg/xds/server/callbacks/dataplane_metadata_tracker.go
@@ -27,11 +27,6 @@ func (d *DataplaneMetadataTracker) Metadata(dpKey core_model.ResourceKey) *core_
 	return d.metadataForDp[dpKey]
 }
 
-func (d *DataplaneMetadataTracker) OnProxyReconnected(_ core_xds.StreamID, dpKey core_model.ResourceKey, _ context.Context, metadata core_xds.DataplaneMetadata) error {
-	d.storeMetadata(dpKey, metadata)
-	return nil
-}
-
 func (d *DataplaneMetadataTracker) OnProxyConnected(_ core_xds.StreamID, dpKey core_model.ResourceKey, _ context.Context, metadata core_xds.DataplaneMetadata) error {
 	d.storeMetadata(dpKey, metadata)
 	return nil

--- a/pkg/xds/server/callbacks/dataplane_sync_tracker.go
+++ b/pkg/xds/server/callbacks/dataplane_sync_tracker.go
@@ -17,7 +17,7 @@ type NewDataplaneWatchdogFunc func(key core_model.ResourceKey) util_watchdog.Wat
 func NewDataplaneSyncTracker(factoryFunc NewDataplaneWatchdogFunc) DataplaneCallbacks {
 	return &dataplaneSyncTracker{
 		newDataplaneWatchdog: factoryFunc,
-		watchdogs:            map[core_model.ResourceKey]context.CancelFunc{},
+		watchdogs:            map[core_model.ResourceKey]*watchdogState{},
 	}
 }
 
@@ -30,19 +30,23 @@ var _ DataplaneCallbacks = &dataplaneSyncTracker{}
 // Node info can be (but does not have to be) carried only on the first XDS request. That's why need streamsAssociation map
 // that indicates that the stream was already associated
 type dataplaneSyncTracker struct {
-	NoopDataplaneCallbacks
-
 	newDataplaneWatchdog NewDataplaneWatchdogFunc
 
 	stdsync.RWMutex // protects access to the fields below
-	watchdogs       map[core_model.ResourceKey]context.CancelFunc
+	watchdogs       map[core_model.ResourceKey]*watchdogState
+}
+type watchdogState struct {
+	cancelFunc context.CancelFunc
+	stopped    chan struct{}
 }
 
+//nolint:contextcheck // it's not clear how the parent go-control-plane context lives
 func (t *dataplaneSyncTracker) OnProxyConnected(streamID core_xds.StreamID, dpKey core_model.ResourceKey, _ context.Context, _ core_xds.DataplaneMetadata) error {
 	// We use OnProxyConnected because there should be only one watchdog for given dataplane.
 	t.Lock()
 	defer t.Unlock()
 
+<<<<<<< HEAD
 	stopCh := make(chan struct{})
 
 	t.watchdogs[dpKey] = func() {
@@ -51,14 +55,34 @@ func (t *dataplaneSyncTracker) OnProxyConnected(streamID core_xds.StreamID, dpKe
 	}
 	dataplaneSyncTrackerLog.V(1).Info("starting Watchdog for a Dataplane", "dpKey", dpKey, "streamID", streamID)
 	go t.newDataplaneWatchdog(dpKey).Start(stopCh)
+=======
+	ctx, cancel := context.WithCancel(context.Background())
+	state := &watchdogState{
+		cancelFunc: cancel,
+		stopped:    make(chan struct{}),
+	}
+	dataplaneSyncTrackerLog.V(1).Info("starting Watchdog for a Dataplane", "dpKey", dpKey, "streamID", streamID)
+	stoppedDone := state.stopped
+	go func() {
+		defer close(stoppedDone)
+		t.newDataplaneWatchdog(dpKey).Start(ctx)
+	}()
+	t.watchdogs[dpKey] = state
+>>>>>>> a6a9cbdf5 (fix(kuma-dp): prevent watchers from being cleaned up unexpectedly (backport of #12886) (#12941))
 	return nil
 }
 
-func (t *dataplaneSyncTracker) OnProxyDisconnected(_ context.Context, _ core_xds.StreamID, dpKey core_model.ResourceKey) {
-	t.Lock()
-	defer t.Unlock()
-	if cancelFn := t.watchdogs[dpKey]; cancelFn != nil {
-		cancelFn()
+func (t *dataplaneSyncTracker) OnProxyDisconnected(_ context.Context, streamID core_xds.StreamID, dpKey core_model.ResourceKey) {
+	t.RLock()
+	dpData := t.watchdogs[dpKey]
+	t.RUnlock()
+
+	if dpData != nil {
+		dpData.cancelFunc()
+		<-dpData.stopped
+		dataplaneSyncTrackerLog.V(1).Info("watchdog for a Dataplane stopped", "dpKey", dpKey, "streamID", streamID)
+		t.Lock()
+		defer t.Unlock()
+		delete(t.watchdogs, dpKey)
 	}
-	delete(t.watchdogs, dpKey)
 }

--- a/pkg/xds/server/callbacks/dataplane_sync_tracker_test.go
+++ b/pkg/xds/server/callbacks/dataplane_sync_tracker_test.go
@@ -131,54 +131,73 @@ var _ = Describe("Sync", func() {
 		It("should start only one watchdog per dataplane", func() {
 			// setup
 			var activeWatchdogs int32
+<<<<<<< HEAD
 			tracker := NewDataplaneSyncTracker(func(key core_model.ResourceKey) util_watchdog.Watchdog {
 				return WatchdogFunc(func(stop <-chan struct{}) {
+=======
+			var cleanupDone atomic.Bool
+			tracker := NewDataplaneSyncTracker(func(key core_model.ResourceKey) util_xds_v3.Watchdog {
+				return WatchdogFunc(func(ctx context.Context) {
+>>>>>>> a6a9cbdf5 (fix(kuma-dp): prevent watchers from being cleaned up unexpectedly (backport of #12886) (#12941))
 					atomic.AddInt32(&activeWatchdogs, 1)
 					<-stop
 					atomic.AddInt32(&activeWatchdogs, -1)
+					cleanupDone.Store(true)
 				})
 			})
 			callbacks := util_xds_v3.AdaptCallbacks(DataplaneCallbacksToXdsCallbacks(tracker))
 
 			// when one stream for backend-01 is connected and request is sent
-			streamID := int64(1)
-			err := callbacks.OnStreamOpen(context.Background(), streamID, "")
+			streamID1 := int64(1)
+			streamID2 := int64(2)
+			streamID3 := int64(3)
+			err := callbacks.OnStreamOpen(context.Background(), streamID1, "")
 			Expect(err).ToNot(HaveOccurred())
-			n := &envoy_core.Node{Id: "default.backend-01"}
-			err = callbacks.OnStreamRequest(streamID, &envoy_sd.DiscoveryRequest{Node: n})
+			node := &envoy_core.Node{Id: "default.backend-01"}
+			err = callbacks.OnStreamRequest(streamID1, &envoy_sd.DiscoveryRequest{Node: node})
 			Expect(err).ToNot(HaveOccurred())
 
+			// then a watchdog is active
+			Expect(atomic.LoadInt32(&activeWatchdogs)).To(Equal(int32(0)))
+
 			// and when new stream from backend-01 is connected  and request is sent
-			streamID = 2
-			err = callbacks.OnStreamOpen(context.Background(), streamID, "")
+			err = callbacks.OnStreamOpen(context.Background(), streamID2, "")
 			Expect(err).ToNot(HaveOccurred())
-			err = callbacks.OnStreamRequest(streamID, &envoy_sd.DiscoveryRequest{
-				Node: &envoy_core.Node{
-					Id: "default.backend-01",
-				},
-			})
-			Expect(err).ToNot(HaveOccurred())
+			err = callbacks.OnStreamRequest(streamID2, &envoy_sd.DiscoveryRequest{Node: node})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("already an active stream"))
 
 			// then only one watchdog is active
 			Eventually(func() int32 {
 				return atomic.LoadInt32(&activeWatchdogs)
 			}, "5s", "10ms").Should(Equal(int32(1)))
 
-			// when first stream is closed
-			callbacks.OnStreamClosed(1, n)
+			callbacks.OnStreamClosed(streamID2, node)
+			Expect(cleanupDone.Load()).To(BeFalse())
 
-			// then watchdog is still active because other stream is opened
+			// when first stream is closed
+			callbacks.OnStreamClosed(streamID1, node)
+			Expect(cleanupDone.Load()).To(BeTrue())
+
+			// then there is no active watchdog
+			Expect(atomic.LoadInt32(&activeWatchdogs)).To(Equal(int32(0)))
+
+			// and when the third stream from backend-01 is connected after the first active stream closed and request is sent
+			err = callbacks.OnStreamOpen(context.Background(), streamID3, "")
+			Expect(err).ToNot(HaveOccurred())
+			err = callbacks.OnStreamRequest(streamID3, &envoy_sd.DiscoveryRequest{Node: node})
+			Expect(err).ToNot(HaveOccurred())
+
+			// then a watchdog is active
 			Eventually(func() int32 {
 				return atomic.LoadInt32(&activeWatchdogs)
 			}, "5s", "10ms").Should(Equal(int32(1)))
 
-			// when other stream is closed
-			callbacks.OnStreamClosed(2, n)
+			// when the third stream is closed
+			callbacks.OnStreamClosed(streamID3, node)
 
-			// then no watchdog is stopped
-			Eventually(func() int32 {
-				return atomic.LoadInt32(&activeWatchdogs)
-			}, "5s", "10ms").Should(Equal(int32(0)))
+			// then no watchdog is active
+			Expect(atomic.LoadInt32(&activeWatchdogs)).To(Equal(int32(0)))
 		})
 	})
 })


### PR DESCRIPTION
Manual cherry-pick of #12941 to branch `release-2.7`

cherry-picked commit a6a9cbdf52f4b6f4ed100827aef0c6a217e3aead

:warning: :warning: :warning: Conflicts found when cherry-picking! :warning: :warning: :warning:
```
On branch backport-12941-to-release-2.7
You are currently cherry-picking commit a6a9cbdf5.
  (fix conflicts and run "git cherry-pick --continue")
  (use "git cherry-pick --skip" to skip this patch)
  (use "git cherry-pick --abort" to cancel the cherry-pick operation)

Changes to be committed:
	modified:   pkg/xds/server/callbacks/dataplane_callbacks.go
	modified:   pkg/xds/server/callbacks/dataplane_callbacks_test.go
	modified:   pkg/xds/server/callbacks/dataplane_lifecycle.go
	modified:   pkg/xds/server/callbacks/dataplane_metadata_tracker.go

Unmerged paths:
  (use "git add <file>..." to mark resolution)
	both modified:   pkg/xds/server/callbacks/dataplane_sync_tracker.go
	both modified:   pkg/xds/server/callbacks/dataplane_sync_tracker_test.go
```