### PR TITLE
test(framework): allow specify watch namespaces for the KIC installer

### DIFF
--- a/test/framework/deployments/kic/deployment.go
+++ b/test/framework/deployments/kic/deployment.go
@@ -2,8 +2,6 @@ package kic
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/test/framework"
@@ -49,7 +47,7 @@ func Install(fs ...deployOptionsFunc) framework.InstallFunc {
 		case *framework.K8sCluster:
 			deployment = &k8sDeployment{
 				ingressNamespace: opts.namespace,
-				watchNamespaces:  strings.Join(opts.watchNamespaces, ","),
+				watchNamespaces:  opts.watchNamespaces,
 				mesh:             opts.mesh,
 				name:             opts.name,
 			}

--- a/test/framework/deployments/kic/deployment.go
+++ b/test/framework/deployments/kic/deployment.go
@@ -2,6 +2,7 @@ package kic
 
 import (
 	"fmt"
+
 	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/test/framework"

--- a/test/framework/deployments/kic/deployment.go
+++ b/test/framework/deployments/kic/deployment.go
@@ -2,6 +2,7 @@ package kic
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -20,9 +21,10 @@ type Deployment interface {
 }
 
 type deployOptions struct {
-	namespace string
-	mesh      string
-	name      string
+	namespace       string
+	watchNamespaces []string
+	mesh            string
+	name            string
 }
 
 type deployOptionsFunc func(*deployOptions)
@@ -47,6 +49,7 @@ func Install(fs ...deployOptionsFunc) framework.InstallFunc {
 		case *framework.K8sCluster:
 			deployment = &k8sDeployment{
 				ingressNamespace: opts.namespace,
+				watchNamespaces:  strings.Join(opts.watchNamespaces, ","),
 				mesh:             opts.mesh,
 				name:             opts.name,
 			}
@@ -60,6 +63,12 @@ func Install(fs ...deployOptionsFunc) framework.InstallFunc {
 func WithNamespace(namespace string) deployOptionsFunc {
 	return func(o *deployOptions) {
 		o.namespace = namespace
+	}
+}
+
+func WithWatchNamespaces(namespaces ...string) deployOptionsFunc {
+	return func(o *deployOptions) {
+		o.watchNamespaces = append(o.watchNamespaces, namespaces...)
 	}
 }
 

--- a/test/framework/deployments/kic/kubernetes.go
+++ b/test/framework/deployments/kic/kubernetes.go
@@ -16,6 +16,7 @@ import (
 
 type k8sDeployment struct {
 	ingressNamespace string
+	watchNamespaces  string
 	mesh             string
 	name             string
 }
@@ -31,13 +32,16 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 	if t.ingressNamespace == "" {
 		t.ingressNamespace = framework.Config.DefaultGatewayNamespace
 	}
+	if t.watchNamespaces == "" {
+		t.watchNamespaces = t.ingressNamespace
+	}
 	opts := helm.Options{
 		KubectlOptions: cluster.GetKubectlOptions(t.ingressNamespace),
 	}
 	_, err = helm.RunHelmCommandAndGetStdOutE(cluster.GetTesting(), &opts, "install", t.name,
 		"--namespace", t.ingressNamespace,
 		"--repo", "https://charts.konghq.com",
-		"--set", "controller.ingressController.watchNamespaces={"+t.ingressNamespace+"}",
+		"--set", "controller.ingressController.watchNamespaces={"+t.watchNamespaces+"}",
 		"--set", "controller.ingressController.ingressClass="+t.name,
 		"--set", "controller.podAnnotations.kuma\\.io/mesh="+t.mesh,
 		"--set", "gateway.podAnnotations.kuma\\.io/mesh="+t.mesh,

--- a/test/framework/deployments/kic/kubernetes.go
+++ b/test/framework/deployments/kic/kubernetes.go
@@ -2,6 +2,8 @@ package kic
 
 import (
 	"fmt"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
@@ -16,7 +18,7 @@ import (
 
 type k8sDeployment struct {
 	ingressNamespace string
-	watchNamespaces  string
+	watchNamespaces  []string
 	mesh             string
 	name             string
 }
@@ -32,16 +34,21 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 	if t.ingressNamespace == "" {
 		t.ingressNamespace = framework.Config.DefaultGatewayNamespace
 	}
-	if t.watchNamespaces == "" {
-		t.watchNamespaces = t.ingressNamespace
+
+	if len(t.watchNamespaces) == 0 {
+		t.watchNamespaces = []string{t.ingressNamespace}
+	} else if !slices.Contains(t.watchNamespaces, t.ingressNamespace) {
+		t.watchNamespaces = append(t.watchNamespaces, t.ingressNamespace)
 	}
+	watchNamespacesVal := strings.Join(t.watchNamespaces, ",")
+
 	opts := helm.Options{
 		KubectlOptions: cluster.GetKubectlOptions(t.ingressNamespace),
 	}
 	_, err = helm.RunHelmCommandAndGetStdOutE(cluster.GetTesting(), &opts, "install", t.name,
 		"--namespace", t.ingressNamespace,
 		"--repo", "https://charts.konghq.com",
-		"--set", "controller.ingressController.watchNamespaces={"+t.watchNamespaces+"}",
+		"--set", "controller.ingressController.watchNamespaces={"+watchNamespacesVal+"}",
 		"--set", "controller.ingressController.ingressClass="+t.name,
 		"--set", "controller.podAnnotations.kuma\\.io/mesh="+t.mesh,
 		"--set", "gateway.podAnnotations.kuma\\.io/mesh="+t.mesh,


### PR DESCRIPTION
## Motivation

Fixing a bug in the KIC installer of the test framework which prevent us from specifying watch namespaces.

The issue was introduced by this PR  https://github.com/kumahq/kuma/pull/12848 which tried to isolate the impact between multiple test suites on the same cluster.

The issue is causing some integration test failures in child-repo projects.

## Implementation information

In our test framework, add a new option `watchNamespaces` onto the `k8sDeployment` struct of the KIC installer. In this way, we differenciate the semantic of `ingressNamespace` and `watchNamespaces` in that struct.

The mentioned PR above made the KIC installer include `watchNamespaces` parameter and made its value to equal `ingressNamespace`. This design prevented the installed KIC to watch Kong Gateway resources/plugins from any other namespaces than the namespace in which the KIC components are placed in. It's a major shortage to the original implmentation. 

## Supporting documentation

https://docs.konghq.com/kubernetes-ingress-controller/2.8.x/references/cli-arguments/


> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
