### PR TITLE
fix(deps): fix update-vulnerable-dependencies.sh

### DIFF
--- a/tools/ci/update-vulnerable-dependencies/update-vulnerable-dependencies.sh
+++ b/tools/ci/update-vulnerable-dependencies/update-vulnerable-dependencies.sh
@@ -8,7 +8,8 @@ command -v jq >/dev/null 2>&1 || { echo >&2 "jq not installed!"; exit 1; }
 SCRIPT_PATH="${BASH_SOURCE[0]:-$0}";
 SCRIPT_DIR="$(dirname -- "$SCRIPT_PATH")"
 
-for dep in $(osv-scanner "$OSV_SCANNER_ADDITIONAL_OPTS" --lockfile=go.mod --json | jq -c '.results[].packages[] | .package.name as $vulnerablePackage | {
+# shellcheck disable=SC2086
+for dep in $(osv-scanner $OSV_SCANNER_ADDITIONAL_OPTS --lockfile=go.mod --json | jq -c '.results[].packages[] | .package.name as $vulnerablePackage | {
   name: $vulnerablePackage,
   current: .package.version,
   fixedVersions: [.vulnerabilities[].affected[] | select(.package.name == $vulnerablePackage) | .ranges[].events |


### PR DESCRIPTION
## Motivation

Otherwise `make update-vulnerable-dependencies` fails with:

```
Unable to parse git ignores: stat : no such file or directory
lstat : no such file or directory
jq: parse error: Invalid numeric literal at line 1, column 9
```

For some reason `osv-scanner` does not like these "" (but it used to work).

<!-- Why are we doing this change -->

## Implementation information

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
