### PR TITLE
ci(.github): fix the provenance workflow

### DIFF
--- a/.github/workflows/_provenance.yaml
+++ b/.github/workflows/_provenance.yaml
@@ -30,7 +30,7 @@ jobs:
       actions: read # For getting workflow run info to build provenance
       id-token: write # needed for signing the images
     # need to use non hash version because of: https://github.com/slsa-framework/slsa-github-generator/issues/3498
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.10.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
     with:
       base64-subjects: ${{ inputs.BINARY_ARTIFACTS_HASH_AS_FILE }}
       upload-assets: ${{ github.ref_type == 'tag' }}
@@ -57,10 +57,13 @@ jobs:
       matrix:
         IMAGE: ${{ fromJSON(inputs.IMAGES) }}
     # need to use non hash version because of: https://github.com/slsa-framework/slsa-github-generator/issues/3498
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.10.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
     with:
       image: ${{ inputs.REGISTRY }}/${{ matrix.IMAGE }}
       digest: ${{ fromJSON(inputs.IMAGE_DIGESTS)[matrix.IMAGE] }}
+      provenance-repository: ${{ inputs.REGISTRY }}/${{ inputs.NOTARY_REPOSITORY }}
       registry-username: ${{ vars.DOCKER_USERNAME }}
+      provenance-registry-username: ${{ vars.DOCKER_USERNAME }}
     secrets:
       registry-password: ${{ secrets.DOCKER_API_KEY }}
+      provenance-registry-password: ${{ secrets.DOCKER_API_KEY }}


### PR DESCRIPTION
## Motivation

fix the CI failure caused by out-dated provenance workflow:

https://github.com/kumahq/kuma/actions/runs/13560066168/job/37965057131

## Implementation information

Upgrade the `slsa generator` to version `2.0.0`.

## Supporting documentation

Consulted security experts.

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
