### PR TITLE
chore(renovate): upgrade backend preset to 1.4.0 and reuse GitHub Actions preset

### DIFF
--- a/.renovate/github-actions.json
+++ b/.renovate/github-actions.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Preset for reuse with github-actions manager or custom managers updating GitHub Actions. Adds 'ci/skip-test' label, custom PR body, and footer marking changelog as skippable",
+  "addLabels": [
+    "ci/skip-test"
+  ],
+  "prBodyTemplate": "{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}{{{controls}}}{{{footer}}}",
+  "prFooter": "> Changelog: skip"
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>Kong/public-shared-renovate:backend#1.3.0",
+    "github>Kong/public-shared-renovate:backend#1.4.0",
     "local>kumahq/kuma//.renovate/go-control-plane"
   ],
   "enabledManagers": [
@@ -14,35 +14,35 @@
   ],
   "ignorePaths": [],
   "kubernetes": {
-    "description": "Include Kubernetes manifests from 'kumactl install demo|observability' to let Renovate update the image versions in these resources",
+    "description": "Update image versions in Kubernetes manifests from 'kumactl install demo|observability'",
     "fileMatch": [
       "app/kumactl/data/install/k8s/.+\\.ya?ml$"
     ]
   },
-  "prBodyTemplate": "{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}{{{controls}}}",
   "packageRules": [
     {
-      "description": "Skip tests for GitHub Actions updates",
+      "description": "Skip tests and apply preset config for GitHub Actions updates",
       "matchManagers": [
         "github-actions"
       ],
-      "addLabels": [
-        "ci/skip-test"
+      "extends": [
+        "local>kumahq/kuma//.renovate/github-actions"
       ]
     },
     {
-      "description": "Set commit scope to `deps/github-actions` for `Kong/public-shared-actions` GitHub Actions managed by `github>Kong/public-shared-renovate:backend`. Skip tests since these are also GitHub Actions updates but are not covered by the earlier rule",
+      "description": "Skip tests and apply GitHub Actions preset for 'Kong/public-shared-actions' managed by custom regex manager",
       "matchManagers": [
         "custom.regex"
       ],
       "matchPackageNames": [
         "Kong/public-shared-actions/**"
       ],
-      "addLabels": [
-        "ci/skip-test"
+      "extends": [
+        "local>kumahq/kuma//.renovate/github-actions"
       ]
     },
     {
+      "description": "Group container image updates for 'kumactl install demo|observability' Kubernetes manifests",
       "groupName": "kumactl install demo|observability container images",
       "groupSlug": "kumactl-install-k8s",
       "matchFileNames": [


### PR DESCRIPTION
## Motivation

It's unnecessary to include github-actions dependency updates in changelog

## Implementation information

- Upgraded `Kong/public-shared-renovate:backend` preset from `1.3.0` to `1.4.0`
- Removed unnecessary `prBodyTemplate`, now included in the updated preset
- Applied reusable GitHub Actions preset which adds `> Changelog: skip` footer
- Improved descriptions for Kubernetes image updates and GitHub Actions rules

## Supporting documentation

Tested on fork