### PR TITLE
chore(scan): reenable skip_cis_scan since the issue was fixed upstream

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -139,7 +139,7 @@ jobs:
           asset_prefix: image_${{ matrix.image }}-amd64
           image: ./build/docker/${{ matrix.image }}-amd64.tar
           upload-sbom-release-assets: true
-          skip_cis_scan: true
+          skip_cis_scan: false
       - name: scan arm64 image
         id: scan_image-arm64
         if: ${{ fromJSON(inputs.FULL_MATRIX) }}
@@ -148,7 +148,7 @@ jobs:
           asset_prefix: image_${{ matrix.image }}-arm64
           image: ./build/docker/${{ matrix.image }}-arm64.tar
           upload-sbom-release-assets: true
-          skip_cis_scan: true
+          skip_cis_scan: false
         # TODO in the future we may want to have prerelease images and use `regctl image copy` to move them to their final location
       - name: publish images
         id: release_images


### PR DESCRIPTION
## Motivation

Got an answer on slack that https://github.com/Kong/public-shared-actions/releases/tag/%40security-actions%2Fscan-docker-image%404.1.5 fixed this issue so let's try an re-enable it.

## Implementation information

Change to false.

Closes https://github.com/kumahq/kuma/issues/11544