### PR TITLE
feat(helm): set kuma.io/sidecar-injection on system namespace

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -14,6 +14,12 @@ In previous versions, Kuma did not explicitly set `allowPrivilegeEscalation`. St
 
 Before upgrading, ensure that your configuration does not override this setting.
 
+### System namespace requires the `kuma.io/sidecar-injection: false` label
+
+To simplify the namespace selector logic in webhooks, we now require the `kuma.io/sidecar-injection: false` label to be set on the system namespace.
+
+Since Kubernetes v1.22, the API server automatically adds the `kubernetes.io/metadata.name` label to all namespaces. As a result, we’ve replaced the use of the custom `kuma.io/system-namespace` label in the secret webhook selector with this standard label.
+
 ## Upgrade to `2.10.x`
 
 ### API Server behaviour changes

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -20,6 +20,12 @@ To simplify the namespace selector logic in webhooks, we now require the `kuma.i
 
 Since Kubernetes v1.22, the API server automatically adds the `kubernetes.io/metadata.name` label to all namespaces. As a result, we’ve replaced the use of the custom `kuma.io/system-namespace` label in the secret webhook selector with this standard label.
 
+If you are running helm with `noHelmHooks` please set label on the system namespace:
+
+```bash
+kubectl label namespace SYSTEM_NAMESPACE kuma.io/sidecar-injection=disabled
+```
+
 ## Upgrade to `2.10.x`
 
 ### API Server behaviour changes

--- a/app/kumactl/cmd/install/render_helm_files.go
+++ b/app/kumactl/cmd/install/render_helm_files.go
@@ -37,7 +37,7 @@ kind: Namespace
 metadata:
   name: %s
   labels:
-    kuma.io/system-namespace: "true"
+    kuma.io/sidecar-injection: "false"
 `, namespace)
 }
 

--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -5,7 +5,7 @@ kind: Namespace
 metadata:
   name: kuma-system
   labels:
-    kuma.io/system-namespace: "true"
+    kuma.io/sidecar-injection: "false"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -588,7 +588,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 27eaaaa811fc2eed212bbcd5e84e09074d6da6742b4c89a96a33cce0fefd7ecb
+        checksum/tls-secrets: 9a78e134eea0948a37b49fe2fdab525eb0669f1a56a5b5d0479a537dc5e86219
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -1006,8 +1006,11 @@ webhooks:
   - name: secret.validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]
     namespaceSelector:
-      matchLabels:
-        kuma.io/system-namespace: "true"
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          - kuma-system
     failurePolicy: Ignore
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -5,7 +5,7 @@ kind: Namespace
 metadata:
   name: kuma-system
   labels:
-    kuma.io/system-namespace: "true"
+    kuma.io/sidecar-injection: "false"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -10777,7 +10777,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 27eaaaa811fc2eed212bbcd5e84e09074d6da6742b4c89a96a33cce0fefd7ecb
+        checksum/tls-secrets: 9a78e134eea0948a37b49fe2fdab525eb0669f1a56a5b5d0479a537dc5e86219
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -11189,8 +11189,11 @@ webhooks:
   - name: secret.validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]
     namespaceSelector:
-      matchLabels:
-        kuma.io/system-namespace: "true"
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          - kuma-system
     failurePolicy: Ignore
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -5,7 +5,7 @@ kind: Namespace
 metadata:
   name: kuma-system
   labels:
-    kuma.io/system-namespace: "true"
+    kuma.io/sidecar-injection: "false"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -10777,7 +10777,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 27eaaaa811fc2eed212bbcd5e84e09074d6da6742b4c89a96a33cce0fefd7ecb
+        checksum/tls-secrets: 9a78e134eea0948a37b49fe2fdab525eb0669f1a56a5b5d0479a537dc5e86219
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -11196,8 +11196,11 @@ webhooks:
   - name: secret.validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]
     namespaceSelector:
-      matchLabels:
-        kuma.io/system-namespace: "true"
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          - kuma-system
     failurePolicy: Ignore
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-control-plane.global-universal-on-k8s.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.global-universal-on-k8s.golden.yaml
@@ -5,7 +5,7 @@ kind: Namespace
 metadata:
   name: kuma-system
   labels:
-    kuma.io/system-namespace: "true"
+    kuma.io/sidecar-injection: "false"
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
@@ -5,7 +5,7 @@ kind: Namespace
 metadata:
   name: kuma-system
   labels:
