### PR TITLE
chore(check): verify that UPGRADE.md has changed after Role change

### DIFF
--- a/mk/check.mk
+++ b/mk/check.mk
@@ -74,7 +74,7 @@ api-lint:
 		github.com/kumahq/kuma/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1
 
 .PHONY: check
-check: format lint ## Dev: Run code checks (go fmt, go vet, ...)
+check: format lint check/rbac ## Dev: Run code checks (go fmt, go vet, ...)
 	@untracked() { git ls-files --other --directory --exclude-standard --no-empty-directory; }; \
 	check-changes() { git --no-pager diff "$$@"; }; \
 	if [ $$(untracked | wc -l) -gt 0 ]; then \
@@ -88,6 +88,15 @@ check: format lint ## Dev: Run code checks (go fmt, go vet, ...)
 		check-changes; \
 	fi; \
 	if [ "$$FAILED" = true ]; then exit 1; fi
+
+.PHONY: check/rbac
+check/rbac:
+	@RBAC_CHANGED=$$(git --no-pager diff --name-only -- deployments/ | xargs grep -E 'kind: (Role|RoleBinding|ClusterRole|ClusterRoleBinding)' || true); \
+	UPGRADE_CHANGED=$$(git --no-pager diff --quiet UPGRADE.md; [ $$? -ne 0 ] && echo true || echo ""); \
+	if [ -n "$$RBAC_CHANGED" ] && [ -z "$$UPGRADE_CHANGED" ]; then \
+		echo "Detected RBAC changes, but UPGRADE.md was not updated. Please document the change in UPGRADE.md."; \
+		exit 1; \
+	fi
 
 .PHONY: update-vulnerable-dependencies
 update-vulnerable-dependencies:


### PR DESCRIPTION
## Motivation

We want to avoid frequent changes to RBAC and ensure that users who upgrade and have RBAC creation disabled will see a note about it in the UPGRADE.md.

## Implementation information

I've added a `check/rbac` command to check for changed files, specifically looking for `Role`, `RoleBinding`, `ClusterRole`, or `ClusterRoleBinding`. It also verifies that `UPGRADE.md` has been updated. If any RBAC-related changes are detected, the command will fail with a message.

## Supporting documentation

Fix: https://github.com/kumahq/kuma/issues/13386