### PR TITLE
fix(rules): incorrect behaviour of MeshTimeout/MeshRetry policies when referencing routes

### DIFF
--- a/pkg/core/xds/resource.go
+++ b/pkg/core/xds/resource.go
@@ -184,10 +184,17 @@ func NonGatewayResources(r *Resource) bool {
 }
 
 func HasAssociatedServiceResource(r *Resource) bool {
-	return r.ResourceOrigin != nil &&
-		(r.ResourceOrigin.ResourceType == meshservice_api.MeshServiceType ||
-			r.ResourceOrigin.ResourceType == meshexternalservice_api.MeshExternalServiceType ||
-			r.ResourceOrigin.ResourceType == meshmultizoneservice_api.MeshMultiZoneServiceType)
+	if r.ResourceOrigin == nil {
+		return false
+	}
+	switch r.ResourceOrigin.ResourceType {
+	case
+		meshservice_api.MeshServiceType,
+		meshexternalservice_api.MeshExternalServiceType,
+		meshmultizoneservice_api.MeshMultiZoneServiceType:
+		return true
+	}
+	return false
 }
 
 type ResourcesByType map[string][]*Resource

--- a/pkg/core/xds/resource.go
+++ b/pkg/core/xds/resource.go
@@ -10,8 +10,8 @@ import (
 	"github.com/kumahq/kuma/pkg/core/kri"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	meshexternalservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
-	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	meshmultizoneservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1"
+	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
 )
 
 // ResourcePayload is a convenience type alias.

--- a/pkg/core/xds/resource.go
+++ b/pkg/core/xds/resource.go
@@ -10,6 +10,8 @@ import (
 	"github.com/kumahq/kuma/pkg/core/kri"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	meshexternalservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
+	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
+	meshmultizoneservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1"
 )
 
 // ResourcePayload is a convenience type alias.
@@ -181,8 +183,11 @@ func NonGatewayResources(r *Resource) bool {
 	return r.ResourceOrigin == nil || (r.ResourceOrigin != nil && r.Origin != "gateway")
 }
 
-func HasResourceOrigin(r *Resource) bool {
-	return r.ResourceOrigin != nil
+func HasAssociatedServiceResource(r *Resource) bool {
+	return r.ResourceOrigin != nil &&
+		(r.ResourceOrigin.ResourceType == meshservice_api.MeshServiceType ||
+			r.ResourceOrigin.ResourceType == meshexternalservice_api.MeshExternalServiceType ||
+			r.ResourceOrigin.ResourceType == meshmultizoneservice_api.MeshMultiZoneServiceType)
 }
 
 type ResourcesByType map[string][]*Resource

--- a/pkg/plugins/policies/core/rules/outbound/context.go
+++ b/pkg/plugins/policies/core/rules/outbound/context.go
@@ -1,0 +1,57 @@
+package outbound
+
+import (
+	"github.com/kumahq/kuma/pkg/core/kri"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+)
+
+// ResourceContext represents a hierarchical resource structure and
+// is always ready to return the appropriate conf by using Conf method.
+// The RootContext is always the mesh. As we're iterating over resource in ResourceSet
+// and going deeper to configure Listeners/Routes, we need to add more resources
+// to the ResourceContext by using WithID method.
+//
+// For example:
+// 1. At the beginning of Apply method in plugin.go rctx := RootContext()
+// 2. As we start iterating over outbound listeners, rctx = rctx.WithID(outboundListenerKRI)
+// 3. As we start iterating over the routes of the outbound listener, rctx = rctx.WithID(routeKRI)
+//
+// At any moment we can call rctx.Conf() and get right configuration.
+type ResourceContext[T any] struct {
+	ids   []kri.Identifier
+	rules ResourceRules
+}
+
+func RootContext[T any](mesh *core_mesh.MeshResource, rules ResourceRules) *ResourceContext[T] {
+	return &ResourceContext[T]{
+		ids: []kri.Identifier{
+			kri.From(mesh, ""),
+		},
+		rules: rules,
+	}
+}
+
+// WithID creates a new ResourceContext with the provided identifier,
+// giving it higher priority during configuration lookup.
+// This allows for more specific configurations to override more general ones.
+func (rc *ResourceContext[T]) WithID(id kri.Identifier) *ResourceContext[T] {
+	newRc := &ResourceContext[T]{
+		ids:   []kri.Identifier{id},
+		rules: rc.rules,
+	}
+	newRc.ids = append(newRc.ids, rc.ids...)
+	return newRc
+}
+
+// Conf retrieves the configuration of type T by searching through the identifiers
+// in priority order (first to last) and returning the first matching configuration.
+// If no matching configuration is found, it returns a zero value of type T.
+func (rc *ResourceContext[T]) Conf() T {
+	for _, id := range rc.ids {
+		if rule, ok := rc.rules[id]; ok {
+			return rule.Conf[0].(T)
+		}
+	}
+	var conf T
+	return conf
+}

--- a/pkg/plugins/policies/core/rules/outbound/context_test.go
+++ b/pkg/plugins/policies/core/rules/outbound/context_test.go
@@ -1,0 +1,78 @@
+package outbound_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/pkg/core/kri"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/plugins/policies/core/rules/outbound"
+	"github.com/kumahq/kuma/pkg/test/resources/builders"
+)
+
+var _ = Describe("ResourceContext", func() {
+	var mesh *core_mesh.MeshResource
+
+	BeforeEach(func() {
+		mesh = builders.Mesh().WithName("test-mesh").Build()
+	})
+
+	Describe("RootContext", func() {
+		It("should create a ResourceContext with mesh identifier", func() {
+			// when
+			resourceRules := outbound.ResourceRules{
+				kri.From(mesh, ""): outbound.ResourceRule{Conf: []interface{}{"mesh-conf"}},
+			}
+			rc := outbound.RootContext[string](mesh, resourceRules)
+
+			// then
+			Expect(rc).NotTo(BeNil())
+			Expect(rc.Conf()).To(Equal("mesh-conf"))
+		})
+	})
+
+	Describe("WithID", func() {
+		It("should add a new identifier to the ResourceContext", func() {
+			// given
+			id := kri.Identifier{
+				ResourceType: "TestResource",
+				Mesh:         "test-mesh",
+				Name:         "test-resource",
+			}
+			resourceRules := outbound.ResourceRules{
+				kri.From(mesh, ""): outbound.ResourceRule{Conf: []interface{}{"mesh-conf"}},
+				id:                 outbound.ResourceRule{Conf: []interface{}{"test-conf"}},
+			}
+			rc := outbound.RootContext[string](mesh, resourceRules)
+
+			// when
+			newRc := rc.WithID(id)
+
+			// then
+			Expect(newRc).NotTo(BeNil())
+			Expect(newRc).NotTo(BeIdenticalTo(rc)) // Should be a new instance
+			Expect(newRc.Conf()).To(Equal("test-conf"))
+		})
+
+		It("should return mesh's conf when there is no specific conf for the test-resource", func() {
+			// given
+			id := kri.Identifier{
+				ResourceType: "TestResource",
+				Mesh:         "test-mesh",
+				Name:         "test-resource",
+			}
+			resourceRules := outbound.ResourceRules{
+				kri.From(mesh, ""): outbound.ResourceRule{Conf: []interface{}{"mesh-conf"}},
+			}
+			rc := outbound.RootContext[string](mesh, resourceRules)
+
+			// when
+			newRc := rc.WithID(id)
+
+			// then
+			Expect(newRc).NotTo(BeNil())
+			Expect(newRc).NotTo(BeIdenticalTo(rc)) // Should be a new instance
+			Expect(newRc.Conf()).To(Equal("mesh-conf"))
+		})
+	})
+})

--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin.go
@@ -25,6 +25,7 @@ import (
 	util_slices "github.com/kumahq/kuma/pkg/util/slices"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	listeners_v3 "github.com/kumahq/kuma/pkg/xds/envoy/listeners/v3"
+	"github.com/kumahq/kuma/pkg/util/pointer"
 )
 
 var _ core_plugins.PolicyPlugin = &plugin{}
@@ -56,11 +57,24 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 		return err
 	}
 
