### PR TITLE
chore(renovate): group kumactl install k8s container images

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,6 +31,13 @@
       "matchPackageNames": ["Kong/public-shared-actions/**"],
       "semanticCommitScope": "deps/github-actions",
       "addLabels": ["ci/skip-test"]
+    },
+    {
+      "groupName": "kumactl install demo|observability container images",
+      "groupSlug": "kumactl-install-k8s",
+      "matchFileNames": [
+        "app/kumactl/data/install/k8s/**"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Motivation & Implementation information

Added a package group for `kumactl install demo|observability` container images. This helps reduce the number of PRs since each update requires running `make format` and updating golden files, making singular PRs tedious.

## Supporting documentation

Related to: https://github.com/kumahq/kuma/issues/12529