### PR TITLE
fix(policy): rename `interpret_from_entries_as_rules` market to `is_from_as_rules`

### DIFF
--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -15955,4 +15955,3 @@ components:
             zones:
               - name: east
               - name: west
-

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -15955,3 +15955,4 @@ components:
             zones:
               - name: east
               - name: west
+

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/meshaccesslog.go
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/meshaccesslog.go
@@ -9,7 +9,7 @@ import (
 
 // MeshAccessLog defines access log policies between different data plane
 // proxies entities.
-// +kuma:policy:interpret_from_entries_as_rules=true
+// +kuma:policy:is_from_as_rules=true
 type MeshAccessLog struct {
 	// TargetRef is a reference to the resource the policy takes an effect on.
 	// The resource could be either a real store object or virtual resource

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/meshcircuitbreaker.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/meshcircuitbreaker.go
@@ -9,7 +9,7 @@ import (
 )
 
 // MeshCircuitBreaker
-// +kuma:policy:interpret_from_entries_as_rules=true
+// +kuma:policy:is_from_as_rules=true
 type MeshCircuitBreaker struct {
 	// TargetRef is a reference to the resource the policy takes an effect on.
 	// The resource could be either a real store object or virtual resource

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/meshratelimit.go
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/meshratelimit.go
@@ -8,7 +8,7 @@ import (
 )
 
 // MeshRateLimit
-// +kuma:policy:interpret_from_entries_as_rules=true
+// +kuma:policy:is_from_as_rules=true
 type MeshRateLimit struct {
 	// TargetRef is a reference to the resource the policy takes an effect on.
 	// The resource could be either a real store object or virtual resource

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/meshtimeout.go
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/meshtimeout.go
@@ -8,7 +8,7 @@ import (
 )
 
 // MeshTimeout allows users to configure timeouts for communication between services in mesh
-// +kuma:policy:interpret_from_entries_as_rules=true
+// +kuma:policy:is_from_as_rules=true
 type MeshTimeout struct {
 	// TargetRef is a reference to the resource the policy takes an effect on.
 	// The resource could be either a real store object or virtual resource

--- a/pkg/plugins/policies/meshtls/api/v1alpha1/meshtls.go
+++ b/pkg/plugins/policies/meshtls/api/v1alpha1/meshtls.go
@@ -8,7 +8,7 @@ import (
 
 // MeshTLS
 // +kuma:policy:singular_display_name=Mesh TLS
-// +kuma:policy:interpret_from_entries_as_rules=true
+// +kuma:policy:is_from_as_rules=true
 type MeshTLS struct {
 	// TargetRef is a reference to the resource the policy takes an effect on.
 	// The resource could be either a real store object or virtual resource

--- a/tools/policy-gen/generator/pkg/parse/policyconfig.go
+++ b/tools/policy-gen/generator/pkg/parse/policyconfig.go
@@ -167,7 +167,7 @@ func newPolicyConfig(pkg, name string, markers map[string]string, fields map[str
 	if v, ok := parseBool(markers, "kuma:policy:is_referenceable_in_to"); ok {
 		res.IsReferenceableInTo = v
 	}
-	if v, ok := parseBool(markers, "kuma:policy:interpret_from_entries_as_rules"); ok {
+	if v, ok := parseBool(markers, "kuma:policy:is_from_as_rules"); ok {
 		res.IsFromAsRules = v
 	}
 	if v, ok := markers["kuma:policy:kds_flags"]; ok {


### PR DESCRIPTION
## Motivation

Renamed the descriptor field in my previous [PR](https://github.com/kumahq/kuma/pull/12713) but missed these policy markers.