-    kuma.io/system-namespace: "true"
+    kuma.io/sidecar-injection: "false"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -390,7 +390,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f1a4df5e47b745b7cd65510548092d78f5d4b4193d05728d8012a478ae463c6d
+        checksum/tls-secrets: 600730593e6d150b14d4d87b651b73315e0e2138bf0987a27ba9cb05e08de4c9
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -747,8 +747,11 @@ webhooks:
   - name: secret.validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]
     namespaceSelector:
-      matchLabels:
-        kuma.io/system-namespace: "true"
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          - kuma-system
     failurePolicy: Ignore
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
@@ -5,7 +5,7 @@ kind: Namespace
 metadata:
   name: kuma-system
   labels:
-    kuma.io/system-namespace: "true"
+    kuma.io/sidecar-injection: "false"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -374,7 +374,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 27eaaaa811fc2eed212bbcd5e84e09074d6da6742b4c89a96a33cce0fefd7ecb
+        checksum/tls-secrets: 9a78e134eea0948a37b49fe2fdab525eb0669f1a56a5b5d0479a537dc5e86219
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -786,8 +786,11 @@ webhooks:
   - name: secret.validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]
     namespaceSelector:
-      matchLabels:
-        kuma.io/system-namespace: "true"
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          - kuma-system
     failurePolicy: Ignore
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
@@ -5,7 +5,7 @@ kind: Namespace
 metadata:
   name: kuma
   labels:
-    kuma.io/system-namespace: "true"
+    kuma.io/sidecar-injection: "false"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -374,7 +374,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 154c47a95fc93687dd1e825cea7f843d0fe8c450f82014d27cd7eb1a49f3bd35
-        checksum/tls-secrets: 1886632c0f25e96e60fd37d542b737d9cc6a876c8d2ca8382b5f7f23024fe8e0
+        checksum/tls-secrets: 865ed0c3168e730eff2443ea7736039ed804a00676dd9d6c1d3c90cabd2c81d9
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -819,8 +819,11 @@ webhooks:
   - name: secret.validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]
     namespaceSelector:
-      matchLabels:
-        kuma.io/system-namespace: "true"
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          - kuma
     failurePolicy: Ignore
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
@@ -5,7 +5,7 @@ kind: Namespace
 metadata:
   name: kuma-system
   labels:
-    kuma.io/system-namespace: "true"
+    kuma.io/sidecar-injection: "false"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -374,7 +374,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 27eaaaa811fc2eed212bbcd5e84e09074d6da6742b4c89a96a33cce0fefd7ecb
+        checksum/tls-secrets: 9a78e134eea0948a37b49fe2fdab525eb0669f1a56a5b5d0479a537dc5e86219
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -786,8 +786,11 @@ webhooks:
   - name: secret.validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]
     namespaceSelector:
-      matchLabels:
-        kuma.io/system-namespace: "true"
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          - kuma-system
     failurePolicy: Ignore
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-control-plane.tproxy-ebpf-experimental-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.tproxy-ebpf-experimental-enabled.golden.yaml
@@ -5,7 +5,7 @@ kind: Namespace
 metadata:
   name: kuma-system
   labels:
-    kuma.io/system-namespace: "true"
+    kuma.io/sidecar-injection: "false"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -374,7 +374,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 27eaaaa811fc2eed212bbcd5e84e09074d6da6742b4c89a96a33cce0fefd7ecb
+        checksum/tls-secrets: 9a78e134eea0948a37b49fe2fdab525eb0669f1a56a5b5d0479a537dc5e86219
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -796,8 +796,11 @@ webhooks:
   - name: secret.validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]
     namespaceSelector:
-      matchLabels:
-        kuma.io/system-namespace: "true"
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          - kuma-system
     failurePolicy: Ignore
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
@@ -5,7 +5,7 @@ kind: Namespace
 metadata:
   name: kuma-system
   labels:
-    kuma.io/system-namespace: "true"
+    kuma.io/sidecar-injection: "false"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -405,7 +405,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 27eaaaa811fc2eed212bbcd5e84e09074d6da6742b4c89a96a33cce0fefd7ecb
+        checksum/tls-secrets: 9a78e134eea0948a37b49fe2fdab525eb0669f1a56a5b5d0479a537dc5e86219
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -948,8 +948,11 @@ webhooks:
   - name: secret.validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]
     namespaceSelector:
