### PR TITLE
fix(helm): rename enabledNamespace to namespaceAllowList

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -43,7 +43,7 @@ We have split the `ClusterRole` for the control plane into two parts:
 * A cluster-scoped `ClusterRole` with read access to namespaced resources.
 * A `ClusterRole` with write permissions, now scoped more narrowly.
 
-By default, a `ClusterRoleBinding` is used to grant write permissions to the control plane, and no action is required from the user. However, if you want the control plane to have access only in specific namespaces, you can use the `enabledNamespaces` configuration to define where it should have write permissions.
+By default, a `ClusterRoleBinding` is used to grant write permissions to the control plane, and no action is required from the user. However, if you want the control plane to have access only in specific namespaces, you can use the `namespaceAllowList` configuration to define where it should have write permissions.
 
 ### Namespaces that are part of the Mesh requires `kuma.io/sidecar-injection` label to exist
 

--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -20,9 +20,9 @@ installCrdsOnUpgrade:
 # -- Whether to disable all helm hooks
 noHelmHooks: false
 
-# -- Namespaces that are part of the Mesh. When specified, the control plane receives write permissions only for the listed namespaces.
+# -- Namespaces that are part of the Mesh. When specified, the control plane receives write permissions only for the allowed namespaces.
 # If not specified, the control plane has write permissions for all namespaces.
-enabledNamespaces: []
+namespaceAllowList: []
 
 # -- Determines whether ClusterRole, Role, ClusterRoleBinding, RoleBinding for Kuma should be created.
 # If set to true, the user must manually create these resources before installation.

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/roleBindingInNamespaces.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/roleBindingInNamespaces.golden.yaml
@@ -289,23 +289,6 @@ subjects:
     namespace: kuma-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: kuma-control-plane-writer
-  labels: 
-    app: kuma-control-plane
-    app.kubernetes.io/name: kuma
-    app.kubernetes.io/instance: kuma
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: kuma-control-plane-writer
-subjects:
-  - kind: ServiceAccount
-    name: kuma-control-plane
-    namespace: kuma-system
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: kuma-control-plane
@@ -377,6 +360,42 @@ rules:
       - get
       - patch
       - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kuma-control-plane-writer
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+  namespace: kuma-demo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kuma-control-plane-writer
+subjects:
+  - kind: ServiceAccount
+    name: kuma-control-plane
+    namespace: kuma-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kuma-control-plane-writer
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+  namespace: kuma-test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kuma-control-plane-writer
+subjects:
+  - kind: ServiceAccount
+    name: kuma-control-plane
+    namespace: kuma-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/roleBindingInNamespaces.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/roleBindingInNamespaces.golden.yaml
@@ -289,6 +289,23 @@ subjects:
     namespace: kuma-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kuma-control-plane-writer
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kuma-control-plane-writer
+subjects:
+  - kind: ServiceAccount
+    name: kuma-control-plane
+    namespace: kuma-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: kuma-control-plane
@@ -360,42 +377,6 @@ rules:
       - get
       - patch
       - update
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: kuma-control-plane-writer
-  labels: 
-    app: kuma-control-plane
-    app.kubernetes.io/name: kuma
-    app.kubernetes.io/instance: kuma
-  namespace: kuma-demo
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: kuma-control-plane-writer
-subjects:
-  - kind: ServiceAccount
-    name: kuma-control-plane
-    namespace: kuma-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: kuma-control-plane-writer
-  labels: 
-    app: kuma-control-plane
-    app.kubernetes.io/name: kuma
-    app.kubernetes.io/instance: kuma
-  namespace: kuma-test
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: kuma-control-plane-writer
-subjects:
-  - kind: ServiceAccount
-    name: kuma-control-plane
-    namespace: kuma-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/roleBindingInNamespaces.values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/roleBindingInNamespaces.values.yaml
@@ -1,1 +1,1 @@
-enabledNamespaces: ["kuma-demo", "kuma-test"]
+meshNamespaces: ["kuma-demo", "kuma-test"]

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/roleBindingInNamespaces.values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/roleBindingInNamespaces.values.yaml
@@ -1,1 +1,1 @@
-meshNamespaces: ["kuma-demo", "kuma-test"]
+namespaceAllowList: ["kuma-demo", "kuma-test"]

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -17,7 +17,7 @@ A Helm chart for the Kuma Control Plane
 | installCrdsOnUpgrade.enabled | bool | `true` | Whether install new CRDs before upgrade (if any were introduced with the new version of Kuma) |
 | installCrdsOnUpgrade.imagePullSecrets | list | `[]` | The `imagePullSecrets` to attach to the Service Account running CRD installation. This field will be deprecated in a future release, please use .global.imagePullSecrets |
 | noHelmHooks | bool | `false` | Whether to disable all helm hooks |
