### PR TITLE
feat(renovate): improve go-control-plane updates and grouping

### DIFF
--- a/.renovate/go-control-plane.json
+++ b/.renovate/go-control-plane.json
@@ -27,7 +27,7 @@
         "gomod"
       ],
       "matchDepNames": [
-        "/^github.com\\/kumahq\\/go-control-plane/"
+        "github.com/kumahq/go-control-plane{/,}**"
       ],
       "matchDepTypes": [
         "replace"
@@ -46,7 +46,7 @@
         "replace"
       ],
       "matchPackageNames": [
-        "/^github.com\\/kumahq\\/go-control-plane/"
+        "github.com/kumahq/go-control-plane{/,}**"
       ],
       "semanticCommitScope": "deps/gomod",
       "commitMessageTopic": "{{{packageName}}}",
@@ -54,6 +54,19 @@
         "gomodTidy",
         "gomodUpdateImportPaths"
       ]
+    },
+    {
+      "groupName": "github.com/envoyproxy/go-control-plane*",
+      "groupSlug": "github.com-envoyproxy-go-control-plane",
+      "matchDatasources": [
+        "go"
+      ],
+      "matchPackageNames": [
+        "github.com/{envoyproxy,kumahq}/go-control-plane{/,}**"
+      ],
+      "prBodyDefinitions": {
+        "Package": "[{{{packageName}}}]({{{sourceUrl}}}) ([source]({{{sourceUrl}}}/tree/{{#if newVersion}}{{{depName}}}/{{{newVersion}}}{{else}}main{{/if}}/{{{depName}}}))"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Motivation & Implementation information

- Grouped all `go-control-plane` updates, including `envoyproxy` and `kumahq` (fork replaces)
- Switched package matching from regex to glob for better readability
- Fixed PR table links to correctly display updated dependencies

## Supporting documentation

Related to: https://github.com/kumahq/kuma/issues/12529

> Changelog: skip