### PR TITLE
test(unit): compare file content instead of yaml

### DIFF
--- a/pkg/kds/context/full_sync_test.go
+++ b/pkg/kds/context/full_sync_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Full sync tests", func() {
 		for _, file := range files {
 			if strings.HasSuffix(file.Name(), ".input.yaml") {
 				zoneName := strings.TrimSuffix(file.Name(), ".input.yaml")
-				resourceStore := memory.NewStore()
+				resourceStore := store.NewPaginationStore(memory.NewStore())
 				fullPath := path.Join(folder, file.Name())
 				Expect(test_store.LoadResourcesFromFile(ctx, resourceStore, fullPath)).To(Succeed())
 				zones[zoneName] = resourceStore
@@ -94,7 +94,7 @@ var _ = Describe("Full sync tests", func() {
 		for zoneName, zoneStore := range zones {
 			out, err := test_store.ExtractResources(ctx, zoneStore)
 			Expect(err).To(Succeed())
-			Expect(out).To(matchers.MatchGoldenYAML(folder, zoneName+".golden.yaml"), "zone %s", zoneName)
+			Expect(out).To(matchers.MatchGoldenEqual(folder, zoneName+".golden.yaml"), "zone %s", zoneName)
 		}
 	}, test.EntriesAsFolder("full_sync"))
 })

--- a/pkg/kds/context/testdata/full_sync/policy-with-kds-disabled/global.golden.yaml
+++ b/pkg/kds/context/testdata/full_sync/policy-with-kds-disabled/global.golden.yaml
@@ -45,7 +45,7 @@ creationTime: "0001-01-01T00:00:00Z"
 healthCheck:
   time: "0001-01-01T00:00:00Z"
 modificationTime: "0001-01-01T00:00:00Z"
-name: zone-2
+name: zone-1
 type: ZoneInsight
 
 ---
@@ -53,6 +53,6 @@ creationTime: "0001-01-01T00:00:00Z"
 healthCheck:
   time: "0001-01-01T00:00:00Z"
 modificationTime: "0001-01-01T00:00:00Z"
-name: zone-1
+name: zone-2
 type: ZoneInsight
 

--- a/pkg/test/store/load.go
+++ b/pkg/test/store/load.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"regexp"
 	"slices"
+	"strings"
 
 	"github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
@@ -73,7 +74,7 @@ func ExtractResources(ctx context.Context, rs store.ResourceStore) (string, erro
 		items := slices.SortedFunc(
 			slices.Values(resList.GetItems()),
 			func(a, b model.Resource) int {
-				return cmp.Compare(a.GetMeta().GetName(), b.GetMeta().GetName())
+				return strings.Compare(a.GetMeta().GetName(), b.GetMeta().GetName())
 			},
 		)
 

--- a/pkg/test/store/load.go
+++ b/pkg/test/store/load.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"regexp"
 	"slices"
-	"strings"
 
 	"github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
@@ -74,7 +73,7 @@ func ExtractResources(ctx context.Context, rs store.ResourceStore) (string, erro
 		items := slices.SortedFunc(
 			slices.Values(resList.GetItems()),
 			func(a, b model.Resource) int {
-				return strings.Compare(a.GetMeta().GetName(), b.GetMeta().GetName())
+				return cmp.Compare(a.GetMeta().GetName(), b.GetMeta().GetName())
 			},
 		)
 


### PR DESCRIPTION
## Motivation

While debugging a flake I noticed that `MatchGoldenYAML` doesn't work correctly. In the match, it compares only the first element of the file. 

https://pkg.go.dev/gopkg.in/yaml.v3#section-readme
> Multi-document unmarshalling is not yet implemented, and base-60 floats from YAML 1.1 are purposefully not supported since they're a poor design and are gone in YAML 1.2.

## Implementation information

Changed to `MatchGoldenEqual` since we are using it in other tests. Also, change sort to `strings.Cmp`

> Changelog: skip
