### PR TITLE
chore(e2e): add echo argument otherwise test server never started

### DIFF
--- a/test/e2e_env/multizone/meshservice/migration.go
+++ b/test/e2e_env/multizone/meshservice/migration.go
@@ -43,7 +43,7 @@ func Migration() {
 			SetupInGroup(multizone.KubeZone1, &group)
 
 		NewClusterSetup().
-			Install(TestServerUniversal("test-server", meshName)).
+			Install(TestServerUniversal("test-server", meshName, WithArgs([]string{"echo"}))).
 			SetupInGroup(multizone.UniZone1, &group)
 		Expect(group.Wait()).To(Succeed())
 	})


### PR DESCRIPTION
## Motivation

Otherwise [here](https://github.com/kumahq/kuma/actions/runs/14195942787/job/39772966862#step:12:17733) we're getting:

```
Error: unknown flag: --port
Usage:
  test-server [command]

Available Commands:
  completion   Generate the autocompletion script for the specified shell
  echo         Run Test Server with generic echo response
  grpc         GRPC testing
  health-check Run Test Server for Health Check test
  help         Help about any command

Flags:
  -h, --help               help for test-server
      --log-level string   log level: one of off|info|debug (default "info")

Use "test-server [command] --help" for more information about a command.
``` 

In the logs. The test is not failing but to avoid confusion in the future it's better to add it.

## Implementation information

Add echo command.
