### PR TITLE
test(e2e): upgrade gateway-api test from 1.2.1 to 1.3.0

### DIFF
--- a/test/framework/k8s.go
+++ b/test/framework/k8s.go
@@ -70,7 +70,7 @@ func GatewayAPICRDs(cluster Cluster) error {
 	return k8s.RunKubectlE(
 		cluster.GetTesting(),
 		cluster.GetKubectlOptions(),
-		"apply", "-f", "https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml")
+		"apply", "-f", "https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.3.0/standard-install.yaml")
 }
 
 func UpdateKubeObject(


### PR DESCRIPTION
## Motivation

https://github.com/kumahq/kuma/pull/13477#pullrequestreview-2798952463

## Implementation information

we should probably upgrade this

## Supporting documentation



> Changelog: skip
