### PR TITLE
fix(util): fix bad sanitization of report entry names

### DIFF
--- a/test/framework/report/report.go
+++ b/test/framework/report/report.go
@@ -118,7 +118,7 @@ func DumpReport(report ginkgo.Report) {
 			writeEntry(path.Join(entryPath, "report.txt"), f.String())
 
 			for _, e := range entry.ReportEntries {
-				writeEntry(path.Join(entryPath, e.Name), e.StringRepresentation())
+				writeEntry(path.Join(entryPath, files.ToValidUnixFilename(e.Name)), e.StringRepresentation())
 			}
 		}
 	}


### PR DESCRIPTION
## Motivation

Otherwise we're going to be seeing:

```
The path for one of the files in artifact is not valid: /e2e-debug/MeshTLS_should_set_cypher_and_version/kuma-3/universal/exec/kuma-3_mesh-tls-test-server/envoytunnelgetstats_listener.(.*)_80.ssl.ciphers.ECDHE-RSA-AES256-GCM-SHA384-10/cmd-debug.txt. Contains the following character:  Asterisk *
          
Invalid characters include:  Double quote ", Colon :, Less than <, Greater than >, Vertical bar |, Asterisk *, Question mark ?, Carriage return \r, Line feed \n
          
The following characters are not allowed in files that are uploaded due to limitations with certain file systems such as NTFS. To maintain file system agnostic behavior, these characters are intentionally not allowed to prevent potential problems with downloads on different file systems.
```

![image](https://github.com/user-attachments/assets/a7f713a5-8cca-4e26-94d3-3170fb393fef)

from: https://github.com/kumahq/kuma/actions/runs/14457435550

## Implementation information

Sanitise report entry as well.

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

xrel: https://github.com/kumahq/kuma/pull/13220

> Changelog: skip
