### PR TITLE
chore(e2e): expose e2e test config so it can be overwritten

### DIFF
--- a/test/framework/config.go
+++ b/test/framework/config.go
@@ -186,7 +186,7 @@ func (c E2eConfig) GetUniversalImage() string {
 	}
 }
 
-var defaultConf = E2eConfig{
+var DefaultConf = E2eConfig{
 	HelmChartName:                 "kuma/kuma",
 	HelmChartPath:                 "../../../deployments/charts/kuma",
 	VersionsYamlPath:              "../../../versions.yml",
@@ -264,7 +264,7 @@ var defaultConf = E2eConfig{
 }
 
 func init() {
-	Config = defaultConf
+	Config = DefaultConf
 	if err := config.Load(os.Getenv("E2E_CONFIG_FILE"), &Config); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Motivation

That way in a parent project we can get the default and overwrite only the parts of the config that we care about. So if a change happens like in https://github.com/kumahq/kuma/pull/12982/files#diff-4097df65e73d6b3a2813df0ea3c87f15a6c43ba3aca9b73b3e60346758ef0344R65 we won't need to modify the parent project, it should just work ™

<!-- Why are we doing this change -->

## Implementation information

Make default conf public.
