### PR TITLE
docs(MADR): defining and migrating to consistent naming for non-system Envoy resources and stats

### DIFF
--- a/docs/madr/decisions/077-migrating-to-consistent-and-well-defined-naming-for-non-system-envoy-resources-and-stats.md
+++ b/docs/madr/decisions/077-migrating-to-consistent-and-well-defined-naming-for-non-system-envoy-resources-and-stats.md
@@ -26,10 +26,7 @@ The original goal of this MADR was to describe how to switch all non-system Envo
 This MADR now:
 
 * Defines how non-system Envoy resources and stat names should be structured
-* Introduces and formally defines the `self_<descriptor>` naming format for resources that exist only in the context of the current `Dataplane`
-* Defines valid formats for `<descriptor>`, including:
-   * Port names or values for non-system inbounds
-   * Predefined values for passthrough traffic (e.g., `passthrough-ipv4-inbound`)
+* Introduces and formally defines the `self_<descriptor>` contextual naming format
 * Specifies which resource types must use the `self_<descriptor>` format
 * Describes when KRI format (defined in [MADR-070](070-resource-identifier.md)) is used for resources tied to distinct Kuma objects
 * Provides a migration path to switch to the new formats safely and gradually


### PR DESCRIPTION
## Motivation

We want to build new functionalities based on metrics and we should keep them consitant and easy to reference in config

## Implementation information

Fix https://github.com/kumahq/kuma/issues/13264

@slonka edit: poc branch https://github.com/lukidzi/kuma/tree/stats-renaming