### PR TITLE
test(unit): remove skipped MeshHealthCheck test

### DIFF
--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/validator.go
@@ -11,6 +11,9 @@ func (r *MeshHealthCheckResource) validate() error {
 	var verr validators.ValidationError
 	path := validators.RootedAt("spec")
 	verr.AddErrorAt(path.Field("targetRef"), r.validateTop(r.Spec.TargetRef))
+	if len(pointer.Deref(r.Spec.To)) == 0 {
+		verr.AddViolationAt(path.Field("to"), "needs at least one item")
+	}
 	verr.AddErrorAt(path, validateTo(pointer.DerefOr(r.Spec.TargetRef, common_api.TargetRef{Kind: common_api.Mesh}), pointer.Deref(r.Spec.To)))
 	return verr.OrNil()
 }

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/validator.go
@@ -11,9 +11,6 @@ func (r *MeshHealthCheckResource) validate() error {
 	var verr validators.ValidationError
 	path := validators.RootedAt("spec")
 	verr.AddErrorAt(path.Field("targetRef"), r.validateTop(r.Spec.TargetRef))
-	if len(pointer.Deref(r.Spec.To)) == 0 {
-		verr.AddViolationAt(path.Field("to"), "needs at least one item")
-	}
 	verr.AddErrorAt(path, validateTo(pointer.DerefOr(r.Spec.TargetRef, common_api.TargetRef{Kind: common_api.Mesh}), pointer.Deref(r.Spec.To)))
 	return verr.OrNil()
 }

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/validator_test.go
@@ -82,18 +82,6 @@ to:
       tcp: # it will pick the protocol as described in 'protocol selection' section
         disabled: true # new, default false, can be disabled for override
 `),
-			XEntry("to level MeshExternalService", `
-targetRef:
-  kind: Mesh
-to:
-  - targetRef:
-      kind: MeshExternalService
-      name: mes
-    default:
-      interval: 10s
-      tcp: # it will pick the protocol as described in 'protocol selection' section
-        disabled: true # new, default false, can be disabled for override
-`),
 			Entry("to level MeshMultiZoneService", `
 targetRef:
   kind: Mesh
@@ -140,7 +128,7 @@ violations:
   - field: spec.targetRef.kind
     message: value is not supported`, // this could be more specific
 			}),
-			PEntry("to field is an empty array", testCase{ // this does not work, needs
+			Entry("to field is an empty array", testCase{
 				inputYaml: `
 targetRef:
   kind: MeshService
@@ -294,30 +282,6 @@ violations:
     message: must be in inclusive range [100, 599]
   - field: spec.to[0].default.http.expectedStatuses[1]
     message: must be in inclusive range [100, 599]`,
-			}),
-			XEntry("cannot use MeshExternalService with other type than Mesh", testCase{
-				inputYaml: `
-targetRef:
-  kind: MeshSubset
-  tags:
-    kuma.io/service: backend
-to:
-  - targetRef:
-      kind: MeshExternalService
-      name: web-backend
-    default:
-      interval: 10s
-      timeout: 2s
-      unhealthyThreshold: 3
-      healthyThreshold: 1
-      http:
-        path: /health
-        expectedStatuses: [200, 204]
-`,
-				expected: `
-violations:
-  - field: spec.to[0].targetRef.kind
-    message: 'kind MeshExternalService is only allowed with targetRef.kind: Mesh as it is configured on the Zone Egress and shared by all clients in the mesh'`,
 			}),
 		)
 	})

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/validator_test.go
@@ -128,18 +128,6 @@ violations:
   - field: spec.targetRef.kind
     message: value is not supported`, // this could be more specific
 			}),
