### PR TITLE
test(e2e): fix getting cp logs after panic

### DIFF
--- a/test/framework/debug.go
+++ b/test/framework/debug.go
@@ -22,6 +22,7 @@ import (
 
 func ControlPlaneAssertions(cluster Cluster) {
 	ginkgo.GinkgoHelper()
+	defer ginkgo.GinkgoRecover() // Ensures that Ginkgo can recover from any failures
 	logs := cluster.GetKumaCPLogs()
 	for k, log := range logs {
 		Expect(utils.HasPanicInCpLogs(log)).To(BeFalse(), fmt.Sprintf("CP %s has panic in logs %s", cluster.Name(), k))

--- a/test/framework/envs/universal/env.go
+++ b/test/framework/envs/universal/env.go
@@ -56,6 +56,7 @@ func RestoreState(bytes []byte) {
 
 func SynchronizedAfterSuite() {
 	framework.ControlPlaneAssertions(Cluster)
+	framework.DebugCPLogs(Cluster)
 	Expect(Cluster.DismissCluster()).To(Succeed())
 }
 


### PR DESCRIPTION
## Motivation

When there is a panic in the logs but the test suite succeeds, the control plane logs are not included in the debug package, making it more difficult to debug the issue.

## Implementation information

The issue was that when an assertion fails at [this line](https://github.com/kumahq/kuma/blob/master/test/framework/debug.go#L27), it stops the resource dumping process. To prevent this, we need to use GinkgoRecover to ensure the function continues executing. More details can be found in the [Ginkgo documentation](https://onsi.github.io/ginkgo/#mental-model-how-ginkgo-handles-failure).

Also, we were missing a dump log step on universal

## Supporting documentation

Fix https://github.com/kumahq/kuma/issues/13260

> Changelog: skip
