### PR TITLE
chore(deps): bump release-tool from v1.1.4 to v1.1.5

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: install-kuma-ci-tools
         run: |
           echo $(go env GOPATH)/bin >> $GITHUB_PATH
-          go install github.com/kumahq/ci-tools/cmd/release-tool@v1.1.4
+          go install github.com/kumahq/ci-tools/cmd/release-tool@v1.1.5
       - name: Generate GitHub app token
         id: github-app-token
         uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e # v1.11.6


### PR DESCRIPTION
## Motivation

Use the new `release-tool` which fixed a changelog generation bug. The old changelog generation would keep the PRs with "Changelog: skip" signs due to a wrong conditional check.

> Changelog: skip

