### PR TITLE
fix(openapi): rename RSAbits to rsaBits

### DIFF
--- a/api/mesh/v1alpha1/builtincertificateauthorityconfig/schema.yaml
+++ b/api/mesh/v1alpha1/builtincertificateauthorityconfig/schema.yaml
@@ -4,11 +4,11 @@ components:
       properties:
         caCert:
           properties:
-            RSAbits:
-              format: uint32
-              type: integer
             expiration:
               type: string
+            rsaBits:
+              format: uint32
+              type: integer
           type: object
       type: object
 info:

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -13676,11 +13676,11 @@ components:
       properties:
         caCert:
           properties:
-            RSAbits:
-              format: uint32
-              type: integer
             expiration:
               type: string
+            rsaBits:
+              format: uint32
+              type: integer
           type: object
       type: object
     DatadogTracingBackendConfig:

--- a/tools/resource-gen/pkg/generator/main.go
+++ b/tools/resource-gen/pkg/generator/main.go
@@ -456,11 +456,16 @@ var ProtoTypeToType = map[string]reflect.Type{
 
 func openApiGenerator(pkg string, resources []ResourceInfo) error {
 	// this is where the new types need to be added if we want to generate openAPI for it
-
 	reflector := jsonschema.Reflector{
 		ExpandedStruct:            true,
 		DoNotReference:            true,
 		AllowAdditionalProperties: true,
+		KeyNamer: func(key string) string {
+			if key == "RSAbits" {
+				return "rsaBits"
+			}
+			return key
+		},
 	}
 	err := reflector.AddGoComments("github.com/kumahq/kuma/", path.Join(readDir, "api/"))
 	if err != nil {


### PR DESCRIPTION
## Motivation

so it's generated as `rsa_bits` in the terraform provider (and not as `rs_abits`)

## Implementation information

add a key mapper

## Supporting documentation

Fix https://github.com/Kong/terraform-provider-kong-mesh/pull/6
