### PR TITLE
ci(gha): pin slsa workflow version and update backport runner to ubuntu-24.04

### DIFF
--- a/.github/workflows/_provenance.yaml
+++ b/.github/workflows/_provenance.yaml
@@ -30,7 +30,7 @@ jobs:
       actions: read # For getting workflow run info to build provenance
       id-token: write # needed for signing the images
     # need to use non hash version because of: https://github.com/slsa-framework/slsa-github-generator/issues/3498
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       base64-subjects: ${{ inputs.BINARY_ARTIFACTS_HASH_AS_FILE }}
       upload-assets: ${{ github.ref_type == 'tag' }}
@@ -57,7 +57,7 @@ jobs:
       matrix:
         IMAGE: ${{ fromJSON(inputs.IMAGES) }}
     # need to use non hash version because of: https://github.com/slsa-framework/slsa-github-generator/issues/3498
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       image: ${{ inputs.REGISTRY }}/${{ matrix.IMAGE }}
       digest: ${{ fromJSON(inputs.IMAGE_DIGESTS)[matrix.IMAGE] }}

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -30,7 +30,7 @@ jobs:
       pr_base_ref: ${{ steps.get-pr-info.outputs.pr_base_ref }}
       pr_merge_commit_sha: ${{ steps.get-pr-info.outputs.pr_merge_commit_sha }}
       branches: ${{ steps.generate-matrix.outputs.branches }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - id: get-pr-info
         name: get-pr-info
@@ -112,7 +112,7 @@ jobs:
       fail-fast: false
       matrix:
         branch: ${{ fromJSON(needs.collect-info.outputs.branches) }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       PR_NUMBER: ${{ inputs.PR }}
       PR_TITLE: ${{ needs.collect-info.outputs.pr_title }}


### PR DESCRIPTION
## Motivation

Security + stability

## Implementation information

- Replaced version tags with full commit SHA for slsa-generator workflows
- Updated `runs-on` from `ubuntu-latest` to `ubuntu-24.04` in backport workflow