### PR TITLE
feat(e2e): rewrite envoy config e2e test to make it reusable in other projects

### DIFF
--- a/test/e2e_env/universal/envoyconfig/builtingateway.go
+++ b/test/e2e_env/universal/envoyconfig/builtingateway.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	meshaccesslog "github.com/kumahq/kuma/pkg/plugins/policies/meshaccesslog/api/v1alpha1"
 	meshtimeout "github.com/kumahq/kuma/pkg/plugins/policies/meshtimeout/api/v1alpha1"
 	meshtls "github.com/kumahq/kuma/pkg/plugins/policies/meshtls/api/v1alpha1"
@@ -23,18 +24,17 @@ import (
 	"github.com/kumahq/kuma/test/framework/envs/universal"
 )
 
-func BuiltinGateway() {
-	mesh := "envoyconfig-builtingateway"
+const mesh = "envoyconfig-builtingateway"
 
-	const gatewayPort = 8080
+const gatewayPort = 8080
 
-	gatewayAddressPort := func(appName string, port int) string {
-		ip := universal.Cluster.GetApp(appName).GetIP()
-		return net.JoinHostPort(ip, strconv.Itoa(port))
-	}
+var gatewayAddressPort = func(appName string, port int) string {
+	ip := universal.Cluster.GetApp(appName).GetIP()
+	return net.JoinHostPort(ip, strconv.Itoa(port))
+}
 
-	meshGateway := func() string {
-		return fmt.Sprintf(`
+var meshGateway = func() string {
+	return fmt.Sprintf(`
 type: MeshGateway
 name: gateway-proxy
 mesh: %s
@@ -47,10 +47,10 @@ conf:
     protocol: HTTP
     hostname: example.kuma.io
 `, mesh, gatewayPort)
-	}
+}
 
-	meshHTTPRoute := func() string {
-		return fmt.Sprintf(`
+var meshHTTPRoute = func() string {
+	return fmt.Sprintf(`
 type: MeshHTTPRoute
 name: gateway-proxy-route
 mesh: %s
@@ -72,72 +72,81 @@ spec:
                 name: echo-service
                 port: 80
 `, mesh)
-	}
+}
 
-	BeforeAll(func() {
-		setup := NewClusterSetup().
-			Install(
-				Yaml(
-					builders.Mesh().
-						WithName(mesh).
-						WithoutInitialPolicies().
-						WithMeshServicesEnabled(mesh_proto.Mesh_MeshServices_Exclusive).
-						WithBuiltinMTLSBackend("ca-1").WithEnabledMTLSBackend("ca-1"),
-				),
-			).
-			Install(MeshTrafficPermissionAllowAllUniversal(mesh)).
-			Install(GatewayClientAppUniversal("gateway-client")).
-			Install(EchoServerApp(mesh, "echo-server", "echo-service", "universal")).
-			Install(GatewayProxyUniversal(mesh, "gateway-proxy")).
-			Install(YamlUniversal(meshGateway())).
-			Install(YamlUniversal(meshHTTPRoute()))
+func BuiltinGateway() {
+	BeforeAll(SetupGatewayCluster)
 
-		Expect(setup.Setup(universal.Cluster)).To(Succeed())
+	AfterEachFailure(AfterGatewayFailure)
 
-		waitMeshServiceReady(mesh, "echo-service")
+	E2EAfterAll(CleanupAfterGatewaySuite)
 
-		Eventually(ProxySimpleRequests(universal.Cluster, "universal",
-			gatewayAddressPort("gateway-proxy", gatewayPort), "example.kuma.io"), "60s", "1s").Should(Succeed())
-	})
-
-	AfterEachFailure(func() {
-		DebugUniversal(universal.Cluster, mesh)
-	})
-
-	E2EAfterAll(func() {
-		Expect(universal.Cluster.DeleteApp("gateway-client")).To(Succeed())
-		Expect(universal.Cluster.DeleteMeshApps(mesh)).To(Succeed())
-		Expect(universal.Cluster.DeleteMesh(mesh)).To(Succeed())
-	})
-
-	E2EAfterEach(func() {
-		Expect(DeleteMeshResources(
-			universal.Cluster,
-			mesh,
-			meshaccesslog.MeshAccessLogResourceTypeDescriptor,
-			meshtls.MeshTLSResourceTypeDescriptor,
-			meshtimeout.MeshTimeoutResourceTypeDescriptor,
-		)).To(Succeed())
-	})
+	E2EAfterEach(CleanupAfterGatewayTest(
+		meshaccesslog.MeshAccessLogResourceTypeDescriptor,
+		meshtls.MeshTLSResourceTypeDescriptor,
+		meshtimeout.MeshTimeoutResourceTypeDescriptor,
+	))
 
 	DescribeTable("should generate proper Envoy config",
-		func(inputFile string) {
-			// given
-			input, err := os.ReadFile(inputFile)
-			Expect(err).ToNot(HaveOccurred())
-
-			// when
-			if len(input) > 0 {
-				Expect(universal.Cluster.Install(YamlUniversal(string(input)))).To(Succeed())
-			}
-
-			// then
-			Eventually(func(g Gomega) {
-				g.Expect(getConfig(mesh, "gateway-proxy")).To(matchers.MatchGoldenJSON(strings.Replace(inputFile, "input.yaml", "gateway-proxy.golden.json", 1)))
-			}).Should(Succeed())
-		},
+		TestBuiltinGatewayConfig,
 		test.EntriesForFolder(filepath.Join("builtingateway", "meshaccesslog"), "envoyconfig"),
 		test.EntriesForFolder(filepath.Join("builtingateway", "meshtls"), "envoyconfig"),
 		test.EntriesForFolder(filepath.Join("builtingateway", "meshtimeout"), "envoyconfig"),
 	)
+}
+
+func TestBuiltinGatewayConfig(inputFile string) {
+	// given
+	input, err := os.ReadFile(inputFile)
+	Expect(err).ToNot(HaveOccurred())
+
+	// when
+	if len(input) > 0 {
+		Expect(universal.Cluster.Install(YamlUniversal(string(input)))).To(Succeed())
+	}
+
+	// then
+	Eventually(func(g Gomega) {
+		g.Expect(getConfig(mesh, "gateway-proxy")).To(matchers.MatchGoldenJSON(strings.Replace(inputFile, "input.yaml", "gateway-proxy.golden.json", 1)))
+	}).Should(Succeed())
+}
+
+func SetupGatewayCluster() {
+	setup := NewClusterSetup().
+		Install(
+			Yaml(
+				builders.Mesh().
+					WithName(mesh).
+					WithoutInitialPolicies().
+					WithMeshServicesEnabled(mesh_proto.Mesh_MeshServices_Exclusive).
+					WithBuiltinMTLSBackend("ca-1").WithEnabledMTLSBackend("ca-1"),
+			),
+		).
+		Install(MeshTrafficPermissionAllowAllUniversal(mesh)).
+		Install(GatewayClientAppUniversal("gateway-client")).
+		Install(EchoServerApp(mesh, "echo-server", "echo-service", "universal")).
+		Install(GatewayProxyUniversal(mesh, "gateway-proxy")).
+		Install(YamlUniversal(meshGateway())).
+		Install(YamlUniversal(meshHTTPRoute()))
+
+	Expect(setup.Setup(universal.Cluster)).To(Succeed())
+
+	waitMeshServiceReady(mesh, "echo-service")
+
+	Eventually(ProxySimpleRequests(universal.Cluster, "universal",
+		gatewayAddressPort("gateway-proxy", gatewayPort), "example.kuma.io"), "60s", "1s").Should(Succeed())
+}
+
+func CleanupAfterGatewayTest(policies ...core_model.ResourceTypeDescriptor) func() {
+	return cleanupAfterTest(mesh, policies...)
+}
+
+func CleanupAfterGatewaySuite() {
+	Expect(universal.Cluster.DeleteApp("gateway-client")).To(Succeed())
+	Expect(universal.Cluster.DeleteMeshApps(mesh)).To(Succeed())
+	Expect(universal.Cluster.DeleteMesh(mesh)).To(Succeed())
+}
+
+func AfterGatewayFailure() {
+	DebugUniversal(universal.Cluster, mesh)
 }

--- a/test/e2e_env/universal/envoyconfig/sidecars.go
+++ b/test/e2e_env/universal/envoyconfig/sidecars.go
@@ -31,9 +31,7 @@ const meshName = "envoyconfig"
 func Sidecars() {
 	BeforeAll(SetupSidecarCluster)
 
-	AfterEachFailure(func() {
-		DebugUniversal(universal.Cluster, meshName)
-	})
+	AfterEachFailure(AfterSidecarFailure)
 
 	E2EAfterAll(CleanupAfterSidecarSuite)
 
@@ -108,10 +106,14 @@ func SetupSidecarCluster() {
 }
 
 func CleanupAfterSidecarTest(policies ...core_model.ResourceTypeDescriptor) func() {
-	return cleanupAfterTest(mesh, policies...)
+	return cleanupAfterTest(meshName, policies...)
 }
 
 func CleanupAfterSidecarSuite() {
 	Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
 	Expect(universal.Cluster.DeleteMesh(meshName)).To(Succeed())
+}
+
+func AfterSidecarFailure() {
+	DebugUniversal(universal.Cluster, meshName)
 }

--- a/test/e2e_env/universal/envoyconfig/sidecars.go
+++ b/test/e2e_env/universal/envoyconfig/sidecars.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	meshaccesslog "github.com/kumahq/kuma/pkg/plugins/policies/meshaccesslog/api/v1alpha1"
 	meshcircuitbreaker "github.com/kumahq/kuma/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1"
 	meshfaultinjection "github.com/kumahq/kuma/pkg/plugins/policies/meshfaultinjection/api/v1alpha1"
@@ -25,80 +26,30 @@ import (
 	"github.com/kumahq/kuma/test/framework/envs/universal"
 )
 
+const meshName = "envoyconfig"
+
 func Sidecars() {
-	meshName := "envoyconfig"
-
-	BeforeAll(func() {
-		err := NewClusterSetup().
-			Install(
-				Yaml(
-					builders.Mesh().
-						WithName(meshName).
-						WithoutInitialPolicies().
-						WithMeshServicesEnabled(mesh_proto.Mesh_MeshServices_Exclusive).
-						WithBuiltinMTLSBackend("ca-1").WithEnabledMTLSBackend("ca-1"),
-				),
-			).
-			Install(MeshTrafficPermissionAllowAllUniversal(meshName)).
-			Install(DemoClientUniversal("demo-client", meshName,
-				WithTransparentProxy(true)),
-			).
-			Install(TestServerUniversal("test-server", meshName,
-				WithArgs([]string{"echo", "--instance", "universal-1"})),
-			).
-			Setup(universal.Cluster)
-		Expect(err).ToNot(HaveOccurred())
-
-		waitMeshServiceReady(meshName, "demo-client")
-		waitMeshServiceReady(meshName, "test-server")
-
-		Eventually(func(g Gomega) {
-			_, err := client.CollectEchoResponse(universal.Cluster, "demo-client", "test-server.svc.mesh.local")
-			g.Expect(err).ToNot(HaveOccurred())
-		}).Should(Succeed())
-	})
+	BeforeAll(SetupSidecarCluster)
 
 	AfterEachFailure(func() {
 		DebugUniversal(universal.Cluster, meshName)
 	})
 
-	E2EAfterAll(func() {
-		Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
-		Expect(universal.Cluster.DeleteMesh(meshName)).To(Succeed())
-	})
+	E2EAfterAll(CleanupAfterSidecarSuite)
 
-	E2EAfterEach(func() {
-		Expect(DeleteMeshResources(
-			universal.Cluster,
-			meshName,
-			meshtimeout.MeshTimeoutResourceTypeDescriptor,
-			meshaccesslog.MeshAccessLogResourceTypeDescriptor,
-			meshfaultinjection.MeshFaultInjectionResourceTypeDescriptor,
-			meshratelimit.MeshRateLimitResourceTypeDescriptor,
-			meshtls.MeshTLSResourceTypeDescriptor,
-			meshhealthcheck.MeshHealthCheckResourceTypeDescriptor,
-			meshcircuitbreaker.MeshCircuitBreakerResourceTypeDescriptor,
-			meshhttproute.MeshHTTPRouteResourceTypeDescriptor,
-		)).To(Succeed())
-	})
+	E2EAfterEach(CleanupAfterSidecarTest(
+		meshtimeout.MeshTimeoutResourceTypeDescriptor,
+		meshaccesslog.MeshAccessLogResourceTypeDescriptor,
+		meshfaultinjection.MeshFaultInjectionResourceTypeDescriptor,
+		meshratelimit.MeshRateLimitResourceTypeDescriptor,
+		meshtls.MeshTLSResourceTypeDescriptor,
+		meshhealthcheck.MeshHealthCheckResourceTypeDescriptor,
+		meshcircuitbreaker.MeshCircuitBreakerResourceTypeDescriptor,
+		meshhttproute.MeshHTTPRouteResourceTypeDescriptor,
+	))
 
 	DescribeTable("should generate proper Envoy config",
-		func(inputFile string) {
-			// given
-			input, err := os.ReadFile(inputFile)
-			Expect(err).ToNot(HaveOccurred())
-
-			// when
-			if len(input) > 0 {
-				Expect(universal.Cluster.Install(YamlUniversal(string(input)))).To(Succeed())
-			}
-
-			// then
-			Eventually(func(g Gomega) {
-				g.Expect(getConfig(meshName, "demo-client")).To(matchers.MatchGoldenJSON(strings.Replace(inputFile, "input.yaml", "demo-client.golden.json", 1)))
-				g.Expect(getConfig(meshName, "test-server")).To(matchers.MatchGoldenJSON(strings.Replace(inputFile, "input.yaml", "test-server.golden.json", 1)))
-			}).Should(Succeed())
-		},
+		TestSidecarConfig,
 		test.EntriesForFolder(filepath.Join("sidecars", "meshtimeout"), "envoyconfig"),
 		test.EntriesForFolder(filepath.Join("sidecars", "meshaccesslog"), "envoyconfig"),
 		test.EntriesForFolder(filepath.Join("sidecars", "meshfaultinjection"), "envoyconfig"),
@@ -107,4 +58,60 @@ func Sidecars() {
 		test.EntriesForFolder(filepath.Join("sidecars", "meshcircuitbreaker"), "envoyconfig"),
 		test.EntriesForFolder(filepath.Join("sidecars", "meshretry"), "envoyconfig"),
 	)
+}
+
+func TestSidecarConfig(inputFile string) {
+	// given
+	input, err := os.ReadFile(inputFile)
+	Expect(err).ToNot(HaveOccurred())
+
+	// when
+	if len(input) > 0 {
+		Expect(universal.Cluster.Install(YamlUniversal(string(input)))).To(Succeed())
+	}
+
+	// then
+	Eventually(func(g Gomega) {
+		g.Expect(getConfig(meshName, "demo-client")).To(matchers.MatchGoldenJSON(strings.Replace(inputFile, "input.yaml", "demo-client.golden.json", 1)))
+		g.Expect(getConfig(meshName, "test-server")).To(matchers.MatchGoldenJSON(strings.Replace(inputFile, "input.yaml", "test-server.golden.json", 1)))
+	}).Should(Succeed())
+}
+
+func SetupSidecarCluster() {
+	err := NewClusterSetup().
+		Install(
+			Yaml(
+				builders.Mesh().
+					WithName(meshName).
+					WithoutInitialPolicies().
+					WithMeshServicesEnabled(mesh_proto.Mesh_MeshServices_Exclusive).
+					WithBuiltinMTLSBackend("ca-1").WithEnabledMTLSBackend("ca-1"),
+			),
+		).
+		Install(MeshTrafficPermissionAllowAllUniversal(meshName)).
+		Install(DemoClientUniversal("demo-client", meshName,
+			WithTransparentProxy(true)),
+		).
+		Install(TestServerUniversal("test-server", meshName,
+			WithArgs([]string{"echo", "--instance", "universal-1"})),
+		).
+		Setup(universal.Cluster)
+	Expect(err).ToNot(HaveOccurred())
+
+	waitMeshServiceReady(meshName, "demo-client")
+	waitMeshServiceReady(meshName, "test-server")
+
+	Eventually(func(g Gomega) {
+		_, err := client.CollectEchoResponse(universal.Cluster, "demo-client", "test-server.svc.mesh.local")
+		g.Expect(err).ToNot(HaveOccurred())
+	}).Should(Succeed())
+}
+
+func CleanupAfterSidecarTest(policies ...core_model.ResourceTypeDescriptor) func() {
+	return cleanupAfterTest(mesh, policies...)
+}
+
+func CleanupAfterSidecarSuite() {
+	Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
+	Expect(universal.Cluster.DeleteMesh(meshName)).To(Succeed())
 }

--- a/test/e2e_env/universal/envoyconfig/utils.go
+++ b/test/e2e_env/universal/envoyconfig/utils.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kumahq/kuma/api/openapi/types"
 	api_common "github.com/kumahq/kuma/api/openapi/types/common"
 	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/util/pointer"
 	. "github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/framework/envs/universal"
@@ -94,4 +95,10 @@ var statsPrefixRegex = regexp.MustCompile("\"statPrefix\":\\s\".*\"")
 
 func redactStatPrefixes(jsonStr string) string {
 	return statsPrefixRegex.ReplaceAllString(jsonStr, "\"statPrefix\": \"STAT_PREFIX_REDACTED\"")
+}
+
+func cleanupAfterTest(mesh string, policies ...core_model.ResourceTypeDescriptor) func() {
+	return func() {
+		Expect(DeleteMeshResources(universal.Cluster, mesh, policies...)).To(Succeed())
+	}
 }


### PR DESCRIPTION
## Motivation

We want to write envoy config e2e tests in other projects like Kong Mesh. These changes make it easy to reuse

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
