### PR TITLE
ci(deps): add retry to downloading envoy and coredns

### DIFF
--- a/mk/build.mk
+++ b/mk/build.mk
@@ -115,13 +115,13 @@ build/artifacts-$(1)-$(2)/install-cni:
 build/artifacts-$(1)-$(2)/coredns:
 	mkdir -p $$(@) && \
 	[ -f $$(@)/coredns ] || \
-	curl -s --fail --location https://github.com/kumahq/coredns-builds/releases/download/$(COREDNS_VERSION)/coredns_$(COREDNS_VERSION)_$(1)_$(2)$(COREDNS_EXT).tar.gz | tar -C $$(@) -xz
+	curl --retry 3 --retry-delay 60 -s --fail --location https://github.com/kumahq/coredns-builds/releases/download/$(COREDNS_VERSION)/coredns_$(COREDNS_VERSION)_$(1)_$(2)$(COREDNS_EXT).tar.gz | tar -C $$(@) -xz
 
 .PHONY: build/artifacts-$(1)-$(2)/envoy
 build/artifacts-$(1)-$(2)/envoy:
 	mkdir -p $$(@) && \
 	[ -f $$(@)/envoy ] || \
-	curl -s --fail --location https://github.com/kumahq/envoy-builds/releases/download/v$$(ENVOY_VERSION_$(1)_$(2))/envoy-$(1)-$(2)-v$$(ENVOY_VERSION_$(1)_$(2))$(ENVOY_EXT_$(1)_$(2)).tar.gz | tar -C $$(@) -xz
+	curl --retry 3 --retry-delay 60 -s --fail --location https://github.com/kumahq/envoy-builds/releases/download/v$$(ENVOY_VERSION_$(1)_$(2))/envoy-$(1)-$(2)-v$$(ENVOY_VERSION_$(1)_$(2))$(ENVOY_EXT_$(1)_$(2)).tar.gz | tar -C $$(@) -xz
 
 .PHONY: build/artifacts-$(1)-$(2)/test-server
 build/artifacts-$(1)-$(2)/test-server:


### PR DESCRIPTION
## Motivation

I think I saw errors similar to https://github.com/kumahq/kuma/actions/runs/14250742362/job/39944674349#step:7:38

```
mkdir -p build/artifacts-linux-amd64/envoy && [ -f build/artifacts-linux-amd64/envoy/envoy ] || curl -s --fail --location https://github.com/kumahq/envoy-builds/releases/download/v1.30.11/envoy-linux-amd64-v1.30.11.tar.gz | tar -C build/artifacts-linux-amd64/envoy -xz

gzip: stdin: unexpected end of file
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```

a couple of times. This way we'll retry 3 times before failing.

## Implementation information

Add ` --retry 3 --retry-delay 60` to curl command.

