### PR TITLE
test(gatewayapi): allow secrets in all namespaces

### DIFF
--- a/test/e2e_env/gatewayapi/conformance_test.go
+++ b/test/e2e_env/gatewayapi/conformance_test.go
@@ -83,7 +83,10 @@ func TestConformance(t *testing.T) {
 
 	g.Expect(cluster.Install(GatewayAPICRDs)).To(Succeed())
 	g.Eventually(func() error {
-		return NewClusterSetup().Install(Kuma(config_core.Zone)).Setup(cluster)
+		return NewClusterSetup().Install(
+			Kuma(config_core.Zone,
+				WithCtlOpts(map[string]string{"--set": "controlPlane.supportGatewaySecretsInAllNamespaces=true"}),
+			)).Setup(cluster)
 	}, "90s", "3s").Should(Succeed())
 
 	configPath, err := opts.GetConfigPath(t)


### PR DESCRIPTION
## Motivation

[PR](https://github.com/kumahq/kuma/pull/13104) broke gateway api test, since it requires secret access.

## Implementation information

Enabled allow secrets in all namespaces for a gatewayapi test

## Supporting documentation

> Changelog: skip
