### PR TITLE
chore(api): export all computed labels to be used in another project

### DIFF
--- a/pkg/core/resources/model/labels/labels.go
+++ b/pkg/core/resources/model/labels/labels.go
@@ -1,0 +1,16 @@
+package labels
+
+import (
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/metadata"
+)
+
+var AllComputedLabels = map[string]struct{}{
+	metadata.KumaMeshLabel:         {},
+	mesh_proto.ResourceOriginLabel: {},
+	mesh_proto.ZoneTag:             {},
+	mesh_proto.EnvTag:              {},
+	mesh_proto.KubeNamespaceTag:    {},
+	mesh_proto.PolicyRoleLabel:     {},
+	mesh_proto.ProxyTypeLabel:      {},
+}


### PR DESCRIPTION
## Motivation

**This PR does not change anything from `kuma` perspective.**

Terraform will show changes to labels that are automatically generated, like `kuma.io/mesh` so applying:

```
resource "konnect_mesh_external_service" "my_meshexternalservice" {
  cp_id = konnect_mesh_control_plane.my_meshcontrolplane.id

  labels = {
    environment = "production"
    # "kuma.io/mesh" = konnect_mesh.default.name
  }

...
}
```

Will succeed but on the next `apply` we would see `kuma.io/mesh` because it's automatically generated:

```
  # konnect_mesh_external_service.my_meshexternalservice will be updated in-place
  ~ resource "konnect_mesh_external_service" "my_meshexternalservice" {
      ~ labels            = {
          - "kuma.io/mesh" = "mesh-9" -> null
            # (1 unchanged element hidden)
        }
        name              = "external-service-example"
        # (7 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

This PR allows the provider to import `AllComputedLabels` and remove them from terraform plan.

## Implementation information

Export AllComputedLabels and make sure that in the future this list is updated.

This can be achieved without this PR but the labels might get out of sync in the future if we don't update it in the provider.

## Supporting documentation

Xrel: https://github.com/Kong/platform-api/issues/1023