### PR TITLE
feat(k8s): don't watch configMap/secrets in all namespaces

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -101,19 +101,11 @@ rules:
     resources:
       - namespaces
       - pods
-      - configmaps
       - nodes
     verbs:
       - get
       - list
       - watch
-  - apiGroups:
-    - ""
-    resources:
-      - secrets
-    verbs:
-    - list
-    - watch
   - apiGroups:
     - "discovery.k8s.io"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -10449,19 +10449,11 @@ rules:
     resources:
       - namespaces
       - pods
-      - configmaps
       - nodes
     verbs:
       - get
       - list
       - watch
-  - apiGroups:
-    - ""
-    resources:
-      - secrets
-    verbs:
-    - list
-    - watch
   - apiGroups:
     - "discovery.k8s.io"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -10449,19 +10449,11 @@ rules:
     resources:
       - namespaces
       - pods
-      - configmaps
       - nodes
     verbs:
       - get
       - list
       - watch
-  - apiGroups:
-    - ""
-    resources:
-      - secrets
-    verbs:
-    - list
-    - watch
   - apiGroups:
     - "discovery.k8s.io"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
@@ -46,19 +46,11 @@ rules:
     resources:
       - namespaces
       - pods
-      - configmaps
       - nodes
     verbs:
       - get
       - list
       - watch
-  - apiGroups:
-    - ""
-    resources:
-      - secrets
-    verbs:
-    - list
-    - watch
   - apiGroups:
     - "discovery.k8s.io"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
@@ -46,19 +46,11 @@ rules:
     resources:
       - namespaces
       - pods
-      - configmaps
       - nodes
     verbs:
       - get
       - list
       - watch
-  - apiGroups:
-    - ""
-    resources:
-      - secrets
-    verbs:
-    - list
-    - watch
   - apiGroups:
     - "discovery.k8s.io"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
@@ -46,19 +46,11 @@ rules:
     resources:
       - namespaces
       - pods
-      - configmaps
       - nodes
     verbs:
       - get
       - list
       - watch
-  - apiGroups:
-    - ""
-    resources:
-      - secrets
-    verbs:
-    - list
-    - watch
   - apiGroups:
     - "discovery.k8s.io"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
@@ -46,19 +46,11 @@ rules:
     resources:
       - namespaces
       - pods
-      - configmaps
       - nodes
     verbs:
       - get
       - list
       - watch
-  - apiGroups:
-    - ""
-    resources:
-      - secrets
-    verbs:
-    - list
-    - watch
   - apiGroups:
     - "discovery.k8s.io"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.tproxy-ebpf-experimental-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.tproxy-ebpf-experimental-enabled.golden.yaml
@@ -46,19 +46,11 @@ rules:
     resources:
       - namespaces
       - pods
-      - configmaps
       - nodes
     verbs:
       - get
       - list
       - watch
-  - apiGroups:
-    - ""
-    resources:
-      - secrets
-    verbs:
-    - list
-    - watch
   - apiGroups:
     - "discovery.k8s.io"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
@@ -56,19 +56,11 @@ rules:
     resources:
       - namespaces
       - pods
-      - configmaps
       - nodes
     verbs:
       - get
       - list
       - watch
-  - apiGroups:
-    - ""
-    resources:
-      - secrets
-    verbs:
-    - list
-    - watch
   - apiGroups:
     - "discovery.k8s.io"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -10469,19 +10469,11 @@ rules:
     resources:
       - namespaces
       - pods
-      - configmaps
       - nodes
     verbs:
       - get
       - list
       - watch
-  - apiGroups:
-    - ""
-    resources:
-      - secrets
-    verbs:
-    - list
-    - watch
   - apiGroups:
     - "discovery.k8s.io"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
@@ -46,19 +46,11 @@ rules:
     resources:
       - namespaces
       - pods
-      - configmaps
       - nodes
     verbs:
       - get
       - list
       - watch
-  - apiGroups:
-    - ""
-    resources:
-      - secrets
-    verbs:
-    - list
-    - watch
   - apiGroups:
     - "discovery.k8s.io"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -56,19 +56,11 @@ rules:
     resources:
       - namespaces
       - pods
-      - configmaps
       - nodes
     verbs:
       - get
       - list
       - watch
-  - apiGroups:
-    - ""
-    resources:
-      - secrets
-    verbs:
-    - list
-    - watch
   - apiGroups:
     - "discovery.k8s.io"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