-      matchLabels:
-        kuma.io/system-namespace: "true"
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          - kuma-system
     failurePolicy: Ignore
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -5,7 +5,7 @@ kind: Namespace
 metadata:
   name: kuma-system
   labels:
-    kuma.io/system-namespace: "true"
+    kuma.io/sidecar-injection: "false"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -10839,7 +10839,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 27eaaaa811fc2eed212bbcd5e84e09074d6da6742b4c89a96a33cce0fefd7ecb
+        checksum/tls-secrets: 9a78e134eea0948a37b49fe2fdab525eb0669f1a56a5b5d0479a537dc5e86219
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -11519,8 +11519,11 @@ webhooks:
   - name: secret.validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]
     namespaceSelector:
-      matchLabels:
-        kuma.io/system-namespace: "true"
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          - kuma-system
     failurePolicy: Ignore
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
@@ -5,7 +5,7 @@ kind: Namespace
 metadata:
   name: kuma-system
   labels:
-    kuma.io/system-namespace: "true"
+    kuma.io/sidecar-injection: "false"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -374,7 +374,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 27eaaaa811fc2eed212bbcd5e84e09074d6da6742b4c89a96a33cce0fefd7ecb
+        checksum/tls-secrets: 9a78e134eea0948a37b49fe2fdab525eb0669f1a56a5b5d0479a537dc5e86219
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -786,8 +786,11 @@ webhooks:
   - name: secret.validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]
     namespaceSelector:
-      matchLabels:
-        kuma.io/system-namespace: "true"
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          - kuma-system
     failurePolicy: Ignore
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -5,7 +5,7 @@ kind: Namespace
 metadata:
   name: kuma-system
   labels:
-    kuma.io/system-namespace: "true"
+    kuma.io/sidecar-injection: "false"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -405,7 +405,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 27eaaaa811fc2eed212bbcd5e84e09074d6da6742b4c89a96a33cce0fefd7ecb
+        checksum/tls-secrets: 9a78e134eea0948a37b49fe2fdab525eb0669f1a56a5b5d0479a537dc5e86219
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -954,8 +954,11 @@ webhooks:
   - name: secret.validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]
     namespaceSelector:
-      matchLabels:
-        kuma.io/system-namespace: "true"
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          - kuma-system
     failurePolicy: Ignore
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone-universal-on-k8s.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone-universal-on-k8s.golden.yaml
@@ -5,7 +5,7 @@ kind: Namespace
 metadata:
   name: kuma-system
   labels:
-    kuma.io/system-namespace: "true"
+    kuma.io/sidecar-injection: "false"
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
@@ -5,7 +5,7 @@ kind: Namespace
 metadata:
   name: kuma-system
   labels:
-    kuma.io/system-namespace: "true"
+    kuma.io/sidecar-injection: "false"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -374,7 +374,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 27eaaaa811fc2eed212bbcd5e84e09074d6da6742b4c89a96a33cce0fefd7ecb
+        checksum/tls-secrets: 9a78e134eea0948a37b49fe2fdab525eb0669f1a56a5b5d0479a537dc5e86219
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -790,8 +790,11 @@ webhooks:
   - name: secret.validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]
     namespaceSelector:
-      matchLabels:
-        kuma.io/system-namespace: "true"
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          - kuma-system
     failurePolicy: Ignore
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/dnsConfigOption.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/dnsConfigOption.golden.yaml
@@ -5,7 +5,7 @@ kind: Namespace
 metadata:
   name: kuma-system
   labels:
-    kuma.io/system-namespace: "true"
+    kuma.io/sidecar-injection: "false"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -436,7 +436,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 27eaaaa811fc2eed212bbcd5e84e09074d6da6742b4c89a96a33cce0fefd7ecb
+        checksum/tls-secrets: 9a78e134eea0948a37b49fe2fdab525eb0669f1a56a5b5d0479a537dc5e86219
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -1125,8 +1125,11 @@ webhooks:
   - name: secret.validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]
     namespaceSelector:
-      matchLabels:
-        kuma.io/system-namespace: "true"
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          - kuma-system
     failurePolicy: Ignore
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/doNotChangeTlsChecksum.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/doNotChangeTlsChecksum.golden.yaml
@@ -5,7 +5,7 @@ kind: Namespace
 metadata:
   name: kuma-system
   labels:
-    kuma.io/system-namespace: "true"
+    kuma.io/sidecar-injection: "false"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -785,8 +785,11 @@ webhooks:
   - name: secret.validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]
     namespaceSelector:
