### PR TITLE
chore(e2e): disable MeshRetry on MeshHTTPRoute test

### DIFF
--- a/test/e2e_env/multizone/producer/producer.go
+++ b/test/e2e_env/multizone/producer/producer.go
@@ -237,7 +237,7 @@ spec:
 		}, "1m", "1s", MustPassRepeatedly(5)).Should(Succeed())
 	})
 
-	It("should sync producer MeshRetry that targets producer route to other clusters", func() {
+	XIt("should sync producer MeshRetry that targets producer route to other clusters", func() {
 		Expect(YamlK8s(fmt.Sprintf(`
 apiVersion: kuma.io/v1alpha1
 kind: MeshFaultInjection


### PR DESCRIPTION
## Motivation

It constantly fails, i.e. https://github.com/kumahq/kuma/actions/runs/15022018662/job/42215564633

