### PR TITLE
test(e2e): fix Ingress config fetch type

### DIFF
--- a/test/framework/debug.go
+++ b/test/framework/debug.go
@@ -208,7 +208,7 @@ type dpType string
 const (
 	dataplaneType   dpType = "dataplane"
 	zoneegressType  dpType = "zoneegress"
-	zoneingressType dpType = "zoneingress"
+	zoneingressType dpType = "zone-ingress"
 )
 
 func inspectDataplane(kumactlOpts *kumactl.KumactlOptions, cluster Cluster, mesh string, dpType dpType) error {


### PR DESCRIPTION
## Motivation

Our api for kumactl is not consistant and there is no `zoneingresses`, instead there is `zone-ingresses`. We cannot change api since it's a breaking change maybe we could introduce `zoneingresses` as an alias https://github.com/kumahq/kuma/blob/master/api/mesh/v1alpha1/zone_ingress.proto#L23

> Changelog: skip


We should probably cover it https://github.com/kumahq/kuma/issues/3233