### PR TITLE
chore(renovate): simplify shared config references by removing prefixes

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>Kong/public-shared-renovate:backend#1.4.0",
-    "local>kumahq/kuma//.renovate/go-control-plane"
+    "Kong/public-shared-renovate:backend",
+    "kumahq/kuma//.renovate/go-control-plane"
   ],
   "enabledManagers": [
     "custom.regex",


### PR DESCRIPTION
## Motivation & Implementation information

- Dropped unnecessary "github>" and "local>" prefixes from shared config paths
- Removed version pins from presets, as pinning doesn't improve security here - even if tags were overwritten, the impact is minimal as it would result in opening suspicious update PRs, which are manually reviewed