### PR TITLE
feat(kuma-dp): use home directory to store configs instead of tmp dir

### DIFF
--- a/app/kuma-dp/cmd/run.go
+++ b/app/kuma-dp/cmd/run.go
@@ -132,6 +132,7 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 					err = os.MkdirAll(workDir, os.ModePerm)
 					if err != nil && !os.IsExist(err) {
 						runLog.Error(err, fmt.Sprintf("failed to create a working directory '%s' inside $HOME", workDir))
+						return err
 					}
 				}
 

--- a/pkg/config/app/kuma-dp/config.go
+++ b/pkg/config/app/kuma-dp/config.go
@@ -33,7 +33,8 @@ var DefaultConfig = func() Config {
 		},
 		DataplaneRuntime: DataplaneRuntime{
 			BinaryPath: "envoy",
-			ConfigDir:  "", // if left empty, a temporary directory will be generated automatically
+			ConfigDir:  "",
+			SocketDir:  "",
 			DynamicConfiguration: DynamicConfiguration{
 				RefreshInterval: config_types.Duration{Duration: 10 * time.Second},
 			},
@@ -44,7 +45,7 @@ var DefaultConfig = func() Config {
 			EnvoyDNSPort:              15054,
 			CoreDNSBinaryPath:         "coredns",
 			CoreDNSConfigTemplatePath: "",
-			ConfigDir:                 "", // if left empty, a temporary directory will be generated automatically
+			ConfigDir:                 "",
 			PrometheusPort:            19153,
 			CoreDNSLogging:            false,
 		},
@@ -187,6 +188,7 @@ type DataplaneRuntime struct {
 	// Path to Envoy binary.
 	BinaryPath string `json:"binaryPath,omitempty" envconfig:"kuma_dataplane_runtime_binary_path"`
 	// Dir to store auto-generated Envoy bootstrap config in.
+	// If empty then the working directory is $HOME/.kuma
 	ConfigDir string `json:"configDir,omitempty" envconfig:"kuma_dataplane_runtime_config_dir"`
 	// Concurrency specifies how to generate the Envoy concurrency flag.
 	Concurrency uint32 `json:"concurrency,omitempty" envconfig:"kuma_dataplane_runtime_concurrency"`
@@ -210,6 +212,7 @@ type DataplaneRuntime struct {
 	// Resources defines the resources for this proxy.
 	Resources DataplaneResources `json:"resources,omitempty"`
 	// SocketDir dir to store socket used between Envoy and the dp process
+	// If empty then the working directory is $HOME/.kuma
 	SocketDir string `json:"socketDir,omitempty" envconfig:"kuma_dataplane_runtime_socket_dir"`
 	// Metrics defines properties of metrics
 	Metrics Metrics `json:"metrics,omitempty"`
@@ -370,6 +373,7 @@ type DNS struct {
 	// CoreDNSConfigTemplatePath defines a path to a CoreDNS config template.
 	CoreDNSConfigTemplatePath string `json:"coreDnsConfigTemplatePath,omitempty" envconfig:"kuma_dns_core_dns_config_template_path"`
 	// Dir to store auto-generated DNS Server config in.
+	// If empty then the working directory is $HOME/.kuma
 	ConfigDir string `json:"configDir,omitempty" envconfig:"kuma_dns_config_dir"`
 	// PrometheusPort where Prometheus stats will be exposed for the DNS Server
 	PrometheusPort uint32 `json:"prometheusPort,omitempty" envconfig:"kuma_dns_prometheus_port"`

--- a/test/framework/universal_app.go
+++ b/test/framework/universal_app.go
@@ -433,7 +433,11 @@ cp %s/envoy /usr/bin/envoy
 		_, _ = fmt.Fprintf(cmd, "/usr/bin/kumactl install transparent-proxy --exclude-inbound-ports %s %s\n", sshPort, strings.Join(extraArgs, " "))
 	}
 
-	// run the DP as user `envoy` so iptables can distinguish its traffic if needed
+	// run the DP as user `envoy` so iptables can distinguish its traffic if needed.
+	_, _ = fmt.Fprintf(cmd, "mkdir -p /home/kuma-dp\n")
+	_, _ = fmt.Fprintf(cmd, "chown kuma-dp /home/kuma-dp\n")
+	_, _ = fmt.Fprintf(cmd, "chmod 700 /home/kuma-dp\n")
+
 	args := []string{
 		"runuser", "-u", "kuma-dp", "--",
 		"/usr/bin/kuma-dp", "run",


### PR DESCRIPTION
## Motivation

We should set a default path for kuma-dp to store configs, sockets just like what we did for kuma-cp.

But just one thing to take care of, we use read-only root FS for sidecar container which makes us keep using tmp dir in kubernetes environment.

## Implementation information

1. check the current DP environment by detecting the environment with k8s downward API.
2. choose to use $HOME dir or tmp dir based on the environment.

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #7268 

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