-| enabledNamespaces | list | `[]` | Namespaces that are part of the Mesh. When specified, the control plane receives write permissions only for the listed namespaces. If not specified, the control plane has write permissions for all namespaces. |
+| namespaceAllowList | list | `[]` | Namespaces that are part of the Mesh. When specified, the control plane receives write permissions only for the allowed namespaces. If not specified, the control plane has write permissions for all namespaces. |
 | skipRBAC | bool | `false` | Determines whether ClusterRole, Role, ClusterRoleBinding, RoleBinding for Kuma should be created. If set to true, the user must manually create these resources before installation. |
 | restartOnSecretChange | bool | `true` | Whether to restart control-plane by calculating a new checksum for the secret |
 | controlPlane.environment | string | `"kubernetes"` | Environment that control plane is run in, useful when running universal global control plane on k8s |

--- a/deployments/charts/kuma/templates/cni-rbac.yaml
+++ b/deployments/charts/kuma/templates/cni-rbac.yaml
@@ -32,9 +32,9 @@ rules:
       - list
       - watch
       {{- end }}
-{{- if gt (len .Values.enabledNamespaces) 0 }}
+{{- if gt (len .Values.namespaceAllowList) 0 }}
 {{- $root := . }}
-{{- range $element := .Values.enabledNamespaces }}
+{{- range $element := .Values.namespaceAllowList }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/deployments/charts/kuma/templates/cp-rbac.yaml
+++ b/deployments/charts/kuma/templates/cp-rbac.yaml
@@ -295,9 +295,9 @@ rules:
       - delete
   {{- end }}
 {{- end }}
-{{- if gt (len .Values.enabledNamespaces) 0 }}
+{{- if gt (len .Values.namespaceAllowList) 0 }}
 {{- $root := . }}
-{{- range $element := .Values.enabledNamespaces }}
+{{- range $element := .Values.namespaceAllowList }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -315,7 +315,7 @@ subjects:
     namespace: {{ $root.Release.Namespace }}
 {{- end }}
 {{- end }}
-{{- if and (eq (len .Values.enabledNamespaces) 0) (not .Values.controlPlane.skipClusterRoleCreation) }}
+{{- if and (eq (len .Values.namespaceAllowList) 0) (not .Values.controlPlane.skipClusterRoleCreation) }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -20,9 +20,9 @@ installCrdsOnUpgrade:
 # -- Whether to disable all helm hooks
 noHelmHooks: false
 
-# -- Namespaces that are part of the Mesh. When specified, the control plane receives write permissions only for the listed namespaces.
+# -- Namespaces that are part of the Mesh. When specified, the control plane receives write permissions only for the allowed namespaces.
 # If not specified, the control plane has write permissions for all namespaces.
-enabledNamespaces: []
+namespaceAllowList: []
 
 # -- Determines whether ClusterRole, Role, ClusterRoleBinding, RoleBinding for Kuma should be created.
 # If set to true, the user must manually create these resources before installation.

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -20,9 +20,9 @@ installCrdsOnUpgrade:
 # -- Whether to disable all helm hooks
 noHelmHooks: false
 
-# -- Namespaces that are part of the Mesh. When specified, the control plane receives write permissions only for the listed namespaces.
+# -- Namespaces that are part of the Mesh. When specified, the control plane receives write permissions only for the allowed namespaces.
 # If not specified, the control plane has write permissions for all namespaces.
-enabledNamespaces: []
+namespaceAllowList: []
 
 # -- Determines whether ClusterRole, Role, ClusterRoleBinding, RoleBinding for Kuma should be created.
 # If set to true, the user must manually create these resources before installation.


### PR DESCRIPTION
## Motivation

`enabledNamespace` is not a good name, we decided to rename.

## Implementation information

rename to `namespaceAllowList`

## Supporting documentation

Fix #13459 
