### PR TITLE
fix(secrets): correctly compare other meshes secrets when using crossMesh

### DIFF
--- a/pkg/xds/secrets/secrets.go
+++ b/pkg/xds/secrets/secrets.go
@@ -75,20 +75,11 @@ func NewSecrets(caProvider CaProvider, identityProvider IdentityProvider, metric
 		return nil, err
 	}
 
-	otherMeshesCertGenerationsMetric := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Help: "Number of generated certificates for other meshes",
-		Name: "cert_generation_other_meshes",
-	}, []string{"mesh", "other_mesh"})
-	if err := metrics.Register(otherMeshesCertGenerationsMetric); err != nil {
-		return nil, err
-	}
-
 	return &secrets{
-		caProvider:                       caProvider,
-		identityProvider:                 identityProvider,
-		cachedCerts:                      map[certCacheKey]*certs{},
-		certGenerationsMetric:            certGenerationsMetric,
-		otherMeshesCertGenerationsMetric: otherMeshesCertGenerationsMetric,
+		caProvider:            caProvider,
+		identityProvider:      identityProvider,
+		cachedCerts:           map[certCacheKey]*certs{},
+		certGenerationsMetric: certGenerationsMetric,
 	}, nil
 }
 
@@ -102,9 +93,8 @@ type secrets struct {
 	identityProvider IdentityProvider
 
 	sync.RWMutex
-	cachedCerts                      map[certCacheKey]*certs
-	certGenerationsMetric            *prometheus.CounterVec
-	otherMeshesCertGenerationsMetric *prometheus.CounterVec
+	cachedCerts           map[certCacheKey]*certs
+	certGenerationsMetric *prometheus.CounterVec
 }
 
 var _ Secrets = &secrets{}
@@ -387,7 +377,6 @@ func (s *secrets) generateCerts(
 				continue
 			}
 			otherMeshName := otherMesh.GetMeta().GetName()
