### PR TITLE
fix(meshservice): fix inbound port selecting logic on MeshService

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -107,7 +107,7 @@ Authentication between the control plane and dataplanes is now only checked at c
 
 ### MeshService
 
-There are two changes on collecting endpoints for MeshServices when matching data plane inbound ports with ports on MeshServices. 
+There are two changes to collecting endpoints for MeshServices when matching data plane inbound ports with ports on MeshServices. 
 
 Only name/number of targetPort on MeshServices will be used to match data plane inbound ports when collecting endpoints for MeshServices. On Kubernetes, this means you should use targetPort on Service ports to match the port defined on Pods, which is a correct and common usage on Kubernetes.
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -101,9 +101,23 @@ is not a correct value, we have decided to deprecate it. If you are using `Sourc
 
 The `healthyPanicThreshold` field in the `MeshHealthCheck` policy is deprecated and will be removed in a future release. It has been moved to the `MeshCircuitBreaker` policy.
 
-### Changes on revoking dataplane tokens
+### Changes to revoking dataplane tokens
 
 Authentication between the control plane and dataplanes is now only checked at connection start. This means if a token expires or is revoked after the dataplane connects, the connection won't stop. The recommended action on token revocation is to restart either the control plane or the concerned dataplanes.
+
+### MeshService
+
+There are two changes on collecting endpoints for MeshServices when matching data plane inbound ports with ports on MeshServices. 
+
+Only name/number of targetPort on MeshServices will be used to match data plane inbound ports when collecting endpoints for MeshServices. On Kubernetes, this means you should use targetPort on Service ports to match the port defined on Pods, which is a correct and common usage on Kubernetes.
+
+#### Removal of endpoint generating based on port naming matching
+
+A data plane was treated as an endpoint when it has an inbound whose name matches one of the port names on the MeshService. This has been removed since it was an incorrect implementation. We no longer match port names of Services to container ports on Pods, please use name/number of targetPort on the MeshService to match the port defined on the data plane.
+
+#### Changes to endpoint generating based on port matching
+
+A data plane was treated as an endpoint when it has an inbound whose port matches one of the port on the MeshService using the `port` field. This has been changed to match `targetPort` on the MeshService since the previous implementation was incorrect. Please use name/number of targetPort on the MeshService to match the port defined on the data plane.
 
 ## Upgrade to `2.9.x`
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -101,23 +101,9 @@ is not a correct value, we have decided to deprecate it. If you are using `Sourc
 
 The `healthyPanicThreshold` field in the `MeshHealthCheck` policy is deprecated and will be removed in a future release. It has been moved to the `MeshCircuitBreaker` policy.
 
-### Changes to revoking dataplane tokens
+### Changes on revoking dataplane tokens
 
 Authentication between the control plane and dataplanes is now only checked at connection start. This means if a token expires or is revoked after the dataplane connects, the connection won't stop. The recommended action on token revocation is to restart either the control plane or the concerned dataplanes.
-
-### MeshService
-
-There are two changes to collecting endpoints for MeshServices when matching data plane inbound ports with ports on MeshServices. 
-
-Only name/number of targetPort on MeshServices will be used to match data plane inbound ports when collecting endpoints for MeshServices. On Kubernetes, this means you should use targetPort on Service ports to match the port defined on Pods, which is a correct and common usage on Kubernetes.
-
-#### Removal of endpoint generating based on port naming matching
-
-A data plane was treated as an endpoint when it has an inbound whose name matches one of the port names on the MeshService. This has been removed since it was an incorrect implementation. We no longer match port names of Services to container ports on Pods, please use name/number of targetPort on the MeshService to match the port defined on the data plane.
-
-#### Changes to endpoint generating based on port matching
-
-A data plane was treated as an endpoint when it has an inbound whose port matches one of the port on the MeshService using the `port` field. This has been changed to match `targetPort` on the MeshService since the previous implementation was incorrect. Please use name/number of targetPort on the MeshService to match the port defined on the data plane.
 
 ## Upgrade to `2.9.x`
 

