### PR TITLE
fix(kuma-cp): fix top level MeshService deprecation message and point users to Dataplane kind

### DIFF
--- a/pkg/plugins/policies/core/jsonpatch/validators/validator.go
+++ b/pkg/plugins/policies/core/jsonpatch/validators/validator.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
-	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/validators"
 )
 
@@ -123,12 +122,12 @@ func TopLevelTargetRefDeprecations(targetRef *common_api.TargetRef) []string {
 	if targetRef == nil {
 		return nil
 	}
-	if targetRef.Kind == common_api.MeshService {
-		return []string{
-			fmt.Sprintf("%s value for 'targetRef.kind' is deprecated, use %s with '%s' tag instead", common_api.MeshService, common_api.MeshSubset, mesh_proto.ServiceTag),
-		}
+	replacedByDataplane := map[common_api.TargetRefKind]struct{}{
+		common_api.MeshService:       {},
+		common_api.MeshServiceSubset: {},
+		common_api.MeshSubset:        {},
 	}
-	if targetRef.Kind == common_api.MeshSubset {
+	if _, ok := replacedByDataplane[targetRef.Kind]; ok {
 		return []string{
 			fmt.Sprintf("%s value for 'targetRef.kind' is deprecated, use %s with labels instead", common_api.MeshSubset, common_api.Dataplane),
 		}

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtlbs.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtlbs.global.golden.yaml
@@ -7,5 +7,4 @@ uid: "12345"
 warnings:
 - SourceIP type for 'spec.to[0].default.loadBalancer.ringHash.hashPolicies[0].type'
   is deprecated, use Connection instead
-- MeshService value for 'targetRef.kind' is deprecated, use MeshSubset with 'kuma.io/service'
-  tag instead
+- MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtlbs.non-federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtlbs.non-federated.golden.yaml
@@ -7,5 +7,4 @@ uid: "12345"
 warnings:
 - SourceIP type for 'spec.to[0].default.loadBalancer.ringHash.hashPolicies[0].type'
   is deprecated, use Connection instead
-- MeshService value for 'targetRef.kind' is deprecated, use MeshSubset with 'kuma.io/service'
-  tag instead
+- MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtp.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtp.global.golden.yaml
@@ -5,7 +5,6 @@ status:
   metadata: {}
 uid: "12345"
 warnings:
-- MeshService value for 'targetRef.kind' is deprecated, use MeshSubset with 'kuma.io/service'
-  tag instead
+- MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead
 - MeshService value for 'from[].targetRef.kind' is deprecated, use MeshSubset with
   'kuma.io/service' instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtp.non-federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtp.non-federated.golden.yaml
@@ -5,7 +5,6 @@ status:
   metadata: {}
 uid: "12345"
 warnings:
-- MeshService value for 'targetRef.kind' is deprecated, use MeshSubset with 'kuma.io/service'
-  tag instead
+- MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead
 - MeshService value for 'from[].targetRef.kind' is deprecated, use MeshSubset with
   'kuma.io/service' instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_zone-mtp.federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_zone-mtp.federated.golden.yaml
@@ -5,7 +5,6 @@ status:
   metadata: {}
 uid: "12345"
 warnings:
-- MeshService value for 'targetRef.kind' is deprecated, use MeshSubset with 'kuma.io/service'
-  tag instead
+- MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead
 - MeshService value for 'from[].targetRef.kind' is deprecated, use MeshSubset with
   'kuma.io/service' instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_zone-mtp.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_zone-mtp.global.golden.yaml
@@ -5,7 +5,6 @@ status:
   metadata: {}
 uid: "12345"
 warnings:
-- MeshService value for 'targetRef.kind' is deprecated, use MeshSubset with 'kuma.io/service'
-  tag instead
+- MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead
 - MeshService value for 'from[].targetRef.kind' is deprecated, use MeshSubset with
   'kuma.io/service' instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_zone-mtp.non-federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_zone-mtp.non-federated.golden.yaml
@@ -5,7 +5,6 @@ status:
   metadata: {}
 uid: "12345"
 warnings:
-- MeshService value for 'targetRef.kind' is deprecated, use MeshSubset with 'kuma.io/service'
-  tag instead
+- MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead
 - MeshService value for 'from[].targetRef.kind' is deprecated, use MeshSubset with
   'kuma.io/service' instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.federated.golden.yaml
@@ -7,5 +7,4 @@ uid: "12345"
 warnings:
 - SourceIP type for 'spec.to[0].default.loadBalancer.ringHash.hashPolicies[0].type'
   is deprecated, use Connection instead
-- MeshService value for 'targetRef.kind' is deprecated, use MeshSubset with 'kuma.io/service'
-  tag instead
+- MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.global.golden.yaml
@@ -7,5 +7,4 @@ uid: "12345"
 warnings:
 - SourceIP type for 'spec.to[0].default.loadBalancer.ringHash.hashPolicies[0].type'
   is deprecated, use Connection instead
-- MeshService value for 'targetRef.kind' is deprecated, use MeshSubset with 'kuma.io/service'
-  tag instead
+- MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.non-federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.non-federated.golden.yaml
@@ -7,5 +7,4 @@ uid: "12345"
 warnings:
 - SourceIP type for 'spec.to[0].default.loadBalancer.ringHash.hashPolicies[0].type'
   is deprecated, use Connection instead
-- MeshService value for 'targetRef.kind' is deprecated, use MeshSubset with 'kuma.io/service'
-  tag instead
+- MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mtp.federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mtp.federated.golden.yaml
@@ -5,7 +5,6 @@ status:
   metadata: {}
 uid: "12345"
 warnings:
-- MeshService value for 'targetRef.kind' is deprecated, use MeshSubset with 'kuma.io/service'
-  tag instead
+- MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead
 - MeshService value for 'from[].targetRef.kind' is deprecated, use MeshSubset with
   'kuma.io/service' instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mtp.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mtp.global.golden.yaml
@@ -5,7 +5,6 @@ status:
   metadata: {}
 uid: "12345"
 warnings:
-- MeshService value for 'targetRef.kind' is deprecated, use MeshSubset with 'kuma.io/service'
-  tag instead
+- MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead
 - MeshService value for 'from[].targetRef.kind' is deprecated, use MeshSubset with
   'kuma.io/service' instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mtp.non-federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mtp.non-federated.golden.yaml
@@ -5,7 +5,6 @@ status:
   metadata: {}
 uid: "12345"
 warnings:
-- MeshService value for 'targetRef.kind' is deprecated, use MeshSubset with 'kuma.io/service'
-  tag instead
+- MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead
 - MeshService value for 'from[].targetRef.kind' is deprecated, use MeshSubset with
   'kuma.io/service' instead


### PR DESCRIPTION
## Motivation

When we deprecated MeshSubset in top level targetRef we forgot to change the deprecation message for MeshService. So now we tell users to use MeshSubset which is also deprecated and confuses users

Fix https://github.com/kumahq/kuma/issues/13435

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
