### PR TITLE
test(unit): remove skipped MeshLoadBalancingPolicy

### DIFF
--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator_test.go
@@ -323,27 +323,6 @@ to:
           failoverThreshold:
             percentage: 0
 `),
-		XErrorCases("MeshExternalService can be set only with Mesh", []validators.Violation{{
-			Field:   "spec.to[0].targetRef.kind",
-			Message: "kind MeshExternalService is only allowed with targetRef.kind: Mesh as it is configured on the Zone Egress and shared by all clients in the mesh",
-		}}, `
-type: MeshLoadBalancingStrategy
-mesh: mesh-1
-name: route-1
-targetRef:
-  kind: MeshSubset
-  tags:
-    kuma.io/service: test
-to:
-  - targetRef:
-      kind: MeshExternalService
-      name: svc-1
-    default:
-      localityAwareness:
-        disabled: true
-      loadBalancer:
-        type: LeastRequest
-`),
 		ErrorCases("percentage is not a parseable number", []validators.Violation{{
 			Field:   "spec.to[0].default.localityAwareness.crossZone.failoverThreshold.percentage",
 			Message: "string must be a valid number",
@@ -562,26 +541,6 @@ to:
     default:
       localityAwareness:
         disabled: true
-`),
-		XEntry(
-			"to MeshExternalService",
-			`
-type: MeshLoadBalancingStrategy
-mesh: mesh-1
-name: route-1
-targetRef:
-  kind: Mesh
-to:
-  - targetRef:
-      kind: MeshExternalService
-      name: mes
-    default:
-      localityAwareness:
-        disabled: true
-      loadBalancer:
-        type: LeastRequest
-        leastRequest:
-          activeRequestBias: "1.3"
 `),
 	)
 })

--- a/pkg/test/resources/validators/validation.go
+++ b/pkg/test/resources/validators/validation.go
@@ -127,13 +127,3 @@ func ErrorCases(description string, errs []validators.Violation, yaml string) Ta
 		},
 	)
 }
-
-func XErrorCases(description string, errs []validators.Violation, yaml string) TableEntry {
-	return XEntry(
-		description,
-		ResourceValidationCase{
-			Violations: errs,
-			Resource:   yaml,
-		},
-	)
-}


### PR DESCRIPTION
## Motivation

We don't support egress policies for MeshExternalService

## Supporting documentation

xref: https://github.com/kumahq/kuma/issues/12849

Fix: https://github.com/kumahq/kuma/issues/13255

> Changelog: skip
