### PR TITLE
chore(deps): upgrade debian11 to debian12 image

### DIFF
--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -24,15 +24,15 @@ export DOCKER_BUILDKIT := 1
 define IMAGE_TARGETS_BY_ARCH
 .PHONY: image/static/$(1)
 image/static/$(1): ## Dev: Rebuild `kuma-static` Docker image
-	docker build -t kumahq/static-debian11:no-push-$(1) --build-arg ARCH=$(1) --platform=linux/$(1) -f $(TOOLS_DIR)/releases/dockerfiles/static.Dockerfile .
+	docker build -t kumahq/static-debian12:no-push-$(1) --build-arg ARCH=$(1) --platform=linux/$(1) -f $(TOOLS_DIR)/releases/dockerfiles/static.Dockerfile .
 
 .PHONY: image/base/$(1)
 image/base/$(1): ## Dev: Rebuild `kuma-base` Docker image
-	docker build -t kumahq/base-nossl-debian11:no-push-$(1) --build-arg ARCH=$(1) --platform=linux/$(1) -f $(TOOLS_DIR)/releases/dockerfiles/base.Dockerfile .
+	docker build -t kumahq/base-nossl-debian12:no-push-$(1) --build-arg ARCH=$(1) --platform=linux/$(1) -f $(TOOLS_DIR)/releases/dockerfiles/base.Dockerfile .
 
 .PHONY: image/base-root/$(1)
 image/base-root/$(1): ## Dev: Rebuild `kuma-base-root` Docker image
-	docker build -t kumahq/base-root-debian11:no-push-$(1) --build-arg ARCH=$(1) --platform=linux/$(1) -f $(TOOLS_DIR)/releases/dockerfiles/base-root.Dockerfile .
+	docker build -t kumahq/base-root-debian12:no-push-$(1) --build-arg ARCH=$(1) --platform=linux/$(1) -f $(TOOLS_DIR)/releases/dockerfiles/base-root.Dockerfile .
 
 .PHONY: image/envoy/$(1)
 image/envoy/$(1): build/artifacts-linux-$(1)/envoy ## Dev: Rebuild `envoy` Docker image

--- a/tools/releases/dockerfiles/base-root.Dockerfile
+++ b/tools/releases/dockerfiles/base-root.Dockerfile
@@ -1,5 +1,5 @@
 # use only when root is really needed
-FROM gcr.io/distroless/base-nossl-debian11:debug@sha256:d66c60eff6c55972af9e661a57c1afe96ef4ddfa4fff37b625a448df41a15820
+FROM gcr.io/distroless/base-nossl-debian12:debug@sha256:1368c7b5edff36920f9169f87f8e8108f532b6f343ab68ce7895a184bbfdb930
 
 COPY /tools/releases/templates/LICENSE \
     /tools/releases/templates/README \

--- a/tools/releases/dockerfiles/base.Dockerfile
+++ b/tools/releases/dockerfiles/base.Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/base-nossl-debian11:debug-nonroot@sha256:934b713496a9ed100550aaa58636270c4d69c27040e44f2aed1fa39594c45eba
+FROM gcr.io/distroless/base-nossl-debian12:debug-nonroot@sha256:393a39691519a85382db0f75cedffc6f0208911484d138b2afc46c7d218e46af
 
 COPY /tools/releases/templates/LICENSE \
     /tools/releases/templates/README \

--- a/tools/releases/dockerfiles/kuma-cni.Dockerfile
+++ b/tools/releases/dockerfiles/kuma-cni.Dockerfile
@@ -1,5 +1,5 @@
 ARG ARCH
-FROM kumahq/base-root-debian11:no-push-$ARCH
+FROM kumahq/base-root-debian12:no-push-$ARCH
 ARG ARCH
 
 COPY /build/artifacts-linux-$ARCH/kuma-cni/kuma-cni /opt/cni/bin/kuma-cni

--- a/tools/releases/dockerfiles/kuma-cp.Dockerfile
+++ b/tools/releases/dockerfiles/kuma-cp.Dockerfile
@@ -1,5 +1,5 @@
 ARG ARCH
-FROM kumahq/static-debian11:no-push-$ARCH
+FROM kumahq/static-debian12:no-push-$ARCH
 ARG ARCH
 
 COPY /build/artifacts-linux-${ARCH}/kuma-cp/kuma-cp /usr/bin

--- a/tools/releases/dockerfiles/kuma-dp.Dockerfile
+++ b/tools/releases/dockerfiles/kuma-dp.Dockerfile
@@ -1,6 +1,6 @@
 ARG ARCH
 FROM kumahq/envoy:no-push-$ARCH AS envoy
-FROM kumahq/base-nossl-debian11:no-push-$ARCH
+FROM kumahq/base-nossl-debian12:no-push-$ARCH
 ARG ARCH
 
 COPY /build/artifacts-linux-$ARCH/kuma-dp/kuma-dp \

--- a/tools/releases/dockerfiles/kumactl.Dockerfile
+++ b/tools/releases/dockerfiles/kumactl.Dockerfile
@@ -1,5 +1,5 @@
 ARG ARCH
-FROM kumahq/base-nossl-debian11:no-push-$ARCH
+FROM kumahq/base-nossl-debian12:no-push-$ARCH
 ARG ARCH
 
 # override NOTICE

--- a/tools/releases/dockerfiles/static.Dockerfile
+++ b/tools/releases/dockerfiles/static.Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/static-debian11:debug-nonroot@sha256:55716e80a7d4320ce9bc2dc8636fc193b418638041b817cf3306696bd0f975d1
+FROM gcr.io/distroless/static-debian12:debug-nonroot@sha256:14a28be5b9e710e8d5a519cd7d76ab2714b35edb641307c07a264372ed0c81a9
 
 COPY /tools/releases/templates/LICENSE \
     /tools/releases/templates/README \


### PR DESCRIPTION
## Motivation

We are using debian 11 for out base images
https://www.debian.org/releases/bullseye/
> The Debian 11 life cycle encompasses five years: the initial three years of full Debian support, until August 14th, 2024, and two years of Long Term Support (LTS), until August 31st, 2026.

which means it doesn't get some basic updates of the packages

## Implementation information

Upgraded to debian 12

> The Debian 12 life cycle encompasses five years: the initial three years of full Debian support, until June 10th, 2026, and two years of Long Term Support (LTS), until June 30th, 2028.

