### PR TITLE
refactor(rules): use ResourceList instead of []Resource in function signatures

### DIFF
--- a/pkg/plugins/policies/core/matchers/egress.go
+++ b/pkg/plugins/policies/core/matchers/egress.go
@@ -63,7 +63,7 @@ func EgressMatchedPolicies(rType core_model.ResourceType, tags map[string]string
 		if err != nil {
 			return core_xds.TypedMatchingPolicies{}, err
 		}
-		tr, err = processToResourceRules(policies.GetItems(), resources)
+		tr, err = processToResourceRules(policies, resources)
 	case isFrom:
 		fr, err = processFromRules(tags, policies)
 	case isTo:
@@ -71,7 +71,7 @@ func EgressMatchedPolicies(rType core_model.ResourceType, tags map[string]string
 		if err != nil {
 			return core_xds.TypedMatchingPolicies{}, err
 		}
-		tr, err = processToResourceRules(policies.GetItems(), resources)
+		tr, err = processToResourceRules(policies, resources)
 	}
 
 	if err != nil {
@@ -200,7 +200,7 @@ func processToRules(tags map[string]string, policies core_model.ResourceList) (c
 	}, nil
 }
 
-func processToResourceRules(policies []core_model.Resource, resources xds_context.Resources) (core_rules.ToRules, error) {
+func processToResourceRules(policies core_model.ResourceList, resources xds_context.Resources) (core_rules.ToRules, error) {
 	resourceRules, err := outbound.BuildRules(policies, resources)
 	if err != nil {
 		return core_rules.ToRules{}, err

--- a/pkg/plugins/policies/core/rules/outbound/resourcerules.go
+++ b/pkg/plugins/policies/core/rules/outbound/resourcerules.go
@@ -83,7 +83,7 @@ type ToEntry interface {
 
 // BuildRules constructs ResourceRules from the given policies and resource reader.
 // It first extracts 'to' entries from the policies and then builds the rules based on these entries.
-func BuildRules(policies []core_model.Resource, reader common.ResourceReader) (ResourceRules, error) {
+func BuildRules(policies core_model.ResourceList, reader common.ResourceReader) (ResourceRules, error) {
 	entries, err := GetEntries(policies)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get 'to' entries")
@@ -91,8 +91,8 @@ func BuildRules(policies []core_model.Resource, reader common.ResourceReader) (R
 	return buildRules(entries, reader)
 }
 
-func GetEntries(policies []core_model.Resource) ([]common.WithPolicyAttributes[ToEntry], error) {
-	policiesWithTo, ok := common.Cast[core_model.PolicyWithToList](policies)
+func GetEntries(policies core_model.ResourceList) ([]common.WithPolicyAttributes[ToEntry], error) {
+	policiesWithTo, ok := common.Cast[core_model.PolicyWithToList](policies.GetItems())
 	if !ok {
 		return nil, nil
 	}
@@ -103,7 +103,7 @@ func GetEntries(policies []core_model.Resource) ([]common.WithPolicyAttributes[T
 		for j, item := range pwt.GetToList() {
 			entries = append(entries, common.WithPolicyAttributes[ToEntry]{
 				Entry:     item,
-				Meta:      policies[i].GetMeta(),
+				Meta:      policies.GetItems()[i].GetMeta(),
 				TopLevel:  pwt.GetTargetRef(),
 				RuleIndex: j,
 			})

--- a/pkg/plugins/policies/core/rules/outbound/suite_test.go
+++ b/pkg/plugins/policies/core/rules/outbound/suite_test.go
@@ -4,10 +4,11 @@ import (
 	"strings"
 	"testing"
 
+	. "github.com/onsi/gomega"
+
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/registry"
 	"github.com/kumahq/kuma/pkg/test"
-	. "github.com/onsi/gomega"
 )
 
 func TestRules(t *testing.T) {

--- a/pkg/plugins/policies/core/rules/outbound/suite_test.go
+++ b/pkg/plugins/policies/core/rules/outbound/suite_test.go
@@ -5,19 +5,25 @@ import (
 	"testing"
 
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/core/resources/registry"
 	"github.com/kumahq/kuma/pkg/test"
+	. "github.com/onsi/gomega"
 )
 
 func TestRules(t *testing.T) {
 	test.RunSpecs(t, "Outbound Rules Suite")
 }
 
-func matchedPolicies(rs []core_model.Resource) []core_model.Resource {
-	var matched []core_model.Resource
+func matchedPolicies(rs []core_model.Resource) core_model.ResourceList {
+	Expect(rs).ToNot(BeEmpty())
+	policyType := rs[0].Descriptor().Name
+	list, err := registry.Global().NewList(policyType)
+	Expect(err).ToNot(HaveOccurred())
+
 	for _, p := range rs {
 		if strings.HasPrefix(p.GetMeta().GetName(), "matched-for-rules-") {
-			matched = append(matched, p)
+			Expect(list.AddItem(p)).To(Succeed())
 		}
 	}
-	return matched
+	return list
 }

--- a/pkg/plugins/policies/core/rules/rules.go
+++ b/pkg/plugins/policies/core/rules/rules.go
@@ -3,7 +3,6 @@ package rules
 import (
 	"encoding"
 	"fmt"
-	"slices"
 	"sort"
 	"strings"
 
@@ -228,12 +227,7 @@ func BuildToRules(matchedPolicies core_model.ResourceList, reader common.Resourc
 		return ToRules{}, err
 	}
 
-	// we have to exclude top-level targetRef 'MeshHTTPRoute' as new outbound rules work with MeshHTTPRoute differently,
-	// see docs/madr/decisions/060-policy-matching-with-real-resources.md
-	excludeTopLevelMeshHTTPRoute := slices.DeleteFunc(slices.Clone(matchedPolicies.GetItems()), func(r core_model.Resource) bool {
-		return r.GetSpec().(core_model.Policy).GetTargetRef().Kind == common_api.MeshHTTPRoute
-	})
-	resourceRules, err := outbound.BuildRules(excludeTopLevelMeshHTTPRoute, reader)
+	resourceRules, err := outbound.BuildRules(matchedPolicies, reader)
 	if err != nil {
 		return ToRules{}, err
 	}

--- a/pkg/plugins/policies/core/rules/rules.go
+++ b/pkg/plugins/policies/core/rules/rules.go
@@ -15,14 +15,13 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/registry"
-	"github.c
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/rules/common"
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/rules/inbound"
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/rules/merge"
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/rules/outbound"
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/rules/subsetutils"
 	meshhttproute_api "github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
-	"github.com/kumahq/kuma/pkg/core/resources/registry"
+	"github.com/kumahq/kuma/pkg/util/pointer"
 )
 
 const RuleMatchesHashTag = "__rule-matches-hash__"


### PR DESCRIPTION
## Motivation

Same as https://github.com/kumahq/kuma/pull/12603, but for outbound rules


