### PR TITLE
fix(resource): use kuma.io/display-name instead of name

### DIFF
--- a/pkg/api-server/testdata/resources/crud/put_meshes_04.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_meshes_04.golden.json
@@ -1,5 +1,5 @@
 {
-  "warnings": [
-    "Name that doesn't conform DNS (RFC 1035) format is deprecated: a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')"
-  ]
+ "warnings": [
+  "Invalid name: 'aa.a'. It does not conform to the DNS format (RFC 1035). This is deprecated. Errors: a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')"
+ ]
 }

--- a/pkg/api-server/testdata/resources/crud/put_meshes_04.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_meshes_04.golden.json
@@ -1,5 +1,5 @@
 {
  "warnings": [
-  "Invalid name: 'aa.a'. It does not conform to the DNS format (RFC 1035). This is deprecated. Errors: a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')"
+  "Invalid Mesh resource name: 'aa.a'. It does not conform to the DNS format (RFC 1035). This is deprecated. Errors: a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')"
  ]
 }

--- a/pkg/api-server/testdata/resources/crud/put_meshexternalservice_01.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_meshexternalservice_01.golden.json
@@ -1,29 +1,29 @@
 {
-  "type": "MeshExternalService",
-  "mesh": "default",
-  "name": "mes-tcp",
-  "creationTime": "0001-01-01T00:00:00Z",
-  "modificationTime": "0001-01-01T00:00:00Z",
-  "labels": {
-    "kuma.io/env": "universal",
-    "kuma.io/mesh": "default",
-    "kuma.io/origin": "zone",
-    "kuma.io/zone": "default"
+ "type": "MeshExternalService",
+ "mesh": "default",
+ "name": "mes-tcp",
+ "creationTime": "0001-01-01T00:00:00Z",
+ "modificationTime": "0001-01-01T00:00:00Z",
+ "labels": {
+  "kuma.io/env": "universal",
+  "kuma.io/mesh": "default",
+  "kuma.io/origin": "zone",
+  "kuma.io/zone": "default"
+ },
+ "spec": {
+  "match": {
+   "type": "HostnameGenerator",
+   "port": 4242,
+   "protocol": "tcp"
   },
-  "spec": {
-    "match": {
-      "type": "HostnameGenerator",
-      "port": 4242,
-      "protocol": "tcp"
-    },
-    "endpoints": [
-      {
-        "address": "tcpbin.com",
-        "port": 4242
-      }
-    ]
-  },
-  "status": {
-    "vip": {}
-  }
+  "endpoints": [
+   {
+    "address": "tcpbin.com",
+    "port": 4242
+   }
+  ]
+ },
+ "status": {
+  "vip": {}
+ }
 }

--- a/pkg/api-server/testdata/resources/crud/put_meshexternalservice_02.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_meshexternalservice_02.golden.json
@@ -1,5 +1,5 @@
 {
  "warnings": [
-  "Invalid name: 'mes.http'. It does not conform to the DNS format (RFC 1035). This is deprecated. Errors: a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')"
+  "Invalid MeshExternalService resource name: 'mes.http'. It does not conform to the DNS format (RFC 1035). This is deprecated. Errors: a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')"
  ]
 }

--- a/pkg/api-server/testdata/resources/crud/put_meshexternalservice_02.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_meshexternalservice_02.golden.json
@@ -1,5 +1,5 @@
 {
-  "warnings": [
-    "Name that doesn't conform DNS (RFC 1035) format is deprecated: a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')"
-  ]
+ "warnings": [
+  "Invalid name: 'mes.http'. It does not conform to the DNS format (RFC 1035). This is deprecated. Errors: a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')"
+ ]
 }

--- a/pkg/api-server/testdata/resources/crud/put_meshmultizoneservice_01.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_meshmultizoneservice_01.golden.json
@@ -1,26 +1,26 @@
 {
-  "type": "MeshMultiZoneService",
-  "mesh": "default",
-  "name": "redis",
-  "creationTime": "0001-01-01T00:00:00Z",
-  "modificationTime": "0001-01-01T00:00:00Z",
-  "labels": {
-    "kuma.io/mesh": "default"
+ "type": "MeshMultiZoneService",
+ "mesh": "default",
+ "name": "redis",
+ "creationTime": "0001-01-01T00:00:00Z",
+ "modificationTime": "0001-01-01T00:00:00Z",
+ "labels": {
+  "kuma.io/mesh": "default"
+ },
+ "spec": {
+  "selector": {
+   "meshService": {
+    "matchLabels": {
+     "kuma.io/display-name": "redis"
+    }
+   }
   },
-  "spec": {
-    "selector": {
-      "meshService": {
-        "matchLabels": {
-          "kuma.io/display-name": "redis"
-        }
-      }
-    },
-    "ports": [
-      {
-        "port": 6379,
-        "appProtocol": "tcp"
-      }
-    ]
-  },
-  "status": {}
+  "ports": [
+   {
+    "port": 6379,
+    "appProtocol": "tcp"
+   }
+  ]
+ },
+ "status": {}
 }

--- a/pkg/api-server/testdata/resources/crud/put_meshmultizoneservice_02.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_meshmultizoneservice_02.golden.json
@@ -1,5 +1,5 @@
 {
  "warnings": [
-  "Invalid name: 'http.bin'. It does not conform to the DNS format (RFC 1035). This is deprecated. Errors: a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')"
+  "Invalid MeshMultiZoneService resource name: 'http.bin'. It does not conform to the DNS format (RFC 1035). This is deprecated. Errors: a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')"
  ]
 }

--- a/pkg/api-server/testdata/resources/crud/put_meshmultizoneservice_02.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_meshmultizoneservice_02.golden.json
@@ -1,5 +1,5 @@
 {
-  "warnings": [
-    "Name that doesn't conform DNS (RFC 1035) format is deprecated: a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')"
-  ]
+ "warnings": [
+  "Invalid name: 'http.bin'. It does not conform to the DNS format (RFC 1035). This is deprecated. Errors: a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')"
+ ]
 }

--- a/pkg/api-server/testdata/resources/crud/put_meshservice_02.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_meshservice_02.golden.json
@@ -1,5 +1,5 @@
 {
-  "warnings": [
-    "Name that doesn't conform DNS (RFC 1035) format is deprecated: a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')"
-  ]
+ "warnings": [
+  "Invalid name: 'aa.a'. It does not conform to the DNS format (RFC 1035). This is deprecated. Errors: a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')"
+ ]
 }

--- a/pkg/api-server/testdata/resources/crud/put_meshservice_02.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_meshservice_02.golden.json
@@ -1,5 +1,5 @@
 {
  "warnings": [
-  "Invalid name: 'aa.a'. It does not conform to the DNS format (RFC 1035). This is deprecated. Errors: a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')"
+  "Invalid MeshService resource name: 'aa.a'. It does not conform to the DNS format (RFC 1035). This is deprecated. Errors: a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')"
  ]
 }

--- a/pkg/core/resources/apis/mesh/deprecated.go
+++ b/pkg/core/resources/apis/mesh/deprecated.go
@@ -5,15 +5,18 @@ import (
 	"strings"
 
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
+
+	"github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
 func (t *MeshResource) Deprecations() []string {
 	var deprecations []string
 
-	allErrs := apimachineryvalidation.NameIsDNS1035Label(t.GetMeta().GetName(), false)
+	name := model.GetDisplayName(t.GetMeta())
+	allErrs := apimachineryvalidation.NameIsDNS1035Label(name, false)
 	if len(allErrs) != 0 {
-		nameDeprecationMsg := fmt.Sprintf("Name that doesn't conform DNS (RFC 1035) format is deprecated: %s",
-			strings.Join(allErrs, "; "))
+		nameDeprecationMsg := fmt.Sprintf("Invalid name: '%s'. It does not conform to the DNS format (RFC 1035). This is deprecated. Errors: %s",
+			name, strings.Join(allErrs, "; "))
 		deprecations = append(deprecations, nameDeprecationMsg)
 	}
 

--- a/pkg/core/resources/apis/mesh/deprecated.go
+++ b/pkg/core/resources/apis/mesh/deprecated.go
@@ -15,8 +15,8 @@ func (t *MeshResource) Deprecations() []string {
 	name := model.GetDisplayName(t.GetMeta())
 	allErrs := apimachineryvalidation.NameIsDNS1035Label(name, false)
 	if len(allErrs) != 0 {
-		nameDeprecationMsg := fmt.Sprintf("Invalid name: '%s'. It does not conform to the DNS format (RFC 1035). This is deprecated. Errors: %s",
-			name, strings.Join(allErrs, "; "))
+		nameDeprecationMsg := fmt.Sprintf("Invalid %s resource name: '%s'. It does not conform to the DNS format (RFC 1035). This is deprecated. Errors: %s",
+			MeshResourceTypeDescriptor.Name, name, strings.Join(allErrs, "; "))
 		deprecations = append(deprecations, nameDeprecationMsg)
 	}
 

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/deprecated.go
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/deprecated.go
@@ -15,8 +15,8 @@ func (t *MeshExternalServiceResource) Deprecations() []string {
 	name := model.GetDisplayName(t.GetMeta())
 	allErrs := apimachineryvalidation.NameIsDNS1035Label(name, false)
 	if len(allErrs) != 0 {
-		nameDeprecationMsg := fmt.Sprintf("Invalid name: '%s'. It does not conform to the DNS format (RFC 1035). This is deprecated. Errors: %s",
-			name, strings.Join(allErrs, "; "))
+		nameDeprecationMsg := fmt.Sprintf("Invalid %s resource name: '%s'. It does not conform to the DNS format (RFC 1035). This is deprecated. Errors: %s",
+			MeshExternalServiceResourceTypeDescriptor.Name, name, strings.Join(allErrs, "; "))
 		deprecations = append(deprecations, nameDeprecationMsg)
 	}
 

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/deprecated.go
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/deprecated.go
@@ -5,15 +5,18 @@ import (
 	"strings"
 
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
+
+	"github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
 func (t *MeshExternalServiceResource) Deprecations() []string {
 	var deprecations []string
 
-	allErrs := apimachineryvalidation.NameIsDNS1035Label(t.GetMeta().GetName(), false)
+	name := model.GetDisplayName(t.GetMeta())
+	allErrs := apimachineryvalidation.NameIsDNS1035Label(name, false)
 	if len(allErrs) != 0 {
-		nameDeprecationMsg := fmt.Sprintf("Name that doesn't conform DNS (RFC 1035) format is deprecated: %s",
-			strings.Join(allErrs, "; "))
+		nameDeprecationMsg := fmt.Sprintf("Invalid name: '%s'. It does not conform to the DNS format (RFC 1035). This is deprecated. Errors: %s",
+			name, strings.Join(allErrs, "; "))
 		deprecations = append(deprecations, nameDeprecationMsg)
 	}
 

--- a/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/deprecated.go
+++ b/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/deprecated.go
@@ -15,8 +15,8 @@ func (t *MeshMultiZoneServiceResource) Deprecations() []string {
 	name := model.GetDisplayName(t.GetMeta())
 	allErrs := apimachineryvalidation.NameIsDNS1035Label(name, false)
 	if len(allErrs) != 0 {
-		nameDeprecationMsg := fmt.Sprintf("Invalid name: '%s'. It does not conform to the DNS format (RFC 1035). This is deprecated. Errors: %s",
-			name, strings.Join(allErrs, "; "))
+		nameDeprecationMsg := fmt.Sprintf("Invalid %s resource name: '%s'. It does not conform to the DNS format (RFC 1035). This is deprecated. Errors: %s",
+			MeshMultiZoneServiceResourceTypeDescriptor.Name, name, strings.Join(allErrs, "; "))
 		deprecations = append(deprecations, nameDeprecationMsg)
 	}
 

--- a/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/deprecated.go
+++ b/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/deprecated.go
@@ -5,15 +5,18 @@ import (
 	"strings"
 
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
+
+	"github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
 func (t *MeshMultiZoneServiceResource) Deprecations() []string {
 	var deprecations []string
 
-	allErrs := apimachineryvalidation.NameIsDNS1035Label(t.GetMeta().GetName(), false)
+	name := model.GetDisplayName(t.GetMeta())
+	allErrs := apimachineryvalidation.NameIsDNS1035Label(name, false)
 	if len(allErrs) != 0 {
-		nameDeprecationMsg := fmt.Sprintf("Name that doesn't conform DNS (RFC 1035) format is deprecated: %s",
-			strings.Join(allErrs, "; "))
+		nameDeprecationMsg := fmt.Sprintf("Invalid name: '%s'. It does not conform to the DNS format (RFC 1035). This is deprecated. Errors: %s",
+			name, strings.Join(allErrs, "; "))
 		deprecations = append(deprecations, nameDeprecationMsg)
 	}
 

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/deprecated.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/deprecated.go
@@ -15,8 +15,8 @@ func (t *MeshServiceResource) Deprecations() []string {
 	name := model.GetDisplayName(t.GetMeta())
 	allErrs := apimachineryvalidation.NameIsDNS1035Label(name, false)
 	if len(allErrs) != 0 {
-		nameDeprecationMsg := fmt.Sprintf("Invalid name: '%s'. It does not conform to the DNS format (RFC 1035). This is deprecated. Errors: %s",
-			name, strings.Join(allErrs, "; "))
+		nameDeprecationMsg := fmt.Sprintf("Invalid %s resource name: '%s'. It does not conform to the DNS format (RFC 1035). This is deprecated. Errors: %s",
+			MeshServiceResourceTypeDescriptor.Name, name, strings.Join(allErrs, "; "))
 		deprecations = append(deprecations, nameDeprecationMsg)
 	}
 

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/deprecated.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/deprecated.go
@@ -5,15 +5,18 @@ import (
 	"strings"
 
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
+
+	"github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
 func (t *MeshServiceResource) Deprecations() []string {
 	var deprecations []string
 
-	allErrs := apimachineryvalidation.NameIsDNS1035Label(t.GetMeta().GetName(), false)
+	name := model.GetDisplayName(t.GetMeta())
+	allErrs := apimachineryvalidation.NameIsDNS1035Label(name, false)
 	if len(allErrs) != 0 {
-		nameDeprecationMsg := fmt.Sprintf("Name that doesn't conform DNS (RFC 1035) format is deprecated: %s",
-			strings.Join(allErrs, "; "))
+		nameDeprecationMsg := fmt.Sprintf("Invalid name: '%s'. It does not conform to the DNS format (RFC 1035). This is deprecated. Errors: %s",
+			name, strings.Join(allErrs, "; "))
 		deprecations = append(deprecations, nameDeprecationMsg)
 	}
 

--- a/pkg/core/resources/apis/system/deprecated.go
+++ b/pkg/core/resources/apis/system/deprecated.go
@@ -15,7 +15,7 @@ func (t *ZoneResource) Deprecations() []string {
 	name := model.GetDisplayName(t.GetMeta())
 	allErrs := apimachineryvalidation.NameIsDNS1035Label(name, false)
 	if len(allErrs) != 0 {
-		nameDeprecationMsg := fmt.Sprintf("Name that doesn't conform DNS (RFC 1035) format is deprecated, name %s, error: %s",
+		nameDeprecationMsg := fmt.Sprintf("Invalid name: '%s'. It does not conform to the DNS format (RFC 1035). This is deprecated. Errors: %s",
 			name, strings.Join(allErrs, "; "))
 		deprecations = append(deprecations, nameDeprecationMsg)
 	}

--- a/pkg/core/resources/apis/system/deprecated.go
+++ b/pkg/core/resources/apis/system/deprecated.go
@@ -15,8 +15,8 @@ func (t *ZoneResource) Deprecations() []string {
 	name := model.GetDisplayName(t.GetMeta())
 	allErrs := apimachineryvalidation.NameIsDNS1035Label(name, false)
 	if len(allErrs) != 0 {
-		nameDeprecationMsg := fmt.Sprintf("Invalid name: '%s'. It does not conform to the DNS format (RFC 1035). This is deprecated. Errors: %s",
-			name, strings.Join(allErrs, "; "))
+		nameDeprecationMsg := fmt.Sprintf("Invalid %s resource name: '%s'. It does not conform to the DNS format (RFC 1035). This is deprecated. Errors: %s",
+			ZoneResourceTypeDescriptor.Name, name, strings.Join(allErrs, "; "))
 		deprecations = append(deprecations, nameDeprecationMsg)
 	}
 

--- a/pkg/core/resources/apis/system/deprecated.go
+++ b/pkg/core/resources/apis/system/deprecated.go
@@ -5,15 +5,18 @@ import (
 	"strings"
 
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
+
+	"github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
 func (t *ZoneResource) Deprecations() []string {
 	var deprecations []string
 
-	allErrs := apimachineryvalidation.NameIsDNS1035Label(t.GetMeta().GetName(), false)
+	name := model.GetDisplayName(t.GetMeta())
+	allErrs := apimachineryvalidation.NameIsDNS1035Label(name, false)
 	if len(allErrs) != 0 {
-		nameDeprecationMsg := fmt.Sprintf("Name that doesn't conform DNS (RFC 1035) format is deprecated: %s",
-			strings.Join(allErrs, "; "))
+		nameDeprecationMsg := fmt.Sprintf("Name that doesn't conform DNS (RFC 1035) format is deprecated, name %s, error: %s",
+			name, strings.Join(allErrs, "; "))
 		deprecations = append(deprecations, nameDeprecationMsg)
 	}
 

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mes.federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mes.federated.golden.yaml
@@ -5,7 +5,8 @@ status:
   metadata: {}
 uid: "12345"
 warnings:
-- 'Invalid name: ''mes.kuma-global''. It does not conform to the DNS format (RFC 1035).
-  This is deprecated. Errors: a DNS-1035 label must consist of lower case alphanumeric
-  characters or ''-'', start with an alphabetic character, and end with an alphanumeric
-  character (e.g. ''my-name'',  or ''abc-123'', regex used for validation is ''[a-z]([-a-z0-9]*[a-z0-9])?'')'
+- 'Invalid MeshExternalService resource name: ''mes.kuma-global''. It does not conform
+  to the DNS format (RFC 1035). This is deprecated. Errors: a DNS-1035 label must
+  consist of lower case alphanumeric characters or ''-'', start with an alphabetic
+  character, and end with an alphanumeric character (e.g. ''my-name'',  or ''abc-123'',
+  regex used for validation is ''[a-z]([-a-z0-9]*[a-z0-9])?'')'

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mes.federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mes.federated.golden.yaml
@@ -1,0 +1,11 @@
+Patches: null
+allowed: true
+status:
+  code: 200
+  metadata: {}
+uid: "12345"
+warnings:
+- 'Invalid name: ''mes.kuma-global''. It does not conform to the DNS format (RFC 1035).
+  This is deprecated. Errors: a DNS-1035 label must consist of lower case alphanumeric
+  characters or ''-'', start with an alphabetic character, and end with an alphanumeric
+  character (e.g. ''my-name'',  or ''abc-123'', regex used for validation is ''[a-z]([-a-z0-9]*[a-z0-9])?'')'

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mes.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mes.global.golden.yaml
@@ -5,7 +5,8 @@ status:
   metadata: {}
 uid: "12345"
 warnings:
-- 'Invalid name: ''mes.kuma-global''. It does not conform to the DNS format (RFC 1035).
-  This is deprecated. Errors: a DNS-1035 label must consist of lower case alphanumeric
-  characters or ''-'', start with an alphabetic character, and end with an alphanumeric
-  character (e.g. ''my-name'',  or ''abc-123'', regex used for validation is ''[a-z]([-a-z0-9]*[a-z0-9])?'')'
+- 'Invalid MeshExternalService resource name: ''mes.kuma-global''. It does not conform
+  to the DNS format (RFC 1035). This is deprecated. Errors: a DNS-1035 label must
+  consist of lower case alphanumeric characters or ''-'', start with an alphabetic
+  character, and end with an alphanumeric character (e.g. ''my-name'',  or ''abc-123'',
+  regex used for validation is ''[a-z]([-a-z0-9]*[a-z0-9])?'')'

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mes.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mes.global.golden.yaml
@@ -1,0 +1,11 @@
+Patches: null
+allowed: true
+status:
+  code: 200
+  metadata: {}
+uid: "12345"
+warnings:
+- 'Invalid name: ''mes.kuma-global''. It does not conform to the DNS format (RFC 1035).
+  This is deprecated. Errors: a DNS-1035 label must consist of lower case alphanumeric
+  characters or ''-'', start with an alphabetic character, and end with an alphanumeric
+  character (e.g. ''my-name'',  or ''abc-123'', regex used for validation is ''[a-z]([-a-z0-9]*[a-z0-9])?'')'

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mes.input.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mes.input.yaml
@@ -1,0 +1,16 @@
+# user=system:serviceaccount:kuma-system:kuma-control-plane,operation=CREATE
+apiVersion: kuma.io/v1alpha1
+kind: MeshExternalService
+metadata:
+  name: mes.kuma-global
+  namespace: kuma-system
+  labels:
+    kuma.io/mesh: default
+spec:
+  match:
+    type: HostnameGenerator
+    port: 80
+    protocol: http
+  endpoints:
+    - address: example.com
+      port: 80

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mes.non-federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mes.non-federated.golden.yaml
@@ -5,7 +5,8 @@ status:
   metadata: {}
 uid: "12345"
 warnings:
-- 'Invalid name: ''mes.kuma-global''. It does not conform to the DNS format (RFC 1035).
-  This is deprecated. Errors: a DNS-1035 label must consist of lower case alphanumeric
-  characters or ''-'', start with an alphabetic character, and end with an alphanumeric
-  character (e.g. ''my-name'',  or ''abc-123'', regex used for validation is ''[a-z]([-a-z0-9]*[a-z0-9])?'')'
+- 'Invalid MeshExternalService resource name: ''mes.kuma-global''. It does not conform
+  to the DNS format (RFC 1035). This is deprecated. Errors: a DNS-1035 label must
+  consist of lower case alphanumeric characters or ''-'', start with an alphabetic
+  character, and end with an alphanumeric character (e.g. ''my-name'',  or ''abc-123'',
+  regex used for validation is ''[a-z]([-a-z0-9]*[a-z0-9])?'')'

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mes.non-federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mes.non-federated.golden.yaml
@@ -1,0 +1,11 @@
+Patches: null
+allowed: true
+status:
+  code: 200
+  metadata: {}
+uid: "12345"
+warnings:
+- 'Invalid name: ''mes.kuma-global''. It does not conform to the DNS format (RFC 1035).
+  This is deprecated. Errors: a DNS-1035 label must consist of lower case alphanumeric
+  characters or ''-'', start with an alphabetic character, and end with an alphanumeric
+  character (e.g. ''my-name'',  or ''abc-123'', regex used for validation is ''[a-z]([-a-z0-9]*[a-z0-9])?'')'


### PR DESCRIPTION
## Motivation

When running on k8s `r.GetMeta().GetName()` returns namespaces name which doesn't pass validation. We shouldn't use this value but instead `GetDisplayName()`

## Implementation information

Check if `kuma.io/display-name` fulfill the requirement.

## Supporting documentation

Fix https://github.com/kumahq/kuma/issues/13023
