### PR TITLE
fix(kuma-dp): prevent watchers from being cleaned up unexpectedly (backport of #12886)

### DIFF
--- a/pkg/xds/server/callbacks/dataplane_callbacks.go
+++ b/pkg/xds/server/callbacks/dataplane_callbacks.go
@@ -20,12 +20,9 @@ import (
 // If there are many instances of the Control Plane and Dataplane reconnects, there might be an old stream
 // in one instance of CP and a new stream in a new instance of CP.
 type DataplaneCallbacks interface {
-	// OnProxyConnected is executed when proxy is connected after it was disconnected before.
+	// OnProxyConnected is executed when an active stream from a proxy is connected
 	OnProxyConnected(streamID core_xds.StreamID, dpKey core_model.ResourceKey, ctx context.Context, metadata core_xds.DataplaneMetadata) error
-	// OnProxyReconnected is executed when proxy is already connected, but there is another stream.
-	// This can happen when there is a delay with closing the old connection from the proxy to the control plane.
-	OnProxyReconnected(streamID core_xds.StreamID, dpKey core_model.ResourceKey, ctx context.Context, metadata core_xds.DataplaneMetadata) error
-	// OnProxyDisconnected is executed only when the last stream of the proxy disconnects.
+	// OnProxyDisconnected is executed only when an active stream of the proxy disconnects
 	OnProxyDisconnected(ctx context.Context, streamID core_xds.StreamID, dpKey core_model.ResourceKey)
 }
 
@@ -35,14 +32,14 @@ type xdsCallbacks struct {
 
 	sync.RWMutex
 	dpStreams     map[core_xds.StreamID]dpStream
-	activeStreams map[core_model.ResourceKey]int
+	activeStreams map[core_model.ResourceKey]core_xds.StreamID
 }
 
 func DataplaneCallbacksToXdsCallbacks(callbacks DataplaneCallbacks) util_xds.Callbacks {
 	return &xdsCallbacks{
 		callbacks:     callbacks,
 		dpStreams:     map[core_xds.StreamID]dpStream{},
-		activeStreams: map[core_model.ResourceKey]int{},
+		activeStreams: map[core_model.ResourceKey]core_xds.StreamID{},
 	}
 }
 
@@ -54,22 +51,23 @@ type dpStream struct {
 var _ util_xds.Callbacks = &xdsCallbacks{}
 
 func (d *xdsCallbacks) OnStreamClosed(streamID core_xds.StreamID) {
-	var lastStreamDpKey *core_model.ResourceKey
-	d.Lock()
+	var streamDpKey *core_model.ResourceKey
+	d.RLock()
 	dpStream := d.dpStreams[streamID]
-	if dpKey := dpStream.dp; dpKey != nil {
-		d.activeStreams[*dpKey]--
-		if d.activeStreams[*dpKey] == 0 {
-			lastStreamDpKey = dpKey
-			delete(d.activeStreams, *dpKey)
-		}
+	streamDpKey = dpStream.dp
+	d.RUnlock()
+
+	if streamDpKey != nil {
+		// execute callback after lock is freed, so heavy callback implementation won't block every callback for every DPP.
+		d.callbacks.OnProxyDisconnected(dpStream.ctx, streamID, *streamDpKey)
+	}
+
+	d.Lock()
+	if streamDpKey != nil {
+		delete(d.activeStreams, *streamDpKey)
 	}
 	delete(d.dpStreams, streamID)
 	d.Unlock()
-	if lastStreamDpKey != nil {
-		// execute callback after lock is freed, so heavy callback implementation won't block every callback for every DPP.
-		d.callbacks.OnProxyDisconnected(dpStream.ctx, streamID, *lastStreamDpKey)
-	}
 }
 
 func (d *xdsCallbacks) OnStreamRequest(streamID core_xds.StreamID, request util_xds.DiscoveryRequest) error {
@@ -102,31 +100,29 @@ func (d *xdsCallbacks) OnStreamRequest(streamID core_xds.StreamID, request util_
 
 	d.Lock()
 	// in case client will open 2 concurrent request for the same streamID then
-	// we don't to increment the counter twice, so checking once again that stream
-	// wasn't processed
+	// checking once again that stream wasn't processed
 	alreadyProcessed = d.dpStreams[streamID].dp != nil
 	if alreadyProcessed {
+		d.Unlock()
 		return nil
 	}
 
-	dpStream := d.dpStreams[streamID]
-	dpStream.dp = &dpKey
-	d.dpStreams[streamID] = dpStream
+	var streamInfo dpStream
+	_, alreadyConnected := d.activeStreams[dpKey]
+	if !alreadyConnected {
+		streamInfo = d.dpStreams[streamID]
+		streamInfo.dp = &dpKey
+		d.dpStreams[streamID] = streamInfo
 
-	activeStreams := d.activeStreams[dpKey]
-	d.activeStreams[dpKey]++
+		d.activeStreams[dpKey] = streamID
+	}
 	d.Unlock()
 
-	if activeStreams == 0 {
-		if err := d.callbacks.OnProxyConnected(streamID, dpKey, dpStream.ctx, *metadata); err != nil {
-			return err
-		}
-	} else {
-		if err := d.callbacks.OnProxyReconnected(streamID, dpKey, dpStream.ctx, *metadata); err != nil {
-			return err
-		}
+	if !alreadyConnected {
+		return d.callbacks.OnProxyConnected(streamID, dpKey, streamInfo.ctx, *metadata)
 	}
-	return nil
+	// we don't allow more than one active stream from a data plane as there can be race conditions
+	return errors.New("there is already an active stream from this node, try again later")
 }
 
 func (d *xdsCallbacks) OnStreamOpen(ctx context.Context, streamID core_xds.StreamID, _ string) error {
@@ -142,15 +138,11 @@ func (d *xdsCallbacks) OnStreamOpen(ctx context.Context, streamID core_xds.Strea
 // NoopDataplaneCallbacks are empty callbacks that helps to implement DataplaneCallbacks without need to implement every function.
 type NoopDataplaneCallbacks struct{}
 
-func (n *NoopDataplaneCallbacks) OnProxyReconnected(core_xds.StreamID, core_model.ResourceKey, context.Context, core_xds.DataplaneMetadata) error {
-	return nil
-}
-
 func (n *NoopDataplaneCallbacks) OnProxyConnected(core_xds.StreamID, core_model.ResourceKey, context.Context, core_xds.DataplaneMetadata) error {
 	return nil
 }
 
-func (n *NoopDataplaneCallbacks) OnProxyDisconnected(context.Context, core_xds.StreamID, core_model.ResourceKey) {
+func (n *NoopDataplaneCallbacks) OnProxyDisconnected(_ context.Context, _ core_xds.StreamID, _ core_model.ResourceKey) {
 }
 
 var _ DataplaneCallbacks = &NoopDataplaneCallbacks{}

--- a/pkg/xds/server/callbacks/dataplane_lifecycle.go
+++ b/pkg/xds/server/callbacks/dataplane_lifecycle.go
@@ -76,16 +76,6 @@ func (d *DataplaneLifecycle) OnProxyConnected(streamID core_xds.StreamID, proxyK
 	return d.register(ctx, streamID, proxyKey, md)
 }
 
-func (d *DataplaneLifecycle) OnProxyReconnected(streamID core_xds.StreamID, proxyKey core_model.ResourceKey, ctx context.Context, md core_xds.DataplaneMetadata) error {
-	if md.Resource == nil {
-		return nil
-	}
-	if err := d.validateProxyKey(proxyKey, md.Resource); err != nil {
-		return err
-	}
-	return d.register(ctx, streamID, proxyKey, md)
-}
-
 func (d *DataplaneLifecycle) OnProxyDisconnected(ctx context.Context, streamID core_xds.StreamID, proxyKey core_model.ResourceKey) {
 	// OnStreamClosed method could be called either in case data plane proxy is down or
 	// Kuma CP is gracefully shutting down. If Kuma CP is gracefully shutting down we

--- a/pkg/xds/server/callbacks/dataplane_metadata_tracker.go
+++ b/pkg/xds/server/callbacks/dataplane_metadata_tracker.go
@@ -27,11 +27,6 @@ func (d *DataplaneMetadataTracker) Metadata(dpKey core_model.ResourceKey) *core_
 	return d.metadataForDp[dpKey]
 }
 
-func (d *DataplaneMetadataTracker) OnProxyReconnected(_ core_xds.StreamID, dpKey core_model.ResourceKey, _ context.Context, metadata core_xds.DataplaneMetadata) error {
-	d.storeMetadata(dpKey, metadata)
-	return nil
-}
-
 func (d *DataplaneMetadataTracker) OnProxyConnected(_ core_xds.StreamID, dpKey core_model.ResourceKey, _ context.Context, metadata core_xds.DataplaneMetadata) error {
 	d.storeMetadata(dpKey, metadata)
 	return nil

--- a/pkg/xds/server/callbacks/dataplane_sync_tracker.go
+++ b/pkg/xds/server/callbacks/dataplane_sync_tracker.go
@@ -46,29 +46,21 @@ func (t *dataplaneSyncTracker) OnProxyConnected(streamID core_xds.StreamID, dpKe
 	t.Lock()
 	defer t.Unlock()
 
-<<<<<<< HEAD
 	stopCh := make(chan struct{})
 
-	t.watchdogs[dpKey] = func() {
-		dataplaneSyncTrackerLog.V(1).Info("stopping Watchdog for a Dataplane", "dpKey", dpKey, "streamID", streamID)
-		close(stopCh)
-	}
-	dataplaneSyncTrackerLog.V(1).Info("starting Watchdog for a Dataplane", "dpKey", dpKey, "streamID", streamID)
-	go t.newDataplaneWatchdog(dpKey).Start(stopCh)
-=======
-	ctx, cancel := context.WithCancel(context.Background())
 	state := &watchdogState{
-		cancelFunc: cancel,
-		stopped:    make(chan struct{}),
+		cancelFunc: func() {
+			close(stopCh)
+		},
+		stopped: make(chan struct{}),
 	}
 	dataplaneSyncTrackerLog.V(1).Info("starting Watchdog for a Dataplane", "dpKey", dpKey, "streamID", streamID)
 	stoppedDone := state.stopped
 	go func() {
 		defer close(stoppedDone)
-		t.newDataplaneWatchdog(dpKey).Start(ctx)
+		t.newDataplaneWatchdog(dpKey).Start(stopCh)
 	}()
 	t.watchdogs[dpKey] = state
->>>>>>> f6f58cf76 (fix(kuma-dp): prevent watchers from being cleaned up unexpectedly (#12886))
 	return nil
 }
 

--- a/pkg/xds/server/callbacks/dataplane_sync_tracker.go
+++ b/pkg/xds/server/callbacks/dataplane_sync_tracker.go
@@ -17,7 +17,7 @@ type NewDataplaneWatchdogFunc func(key core_model.ResourceKey) util_watchdog.Wat
 func NewDataplaneSyncTracker(factoryFunc NewDataplaneWatchdogFunc) DataplaneCallbacks {
 	return &dataplaneSyncTracker{
 		newDataplaneWatchdog: factoryFunc,
-		watchdogs:            map[core_model.ResourceKey]context.CancelFunc{},
+		watchdogs:            map[core_model.ResourceKey]*watchdogState{},
 	}
 }
 
@@ -30,19 +30,23 @@ var _ DataplaneCallbacks = &dataplaneSyncTracker{}
 // Node info can be (but does not have to be) carried only on the first XDS request. That's why need streamsAssociation map
 // that indicates that the stream was already associated
 type dataplaneSyncTracker struct {
-	NoopDataplaneCallbacks
-
 	newDataplaneWatchdog NewDataplaneWatchdogFunc
 
 	stdsync.RWMutex // protects access to the fields below
-	watchdogs       map[core_model.ResourceKey]context.CancelFunc
+	watchdogs       map[core_model.ResourceKey]*watchdogState
+}
+type watchdogState struct {
+	cancelFunc context.CancelFunc
+	stopped    chan struct{}
 }
 
+//nolint:contextcheck // it's not clear how the parent go-control-plane context lives
 func (t *dataplaneSyncTracker) OnProxyConnected(streamID core_xds.StreamID, dpKey core_model.ResourceKey, _ context.Context, _ core_xds.DataplaneMetadata) error {
 	// We use OnProxyConnected because there should be only one watchdog for given dataplane.
 	t.Lock()
 	defer t.Unlock()
 
+<<<<<<< HEAD
 	stopCh := make(chan struct{})
 
 	t.watchdogs[dpKey] = func() {
@@ -51,14 +55,34 @@ func (t *dataplaneSyncTracker) OnProxyConnected(streamID core_xds.StreamID, dpKe
 	}
 	dataplaneSyncTrackerLog.V(1).Info("starting Watchdog for a Dataplane", "dpKey", dpKey, "streamID", streamID)
 	go t.newDataplaneWatchdog(dpKey).Start(stopCh)
+=======
+	ctx, cancel := context.WithCancel(context.Background())
+	state := &watchdogState{
+		cancelFunc: cancel,
+		stopped:    make(chan struct{}),
+	}
+	dataplaneSyncTrackerLog.V(1).Info("starting Watchdog for a Dataplane", "dpKey", dpKey, "streamID", streamID)
+	stoppedDone := state.stopped
+	go func() {
+		defer close(stoppedDone)
+		t.newDataplaneWatchdog(dpKey).Start(ctx)
+	}()
+	t.watchdogs[dpKey] = state
+>>>>>>> f6f58cf76 (fix(kuma-dp): prevent watchers from being cleaned up unexpectedly (#12886))
 	return nil
 }
 
-func (t *dataplaneSyncTracker) OnProxyDisconnected(_ context.Context, _ core_xds.StreamID, dpKey core_model.ResourceKey) {
-	t.Lock()
-	defer t.Unlock()
-	if cancelFn := t.watchdogs[dpKey]; cancelFn != nil {
-		cancelFn()
+func (t *dataplaneSyncTracker) OnProxyDisconnected(_ context.Context, streamID core_xds.StreamID, dpKey core_model.ResourceKey) {
+	t.RLock()
+	dpData := t.watchdogs[dpKey]
+	t.RUnlock()
+
+	if dpData != nil {
+		dpData.cancelFunc()
+		<-dpData.stopped
+		dataplaneSyncTrackerLog.V(1).Info("watchdog for a Dataplane stopped", "dpKey", dpKey, "streamID", streamID)
+		t.Lock()
+		defer t.Unlock()
+		delete(t.watchdogs, dpKey)
 	}
-	delete(t.watchdogs, dpKey)
 }

--- a/pkg/xds/server/callbacks/dataplane_sync_tracker_test.go
+++ b/pkg/xds/server/callbacks/dataplane_sync_tracker_test.go
@@ -131,54 +131,73 @@ var _ = Describe("Sync", func() {
 		It("should start only one watchdog per dataplane", func() {
 			// setup
 			var activeWatchdogs int32
+<<<<<<< HEAD
 			tracker := NewDataplaneSyncTracker(func(key core_model.ResourceKey) util_watchdog.Watchdog {
 				return WatchdogFunc(func(stop <-chan struct{}) {
+=======
+			var cleanupDone atomic.Bool
+			tracker := NewDataplaneSyncTracker(func(key core_model.ResourceKey) util_xds_v3.Watchdog {
+				return WatchdogFunc(func(ctx context.Context) {
+>>>>>>> f6f58cf76 (fix(kuma-dp): prevent watchers from being cleaned up unexpectedly (#12886))
 					atomic.AddInt32(&activeWatchdogs, 1)
 					<-stop
 					atomic.AddInt32(&activeWatchdogs, -1)
+					cleanupDone.Store(true)
 				})
 			})
 			callbacks := util_xds_v3.AdaptCallbacks(DataplaneCallbacksToXdsCallbacks(tracker))
 
 			// when one stream for backend-01 is connected and request is sent
-			streamID := int64(1)
-			err := callbacks.OnStreamOpen(context.Background(), streamID, "")
+			streamID1 := int64(1)
+			streamID2 := int64(2)
+			streamID3 := int64(3)
+			err := callbacks.OnStreamOpen(context.Background(), streamID1, "")
 			Expect(err).ToNot(HaveOccurred())
-			n := &envoy_core.Node{Id: "default.backend-01"}
-			err = callbacks.OnStreamRequest(streamID, &envoy_sd.DiscoveryRequest{Node: n})
+			node := &envoy_core.Node{Id: "default.backend-01"}
+			err = callbacks.OnStreamRequest(streamID1, &envoy_sd.DiscoveryRequest{Node: node})
 			Expect(err).ToNot(HaveOccurred())
 
+			// then a watchdog is active
+			Expect(atomic.LoadInt32(&activeWatchdogs)).To(Equal(int32(0)))
+
 			// and when new stream from backend-01 is connected  and request is sent
-			streamID = 2
-			err = callbacks.OnStreamOpen(context.Background(), streamID, "")
+			err = callbacks.OnStreamOpen(context.Background(), streamID2, "")
 			Expect(err).ToNot(HaveOccurred())
-			err = callbacks.OnStreamRequest(streamID, &envoy_sd.DiscoveryRequest{
-				Node: &envoy_core.Node{
-					Id: "default.backend-01",
-				},
-			})
-			Expect(err).ToNot(HaveOccurred())
+			err = callbacks.OnStreamRequest(streamID2, &envoy_sd.DiscoveryRequest{Node: node})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("already an active stream"))
 
 			// then only one watchdog is active
 			Eventually(func() int32 {
 				return atomic.LoadInt32(&activeWatchdogs)
 			}, "5s", "10ms").Should(Equal(int32(1)))
 
-			// when first stream is closed
-			callbacks.OnStreamClosed(1, n)
+			callbacks.OnStreamClosed(streamID2, node)
+			Expect(cleanupDone.Load()).To(BeFalse())
 
-			// then watchdog is still active because other stream is opened
+			// when first stream is closed
+			callbacks.OnStreamClosed(streamID1, node)
+			Expect(cleanupDone.Load()).To(BeTrue())
+
+			// then there is no active watchdog
+			Expect(atomic.LoadInt32(&activeWatchdogs)).To(Equal(int32(0)))
+
+			// and when the third stream from backend-01 is connected after the first active stream closed and request is sent
+			err = callbacks.OnStreamOpen(context.Background(), streamID3, "")
+			Expect(err).ToNot(HaveOccurred())
+			err = callbacks.OnStreamRequest(streamID3, &envoy_sd.DiscoveryRequest{Node: node})
+			Expect(err).ToNot(HaveOccurred())
+
+			// then a watchdog is active
 			Eventually(func() int32 {
 				return atomic.LoadInt32(&activeWatchdogs)
 			}, "5s", "10ms").Should(Equal(int32(1)))
 
-			// when other stream is closed
-			callbacks.OnStreamClosed(2, n)
+			// when the third stream is closed
+			callbacks.OnStreamClosed(streamID3, node)
 
-			// then no watchdog is stopped
-			Eventually(func() int32 {
-				return atomic.LoadInt32(&activeWatchdogs)
-			}, "5s", "10ms").Should(Equal(int32(0)))
+			// then no watchdog is active
+			Expect(atomic.LoadInt32(&activeWatchdogs)).To(Equal(int32(0)))
 		})
 	})
 })

--- a/pkg/xds/server/callbacks/dataplane_sync_tracker_test.go
+++ b/pkg/xds/server/callbacks/dataplane_sync_tracker_test.go
@@ -131,14 +131,9 @@ var _ = Describe("Sync", func() {
 		It("should start only one watchdog per dataplane", func() {
 			// setup
 			var activeWatchdogs int32
-<<<<<<< HEAD
+			var cleanupDone atomic.Bool
 			tracker := NewDataplaneSyncTracker(func(key core_model.ResourceKey) util_watchdog.Watchdog {
 				return WatchdogFunc(func(stop <-chan struct{}) {
-=======
-			var cleanupDone atomic.Bool
-			tracker := NewDataplaneSyncTracker(func(key core_model.ResourceKey) util_xds_v3.Watchdog {
-				return WatchdogFunc(func(ctx context.Context) {
->>>>>>> f6f58cf76 (fix(kuma-dp): prevent watchers from being cleaned up unexpectedly (#12886))
 					atomic.AddInt32(&activeWatchdogs, 1)
 					<-stop
 					atomic.AddInt32(&activeWatchdogs, -1)


### PR DESCRIPTION
Manual cherry-pick of #12886 to branch `release-2.8`

cherry-picked commit f6f58cf76539055f7d0f5c14b1135bd3680419c9
