### PR TITLE
chore(kuma-dp): improve transparent proxy config handling and JSON serialization

### DIFF
--- a/app/kuma-dp/cmd/run.go
+++ b/app/kuma-dp/cmd/run.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"testing"
 	"time"
 
 	envoy_bootstrap_v3 "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v3"
@@ -75,7 +76,7 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 
 			var tpCfg *tproxy_dp.DataplaneConfig
 			if len(tpCfgValues) > 0 || tpEnabled {
-				if runtime.GOOS != "linux" {
+				if !testing.Testing() && runtime.GOOS != "linux" {
 					return errors.New("transparent proxy is supported only on Linux systems")
 				}
 

--- a/pkg/transparentproxy/config/dataplane/config_dataplane.go
+++ b/pkg/transparentproxy/config/dataplane/config_dataplane.go
@@ -52,7 +52,7 @@ type DataplaneRedirect struct {
 }
 
 type DataplaneConfig struct {
-	core_config.BaseConfig
+	core_config.BaseConfig `json:"-"`
 
 	IPFamilyMode tproxy_config.IPFamilyMode `json:"ipFamilyMode"`
 	Redirect     DataplaneRedirect          `json:"redirect"`

--- a/pkg/util/proto/types.go
+++ b/pkg/util/proto/types.go
@@ -112,10 +112,17 @@ func StructToMapOfAny(value any) map[string]any {
 		if field.PkgPath != "" {
 			continue
 		}
-		key := field.Tag.Get("json")
-		if key == "" {
+
+		var key string
+		switch k := field.Tag.Get("json"); k {
+		case "-":
+			continue
+		case "":
 			key = field.Name
+		default:
+			key = k
 		}
+
 		val := v.Field(i)
 
 		switch val.Kind() {


### PR DESCRIPTION
## Motivation

Empty `BaseConfig` field was incorrectly being passed in the metadata

## Implementation information

- Allow transparent proxy on non-linux during tests by checking testing mode
- Ignore `BaseConfig` field when serializing `DataplaneConfig` to JSON
- Skip struct fields tagged with `json:"-"` in `StructToMapOfAny`

## Supporting documentation

Related to: https://github.com/kumahq/kuma/issues/13338