--- a/pkg/core/resources/apis/meshservice/match.go
+++ b/pkg/core/resources/apis/meshservice/match.go
@@ -1,12 +1,13 @@
 package meshservice
 
 import (
+	"k8s.io/apimachinery/pkg/util/intstr"
+
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/util/maps"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 type dppsByNameByTagKey struct {

--- a/pkg/core/resources/apis/meshservice/match.go
+++ b/pkg/core/resources/apis/meshservice/match.go
@@ -6,6 +6,7 @@ import (
 	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/util/maps"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 type dppsByNameByTagKey struct {
@@ -139,4 +140,14 @@ func matchByTags(
 		}
 	}
 	return dpps
+}
+
+func MatchInboundWithMeshServicePort(inbound *mesh_proto.Dataplane_Networking_Inbound, port meshservice_api.Port) bool {
+	switch port.TargetPort.Type {
+	case intstr.Int:
+		return uint32(port.TargetPort.IntVal) == inbound.Port
+	case intstr.String:
+		return port.TargetPort.StrVal == inbound.Name
+	}
+	return false
 }

--- a/pkg/core/resources/apis/meshservice/match.go
+++ b/pkg/core/resources/apis/meshservice/match.go
@@ -143,12 +143,12 @@ func matchByTags(
 	return dpps
 }
 
