### PR TITLE
feat(k8s): set allowPrivilegeEscalation to false

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,14 @@ with `x.y.z` being the version you are planning to upgrade to.
 If such a section does not exist, the upgrade you want to perform
 does not have any particular instructions.
 
+## Upgrade to `2.11.x`
+
+### `kuma-sidecar` container has `allowPrivilegeEscalation` set to `false`
+
+In previous versions, Kuma did not explicitly set `allowPrivilegeEscalation`. Starting with this version, it is now explicitly set to `false`.
+
+Before upgrading, ensure that your configuration does not override this setting.
+
 ## Upgrade to `2.10.x`
 
 ### API Server behaviour changes

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
@@ -125,6 +125,7 @@ func (i *KumaInjector) InjectKuma(ctx context.Context, pod *kube_core.Pod) error
 		ReadOnly:  false,
 	})
 	container.SecurityContext.ReadOnlyRootFilesystem = pointer.To(true)
+	container.SecurityContext.AllowPrivilegeEscalation = pointer.To(false)
 
 	patchedContainer, err := i.applyCustomPatches(logger, container, sidecarPatches)
 	if err != nil {

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.01.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.01.golden.yaml
@@ -105,6 +105,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.02.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.02.golden.yaml
@@ -106,6 +106,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.03.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.03.golden.yaml
@@ -113,6 +113,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.04.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.04.golden.yaml
@@ -106,6 +106,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.05.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.05.golden.yaml
@@ -106,6 +106,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.06.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.06.golden.yaml
@@ -106,6 +106,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.07.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.07.golden.yaml
@@ -105,6 +105,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.08.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.08.golden.yaml
@@ -108,6 +108,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.09.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.09.golden.yaml
@@ -107,6 +107,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.10.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.10.golden.yaml
@@ -106,6 +106,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.11.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.11.golden.yaml
@@ -105,6 +105,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.12.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.12.golden.yaml
@@ -106,6 +106,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.13.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.13.golden.yaml
@@ -105,6 +105,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.14.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.14.golden.yaml
@@ -105,6 +105,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.15.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.15.golden.yaml
@@ -105,6 +105,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.16.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.16.golden.yaml
@@ -107,6 +107,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.17.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.17.golden.yaml
@@ -107,6 +107,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.18.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.18.golden.yaml
@@ -107,6 +107,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.19.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.19.golden.yaml
@@ -105,6 +105,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.20.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.20.golden.yaml
@@ -105,6 +105,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.21.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.21.golden.yaml
@@ -105,6 +105,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.22.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.22.golden.yaml
@@ -111,6 +111,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.23.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.23.golden.yaml
@@ -120,6 +120,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.24.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.24.golden.yaml
@@ -121,6 +121,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.25.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.25.golden.yaml
@@ -120,6 +120,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.26.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.26.golden.yaml
@@ -107,6 +107,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.27.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.27.golden.yaml
@@ -106,6 +106,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.28.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.28.golden.yaml
@@ -110,6 +110,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.29.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.29.golden.yaml
@@ -116,6 +116,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.30.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.30.golden.yaml
@@ -111,6 +111,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.31.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.31.golden.yaml
@@ -105,6 +105,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.32.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.32.golden.yaml
@@ -106,6 +106,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.33.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.33.golden.yaml
@@ -105,6 +105,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.34.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.34.golden.yaml
@@ -107,6 +107,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.35.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.35.golden.yaml
@@ -105,6 +105,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.36.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.36.golden.yaml
@@ -106,6 +106,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.37.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.37.golden.yaml
@@ -106,6 +106,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.38.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.38.golden.yaml
@@ -106,6 +106,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.39.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.39.golden.yaml
@@ -106,6 +106,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.40.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.40.golden.yaml
@@ -105,6 +105,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.41.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.41.golden.yaml
@@ -107,6 +107,7 @@ spec:
         ephemeral-storage: 50M
         memory: 164Mi
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.01.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.01.golden.yaml
@@ -154,6 +154,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.02.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.02.golden.yaml
@@ -155,6 +155,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.03.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.03.golden.yaml
@@ -235,6 +235,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.04.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.04.golden.yaml
@@ -155,6 +155,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.05.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.05.golden.yaml
@@ -151,6 +151,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.06.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.06.golden.yaml
@@ -155,6 +155,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.07.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.07.golden.yaml
@@ -154,6 +154,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.08.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.08.golden.yaml
@@ -157,6 +157,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.09.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.09.golden.yaml
@@ -156,6 +156,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.10.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.10.golden.yaml
@@ -155,6 +155,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.11.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.11.golden.yaml
@@ -154,6 +154,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.12.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.12.golden.yaml
@@ -155,6 +155,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.13.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.13.golden.yaml
@@ -166,6 +166,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.14.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.14.golden.yaml
@@ -166,6 +166,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.15.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.15.golden.yaml
@@ -165,6 +165,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.16.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.16.golden.yaml
@@ -157,6 +157,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.17.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.17.golden.yaml
@@ -157,6 +157,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.18.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.18.golden.yaml
@@ -155,6 +155,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.19.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.19.golden.yaml
@@ -171,6 +171,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.20.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.20.golden.yaml
@@ -171,6 +171,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.21.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.21.golden.yaml
@@ -179,6 +179,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.22.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.22.golden.yaml
@@ -159,6 +159,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.23.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.23.golden.yaml
@@ -170,6 +170,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.24.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.24.golden.yaml
@@ -171,6 +171,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.25.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.25.golden.yaml
@@ -170,6 +170,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.26.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.26.golden.yaml
@@ -152,6 +152,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.27.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.27.golden.yaml
@@ -151,6 +151,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.28.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.28.golden.yaml
@@ -154,6 +154,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.29.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.29.golden.yaml
@@ -162,6 +162,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.30.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.30.golden.yaml
@@ -163,6 +163,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.31.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.31.golden.yaml
@@ -152,6 +152,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.32.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.32.golden.yaml
@@ -151,6 +151,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.33.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.33.golden.yaml
@@ -154,6 +154,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.34.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.34.golden.yaml
@@ -155,6 +155,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.35.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.35.golden.yaml
@@ -154,6 +154,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.36.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.36.golden.yaml
@@ -156,6 +156,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.37.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.37.golden.yaml
@@ -156,6 +156,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.38.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.38.golden.yaml
@@ -156,6 +156,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.39.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.39.golden.yaml
@@ -156,6 +156,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.40.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.40.golden.yaml
@@ -175,6 +175,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.41.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.sidecar-feature.41.golden.yaml
@@ -123,6 +123,7 @@ spec:
         memory: 164Mi
     restartPolicy: Always
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/test/e2e_env/kubernetes/container_patch/container_patch.go
+++ b/test/e2e_env/kubernetes/container_patch/container_patch.go
@@ -30,7 +30,7 @@ spec:
   sidecarPatch:
     - op: add
       path: /securityContext/privileged
-      value: "true"`, ns)
+      value: "false"`, ns)
 	}
 	containerPatch2 := func(ns string) string {
 		return fmt.Sprintf(`apiVersion: kuma.io/v1alpha1
@@ -113,8 +113,8 @@ spec:
 		Expect(err).ToNot(HaveOccurred())
 
 		// then
-		pointerTrue := new(bool)
-		*pointerTrue = true
+		pointerFalse := new(bool)
+		*pointerFalse = false
 		Expect(pod.Spec.InitContainers).To(
 			Or(HaveLen(1), HaveLen(2)),
 		)
@@ -123,17 +123,17 @@ spec:
 		Expect(pod.Spec.Containers).To(
 			Or(HaveLen(2), HaveLen(1)),
 		)
-		beSidecarWithPrivileged := And(
+		beSidecarWithPrivilegedDisabled := And(
 			WithTransform(func(c kube_core.Container) string { return c.Name }, BeEquivalentTo(k8s_util.KumaSidecarContainerName)),
-			WithTransform(func(c kube_core.Container) *bool { return c.SecurityContext.Privileged }, Equal(pointerTrue)),
+			WithTransform(func(c kube_core.Container) *bool { return c.SecurityContext.Privileged }, Equal(pointerFalse)),
 		)
 		if len(pod.Spec.Containers) == 2 {
 			// kuma-sidecar is the first container
-			Expect(pod.Spec.Containers[0]).To(beSidecarWithPrivileged)
+			Expect(pod.Spec.Containers[0]).To(beSidecarWithPrivilegedDisabled)
 		} else {
 			Expect(pod.Spec.InitContainers).To(HaveLen(2))
 			// kuma-sidecar is the second init container
-			Expect(pod.Spec.InitContainers[1]).To(beSidecarWithPrivileged)
+			Expect(pod.Spec.InitContainers[1]).To(beSidecarWithPrivilegedDisabled)
 		}
 	})
 


### PR DESCRIPTION
## Motivation

We don't set `allowPrivilegeEscalation`, but it's unnecessary since our process runs with a different UID, and the `kuma-dp` container does not require escalation.

## Implementation information

Set explicitly `allowPrivilegeEscalation` to `false`.

## Supporting documentation

Fix https://github.com/kumahq/kuma/issues/13289

