### PR TITLE
chore(codeql): ignore hostkeycallback in test file

### DIFF
--- a/.codeqlignore
+++ b/.codeqlignore
@@ -1,6 +1,0 @@
-# Ignore internal Dockerfile
-tools/releases/dockerfiles/kumactl.Dockerfile
-tools/releases/dockerfiles/kuma-cp.Dockerfile
-tools/releases/dockerfiles/kuma-cni.Dockerfile
-tools/releases/dockerfiles/kuma-dp.Dockerfile
-tools/releases/dockerfiles/kuma-init.Dockerfile

--- a/.codeqlignore
+++ b/.codeqlignore
@@ -1,0 +1,6 @@
+# Ignore internal Dockerfile
+tools/releases/dockerfiles/kumactl.Dockerfile
+tools/releases/dockerfiles/kuma-cp.Dockerfile
+tools/releases/dockerfiles/kuma-cni.Dockerfile
+tools/releases/dockerfiles/kuma-dp.Dockerfile
+tools/releases/dockerfiles/kuma-init.Dockerfile

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,7 +1,8 @@
-paths-ignore:
-  # this is to ignore InsecureIgnoreHostKey call from specific test file
-  - test/framework/universal/networking.go
 query-filters:
   - exclude:
       # this is to ignore every warning about InsecureSkipVerify: true
       id: go/disabled-certificate-check
+  - exclude:
+      id: go/insecure-hostkeycallback
+      paths:
+      - test/framework/universal/networking.go

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -2,7 +2,3 @@ query-filters:
   - exclude:
       # this is to ignore every warning about InsecureSkipVerify: true
       id: go/disabled-certificate-check
-  - exclude:
-      id: go/insecure-hostkeycallback
-      paths:
-      - test/framework/universal/networking.go

--- a/test/framework/universal/networking.go
+++ b/test/framework/universal/networking.go
@@ -40,7 +40,7 @@ func (s *Networking) initSSH() (int, error) {
 				return s.id, errors.New("failed to connect to container")
 			}
 			client, err := ssh.Dial("tcp", net.JoinHostPort("localhost", s.SshPort), &ssh.ClientConfig{
-				HostKeyCallback: ssh.InsecureIgnoreHostKey(), //#nosec G106 // skip for tests
+				HostKeyCallback: ssh.InsecureIgnoreHostKey(), //#nosec G106 // skip for tests // lgtm [go/insecure-hostkeycallback]
 				User:            "root",
 			})
 			if err == nil {


### PR DESCRIPTION
## Motivation

`paths-ignore` are not supported for golang

> Changelog: skip