-      matchLabels:
-        kuma.io/system-namespace: "true"
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          - kuma-system
     failurePolicy: Ignore
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
@@ -5,7 +5,7 @@ kind: Namespace
 metadata:
   name: kuma-system
   labels:
-    kuma.io/system-namespace: "true"
+    kuma.io/sidecar-injection: "false"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -374,7 +374,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 27eaaaa811fc2eed212bbcd5e84e09074d6da6742b4c89a96a33cce0fefd7ecb
+        checksum/tls-secrets: 9a78e134eea0948a37b49fe2fdab525eb0669f1a56a5b5d0479a537dc5e86219
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -786,8 +786,11 @@ webhooks:
   - name: secret.validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]
     namespaceSelector:
-      matchLabels:
-        kuma.io/system-namespace: "true"
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          - kuma-system
     failurePolicy: Ignore
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/envVarsDownwardApi.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/envVarsDownwardApi.golden.yaml
@@ -5,7 +5,7 @@ kind: Namespace
 metadata:
   name: kuma-system
   labels:
-    kuma.io/system-namespace: "true"
+    kuma.io/sidecar-injection: "false"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -374,7 +374,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 27eaaaa811fc2eed212bbcd5e84e09074d6da6742b4c89a96a33cce0fefd7ecb
+        checksum/tls-secrets: 9a78e134eea0948a37b49fe2fdab525eb0669f1a56a5b5d0479a537dc5e86219
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -790,8 +790,11 @@ webhooks:
   - name: secret.validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]
     namespaceSelector:
-      matchLabels:
-        kuma.io/system-namespace: "true"
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          - kuma-system
     failurePolicy: Ignore
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix12847.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix12847.golden.yaml
@@ -5,7 +5,7 @@ kind: Namespace
 metadata:
   name: kuma-system
   labels:
-    kuma.io/system-namespace: "true"
+    kuma.io/sidecar-injection: "false"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -590,7 +590,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 27eaaaa811fc2eed212bbcd5e84e09074d6da6742b4c89a96a33cce0fefd7ecb
+        checksum/tls-secrets: 9a78e134eea0948a37b49fe2fdab525eb0669f1a56a5b5d0479a537dc5e86219
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -1008,8 +1008,11 @@ webhooks:
   - name: secret.validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]
     namespaceSelector:
-      matchLabels:
-        kuma.io/system-namespace: "true"
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          - kuma-system
     failurePolicy: Ignore
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix13029.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix13029.golden.yaml
@@ -5,7 +5,7 @@ kind: Namespace
 metadata:
   name: kuma-system
   labels:
-    kuma.io/system-namespace: "true"
+    kuma.io/sidecar-injection: "false"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -608,7 +608,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 27eaaaa811fc2eed212bbcd5e84e09074d6da6742b4c89a96a33cce0fefd7ecb
+        checksum/tls-secrets: 9a78e134eea0948a37b49fe2fdab525eb0669f1a56a5b5d0479a537dc5e86219
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -1026,8 +1026,11 @@ webhooks:
   - name: secret.validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]
     namespaceSelector:
-      matchLabels:
-        kuma.io/system-namespace: "true"
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          - kuma-system
     failurePolicy: Ignore
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
@@ -5,7 +5,7 @@ kind: Namespace
 metadata:
   name: kuma-system
   labels:
-    kuma.io/system-namespace: "true"
+    kuma.io/sidecar-injection: "false"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -396,7 +396,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 3a137bbfcbbe6ba5a3997b30b1b047b2b080a9f912520a5fa683f11c4c6b6f3c
-        checksum/tls-secrets: 657976d1d15be570530803f20447e8f2958e1ce203d615f98c74be75c89636e1
+        checksum/tls-secrets: 6ca677bfd7776d1b12e940c3f3b292cf19c869d3a610054810f3a63961ed3187
       labels: 
         app: kuma-control-plane
         "foo": "baz"
@@ -817,8 +817,11 @@ webhooks:
   - name: secret.validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]
     namespaceSelector:
-      matchLabels:
-        kuma.io/system-namespace: "true"
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          - kuma-system
     failurePolicy: Ignore
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
@@ -5,7 +5,7 @@ kind: Namespace
 metadata:
   name: kuma-system
   labels:
