### PR TITLE
test(kds): increase wait time in full sync test to reduce flakiness

### DIFF
--- a/pkg/kds/context/full_sync_test.go
+++ b/pkg/kds/context/full_sync_test.go
@@ -86,7 +86,7 @@ var _ = Describe("Full sync tests", func() {
 		}
 
 		// Wait for some time to ensure sync was complete
-		time.Sleep(time.Second * 2)
+		time.Sleep(time.Second * 5)
 		close(done)
 		wg.Wait()
 


### PR DESCRIPTION
## Motivation & Implementation information

- Increased `time.Sleep` from 2s to 5s to ensure sync completes before proceeding
- Debugging showed that lowering this value to 100ms increased flakiness, reproducing the same failures seen in CI
- If this change doesn't resolve the flakes, we will need to find a more reliable way to verify sync completion.