### PR TITLE
ci(publish): change timeout of build_publish to 50 min from 40 min

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -42,7 +42,7 @@ env:
   GH_REPO: "charts"
 jobs:
   build-binaries:
-    timeout-minutes: 40
+    timeout-minutes: 50
     runs-on: ubuntu-24.04
     outputs:
       BINARY_ARTIFACT_DIGEST_BASE64: ${{ steps.inspect-binary-output.outputs.binary_artifact_digest_base64 }}


### PR DESCRIPTION
## Motivation

Build binaries is nearly timing out (mostly on cleanup) in parent project. Let's bump the time while we investigate. Please take a look at the list of failing builds in the linked parent project PR.

## Implementation information

Bump the time.