-    kuma.io/system-namespace: "true"
+    kuma.io/sidecar-injection: "false"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -415,7 +415,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 2f553eadd8f68661f4b1fd0b3ccbbc562943d89fa76f2f2ba2975541290fda71
-        checksum/tls-secrets: 3151f37535f344e57c3df6ac2a14306ea9c637f139c3811b0256324f78bb9afd
+        checksum/tls-secrets: a1a2c445de348d454f7f963fdb77a929d313a47872eabc63a827fd0ba6e34bfd
       labels: 
         app: kuma-control-plane
         "foo": "bar"
@@ -993,8 +993,11 @@ webhooks:
   - name: secret.validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]
     namespaceSelector:
-      matchLabels:
-        kuma.io/system-namespace: "true"
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          - kuma-system
     failurePolicy: Ignore
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
@@ -5,7 +5,7 @@ kind: Namespace
 metadata:
   name: kuma-system
   labels:
-    kuma.io/system-namespace: "true"
+    kuma.io/sidecar-injection: "false"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -658,7 +658,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 27eaaaa811fc2eed212bbcd5e84e09074d6da6742b4c89a96a33cce0fefd7ecb
+        checksum/tls-secrets: 9a78e134eea0948a37b49fe2fdab525eb0669f1a56a5b5d0479a537dc5e86219
         bim: "bam"
         foo: "{\"bar\": \"baz\"}"
       labels: 
@@ -1378,8 +1378,11 @@ webhooks:
   - name: secret.validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]
     namespaceSelector:
-      matchLabels:
-        kuma.io/system-namespace: "true"
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          - kuma-system
     failurePolicy: Ignore
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix5978.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix5978.golden.yaml
@@ -5,7 +5,7 @@ kind: Namespace
 metadata:
   name: kuma-system
   labels:
-    kuma.io/system-namespace: "true"
+    kuma.io/sidecar-injection: "false"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -436,7 +436,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 27eaaaa811fc2eed212bbcd5e84e09074d6da6742b4c89a96a33cce0fefd7ecb
+        checksum/tls-secrets: 9a78e134eea0948a37b49fe2fdab525eb0669f1a56a5b5d0479a537dc5e86219
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -1119,8 +1119,11 @@ webhooks:
   - name: secret.validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]
     namespaceSelector:
-      matchLabels:
-        kuma.io/system-namespace: "true"
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          - kuma-system
     failurePolicy: Ignore
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix7724.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix7724.golden.yaml
@@ -5,7 +5,7 @@ kind: Namespace
 metadata:
   name: kuma-system
   labels:
-    kuma.io/system-namespace: "true"
+    kuma.io/sidecar-injection: "false"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -377,7 +377,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 27eaaaa811fc2eed212bbcd5e84e09074d6da6742b4c89a96a33cce0fefd7ecb
+        checksum/tls-secrets: 9a78e134eea0948a37b49fe2fdab525eb0669f1a56a5b5d0479a537dc5e86219
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -789,8 +789,11 @@ webhooks:
   - name: secret.validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]
     namespaceSelector:
-      matchLabels:
-        kuma.io/system-namespace: "true"
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          - kuma-system
     failurePolicy: Ignore
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix7824.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix7824.golden.yaml
@@ -5,7 +5,7 @@ kind: Namespace
 metadata:
   name: kuma-system
   labels:
-    kuma.io/system-namespace: "true"
+    kuma.io/sidecar-injection: "false"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -451,7 +451,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 27eaaaa811fc2eed212bbcd5e84e09074d6da6742b4c89a96a33cce0fefd7ecb
+        checksum/tls-secrets: 9a78e134eea0948a37b49fe2fdab525eb0669f1a56a5b5d0479a537dc5e86219
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -1194,8 +1194,11 @@ webhooks:
   - name: secret.validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]
     namespaceSelector:
-      matchLabels:
-        kuma.io/system-namespace: "true"
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          - kuma-system
     failurePolicy: Ignore
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/minReadySeconds.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/minReadySeconds.golden.yaml
@@ -5,7 +5,7 @@ kind: Namespace
 metadata:
   name: kuma-system
   labels:
-    kuma.io/system-namespace: "true"
+    kuma.io/sidecar-injection: "false"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -374,7 +374,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 27eaaaa811fc2eed212bbcd5e84e09074d6da6742b4c89a96a33cce0fefd7ecb
+        checksum/tls-secrets: 9a78e134eea0948a37b49fe2fdab525eb0669f1a56a5b5d0479a537dc5e86219
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -786,8 +786,11 @@ webhooks:
   - name: secret.validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]
     namespaceSelector:
