### PR TITLE
test(unit): check correctly active watchdogs (backport of #12948)

### DIFF
--- a/pkg/xds/server/callbacks/dataplane_sync_tracker_test.go
+++ b/pkg/xds/server/callbacks/dataplane_sync_tracker_test.go
@@ -153,7 +153,9 @@ var _ = Describe("Sync", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// then a watchdog is active
-			Expect(atomic.LoadInt32(&activeWatchdogs)).To(Equal(int32(0)))
+			Eventually(func() int32 {
+				return atomic.LoadInt32(&activeWatchdogs)
+			}, "5s", "10ms").Should(Equal(int32(1)))
 
 			// and when new stream from backend-01 is connected  and request is sent
 			err = callbacks.OnStreamOpen(context.Background(), streamID2, "")


### PR DESCRIPTION
Manual cherry-pick of #12948 to branch `release-2.8`

cherry-picked commit 4c0866462eacc77d1ca1e1b8e01fca4807fa1477

> Changelog: skip