### PR TITLE
test(e2e): fix zoneingress debug command

### DIFF
--- a/test/framework/debug.go
+++ b/test/framework/debug.go
@@ -208,7 +208,7 @@ type dpType string
 const (
 	dataplaneType   dpType = "dataplane"
 	zoneegressType  dpType = "zoneegress"
-	zoneingressType dpType = "zone-ingress"
+	zoneingressType dpType = "zoneingress"
 )
 
 func inspectDataplane(kumactlOpts *kumactl.KumactlOptions, cluster Cluster, mesh string, dpType dpType) error {
@@ -251,7 +251,11 @@ func inspectDataplane(kumactlOpts *kumactl.KumactlOptions, cluster Cluster, mesh
 			args := []string{"inspect", string(dpType), dpName, "--type", inspectType}
 			switch inspectType {
 			case "get":
-				args = []string{"get", string(dpType), dpName, "-oyaml"}
+				if dpType == zoneingressType {
+					args = []string{"get", "zone-ingress", dpName, "-oyaml"}
+				} else {
+					args = []string{"get", string(dpType), dpName, "-oyaml"}
+				}
 			}
 			if dpType == dataplaneType {
 				args = append(args, "--mesh", mesh)


### PR DESCRIPTION
## Motivation

```
./kumactl get -h
Available Commands:
  zone-ingress                Show a single ZoneIngress resource
  zone-ingresses              Show ZoneIngress

-------
./kumactl inspect -h
Available Commands:
  zone-ingresses            Inspect Zone Ingresses
  zoneingress               Inspect ZoneIngress
```

There is no consistency so we need to support 2 different kind of naming.

> Changelog: skip
