### PR TITLE
ci(pr-comments): fix format comment

### DIFF
--- a/.github/workflows/pr-comments.yaml
+++ b/.github/workflows/pr-comments.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: format
         if: contains(github.event.comment.body, '/format') # check the comment if it contains the keywords
         run: |
-          make clean/generated generate format
+          make clean/generated check
       - name: run golden_files
         if: contains(github.event.comment.body, '/golden_files') # check the comment if it contains the keywords
         run: |


### PR DESCRIPTION
## Motivation

We didnt run a linter.

## Implementation information

Changed a generate and format to check command

## Supporting documentation

> Changelog: skip
