### PR TITLE
Reapply "ci(ipv6): disable kind ip v6 because of a kernel bug (#13392…)" (#13445)

### DIFF
--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -23,7 +23,8 @@ jobs:
     timeout-minutes: 60
     # can't use env vars here
     runs-on: ${{ inputs.runner }}
-    if: ${{ inputs.runner != '' }}
+    # workaround for this bug https://github.com/actions/runner-images/issues/11985 - revert when done
+    if: ${{ fromJSON(inputs.matrix).k8sVersion != 'kindipv6' && inputs.runner != '' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This reverts commit 49c6f49f72ce45b21e8682a92c2877231b55df2b.

## Motivation

It seems the underlying kernel issue was not fixed as we thought