### PR TITLE
chore(oapi): ignore structpb.Struct from oas generation

### DIFF
--- a/api/mesh/v1alpha1/dataplaneoverview/schema.yaml
+++ b/api/mesh/v1alpha1/dataplaneoverview/schema.yaml
@@ -415,15 +415,7 @@ components:
                   type: array
               type: object
             metadata:
-              properties:
-                fields:
-                  additionalProperties:
-                    properties:
-                      Kind: true
-                    required:
-                    - Kind
-                    type: object
-                  type: object
+              properties: {}
               type: object
             subscriptions:
               description: List of ADS subscriptions created by a given Dataplane.

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -4740,15 +4740,7 @@ components:
                   type: array
               type: object
             metadata:
-              properties:
-                fields:
-                  additionalProperties:
-                    properties:
-                      Kind: true
-                    required:
-                      - Kind
-                    type: object
-                  type: object
+              properties: {}
               type: object
             subscriptions:
               description: List of ADS subscriptions created by a given Dataplane.

--- a/tools/resource-gen/pkg/generator/main.go
+++ b/tools/resource-gen/pkg/generator/main.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/text/language"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	"sigs.k8s.io/yaml"
 
@@ -464,6 +465,7 @@ func openApiGenerator(pkg string, resources []ResourceInfo) error {
 		ExpandedStruct:            true,
 		DoNotReference:            true,
 		AllowAdditionalProperties: true,
+		IgnoredTypes:              []any{structpb.Struct{}},
 		KeyNamer: func(key string) string {
 			if key == "RSAbits" {
 				return "rsaBits"


### PR DESCRIPTION
## Motivation

https://github.com/kumahq/kuma/pull/13542 did not help because I think I confused it with a fix for another cryptic error. The actual fix should be https://github.com/kumahq/kuma/pull/12329/files#diff-d719909e3a90ac11d2e421de4759332f4795fa80fa0a2d0635a599cdae2dadd6R449 the same as in this PR.

## Implementation information

Add `structpb.Struct` to ignored types.
