### PR TITLE
chore(deps): bump golangci-lint to v1.60.3 (backport of #11362)

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -48,8 +48,13 @@ jobs:
       - uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # v6.0.1
         with:
           args: --fix=false --verbose
+<<<<<<< HEAD
           version: v1.59.0
       - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+=======
+          version: v1.60.3
+      - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+>>>>>>> 23ecef9db (chore(deps): bump golangci-lint to v1.60.3 (#11362))
         with:
           path: |
             ${{ env.CI_TOOLS_DIR }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,6 +41,9 @@ linters-settings:
   gocritic:
     disabled-checks:
       - singleCaseSwitch
+  gosec:
+    excludes:
+    - G115
   gci:
     sections:
     - standard

--- a/app/kumactl/cmd/get/get_resources.go
+++ b/app/kumactl/cmd/get/get_resources.go
@@ -33,7 +33,7 @@ func NewGetResourcesCmd(pctx *kumactl_cmd.RootContext, desc model.ResourceTypeDe
 				currentMesh = ""
 			}
 			if err := rs.List(context.Background(), resources, core_store.ListByMesh(currentMesh), core_store.ListByPage(pctx.ListContext.Args.Size, pctx.ListContext.Args.Offset)); err != nil {
-				return errors.Wrapf(err, "failed to list "+string(desc.Name))
+				return errors.Wrap(err, "failed to list "+string(desc.Name))
 			}
 
 			format := output.Format(pctx.GetContext.Args.OutputFormat)

--- a/mk/dependencies/deps.lock
+++ b/mk/dependencies/deps.lock
@@ -1,1 +1,5 @@
+<<<<<<< HEAD
 875e8c75671552dbf5bbd0934a3cdec15d5afcb6
+=======
+7cf725e6e74fc99f84483c82810e493110f84816
+>>>>>>> 23ecef9db (chore(deps): bump golangci-lint to v1.60.3 (#11362))

--- a/mk/dev.mk
+++ b/mk/dev.mk
@@ -24,7 +24,7 @@ CI_TOOLS_BIN_DIR=$(CI_TOOLS_DIR)/bin
 K8S_MIN_VERSION = v1.23.17-k3s1
 K8S_MAX_VERSION = v1.30.0-k3s1
 export GO_VERSION=$(shell go mod edit -json | jq -r .Go)
-export GOLANGCI_LINT_VERSION=v1.59.0
+export GOLANGCI_LINT_VERSION=v1.60.3
 GOOS := $(shell go env GOOS)
 GOARCH := $(shell go env GOARCH)
 

--- a/pkg/transparentproxy/config/config_executables.go
+++ b/pkg/transparentproxy/config/config_executables.go
@@ -586,6 +586,7 @@ func getPathsToSearchForExecutable(
 func findPath(path string) string {
 	found, err := exec.LookPath(path)
 	switch {
+<<<<<<< HEAD
 	case err == nil:
 		return found
 	case errors.Is(err, exec.ErrDot):
@@ -601,6 +602,31 @@ func findPath(path string) string {
 	}
 
 	return ""
+=======
+	case err != nil && isVersionMissing(err.Error()):
+		return Version{Mode: consts.IptablesModeLegacy}, nil
+	case stderr.Len() > 0 && isVersionMissing(stderr.String()):
+		return Version{Mode: consts.IptablesModeLegacy}, nil
+	case err != nil:
+		return Version{}, formatIptablesVersionError(err.Error())
+	}
+
+	matched := consts.IptablesModeRegex.FindStringSubmatch(stdout.String())
+	if len(matched) < 2 {
+		return Version{}, errors.Wrap(formatIptablesVersionError(stdout.String()), "unable to parse iptables version")
+	}
+
+	version, err := k8s_version.ParseGeneric(matched[1])
+	if err != nil {
+		return Version{}, errors.Wrapf(formatIptablesVersionError(err.Error()), "invalid iptables version string: '%s'", matched[1])
+	}
+
+	if len(matched) < 3 {
+		return Version{Version: *version, Mode: consts.IptablesModeLegacy}, nil
+	}
+
+	return Version{Version: *version, Mode: consts.IptablesModeMap[matched[2]]}, nil
+>>>>>>> 23ecef9db (chore(deps): bump golangci-lint to v1.60.3 (#11362))
 }
 
 // joinNonEmptyWithHyphen joins a slice of strings with hyphens (-) as
@@ -695,5 +721,21 @@ func configureIPv6OutboundAddress() error {
 		)
 	}
 
+<<<<<<< HEAD
 	return nil
+=======
+	return result
+}
+
+func formatIptablesVersionError(msg string) error {
+	msgWithoutNewLines := strings.ReplaceAll(msg, "\n", " ")
+	msgWithoutDuplicatedSpaces := strings.ReplaceAll(msgWithoutNewLines, "  ", " ")
+	msgWithoutDotSuffix := strings.TrimRight(msgWithoutDuplicatedSpaces, ".")
+
+	if len(msgWithoutDotSuffix) > 500 {
+		msgWithoutDotSuffix = fmt.Sprintf("%.500s...", msgWithoutDotSuffix)
+	}
+
+	return errors.New(msgWithoutDotSuffix)
+>>>>>>> 23ecef9db (chore(deps): bump golangci-lint to v1.60.3 (#11362))
 }

--- a/pkg/transparentproxy/ebpf/programs/amd64/programs.go
+++ b/pkg/transparentproxy/ebpf/programs/amd64/programs.go
@@ -1,4 +1,5 @@
-// go:build linux && amd64
+//go:build linux && amd64
+
 package amd64
 
 import "embed"

--- a/pkg/transparentproxy/ebpf/programs/arm64/programs.go
+++ b/pkg/transparentproxy/ebpf/programs/arm64/programs.go
@@ -1,4 +1,5 @@
-// go:build linux && arm64
+//go:build linux && arm64
+
 package arm64
 
 import "embed"

--- a/test/framework/kumactl/kumactl.go
+++ b/test/framework/kumactl/kumactl.go
@@ -55,7 +55,7 @@ func NewKumactlOptions(
 func (k *KumactlOptions) RunKumactl(args ...string) error {
 	out, err := k.RunKumactlAndGetOutput(args...)
 	if err != nil {
-		return errors.Wrapf(err, out)
+		return errors.Wrap(err, out)
 	}
 	return nil
 }

--- a/test/framework/universal_app.go
+++ b/test/framework/universal_app.go
@@ -527,5 +527,5 @@ func (s *UniversalApp) getIP(isipv6 bool) (string, error) {
 	if isipv6 {
 		errString = "No IPv6 address found"
 	}
-	return "", errors.Errorf(errString)
+	return "", errors.New(errString)
 }


### PR DESCRIPTION
Manual cherry-pick of #11362 to branch `release-2.8`

cherry-picked commit 23ecef9db2298c8987c2e4a8de513c46fb84ca29

:warning: :warning: :warning: Conflicts found when cherry-picking! :warning: :warning: :warning:
```
On branch backport-11362-to-release-2.8
You are currently cherry-picking commit 23ecef9db.
  (fix conflicts and run "git cherry-pick --continue")
  (use "git cherry-pick --skip" to skip this patch)
  (use "git cherry-pick --abort" to cancel the cherry-pick operation)

Changes to be committed:
	modified:   .golangci.yml
	modified:   app/kumactl/cmd/get/get_resources.go
	modified:   mk/dev.mk
	modified:   pkg/transparentproxy/ebpf/programs/amd64/programs.go
	modified:   pkg/transparentproxy/ebpf/programs/arm64/programs.go
	modified:   test/framework/kumactl/kumactl.go
	modified:   test/framework/universal_app.go

Unmerged paths:
  (use "git add <file>..." to mark resolution)
	both modified:   .github/workflows/build-test-distribute.yaml
	both modified:   mk/dependencies/deps.lock
	both modified:   pkg/transparentproxy/config/config_executables.go
```