### PR TITLE
chore(test/unit): fix order in golden files for kds context sync tests

### DIFF
--- a/pkg/kds/context/testdata/full_sync/mesh-only/global.golden.yaml
+++ b/pkg/kds/context/testdata/full_sync/mesh-only/global.golden.yaml
@@ -26,7 +26,7 @@ creationTime: "0001-01-01T00:00:00Z"
 healthCheck:
   time: "0001-01-01T00:00:00Z"
 modificationTime: "0001-01-01T00:00:00Z"
-name: zone-2
+name: zone-1
 type: ZoneInsight
 
 ---
@@ -34,6 +34,6 @@ creationTime: "0001-01-01T00:00:00Z"
 healthCheck:
   time: "0001-01-01T00:00:00Z"
 modificationTime: "0001-01-01T00:00:00Z"
-name: zone-1
+name: zone-2
 type: ZoneInsight
 

--- a/pkg/kds/context/testdata/full_sync/policy-simple/zone-1.golden.yaml
+++ b/pkg/kds/context/testdata/full_sync/policy-simple/zone-1.golden.yaml
@@ -10,9 +10,12 @@ type: Mesh
 # MeshTimeout
 ---
 creationTime: "0001-01-01T00:00:00Z"
+labels:
+  kuma.io/display-name: default-timeout-global
+  kuma.io/origin: global
 mesh: default
 modificationTime: "0001-01-01T00:00:00Z"
-name: default-timeout-zone-1
+name: default-timeout-global-54dbd4c66zwbcf9c
 spec:
   to:
   - default:
@@ -26,12 +29,9 @@ type: MeshTimeout
 
 ---
 creationTime: "0001-01-01T00:00:00Z"
-labels:
-  kuma.io/display-name: default-timeout-global
-  kuma.io/origin: global
 mesh: default
 modificationTime: "0001-01-01T00:00:00Z"
-name: default-timeout-global-54dbd4c66zwbcf9c
+name: default-timeout-zone-1
 spec:
   to:
   - default:

--- a/pkg/test/store/load.go
+++ b/pkg/test/store/load.go
@@ -69,11 +69,19 @@ func ExtractResources(ctx context.Context, rs store.ResourceStore) (string, erro
 		if err != nil {
 			return "", err
 		}
-		if len(resList.GetItems()) > 0 {
+
+		items := slices.SortedFunc(
+			slices.Values(resList.GetItems()),
+			func(a, b model.Resource) int {
+				return cmp.Compare(a.GetMeta().GetName(), b.GetMeta().GetName())
+			},
+		)
+
+		if len(items) > 0 {
 			_, _ = fmt.Fprintf(outputs, "# %s\n", tDesc.Name)
 		}
 
-		for i, resource := range resList.GetItems() {
+		for i, resource := range items {
 			if resource.Descriptor().Name == system.ZoneInsightType {
 				zi := resource.(*system.ZoneInsightResource)
 				zi.Spec.Subscriptions = nil


### PR DESCRIPTION
## Motivation

These tests were flaking

## Implementation information

Sort resource names before building golden YAML