### PR TITLE
feat(kuma-dp): add support for dynamic transparent proxy config

### DIFF
--- a/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap.go
@@ -187,7 +187,8 @@ func (b *remoteBootstrap) requestForBootstrap(ctx context.Context, client *http.
 			CertPath: params.MetricsCertPath,
 			KeyPath:  params.MetricsKeyPath,
 		},
-		SystemCaPath: params.SystemCaPath,
+		SystemCaPath:     params.SystemCaPath,
+		TransparentProxy: cfg.DataplaneRuntime.TransparentProxy,
 	}
 	jsonBytes, err := json.MarshalIndent(request, "", " ")
 	if err != nil {

--- a/app/kumactl/cmd/install/install_transparent_proxy.go
+++ b/app/kumactl/cmd/install/install_transparent_proxy.go
@@ -166,7 +166,7 @@ runuser -u kuma-dp -- \
 
 			// After parsing the config flags, we load the configuration, which involves parsing
 			// the provided YAML or JSON, and including environment variables if present
-			if err := cfgLoader.Load(cmd.InOrStdin(), []byte(configValue), configFile); err != nil {
+			if err := cfgLoader.Load(cmd.InOrStdin(), configFile, configValue); err != nil {
 				return errors.Wrap(err, "failed to load configuration from provided input")
 			}
 

--- a/pkg/config/app/kuma-dp/config.go
+++ b/pkg/config/app/kuma-dp/config.go
@@ -13,7 +13,8 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/config"
 	config_types "github.com/kumahq/kuma/pkg/config/types"
-	"github.com/kumahq/kuma/pkg/core/xds"
+	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
+	tproxy_config "github.com/kumahq/kuma/pkg/transparentproxy/config/dataplane"
 )
 
 var DefaultConfig = func() Config {
@@ -72,11 +73,17 @@ type Config struct {
 
 func (c *Config) Features() []string {
 	base := []string{
-		xds.FeatureTCPAccessLogViaNamedPipe,
+		xds_types.FeatureTCPAccessLogViaNamedPipe,
 	}
+
 	if c.DNS.ProxyPort != 0 {
-		base = append(base, xds.FeatureEmbeddedDNS)
+		base = append(base, xds_types.FeatureEmbeddedDNS)
 	}
+
+	if c.DataplaneRuntime.TransparentProxy != nil {
+		base = append(base, xds_types.FeatureTransparentProxyInDataplaneMetadata)
+	}
+
 	return base
 }
 
@@ -234,6 +241,10 @@ type DataplaneRuntime struct {
 	DynamicConfiguration DynamicConfiguration `json:"dynamicConfiguration" envconfig:"kuma_dataplane_runtime_dynamic_configuration"`
 	// SystemCaPath defines path of system provided Ca
 	SystemCaPath string `json:"systemCaPath,omitempty" envconfig:"kuma_dataplane_runtime_dynamic_system_ca_path"`
+	// TransparentProxy configures transparent proxy settings for the dataplane,
+	// including redirect behavior, DNS capture, and IP family mode.
+	// This is used to determine how traffic redirection and interception is handled.
+	TransparentProxy *tproxy_config.DataplaneConfig `json:"transparentProxy,omitempty" envconfig:"kuma_dataplane_runtime_transparent_proxy"`
 }
 
 type Metrics struct {

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"reflect"
+	"strings"
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/pkg/errors"
@@ -39,14 +40,26 @@ func (l *Loader) WithValidation() *Loader {
 	return l
 }
 
-func (l *Loader) Load(stdin io.Reader, content []byte, filename string) error {
-	switch filename {
-	case "-":
+func (l *Loader) Load(stdin io.Reader, values ...string) error {
+	for _, value := range values {
+		if err := l.load(stdin, value); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (l *Loader) load(stdin io.Reader, value string) error {
+	switch {
+	case strings.TrimSpace(value) == "":
+		return nil
+	case value == "-":
 		return l.LoadReader(stdin)
-	case "":
-		return l.LoadBytes(content)
+	case l.LoadBytes([]byte(value)) != nil:
+		return l.LoadFile(value)
 	default:
-		return l.LoadFile(filename)
+		return nil
 	}
 }
 

--- a/pkg/core/resources/apis/mesh/dataplane_helpers_test.go
+++ b/pkg/core/resources/apis/mesh/dataplane_helpers_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	. "github.com/kumahq/kuma/pkg/test/matchers"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
+	tproxy_dp "github.com/kumahq/kuma/pkg/transparentproxy/config/dataplane"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 )
 
@@ -563,7 +564,7 @@ var _ = Describe("Dataplane", func() {
 				}
 
 				// expect
-				Expect(dataplane.IsUsingTransparentProxy()).To(Equal(given.expected))
+				Expect(tproxy_dp.GetDataplaneConfig(dataplane, nil).Enabled()).To(Equal(given.expected))
 			},
 			Entry("`nil` dataplane", testCase{
 				dataplane: ``,

--- a/pkg/core/xds/types.go
+++ b/pkg/core/xds/types.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/registry"
 	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
 	util_tls "github.com/kumahq/kuma/pkg/tls"
+	tproxy_dp "github.com/kumahq/kuma/pkg/transparentproxy/config/dataplane"
 )
 
 type APIVersion string
@@ -194,6 +195,10 @@ type Proxy struct {
 	Zone string
 	// InternalAddresses is a set of address prefixes that are considered internal to the mesh, it will be configured to in Envoy HCM config
 	InternalAddresses []InternalAddress
+}
+
+func (p *Proxy) GetTransparentProxy() *tproxy_dp.DataplaneConfig {
+	return tproxy_dp.GetDataplaneConfig(p.Dataplane, p.Metadata)
 }
 
 type ServerSideMTLSCerts struct {

--- a/pkg/core/xds/types/features.go
+++ b/pkg/core/xds/types/features.go
@@ -1,4 +1,4 @@
-package xds
+package types
 
 // Features is a set of features which a data plane has enabled.
 type Features map[string]bool
@@ -17,3 +17,5 @@ const FeatureTCPAccessLogViaNamedPipe string = "feature-tcp-accesslog-via-named-
 
 // FeatureEmbeddedDNS indicates that the DP runs with the embedded DNS instead of the buddy coreDNS
 const FeatureEmbeddedDNS string = "feature-embedded-dns"
+
+const FeatureTransparentProxyInDataplaneMetadata string = "feature-transparent-proxy-in-dataplane-metadata"

--- a/pkg/hds/tracker/healthcheck_generator.go
+++ b/pkg/hds/tracker/healthcheck_generator.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/user"
 	"github.com/kumahq/kuma/pkg/core/xds"
 	v3 "github.com/kumahq/kuma/pkg/hds/v3"
+	tproxy_dp "github.com/kumahq/kuma/pkg/transparentproxy/config/dataplane"
 	"github.com/kumahq/kuma/pkg/util/net"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	util_xds_v3 "github.com/kumahq/kuma/pkg/util/xds/v3"
@@ -124,7 +125,9 @@ func (g *SnapshotGenerator) GenerateSnapshot(ctx context.Context, node *envoy_co
 			},
 		}
 
-		if dp.IsUsingTransparentProxy() && (intf.WorkloadIP != mesh.IPv4Loopback.String() && intf.WorkloadIP != mesh.IPv6Loopback.String()) {
+		meta := xds.DataplaneMetadataFromXdsMetadata(node.GetMetadata())
+		tpCfg := tproxy_dp.GetDataplaneConfig(dp, meta)
+		if tpCfg.Enabled() && (intf.WorkloadIP != mesh.IPv4Loopback.String() && intf.WorkloadIP != mesh.IPv6Loopback.String()) {
 			if net.IsAddressIPv6(intf.WorkloadIP) {
 				hc.UpstreamBindConfig = g.upstreamBindConfig(generator.InPassThroughIPv6, 0)
 			} else {

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
@@ -33,7 +33,7 @@ func generateFromService(
 	svc meshroute_xds.DestinationService,
 ) (*core_xds.ResourceSet, error) {
 	listenerBuilder := envoy_listeners.NewOutboundListenerBuilder(proxy.APIVersion, svc.Outbound.GetAddress(), svc.Outbound.GetPort(), core_xds.SocketAddressProtocolTCP).
-		Configure(envoy_listeners.TransparentProxying(proxy.Dataplane.Spec.Networking.GetTransparentProxying())).
+		Configure(envoy_listeners.TransparentProxying(proxy)).
 		Configure(envoy_listeners.TagsMetadata(envoy_tags.Tags(svc.Outbound.TagsOrNil()).WithoutTags(mesh_proto.MeshTag)))
 
 	resourceName := svc.ServiceName

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners.go
@@ -97,9 +97,7 @@ func buildOutboundListener(
 		core_xds.SocketAddressProtocolTCP,
 	)
 
-	tproxy := envoy_listeners.TransparentProxying(
-		proxy.Dataplane.Spec.GetNetworking().GetTransparentProxying(),
-	)
+	tproxy := envoy_listeners.TransparentProxying(proxy)
 
 	tagsMetadata := envoy_listeners.TagsMetadata(
 		envoy_tags.Tags(svc.Outbound.TagsOrNil()).WithoutTags(mesh_proto.MeshTag),

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin.go
@@ -274,7 +274,7 @@ func configure(
 	service := inbound.GetService()
 	routes := generator.GenerateRoutes(proxy, iface, cluster)
 	listenerBuilder := envoy_listeners.NewInboundListenerBuilder(proxy.APIVersion, iface.DataplaneIP, iface.DataplanePort, core_xds.SocketAddressProtocolTCP).
-		Configure(envoy_listeners.TransparentProxying(proxy.Dataplane.Spec.Networking.GetTransparentProxying())).
+		Configure(envoy_listeners.TransparentProxying(proxy)).
 		Configure(envoy_listeners.TagsMetadata(inbound.GetTags()))
 
 	switch mode {

--- a/pkg/transparentproxy/config/config.go
+++ b/pkg/transparentproxy/config/config.go
@@ -18,6 +18,7 @@ import (
 	core_config "github.com/kumahq/kuma/pkg/config"
 	config_types "github.com/kumahq/kuma/pkg/config/types"
 	"github.com/kumahq/kuma/pkg/transparentproxy/consts"
+	"github.com/kumahq/kuma/pkg/util/pointer"
 )
 
 // ValueOrRangeList is a format acceptable by iptables in which
@@ -56,7 +57,9 @@ var _ json.Unmarshaler = (*Port)(nil)
 
 type Port uint16
 
-func (p *Port) String() string { return strconv.Itoa(int(*p)) }
+func (p *Port) Uint32() uint32 { return uint32(pointer.Deref(p)) }
+
+func (p *Port) String() string { return strconv.Itoa(int(pointer.Deref(p))) }
 
 func (p *Port) Type() string { return "uint16" }
 
@@ -689,6 +692,10 @@ func (c Config) InitializeKumaDPUser() (string, error) {
 }
 
 type IPFamilyMode string
+
+func IPFamilyModeFromStringer(s fmt.Stringer) IPFamilyMode {
+	return IPFamilyMode(strings.ToLower(s.String()))
+}
 
 func (e *IPFamilyMode) UnmarshalJSON(bs []byte) error {
 	var value string

--- a/pkg/transparentproxy/config/dataplane/config_dataplane.go
+++ b/pkg/transparentproxy/config/dataplane/config_dataplane.go
@@ -1,0 +1,164 @@
+package dataplane
+
+import (
+	"github.com/asaskevich/govalidator"
+	"golang.org/x/exp/constraints"
+
+	core_config "github.com/kumahq/kuma/pkg/config"
+	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
+	tproxy_config "github.com/kumahq/kuma/pkg/transparentproxy/config"
+	"github.com/kumahq/kuma/pkg/util/pointer"
+)
+
+type PortLike interface {
+	constraints.Integer | constraints.Float | tproxy_config.Port
+}
+
+type DataplaneConfigGetter interface {
+	GetTransparentProxy() *DataplaneConfig
+}
+
+type DataplaneResourcer interface {
+	DataplaneConfigGetter
+	GetAddress() string
+}
+
+type DataplaneMetadater interface {
+	DataplaneConfigGetter
+	HasFeature(string) bool
+	GetDNSPort() uint32
+}
+
+type DatalpaneTrafficFlow struct {
+	Enabled bool               `json:"enabled"`
+	Port    tproxy_config.Port `json:"port"`
+}
+
+func NewDataplaneTrafficFlow[T PortLike](enabled bool, port T) DatalpaneTrafficFlow {
+	return DatalpaneTrafficFlow{
+		Enabled: enabled,
+		Port:    tproxy_config.Port(port),
+	}
+}
+
+func DataplaneTrafficFlowFromPortLike[T PortLike](port T) DatalpaneTrafficFlow {
+	return NewDataplaneTrafficFlow(port > 0, port)
+}
+
+type DataplaneRedirect struct {
+	Inbound  DatalpaneTrafficFlow `json:"inbound"`
+	Outbound DatalpaneTrafficFlow `json:"outbound"`
+	DNS      DatalpaneTrafficFlow `json:"dns"`
+}
+
+type DataplaneConfig struct {
+	core_config.BaseConfig
+
+	IPFamilyMode tproxy_config.IPFamilyMode `json:"ipFamilyMode"`
+	Redirect     DataplaneRedirect          `json:"redirect"`
+
+	address string
+}
+
+func (c *DataplaneConfig) withAddress(address string) *DataplaneConfig {
+	if c == nil {
+		return nil
+	}
+	c.address = address
+	return c
+}
+
+func (c *DataplaneConfig) withDNSPort(port uint32) *DataplaneConfig {
+	if c == nil {
+		return nil
+	}
+	c.Redirect.DNS = DataplaneTrafficFlowFromPortLike(port)
+	return c
+}
+
+func (c *DataplaneConfig) Enabled() bool {
+	if c == nil || !c.Redirect.Inbound.Enabled || !c.Redirect.Outbound.Enabled {
+		return false
+	}
+	return c.IPFamilyMode != tproxy_config.IPFamilyModeIPv4 || govalidator.IsIPv4(c.address)
+}
+
+func (c *DataplaneConfig) EnabledIPv6() bool {
+	if c == nil {
+		return false
+	}
+	// IPv4 addresses can always be represented in IPv6 format (as ::ffff:a.b.c.d),
+	// so there's no need to verify the format of the address itself.
+	// It's enough to check that the configured IP family mode is not IPv4.
+	return c.IPFamilyMode != tproxy_config.IPFamilyModeIPv4
+}
+
+func hasFeature(meta DataplaneMetadater, feature string) bool {
+	if meta == nil {
+		return false
+	}
+	return meta.HasFeature(feature)
+}
+
+func getDNSPort(meta DataplaneMetadater) uint32 {
+	if meta == nil {
+		return 0
+	}
+	return meta.GetDNSPort()
+}
+
+func getAddress(dp DataplaneResourcer) string {
+	if dp == nil {
+		return ""
+	}
+	return dp.GetAddress()
+}
+
+func getConfig(cg DataplaneConfigGetter, fallback DataplaneConfig) *DataplaneConfig {
+	if cg == nil {
+		return pointer.To(fallback)
+	}
+
+	if tp := cg.GetTransparentProxy(); tp != nil {
+		return tp
+	}
+
+	return pointer.To(fallback)
+}
+
+func GetDataplaneConfig(dp DataplaneResourcer, meta DataplaneMetadater) *DataplaneConfig {
+	dnsPort := getDNSPort(meta)
+	address := getAddress(dp)
+
+	if hasFeature(meta, xds_types.FeatureTransparentProxyInDataplaneMetadata) {
+		return getConfig(meta, DefaultDataplaneConfig()).
+			withDNSPort(dnsPort).
+			withAddress(address)
+	}
+
+	return getConfig(dp, DataplaneConfig{}).
+		withDNSPort(dnsPort).
+		withAddress(address)
+}
+
+func DefaultDataplaneConfig() DataplaneConfig {
+	cfg := tproxy_config.DefaultConfig()
+
+	return DataplaneConfig{
+		IPFamilyMode: cfg.IPFamilyMode,
+		Redirect: DataplaneRedirect{
+			Inbound: NewDataplaneTrafficFlow(
+				cfg.Redirect.Inbound.Enabled,
+				cfg.Redirect.Inbound.Port,
+			),
+			Outbound: NewDataplaneTrafficFlow(
+				cfg.Redirect.Outbound.Enabled,
+				cfg.Redirect.Outbound.Port,
+			),
+			DNS: NewDataplaneTrafficFlow(
+				cfg.Redirect.DNS.Enabled,
+				cfg.Redirect.DNS.Port,
+			),
+		},
+	}
+}

--- a/pkg/transparentproxy/config/dataplane/config_dataplane_suite_test.go
+++ b/pkg/transparentproxy/config/dataplane/config_dataplane_suite_test.go
@@ -1,0 +1,13 @@
+package dataplane_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func Test(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Transparent Proxy DataplaneConfig Suite")
+}

--- a/pkg/transparentproxy/config/dataplane/config_dataplane_test.go
+++ b/pkg/transparentproxy/config/dataplane/config_dataplane_test.go
@@ -111,7 +111,7 @@ var _ = Describe("DataplaneConfig functions", func() {
 				features: map[string]bool{
 					core_xds.FeatureTransparentProxyInDataplaneMetadata: true,
 				},
-				dnsPort:  12345,
+				dnsPort: 12345,
 			}
 
 			// when

--- a/pkg/transparentproxy/config/dataplane/config_dataplane_test.go
+++ b/pkg/transparentproxy/config/dataplane/config_dataplane_test.go
@@ -1,0 +1,146 @@
+package dataplane_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	core_xds "github.com/kumahq/kuma/pkg/core/xds/types"
+	tproxy_config "github.com/kumahq/kuma/pkg/transparentproxy/config"
+	tproxy_dp "github.com/kumahq/kuma/pkg/transparentproxy/config/dataplane"
+)
+
+type dummyMeta struct {
+	tproxy_dp.DataplaneConfig
+	features map[string]bool
+	dnsPort  uint32
+}
+
+func (d *dummyMeta) GetTransparentProxy() *tproxy_dp.DataplaneConfig { return &d.DataplaneConfig }
+
+func (d *dummyMeta) HasFeature(f string) bool { return d.features[f] }
+
+func (d *dummyMeta) GetDNSPort() uint32 { return d.dnsPort }
+
+type dummyDP struct {
+	tproxy_dp.DataplaneConfig
+	address string
+}
+
+func (d *dummyDP) GetTransparentProxy() *tproxy_dp.DataplaneConfig { return &d.DataplaneConfig }
+
+func (d *dummyDP) GetAddress() string { return d.address }
+
+var _ = Describe("DataplaneConfig functions", func() {
+	Describe("Enabled", func() {
+		It("should return true if IPv4 and redirect is enabled", func() {
+			// given
+			dp := &dummyDP{
+				DataplaneConfig: tproxy_dp.DataplaneConfig{
+					IPFamilyMode: tproxy_config.IPFamilyModeDualStack,
+					Redirect: tproxy_dp.DataplaneRedirect{
+						Inbound:  tproxy_dp.DatalpaneTrafficFlow{Enabled: true},
+						Outbound: tproxy_dp.DatalpaneTrafficFlow{Enabled: true},
+					},
+				},
+				address: "192.0.2.1",
+			}
+
+			// when
+			cfg := tproxy_dp.GetDataplaneConfig(dp, nil)
+
+			// then
+			Expect(cfg.Enabled()).To(BeTrue())
+		})
+
+		It("should return false if address is not IPv4 and mode is IPv4", func() {
+			// given
+			dp := &dummyDP{
+				DataplaneConfig: tproxy_dp.DataplaneConfig{
+					IPFamilyMode: tproxy_config.IPFamilyModeIPv4,
+					Redirect: tproxy_dp.DataplaneRedirect{
+						Inbound:  tproxy_dp.DatalpaneTrafficFlow{Enabled: true},
+						Outbound: tproxy_dp.DatalpaneTrafficFlow{Enabled: true},
+					},
+				},
+				address: "::1",
+			}
+
+			// when
+			cfg := tproxy_dp.GetDataplaneConfig(dp, nil)
+
+			// then
+			Expect(cfg.Enabled()).To(BeFalse())
+		})
+	})
+
+	Describe("EnabledIPv6", func() {
+		It("should return true for mode not IPv4", func() {
+			// given
+			dp := &dummyDP{
+				DataplaneConfig: tproxy_dp.DataplaneConfig{
+					IPFamilyMode: tproxy_config.IPFamilyModeDualStack,
+				},
+			}
+
+			// when
+			cfg := tproxy_dp.GetDataplaneConfig(dp, nil)
+
+			// then
+			Expect(cfg.EnabledIPv6()).To(BeTrue())
+		})
+	})
+
+	Describe("GetDataplaneConfig", func() {
+		It("should return fallback if nil", func() {
+			cfg := tproxy_dp.GetDataplaneConfig(nil, nil)
+			Expect(cfg).ToNot(BeNil())
+		})
+
+		It("should use meta and dp values", func() {
+			// given
+			dp := &dummyDP{address: "192.0.2.100"}
+
+			meta := &dummyMeta{
+				DataplaneConfig: tproxy_dp.DataplaneConfig{
+					IPFamilyMode: tproxy_config.IPFamilyModeDualStack,
+					Redirect: tproxy_dp.DataplaneRedirect{
+						Inbound:  tproxy_dp.DatalpaneTrafficFlow{Enabled: true},
+						Outbound: tproxy_dp.DatalpaneTrafficFlow{Enabled: true},
+					},
+				},
+				features: map[string]bool{
+					core_xds.FeatureTransparentProxyInDataplaneMetadata: true,
+				},
+				dnsPort:  12345,
+			}
+
+			// when
+			cfg := tproxy_dp.GetDataplaneConfig(dp, meta)
+
+			// then
+			Expect(cfg.Redirect.DNS.Port.Uint32()).To(Equal(uint32(12345)))
+			Expect(cfg.Enabled()).To(BeTrue())
+		})
+
+		It("should fallback to dataplane config", func() {
+			// given
+			dp := &dummyDP{
+				DataplaneConfig: tproxy_dp.DataplaneConfig{
+					IPFamilyMode: tproxy_config.IPFamilyModeDualStack,
+					Redirect: tproxy_dp.DataplaneRedirect{
+						Inbound:  tproxy_dp.DatalpaneTrafficFlow{Enabled: true},
+						Outbound: tproxy_dp.DatalpaneTrafficFlow{Enabled: true},
+					},
+				},
+				address: "192.0.2.50",
+			}
+
+			// when
+			cfg := tproxy_dp.GetDataplaneConfig(dp, nil)
+
+			// then
+			Expect(cfg.Redirect.DNS.Port.Uint32()).To(Equal(uint32(0)))
+			Expect(cfg.Enabled()).To(BeTrue())
+		})
+	})
+})

--- a/pkg/xds/bootstrap/generator.go
+++ b/pkg/xds/bootstrap/generator.go
@@ -115,6 +115,7 @@ func (b *bootstrapGenerator) Generate(ctx context.Context, request types.Bootstr
 		MetricsCertPath:      request.MetricsResources.CertPath,
 		MetricsKeyPath:       request.MetricsResources.KeyPath,
 		SystemCaPath:         request.SystemCaPath,
+		TransparentProxy:     request.TransparentProxy,
 	}
 
 	setAdminPort := func(adminPortFromResource uint32) {
@@ -151,7 +152,6 @@ func (b *bootstrapGenerator) Generate(ctx context.Context, request types.Bootstr
 		if dataplane.Spec.IsBuiltinGateway() {
 			params.IsGatewayDataplane = true
 		}
-		kumaDpBootstrap.NetworkingConfig.IsUsingTransparentProxy = dataplane.IsUsingTransparentProxy()
 		kumaDpBootstrap.NetworkingConfig.Address = dataplane.Spec.GetNetworking().GetAddress()
 		if b.config.Params.CorefileTemplatePath != "" {
 			corefileTemplate, err := os.ReadFile(b.config.Params.CorefileTemplatePath)

--- a/pkg/xds/bootstrap/generator_test.go
+++ b/pkg/xds/bootstrap/generator_test.go
@@ -698,7 +698,6 @@ Provide CA that was used to sign a certificate used in the control plane by usin
 		// and config is as expected
 		_, err = util_proto.ToYAML(bootstrapConfig)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(configParam.NetworkingConfig.IsUsingTransparentProxy).To(BeTrue())
 		Expect(configParam.AggregateMetricsConfig).To(ContainElements([]AggregateMetricsConfig{
 			{
 				Address: "8.8.8.8",
@@ -794,7 +793,6 @@ Provide CA that was used to sign a certificate used in the control plane by usin
 		// and config is as expected
 		_, err = util_proto.ToYAML(bootstrapConfig)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(configParam.NetworkingConfig.IsUsingTransparentProxy).To(BeFalse())
 		Expect(configParam.AggregateMetricsConfig).To(Equal([]AggregateMetricsConfig{
 			{
 				Address: "8.8.8.8",

--- a/pkg/xds/bootstrap/handler.go
+++ b/pkg/xds/bootstrap/handler.go
@@ -128,9 +128,8 @@ func createBootstrapResponse(bootstrap []byte, config *KumaDpBootstrap) *types.B
 			Aggregate: aggregate,
 		},
 		Networking: types.NetworkingConfiguration{
-			IsUsingTransparentProxy: config.NetworkingConfig.IsUsingTransparentProxy,
-			Address:                 config.NetworkingConfig.Address,
-			CorefileTemplate:        config.NetworkingConfig.CorefileTemplate,
+			Address:          config.NetworkingConfig.Address,
+			CorefileTemplate: config.NetworkingConfig.CorefileTemplate,
 		},
 	}
 	return &bootstrapConfig

--- a/pkg/xds/bootstrap/parameters.go
+++ b/pkg/xds/bootstrap/parameters.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	tproxy_config "github.com/kumahq/kuma/pkg/transparentproxy/config/dataplane"
 	"github.com/kumahq/kuma/pkg/xds/bootstrap/types"
 )
 
@@ -13,9 +14,8 @@ type KumaDpBootstrap struct {
 }
 
 type NetworkingConfig struct {
-	IsUsingTransparentProxy bool
-	CorefileTemplate        []byte
-	Address                 string
+	CorefileTemplate []byte
+	Address          string
 }
 
 type AggregateMetricsConfig struct {
@@ -52,4 +52,5 @@ type configParameters struct {
 	IsGatewayDataplane   bool
 	Resources            types.ProxyResources
 	SystemCaPath         string
+	TransparentProxy     *tproxy_config.DataplaneConfig
 }

--- a/pkg/xds/bootstrap/template_v3.go
+++ b/pkg/xds/bootstrap/template_v3.go
@@ -359,6 +359,15 @@ func genConfig(parameters configParameters, proxyConfig xds.Proxy, enableReloada
 		}
 		res.Node.Metadata.Fields[core_xds.FieldDynamicMetadata] = util_proto.MustNewValueForStruct(md)
 	}
+
+	if parameters.TransparentProxy != nil {
+		res.Node.Metadata.Fields[core_xds.FieldTransparentProxy] = &structpb.Value{
+			Kind: &structpb.Value_StructValue{
+				StructValue: util_proto.MustStructToProtoStruct(parameters.TransparentProxy),
+			},
+		}
+	}
+
 	return res, nil
 }
 

--- a/pkg/xds/bootstrap/types/bootstrap_request.go
+++ b/pkg/xds/bootstrap/types/bootstrap_request.go
@@ -1,5 +1,9 @@
 package types
 
+import (
+	tproxy_dp "github.com/kumahq/kuma/pkg/transparentproxy/config/dataplane"
+)
+
 type BootstrapRequest struct {
 	Mesh               string  `json:"mesh"`
 	Name               string  `json:"name"`
@@ -10,17 +14,18 @@ type BootstrapRequest struct {
 	Host               string  `json:"-"`
 	Version            Version `json:"version"`
 	// CaCert is a PEM-encoded CA cert that DP uses to verify CP
-	CaCert               string            `json:"caCert"`
-	DynamicMetadata      map[string]string `json:"dynamicMetadata"`
-	DNSPort              uint32            `json:"dnsPort,omitempty"`
-	ReadinessPort        uint32            `json:"readinessPort,omitempty"`
-	AppProbeProxyEnabled bool              `json:"appProbeProxyDisabled,omitempty"`
-	OperatingSystem      string            `json:"operatingSystem"`
-	Features             []string          `json:"features"`
-	Resources            ProxyResources    `json:"resources"`
-	Workdir              string            `json:"workdir"`
-	MetricsResources     MetricsResources  `json:"metricsResources"`
-	SystemCaPath         string            `json:"systemCaPath"`
+	CaCert               string                     `json:"caCert"`
+	DynamicMetadata      map[string]string          `json:"dynamicMetadata"`
+	DNSPort              uint32                     `json:"dnsPort,omitempty"`
+	ReadinessPort        uint32                     `json:"readinessPort,omitempty"`
+	AppProbeProxyEnabled bool                       `json:"appProbeProxyDisabled,omitempty"`
+	OperatingSystem      string                     `json:"operatingSystem"`
+	Features             []string                   `json:"features"`
+	Resources            ProxyResources             `json:"resources"`
+	Workdir              string                     `json:"workdir"`
+	MetricsResources     MetricsResources           `json:"metricsResources"`
+	SystemCaPath         string                     `json:"systemCaPath"`
+	TransparentProxy     *tproxy_dp.DataplaneConfig `json:"dataplaneConfig,omitempty"`
 }
 
 type Version struct {

--- a/pkg/xds/bootstrap/types/bootstrap_response.go
+++ b/pkg/xds/bootstrap/types/bootstrap_response.go
@@ -22,9 +22,8 @@ type KumaSidecarConfiguration struct {
 }
 
 type NetworkingConfiguration struct {
-	IsUsingTransparentProxy bool   `json:"isUsingTransparentProxy"`
-	CorefileTemplate        []byte `json:"corefileTemplate"`
-	Address                 string `json:"address"`
+	CorefileTemplate []byte `json:"corefileTemplate"`
+	Address          string `json:"address"`
 }
 
 type MetricsConfiguration struct {

--- a/pkg/xds/envoy/listeners/v3/http_access_log_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_access_log_configurer_test.go
@@ -7,6 +7,7 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
 	"github.com/kumahq/kuma/pkg/test/resources/model"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	"github.com/kumahq/kuma/pkg/xds/envoy"
@@ -33,7 +34,7 @@ var _ = Describe("HttpAccessLogConfigurer", func() {
 			destinationService := "backend"
 			metaData := &core_xds.DataplaneMetadata{WorkDir: "/tmp"}
 			if !given.legacyTcpAccessLog {
-				metaData.Features = core_xds.Features{core_xds.FeatureTCPAccessLogViaNamedPipe: true}
+				metaData.Features = xds_types.Features{xds_types.FeatureTCPAccessLogViaNamedPipe: true}
 			}
 			proxy := &core_xds.Proxy{
 				Id:       *core_xds.BuildProxyId(mesh, "dataplane0"),

--- a/pkg/xds/envoy/listeners/v3/network_access_log_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/network_access_log_configurer_test.go
@@ -7,6 +7,7 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
 	"github.com/kumahq/kuma/pkg/test/resources/model"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
@@ -34,7 +35,7 @@ var _ = Describe("NetworkAccessLogConfigurer", func() {
 			proxy := &core_xds.Proxy{
 				Id: *core_xds.BuildProxyId(meshName, "dataplane0"),
 				Metadata: &core_xds.DataplaneMetadata{
-					Features: core_xds.Features{core_xds.FeatureTCPAccessLogViaNamedPipe: true},
+					Features: xds_types.Features{xds_types.FeatureTCPAccessLogViaNamedPipe: true},
 					WorkDir:  "/tmp",
 				},
 				Dataplane: &core_mesh.DataplaneResource{

--- a/pkg/xds/envoy/listeners/v3/transparent_proxying_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/transparent_proxying_configurer_test.go
@@ -4,8 +4,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/xds"
+	tproxy_dp "github.com/kumahq/kuma/pkg/transparentproxy/config/dataplane"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	"github.com/kumahq/kuma/pkg/xds/envoy"
 	. "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
@@ -16,7 +16,7 @@ var _ = Describe("TransparentProxyingConfigurer", func() {
 		listenerProtocol    xds.SocketAddressProtocol
 		listenerAddress     string
 		listenerPort        uint32
-		transparentProxying *mesh_proto.Dataplane_Networking_TransparentProxying
+		transparentProxying *tproxy_dp.DataplaneConfig
 		expected            string
 	}
 
@@ -38,9 +38,11 @@ var _ = Describe("TransparentProxyingConfigurer", func() {
 		Entry("basic listener with transparent proxying", testCase{
 			listenerAddress: "192.168.0.1",
 			listenerPort:    8080,
-			transparentProxying: &mesh_proto.Dataplane_Networking_TransparentProxying{
-				RedirectPortOutbound: 12345,
-				RedirectPortInbound:  12346,
+			transparentProxying: &tproxy_dp.DataplaneConfig{
+				Redirect: tproxy_dp.DataplaneRedirect{
+					Inbound:  tproxy_dp.DataplaneTrafficFlowFromPortLike(12345),
+					Outbound: tproxy_dp.DataplaneTrafficFlowFromPortLike(12346),
+				},
 			},
 			expected: `
             name: inbound:192.168.0.1:8080
@@ -56,7 +58,7 @@ var _ = Describe("TransparentProxyingConfigurer", func() {
 		Entry("basic listener without transparent proxying", testCase{
 			listenerAddress:     "192.168.0.1",
 			listenerPort:        8080,
-			transparentProxying: &mesh_proto.Dataplane_Networking_TransparentProxying{},
+			transparentProxying: &tproxy_dp.DataplaneConfig{},
 			expected: `
             name: inbound:192.168.0.1:8080
             trafficDirection: INBOUND

--- a/pkg/xds/generator/direct_access_proxy_generator.go
+++ b/pkg/xds/generator/direct_access_proxy_generator.go
@@ -34,9 +34,9 @@ func DirectAccessEndpointName(endpoint Endpoint) string {
 }
 
 func (DirectAccessProxyGenerator) Generate(ctx context.Context, _ *core_xds.ResourceSet, xdsCtx xds_context.Context, proxy *core_xds.Proxy) (*core_xds.ResourceSet, error) {
-	tproxy := proxy.Dataplane.Spec.Networking.GetTransparentProxying()
 	resources := core_xds.NewResourceSet()
-	if tproxy.GetRedirectPortOutbound() == 0 || tproxy.GetRedirectPortInbound() == 0 || len(tproxy.GetDirectAccessServices()) == 0 {
+	directAccessServices := proxy.Dataplane.Spec.GetNetworking().TransparentProxying.GetDirectAccessServices()
+	if !proxy.GetTransparentProxy().Enabled() || len(directAccessServices) == 0 {
 		return resources, nil
 	}
 
@@ -62,7 +62,7 @@ func (DirectAccessProxyGenerator) Generate(ctx context.Context, _ *core_xds.Reso
 					xdsCtx.Mesh.GetLoggingBackend(proxy.Policies.TrafficLogs[core_mesh.PassThroughService]),
 					proxy,
 				)))).
-			Configure(envoy_listeners.TransparentProxying(proxy.Dataplane.Spec.Networking.GetTransparentProxying())).
+			Configure(envoy_listeners.TransparentProxying(proxy)).
 			Build()
 		if err != nil {
 			return nil, err

--- a/pkg/xds/generator/dns_generator.go
+++ b/pkg/xds/generator/dns_generator.go
@@ -8,6 +8,7 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
 	"github.com/kumahq/kuma/pkg/dns/dpapi"
 	util_net "github.com/kumahq/kuma/pkg/util/net"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
@@ -51,7 +52,7 @@ func (g DNSGenerator) Generate(ctx context.Context, rs *core_xds.ResourceSet, xd
 			vips[domain] = addresses
 		}
 	}
-	if proxy.Metadata.Features.HasFeature(core_xds.FeatureEmbeddedDNS) {
+	if proxy.Metadata.HasFeature(xds_types.FeatureEmbeddedDNS) {
 		dnsInfo := dpapi.DNSProxyConfig{TTL: 3600, Records: []dpapi.DNSRecord{}}
 		for name, addresses := range vips {
 			dnsInfo.Records = append(dnsInfo.Records, dpapi.DNSRecord{

--- a/pkg/xds/generator/inbound_proxy_generator.go
+++ b/pkg/xds/generator/inbound_proxy_generator.go
@@ -44,7 +44,7 @@ func (g InboundProxyGenerator) Generate(ctx context.Context, _ *core_xds.Resourc
 			Configure(envoy_clusters.Timeout(defaults_mesh.DefaultInboundTimeout(), protocol))
 		// localhost traffic is routed dirrectly to the application, in case of other interface we are going to set source address to
 		// 127.0.0.6 to avoid redirections and thanks to first iptables rule just return fast
-		if proxy.Dataplane.IsUsingTransparentProxy() && (endpoint.WorkloadIP != core_mesh.IPv4Loopback.String() && endpoint.WorkloadIP != core_mesh.IPv6Loopback.String()) {
+		if proxy.GetTransparentProxy().Enabled() && (endpoint.WorkloadIP != core_mesh.IPv4Loopback.String() && endpoint.WorkloadIP != core_mesh.IPv6Loopback.String()) {
 			switch net.IsAddressIPv6(endpoint.WorkloadIP) {
 			case true:
 				clusterBuilder.Configure(envoy_clusters.UpstreamBindConfig(InPassThroughIPv6, 0))
@@ -77,7 +77,7 @@ func (g InboundProxyGenerator) Generate(ctx context.Context, _ *core_xds.Resourc
 		inboundListenerName := envoy_names.GetInboundListenerName(endpoint.DataplaneIP, endpoint.DataplanePort)
 
 		listenerBuilder := envoy_listeners.NewInboundListenerBuilder(proxy.APIVersion, endpoint.DataplaneIP, endpoint.DataplanePort, core_xds.SocketAddressProtocolTCP).
-			Configure(envoy_listeners.TransparentProxying(proxy.Dataplane.Spec.Networking.GetTransparentProxying())).
+			Configure(envoy_listeners.TransparentProxying(proxy)).
 			Configure(envoy_listeners.TagsMetadata(iface.GetTags()))
 
 		switch xdsCtx.Mesh.Resource.GetEnabledCertificateAuthorityBackend().GetMode() {

--- a/pkg/xds/generator/outbound_proxy_generator.go
+++ b/pkg/xds/generator/outbound_proxy_generator.go
@@ -183,7 +183,7 @@ func (OutboundProxyGenerator) generateLDS(ctx xds_context.Context, proxy *model.
 	}()
 	listener, err := envoy_listeners.NewOutboundListenerBuilder(proxy.APIVersion, oface.DataplaneIP, oface.DataplanePort, model.SocketAddressProtocolTCP).
 		Configure(envoy_listeners.FilterChain(filterChainBuilder)).
-		Configure(envoy_listeners.TransparentProxying(proxy.Dataplane.Spec.Networking.GetTransparentProxying())).
+		Configure(envoy_listeners.TransparentProxying(proxy)).
 		Configure(envoy_listeners.TagsMetadata(envoy_tags.Tags(outbound.GetTags()).WithoutTags(mesh_proto.MeshTag))).
 		Build()
 	if err != nil {

--- a/pkg/xds/generator/outbound_proxy_generator_test.go
+++ b/pkg/xds/generator/outbound_proxy_generator_test.go
@@ -629,7 +629,7 @@ var _ = Describe("OutboundProxyGenerator", func() {
 					},
 				},
 				Metadata: &model.DataplaneMetadata{
-					Features: model.Features{"feature-tcp-accesslog-via-named-pipe": true},
+					Features: xds_types.Features{"feature-tcp-accesslog-via-named-pipe": true},
 				},
 			}
 

--- a/pkg/xds/generator/probe_generator.go
+++ b/pkg/xds/generator/probe_generator.go
@@ -70,7 +70,7 @@ func (g ProbeProxyGenerator) Generate(ctx context.Context, _ *model.ResourceSet,
 			Configure(envoy_listeners.HttpConnectionManager(listenerName, false, nil)).
 			Configure(envoy_listeners.HttpStaticRoute(envoy_routes.NewRouteConfigurationBuilder(proxy.APIVersion, routeConfigurationName).
 				Configure(envoy_routes.VirtualHost(virtualHostBuilder)))))).
-		Configure(envoy_listeners.TransparentProxying(proxy.Dataplane.Spec.Networking.GetTransparentProxying())).
+		Configure(envoy_listeners.TransparentProxying(proxy)).
 		Build()
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not generate listener %s", listenerName)


### PR DESCRIPTION
## Motivation

As part of the work described in the MADR [*Transparent Proxy ConfigMap Handling Outside the Control Plane*](https://github.com/kumahq/kuma/blob/a2a5110b718bf5b4d8312c57cbb76ea2af7d1148/docs/madr/decisions/071-transparent-proxy-config-map-handling-outside-the-control-plane.md), we are moving toward configuring transparent proxy settings via CLI and passing them through Dataplane Metadata. This change is necessary to remove the requirement for the control plane to access ConfigMaps in all namespaces.

## Implementation information

This introduces full support for configuring transparent proxy behavior dynamically via the `--transparent-proxy` and `--transparent-proxy-config` flags in `kuma-dp run`.

Key changes:
- Adds `DataplaneConfig` struct with validation, defaults, and feature flags
- Sets proxy redirect, DNS, and IP family settings based on the provided config
- Detects OS and ensures transparent proxy is only allowed on Linux
- Adds support for embedding the config into xDS bootstrap metadata
- Refactors `IsUsingTransparentProxy()` to a config-aware `.Enabled()` check
- Introduces dynamic per-dataplane feature `feature-transparent-proxy-in-dataplane-metadata`
- Ensures config is passed to listeners, metrics, generators, and policies
- Improves CLI flag handling to support inline YAML/JSON or file-based config input

## Supporting documentation

Related to: https://github.com/kumahq/kuma/issues/13338
