### PR TITLE
test(e2e): wait for Mesh sync in multizone setup

### DIFF
--- a/test/e2e_env/multizone/gateway/cross-mesh.go
+++ b/test/e2e_env/multizone/gateway/cross-mesh.go
@@ -88,6 +88,8 @@ func CrossMeshGatewayOnMultizone() {
 			Install(YamlUniversal(crossMeshGatewayYaml)).
 			Install(YamlUniversal(edgeGatewayYaml))
 		Expect(globalSetup.Setup(multizone.Global)).To(Succeed())
+		Expect(WaitForMesh(gatewayMesh, multizone.Zones())).To(Succeed())
+		Expect(WaitForMesh(gatewayOtherMesh, multizone.Zones())).To(Succeed())
 
 		group := errgroup.Group{}
 		NewClusterSetup().

--- a/test/e2e_env/multizone/meshservice/migration.go
+++ b/test/e2e_env/multizone/meshservice/migration.go
@@ -23,6 +23,7 @@ func Migration() {
 			Install(MTLSMeshUniversal(meshName)).
 			Setup(multizone.Global)
 		Expect(err).ToNot(HaveOccurred())
+		Expect(WaitForMesh(meshName, multizone.Zones())).To(Succeed())
 
 		group := errgroup.Group{}
 		NewClusterSetup().


### PR DESCRIPTION
## Motivation

Test fail

> 2025-04-01T13:23:51.147Z	INFO	dataplane	trying to fetch bootstrap configuration from the Control Plane
Error: Failed to generate Envoy bootstrap config. Invalid request: mesh: mesh "msmigration" does not exist

## Implementation information

Added wait for mesh sync

> Changelog: skip