-			Entry("to field is an empty array", testCase{
-				inputYaml: `
-targetRef:
-  kind: MeshService
-  name: backend
-to: []
-`,
-				expected: `
-violations:
-  - field: spec.to
-    message: must not be empty`,
-			}),
 			Entry("required fields are missing", testCase{
 				inputYaml: `
 targetRef:

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
@@ -3,7 +3,6 @@ package v1alpha1_test
 import (
 	"context"
 	"fmt"
-	"path"
 	"path/filepath"
 
 	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
@@ -15,7 +14,6 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	meshexternalservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
 	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
@@ -44,7 +42,6 @@ import (
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	"github.com/kumahq/kuma/pkg/xds/envoy/clusters"
 	"github.com/kumahq/kuma/pkg/xds/generator"
-	"github.com/kumahq/kuma/pkg/xds/generator/egress"
 )
 
 var _ = Describe("MeshHealthCheck", func() {
@@ -60,18 +57,6 @@ var _ = Describe("MeshHealthCheck", func() {
 		},
 		ResourceType: "MeshService",
 		SectionName:  "",
-	}
-
-	backendMeshExternalServiceIdentifier := func(mesh string) *core_model.TypedResourceIdentifier {
-		return &core_model.TypedResourceIdentifier{
-			ResourceIdentifier: core_model.ResourceIdentifier{
-				Name:      "external",
-				Mesh:      mesh,
-				Namespace: "",
-				Zone:      "",
-			},
-			ResourceType: "MeshExternalService",
-		}
 	}
 
 	type testCase struct {
@@ -286,122 +271,6 @@ var _ = Describe("MeshHealthCheck", func() {
 			expectedClusters: []string{"basic_tcp_health_check_cluster_real_ms.golden.yaml"},
 		}),
 	)
-
-	XIt("should generate correct configuration for MeshExternalService with ZoneEgress", func() {
-		// given
-		rs := core_xds.NewResourceSet()
-		rs.Add(&core_xds.Resource{
-			Name:           "external-default",
-			Origin:         egress.OriginEgress,
-			Resource:       clusters.NewClusterBuilder(envoy_common.APIV3, "external").MustBuild(),
-			ResourceOrigin: backendMeshExternalServiceIdentifier("default"),
-			Protocol:       core_mesh.ProtocolTCP,
-		})
-		rs.Add(&core_xds.Resource{
-			Name:           "external-mesh2",
-			Origin:         egress.OriginEgress,
-			Resource:       clusters.NewClusterBuilder(envoy_common.APIV3, "external").MustBuild(),
-			ResourceOrigin: backendMeshExternalServiceIdentifier("mesh2"),
-			Protocol:       core_mesh.ProtocolTCP,
-		})
-
-		proxy := &core_xds.Proxy{
-			APIVersion: envoy_common.APIV3,
-			ZoneEgressProxy: &core_xds.ZoneEgressProxy{
-				ZoneEgressResource: &core_mesh.ZoneEgressResource{
-					Meta: &test_model.ResourceMeta{Name: "dp1", Mesh: "default"},
-					Spec: &mesh_proto.ZoneEgress{
-						Networking: &mesh_proto.ZoneEgress_Networking{
-							Address: "192.168.0.1",
-							Port:    10002,
-						},
-					},
-				},
-				ZoneIngresses: []*core_mesh.ZoneIngressResource{},
-				MeshResourcesList: []*core_xds.MeshResources{
-					{
-						Mesh: builders.Mesh().WithName("default").WithEnabledMTLSBackend("ca-1").WithBuiltinMTLSBackend("ca-1").Build(),
-						Resources: map[core_model.ResourceType]core_model.ResourceList{
-							meshexternalservice_api.MeshExternalServiceType: &meshexternalservice_api.MeshExternalServiceResourceList{
-								Items: []*meshexternalservice_api.MeshExternalServiceResource{
-									samples.MeshExternalServiceExampleBuilder().WithMesh("default").WithName("external").Build(),
-								},
-							},
-						},
-						Dynamic: core_xds.ExternalServiceDynamicPolicies{
-							"default_external___extsvc_9000": {
-								api.MeshHealthCheckType: core_xds.TypedMatchingPolicies{
-									ToRules: core_rules.ToRules{
-										ResourceRules: outbound.ResourceRules{
-											*backendMeshExternalServiceIdentifier("default"): {
-												Conf: []interface{}{
-													api.Conf{
-														Interval:           test.ParseDuration("11s"),
-														Timeout:            test.ParseDuration("99s"),
-														UnhealthyThreshold: pointer.To[int32](7),
-														HealthyThreshold:   pointer.To[int32](77),
-														Tcp: &api.TcpHealthCheck{
-															Disabled: pointer.To(false),
-															Send:     pointer.To("cGluZwo="),
-															Receive:  &[]string{"cG9uZwo="},
-														},
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-					{
-						Mesh: builders.Mesh().WithName("mesh2").WithEnabledMTLSBackend("ca-2").WithBuiltinMTLSBackend("ca-2").Build(),
-						Resources: map[core_model.ResourceType]core_model.ResourceList{
-							meshexternalservice_api.MeshExternalServiceType: &meshexternalservice_api.MeshExternalServiceResourceList{
-								Items: []*meshexternalservice_api.MeshExternalServiceResource{
-									samples.MeshExternalServiceExampleBuilder().WithName("external").WithMesh("mesh-2").Build(),
-								},
-							},
-						},
-						Dynamic: core_xds.ExternalServiceDynamicPolicies{
-							"mesh-2_external___extsvc_9000": {
-								api.MeshHealthCheckType: core_xds.TypedMatchingPolicies{
-									ToRules: core_rules.ToRules{
-										ResourceRules: outbound.ResourceRules{
-											*backendMeshExternalServiceIdentifier("mesh2"): {
-												Conf: []interface{}{
-													api.Conf{
-														Interval:           test.ParseDuration("55s"),
-														Timeout:            test.ParseDuration("5s"),
-														UnhealthyThreshold: pointer.To[int32](122),
-														HealthyThreshold:   pointer.To[int32](311),
-														Tcp: &api.TcpHealthCheck{
-															Disabled: pointer.To(false),
-															Send:     pointer.To("cGluZwo="),
-															Receive:  &[]string{"cG9uZwo="},
-														},
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		}
-
-		// when
-		p := plugin.NewPlugin().(core_plugins.PolicyPlugin)
-		err := p.Apply(rs, xds_context.Context{}, proxy)
-		Expect(err).ToNot(HaveOccurred())
-
-		// then
-		Expect(getResource(rs, envoy_resource.ClusterType)).
-			To(test_matchers.MatchGoldenYAML(path.Join("testdata", "basic_egress_meshexternalservice_cluster.golden.yaml")))
-	})
 
 	type gatewayTestCase struct {
 		name           string
@@ -890,15 +759,3 @@ var _ = Describe("MeshHealthCheck", func() {
 		}),
 	)
 })
-
-func getResource(
-	resourceSet *core_xds.ResourceSet,
-	typ envoy_resource.Type,
-) []byte {
-	resources, err := resourceSet.ListOf(typ).ToDeltaDiscoveryResponse()
-	Expect(err).ToNot(HaveOccurred())
-	actual, err := util_proto.ToYAML(resources)
-	Expect(err).ToNot(HaveOccurred())
-
-	return actual
-}


### PR DESCRIPTION
## Motivation

We don't need these skipped tests since we don't support egress matching. Also, it makes sense to create an empty list of rules in some cases but we should review them

Fix https://github.com/kumahq/kuma/issues/13258

xref: https://github.com/kumahq/kuma/issues/12849

> Changelog: skip
