### PR TITLE
test(e2e): enabled federation test

### DIFF
--- a/test/e2e/federation/federation_kubernetes.go
+++ b/test/e2e/federation/federation_kubernetes.go
@@ -86,8 +86,8 @@ func FederateKubeZoneCPToKubeGlobal() {
 
 			// sometimes we can hit a race condition which I can't reproduce
 			Eventually(func(g Gomega) {
-				Expect(k8s.KubectlApplyFromStringE(global.GetTesting(), global.GetKubectlOptions(), out)).To(Succeed())
-			}, "10s", "1s")
+				g.Expect(k8s.KubectlApplyFromStringE(global.GetTesting(), global.GetKubectlOptions(), out)).To(Succeed())
+			}, "10s", "1s").Should(Succeed())
 			Expect(zone.(*K8sCluster).UpgradeKuma(core.Zone,
 				WithHelmReleaseName(releaseName),
 				WithGlobalAddress(global.GetKuma().GetKDSServerAddress()),

--- a/test/e2e/federation/federation_suite_test.go
+++ b/test/e2e/federation/federation_suite_test.go
@@ -16,6 +16,6 @@ func TestE2E(t *testing.T) {
 
 var (
 	_ = ReportAfterSuite("report suite", report.DumpReport)
-	_ = XDescribe("Federation with Kube Global", Label("job-3"), federation.FederateKubeZoneCPToKubeGlobal, Ordered)
+	_ = Describe("Federation with Kube Global", Label("job-3"), federation.FederateKubeZoneCPToKubeGlobal, Ordered)
 	_ = Describe("Federation with Universal Global", Label("job-3"), federation.FederateKubeZoneCPToUniversalGlobal, Ordered)
 )


### PR DESCRIPTION
## Motivation

We noticed a flake. I tried to replicate it but was unsuccessful. This issue is strange because, in the test, we use kubectl apply -f config.yaml, which should override the secrets created by the controller. Additionally, apply does not return a conflict (at least, I couldn't reproduce it manually or in the test).

I believe reverting [this PR](https://github.com/kumahq/kuma/pull/13111) might be a more reliable solution. Here's the sequence of events:

1. The user creates a Mesh with mTLS enabled.
2. At the same time, the control plane generates a certificate and key for the mesh and the user applies them using kubectl apply -f. This introduces a potential race condition.

To avoid this race condition, I think we should revert [this PR](https://github.com/kumahq/kuma/pull/13111).

Fix #[13217](https://github.com/kumahq/kuma/issues/13217)

