### PR TITLE
chore(lint): add rule to deny `sigs.k8s.io/controller-runtime/pkg/log` usage

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,7 +42,7 @@ linters:
           files:
             - $all
           deny:
-            - pkg: sigs.k8s.io/controller-runtime/pkg/log
+            - pkg: sigs.k8s.io/controller-runtime/pkg/log$
               desc: Disallowed due to internal data races caused by cyclic dependencies and global state in controller-runtime. This can lead to long delays (up to 2 minutes) in init containers. Use sigs.k8s.io/controller-runtime instead. See https://github.com/kumahq/kuma/issues/13299
         pkg-import:
           list-mode: lax

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,6 +38,16 @@ linters:
           deny:
             - pkg: google.golang.org/protobuf/encoding/protojson
               desc: don't use the protojson package, it's incompatible and might cause issues(https://github.com/golang/protobuf/issues/1374); use github.com/golang/protobuf/jsonpb instead
+        DenyControllerRuntimePkgLog:
+          files:
+          - $all
+          deny:
+          - pkg: sigs.k8s.io/controller-runtime/pkg/log
+            desc: >
+              Disallowed due to internal data races caused by cyclic dependencies and global
+              state in controller-runtime. This can lead to long delays (up to 2 minutes)
+              in init containers. Use sigs.k8s.io/controller-runtime instead. 
+              See https://github.com/kumahq/kuma/issues/13299
         pkg-import:
           list-mode: lax
           files:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,14 +40,10 @@ linters:
               desc: don't use the protojson package, it's incompatible and might cause issues(https://github.com/golang/protobuf/issues/1374); use github.com/golang/protobuf/jsonpb instead
         DenyControllerRuntimePkgLog:
           files:
-          - $all
+            - $all
           deny:
-          - pkg: sigs.k8s.io/controller-runtime/pkg/log
-            desc: >
-              Disallowed due to internal data races caused by cyclic dependencies and global
-              state in controller-runtime. This can lead to long delays (up to 2 minutes)
-              in init containers. Use sigs.k8s.io/controller-runtime instead. 
-              See https://github.com/kumahq/kuma/issues/13299
+            - pkg: sigs.k8s.io/controller-runtime/pkg/log
+              desc: Disallowed due to internal data races caused by cyclic dependencies and global state in controller-runtime. This can lead to long delays (up to 2 minutes) in init containers. Use sigs.k8s.io/controller-runtime instead. See https://github.com/kumahq/kuma/issues/13299
         pkg-import:
           list-mode: lax
           files:

--- a/pkg/test/ginkgo.go
+++ b/pkg/test/ginkgo.go
@@ -11,7 +11,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	kube_ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/kumahq/kuma/pkg/core"
@@ -52,7 +52,7 @@ func runSpecs(t *testing.T, description string) {
 
 	// Log to the Ginkgo writer. This makes Ginkgo emit logs on
 	// test failure.
-	log.SetLogger(zap.New(
+	kube_ctrl.SetLogger(zap.New(
 		zap.UseDevMode(true),
 		zap.WriteTo(ginkgo.GinkgoWriter),
 	))


### PR DESCRIPTION
## Motivation & Implementation information

Adds `golangci-lint` rule to block `sigs.k8s.io/controller-runtime/pkg/log` due to global logger assignment issues causing cyclic dependency races and long delays in binaries; use root controller-runtime import instead

## Supporting documentation

Followup for https://github.com/kumahq/kuma/issues/13299