@@ -46,19 +46,11 @@ rules:
     resources:
       - namespaces
       - pods
-      - configmaps
       - nodes
     verbs:
       - get
       - list
       - watch
-  - apiGroups:
-    - ""
-    resources:
-      - secrets
-    verbs:
-    - list
-    - watch
   - apiGroups:
     - "discovery.k8s.io"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/dnsConfigOption.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/dnsConfigOption.golden.yaml
@@ -66,19 +66,11 @@ rules:
     resources:
       - namespaces
       - pods
-      - configmaps
       - nodes
     verbs:
       - get
       - list
       - watch
-  - apiGroups:
-    - ""
-    resources:
-      - secrets
-    verbs:
-    - list
-    - watch
   - apiGroups:
     - "discovery.k8s.io"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/doNotChangeTlsChecksum.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/doNotChangeTlsChecksum.golden.yaml
@@ -46,19 +46,11 @@ rules:
     resources:
       - namespaces
       - pods
-      - configmaps
       - nodes
     verbs:
       - get
       - list
       - watch
-  - apiGroups:
-    - ""
-    resources:
-      - secrets
-    verbs:
-    - list
-    - watch
   - apiGroups:
     - "discovery.k8s.io"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
@@ -46,19 +46,11 @@ rules:
     resources:
       - namespaces
       - pods
-      - configmaps
       - nodes
     verbs:
       - get
       - list
       - watch
-  - apiGroups:
-    - ""
-    resources:
-      - secrets
-    verbs:
-    - list
-    - watch
   - apiGroups:
     - "discovery.k8s.io"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/envVarsDownwardApi.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/envVarsDownwardApi.golden.yaml
@@ -46,19 +46,11 @@ rules:
     resources:
       - namespaces
       - pods
-      - configmaps
       - nodes
     verbs:
       - get
       - list
       - watch
-  - apiGroups:
-    - ""
-    resources:
-      - secrets
-    verbs:
-    - list
-    - watch
   - apiGroups:
     - "discovery.k8s.io"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix12847.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix12847.golden.yaml
@@ -101,19 +101,11 @@ rules:
     resources:
       - namespaces
       - pods
-      - configmaps
       - nodes
     verbs:
       - get
       - list
       - watch
-  - apiGroups:
-    - ""
-    resources:
-      - secrets
-    verbs:
-    - list
-    - watch
   - apiGroups:
     - "discovery.k8s.io"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix13029.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix13029.golden.yaml
@@ -101,19 +101,11 @@ rules:
     resources:
       - namespaces
       - pods
-      - configmaps
       - nodes
     verbs:
       - get
       - list
       - watch
-  - apiGroups:
-    - ""
-    resources:
-      - secrets
-    verbs:
-    - list
-    - watch
   - apiGroups:
     - "discovery.k8s.io"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
@@ -63,19 +63,11 @@ rules:
     resources:
       - namespaces
       - pods
-      - configmaps
       - nodes
     verbs:
       - get
       - list
       - watch
-  - apiGroups:
-    - ""
-    resources:
-      - secrets
-    verbs:
-    - list
-    - watch
   - apiGroups:
     - "discovery.k8s.io"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
@@ -60,19 +60,11 @@ rules:
     resources:
       - namespaces
       - pods
-      - configmaps
       - nodes
     verbs:
       - get
       - list
       - watch
-  - apiGroups:
-    - ""
-    resources:
-      - secrets
-    verbs:
-    - list
-    - watch
   - apiGroups:
     - "discovery.k8s.io"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
@@ -121,19 +121,11 @@ rules:
     resources:
       - namespaces
       - pods
-      - configmaps
       - nodes
     verbs:
       - get
       - list
       - watch
-  - apiGroups:
-    - ""
-    resources:
-      - secrets
-    verbs:
-    - list
-    - watch
   - apiGroups:
     - "discovery.k8s.io"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix5978.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix5978.golden.yaml
@@ -66,19 +66,11 @@ rules:
     resources:
       - namespaces
       - pods
-      - configmaps
       - nodes
     verbs:
       - get
       - list
       - watch
-  - apiGroups:
-    - ""
-    resources:
-      - secrets
-    verbs:
-    - list
-    - watch
   - apiGroups:
     - "discovery.k8s.io"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix7724.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix7724.golden.yaml
@@ -49,19 +49,11 @@ rules:
     resources:
       - namespaces
       - pods
