### PR TITLE
chore(codeql): ignore security warning in test file

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,3 +1,6 @@
+paths-ignore:
+  # this is to ignore InsecureIgnoreHostKey call from specific test file
+  - test/framework/universal/networking.go
 query-filters:
   - exclude:
       # this is to ignore every warning about InsecureSkipVerify: true


### PR DESCRIPTION
## Motivation

We can see a security warning 

> Use of insecure HostKeyCallback implementation

But it's in a test file that won't affect anyone and it's required for ssh in e2e test

## Implementation information

Ignored specific failed from CodeQL check