### PR TITLE
fix(kuma-cp): change usage of deprecated global_downstream_max_connections

### DIFF
--- a/pkg/xds/bootstrap/testdata/bootstrap.gateway.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.gateway.golden.yaml
@@ -37,9 +37,6 @@ layeredRuntime:
     staticLayer:
       re2.max_program_size.error_level: 4294967295
       re2.max_program_size.warn_level: 1000
-  - name: gateway
-    staticLayer:
-      overload.global_downstream_max_connections: 50000
   - name: gateway.listeners
     rtdsLayer:
       name: gateway.listeners
@@ -79,6 +76,10 @@ overloadManager:
         value: 0.98
   refreshInterval: 0.250s
   resourceMonitors:
+  - name: envoy.resource_monitors.global_downstream_max_connections
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+      maxActiveDownstreamConnections: "50000"
   - name: envoy.resource_monitors.fixed_heap
     typedConfig:
       '@type': type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig

--- a/pkg/xds/bootstrap/testdata/generator.gateway.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.gateway.golden.yaml
@@ -57,9 +57,6 @@ layeredRuntime:
     staticLayer:
       re2.max_program_size.error_level: 4294967295
       re2.max_program_size.warn_level: 1000
-  - name: gateway
-    staticLayer:
-      overload.global_downstream_max_connections: 35678
   - name: gateway.listeners
     rtdsLayer:
       name: gateway.listeners
@@ -86,6 +83,13 @@ node:
         gitTag: v0.0.1
         version: 0.0.1
     workdir: /tmp
+overloadManager:
+  refreshInterval: 0.250s
+  resourceMonitors:
+  - name: envoy.resource_monitors.global_downstream_max_connections
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+      maxActiveDownstreamConnections: "35678"
 staticResources:
   clusters:
   - connectTimeout: 1s


### PR DESCRIPTION
## Motivation

We can see in the logs
```
Usage of the deprecated runtime key overload.global_downstream_max_connections, consider switching to `envoy.resource_monitors.global_downstream_max_connections` instead.This runtime key will be removed in future.
```

the field was deprecated.

## Implementation information

Changed to `envoy.resource_monitors.global_downstream_max_connections`
