### PR TITLE
chore(renovate): unify commit messages to match dependabot for changelog automation

### DIFF
--- a/.renovate/go-control-plane.json
+++ b/.renovate/go-control-plane.json
@@ -48,7 +48,6 @@
       "matchPackageNames": [
         "github.com/kumahq/go-control-plane{/,}**"
       ],
-      "semanticCommitScope": "deps/gomod",
       "commitMessageTopic": "{{{packageName}}}",
       "postUpdateOptions": [
         "gomodTidy",

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>Kong/public-shared-renovate:backend#1.2.0",
+    "github>Kong/public-shared-renovate:backend#1.3.0",
     "local>kumahq/kuma//.renovate/go-control-plane"
   ],
   "enabledManagers": [
@@ -19,7 +19,6 @@
       "app/kumactl/data/install/k8s/.+\\.ya?ml$"
     ]
   },
-  "semanticCommitScope": "deps/{{{manager}}}",
   "prBodyTemplate": "{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}{{{controls}}}",
   "packageRules": [
     {
@@ -39,7 +38,6 @@
       "matchPackageNames": [
         "Kong/public-shared-actions/**"
       ],
-      "semanticCommitScope": "deps/github-actions",
       "addLabels": [
         "ci/skip-test"
       ]


### PR DESCRIPTION
## Motivation

Our changelog automation relies on the dependabot commit/PR message format, so changing it would require updates to the automation.

## Implementation information

- Removed custom semanticCommitScope for go-control-plane and GitHub Actions
- Bumped shared config to backend#1.3.0
- Ensures existing changelog automation that relies on dependabot-like commits continues working