### PR TITLE
feat(renovate): add custom manager for go-control-plane and update config

### DIFF
--- a/.renovate/go-control-plane.json
+++ b/.renovate/go-control-plane.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Custom Renovate configuration for managing updates to 'github.com/kumahq/go-control-plane' dependencies in Go modules",
+  "customManagers": [
+    {
+      "description": "Custom regex manager for updating 'github.com/kumahq/go-control-plane' dependencies in go.mod files. It captures both direct and subpackage dependencies and replaces them with the latest version",
+      "customType": "regex",
+      "fileMatch": [
+        "(^|/)go\\.mod$"
+      ],
+      "matchStrings": [
+        "(?<packageName>github.com\\/kumahq\\/(?<depName>go-control-plane)) (?<currentValue>[^\\s]+)",
+        "(?<packageName>github.com\\/kumahq\\/go-control-plane\\/(?<depName>.+)) (?<currentValue>[^\\s]+)"
+      ],
+      "datasourceTemplate": "go",
+      "depTypeTemplate": "replace",
+      "extractVersionTemplate": "^(?:{{{depName}}}\\/)?(?<version>v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>.+))",
+      "autoReplaceStringTemplate": "{{{packageName}}} {{{newVersion}}}",
+      "versioningTemplate": "loose"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Disable updates for 'github.com/kumahq/go-control-plane' dependencies managed by the default Go module manager when they are marked as 'replace'",
+      "groupName": "github.com/kumahq/go-control-plane*",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchDepNames": [
+        "/^github.com\\/kumahq\\/go-control-plane/"
+      ],
+      "matchDepTypes": [
+        "replace"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Ensure updates to 'github.com/kumahq/go-control-plane' dependencies use the custom regex manager. Set commit scope to 'deps/gomod', update import paths when needed, and run 'go mod tidy' after updates",
+      "matchManagers": [
+        "regex"
+      ],
+      "matchDatasources": [
+        "go"
+      ],
+      "matchDepTypes": [
+        "replace"
+      ],
+      "matchPackageNames": [
+        "/^github.com\\/kumahq\\/go-control-plane/"
+      ],
+      "semanticCommitScope": "deps/gomod",
+      "commitMessageTopic": "{{{packageName}}}",
+      "postUpdateOptions": [
+        "gomodTidy",
+        "gomodUpdateImportPaths"
+      ]
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,22 +1,35 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>Kong/public-shared-renovate:backend#1.0.0"
-  ],
-  "baseBranches": [
-    "master"
+    "github>Kong/public-shared-renovate:backend#1.2.0",
+    "local>kumahq/kuma//.renovate/go-control-plane"
   ],
   "enabledManagers": [
     "custom.regex",
     "dockerfile",
     "github-actions",
-    "gomod"
+    "gomod",
+    "helm-values",
+    "kubernetes"
   ],
   "ignorePaths": [],
+  "kubernetes": {
+    "description": "Include Kubernetes manifests from 'kumactl install demo|observability' to let Renovate update the image versions in these resources",
+    "fileMatch": ["app/kumactl/data/install/k8s/.+\\.ya?ml$"]
+  },
+  "semanticCommitScope": "deps/{{{manager}}}",
+  "prBodyTemplate": "{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}{{{controls}}}",
   "packageRules": [
     {
-      "description": "Skip tests for GitHub Actions updates. We match by depType because there isn’t an idiomatic way to target custom manager from Kong/public-shared-renovate:backend preset, which handles Kong/public-shared-actions",
-      "matchDepTypes": ["action"],
+      "description": "Skip tests for GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "addLabels": ["ci/skip-test"]
+    },
+    {
+      "description": "Set commit scope to `deps/github-actions` for `Kong/public-shared-actions` GitHub Actions managed by `github>Kong/public-shared-renovate:backend`. Skip tests since these are also GitHub Actions updates but are not covered by the earlier rule",
+      "matchManagers": ["regex"],
+      "matchPackageNames": ["Kong/public-shared-actions/**"],
+      "semanticCommitScope": "deps/github-actions",
       "addLabels": ["ci/skip-test"]
     }
   ]


### PR DESCRIPTION
## Motivation & Implementation information

- Added a custom Renovate manager for `github.com/kumahq/go-control-plane` (our fork of `envoy/go-control-plane`) dependencies in `go.mod`
  - Ensured updates use a regex-based manager instead of the default Go module manager
  - Disabled updates for `replace` dependencies in `gomod` to avoid conflicts
  - Updated `renovate.json` to extend the new `go-control-plane` preset
- Upgraded `github>Kong/public-shared-renovate:backend` to version `1.2.0`
- Enabled Kubernetes and Helm `values.yaml` updates and improved `prBodyTemplate` (removed unnecessary content)

## Supporting documentation

Part of: https://github.com/kumahq/kuma/issues/12529

> Changelog: skip
