### PR TITLE
test(e2e): fix invalid zone name

### DIFF
--- a/test/e2e_env/multizone/connectivity/available_services.go
+++ b/test/e2e_env/multizone/connectivity/available_services.go
@@ -18,7 +18,7 @@ import (
 )
 
 func AvailableServices() {
-	statefulClusterName := "statefulCluster"
+	statefulClusterName := "stateful-cluster"
 	meshName := "available-services"
 
 	var statefulCluster *UniversalCluster


### PR DESCRIPTION
The zone name validation we currently have is not strict enough. This zone name was creating a lot of noise in the logs

xref: https://github.com/kumahq/kuma/issues/12988