### PR TITLE
fix(secrets): return properky typed errors on conflict

### DIFF
--- a/pkg/plugins/config/k8s/store.go
+++ b/pkg/plugins/config/k8s/store.go
@@ -80,7 +80,10 @@ func (s *KubernetesStore) Create(ctx context.Context, r core_model.Resource, fs 
 		}
 	}
 	if err := s.client.Create(ctx, cm); err != nil {
-		return err
+		if kube_apierrs.IsAlreadyExists(err) {
+			return core_store.ErrorResourceAlreadyExists(r.Descriptor().Name, opts.Name, opts.Mesh)
+		}
+		return errors.Wrap(err, "failed to create k8s resource")
 	}
 	r.SetMeta(&KubernetesMetaAdapter{cm.ObjectMeta})
 	return nil

--- a/test/e2e/federation/federation_kubernetes.go
+++ b/test/e2e/federation/federation_kubernetes.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kumahq/kuma/test/framework/client"
 	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	"github.com/kumahq/kuma/test/framework/deployments/testserver"
+	"github.com/kumahq/kuma/test/framework/report"
 )
 
 func FederateKubeZoneCPToKubeGlobal() {
@@ -80,6 +81,8 @@ func FederateKubeZoneCPToKubeGlobal() {
 
 			out, err := zone.GetKumactlOptions().RunKumactlAndGetOutput("export", "--profile", "federation", "--format", "kubernetes")
 			Expect(err).ToNot(HaveOccurred())
+
+			report.AddFileToReportEntry("kumactl-export-federation-output.yaml", out)
 
 			err = k8s.KubectlApplyFromStringE(global.GetTesting(), global.GetKubectlOptions(), out)
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/federation/federation_kubernetes.go
+++ b/test/e2e/federation/federation_kubernetes.go
@@ -101,7 +101,7 @@ func FederateKubeZoneCPToKubeGlobal() {
 			}, "120s", "1s").Should(Succeed())
 		})
 
-		It("should sync data policies to global cp", func() {
+		It("should sync policies to global cp", func() {
 			Eventually(func(g Gomega) {
 				out, err := k8s.RunKubectlAndGetOutputE(global.GetTesting(), global.GetKubectlOptions(), "get", "meshcircuitbreakers", "-A")
 				g.Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/federation/federation_suite_test.go
+++ b/test/e2e/federation/federation_suite_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kumahq/kuma/pkg/test"
 	"github.com/kumahq/kuma/test/e2e/federation"
+	"github.com/kumahq/kuma/test/framework/report"
 )
 
 func TestE2E(t *testing.T) {
@@ -14,6 +15,7 @@ func TestE2E(t *testing.T) {
 }
 
 var (
+	_ = ReportAfterSuite("report suite", report.DumpReport)
 	_ = Describe("Federation with Kube Global", Label("job-3"), federation.FederateKubeZoneCPToKubeGlobal, Ordered)
 	_ = Describe("Federation with Universal Global", Label("job-3"), federation.FederateKubeZoneCPToUniversalGlobal, Ordered)
 )

--- a/test/e2e/federation/federation_universal.go
+++ b/test/e2e/federation/federation_universal.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kumahq/kuma/test/framework/client"
 	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	"github.com/kumahq/kuma/test/framework/deployments/testserver"
+	"github.com/kumahq/kuma/test/framework/report"
 )
 
 func FederateKubeZoneCPToUniversalGlobal() {
@@ -69,6 +70,8 @@ func FederateKubeZoneCPToUniversalGlobal() {
 
 			out, err := zone.GetKumactlOptions().RunKumactlAndGetOutput("export", "--profile", "federation", "--format", "universal")
 			Expect(err).ToNot(HaveOccurred())
+
+			report.AddFileToReportEntry("kumactl-export-federation-output.yaml", out)
 
 			tmpfile, err := os.CreateTemp("", "export-uni")
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/federation/federation_universal.go
+++ b/test/e2e/federation/federation_universal.go
@@ -95,7 +95,7 @@ func FederateKubeZoneCPToUniversalGlobal() {
 			}, "30s", "1s").Should(Succeed())
 		})
 
-		It("should sync data policies to global cp", func() {
+		It("should sync policies to global cp", func() {
 			Eventually(func(g Gomega) {
 				out, _, err := global.GetKuma().Exec("curl", "--fail", "--show-error", "http://localhost:5681/meshcircuitbreakers")
 				g.Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Other store return errors that are in core_store.
KDS relies on these errors to return errors or NACK.

This fixes a federation test