### PR TITLE
test(e2e): enable skipped helm test for Global admin api

### DIFF
--- a/test/e2e/helm/kuma_helm_deploy_global_zone.go
+++ b/test/e2e/helm/kuma_helm_deploy_global_zone.go
@@ -171,8 +171,7 @@ interCp:
 		})
 	})
 
-	// TODO(bartsmykla): disabled while investingating flake
-	XIt("should execute admin operations on Global CP", func() {
+	It("should execute admin operations on Global CP", func() {
 		// given DP available on Global CP
 		Eventually(func(g Gomega) {
 			dataplanes, err := c1.GetKumactlOptions().KumactlList("dataplanes", "default")


### PR DESCRIPTION
## Motivation

Test passes locally we should enable it. I don't really see reason to have it skipped 

Fix [#13224](https://github.com/kumahq/kuma/issues/13224)