### PR TITLE
fix(dns): enable e2e tests with embedded dns and reduce TTL

### DIFF
--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -71,6 +71,12 @@ jobs:
                 "include":[
                   {"dpDNS": "true", "k8sVersion": "${{ env.K8S_MAX_VERSION }}", "target": "kubernetes", "arch": "amd64"},
                   {"dpDNS": "true", "k8sVersion": "kind", "target": "universal", "arch": "amd64"},
+                  {"sidecarContainers": "sidecarContainers", "k8sVersion": "${{ env.K8S_MAX_VERSION }}", "target": "kubernetes", "arch": "amd64"},
+                  {"k8sVersion": "${{ env.K8S_MIN_VERSION }}", "target": "multizone", "arch": "amd64"},
+                  {"k8sVersion": "${{ env.K8S_MIN_VERSION }}", "target": "kubernetes", "arch": "amd64"},
+                  {"k8sVersion": "kind", "target": "universal", "arch": "arm64"},
+                  {"k8sVersion": "${{ env.K8S_MAX_VERSION }}", "target": "gatewayapi", "arch": "amd64"},
+                  {"cniNetworkPlugin": "calico", "k8sVersion": "${{ env.K8S_MAX_VERSION }}", "target": "multizone", "arch": "amd64"}
                 ]
               }
             }

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -69,12 +69,8 @@ jobs:
                   {"target":"universal", "k8sVersion":"${{ env.K8S_MAX_VERSION }}"}
                 ],
                 "include":[
-                  {"sidecarContainers": "sidecarContainers", "k8sVersion": "${{ env.K8S_MAX_VERSION }}", "target": "kubernetes", "arch": "amd64"},
-                  {"k8sVersion": "${{ env.K8S_MIN_VERSION }}", "target": "multizone", "arch": "amd64"},
-                  {"k8sVersion": "${{ env.K8S_MIN_VERSION }}", "target": "kubernetes", "arch": "amd64"},
-                  {"k8sVersion": "kind", "target": "universal", "arch": "arm64"},
-                  {"k8sVersion": "${{ env.K8S_MAX_VERSION }}", "target": "gatewayapi", "arch": "amd64"},
-                  {"cniNetworkPlugin": "calico", "k8sVersion": "${{ env.K8S_MAX_VERSION }}", "target": "multizone", "arch": "amd64"}
+                  {"dpDNS": "true", "k8sVersion": "${{ env.K8S_MAX_VERSION }}", "target": "kubernetes", "arch": "amd64"},
+                  {"dpDNS": "true", "k8sVersion": "kind", "target": "universal", "arch": "amd64"},
                 ]
               }
             }

--- a/pkg/xds/generator/dns_generator.go
+++ b/pkg/xds/generator/dns_generator.go
@@ -53,7 +53,7 @@ func (g DNSGenerator) Generate(ctx context.Context, rs *core_xds.ResourceSet, xd
 		}
 	}
 	if proxy.Metadata.HasFeature(xds_types.FeatureEmbeddedDNS) {
-		dnsInfo := dpapi.DNSProxyConfig{TTL: 3600, Records: []dpapi.DNSRecord{}}
+		dnsInfo := dpapi.DNSProxyConfig{TTL: 30, Records: []dpapi.DNSRecord{}}
 		for name, addresses := range vips {
 			dnsInfo.Records = append(dnsInfo.Records, dpapi.DNSRecord{
 				Name: name,

--- a/pkg/xds/generator/testdata/dns/4-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/dns/4-envoy-config.golden.yaml
@@ -26,11 +26,11 @@ resources:
                   headers:
                   - name: If-None-Match
                     stringMatch:
-                      exact: 8b2b708ee2e09b69ef2e448f7a8ea04146b56c8ba9a0d45e58460feb1ba2af75
+                      exact: 639772d25f9c22e338f3c54ebe8be0faeae7e30c57f1acbf2d8ba5eb191007fb
                   path: /dns
               - directResponse:
                   body:
-                    inlineString: '{"records":[{"name":"backend.test-ns.svc.8080.mesh","ips":["240.0.0.0","::ffff:f000:0"]},{"name":"backend_test-ns_svc_8080.mesh","ips":["240.0.0.0","::ffff:f000:0"]},{"name":"httpbin.mesh","ips":["240.0.0.1","::ffff:f000:1"]}],"ttl":3600}'
+                    inlineString: '{"records":[{"name":"backend.test-ns.svc.8080.mesh","ips":["240.0.0.0","::ffff:f000:0"]},{"name":"backend_test-ns_svc_8080.mesh","ips":["240.0.0.0","::ffff:f000:0"]},{"name":"httpbin.mesh","ips":["240.0.0.1","::ffff:f000:1"]}],"ttl":30}'
                   status: 200
                 match:
                   path: /dns
@@ -38,6 +38,6 @@ resources:
                 responseHeadersToAdd:
                 - header:
                     key: Etag
-                    value: 8b2b708ee2e09b69ef2e448f7a8ea04146b56c8ba9a0d45e58460feb1ba2af75
+                    value: 639772d25f9c22e338f3c54ebe8be0faeae7e30c57f1acbf2d8ba5eb191007fb
           statPrefix: _kuma_dynamicconfig
     name: _kuma:dynamicconfig


### PR DESCRIPTION
## Motivation

We want to switch to embedded DNS but we had some flakes.

## Implementation information

I've noticed that we fail in the following scenario:

1. We create an ExternalService, which allocates 240.0.0.3 for a real domain (something we don't do for MES).
2. Kong Gateway makes a request to the domain and receives a response with 240.0.0.3.
3. We update the DNS configuration and remove this DNS entry (since we're testing passthrough and removed the ExternalService).
4. Kong Gateway has cached the IP, and we no longer see logs indicating requests to the DNS server.

The default TTL is 3600s, so the cached record isn't refreshed.
This creates a potential issue when a service is removed and later redeployed with a new VIP address. Due to the long TTL, Kong might continue using the stale IP. A shorter TTL would help mitigate this risk.

## Supporting documentation

Fix https://github.com/kumahq/kuma/issues/13353
