### PR TITLE
test(e2e): wait for mesh to be synced

### DIFF
--- a/test/e2e_env/multizone/healthcheck/healthcheck.go
+++ b/test/e2e_env/multizone/healthcheck/healthcheck.go
@@ -18,12 +18,12 @@ func ApplicationOnUniversalClientOnK8s() {
 	meshName := "healthcheck-app-on-universal"
 
 	BeforeAll(func() {
-		err := NewClusterSetup().
+		Expect(NewClusterSetup().
 			Install(MTLSMeshUniversal(meshName)).
 			Install(TrafficRouteUniversal(meshName)).
 			Install(TrafficPermissionUniversal(meshName)).
-			Setup(multizone.Global)
-		Expect(err).ToNot(HaveOccurred())
+			Setup(multizone.Global)).To(Succeed())
+		Expect(WaitForMesh(meshName, multizone.Zones())).To(Succeed())
 
 		group := errgroup.Group{}
 		NewClusterSetup().


### PR DESCRIPTION
## Motivation

Noticed a flake, while checking logs:

```
Error: Failed to generate Envoy bootstrap config. Invalid request: mesh: mesh "healthcheck-app-on-universal" does not exist
```

## Implementation information

Wait for mesh to be synced first

> Changelog: skip