-			s.otherMeshesCertGenerationsMetric.WithLabelValues(meshName, otherMeshName).Inc()
 
 			otherCas = append(otherCas, MeshCa{
 				Mesh:     otherMeshName,

--- a/pkg/xds/secrets/secrets.go
+++ b/pkg/xds/secrets/secrets.go
@@ -52,7 +52,7 @@ type Info struct {
 	SupportedBackends []string
 
 	OwnMesh        MeshInfo
-	OtherMeshInfos []MeshInfo
+	OtherMeshInfos map[string]MeshInfo
 	// this marks our info as having failed last time to get the mesh CAs that
 	// we wanted and so we should retry next time we want certs.
 	failedOtherMeshes bool
@@ -266,8 +266,14 @@ func (s *secrets) shouldGenerateCerts(info *Info, tags mesh_proto.MultiValueTagS
 		updates.AddKind(OtherMeshChange)
 		reason = "Another mesh has been added or removed or we must retry"
 	} else {
-		for i, mesh := range info.OtherMeshInfos {
-			if !proto.Equal(mesh.MTLS, otherMeshInfos[i].Spec.Mtls) {
+		for _, otherMesh := range otherMeshInfos {
+			if previousInfo, found := info.OtherMeshInfos[otherMesh.GetMeta().GetName()]; found {
+				if !proto.Equal(previousInfo.MTLS, otherMesh.Spec.Mtls) {
+					updates.AddKind(OtherMeshChange)
+					reason = "Another Mesh's mTLS settings have changed"
+					break
+				}
+			} else {
 				updates.AddKind(OtherMeshChange)
 				reason = "Another Mesh's mTLS settings have changed"
 				break
@@ -356,16 +362,16 @@ func (s *secrets) generateCerts(
 	}
 
 	if updateKinds.HasType(OtherMeshChange) || updateKinds.HasType(OwnMeshChange) {
-		var otherMeshInfos []MeshInfo
+		otherMeshInfos := make(map[string]MeshInfo, len(otherMeshes))
 		var bytes [][]byte
 		var names []string
 		otherCas = []MeshCa{}
 
 		failedOtherMeshes := false
 		for _, otherMesh := range otherMeshes {
-			otherMeshInfos = append(otherMeshInfos, MeshInfo{
+			otherMeshInfos[otherMesh.GetMeta().GetName()] = MeshInfo{
 				MTLS: otherMesh.Spec.GetMtls(),
-			})
+			}
 
 			// We need to track this mesh but we don't do anything with certs
 			if !otherMesh.MTLSEnabled() {

--- a/pkg/xds/secrets/secrets_test.go
+++ b/pkg/xds/secrets/secrets_test.go
@@ -211,20 +211,23 @@ var _ = Describe("Secrets", Ordered, func() {
 				defaultMesh := newMesh("default")
 
 				// when
-				_, _, err := secrets.GetForDataPlane(context.Background(), newDataplane(), defaultMesh, []*core_mesh.MeshResource{newMesh("mesh-1")})
+				_, caSecrets, err := secrets.GetForDataPlane(context.Background(), newDataplane(), defaultMesh, []*core_mesh.MeshResource{newMesh("mesh-1")})
 
 				// then
 				Expect(err).ToNot(HaveOccurred())
 				Expect(test_metrics.FindMetric(metrics, "cert_generation").GetCounter().GetValue()).To(Equal(1.0))
-				Expect(test_metrics.FindMetric(metrics, "cert_generation_other_meshes", "other_mesh", "mesh-1").GetCounter().GetValue()).To(Equal(1.0))
+				Expect(caSecrets["default"]).ToNot(BeNil())
+				Expect(caSecrets["mesh-1"]).ToNot(BeNil())
 
 				// when
-				_, _, err = secrets.GetForDataPlane(context.Background(), newDataplane(), defaultMesh, []*core_mesh.MeshResource{newMesh("mesh-2")})
+				_, caSecrets, err = secrets.GetForDataPlane(context.Background(), newDataplane(), defaultMesh, []*core_mesh.MeshResource{newMesh("mesh-2")})
 
 				// then
 				Expect(err).ToNot(HaveOccurred())
 				Expect(test_metrics.FindMetric(metrics, "cert_generation").GetCounter().GetValue()).To(Equal(1.0))
-				Expect(test_metrics.FindMetric(metrics, "cert_generation_other_meshes", "other_mesh", "mesh-2").GetCounter().GetValue()).To(Equal(1.0))
+				Expect(caSecrets["default"]).ToNot(BeNil())
+				Expect(caSecrets["mesh-1"]).To(BeNil())
+				Expect(caSecrets["mesh-2"]).ToNot(BeNil())
 			})
 
 			It("when mTLS settings has changed", func() {

--- a/pkg/xds/secrets/secrets_test.go
+++ b/pkg/xds/secrets/secrets_test.go
@@ -206,7 +206,7 @@ var _ = Describe("Secrets", Ordered, func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			FIt("when cross-mesh was added and previous removed", func() {
+			It("when cross-mesh was added and previous removed", func() {
 				// given
 				defaultMesh := newMesh("default")
 

--- a/pkg/xds/secrets/secrets_test.go
+++ b/pkg/xds/secrets/secrets_test.go
@@ -30,10 +30,10 @@ var _ = Describe("Secrets", Ordered, func() {
 	var metrics core_metrics.Metrics
 	var now time.Time
 
-	newMesh := func() *core_mesh.MeshResource {
+	newMesh := func(name string) *core_mesh.MeshResource {
 		return &core_mesh.MeshResource{
 			Meta: &model.ResourceMeta{
-				Name: "default",
+				Name: name,
 			},
 			Spec: &mesh_proto.Mesh{
 				Mtls: &mesh_proto.Mesh_Mtls{
@@ -118,10 +118,22 @@ var _ = Describe("Secrets", Ordered, func() {
 		caManagers := core_ca.Managers{
 			"builtin": builtinCaManager,
 		}
-		mesh := newMesh()
+		mesh := newMesh("default")
 		err := rm.Create(context.Background(), mesh, store.CreateByKey(core_model.DefaultMesh, core_model.NoMesh))
 		Expect(err).ToNot(HaveOccurred())
 		err = builtinCaManager.EnsureBackends(context.Background(), mesh, mesh.Spec.Mtls.Backends)
+		Expect(err).ToNot(HaveOccurred())
+
+		mesh1 := newMesh("mesh-1")
+		err = rm.Create(context.Background(), mesh1, store.CreateByKey("mesh-1", core_model.NoMesh))
+		Expect(err).ToNot(HaveOccurred())
+		err = builtinCaManager.EnsureBackends(context.Background(), mesh1, mesh1.Spec.Mtls.Backends)
+		Expect(err).ToNot(HaveOccurred())
+
+		mesh2 := newMesh("mesh-2")
+		err = rm.Create(context.Background(), mesh2, store.CreateByKey("mesh-2", core_model.NoMesh))
+		Expect(err).ToNot(HaveOccurred())
+		err = builtinCaManager.EnsureBackends(context.Background(), mesh2, mesh2.Spec.Mtls.Backends)
 		Expect(err).ToNot(HaveOccurred())
 
 		m, err := core_metrics.NewMetrics("local")
@@ -145,7 +157,7 @@ var _ = Describe("Secrets", Ordered, func() {
 	Context("dataplane proxy", func() {
 		It("should generate cert and emit statistic and info", func() {
 			// when
-			identity, ca, err := secrets.GetForDataPlane(context.Background(), newDataplane(), newMesh(), nil)
+			identity, ca, err := secrets.GetForDataPlane(context.Background(), newDataplane(), newMesh("default"), nil)
 
 			// then certs are generated
 			Expect(err).ToNot(HaveOccurred())
@@ -172,11 +184,11 @@ var _ = Describe("Secrets", Ordered, func() {
 
 		It("should not regenerate certs if nothing has changed", func() {
 			// given
-			identity, cas, err := secrets.GetForDataPlane(context.Background(), newDataplane(), newMesh(), nil)
+			identity, cas, err := secrets.GetForDataPlane(context.Background(), newDataplane(), newMesh("default"), nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			// when
-			newIdentity, newCa, err := secrets.GetForDataPlane(context.Background(), newDataplane(), newMesh(), nil)
+			newIdentity, newCa, err := secrets.GetForDataPlane(context.Background(), newDataplane(), newMesh("default"), nil)
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
@@ -190,13 +202,34 @@ var _ = Describe("Secrets", Ordered, func() {
 
 		Context("should regenerate certificate", func() {
 			BeforeEach(func() {
-				_, _, err := secrets.GetForDataPlane(context.Background(), newDataplane(), newMesh(), nil)
+				_, _, err := secrets.GetForDataPlane(context.Background(), newDataplane(), newMesh("default"), nil)
 				Expect(err).ToNot(HaveOccurred())
+			})
+
+			FIt("when cross-mesh was added and previous removed", func() {
+				// given
+				defaultMesh := newMesh("default")
+
+				// when
+				_, _, err := secrets.GetForDataPlane(context.Background(), newDataplane(), defaultMesh, []*core_mesh.MeshResource{newMesh("mesh-1")})
+
+				// then
+				Expect(err).ToNot(HaveOccurred())
+				Expect(test_metrics.FindMetric(metrics, "cert_generation").GetCounter().GetValue()).To(Equal(1.0))
+				Expect(test_metrics.FindMetric(metrics, "cert_generation_other_meshes", "other_mesh", "mesh-1").GetCounter().GetValue()).To(Equal(1.0))
+
+				// when
+				_, _, err = secrets.GetForDataPlane(context.Background(), newDataplane(), defaultMesh, []*core_mesh.MeshResource{newMesh("mesh-2")})
+
+				// then
+				Expect(err).ToNot(HaveOccurred())
+				Expect(test_metrics.FindMetric(metrics, "cert_generation").GetCounter().GetValue()).To(Equal(1.0))
+				Expect(test_metrics.FindMetric(metrics, "cert_generation_other_meshes", "other_mesh", "mesh-2").GetCounter().GetValue()).To(Equal(1.0))
 			})
 
 			It("when mTLS settings has changed", func() {
 				// given
-				mesh := newMesh()
+				mesh := newMesh("default")
 				mesh.Spec.Mtls.EnabledBackend = "ca-2"
 
 				// when
@@ -214,7 +247,7 @@ var _ = Describe("Secrets", Ordered, func() {
 				dataplane.Spec.Networking.Inbound[0].Tags["kuma.io/service"] = "web2"
 
 				// when
-				_, _, err := secrets.GetForDataPlane(context.Background(), dataplane, newMesh(), nil)
+				_, _, err := secrets.GetForDataPlane(context.Background(), dataplane, newMesh("default"), nil)
 
 				// then
 				Expect(err).ToNot(HaveOccurred())
@@ -227,7 +260,7 @@ var _ = Describe("Secrets", Ordered, func() {
 				now = now.Add(48*time.Minute + 1*time.Millisecond) // 4/5 of 60 minutes
 
 				// when
-				_, _, err := secrets.GetForDataPlane(context.Background(), newDataplane(), newMesh(), nil)
+				_, _, err := secrets.GetForDataPlane(context.Background(), newDataplane(), newMesh("default"), nil)
 
 				// then
 				Expect(err).ToNot(HaveOccurred())
@@ -240,7 +273,7 @@ var _ = Describe("Secrets", Ordered, func() {
 				secrets.Cleanup(mesh_proto.DataplaneProxyType, core_model.MetaToResourceKey(newDataplane().Meta))
 
 				// when
-				_, _, err := secrets.GetForDataPlane(context.Background(), newDataplane(), newMesh(), nil)
+				_, _, err := secrets.GetForDataPlane(context.Background(), newDataplane(), newMesh("default"), nil)
 
 				// then
 				Expect(err).ToNot(HaveOccurred())
@@ -251,7 +284,7 @@ var _ = Describe("Secrets", Ordered, func() {
 
 		It("should cleanup certs", func() {
 			// given
-			_, _, err := secrets.GetForDataPlane(context.Background(), newDataplane(), newMesh(), nil)
+			_, _, err := secrets.GetForDataPlane(context.Background(), newDataplane(), newMesh("default"), nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			// when
@@ -265,7 +298,7 @@ var _ = Describe("Secrets", Ordered, func() {
 	Context("zone egress", func() {
 		It("should generate cert and emit statistic and info", func() {
 			// when
-			identity, ca, err := secrets.GetForZoneEgress(context.Background(), newZoneEgress(), newMesh())
+			identity, ca, err := secrets.GetForZoneEgress(context.Background(), newZoneEgress(), newMesh("default"))
 
 			// then certs are generated
 			Expect(err).ToNot(HaveOccurred())
@@ -291,11 +324,11 @@ var _ = Describe("Secrets", Ordered, func() {
 
 		It("should not regenerate certs if nothing has changed", func() {
 			// given
-			identity, ca, err := secrets.GetForZoneEgress(context.Background(), newZoneEgress(), newMesh())
+			identity, ca, err := secrets.GetForZoneEgress(context.Background(), newZoneEgress(), newMesh("default"))
 			Expect(err).ToNot(HaveOccurred())
 
 			// when
-			newIdentity, newCa, err := secrets.GetForZoneEgress(context.Background(), newZoneEgress(), newMesh())
+			newIdentity, newCa, err := secrets.GetForZoneEgress(context.Background(), newZoneEgress(), newMesh("default"))
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
@@ -307,13 +340,13 @@ var _ = Describe("Secrets", Ordered, func() {
 
 		Context("should regenerate certificate", func() {
 			BeforeEach(func() {
-				_, _, err := secrets.GetForZoneEgress(context.Background(), newZoneEgress(), newMesh())
+				_, _, err := secrets.GetForZoneEgress(context.Background(), newZoneEgress(), newMesh("default"))
 				Expect(err).ToNot(HaveOccurred())
 			})
 
 			It("when mTLS settings has changed", func() {
 				// given
-				mesh := newMesh()
+				mesh := newMesh("default")
 				mesh.Spec.Mtls.EnabledBackend = "ca-2"
 
 				// when
@@ -330,7 +363,7 @@ var _ = Describe("Secrets", Ordered, func() {
 				now = now.Add(48*time.Minute + 1*time.Millisecond) // 4/5 of 60 minutes
 
 				// when
-				_, _, err := secrets.GetForZoneEgress(context.Background(), newZoneEgress(), newMesh())
+				_, _, err := secrets.GetForZoneEgress(context.Background(), newZoneEgress(), newMesh("default"))
 
 				// then
 				Expect(err).ToNot(HaveOccurred())
@@ -343,7 +376,7 @@ var _ = Describe("Secrets", Ordered, func() {
 				secrets.Cleanup(mesh_proto.EgressProxyType, core_model.MetaToResourceKey(newZoneEgress().Meta))
 
 				// when
-				_, _, err := secrets.GetForZoneEgress(context.Background(), newZoneEgress(), newMesh())
+				_, _, err := secrets.GetForZoneEgress(context.Background(), newZoneEgress(), newMesh("default"))
 
 				// then
 				Expect(err).ToNot(HaveOccurred())
@@ -354,7 +387,7 @@ var _ = Describe("Secrets", Ordered, func() {
 
 		It("should cleanup certs", func() {
 			// given
-			_, _, err := secrets.GetForZoneEgress(context.Background(), newZoneEgress(), newMesh())
+			_, _, err := secrets.GetForZoneEgress(context.Background(), newZoneEgress(), newMesh("default"))
 			Expect(err).ToNot(HaveOccurred())
 
 			// when


### PR DESCRIPTION
## Motivation

While investigating test failures, I noticed a flake that caused the secret not to be loaded.

## Implementation information

While reviewing the code, I found that we were only comparing the number of meshes, but not verifying whether a specific mesh still exists. I added a change to detect cases where a mesh was removed and another was added in a short period of time. I also added a test and a metric to track mesh generation changes.