### PR TITLE
test(framework): use specified chart version when helm upgrade

### DIFF
--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -521,6 +521,11 @@ func (c *K8sCluster) processViaHelm(mode string, fn helmFn) error {
 
 	if c.opts.helmChartVersion != "" {
 		helmOpts.Version = c.opts.helmChartVersion
+		// helm upgrade does not support --version flag
+		// remove this hack until this issue is solved: https://github.com/gruntwork-io/terratest/issues/1531
+		helmOpts.ExtraArgs = map[string][]string{
+			"upgrade": {"--version", c.opts.helmChartVersion},
+		}
 	}
 
 	releaseName := c.opts.helmReleaseName


### PR DESCRIPTION
## Motivation

Fixing the issue of not using specified chart version for the helm upgrade feature in the test framework.

The `K8sCluster` is always using the latest version of the chart to perform helm upgrade actions, instead of the specified chart version in the `opts`. This caused some issues when the new version chart is not compatible of the old version chart.

## Implementation information

It is caused by a bug in `github.com/gruntwork-io/terratest`, and there is a workaround by specifying this `--version` manually using `helm.Options.ExtraArgs`. It does no harm to `helm.Install` as they use different key in `ExtraArgs`.

## Supporting documentation

The bug in the mod is tracked using this issue:

https://github.com/gruntwork-io/terratest/issues/1531


> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
