### PR TITLE
test(e2e): wait for stat to show up for MeshRateLimit

### DIFF
--- a/test/e2e_env/universal/meshratelimit/meshratelimit.go
+++ b/test/e2e_env/universal/meshratelimit/meshratelimit.go
@@ -107,7 +107,9 @@ spec:
 	It("should limit tcp connections", func() {
 		admin := universal.Cluster.GetApp("test-server-tcp").GetEnvoyAdminTunnel()
 		// should have no ratelimited connections
-		Expect(tcpRateLimitStats(admin)).To(stats.BeEqualZero())
+		Eventually(func(g Gomega) {
+			g.Expect(tcpRateLimitStats(admin)).To(stats.BeEqualZero())
+		}, "10s", "1s").Should(Succeed())
 
 		// open connection
 		go keepConnectionOpen()


### PR DESCRIPTION
## Motivation

Noticed a flake

## Implementation information

While checking the logs, I noticed that the metrics were present in the dump, but during the test, they couldn't be found. This might be caused by a delay in configuration delivery, as we only check once if the metrics are available. I added an Eventually block to wait until the metrics appear, which should help avoid issues due to config propagation delays.

> Changelog: skip