-func MatchInboundWithMeshServicePort(inbound *mesh_proto.Dataplane_Networking_Inbound, port meshservice_api.Port) bool {
-	switch port.TargetPort.Type {
+func MatchInboundWithMeshServicePort(inbound *mesh_proto.Dataplane_Networking_Inbound, meshServicePort meshservice_api.Port) bool {
+	switch meshServicePort.TargetPort.Type {
 	case intstr.Int:
-		return uint32(port.TargetPort.IntVal) == inbound.Port
+		return uint32(meshServicePort.TargetPort.IntVal) == inbound.Port
 	case intstr.String:
-		return port.TargetPort.StrVal == inbound.Name
+		return meshServicePort.TargetPort.StrVal == inbound.Name
 	}
 	return false
 }

--- a/pkg/core/resources/apis/meshservice/status/updater.go
+++ b/pkg/core/resources/apis/meshservice/status/updater.go
@@ -2,6 +2,7 @@ package status
 
 import (
 	"context"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"reflect"
 	"time"
 
@@ -195,8 +196,16 @@ func dpInboundForMeshServicePort(inbounds []*mesh_proto.Dataplane_Networking_Inb
 		if port.Name != "" && inbound.Name == port.Name {
 			return inbound
 		}
-		if port.Port == inbound.Port {
-			return inbound
+
+		switch port.TargetPort.Type {
+		case intstr.Int:
+			if uint32(port.TargetPort.IntVal) == inbound.Port {
+				return inbound
+			}
+		case intstr.String:
+			if port.TargetPort.StrVal == inbound.Name {
+				return inbound
+			}
 		}
 	}
 	return nil

--- a/pkg/core/resources/apis/meshservice/status/updater.go
+++ b/pkg/core/resources/apis/meshservice/status/updater.go
@@ -165,7 +165,7 @@ func (s *StatusUpdater) updateStatus(ctx context.Context) error {
 func buildDataplaneProxies(
 	dpps []*core_mesh.DataplaneResource,
 	insightsByKey map[core_model.ResourceKey]*core_mesh.DataplaneInsightResource,
-	ports []meshservice_api.Port,
+	meshServicePorts []meshservice_api.Port,
 ) meshservice_api.DataplaneProxies {
 	result := meshservice_api.DataplaneProxies{}
 	for _, dpp := range dpps {
@@ -176,15 +176,15 @@ func buildDataplaneProxies(
 			}
 		}
 		healthyInbounds := 0
-		for _, port := range ports {
-			for _, inbound := range dpp.Spec.GetNetworking().Inbound {
-				if inbound.State == mesh_proto.Dataplane_Networking_Inbound_Ready &&
-					meshservice.MatchInboundWithMeshServicePort(inbound, port) {
+		for _, meshServicePort := range meshServicePorts {
+			for _, dpInbound := range dpp.Spec.GetNetworking().Inbound {
+				if dpInbound.State == mesh_proto.Dataplane_Networking_Inbound_Ready &&
+					meshservice.MatchInboundWithMeshServicePort(dpInbound, meshServicePort) {
 					healthyInbounds++
 				}
 			}
 		}
-		if healthyInbounds == len(ports) {
+		if healthyInbounds == len(meshServicePorts) {
 			result.Healthy++
 		}
 	}

--- a/pkg/core/resources/apis/meshservice/status/updater.go
+++ b/pkg/core/resources/apis/meshservice/status/updater.go
@@ -181,6 +181,7 @@ func buildDataplaneProxies(
 				if dpInbound.State == mesh_proto.Dataplane_Networking_Inbound_Ready &&
 					meshservice.MatchInboundWithMeshServicePort(dpInbound, meshServicePort) {
 					healthyInbounds++
+					break
 				}
 			}
 		}

--- a/pkg/core/resources/apis/meshservice/status/updater.go
+++ b/pkg/core/resources/apis/meshservice/status/updater.go
@@ -2,13 +2,13 @@ package status
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"reflect"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"

--- a/pkg/core/resources/apis/meshservice/status/updater.go
+++ b/pkg/core/resources/apis/meshservice/status/updater.go
@@ -6,6 +6,9 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/meshservice"
@@ -18,8 +21,6 @@ import (
 	core_metrics "github.com/kumahq/kuma/pkg/metrics"
 	"github.com/kumahq/kuma/pkg/util/maps"
 	util_time "github.com/kumahq/kuma/pkg/util/time"
-	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 type StatusUpdater struct {

--- a/pkg/core/resources/apis/meshservice/status/updater_test.go
+++ b/pkg/core/resources/apis/meshservice/status/updater_test.go
@@ -230,10 +230,10 @@ var _ = Describe("Updater", func() {
 				Total:     3,
 			},
 		}),
-		Entry("should count healthy DPPs", dpProxiesTestCase{
+		Entry("should count healthy DPPs and use MeshService.ports[].targetPort to select DP inbound", dpProxiesTestCase{
 			meshService: samples.MeshServiceBackendBuilder().
 				WithDataplaneTagsSelectorKV("app", "backend").
-				AddIntPort(builders.FirstInboundPort+1, builders.FirstInboundServicePort+1, core_mesh.ProtocolHTTP),
+				AddIntPort(builders.FirstInboundServicePort+1, builders.FirstInboundPort+1, core_mesh.ProtocolHTTP),
 			dpps: []*builders.DataplaneBuilder{
 				builders.Dataplane().
 					WithName("dp-all-inbounds-healthy").

--- a/pkg/xds/topology/outbound.go
+++ b/pkg/xds/topology/outbound.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 
 	"github.com/asaskevich/govalidator"
+	"github.com/pkg/errors"
+
 	common_tls "github.com/kumahq/kuma/api/common/v1alpha1/tls"
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/api/system/v1alpha1"
@@ -23,7 +25,6 @@ import (
 	util_maps "github.com/kumahq/kuma/pkg/util/maps"
 	"github.com/kumahq/kuma/pkg/util/pointer"
 	envoy_tags "github.com/kumahq/kuma/pkg/xds/envoy/tags"
-	"github.com/pkg/errors"
 )
 
 var outboundLog = core.Log.WithName("xds").WithName("outbound")


### PR DESCRIPTION
## Motivation

Fixing an issue on the MeshService updater

## Implementation information

> update MeshService updater to take into account target port

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

fixes https://github.com/kumahq/kuma/issues/12042

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
