### PR TITLE
ci(ipv6): disable kind ip v6 because of a kernel bug

### DIFF
--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -23,7 +23,8 @@ jobs:
     timeout-minutes: 60
     # can't use env vars here
     runs-on: ${{ inputs.runner }}
-    if: ${{ inputs.runner != '' }}
+    # workaround for this bug https://github.com/actions/runner-images/issues/11985 - revert when done
+    if: ${{ fromJSON(inputs.matrix).k8sVersion != 'kindipv6' && inputs.runner != '' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Motivation

Because of https://github.com/actions/runner-images/issues/11985

## Implementation information

Add if around "runs-on".