-      matchLabels:
-        kuma.io/system-namespace: "true"
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          - kuma-system
     failurePolicy: Ignore
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/securityContext.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/securityContext.golden.yaml
@@ -5,7 +5,7 @@ kind: Namespace
 metadata:
   name: kuma-system
   labels:
-    kuma.io/system-namespace: "true"
+    kuma.io/sidecar-injection: "false"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -374,7 +374,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 27eaaaa811fc2eed212bbcd5e84e09074d6da6742b4c89a96a33cce0fefd7ecb
+        checksum/tls-secrets: 9a78e134eea0948a37b49fe2fdab525eb0669f1a56a5b5d0479a537dc5e86219
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -787,8 +787,11 @@ webhooks:
   - name: secret.validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]
     namespaceSelector:
-      matchLabels:
-        kuma.io/system-namespace: "true"
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          - kuma-system
     failurePolicy: Ignore
     clientConfig:
       caBundle: XYZ

--- a/deployments/charts/kuma/templates/cp-webhooks-and-secrets.yaml
+++ b/deployments/charts/kuma/templates/cp-webhooks-and-secrets.yaml
@@ -271,8 +271,11 @@ webhooks:
   - name: secret.validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]
     namespaceSelector:
-      matchLabels:
-        kuma.io/system-namespace: "true"
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          - {{ .Release.Namespace }}
     failurePolicy: Ignore
     clientConfig:
       caBundle: {{ $caBundle }}

--- a/deployments/charts/kuma/templates/pre-install-patch-namespace-job.yaml
+++ b/deployments/charts/kuma/templates/pre-install-patch-namespace-job.yaml
@@ -1,11 +1,11 @@
 {{- if and ( .Values.noHelmHooks ) (eq .Values.controlPlane.environment "kubernetes") }}
-  {{- $errorMessage := ".Values.noHelmHooks is set. You must manually create and label the system namespace with kuma.io/system-namespace: \"true\" before installing or upgrading the chart" }}
+  {{- $errorMessage := ".Values.noHelmHooks is set. You must manually create and label the system namespace with kuma.io/sidecar-injection: \"false\" before installing or upgrading the chart" }}
   {{- $systemNamespace := (lookup "v1" "Namespace" "" .Release.Namespace) }}
   {{- if not $systemNamespace }}
       {{- fail $errorMessage }}
     {{- end }}
   {{- $systemNamespaceLabels := ($systemNamespace).metadata.labels }}
-  {{- if ne (get $systemNamespaceLabels "kuma.io/system-namespace") "true" }}
+  {{- if ne (get $systemNamespaceLabels "kuma.io/sidecar-injection") "false" }}
     {{- fail $errorMessage }}
   {{- end }}
 {{- else}}
@@ -119,6 +119,6 @@ spec:
             - '--type'
             - 'merge'
             - '--patch'
-            - '{ "metadata": { "labels": { "kuma.io/system-namespace": "true" } } }'
+            - '{ "metadata": { "labels": { "kuma.io/sidecar-injection": "false" } } }'
   {{- end }}
 {{- end }}

--- a/pkg/config/app/kuma-dp/testdata/default-config.golden.yaml
+++ b/pkg/config/app/kuma-dp/testdata/default-config.golden.yaml
@@ -7,11 +7,11 @@ controlPlane:
     maxDuration: 5m0s
   url: https://localhost:5678
 dataplane:
-  resilientComponentMaxBackoff: 1m0s
   drainTime: 30s
   proxyType: dataplane
   readinessPort: 9902
   resilientComponentBaseBackoff: 5s
+  resilientComponentMaxBackoff: 1m0s
 dataplaneRuntime:
   binaryPath: envoy
   dynamicConfiguration:


### PR DESCRIPTION
## Motivation

Since Kubernetes 1.22, the API server automatically sets the `kubernetes.io/metadata.name` label on all namespaces. Thanks to this, we no longer need our custom label for the Secret webhook.

## Implementation information

* Don't requires `kuma.io/system-namespace` label
* Set automatically `kuma.io/sidecar-injection: false` on the system namespace
* Secret webhook can filter event by `kuma.io/system-namespace` equal to the `Release.Namespace`
* Added note to the `UPGRADE.md`

## Supporting documentation

Fix https://github.com/kumahq/kuma/issues/13343