### PR TITLE
chore(e2e): rewrite e2e config init

### DIFF
--- a/pkg/test/ginkgo.go
+++ b/pkg/test/ginkgo.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/plugins"
 	core_apis "github.com/kumahq/kuma/pkg/core/resources/apis"
 	"github.com/kumahq/kuma/pkg/plugins/policies"
+	"github.com/kumahq/kuma/test/framework"
 )
 
 // RunSpecs wraps ginkgo+gomega test suite initialization.
@@ -31,7 +32,8 @@ func RunSpecs(t *testing.T, description string) {
 	runSpecs(t, description)
 }
 
-func RunE2ESpecs(t *testing.T, description string) {
+func RunE2ESpecs(t *testing.T, description string, configModificationFunctions ...func(config *framework.E2eConfig)) {
+	framework.Init(configModificationFunctions...)
 	plugins.InitAll(core_apis.NameToModule)
 	plugins.InitAll(policies.NameToModule)
 	gomega.SetDefaultConsistentlyDuration(time.Second * 5)

--- a/test/e2e_env/gatewayapi/conformance_test.go
+++ b/test/e2e_env/gatewayapi/conformance_test.go
@@ -41,6 +41,7 @@ var implementation = conformanceapis.Implementation{
 // TestConformance runs as a `testing` test and not Ginkgo so we have to use an
 // explicit `g` to use Gomega.
 func TestConformance(t *testing.T) {
+	Init() // we need to manually call init on the config because it's not a Ginkgo test
 	if Config.IPV6 {
 		t.Skip("On IPv6 we run on kind which doesn't support load balancers")
 	}

--- a/test/framework/config.go
+++ b/test/framework/config.go
@@ -176,7 +176,7 @@ type CniConf struct {
 	ConfName string
 }
 
-var Config E2eConfig
+var Config *E2eConfig
 
 func (c E2eConfig) GetUniversalImage() string {
 	if c.KumaImageTag != "" {
@@ -263,15 +263,20 @@ var defaultConf = E2eConfig{
 	DumpOnSuccess:                     false,
 }
 
-func init() {
-	Config = defaultConf
-	if err := config.Load(os.Getenv("E2E_CONFIG_FILE"), &Config); err != nil {
+func Init(configModificationFunctions ...func(*E2eConfig)) {
+	Config = &defaultConf
+	if err := config.Load("", Config); err != nil {
 		panic(err)
 	}
 
 	if err := Config.AutoConfigure(); err != nil {
 		panic(err)
 	}
+
+	for _, confModificationFn := range configModificationFunctions {
+		confModificationFn(Config)
+	}
+
 	report.BaseDir, _ = filepath.Abs(Config.DumpDir)
 	report.DumpOnSuccess = Config.DumpOnSuccess
 }


### PR DESCRIPTION
## Motivation

Instead of https://github.com/kumahq/kuma/pull/13165 - because that did not work. Please review the parent PR first.

That way in a parent project we can get the default and overwrite only the parts of the config that we care about. So if a change happens like in https://github.com/kumahq/kuma/pull/12982/files#diff-4097df65e73d6b3a2813df0ea3c87f15a6c43ba3aca9b73b3e60346758ef0344R65 we won't need to modify the parent project.

## Implementation information

Manually init the e2e configuration by moving the init function to `RunE2ESpecs`.