### PR TITLE
chore(mk): print pod logs on wait failure

### DIFF
--- a/mk/kind.mk
+++ b/mk/kind.mk
@@ -58,10 +58,18 @@ kind/wait:
 	@TIMES_TRIED=0; \
 	MAX_ALLOWED_TRIES=30; \
 	until KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) wait -n kube-system --timeout=5s --for condition=Ready --all pods; do \
-    	echo "Waiting for the cluster to come up" && sleep 1; \
-  		TIMES_TRIED=$$((TIMES_TRIED+1)); \
-  		if [[ $$TIMES_TRIED -ge $$MAX_ALLOWED_TRIES ]]; then KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) get pods -n kube-system -o Name | KUBECONFIG=$(KIND_KUBECONFIG) xargs -I % $(KUBECTL) -n kube-system describe %; exit 1; fi \
-    done
+		echo "Waiting for the cluster to come up" && sleep 1; \
+		TIMES_TRIED=$$((TIMES_TRIED+1)); \
+		if [[ $$TIMES_TRIED -ge $$MAX_ALLOWED_TRIES ]]; then \
+			KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) get pods -n kube-system -o name | while read pod; do \
+				echo "=== Describe $$pod ==="; \
+				KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) -n kube-system describe $$pod; \
+				echo "\n=== Logs for $$pod ==="; \
+				KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) -n kube-system logs $$pod || true; \
+			done; \
+			exit 1; \
+		fi; \
+	done
 
 .PHONY: kind/stop
 kind/stop: kind/cleanup-docker-credentials


### PR DESCRIPTION
## Motivation

We need a way to debug why coreDNS readiness probe is failing https://github.com/kumahq/kuma/actions/runs/14436371337/job/40478469657#step:12:649

## Implementation information

make the target a bit easier to read and add invocation to print logs
