### PR TITLE
chore(oapi): bump version to 3.1.0

### DIFF
--- a/api/mesh/v1alpha1/builtincertificateauthorityconfig/schema.yaml
+++ b/api/mesh/v1alpha1/builtincertificateauthorityconfig/schema.yaml
@@ -13,4 +13,4 @@ components:
       type: object
 info:
   x-ref-schema-name: BuiltinCertificateAuthorityConfig
-openapi: 3.0.3
+openapi: 3.1.0

--- a/api/mesh/v1alpha1/datadogtracingbackendconfig/schema.yaml
+++ b/api/mesh/v1alpha1/datadogtracingbackendconfig/schema.yaml
@@ -19,4 +19,4 @@ components:
       type: object
 info:
   x-ref-schema-name: DatadogTracingBackendConfig
-openapi: 3.0.3
+openapi: 3.1.0

--- a/api/mesh/v1alpha1/dataplane/rest.yaml
+++ b/api/mesh/v1alpha1/dataplane/rest.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   version: v1alpha1
   title: Kuma API

--- a/api/mesh/v1alpha1/dataplaneoverview/schema.yaml
+++ b/api/mesh/v1alpha1/dataplaneoverview/schema.yaml
@@ -588,4 +588,4 @@ components:
       type: object
 info:
   x-ref-schema-name: DataplaneOverview
-openapi: 3.0.3
+openapi: 3.1.0

--- a/api/mesh/v1alpha1/fileloggingbackendconfig/schema.yaml
+++ b/api/mesh/v1alpha1/fileloggingbackendconfig/schema.yaml
@@ -8,4 +8,4 @@ components:
       type: object
 info:
   x-ref-schema-name: FileLoggingBackendConfig
-openapi: 3.0.3
+openapi: 3.1.0

--- a/api/mesh/v1alpha1/mesh/rest.yaml
+++ b/api/mesh/v1alpha1/mesh/rest.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   version: v1alpha1
   title: Kuma API

--- a/api/mesh/v1alpha1/meshgateway/rest.yaml
+++ b/api/mesh/v1alpha1/meshgateway/rest.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   version: v1alpha1
   title: Kuma API

--- a/api/mesh/v1alpha1/prometheusmetricsbackendconfig/schema.yaml
+++ b/api/mesh/v1alpha1/prometheusmetricsbackendconfig/schema.yaml
@@ -85,4 +85,4 @@ components:
       type: object
 info:
   x-ref-schema-name: PrometheusMetricsBackendConfig
-openapi: 3.0.3
+openapi: 3.1.0

--- a/api/mesh/v1alpha1/providedcertificateauthorityconfig/schema.yaml
+++ b/api/mesh/v1alpha1/providedcertificateauthorityconfig/schema.yaml
@@ -19,4 +19,4 @@ components:
       type: object
 info:
   x-ref-schema-name: ProvidedCertificateAuthorityConfig
-openapi: 3.0.3
+openapi: 3.1.0

--- a/api/mesh/v1alpha1/tcploggingbackendconfig/schema.yaml
+++ b/api/mesh/v1alpha1/tcploggingbackendconfig/schema.yaml
@@ -8,4 +8,4 @@ components:
       type: object
 info:
   x-ref-schema-name: TcpLoggingBackendConfig
-openapi: 3.0.3
+openapi: 3.1.0

--- a/api/mesh/v1alpha1/zipkintracingbackendconfig/schema.yaml
+++ b/api/mesh/v1alpha1/zipkintracingbackendconfig/schema.yaml
@@ -23,4 +23,4 @@ components:
       type: object
 info:
   x-ref-schema-name: ZipkinTracingBackendConfig
-openapi: 3.0.3
+openapi: 3.1.0

--- a/api/openapi/specs/api.yaml
+++ b/api/openapi/specs/api.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   title: Kuma API
   description: Kuma API

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   title: Kuma API
   description: Kuma API

--- a/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/rest.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   version: v1alpha1
   title: Kuma API

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/rest.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   version: v1alpha1
   title: Kuma API

--- a/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/rest.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   version: v1alpha1
   title: Kuma API

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/rest.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   version: v1alpha1
   title: Kuma API

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/rest.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   version: v1alpha1
   title: Kuma API

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/rest.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   version: v1alpha1
   title: Kuma API

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/rest.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   version: v1alpha1
   title: Kuma API

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/rest.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   version: v1alpha1
   title: Kuma API

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/rest.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   version: v1alpha1
   title: Kuma API

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/rest.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   version: v1alpha1
   title: Kuma API

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/rest.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   version: v1alpha1
   title: Kuma API

--- a/pkg/plugins/policies/meshpassthrough/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshpassthrough/api/v1alpha1/rest.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   version: v1alpha1
   title: Kuma API

--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/rest.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   version: v1alpha1
   title: Kuma API

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/rest.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   version: v1alpha1
   title: Kuma API

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/rest.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   version: v1alpha1
   title: Kuma API

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/rest.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   version: v1alpha1
   title: Kuma API

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/rest.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   version: v1alpha1
   title: Kuma API

--- a/pkg/plugins/policies/meshtls/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtls/api/v1alpha1/rest.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   version: v1alpha1
   title: Kuma API

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/rest.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   version: v1alpha1
   title: Kuma API

--- a/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/rest.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   version: v1alpha1
   title: Kuma API

--- a/tools/openapi/templates/endpoints.yaml
+++ b/tools/openapi/templates/endpoints.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   version: {{ .Package }}
   title: Kuma API

--- a/tools/resource-gen/pkg/generator/main.go
+++ b/tools/resource-gen/pkg/generator/main.go
@@ -552,7 +552,7 @@ func openApiGenerator(pkg string, resources []ResourceInfo) error {
 		}
 
 		wrapped := map[string]interface{}{
-			"openapi": "3.0.3",
+			"openapi": "3.1.0",
 			"info": map[string]string{
 				"x-ref-schema-name": tpe.Name(),
 			},


### PR DESCRIPTION
## Motivation

Otherwise the merge tool fails in parent project on:

```
error loading swagger spec in api/openapi/specs/global_insight.yaml
: failed to load OpenAPI specification: error resolving reference "../kuma/openapi.yaml#/components/schemas/GlobalInsight": failed to unmarshal data: json error: invalid character 'o' looking for beginning of value, yaml error: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal bool into field Schema.properties of type openapi3.Schema
error loading swagger spec in api/openapi/specs/tenants.yaml
: failed to load OpenAPI specification: error resolving reference "../kuma/openapi.yaml#/components/responses/BadRequest": failed to unmarshal data: json error: invalid character 'o' looking for beginning of value, yaml error: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal bool into field Schema.properties of type openapi3.Schema
make: *** [kuma/mk/generate.mk:108: generate/oas] Error 1
```

Not sure why proto generator generates 

```
Kind: true
```

which is not valid but somehow passes for `3.1.0` 🤷 

## Implementation information

Change oapi version to 3.1.0.

## Supporting documentation

We already set the oapi version to 3.1.0 in the terraform provider https://github.com/Kong/terraform-provider-kong-mesh/blob/main/openapi.yaml#L1 so this shouldn't change anything.