### PR TITLE
fix(kuma-dp): change log level of fetcher to debug

### DIFF
--- a/app/kuma-dp/pkg/dataplane/configfetcher/component.go
+++ b/app/kuma-dp/pkg/dataplane/configfetcher/component.go
@@ -136,7 +136,7 @@ func (cf *ConfigFetcher) stepForHandler(h *handlerInfo) (bool, error) {
 	if err != nil {
 		var opErr *net.OpError
 		if errors.As(err, &opErr) && os.IsNotExist(opErr.Err) {
-			h.l.Info("skipping fetch endpoint scrape since socket does not exist, this is likely about to start", "err", err)
+			h.l.V(1).Info("skipping fetch endpoint scrape since socket does not exist, this is likely about to start", "err", err)
 			return false, nil
 		}
 		// this error can only occur when we configured policy once and then remove it. Listener is removed but socket file


### PR DESCRIPTION
## Motivation

`kuma-dp` starts a fetcher to retrieve the configuration for various components, such as DNS and mesh metrics. For DNS, this is controlled by a flag that enables or disables it. The issue lies with mesh metrics, which are dynamically configured via policy. This means we need to attempt to fetch the configuration on each tick. If no configuration is found, we log a message. However, this log is overly aggressive and can obscure other potential issues.

## Implementation information

Change log level to debug

## Supporting documentation

Fix https://github.com/kumahq/kuma/issues/13357
