### PR TITLE
ci(update-insecure-dependencies): no need to use -u for go get

### DIFF
--- a/tools/ci/update-vulnerable-dependencies/update-vulnerable-dependencies.sh
+++ b/tools/ci/update-vulnerable-dependencies/update-vulnerable-dependencies.sh
@@ -37,7 +37,7 @@ for dep in $(osv-scanner "${OSV_FLAGS[@]}" | jq -c '.results[].packages[] | .pac
     if [[ "$package" == "stdlib" ]]; then
       go mod edit -go="$fixVersion"
     else
-      go get -u "$package"@v"$fixVersion"
+      go get "$package"@v"$fixVersion"
     fi
   fi
 done


### PR DESCRIPTION
## Motivation

Insecure deps update started failing - https://github.com/kumahq/kuma/actions/runs/14050838168/job/39340820166#step:7:212

and it seems that we needlessly try to update `github.com/envoyproxy/go-control-plane/envoy v1.32.4` which causes the problem, because:

`-u` will 

```
The -u flag instructs get to update modules providing dependencies
of packages named on the command line to use newer minor or patch
releases when available.
```

**newer minor or patch releases when available** is the key here.

Since we manually pick the correct version in `leastcommonversion.Deduct` we no longer need that because we will pick the minimal correct version if there are 2 versions that "fix" an issue (see https://github.com/kumahq/kuma/pull/9539 for details). This `-u` was there before we had this script to pick the highest available version.

See below PRs showing that upgrading without `-u` works:
- https://github.com/kumahq/kuma/pull/13201
- https://github.com/kumahq/kuma/pull/13202

## Implementation information

Remove `-u`.
