### PR TITLE
ci(codeql): skip warning in the test file

### DIFF
--- a/test/framework/universal/networking.go
+++ b/test/framework/universal/networking.go
@@ -69,20 +69,20 @@ func (s *Networking) initSSH() (int, error) {
 					return s.id, fmt.Errorf("failed to parse ssh private key: %w", err)
 				}
 
+				// codeql[go/insecure-hostkeycallback]: just for tests
 				configCfg := &ssh.ClientConfig{
 					User: s.RemoteHost.User,
 					Auth: []ssh.AuthMethod{
 						ssh.PublicKeys(signer),
 					},
-					// codeql[go/insecure-hostkeycallback]: just for tests
 					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //#nosec G106 // skip for tests
 				}
 
 				client, err = ssh.Dial("tcp", net.JoinHostPort(s.RemoteHost.Address,
 					strconv.Itoa(s.RemoteHost.Port)), configCfg)
 			} else {
+				// codeql[go/insecure-hostkeycallback]: just for tests
 				client, err = ssh.Dial("tcp", net.JoinHostPort("localhost", s.SshPort), &ssh.ClientConfig{
-					// codeql[go/insecure-hostkeycallback]: just for tests
 					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //#nosec G106 // skip for tests
 					User:            "root",
 				})

--- a/test/framework/universal/networking.go
+++ b/test/framework/universal/networking.go
@@ -74,14 +74,16 @@ func (s *Networking) initSSH() (int, error) {
 					Auth: []ssh.AuthMethod{
 						ssh.PublicKeys(signer),
 					},
-					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //#nosec G106 // skip for tests // codeql[go/insecure-hostkeycallback]: just for tests
+					// codeql[go/insecure-hostkeycallback]: just for tests
+					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //#nosec G106 // skip for tests
 				}
 
 				client, err = ssh.Dial("tcp", net.JoinHostPort(s.RemoteHost.Address,
 					strconv.Itoa(s.RemoteHost.Port)), configCfg)
 			} else {
 				client, err = ssh.Dial("tcp", net.JoinHostPort("localhost", s.SshPort), &ssh.ClientConfig{
-					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //#nosec G106 // skip for tests // codeql[go/insecure-hostkeycallback]: just for tests
+					// codeql[go/insecure-hostkeycallback]: just for tests
+					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //#nosec G106 // skip for tests
 					User:            "root",
 				})
 			}

--- a/test/framework/universal/networking.go
+++ b/test/framework/universal/networking.go
@@ -74,14 +74,14 @@ func (s *Networking) initSSH() (int, error) {
 					Auth: []ssh.AuthMethod{
 						ssh.PublicKeys(signer),
 					},
-					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //#nosec G106 // skip for tests
+					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //#nosec G106 // skip for tests // codeql[go/insecure-hostkeycallback]: just for tests
 				}
 
 				client, err = ssh.Dial("tcp", net.JoinHostPort(s.RemoteHost.Address,
 					strconv.Itoa(s.RemoteHost.Port)), configCfg)
 			} else {
 				client, err = ssh.Dial("tcp", net.JoinHostPort("localhost", s.SshPort), &ssh.ClientConfig{
-					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //#nosec G106 // skip for tests // lgtm [go/insecure-hostkeycallback]
+					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //#nosec G106 // skip for tests // codeql[go/insecure-hostkeycallback]: just for tests
 					User:            "root",
 				})
 			}

--- a/test/framework/universal/networking.go
+++ b/test/framework/universal/networking.go
@@ -69,21 +69,19 @@ func (s *Networking) initSSH() (int, error) {
 					return s.id, fmt.Errorf("failed to parse ssh private key: %w", err)
 				}
 
-				// codeql[go/insecure-hostkeycallback]: just for tests
 				configCfg := &ssh.ClientConfig{
 					User: s.RemoteHost.User,
 					Auth: []ssh.AuthMethod{
 						ssh.PublicKeys(signer),
 					},
-					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //#nosec G106 // skip for tests
+					HostKeyCallback: ssh.InsecureIgnoreHostKey(), // lgtm[go/insecure-hostkeycallback] //#nosec G106 // skip for tests
 				}
 
 				client, err = ssh.Dial("tcp", net.JoinHostPort(s.RemoteHost.Address,
 					strconv.Itoa(s.RemoteHost.Port)), configCfg)
 			} else {
-				// codeql[go/insecure-hostkeycallback]: just for tests
 				client, err = ssh.Dial("tcp", net.JoinHostPort("localhost", s.SshPort), &ssh.ClientConfig{
-					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //#nosec G106 // skip for tests
+					HostKeyCallback: ssh.InsecureIgnoreHostKey(), // lgtm[go/insecure-hostkeycallback] //#nosec G106 // skip for tests
 					User:            "root",
 				})
 			}


### PR DESCRIPTION
## Motivation

We can see security issues but they are not, since we use these files only in tests.

## Implementation information

Ignore this validation in specific line

## Supporting documentation

> Changelog: skip
