### PR TITLE
test(framework): add the ability to customize docker volumes and arguments

### DIFF
--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -35,7 +35,7 @@ type kumaDeploymentOptions struct {
 	helmChartPath               *string
 	helmChartVersion            string
 	helmOpts                    map[string]string
-	noHelmOpts                  []string
+	helmOptsExcluded            []string
 	env                         map[string]string
 	zoneIngress                 bool
 	zoneIngressEnvoyAdminTunnel bool
@@ -56,6 +56,9 @@ type kumaDeploymentOptions struct {
 	// Functions to apply to each mesh after the control plane
 	// is provisioned.
 	meshUpdateFuncs map[string][]func(*mesh_proto.Mesh) *mesh_proto.Mesh
+
+	// extra docker container options to attach when running on universal
+	dockerRunOptions []string
 }
 
 func (k *kumaDeploymentOptions) apply(opts ...KumaDeploymentOption) {
@@ -120,6 +123,7 @@ type appDeploymentOptions struct {
 
 	dockerVolumes       []string
 	dockerContainerName string
+	dockerRunOptions    []string
 }
 
 func (d *appDeploymentOptions) apply(opts ...AppDeploymentOption) {
@@ -256,13 +260,13 @@ func WithHelmOpt(name, value string) KumaDeploymentOption {
 
 func WithoutHelmOpt(name string) KumaDeploymentOption {
 	return KumaOptionFunc(func(o *kumaDeploymentOptions) {
-		o.noHelmOpts = append(o.noHelmOpts, name)
+		o.helmOptsExcluded = append(o.helmOptsExcluded, name)
 	})
 }
 
 func ClearNoHelmOpts() KumaDeploymentOption {
 	return KumaOptionFunc(func(o *kumaDeploymentOptions) {
-		o.noHelmOpts = nil
+		o.helmOptsExcluded = nil
 	})
 }
 
@@ -352,6 +356,12 @@ func WithCtlOpts(opts map[string]string) KumaDeploymentOption {
 		for name, value := range opts {
 			o.ctlOpts[name] = value
 		}
+	})
+}
+
+func WithCPDockerRunOptions(options []string) KumaDeploymentOption {
+	return KumaOptionFunc(func(o *kumaDeploymentOptions) {
+		o.dockerRunOptions = options
 	})
 }
 
@@ -563,6 +573,12 @@ func WithDockerVolumes(volumes ...string) AppDeploymentOption {
 func WithDockerContainerName(name string) AppDeploymentOption {
 	return AppOptionFunc(func(o *appDeploymentOptions) {
 		o.dockerContainerName = name
+	})
+}
+
+func WithAppDockerRunOptions(options []string) AppDeploymentOption {
+	return AppOptionFunc(func(o *appDeploymentOptions) {
+		o.dockerRunOptions = options
 	})
 }
 

--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -59,6 +59,7 @@ type kumaDeploymentOptions struct {
 
 	// extra docker container options to attach when running on universal
 	dockerRunOptions []string
+	dockerVolumes    []string
 }
 
 func (k *kumaDeploymentOptions) apply(opts ...KumaDeploymentOption) {
@@ -362,6 +363,12 @@ func WithCtlOpts(opts map[string]string) KumaDeploymentOption {
 func WithCPDockerRunOptions(options []string) KumaDeploymentOption {
 	return KumaOptionFunc(func(o *kumaDeploymentOptions) {
 		o.dockerRunOptions = options
+	})
+}
+
+func WithCPDockerVolumes(volumes ...string) KumaDeploymentOption {
+	return KumaOptionFunc(func(o *kumaDeploymentOptions) {
+		o.dockerVolumes = append(o.dockerVolumes, volumes...)
 	})
 }
 

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -492,7 +492,7 @@ func (c *K8sCluster) genValues(mode string) map[string]string {
 		}
 	}
 
-	for _, value := range c.opts.noHelmOpts {
+	for _, value := range c.opts.helmOptsExcluded {
 		delete(values, value)
 	}
 

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -642,17 +642,15 @@ func universalZoneProxyRelatedResource(
 
 		app, err := NewUniversalApp(
 			cluster.GetTesting(),
-			uniCluster.GetDockerBackend(),
 			uniCluster.name,
 			dpName,
 			"",
 			appType,
-			Config.IPV6,
-			false,
-			[]string{},
-			[]string{},
-			"",
-			concurrency,
+			UniversalAppRunOptions{
+				Backend:       uniCluster.GetDockerBackend(),
+				DPConcurrency: concurrency,
+				EnableIPv6:    Config.IPV6,
+			},
 		)
 		if err != nil {
 			return err

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -647,7 +647,7 @@ func universalZoneProxyRelatedResource(
 			"",
 			appType,
 			UniversalAppRunOptions{
-				Backend:       uniCluster.GetDockerBackend(),
+				DockerBackend: uniCluster.GetDockerBackend(),
 				DPConcurrency: concurrency,
 				EnableIPv6:    Config.IPV6,
 			},

--- a/test/framework/universal_app.go
+++ b/test/framework/universal_app.go
@@ -209,20 +209,32 @@ type UniversalApp struct {
 	dockerBackend       DockerBackend
 }
 
-func NewUniversalApp(t testing.TestingT, dockerBackend DockerBackend, clusterName, appName, mesh string, mode AppMode, isipv6, verbose bool, caps, volumes []string, containerName string, concurrency int) (*UniversalApp, error) {
+type UniversalAppRunOptions struct {
+	Backend              DockerBackend
+	DPConcurrency        int
+	EnvironmentVariables []string
+	ContainerName        string
+	Volumes              []string
+	Capabilities         []string
+	EnableIPv6           bool
+	Verbose              bool
+	OtherOptions         []string
+}
+
+func NewUniversalApp(t testing.TestingT, clusterName, appName, mesh string, mode AppMode, runOptions UniversalAppRunOptions) (*UniversalApp, error) {
 	app := &UniversalApp{
 		t:             t,
 		ports:         map[string]string{},
-		verbose:       verbose,
+		verbose:       runOptions.Verbose,
 		mesh:          mesh,
 		appName:       appName,
 		containerName: fmt.Sprintf("%s_%s_%s", clusterName, appName, random.UniqueId()),
-		concurrency:   concurrency,
+		concurrency:   runOptions.DPConcurrency,
 		clusterName:   clusterName,
-		dockerBackend: dockerBackend,
+		dockerBackend: runOptions.Backend,
 	}
-	if containerName != "" {
-		app.containerName = containerName
+	if runOptions.ContainerName != "" {
+		app.containerName = runOptions.ContainerName
 	}
 	app.allocatePublicPortsFor("22")
 	if mode == AppModeCP {
@@ -233,27 +245,29 @@ func NewUniversalApp(t testing.TestingT, dockerBackend DockerBackend, clusterNam
 		"--network", DockerNetworkName,
 	}
 	dockerExtraOptions = append(dockerExtraOptions, app.publishPortsForDocker()...)
-	if !isipv6 {
+	if !runOptions.EnableIPv6 {
 		// For now supporting mixed environments with IPv4 and IPv6 addresses is challenging, specifically with
 		// builtin DNS. This is due to our mix of CoreDNS and Envoy DNS architecture.
 		// Here we make sure the IPv6 address is not allocated to the container unless explicitly requested.
 		dockerExtraOptions = append(dockerExtraOptions, "--sysctl", "net.ipv6.conf.all.disable_ipv6=1")
 	}
-	for _, c := range caps {
+	for _, c := range runOptions.Capabilities {
 		dockerExtraOptions = append(dockerExtraOptions, "--cap-add", c)
 	}
+	dockerExtraOptions = append(dockerExtraOptions, runOptions.OtherOptions...)
 	app.logger = logger.Discard
-	if verbose {
+	if runOptions.Verbose {
 		app.logger = logger.Default
 	}
 
 	container, err := app.dockerBackend.RunAndGetIDE(t, Config.GetUniversalImage(), &docker.RunOptions{
-		Detach:       true,
-		Remove:       true,
-		Name:         app.containerName,
-		Volumes:      volumes,
-		OtherOptions: dockerExtraOptions,
-		Logger:       app.logger,
+		Detach:               true,
+		Remove:               true,
+		Name:                 app.containerName,
+		Volumes:              runOptions.Volumes,
+		OtherOptions:         dockerExtraOptions,
+		Logger:               app.logger,
+		EnvironmentVariables: runOptions.EnvironmentVariables,
 	})
 	if err != nil {
 		return nil, err

--- a/test/framework/universal_app.go
+++ b/test/framework/universal_app.go
@@ -210,7 +210,7 @@ type UniversalApp struct {
 }
 
 type UniversalAppRunOptions struct {
-	Backend              DockerBackend
+	DockerBackend        DockerBackend
 	DPConcurrency        int
 	EnvironmentVariables []string
 	ContainerName        string
@@ -231,7 +231,7 @@ func NewUniversalApp(t testing.TestingT, clusterName, appName, mesh string, mode
 		containerName: fmt.Sprintf("%s_%s_%s", clusterName, appName, random.UniqueId()),
 		concurrency:   runOptions.DPConcurrency,
 		clusterName:   clusterName,
-		dockerBackend: runOptions.Backend,
+		dockerBackend: runOptions.DockerBackend,
 	}
 	if runOptions.ContainerName != "" {
 		app.containerName = runOptions.ContainerName
@@ -265,9 +265,9 @@ func NewUniversalApp(t testing.TestingT, clusterName, appName, mesh string, mode
 		Remove:               true,
 		Name:                 app.containerName,
 		Volumes:              runOptions.Volumes,
-		OtherOptions:         dockerExtraOptions,
 		Logger:               app.logger,
 		EnvironmentVariables: runOptions.EnvironmentVariables,
+		OtherOptions:         dockerExtraOptions,
 	})
 	if err != nil {
 		return nil, err

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -196,7 +196,7 @@ func (c *UniversalCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOpt
 
 	app, err := NewUniversalApp(c.t, c.name, AppModeCP, "", AppModeCP,
 		UniversalAppRunOptions{
-			Backend:       c.dockerBackend,
+			DockerBackend: c.dockerBackend,
 			DPConcurrency: 0,
 			EnableIPv6:    c.opts.isipv6,
 			Volumes:       dockerVolumes,
@@ -365,13 +365,14 @@ func (c *UniversalCluster) DeployApp(opt ...AppDeploymentOption) error {
 
 	app, err := NewUniversalApp(c.t, c.name, opts.name, opts.mesh, AppMode(appname),
 		UniversalAppRunOptions{
-			Backend:       c.dockerBackend,
+			DockerBackend: c.dockerBackend,
 			DPConcurrency: 0,
 			EnableIPv6:    opts.isipv6,
 			Verbose:       *opts.verbose,
 			Capabilities:  caps,
 			Volumes:       opts.dockerVolumes,
 			ContainerName: opts.dockerContainerName,
+			OtherOptions:  opts.dockerRunOptions,
 		})
 	if err != nil {
 		return err

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -194,7 +194,13 @@ func (c *UniversalCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOpt
 	}
 	_, _ = fmt.Fprintf(cmd, "%s\n", runCp)
 
-	app, err := NewUniversalApp(c.t, c.dockerBackend, c.name, AppModeCP, "", AppModeCP, c.opts.isipv6, false, []string{}, dockerVolumes, "", 0)
+	app, err := NewUniversalApp(c.t, c.name, AppModeCP, "", AppModeCP,
+		UniversalAppRunOptions{
+			Backend:       c.dockerBackend,
+			DPConcurrency: 0,
+			EnableIPv6:    c.opts.isipv6,
+			Volumes:       dockerVolumes,
+		})
 	if err != nil {
 		return err
 	}
@@ -357,7 +363,16 @@ func (c *UniversalCluster) DeployApp(opt ...AppDeploymentOption) error {
 
 	Logf("IPV6 is %v", opts.isipv6)
 
-	app, err := NewUniversalApp(c.t, c.dockerBackend, c.name, opts.name, opts.mesh, AppMode(appname), opts.isipv6, *opts.verbose, caps, opts.dockerVolumes, opts.dockerContainerName, 0)
+	app, err := NewUniversalApp(c.t, c.name, opts.name, opts.mesh, AppMode(appname),
+		UniversalAppRunOptions{
+			Backend:       c.dockerBackend,
+			DPConcurrency: 0,
+			EnableIPv6:    opts.isipv6,
+			Verbose:       *opts.verbose,
+			Capabilities:  caps,
+			Volumes:       opts.dockerVolumes,
+			ContainerName: opts.dockerContainerName,
+		})
 	if err != nil {
 		return err
 	}

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -133,6 +133,7 @@ func (c *UniversalCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOpt
 	} else {
 		opt = append([]KumaDeploymentOption{WithEnvs(Config.KumaUniversalEnvVars)}, opt...)
 	}
+	c.opts = kumaDeploymentOptions{}
 	c.opts.apply(opt...)
 	if c.opts.installationMode != KumactlInstallationMode {
 		return errors.Errorf("universal clusters only support the '%s' installation mode but got '%s'", KumactlInstallationMode, c.opts.installationMode)

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -165,7 +165,7 @@ func (c *UniversalCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOpt
 		env["KUMA_MULTIZONE_ZONE_KDS_TLS_SKIP_VERIFY"] = "true"
 	}
 
-	var dockerVolumes []string
+	dockerVolumes := c.opts.dockerVolumes
 	if c.opts.yamlConfig != "" {
 		path, err := os.MkdirTemp("", "e2e-cp-cfg-*")
 		if err != nil {
@@ -200,6 +200,7 @@ func (c *UniversalCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOpt
 			DPConcurrency: 0,
 			EnableIPv6:    c.opts.isipv6,
 			Volumes:       dockerVolumes,
+			OtherOptions:  c.opts.dockerRunOptions,
 		})
 	if err != nil {
 		return err


### PR DESCRIPTION
## Motivation

Adding the ability to customize docker volumes and arguments when installing Kuma on Universal. With this ability, we can attach certificates and other resources in E2E tests.

## Implementation information

* Introducing helper method `WithCPDockerVolumes` to test framework
* Introducing helper method `WithCPDockerRunOptions` to test framework (to allow specify docker arguments like `--ip`)

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

An enahancement to https://github.com/kumahq/kuma/pull/13301


> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
