### PR TITLE
fix(kumactl): avoid logger issues by importing controller-runtime directly

### DIFF
--- a/pkg/core/alias.go
+++ b/pkg/core/alias.go
@@ -8,18 +8,18 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	kube_log "sigs.k8s.io/controller-runtime/pkg/log"
+	kube_ctrl "sigs.k8s.io/controller-runtime"
 
 	kuma_log "github.com/kumahq/kuma/pkg/log"
 )
 
 var (
 	// TODO remove dependency on kubernetes see: https://github.com/kumahq/kuma/issues/2798
-	Log                   = kube_log.Log
+	Log                   = kube_ctrl.Log
 	NewLogger             = kuma_log.NewLogger
 	NewLoggerTo           = kuma_log.NewLoggerTo
 	NewLoggerWithRotation = kuma_log.NewLoggerWithRotation
-	SetLogger             = kube_log.SetLogger
+	SetLogger             = kube_ctrl.SetLogger
 	Now                   = time.Now
 
 	SetupSignalHandler = func() (context.Context, context.Context, <-chan struct{}) {


### PR DESCRIPTION
## Motivation & Implementation information

Importing the `controller-runtime/log` subpackage causes global `Log` to be  assigned to the delegated logger, which depends on later `SetLogger` calls. When `controller-runtime` is also imported elsewhere, this re-triggers global init logic, leading to data races and inconsistent logger behavior.

This affects performance and can cause commands like `kumactl install transparent-proxy` or `kumactl install transparent-proxy-validator` to hang for several minutes.

By importing `controller-runtime` directly and using its `Log`/`SetLogger` re-exports, we avoid duplicate initialization and ordering issues.

## Supporting documentation

Closes: https://github.com/kumahq/kuma/issues/13299