### PR TITLE
fix(dpp): save and update labels from Dataplane resource on Universal

### DIFF
--- a/pkg/core/managers/apis/dataplane/dataplane_manager.go
+++ b/pkg/core/managers/apis/dataplane/dataplane_manager.go
@@ -2,8 +2,6 @@ package dataplane
 
 import (
 	"context"
-	"maps"
-
 	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
@@ -56,15 +54,10 @@ func (m *dataplaneManager) Create(ctx context.Context, resource core_model.Resou
 	m.setInboundsClusterTag(dp)
 	m.setGatewayClusterTag(dp)
 	m.setHealth(dp)
-	existingLabels := map[string]string{}
-	maps.Copy(existingLabels, opts.Labels)
-	if resource.GetMeta() != nil && resource.GetMeta().GetLabels() != nil {
-		maps.Copy(existingLabels, resource.GetMeta().GetLabels())
-	}
 	labels, err := core_model.ComputeLabels(
 		resource.Descriptor(),
 		resource.GetSpec(),
-		existingLabels,
+		opts.Labels,
 		core_model.UnsetNamespace,
 		opts.Mesh,
 		m.mode,

--- a/pkg/core/managers/apis/dataplane/dataplane_manager.go
+++ b/pkg/core/managers/apis/dataplane/dataplane_manager.go
@@ -2,6 +2,7 @@ package dataplane
 
 import (
 	"context"
+	"maps"
 
 	"github.com/pkg/errors"
 
@@ -55,10 +56,15 @@ func (m *dataplaneManager) Create(ctx context.Context, resource core_model.Resou
 	m.setInboundsClusterTag(dp)
 	m.setGatewayClusterTag(dp)
 	m.setHealth(dp)
+	existingLabels := map[string]string{}
+	maps.Copy(existingLabels, opts.Labels)
+	if resource.GetMeta() != nil && resource.GetMeta().GetLabels() != nil {
+		maps.Copy(existingLabels, resource.GetMeta().GetLabels())
+	}
 	labels, err := core_model.ComputeLabels(
 		resource.Descriptor(),
 		resource.GetSpec(),
-		opts.Labels,
+		existingLabels,
 		core_model.UnsetNamespace,
 		opts.Mesh,
 		m.mode,

--- a/pkg/core/managers/apis/dataplane/dataplane_manager.go
+++ b/pkg/core/managers/apis/dataplane/dataplane_manager.go
@@ -94,10 +94,12 @@ func (m *dataplaneManager) Update(ctx context.Context, resource core_model.Resou
 
 	m.setInboundsClusterTag(dp)
 	m.setGatewayClusterTag(dp)
+
+	opts := core_store.NewUpdateOptions(fs...)
 	labels, err := core_model.ComputeLabels(
 		resource.Descriptor(),
 		resource.GetSpec(),
-		resource.GetMeta().GetLabels(),
+		opts.Labels,
 		core_model.GetNamespace(resource.GetMeta(), m.systemNamespace),
 		resource.GetMeta().GetMesh(),
 		m.mode,

--- a/pkg/core/managers/apis/dataplane/dataplane_manager.go
+++ b/pkg/core/managers/apis/dataplane/dataplane_manager.go
@@ -2,6 +2,7 @@ package dataplane
 
 import (
 	"context"
+
 	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"

--- a/pkg/test/resources/builders/dataplane_builder.go
+++ b/pkg/test/resources/builders/dataplane_builder.go
@@ -67,6 +67,11 @@ func (d *DataplaneBuilder) WithMesh(mesh string) *DataplaneBuilder {
 	return d
 }
 
+func (d *DataplaneBuilder) WithLabels(labels map[string]string) *DataplaneBuilder {
+	d.res.Meta.(*test_model.ResourceMeta).Labels = labels
+	return d
+}
+
 func (d *DataplaneBuilder) WithVersion(version string) *DataplaneBuilder {
 	d.res.Meta.(*test_model.ResourceMeta).Version = version
 	return d

--- a/pkg/xds/server/callbacks/dataplane_lifecycle.go
+++ b/pkg/xds/server/callbacks/dataplane_lifecycle.go
@@ -124,6 +124,7 @@ func (d *DataplaneLifecycle) register(
 		if err := d.validateUpsert(ctx, md.Resource); err != nil {
 			return errors.Wrap(err, "you are trying to override existing proxy to which you don't have an access.")
 		}
+		existing.SetMeta(md.Resource.GetMeta())
 		return existing.SetSpec(md.Resource.GetSpec())
 	})
 	if err != nil {

--- a/pkg/xds/server/callbacks/dataplane_lifecycle.go
+++ b/pkg/xds/server/callbacks/dataplane_lifecycle.go
@@ -124,9 +124,8 @@ func (d *DataplaneLifecycle) register(
 		if err := d.validateUpsert(ctx, md.Resource); err != nil {
 			return errors.Wrap(err, "you are trying to override existing proxy to which you don't have an access.")
 		}
-		existing.SetMeta(md.Resource.GetMeta())
 		return existing.SetSpec(md.Resource.GetSpec())
-	})
+	}, manager.UpsertWithLabels(md.Resource.GetMeta().GetLabels()))
 	if err != nil {
 		log.Info("cannot register proxy", "reason", err.Error())
 		if !loaded {

--- a/pkg/xds/server/callbacks/dataplane_lifecycle_test.go
+++ b/pkg/xds/server/callbacks/dataplane_lifecycle_test.go
@@ -73,6 +73,9 @@ var _ = Describe("Dataplane Lifecycle", func() {
                                   "type": "Dataplane",
                                   "mesh": "default",
                                   "name": "backend-01",
+                                  "labels": {
+                                    "app": "backend",
+                                  },
                                   "networking": {
                                     "address": "127.0.0.1",
                                     "inbound": [
@@ -106,8 +109,10 @@ var _ = Describe("Dataplane Lifecycle", func() {
 
 		// then dp is created
 		Expect(err).ToNot(HaveOccurred())
-		err = resManager.Get(context.Background(), core_mesh.NewDataplaneResource(), core_store.GetByKey("backend-01", "default"))
+		dp := core_mesh.NewDataplaneResource()
+		err = resManager.Get(context.Background(), dp, core_store.GetByKey("backend-01", "default"))
 		Expect(err).ToNot(HaveOccurred())
+		Expect(dp.GetMeta().GetLabels()).To(HaveKeyWithValue("app", "backend"))
 
 		// when
 		callbacks.OnStreamClosed(streamId, node)

--- a/test/e2e_env/universal/auth/dp_auth.go
+++ b/test/e2e_env/universal/auth/dp_auth.go
@@ -58,12 +58,12 @@ func DpAuth() {
 		Expect(universal.Cluster.Install(ResourceUniversal(dp))).To(Succeed())
 
 		// when
-		err := TestServerUniversal("dp-02", meshName, WithServiceName("test-server"), WithAppLabel("test-server"))(universal.Cluster)
+		err := TestServerUniversal("dp-01", meshName, WithServiceName("test-server"), WithAppLabel("test-server"))(universal.Cluster)
 		Expect(err).ToNot(HaveOccurred())
 
 		// then
 		Eventually(func() (string, error) {
-			return universal.Cluster.GetKumactlOptions().RunKumactlAndGetOutput("get", "dataplanes", "-oyaml")
+			return universal.Cluster.GetKumactlOptions().RunKumactlAndGetOutput("get", "dataplanes", "--mesh", meshName, "-oyaml")
 		}, "30s", "1s").Should(
 			And(
 				Not(ContainSubstring("192.168.0.2")),

--- a/test/e2e_env/universal/auth/dp_auth.go
+++ b/test/e2e_env/universal/auth/dp_auth.go
@@ -64,6 +64,12 @@ func DpAuth() {
 		// then
 		Eventually(func() (string, error) {
 			return universal.Cluster.GetKumactlOptions().RunKumactlAndGetOutput("get", "dataplanes", "-oyaml")
-		}, "30s", "1s").ShouldNot(And(ContainSubstring("192.168.0.2"), ContainSubstring("not-test-server")))
+		}, "30s", "1s").Should(
+			And(
+				Not(ContainSubstring("192.168.0.2")),
+				Not(ContainSubstring("not-test-server")),
+				ContainSubstring("test-server"),
+			),
+		)
 	})
 }

--- a/test/e2e_env/universal/auth/dp_auth.go
+++ b/test/e2e_env/universal/auth/dp_auth.go
@@ -49,7 +49,7 @@ func DpAuth() {
 	It("should be able to override old Dataplane of same service", func() {
 		// given
 		dp := builders.Dataplane().
-			WithName("dp-01").
+			WithName("dp-02").
 			WithMesh(meshName).
 			WithLabels(map[string]string{"app": "not-test-server"}).
 			WithAddress("192.168.0.2").
@@ -58,7 +58,7 @@ func DpAuth() {
 		Expect(universal.Cluster.Install(ResourceUniversal(dp))).To(Succeed())
 
 		// when
-		err := TestServerUniversal("dp-01", meshName, WithServiceName("test-server"), WithAppLabel("test-server"))(universal.Cluster)
+		err := TestServerUniversal("dp-02", meshName, WithServiceName("test-server"), WithAppLabel("test-server"))(universal.Cluster)
 		Expect(err).ToNot(HaveOccurred())
 
 		// then

--- a/test/e2e_env/universal/auth/dp_auth.go
+++ b/test/e2e_env/universal/auth/dp_auth.go
@@ -51,18 +51,19 @@ func DpAuth() {
 		dp := builders.Dataplane().
 			WithName("dp-01").
 			WithMesh(meshName).
+			WithLabels(map[string]string{"app": "not-test-server"}).
 			WithAddress("192.168.0.2").
 			WithServices("test-server").
 			Build()
 		Expect(universal.Cluster.Install(ResourceUniversal(dp))).To(Succeed())
 
 		// when
-		err := TestServerUniversal("dp-02", meshName, WithServiceName("test-server"))(universal.Cluster)
+		err := TestServerUniversal("dp-02", meshName, WithServiceName("test-server"), WithAppLabel("test-server"))(universal.Cluster)
 		Expect(err).ToNot(HaveOccurred())
 
 		// then
 		Eventually(func() (string, error) {
 			return universal.Cluster.GetKumactlOptions().RunKumactlAndGetOutput("get", "dataplanes", "-oyaml")
-		}, "30s", "1s").ShouldNot(ContainSubstring("192.168.0.2"))
+		}, "30s", "1s").ShouldNot(And(ContainSubstring("192.168.0.2"), ContainSubstring("not-test-server")))
 	})
 }

--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -95,6 +95,7 @@ type appDeploymentOptions struct {
 	name                  string
 	appYaml               string
 	appArgs               []string
+	appLabel              string
 	token                 string
 	transparent           *bool
 	builtindns            *bool // true by default
@@ -421,6 +422,12 @@ func WithArgs(appArgs []string) AppDeploymentOption {
 func WithServiceName(name string) AppDeploymentOption {
 	return AppOptionFunc(func(o *appDeploymentOptions) {
 		o.serviceName = name
+	})
+}
+
+func WithAppLabel(app string) AppDeploymentOption {
+	return AppOptionFunc(func(o *appDeploymentOptions) {
+		o.appLabel = app
 	})
 }
 

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -926,6 +926,8 @@ func TestServerUniversal(name string, mesh string, opt ...AppDeploymentOption) I
 type: Dataplane
 mesh: %s
 name: {{ name }}
+labels:
+  app: %s
 networking:
   address:  {{ address }}
   inbound:
@@ -942,7 +944,7 @@ networking:
 %s
 %s
 %s
-`, mesh, "80", "8080", serviceAddress, opts.serviceName, opts.protocol, opts.serviceVersion, opts.serviceInstance, additionalTags, serviceProbe, transparentProxy, opts.appendDataplaneConfig)
+`, mesh, opts.appLabel, "80", "8080", serviceAddress, opts.serviceName, opts.protocol, opts.serviceVersion, opts.serviceInstance, additionalTags, serviceProbe, transparentProxy, opts.appendDataplaneConfig)
 
 		opt = append(opt,
 			WithName(name),


### PR DESCRIPTION
## Motivation

We need to handle dpp labels properly in order to be able to select them in policies

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