-	err := applyToRealResources(util_slices.Filter(rs.List(), core_xds.HasResourceOrigin), policies.ToRules.ResourceRules, ctx.Mesh.Resources)
-	if err != nil {
-		return err
-	}
+	rctx := outbound.RootContext[api.Conf](ctx.Mesh.Resource, policies.ToRules.ResourceRules)
+	for _, r := range util_slices.Filter(rs.List(), core_xds.HasResourceOrigin) {
+		switch r.ResourceOrigin.ResourceType {
+		case meshservice_api.MeshServiceType:
+		case meshexternalservice_api.MeshExternalServiceType:
+		case meshmultizoneservice_api.MeshMultiZoneServiceType:
+		default:
+			continue
+		}
 
+		svcCtx := rctx.
+			WithID(kri.NoSectionName(*r.ResourceOrigin)).
+			WithID(*r.ResourceOrigin)
+
+		if err := applyToRealResource(svcCtx, r); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -147,79 +161,55 @@ func applyToGateway(
 	return nil
 }
 
-func applyToRealResources(
-	rs []*core_xds.Resource,
-	rules outbound.ResourceRules,
-	reader kri.ResourceReader,
-) error {
-	for _, r := range rs {
-		switch r.ResourceOrigin.ResourceType {
-		case meshservice_api.MeshServiceType:
-		case meshexternalservice_api.MeshExternalServiceType:
-		case meshmultizoneservice_api.MeshMultiZoneServiceType:
-		default:
-			continue
+func applyToRealResource(rctx *outbound.ResourceContext[api.Conf], r *core_xds.Resource) error {
+	switch envoyResource := r.Resource.(type) {
+	case *envoy_listener.Listener:
+		configurer := plugin_xds.Configurer{Conf: rctx.Conf(), Protocol: r.Protocol}
+		if err := configurer.ConfigureListener(envoyResource); err != nil {
+			return err
 		}
 
-		var conf api.Conf
-		if rr := rules.Compute(*r.ResourceOrigin, reader); rr != nil {
-			conf = rr.Conf[0].(api.Conf)
-		}
+		for _, fc := range envoyResource.FilterChains {
+			if err := listeners_v3.UpdateHTTPConnectionManager(fc, func(hcm *envoy_hcm.HttpConnectionManager) error {
+				for _, vh := range hcm.GetRouteConfig().VirtualHosts {
+					for _, route := range vh.Routes {
+						if !kri.IsValid(route.Name) {
+							continue
+						}
 
-		switch envoyResource := r.Resource.(type) {
-		case *envoy_listener.Listener:
-			configurer := plugin_xds.Configurer{Conf: conf, Protocol: r.Protocol}
-			if err := configurer.ConfigureListener(envoyResource); err != nil {
-				return err
-			}
+						id, err := kri.FromString(route.Name)
+						if err != nil {
+							return err
+						}
 
-			for _, fc := range envoyResource.FilterChains {
-				if err := listeners_v3.UpdateHTTPConnectionManager(fc, func(hcm *envoy_hcm.HttpConnectionManager) error {
-					return configureRoutes(hcm.GetRouteConfig(), rules, reader, r.Protocol)
-				}); err != nil {
-					return err
+						if err := configureRoute(rctx.WithID(id), route, r.Protocol); err != nil {
+							return err
+						}
+					}
 				}
+				return nil
+			}); err != nil {
+				return err
 			}
 		}
 	}
+
 	return nil
 }
 
-func configureRoutes(
-	rc *envoy_route.RouteConfiguration,
-	rules outbound.ResourceRules,
-	reader kri.ResourceReader,
-	protocol core_mesh.Protocol,
-) error {
-	for _, vh := range rc.VirtualHosts {
-		for _, route := range vh.Routes {
-			if !kri.IsValid(route.Name) {
-				continue
-			}
-
-			id, err := kri.FromString(route.Name)
-			if err != nil {
-				return err
-			}
-
-			var conf api.Conf
-			if rr := rules.Compute(id, reader); rr != nil {
-				conf = rr.Conf[0].(api.Conf)
-			}
-
-			policy, err := plugin_xds.GetRouteRetryConfig(&conf, protocol)
-			if err != nil {
-				return err
-			}
-			if policy == nil {
-				return nil
-			}
-
-			switch a := route.GetAction().(type) {
-			case *envoy_route.Route_Route:
-				a.Route.RetryPolicy = policy
-			}
-		}
+func configureRoute(rctx *outbound.ResourceContext[api.Conf], route *envoy_route.Route, protocol core_mesh.Protocol) error {
+	policy, err := plugin_xds.GetRouteRetryConfig(pointer.To(rctx.Conf()), protocol)
+	if err != nil {
+		return err
 	}
+	if policy == nil {
+		return nil
+	}
+
+	switch a := route.GetAction().(type) {
+	case *envoy_route.Route_Route:
+		a.Route.RetryPolicy = policy
+	}
+
 	return nil
 }

--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin.go
@@ -9,9 +9,6 @@ import (
 	"github.com/kumahq/kuma/pkg/core/kri"
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	meshexternalservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
-	meshmultizoneservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1"
-	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/matchers"
@@ -58,15 +55,7 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 	}
 
 	rctx := outbound.RootContext[api.Conf](ctx.Mesh.Resource, policies.ToRules.ResourceRules)
-	for _, r := range util_slices.Filter(rs.List(), core_xds.HasResourceOrigin) {
-		switch r.ResourceOrigin.ResourceType {
-		case meshservice_api.MeshServiceType:
-		case meshexternalservice_api.MeshExternalServiceType:
-		case meshmultizoneservice_api.MeshMultiZoneServiceType:
-		default:
-			continue
-		}
-
+	for _, r := range util_slices.Filter(rs.List(), core_xds.HasAssociatedServiceResource) {
 		svcCtx := rctx.
 			WithID(kri.NoSectionName(*r.ResourceOrigin)).
 			WithID(*r.ResourceOrigin)

--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin.go
@@ -22,10 +22,10 @@ import (
 	api "github.com/kumahq/kuma/pkg/plugins/policies/meshretry/api/v1alpha1"
 	plugin_xds "github.com/kumahq/kuma/pkg/plugins/policies/meshretry/plugin/xds"
 	gateway_plugin "github.com/kumahq/kuma/pkg/plugins/runtime/gateway"
+	"github.com/kumahq/kuma/pkg/util/pointer"
 	util_slices "github.com/kumahq/kuma/pkg/util/slices"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	listeners_v3 "github.com/kumahq/kuma/pkg/xds/envoy/listeners/v3"
-	"github.com/kumahq/kuma/pkg/util/pointer"
 )
 
 var _ core_plugins.PolicyPlugin = &plugin{}

--- a/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
@@ -10,9 +10,6 @@ import (
 	"github.com/kumahq/kuma/pkg/core/kri"
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	meshexternalservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
-	meshmultizoneservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1"
-	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/matchers"
@@ -76,15 +73,7 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 
 	rctx := outbound.RootContext[api.Conf](ctx.Mesh.Resource, policies.ToRules.ResourceRules)
 
-	for _, r := range util_slices.Filter(rs.List(), core_xds.HasResourceOrigin) {
-		switch r.ResourceOrigin.ResourceType {
-		case meshservice_api.MeshServiceType:
-		case meshexternalservice_api.MeshExternalServiceType:
-		case meshmultizoneservice_api.MeshMultiZoneServiceType:
-		default:
-			continue
-		}
-
+	for _, r := range util_slices.Filter(rs.List(), core_xds.HasAssociatedServiceResource) {
 		svcCtx := rctx.
 			WithID(kri.NoSectionName(*r.ResourceOrigin)).
 			WithID(*r.ResourceOrigin)

--- a/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
@@ -74,11 +74,24 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 		}
 	}
 
-	err := applyToRealResources(util_slices.Filter(rs.List(), core_xds.HasResourceOrigin), policies.ToRules.ResourceRules, ctx.Mesh.Resources)
-	if err != nil {
-		return err
-	}
+	rctx := outbound.RootContext[api.Conf](ctx.Mesh.Resource, policies.ToRules.ResourceRules)
 
+	for _, r := range util_slices.Filter(rs.List(), core_xds.HasResourceOrigin) {
+		switch r.ResourceOrigin.ResourceType {
+		case meshservice_api.MeshServiceType:
+		case meshexternalservice_api.MeshExternalServiceType:
+		case meshmultizoneservice_api.MeshMultiZoneServiceType:
+		default:
+			continue
+		}
+
+		svcCtx := rctx.
+			WithID(kri.NoSectionName(*r.ResourceOrigin)).
+			WithID(*r.ResourceOrigin)
+		if err := applyToRealResource(svcCtx, r); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -269,78 +282,46 @@ func createInboundClusterName(servicePort uint32, listenerPort uint32) string {
 	}
 }
 
-func applyToRealResources(
-	rs []*core_xds.Resource,
-	rules outbound.ResourceRules,
-	reader kri.ResourceReader,
-) error {
-	for _, r := range rs {
-		switch r.ResourceOrigin.ResourceType {
-		case meshservice_api.MeshServiceType:
-		case meshexternalservice_api.MeshExternalServiceType:
-		case meshmultizoneservice_api.MeshMultiZoneServiceType:
-		default:
-			continue
+func applyToRealResource(rctx *outbound.ResourceContext[api.Conf], r *core_xds.Resource) error {
+	switch envoyResource := r.Resource.(type) {
+	case *envoy_listener.Listener:
+		configurer := plugin_xds.ListenerConfigurer{Conf: rctx.Conf(), Protocol: r.Protocol}
+		if err := configurer.ConfigureListener(envoyResource); err != nil {
+			return err
 		}
 
-		var conf api.Conf
-		if rr := rules.Compute(*r.ResourceOrigin, reader); rr != nil {
-			conf = rr.Conf[0].(api.Conf)
-		}
+		for _, fc := range envoyResource.FilterChains {
+			if err := listeners_v3.UpdateHTTPConnectionManager(fc, func(hcm *envoy_hcm.HttpConnectionManager) error {
+				for _, vh := range hcm.GetRouteConfig().VirtualHosts {
+					for _, route := range vh.Routes {
+						if !kri.IsValid(route.Name) {
+							continue
+						}
 
-		switch envoyResource := r.Resource.(type) {
-		case *envoy_listener.Listener:
-			configurer := plugin_xds.ListenerConfigurer{Conf: conf, Protocol: r.Protocol}
-			if err := configurer.ConfigureListener(envoyResource); err != nil {
-				return err
-			}
+						id, err := kri.FromString(route.Name)
+						if err != nil {
+							return err
+						}
 
-			for _, fc := range envoyResource.FilterChains {
-				if err := listeners_v3.UpdateHTTPConnectionManager(fc, func(hcm *envoy_hcm.HttpConnectionManager) error {
-					return configureRoutes(hcm.GetRouteConfig(), rules, reader)
-				}); err != nil {
-					return err
+						routeCtx := rctx.WithID(id)
+
+						plugin_xds.ConfigureRouteAction(
+							route.GetRoute(),
+							pointer.Deref(routeCtx.Conf().Http).RequestTimeout,
+							pointer.Deref(routeCtx.Conf().Http).StreamIdleTimeout,
+						)
+					}
 				}
-			}
-
-		case *envoy_cluster.Cluster:
-			configurer := plugin_xds.ClusterConfigurerFromConf(conf, r.Protocol)
-			if err := configurer.Configure(envoyResource); err != nil {
+				return nil
+			}); err != nil {
 				return err
 			}
 		}
-	}
-	return nil
-}
 
-func configureRoutes(
-	rc *envoy_route.RouteConfiguration,
-	rules outbound.ResourceRules,
-	reader kri.ResourceReader,
-) error {
-	for _, vh := range rc.VirtualHosts {
-		for _, route := range vh.Routes {
-			if !kri.IsValid(route.Name) {
-				continue
-			}
-
-			id, err := kri.FromString(route.Name)
-			if err != nil {
-				return err
-			}
-
-			rr := rules.Compute(id, reader)
-			if rr == nil {
-				continue
-			}
-
-			conf := rr.Conf[0].(api.Conf)
-
-			plugin_xds.ConfigureRouteAction(
-				route.GetRoute(),
-				pointer.Deref(conf.Http).RequestTimeout,
-				pointer.Deref(conf.Http).StreamIdleTimeout,
-			)
+	case *envoy_cluster.Cluster:
+		configurer := plugin_xds.ClusterConfigurerFromConf(rctx.Conf(), r.Protocol)
+		if err := configurer.Configure(envoyResource); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/test/e2e_env/universal/envoyconfig/sidecars.go
+++ b/test/e2e_env/universal/envoyconfig/sidecars.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/framework/client"
 	"github.com/kumahq/kuma/test/framework/envs/universal"
+	meshretry "github.com/kumahq/kuma/pkg/plugins/policies/meshretry/api/v1alpha1"
 )
 
 const meshName = "envoyconfig"
@@ -44,6 +45,7 @@ func Sidecars() {
 		meshhealthcheck.MeshHealthCheckResourceTypeDescriptor,
 		meshcircuitbreaker.MeshCircuitBreakerResourceTypeDescriptor,
 		meshhttproute.MeshHTTPRouteResourceTypeDescriptor,
+		meshretry.MeshRetryResourceTypeDescriptor,
 	))
 
 	DescribeTable("should generate proper Envoy config",

--- a/test/e2e_env/universal/envoyconfig/sidecars.go
+++ b/test/e2e_env/universal/envoyconfig/sidecars.go
@@ -16,6 +16,7 @@ import (
 	meshhealthcheck "github.com/kumahq/kuma/pkg/plugins/policies/meshhealthcheck/api/v1alpha1"
 	meshhttproute "github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
 	meshratelimit "github.com/kumahq/kuma/pkg/plugins/policies/meshratelimit/api/v1alpha1"
+	meshretry "github.com/kumahq/kuma/pkg/plugins/policies/meshretry/api/v1alpha1"
 	meshtimeout "github.com/kumahq/kuma/pkg/plugins/policies/meshtimeout/api/v1alpha1"
 	meshtls "github.com/kumahq/kuma/pkg/plugins/policies/meshtls/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/test"
@@ -24,7 +25,6 @@ import (
 	. "github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/framework/client"
 	"github.com/kumahq/kuma/test/framework/envs/universal"
-	meshretry "github.com/kumahq/kuma/pkg/plugins/policies/meshretry/api/v1alpha1"
 )
 
 const meshName = "envoyconfig"

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-mix.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-mix.demo-client.golden.json
@@ -1,0 +1,767 @@
+{
+  "diff": [
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/match/path",
+      "value": "/test"
+    },
+    {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/match/prefix",
+      "value": "/"
+    },
+    {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/name",
+      "value": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo="
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/name",
+      "value": "kri_mhttpr_envoyconfig_kuma-3__test-route_"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/requestHeadersToAdd",
+      "value": [
+        {
+          "header": {
+            "key": "x-test-header",
+            "value": "added-by-policy"
+          }
+        }
+      ]
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/retryPolicy",
+      "value": {
+        "numRetries": 6,
+        "retryOn": "5xx"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/1",
+      "value": {
+        "match": {
+          "prefix": "/"
+        },
+        "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
+        "route": {
+          "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
+          "idleTimeout": "1800s",
+          "retryPolicy": {
+            "numRetries": 6,
+            "retryOn": "5xx"
+          },
+          "timeout": "15s"
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/1",
+      "value": {
+        "match": {
+          "prefix": "/test/"
+        },
+        "name": "kri_mhttpr_envoyconfig_kuma-3__test-route_",
+        "requestHeadersToAdd": [
+          {
+            "header": {
+              "key": "x-test-header",
+              "value": "added-by-policy"
+            }
+          }
+        ],
+        "route": {
+          "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
+          "idleTimeout": "1800s",
+          "retryPolicy": {
+            "numRetries": 6,
+            "retryOn": "5xx"
+          },
+          "timeout": "15s"
+        }
+      }
+    }
+  ],
+  "xds": {
+    "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
+      "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
+        "edsClusterConfig": {
+          "edsConfig": {
+            "ads": {},
+            "resourceApiVersion": "V3"
+          }
+        },
+        "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/demo-client"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a65abe81bca1750d1.demo-client.3000.envoyconfig.ms"
+          }
+        },
+        "type": "EDS",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicitHttpConfig": {
+              "http2ProtocolOptions": {}
+            }
+          }
+        }
+      },
+      "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
+        "edsClusterConfig": {
+          "edsConfig": {
+            "ads": {},
+            "resourceApiVersion": "V3"
+          }
+        },
+        "name": "envoyconfig_test-server__kuma-3_msvc_80",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/test-server"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a029781856823048e.test-server.80.envoyconfig.ms"
+          }
+        },
+        "type": "EDS",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
+            "explicitHttpConfig": {
+              "http2ProtocolOptions": {}
+            }
+          }
+        }
+      },
+      "inbound:passthrough:ipv4": {
+        "altStatName": "inbound_passthrough_ipv4",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "inbound:passthrough:ipv4",
+        "type": "ORIGINAL_DST",
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "inbound:passthrough:ipv6": {
+        "altStatName": "inbound_passthrough_ipv6",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "inbound:passthrough:ipv6",
+        "type": "ORIGINAL_DST",
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "localhost:3000": {
+        "altStatName": "localhost_3000",
+        "connectTimeout": "5s",
+        "loadAssignment": {
+          "clusterName": "localhost:3000",
+          "endpoints": [
+            {
+              "lbEndpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socketAddress": {
+                        "address": "IP_REDACTED",
+                        "portValue": 3000
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "name": "localhost:3000",
+        "type": "STATIC",
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "outbound:passthrough:ipv4": {
+        "altStatName": "outbound_passthrough_ipv4",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "outbound:passthrough:ipv4",
+        "type": "ORIGINAL_DST"
+      },
+      "outbound:passthrough:ipv6": {
+        "altStatName": "outbound_passthrough_ipv6",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "outbound:passthrough:ipv6",
+        "type": "ORIGINAL_DST"
+      }
+    },
+    "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment": {
+      "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "clusterName": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "IP_REDACTED",
+                      "portValue": 3000
+                    }
+                  }
+                },
+                "loadBalancingWeight": 1,
+                "metadata": {
+                  "filterMetadata": {
+                    "envoy.lb": {
+                      "kuma.io/zone": "kuma-3",
+                      "team": "client-owners"
+                    },
+                    "envoy.transport_socket_match": {
+                      "kuma.io/zone": "kuma-3",
+                      "team": "client-owners"
+                    }
+                  }
+                }
+              }
+            ],
+            "locality": {
+              "zone": "kuma-3"
+            }
+          }
+        ]
+      },
+      "envoyconfig_test-server__kuma-3_msvc_80": {
+        "clusterName": "envoyconfig_test-server__kuma-3_msvc_80",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "IP_REDACTED",
+                      "portValue": 80
+                    }
+                  }
+                },
+                "loadBalancingWeight": 1,
+                "metadata": {
+                  "filterMetadata": {
+                    "envoy.lb": {
+                      "instance": "1",
+                      "kuma.io/protocol": "http",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "server-owners",
+                      "version": "v1"
+                    },
+                    "envoy.transport_socket_match": {
+                      "instance": "1",
+                      "kuma.io/protocol": "http",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "server-owners",
+                      "version": "v1"
+                    }
+                  }
+                }
+              }
+            ],
+            "locality": {
+              "zone": "kuma-3"
+            }
+          }
+        ]
+      }
+    },
+    "type.googleapis.com/envoy.config.listener.v3.Listener": {
+      "inbound:IP_REDACTED:3000": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 3000
+          }
+        },
+        "bindToPort": false,
+        "enableReusePort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.rbac",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+                  "rules": {
+                    "policies": {
+                      "MeshTrafficPermission": {
+                        "permissions": [
+                          {
+                            "any": true
+                          }
+                        ],
+                        "principals": [
+                          {
+                            "any": true
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              },
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "localhost:3000",
+                  "idleTimeout": "3600s",
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ],
+            "transportSocket": {
+              "name": "envoy.transport_sockets.tls",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+                "commonTlsContext": {
+                  "combinedValidationContext": {
+                    "defaultValidationContext": {
+                      "matchTypedSubjectAltNames": [
+                        {
+                          "matcher": {
+                            "prefix": "spiffe://envoyconfig/"
+                          },
+                          "sanType": "URI"
+                        }
+                      ]
+                    },
+                    "validationContextSdsSecretConfig": {
+                      "name": "mesh_ca:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  },
+                  "tlsCertificateSdsSecretConfigs": [
+                    {
+                      "name": "identity_cert:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  ]
+                },
+                "requireClientCertificate": true
+              }
+            }
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {
+              "kuma.io/service": "demo-client",
+              "kuma.io/zone": "kuma-3",
+              "team": "client-owners"
+            }
+          }
+        },
+        "name": "inbound:IP_REDACTED:3000",
+        "trafficDirection": "INBOUND"
+      },
+      "inbound:passthrough:ipv4": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15006
+          }
+        },
+        "enableReusePort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "inbound:passthrough:ipv4",
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "inbound:passthrough:ipv4",
+        "trafficDirection": "INBOUND",
+        "useOriginalDst": true
+      },
+      "inbound:passthrough:ipv6": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15006
+          }
+        },
+        "enableReusePort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "inbound:passthrough:ipv6",
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "inbound:passthrough:ipv6",
+        "trafficDirection": "INBOUND",
+        "useOriginalDst": true
+      },
+      "outbound:IP_REDACTED:3000": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 3000
+          }
+        },
+        "bindToPort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {}
+          }
+        },
+        "name": "outbound:IP_REDACTED:3000",
+        "trafficDirection": "OUTBOUND"
+      },
+      "outbound:IP_REDACTED:80": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 80
+          }
+        },
+        "bindToPort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
+                  "httpFilters": [
+                    {
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
+                    }
+                  ],
+                  "internalAddressConfig": {
+                    "cidrRanges": [
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 8
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 16
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 12
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 7
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 8
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 32
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 128
+                      }
+                    ]
+                  },
+                  "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
+                  "routeConfig": {
+                    "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",
+                    "validateClusters": false,
+                    "virtualHosts": [
+                      {
+                        "domains": [
+                          "*"
+                        ],
+                        "name": "envoyconfig_test-server__kuma-3_msvc_80",
+                        "routes": [
+                          {
+                            "match": {
+                              "path": "/test"
+                            },
+                            "name": "kri_mhttpr_envoyconfig_kuma-3__test-route_",
+                            "requestHeadersToAdd": [
+                              {
+                                "header": {
+                                  "key": "x-test-header",
+                                  "value": "added-by-policy"
+                                }
+                              }
+                            ],
+                            "route": {
+                              "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
+                              "idleTimeout": "1800s",
+                              "retryPolicy": {
+                                "numRetries": 6,
+                                "retryOn": "5xx"
+                              },
+                              "timeout": "15s"
+                            }
+                          },
+                          {
+                            "match": {
+                              "prefix": "/test/"
+                            },
+                            "name": "kri_mhttpr_envoyconfig_kuma-3__test-route_",
+                            "requestHeadersToAdd": [
+                              {
+                                "header": {
+                                  "key": "x-test-header",
+                                  "value": "added-by-policy"
+                                }
+                              }
+                            ],
+                            "route": {
+                              "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
+                              "idleTimeout": "1800s",
+                              "retryPolicy": {
+                                "numRetries": 6,
+                                "retryOn": "5xx"
+                              },
+                              "timeout": "15s"
+                            }
+                          },
+                          {
+                            "match": {
+                              "prefix": "/"
+                            },
+                            "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
+                            "route": {
+                              "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
+                              "idleTimeout": "1800s",
+                              "retryPolicy": {
+                                "numRetries": 6,
+                                "retryOn": "5xx"
+                              },
+                              "timeout": "15s"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {}
+          }
+        },
+        "name": "outbound:IP_REDACTED:80",
+        "trafficDirection": "OUTBOUND"
+      },
+      "outbound:passthrough:ipv4": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15001
+          }
+        },
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "outbound:passthrough:ipv4",
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "outbound:passthrough:ipv4",
+        "trafficDirection": "OUTBOUND",
+        "useOriginalDst": true
+      },
+      "outbound:passthrough:ipv6": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15001
+          }
+        },
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "outbound:passthrough:ipv6",
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "outbound:passthrough:ipv6",
+        "trafficDirection": "OUTBOUND",
+        "useOriginalDst": true
+      }
+    },
+    "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret": {
+      "identity_cert:secret:envoyconfig": {
+        "name": "identity_cert:secret:envoyconfig",
+        "tlsCertificate": {
+          "certificateChain": {
+            "inlineBytes": "Q0VSVA=="
+          },
+          "privateKey": {
+            "inlineBytes": "S0VZ"
+          }
+        }
+      },
+      "mesh_ca:secret:envoyconfig": {
+        "name": "mesh_ca:secret:envoyconfig",
+        "validationContext": {
+          "trustedCa": {
+            "inlineBytes": "Q0E="
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-mix.input.yaml
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-mix.input.yaml
@@ -1,0 +1,55 @@
+type: MeshHTTPRoute
+name: test-route
+mesh: envoyconfig
+labels:
+  kuma.io/effect: shadow
+spec:
+  to:
+    - targetRef:
+        kind: MeshService
+        name: test-server
+      rules:
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /test
+          default:
+            filters:
+              - type: RequestHeaderModifier
+                requestHeaderModifier:
+                  add:
+                    - name: x-test-header
+                      value: added-by-policy
+---
+type: MeshRetry
+name: mr-1
+mesh: envoyconfig
+labels:
+  kuma.io/effect: shadow
+spec:
+  to:
+    - targetRef:
+        kind: MeshService
+        name: test-server
+      default:
+        http:
+          numRetries: 6
+          retryOn:
+            - 5xx
+---
+type: MeshRetry
+name: global
+mesh: envoyconfig
+labels:
+  kuma.io/effect: shadow
+spec:
+  targetRef:
+    kind: Mesh
+  to:
+    - targetRef:
+        kind: Mesh
+      default:
+        http:
+          numRetries: 3
+          retryOn:
+            - Retriable4xx

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-mix.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-mix.test-server.golden.json
@@ -1,0 +1,856 @@
+{
+  "diff": [
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/match/path",
+      "value": "/test"
+    },
+    {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/match/prefix",
+      "value": "/"
+    },
+    {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/name",
+      "value": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo="
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/name",
+      "value": "kri_mhttpr_envoyconfig_kuma-3__test-route_"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/requestHeadersToAdd",
+      "value": [
+        {
+          "header": {
+            "key": "x-test-header",
+            "value": "added-by-policy"
+          }
+        }
+      ]
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/retryPolicy",
+      "value": {
+        "numRetries": 6,
+        "retryOn": "5xx"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/1",
+      "value": {
+        "match": {
+          "prefix": "/"
+        },
+        "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
+        "route": {
+          "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
+          "idleTimeout": "1800s",
+          "retryPolicy": {
+            "numRetries": 6,
+            "retryOn": "5xx"
+          },
+          "timeout": "15s"
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/1",
+      "value": {
+        "match": {
+          "prefix": "/test/"
+        },
+        "name": "kri_mhttpr_envoyconfig_kuma-3__test-route_",
+        "requestHeadersToAdd": [
+          {
+            "header": {
+              "key": "x-test-header",
+              "value": "added-by-policy"
+            }
+          }
+        ],
+        "route": {
+          "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
+          "idleTimeout": "1800s",
+          "retryPolicy": {
+            "numRetries": 6,
+            "retryOn": "5xx"
+          },
+          "timeout": "15s"
+        }
+      }
+    }
+  ],
+  "xds": {
+    "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
+      "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
+        "edsClusterConfig": {
+          "edsConfig": {
+            "ads": {},
+            "resourceApiVersion": "V3"
+          }
+        },
+        "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/demo-client"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a65abe81bca1750d1.demo-client.3000.envoyconfig.ms"
+          }
+        },
+        "type": "EDS",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicitHttpConfig": {
+              "http2ProtocolOptions": {}
+            }
+          }
+        }
+      },
+      "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
+        "edsClusterConfig": {
+          "edsConfig": {
+            "ads": {},
+            "resourceApiVersion": "V3"
+          }
+        },
+        "name": "envoyconfig_test-server__kuma-3_msvc_80",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/test-server"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a029781856823048e.test-server.80.envoyconfig.ms"
+          }
+        },
+        "type": "EDS",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
+            "explicitHttpConfig": {
+              "http2ProtocolOptions": {}
+            }
+          }
+        }
+      },
+      "inbound:passthrough:ipv4": {
+        "altStatName": "inbound_passthrough_ipv4",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "inbound:passthrough:ipv4",
+        "type": "ORIGINAL_DST",
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "inbound:passthrough:ipv6": {
+        "altStatName": "inbound_passthrough_ipv6",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "inbound:passthrough:ipv6",
+        "type": "ORIGINAL_DST",
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "localhost:8080": {
+        "altStatName": "localhost_8080",
+        "connectTimeout": "5s",
+        "loadAssignment": {
+          "clusterName": "localhost:8080",
+          "endpoints": [
+            {
+              "lbEndpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socketAddress": {
+                        "address": "IP_REDACTED",
+                        "portValue": 8080
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "name": "localhost:8080",
+        "type": "STATIC",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
+            "explicitHttpConfig": {
+              "httpProtocolOptions": {}
+            }
+          }
+        },
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "outbound:passthrough:ipv4": {
+        "altStatName": "outbound_passthrough_ipv4",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "outbound:passthrough:ipv4",
+        "type": "ORIGINAL_DST"
+      },
+      "outbound:passthrough:ipv6": {
+        "altStatName": "outbound_passthrough_ipv6",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "outbound:passthrough:ipv6",
+        "type": "ORIGINAL_DST"
+      }
+    },
+    "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment": {
+      "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "clusterName": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "IP_REDACTED",
+                      "portValue": 3000
+                    }
+                  }
+                },
+                "loadBalancingWeight": 1,
+                "metadata": {
+                  "filterMetadata": {
+                    "envoy.lb": {
+                      "kuma.io/zone": "kuma-3",
+                      "team": "client-owners"
+                    },
+                    "envoy.transport_socket_match": {
+                      "kuma.io/zone": "kuma-3",
+                      "team": "client-owners"
+                    }
+                  }
+                }
+              }
+            ],
+            "locality": {
+              "zone": "kuma-3"
+            }
+          }
+        ]
+      },
+      "envoyconfig_test-server__kuma-3_msvc_80": {
+        "clusterName": "envoyconfig_test-server__kuma-3_msvc_80",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "IP_REDACTED",
+                      "portValue": 80
+                    }
+                  }
+                },
+                "loadBalancingWeight": 1,
+                "metadata": {
+                  "filterMetadata": {
+                    "envoy.lb": {
+                      "instance": "1",
+                      "kuma.io/protocol": "http",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "server-owners",
+                      "version": "v1"
+                    },
+                    "envoy.transport_socket_match": {
+                      "instance": "1",
+                      "kuma.io/protocol": "http",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "server-owners",
+                      "version": "v1"
+                    }
+                  }
+                }
+              }
+            ],
+            "locality": {
+              "zone": "kuma-3"
+            }
+          }
+        ]
+      }
+    },
+    "type.googleapis.com/envoy.config.listener.v3.Listener": {
+      "inbound:IP_REDACTED:80": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 80
+          }
+        },
+        "bindToPort": false,
+        "enableReusePort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
+                  "forwardClientCertDetails": "SANITIZE_SET",
+                  "httpFilters": [
+                    {
+                      "name": "envoy.filters.http.rbac",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+                        "rules": {
+                          "policies": {
+                            "MeshTrafficPermission": {
+                              "permissions": [
+                                {
+                                  "any": true
+                                }
+                              ],
+                              "principals": [
+                                {
+                                  "any": true
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
+                    }
+                  ],
+                  "internalAddressConfig": {
+                    "cidrRanges": [
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 8
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 16
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 12
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 7
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 8
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 32
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 128
+                      }
+                    ]
+                  },
+                  "requestHeadersTimeout": "0s",
+                  "routeConfig": {
+                    "name": "inbound:test-server",
+                    "requestHeadersToRemove": [
+                      "x-kuma-tags"
+                    ],
+                    "validateClusters": false,
+                    "virtualHosts": [
+                      {
+                        "domains": [
+                          "*"
+                        ],
+                        "name": "test-server",
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/"
+                            },
+                            "route": {
+                              "cluster": "localhost:8080",
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "setCurrentClientCertDetails": {
+                    "uri": true
+                  },
+                  "statPrefix": "STAT_PREFIX_REDACTED",
+                  "streamIdleTimeout": "3600s"
+                }
+              }
+            ],
+            "transportSocket": {
+              "name": "envoy.transport_sockets.tls",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+                "commonTlsContext": {
+                  "combinedValidationContext": {
+                    "defaultValidationContext": {
+                      "matchTypedSubjectAltNames": [
+                        {
+                          "matcher": {
+                            "prefix": "spiffe://envoyconfig/"
+                          },
+                          "sanType": "URI"
+                        }
+                      ]
+                    },
+                    "validationContextSdsSecretConfig": {
+                      "name": "mesh_ca:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  },
+                  "tlsCertificateSdsSecretConfigs": [
+                    {
+                      "name": "identity_cert:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  ]
+                },
+                "requireClientCertificate": true
+              }
+            }
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {
+              "instance": "1",
+              "kuma.io/protocol": "http",
+              "kuma.io/service": "test-server",
+              "kuma.io/zone": "kuma-3",
+              "team": "server-owners",
+              "version": "v1"
+            }
+          }
+        },
+        "name": "inbound:IP_REDACTED:80",
+        "trafficDirection": "INBOUND"
+      },
+      "inbound:passthrough:ipv4": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15006
+          }
+        },
+        "enableReusePort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "inbound:passthrough:ipv4",
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "inbound:passthrough:ipv4",
+        "trafficDirection": "INBOUND",
+        "useOriginalDst": true
+      },
+      "inbound:passthrough:ipv6": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15006
+          }
+        },
+        "enableReusePort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "inbound:passthrough:ipv6",
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "inbound:passthrough:ipv6",
+        "trafficDirection": "INBOUND",
+        "useOriginalDst": true
+      },
+      "outbound:IP_REDACTED:3000": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 3000
+          }
+        },
+        "bindToPort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {}
+          }
+        },
+        "name": "outbound:IP_REDACTED:3000",
+        "trafficDirection": "OUTBOUND"
+      },
+      "outbound:IP_REDACTED:80": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 80
+          }
+        },
+        "bindToPort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
+                  "httpFilters": [
+                    {
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
+                    }
+                  ],
+                  "internalAddressConfig": {
+                    "cidrRanges": [
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 8
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 16
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 12
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 7
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 8
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 32
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 128
+                      }
+                    ]
+                  },
+                  "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
+                  "routeConfig": {
+                    "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",
+                    "validateClusters": false,
+                    "virtualHosts": [
+                      {
+                        "domains": [
+                          "*"
+                        ],
+                        "name": "envoyconfig_test-server__kuma-3_msvc_80",
+                        "routes": [
+                          {
+                            "match": {
+                              "path": "/test"
+                            },
+                            "name": "kri_mhttpr_envoyconfig_kuma-3__test-route_",
+                            "requestHeadersToAdd": [
+                              {
+                                "header": {
+                                  "key": "x-test-header",
+                                  "value": "added-by-policy"
+                                }
+                              }
+                            ],
+                            "route": {
+                              "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
+                              "idleTimeout": "1800s",
+                              "retryPolicy": {
+                                "numRetries": 6,
+                                "retryOn": "5xx"
+                              },
+                              "timeout": "15s"
+                            }
+                          },
+                          {
+                            "match": {
+                              "prefix": "/test/"
+                            },
+                            "name": "kri_mhttpr_envoyconfig_kuma-3__test-route_",
+                            "requestHeadersToAdd": [
+                              {
+                                "header": {
+                                  "key": "x-test-header",
+                                  "value": "added-by-policy"
+                                }
+                              }
+                            ],
+                            "route": {
+                              "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
+                              "idleTimeout": "1800s",
+                              "retryPolicy": {
+                                "numRetries": 6,
+                                "retryOn": "5xx"
+                              },
+                              "timeout": "15s"
+                            }
+                          },
+                          {
+                            "match": {
+                              "prefix": "/"
+                            },
+                            "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
+                            "route": {
+                              "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
+                              "idleTimeout": "1800s",
+                              "retryPolicy": {
+                                "numRetries": 6,
+                                "retryOn": "5xx"
+                              },
+                              "timeout": "15s"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {}
+          }
+        },
+        "name": "outbound:IP_REDACTED:80",
+        "trafficDirection": "OUTBOUND"
+      },
+      "outbound:passthrough:ipv4": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15001
+          }
+        },
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "outbound:passthrough:ipv4",
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "outbound:passthrough:ipv4",
+        "trafficDirection": "OUTBOUND",
+        "useOriginalDst": true
+      },
+      "outbound:passthrough:ipv6": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15001
+          }
+        },
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "outbound:passthrough:ipv6",
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "outbound:passthrough:ipv6",
+        "trafficDirection": "OUTBOUND",
+        "useOriginalDst": true
+      }
+    },
+    "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret": {
+      "identity_cert:secret:envoyconfig": {
+        "name": "identity_cert:secret:envoyconfig",
+        "tlsCertificate": {
+          "certificateChain": {
+            "inlineBytes": "Q0VSVA=="
+          },
+          "privateKey": {
+            "inlineBytes": "S0VZ"
+          }
+        }
+      },
+      "mesh_ca:secret:envoyconfig": {
+        "name": "mesh_ca:secret:envoyconfig",
+        "validationContext": {
+          "trustedCa": {
+            "inlineBytes": "Q0E="
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-mix.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-mix.demo-client.golden.json
@@ -1,0 +1,759 @@
+{
+  "diff": [
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/match/path",
+      "value": "/test"
+    },
+    {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/match/prefix",
+      "value": "/"
+    },
+    {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/name",
+      "value": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo="
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/name",
+      "value": "kri_mhttpr_envoyconfig_kuma-3__test-route_"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/requestHeadersToAdd",
+      "value": [
+        {
+          "header": {
+            "key": "x-test-header",
+            "value": "added-by-policy"
+          }
+        }
+      ]
+    },
+    {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/idleTimeout",
+      "value": "1800s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/idleTimeout",
+      "value": "33s"
+    },
+    {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
+      "value": "15s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
+      "value": "32s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/1",
+      "value": {
+        "match": {
+          "prefix": "/"
+        },
+        "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
+        "route": {
+          "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
+          "idleTimeout": "33s",
+          "timeout": "32s"
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/1",
+      "value": {
+        "match": {
+          "prefix": "/test/"
+        },
+        "name": "kri_mhttpr_envoyconfig_kuma-3__test-route_",
+        "requestHeadersToAdd": [
+          {
+            "header": {
+              "key": "x-test-header",
+              "value": "added-by-policy"
+            }
+          }
+        ],
+        "route": {
+          "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
+          "idleTimeout": "33s",
+          "timeout": "32s"
+        }
+      }
+    }
+  ],
+  "xds": {
+    "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
+      "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
+        "edsClusterConfig": {
+          "edsConfig": {
+            "ads": {},
+            "resourceApiVersion": "V3"
+          }
+        },
+        "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/demo-client"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a65abe81bca1750d1.demo-client.3000.envoyconfig.ms"
+          }
+        },
+        "type": "EDS",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicitHttpConfig": {
+              "http2ProtocolOptions": {}
+            }
+          }
+        }
+      },
+      "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
+        "edsClusterConfig": {
+          "edsConfig": {
+            "ads": {},
+            "resourceApiVersion": "V3"
+          }
+        },
+        "name": "envoyconfig_test-server__kuma-3_msvc_80",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/test-server"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a029781856823048e.test-server.80.envoyconfig.ms"
+          }
+        },
+        "type": "EDS",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
+            "explicitHttpConfig": {
+              "http2ProtocolOptions": {}
+            }
+          }
+        }
+      },
+      "inbound:passthrough:ipv4": {
+        "altStatName": "inbound_passthrough_ipv4",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "inbound:passthrough:ipv4",
+        "type": "ORIGINAL_DST",
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "inbound:passthrough:ipv6": {
+        "altStatName": "inbound_passthrough_ipv6",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "inbound:passthrough:ipv6",
+        "type": "ORIGINAL_DST",
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "localhost:3000": {
+        "altStatName": "localhost_3000",
+        "connectTimeout": "5s",
+        "loadAssignment": {
+          "clusterName": "localhost:3000",
+          "endpoints": [
+            {
+              "lbEndpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socketAddress": {
+                        "address": "IP_REDACTED",
+                        "portValue": 3000
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "name": "localhost:3000",
+        "type": "STATIC",
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "outbound:passthrough:ipv4": {
+        "altStatName": "outbound_passthrough_ipv4",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "outbound:passthrough:ipv4",
+        "type": "ORIGINAL_DST"
+      },
+      "outbound:passthrough:ipv6": {
+        "altStatName": "outbound_passthrough_ipv6",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "outbound:passthrough:ipv6",
+        "type": "ORIGINAL_DST"
+      }
+    },
+    "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment": {
+      "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "clusterName": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "IP_REDACTED",
+                      "portValue": 3000
+                    }
+                  }
+                },
+                "loadBalancingWeight": 1,
+                "metadata": {
+                  "filterMetadata": {
+                    "envoy.lb": {
+                      "kuma.io/zone": "kuma-3",
+                      "team": "client-owners"
+                    },
+                    "envoy.transport_socket_match": {
+                      "kuma.io/zone": "kuma-3",
+                      "team": "client-owners"
+                    }
+                  }
+                }
+              }
+            ],
+            "locality": {
+              "zone": "kuma-3"
+            }
+          }
+        ]
+      },
+      "envoyconfig_test-server__kuma-3_msvc_80": {
+        "clusterName": "envoyconfig_test-server__kuma-3_msvc_80",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "IP_REDACTED",
+                      "portValue": 80
+                    }
+                  }
+                },
+                "loadBalancingWeight": 1,
+                "metadata": {
+                  "filterMetadata": {
+                    "envoy.lb": {
+                      "instance": "1",
+                      "kuma.io/protocol": "http",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "server-owners",
+                      "version": "v1"
+                    },
+                    "envoy.transport_socket_match": {
+                      "instance": "1",
+                      "kuma.io/protocol": "http",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "server-owners",
+                      "version": "v1"
+                    }
+                  }
+                }
+              }
+            ],
+            "locality": {
+              "zone": "kuma-3"
+            }
+          }
+        ]
+      }
+    },
+    "type.googleapis.com/envoy.config.listener.v3.Listener": {
+      "inbound:IP_REDACTED:3000": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 3000
+          }
+        },
+        "bindToPort": false,
+        "enableReusePort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.rbac",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+                  "rules": {
+                    "policies": {
+                      "MeshTrafficPermission": {
+                        "permissions": [
+                          {
+                            "any": true
+                          }
+                        ],
+                        "principals": [
+                          {
+                            "any": true
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              },
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "localhost:3000",
+                  "idleTimeout": "3600s",
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ],
+            "transportSocket": {
+              "name": "envoy.transport_sockets.tls",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+                "commonTlsContext": {
+                  "combinedValidationContext": {
+                    "defaultValidationContext": {
+                      "matchTypedSubjectAltNames": [
+                        {
+                          "matcher": {
+                            "prefix": "spiffe://envoyconfig/"
+                          },
+                          "sanType": "URI"
+                        }
+                      ]
+                    },
+                    "validationContextSdsSecretConfig": {
+                      "name": "mesh_ca:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  },
+                  "tlsCertificateSdsSecretConfigs": [
+                    {
+                      "name": "identity_cert:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  ]
+                },
+                "requireClientCertificate": true
+              }
+            }
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {
+              "kuma.io/service": "demo-client",
+              "kuma.io/zone": "kuma-3",
+              "team": "client-owners"
+            }
+          }
+        },
+        "name": "inbound:IP_REDACTED:3000",
+        "trafficDirection": "INBOUND"
+      },
+      "inbound:passthrough:ipv4": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15006
+          }
+        },
+        "enableReusePort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "inbound:passthrough:ipv4",
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "inbound:passthrough:ipv4",
+        "trafficDirection": "INBOUND",
+        "useOriginalDst": true
+      },
+      "inbound:passthrough:ipv6": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15006
+          }
+        },
+        "enableReusePort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "inbound:passthrough:ipv6",
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "inbound:passthrough:ipv6",
+        "trafficDirection": "INBOUND",
+        "useOriginalDst": true
+      },
+      "outbound:IP_REDACTED:3000": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 3000
+          }
+        },
+        "bindToPort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {}
+          }
+        },
+        "name": "outbound:IP_REDACTED:3000",
+        "trafficDirection": "OUTBOUND"
+      },
+      "outbound:IP_REDACTED:80": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 80
+          }
+        },
+        "bindToPort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
+                  "httpFilters": [
+                    {
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
+                    }
+                  ],
+                  "internalAddressConfig": {
+                    "cidrRanges": [
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 8
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 16
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 12
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 7
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 8
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 32
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 128
+                      }
+                    ]
+                  },
+                  "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
+                  "routeConfig": {
+                    "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",
+                    "validateClusters": false,
+                    "virtualHosts": [
+                      {
+                        "domains": [
+                          "*"
+                        ],
+                        "name": "envoyconfig_test-server__kuma-3_msvc_80",
+                        "routes": [
+                          {
+                            "match": {
+                              "path": "/test"
+                            },
+                            "name": "kri_mhttpr_envoyconfig_kuma-3__test-route_",
+                            "requestHeadersToAdd": [
+                              {
+                                "header": {
+                                  "key": "x-test-header",
+                                  "value": "added-by-policy"
+                                }
+                              }
+                            ],
+                            "route": {
+                              "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
+                              "idleTimeout": "33s",
+                              "timeout": "32s"
+                            }
+                          },
+                          {
+                            "match": {
+                              "prefix": "/test/"
+                            },
+                            "name": "kri_mhttpr_envoyconfig_kuma-3__test-route_",
+                            "requestHeadersToAdd": [
+                              {
+                                "header": {
+                                  "key": "x-test-header",
+                                  "value": "added-by-policy"
+                                }
+                              }
+                            ],
+                            "route": {
+                              "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
+                              "idleTimeout": "33s",
+                              "timeout": "32s"
+                            }
+                          },
+                          {
+                            "match": {
+                              "prefix": "/"
+                            },
+                            "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
+                            "route": {
+                              "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
+                              "idleTimeout": "33s",
+                              "timeout": "32s"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {}
+          }
+        },
+        "name": "outbound:IP_REDACTED:80",
+        "trafficDirection": "OUTBOUND"
+      },
+      "outbound:passthrough:ipv4": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15001
+          }
+        },
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "outbound:passthrough:ipv4",
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "outbound:passthrough:ipv4",
+        "trafficDirection": "OUTBOUND",
+        "useOriginalDst": true
+      },
+      "outbound:passthrough:ipv6": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15001
+          }
+        },
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "outbound:passthrough:ipv6",
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "outbound:passthrough:ipv6",
+        "trafficDirection": "OUTBOUND",
+        "useOriginalDst": true
+      }
+    },
+    "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret": {
+      "identity_cert:secret:envoyconfig": {
+        "name": "identity_cert:secret:envoyconfig",
+        "tlsCertificate": {
+          "certificateChain": {
+            "inlineBytes": "Q0VSVA=="
+          },
+          "privateKey": {
+            "inlineBytes": "S0VZ"
+          }
+        }
+      },
+      "mesh_ca:secret:envoyconfig": {
+        "name": "mesh_ca:secret:envoyconfig",
+        "validationContext": {
+          "trustedCa": {
+            "inlineBytes": "Q0E="
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-mix.input.yaml
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-mix.input.yaml
@@ -1,0 +1,51 @@
+type: MeshHTTPRoute
+name: test-route
+mesh: envoyconfig
+labels:
+  kuma.io/effect: shadow
+spec:
+  to:
+    - targetRef:
+        kind: MeshService
+        name: test-server
+      rules:
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /test
+          default:
+            filters:
+              - type: RequestHeaderModifier
+                requestHeaderModifier:
+                  add:
+                    - name: x-test-header
+                      value: added-by-policy
+---
+type: MeshTimeout
+name: mt-1
+mesh: envoyconfig
+labels:
+  kuma.io/effect: shadow
+spec:
+  to:
+    - targetRef:
+        kind: MeshService
+        name: test-server
+      default:
+        http:
+          requestTimeout: 32s
+          streamIdleTimeout: 33s
+---
+type: MeshTimeout
+name: global
+mesh: envoyconfig
+labels:
+  kuma.io/effect: shadow
+spec:
+  to:
+    - targetRef:
+        kind: Mesh
+      default:
+        http:
+          requestTimeout: 42s
+          streamIdleTimeout: 43s

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-mix.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-mix.test-server.golden.json
@@ -1,0 +1,848 @@
+{
+  "diff": [
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/match/path",
+      "value": "/test"
+    },
+    {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/match/prefix",
+      "value": "/"
+    },
+    {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/name",
+      "value": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo="
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/name",
+      "value": "kri_mhttpr_envoyconfig_kuma-3__test-route_"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/requestHeadersToAdd",
+      "value": [
+        {
+          "header": {
+            "key": "x-test-header",
+            "value": "added-by-policy"
+          }
+        }
+      ]
+    },
+    {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/idleTimeout",
+      "value": "1800s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/idleTimeout",
+      "value": "33s"
+    },
+    {
+      "op": "remove",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
+      "value": "15s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/0/route/timeout",
+      "value": "32s"
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/1",
+      "value": {
+        "match": {
+          "prefix": "/"
+        },
+        "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
+        "route": {
+          "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
+          "idleTimeout": "33s",
+          "timeout": "32s"
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/outbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/1",
+      "value": {
+        "match": {
+          "prefix": "/test/"
+        },
+        "name": "kri_mhttpr_envoyconfig_kuma-3__test-route_",
+        "requestHeadersToAdd": [
+          {
+            "header": {
+              "key": "x-test-header",
+              "value": "added-by-policy"
+            }
+          }
+        ],
+        "route": {
+          "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
+          "idleTimeout": "33s",
+          "timeout": "32s"
+        }
+      }
+    }
+  ],
+  "xds": {
+    "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
+      "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "connectTimeout": "5s",
+        "edsClusterConfig": {
+          "edsConfig": {
+            "ads": {},
+            "resourceApiVersion": "V3"
+          }
+        },
+        "name": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/demo-client"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a65abe81bca1750d1.demo-client.3000.envoyconfig.ms"
+          }
+        },
+        "type": "EDS",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicitHttpConfig": {
+              "http2ProtocolOptions": {}
+            }
+          }
+        }
+      },
+      "envoyconfig_test-server__kuma-3_msvc_80": {
+        "connectTimeout": "5s",
+        "edsClusterConfig": {
+          "edsConfig": {
+            "ads": {},
+            "resourceApiVersion": "V3"
+          }
+        },
+        "name": "envoyconfig_test-server__kuma-3_msvc_80",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig/test-server"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "mesh_ca:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "identity_cert:secret:envoyconfig",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "a029781856823048e.test-server.80.envoyconfig.ms"
+          }
+        },
+        "type": "EDS",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
+            "explicitHttpConfig": {
+              "http2ProtocolOptions": {}
+            }
+          }
+        }
+      },
+      "inbound:passthrough:ipv4": {
+        "altStatName": "inbound_passthrough_ipv4",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "inbound:passthrough:ipv4",
+        "type": "ORIGINAL_DST",
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "inbound:passthrough:ipv6": {
+        "altStatName": "inbound_passthrough_ipv6",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "inbound:passthrough:ipv6",
+        "type": "ORIGINAL_DST",
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "localhost:8080": {
+        "altStatName": "localhost_8080",
+        "connectTimeout": "5s",
+        "loadAssignment": {
+          "clusterName": "localhost:8080",
+          "endpoints": [
+            {
+              "lbEndpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socketAddress": {
+                        "address": "IP_REDACTED",
+                        "portValue": 8080
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "name": "localhost:8080",
+        "type": "STATIC",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
+            "explicitHttpConfig": {
+              "httpProtocolOptions": {}
+            }
+          }
+        },
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "outbound:passthrough:ipv4": {
+        "altStatName": "outbound_passthrough_ipv4",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "outbound:passthrough:ipv4",
+        "type": "ORIGINAL_DST"
+      },
+      "outbound:passthrough:ipv6": {
+        "altStatName": "outbound_passthrough_ipv6",
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "outbound:passthrough:ipv6",
+        "type": "ORIGINAL_DST"
+      }
+    },
+    "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment": {
+      "envoyconfig_demo-client__kuma-3_msvc_3000": {
+        "clusterName": "envoyconfig_demo-client__kuma-3_msvc_3000",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "IP_REDACTED",
+                      "portValue": 3000
+                    }
+                  }
+                },
+                "loadBalancingWeight": 1,
+                "metadata": {
+                  "filterMetadata": {
+                    "envoy.lb": {
+                      "kuma.io/zone": "kuma-3",
+                      "team": "client-owners"
+                    },
+                    "envoy.transport_socket_match": {
+                      "kuma.io/zone": "kuma-3",
+                      "team": "client-owners"
+                    }
+                  }
+                }
+              }
+            ],
+            "locality": {
+              "zone": "kuma-3"
+            }
+          }
+        ]
+      },
+      "envoyconfig_test-server__kuma-3_msvc_80": {
+        "clusterName": "envoyconfig_test-server__kuma-3_msvc_80",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "IP_REDACTED",
+                      "portValue": 80
+                    }
+                  }
+                },
+                "loadBalancingWeight": 1,
+                "metadata": {
+                  "filterMetadata": {
+                    "envoy.lb": {
+                      "instance": "1",
+                      "kuma.io/protocol": "http",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "server-owners",
+                      "version": "v1"
+                    },
+                    "envoy.transport_socket_match": {
+                      "instance": "1",
+                      "kuma.io/protocol": "http",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "server-owners",
+                      "version": "v1"
+                    }
+                  }
+                }
+              }
+            ],
+            "locality": {
+              "zone": "kuma-3"
+            }
+          }
+        ]
+      }
+    },
+    "type.googleapis.com/envoy.config.listener.v3.Listener": {
+      "inbound:IP_REDACTED:80": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 80
+          }
+        },
+        "bindToPort": false,
+        "enableReusePort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
+                  "forwardClientCertDetails": "SANITIZE_SET",
+                  "httpFilters": [
+                    {
+                      "name": "envoy.filters.http.rbac",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+                        "rules": {
+                          "policies": {
+                            "MeshTrafficPermission": {
+                              "permissions": [
+                                {
+                                  "any": true
+                                }
+                              ],
+                              "principals": [
+                                {
+                                  "any": true
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
+                    }
+                  ],
+                  "internalAddressConfig": {
+                    "cidrRanges": [
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 8
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 16
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 12
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 7
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 8
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 32
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 128
+                      }
+                    ]
+                  },
+                  "requestHeadersTimeout": "0s",
+                  "routeConfig": {
+                    "name": "inbound:test-server",
+                    "requestHeadersToRemove": [
+                      "x-kuma-tags"
+                    ],
+                    "validateClusters": false,
+                    "virtualHosts": [
+                      {
+                        "domains": [
+                          "*"
+                        ],
+                        "name": "test-server",
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/"
+                            },
+                            "route": {
+                              "cluster": "localhost:8080",
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "setCurrentClientCertDetails": {
+                    "uri": true
+                  },
+                  "statPrefix": "STAT_PREFIX_REDACTED",
+                  "streamIdleTimeout": "3600s"
+                }
+              }
+            ],
+            "transportSocket": {
+              "name": "envoy.transport_sockets.tls",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+                "commonTlsContext": {
+                  "combinedValidationContext": {
+                    "defaultValidationContext": {
+                      "matchTypedSubjectAltNames": [
+                        {
+                          "matcher": {
+                            "prefix": "spiffe://envoyconfig/"
+                          },
+                          "sanType": "URI"
+                        }
+                      ]
+                    },
+                    "validationContextSdsSecretConfig": {
+                      "name": "mesh_ca:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  },
+                  "tlsCertificateSdsSecretConfigs": [
+                    {
+                      "name": "identity_cert:secret:envoyconfig",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  ]
+                },
+                "requireClientCertificate": true
+              }
+            }
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {
+              "instance": "1",
+              "kuma.io/protocol": "http",
+              "kuma.io/service": "test-server",
+              "kuma.io/zone": "kuma-3",
+              "team": "server-owners",
+              "version": "v1"
+            }
+          }
+        },
+        "name": "inbound:IP_REDACTED:80",
+        "trafficDirection": "INBOUND"
+      },
+      "inbound:passthrough:ipv4": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15006
+          }
+        },
+        "enableReusePort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "inbound:passthrough:ipv4",
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "inbound:passthrough:ipv4",
+        "trafficDirection": "INBOUND",
+        "useOriginalDst": true
+      },
+      "inbound:passthrough:ipv6": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15006
+          }
+        },
+        "enableReusePort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "inbound:passthrough:ipv6",
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "inbound:passthrough:ipv6",
+        "trafficDirection": "INBOUND",
+        "useOriginalDst": true
+      },
+      "outbound:IP_REDACTED:3000": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 3000
+          }
+        },
+        "bindToPort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "envoyconfig_demo-client__kuma-3_msvc_3000",
+                  "idleTimeout": "3600s",
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {}
+          }
+        },
+        "name": "outbound:IP_REDACTED:3000",
+        "trafficDirection": "OUTBOUND"
+      },
+      "outbound:IP_REDACTED:80": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 80
+          }
+        },
+        "bindToPort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
+                  "httpFilters": [
+                    {
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
+                    }
+                  ],
+                  "internalAddressConfig": {
+                    "cidrRanges": [
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 8
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 16
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 12
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 7
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 8
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 32
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 128
+                      }
+                    ]
+                  },
+                  "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
+                  "routeConfig": {
+                    "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",
+                    "validateClusters": false,
+                    "virtualHosts": [
+                      {
+                        "domains": [
+                          "*"
+                        ],
+                        "name": "envoyconfig_test-server__kuma-3_msvc_80",
+                        "routes": [
+                          {
+                            "match": {
+                              "path": "/test"
+                            },
+                            "name": "kri_mhttpr_envoyconfig_kuma-3__test-route_",
+                            "requestHeadersToAdd": [
+                              {
+                                "header": {
+                                  "key": "x-test-header",
+                                  "value": "added-by-policy"
+                                }
+                              }
+                            ],
+                            "route": {
+                              "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
+                              "idleTimeout": "33s",
+                              "timeout": "32s"
+                            }
+                          },
+                          {
+                            "match": {
+                              "prefix": "/test/"
+                            },
+                            "name": "kri_mhttpr_envoyconfig_kuma-3__test-route_",
+                            "requestHeadersToAdd": [
+                              {
+                                "header": {
+                                  "key": "x-test-header",
+                                  "value": "added-by-policy"
+                                }
+                              }
+                            ],
+                            "route": {
+                              "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
+                              "idleTimeout": "33s",
+                              "timeout": "32s"
+                            }
+                          },
+                          {
+                            "match": {
+                              "prefix": "/"
+                            },
+                            "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
+                            "route": {
+                              "cluster": "envoyconfig_test-server__kuma-3_msvc_80",
+                              "idleTimeout": "33s",
+                              "timeout": "32s"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {}
+          }
+        },
+        "name": "outbound:IP_REDACTED:80",
+        "trafficDirection": "OUTBOUND"
+      },
+      "outbound:passthrough:ipv4": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15001
+          }
+        },
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "outbound:passthrough:ipv4",
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "outbound:passthrough:ipv4",
+        "trafficDirection": "OUTBOUND",
+        "useOriginalDst": true
+      },
+      "outbound:passthrough:ipv6": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15001
+          }
+        },
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "outbound:passthrough:ipv6",
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "outbound:passthrough:ipv6",
+        "trafficDirection": "OUTBOUND",
+        "useOriginalDst": true
+      }
+    },
+    "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret": {
+      "identity_cert:secret:envoyconfig": {
+        "name": "identity_cert:secret:envoyconfig",
+        "tlsCertificate": {
+          "certificateChain": {
+            "inlineBytes": "Q0VSVA=="
+          },
+          "privateKey": {
+            "inlineBytes": "S0VZ"
+          }
+        }
+      },
+      "mesh_ca:secret:envoyconfig": {
+        "name": "mesh_ca:secret:envoyconfig",
+        "validationContext": {
+          "trustedCa": {
+            "inlineBytes": "Q0E="
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Motivation

Method `Compute` is falling back to `Mesh` rules if `MeshHTTPRoute` doesn't exist. See the repro steps in https://github.com/kumahq/kuma/issues/13571.

When computing `MeshHTTPRoute` conf in `Compute` we can't fall back to its `MeshService`, because there might be an ambiguity – `MeshHTTPRoute` could be applied to several `MeshServices`. But when configuring the route, we always know the `MeshService` of the outbound listener. Computing `MeshHTTPRoute` conf is possible only in the context of `MeshService`.

## Implementation information

Instead of passing both `MeshService` and `MeshHTTPRoute` to `Compute` I created a `ResourceContext`:

```go
// ResourceContext represents a hierarchical resource structure and
// is always ready to return the appropriate conf by using Conf method.
// The RootContext is always the mesh. As we're iterating over resource in ResourceSet
// and going deeper to configure Listeners/Routes, we need to add more resources
// to the ResourceContext by using WithID method.
//
// For example:
// 1. At the beginning of Apply method in plugin.go rctx := RootContext()
// 2. As we start iterating over outbound listeners, rctx = rctx.WithID(outboundListenerKRI)
// 3. As we start iterating over the routes of the outbound listener, rctx = rctx.WithID(routeKRI)
//
// At any moment we can call rctx.Conf() and get right configuration.
type ResourceContext[T any] struct {
    ids   []kri.Identifier
    rules ResourceRules
}
```

In `plugin.go` we should start with creating `RootContext`:

```go
func (p plugin) Apply(...) error {
    rctx := outbound.RootContext[meshtimeout_api.Conf](mesh, rules)

    // as we're iterating over listeners/clusters we must add KRI to the context and pass it down
    for _, r := range resources {
        configureListener(rctx.WithID(r.ResourceOrigin), ...)
    }
}

func configureListener(rctx ResourceContext, ...) {
    // as we iterating over routes we again add route's KRI and pass down the context
    for _, route := range routes {
        configureRoute(rctx.WithID(kri.FromString(route.Name)), ...)
    }
}
```

at any moment `rctx.Conf()` is ready to give us the current conf.

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix https://github.com/kumahq/kuma/issues/13571
