### PR TITLE
fix(xds): use correct context to cleanup dataplane object when the proxy is disconnecting

### DIFF
--- a/pkg/xds/server/callbacks/dataplane_lifecycle.go
+++ b/pkg/xds/server/callbacks/dataplane_lifecycle.go
@@ -91,7 +91,7 @@ func (d *DataplaneLifecycle) OnProxyDisconnected(ctx context.Context, streamID c
 	default:
 	}
 
-	// we need to use appCtx here, "ctx" should not be used here because it has the same lifetime with the underlying gRPC stream itself and the gRPC stream is terminating now
+	// we need to use appCtx here, "ctx" should not be used because it has the same lifetime with the underlying gRPC stream itself and the gRPC stream is terminating now
 	d.deregister(d.appCtx, streamID, proxyKey)
 }
 
@@ -188,16 +188,17 @@ func (d *DataplaneLifecycle) deregister(
 		return
 	}
 
-	if connected, err := d.proxyConnectedToAnotherCP(ctx, proxyType, proxyKey, log); err != nil {
+	connected, err := d.proxyConnectedToAnotherCP(ctx, proxyType, proxyKey, log)
+	if err != nil {
 		log.Error(err, "could not check if proxy connected to another CP")
-		return
-	} else if connected {
 		return
 	}
 
-	log.Info("deregister proxy")
-	if err := d.resManager.Delete(ctx, proxyResource(proxyType), store.DeleteBy(proxyKey)); err != nil {
-		log.Error(err, "could not unregister proxy")
+	if !connected {
+		log.Info("deregister proxy")
+		if err := d.resManager.Delete(ctx, proxyResource(proxyType), store.DeleteBy(proxyKey)); err != nil {
+			log.Error(err, "could not unregister proxy")
+		}
 	}
 
 	d.proxyInfos.Delete(proxyKey)

--- a/pkg/xds/server/callbacks/dataplane_lifecycle.go
+++ b/pkg/xds/server/callbacks/dataplane_lifecycle.go
@@ -91,7 +91,8 @@ func (d *DataplaneLifecycle) OnProxyDisconnected(ctx context.Context, streamID c
 	default:
 	}
 
-	d.deregister(ctx, streamID, proxyKey)
+	// we need to use appCtx here, "ctx" should not be used here because it has the same lifetime with the underlying gRPC stream itself and the gRPC stream is terminating now
+	d.deregister(d.appCtx, streamID, proxyKey)
 }
 
 func (d *DataplaneLifecycle) register(

--- a/pkg/xds/server/callbacks/dataplane_lifecycle.go
+++ b/pkg/xds/server/callbacks/dataplane_lifecycle.go
@@ -92,7 +92,7 @@ func (d *DataplaneLifecycle) OnProxyDisconnected(ctx context.Context, streamID c
 	}
 
 	// we need to use appCtx here, "ctx" should not be used because it has the same lifetime with the underlying gRPC stream itself and the gRPC stream is terminating now
-	d.deregister(d.appCtx, streamID, proxyKey)
+	d.deregister(d.appCtx, streamID, proxyKey) // nolint: contextcheck
 }
 
 func (d *DataplaneLifecycle) register(


### PR DESCRIPTION
## Motivation

Fixing the grace termination process of DPPs on Universal.

The issue does not apply  to Kubernetes mode, becasue we have the Pod delete event and DP objects are cleaned up correctly.

## Implementation information

* use the app context instead of the gRPC stream context to delete DP objects

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

fixes https://github.com/kumahq/kuma/issues/13403

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