-      - configmaps
       - nodes
     verbs:
       - get
       - list
       - watch
-  - apiGroups:
-    - ""
-    resources:
-      - secrets
-    verbs:
-    - list
-    - watch
   - apiGroups:
     - "discovery.k8s.io"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix7824.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix7824.golden.yaml
@@ -81,19 +81,11 @@ rules:
     resources:
       - namespaces
       - pods
-      - configmaps
       - nodes
     verbs:
       - get
       - list
       - watch
-  - apiGroups:
-    - ""
-    resources:
-      - secrets
-    verbs:
-    - list
-    - watch
   - apiGroups:
     - "discovery.k8s.io"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/minReadySeconds.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/minReadySeconds.golden.yaml
@@ -46,19 +46,11 @@ rules:
     resources:
       - namespaces
       - pods
-      - configmaps
       - nodes
     verbs:
       - get
       - list
       - watch
-  - apiGroups:
-    - ""
-    resources:
-      - secrets
-    verbs:
-    - list
-    - watch
   - apiGroups:
     - "discovery.k8s.io"
     resources:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/securityContext.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/securityContext.golden.yaml
@@ -46,19 +46,11 @@ rules:
     resources:
       - namespaces
       - pods
-      - configmaps
       - nodes
     verbs:
       - get
       - list
       - watch
-  - apiGroups:
-    - ""
-    resources:
-      - secrets
-    verbs:
-    - list
-    - watch
   - apiGroups:
     - "discovery.k8s.io"
     resources:

--- a/deployments/charts/kuma/templates/cp-rbac.yaml
+++ b/deployments/charts/kuma/templates/cp-rbac.yaml
@@ -27,9 +27,6 @@ rules:
     resources:
       - namespaces
       - pods
-{{- if not (and .Values.transparentProxy.configMap.enabled .Values.transparentProxy.configMap.config) }}
-      - configmaps
-{{- end }}
       - nodes
 {{- if .Values.controlPlane.supportGatewaySecretsInAllNamespaces }}
       - secrets
@@ -38,13 +35,6 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-    - ""
-    resources:
-      - secrets
-    verbs:
-    - list
-    - watch
   - apiGroups:
     - "discovery.k8s.io"
     resources:
@@ -122,9 +112,6 @@ rules:
       - ""
     resources:
       - services
-{{- if and .Values.transparentProxy.configMap.enabled .Values.transparentProxy.configMap.config }}
-      - configmaps
-{{- end }}
     verbs:
       - get
       - delete

--- a/pkg/kds/context/testdata/full_sync/mesh-only/global.golden.yaml
+++ b/pkg/kds/context/testdata/full_sync/mesh-only/global.golden.yaml
@@ -10,14 +10,14 @@ type: Mesh
 creationTime: "0001-01-01T00:00:00Z"
 enabled: true
 modificationTime: "0001-01-01T00:00:00Z"
-name: zone-2
+name: zone-1
 type: Zone
 
 ---
 creationTime: "0001-01-01T00:00:00Z"
 enabled: true
 modificationTime: "0001-01-01T00:00:00Z"
-name: zone-1
+name: zone-2
 type: Zone
 
 # ZoneInsight

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/secret_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/secret_controller.go
@@ -24,10 +24,6 @@ type SecretController struct {
 }
 
 func (r *SecretController) Reconcile(ctx context.Context, req kube_ctrl.Request) (kube_ctrl.Result, error) {
-	if !r.SupportGatewaySecretsInAllNamespaces && req.Namespace != r.SystemNamespace {
-		r.Log.V(1).Info("ignoring reconcile because SupportGatewaySecretsInAllNamespaces is disabled", "req", req)
-		return kube_ctrl.Result{}, nil
-	}
 	r.Log.Info("reconcile", "req", req)
 
 	copiedSecretKey := types.NamespacedName{


### PR DESCRIPTION
## Motivation

For security reasons, some organizations prefer that other components do not watch Secrets and ConfigMaps across all namespaces.

## Implementation information

* Moved RBAC permissions for ConfigMaps from ClusterRole to Role in the system namespace.
* Configured the controller-manager cache to watch only ConfigMaps from the system namespace.
* Configured the controller-manager cache to watch only Secrets from the system namespace, unless `supportGatewaySecretsInAllNamespaces` is defined.
* The check from the controller has been removed, as watching only the system namespace ensures that no events are produced for other namespaces.
