### PR TITLE
ci(ipv6): revert skip ipv6

### DIFF
--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -23,8 +23,7 @@ jobs:
     timeout-minutes: 60
     # can't use env vars here
     runs-on: ${{ inputs.runner }}
-    # workaround for this bug https://github.com/actions/runner-images/issues/11985 - revert when done
-    if: ${{ fromJSON(inputs.matrix).k8sVersion != 'kindipv6' && inputs.runner != '' }}
+    if: ${{ inputs.runner != '' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Motivation

It was resolved for both GH actions and in private runners:

CC @Water-Melon 

```
The self-hosted runner has been bumped to version 20250504.1.
```

## Implementation information

Revert https://github.com/kumahq/kuma/pull/13392/files