### PR TITLE
refactor(e2e): remove unnecessary GinkgoHelper call in meshhttproute test

### DIFF
--- a/test/e2e_env/multizone/meshhttproute/test.go
+++ b/test/e2e_env/multizone/meshhttproute/test.go
@@ -26,8 +26,6 @@ func Test() {
 }
 
 func test(meshName string, meshBuilder *builders.MeshBuilder) {
-	GinkgoHelper()
-
 	BeforeAll(func() {
 		// Global
 		err := NewClusterSetup().


### PR DESCRIPTION
## Motivation

With GinkgoHelper there were wrong line numbers generated when generated list of disabled tests

> Changelog: skip