### PR TITLE
Revert "ci(ipv6): disable kind ip v6 because of a kernel bug (#13392)"

### DIFF
--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -23,8 +23,7 @@ jobs:
     timeout-minutes: 60
     # can't use env vars here
     runs-on: ${{ inputs.runner }}
-    # workaround for this bug https://github.com/actions/runner-images/issues/11985 - revert when done
-    if: ${{ fromJSON(inputs.matrix).k8sVersion != 'kindipv6' && inputs.runner != '' }}
+    if: ${{ inputs.runner != '' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This reverts commit 5f96a0a5453bc177d2249584bb9ba56d30f3be5e.

## Motivation

According to https://github.com/actions/runner-images/issues/11985#issuecomment-2823503856 this should be resolved now