### PR TITLE
fix(api-server): ensure base path start with slash to prevent ServeMux panic

### DIFF
--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -131,9 +131,13 @@ func NewApiServer(
 	// We create a WebService and set up resources endpoints and index endpoint instead of creating WebService
 	// for every resource like /meshes/{mesh}/traffic-permissions, /meshes/{mesh}/traffic-log etc.
 	// because go-restful detects it as a clash (you cannot register 2 WebServices with path /meshes/)
+	apiBasePath := cfg.ApiServer.BasePath
+	if !strings.HasPrefix(apiBasePath, "/") {
+		apiBasePath = "/" + apiBasePath
+	}
 	ws := new(restful.WebService)
 	ws.
-		Path(cfg.ApiServer.BasePath).
+		Path(apiBasePath).
 		Consumes(restful.MIME_JSON).
 		Produces(restful.MIME_JSON)
 


### PR DESCRIPTION
## Motivation

- prevents panic when setting env `KUMA_API_SERVER_BASE_PATH` without `/`

## Implementation information

- prefix check on `BasePath` and adding `/` if missing

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #12335 

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
