### PR TITLE
fix(xds): add internal address config to  direct response configurer

### DIFF
--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/basic.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/basic.listeners.golden.yaml
@@ -14,6 +14,12 @@ resources:
           - name: envoy.filters.http.router
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+            - addressPrefix: ::1
+              prefixLen: 128
           routeConfig:
             virtualHosts:
             - domains:

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/default.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/default.listeners.golden.yaml
@@ -14,6 +14,12 @@ resources:
           - name: envoy.filters.http.router
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+            - addressPrefix: ::1
+              prefixLen: 128
           routeConfig:
             virtualHosts:
             - domains:

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/multiple_otel.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/multiple_otel.listeners.golden.yaml
@@ -14,6 +14,12 @@ resources:
           - name: envoy.filters.http.router
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+            - addressPrefix: ::1
+              prefixLen: 128
           routeConfig:
             virtualHosts:
             - domains:

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/multiple_prometheus.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/multiple_prometheus.listeners.golden.yaml
@@ -14,6 +14,12 @@ resources:
           - name: envoy.filters.http.router
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+            - addressPrefix: ::1
+              prefixLen: 128
           routeConfig:
             virtualHosts:
             - domains:

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/openTelemetry.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/openTelemetry.listeners.golden.yaml
@@ -14,6 +14,12 @@ resources:
           - name: envoy.filters.http.router
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+            - addressPrefix: ::1
+              prefixLen: 128
           routeConfig:
             virtualHosts:
             - domains:

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/otel_and_prometheus.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/otel_and_prometheus.listeners.golden.yaml
@@ -14,6 +14,12 @@ resources:
           - name: envoy.filters.http.router
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+            - addressPrefix: ::1
+              prefixLen: 128
           routeConfig:
             virtualHosts:
             - domains:

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/provided_tls.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/provided_tls.listeners.golden.yaml
@@ -14,6 +14,12 @@ resources:
           - name: envoy.filters.http.router
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+            - addressPrefix: ::1
+              prefixLen: 128
           routeConfig:
             virtualHosts:
             - domains:

--- a/pkg/xds/dynconf/listener.go
+++ b/pkg/xds/dynconf/listener.go
@@ -37,7 +37,7 @@ func AddConfigRoute(proxy *core_xds.Proxy, rs *core_xds.ResourceSet, name string
 			Configure(envoy_listeners.FilterChain(
 				envoy_listeners.NewFilterChainBuilder(proxy.APIVersion, envoy_common.AnonymousResource).
 					Configure(
-						envoy_listeners.DirectResponse(ListenerName, []v3.DirectResponseEndpoints{}),
+						envoy_listeners.DirectResponse(ListenerName, []v3.DirectResponseEndpoints{}, core_xds.LocalHostAddresses),
 					),
 			)).Build()
 		listener = nr.(*envoy_listener.Listener)

--- a/pkg/xds/envoy/listeners/filter_chain_configurers.go
+++ b/pkg/xds/envoy/listeners/filter_chain_configurers.go
@@ -51,10 +51,11 @@ func StaticEndpoints(virtualHostName string, paths []*envoy_common.StaticEndpoin
 	})
 }
 
-func DirectResponse(virtualHostName string, endpoints []v3.DirectResponseEndpoints) FilterChainBuilderOpt {
+func DirectResponse(virtualHostName string, endpoints []v3.DirectResponseEndpoints, internalAddresses []core_xds.InternalAddress) FilterChainBuilderOpt {
 	return AddFilterChainConfigurer(&v3.DirectResponseConfigurer{
-		VirtualHostName: virtualHostName,
-		Endpoints:       endpoints,
+		VirtualHostName:   virtualHostName,
+		Endpoints:         endpoints,
+		InternalAddresses: internalAddresses,
 	})
 }
 

--- a/pkg/xds/envoy/listeners/v3/direct_response_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/direct_response_configurer.go
@@ -6,9 +6,9 @@ import (
 	envoy_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_dresp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/direct_response/v3"
 	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
-	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"google.golang.org/protobuf/types/known/anypb"
 
+	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	util_xds "github.com/kumahq/kuma/pkg/util/xds"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"

--- a/pkg/xds/envoy/listeners/v3/direct_response_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/direct_response_configurer_test.go
@@ -1,10 +1,10 @@
 package v3_test
 
 import (
-	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	"github.com/kumahq/kuma/pkg/xds/envoy"
 	. "github.com/kumahq/kuma/pkg/xds/envoy/listeners"

--- a/pkg/xds/envoy/listeners/v3/direct_response_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/direct_response_configurer_test.go
@@ -1,6 +1,7 @@
 package v3_test
 
 import (
+	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -18,7 +19,7 @@ var _ = Describe("DirectResponseConfigurer", func() {
 				Path:       "/",
 				StatusCode: 200,
 				Response:   "test",
-			}})).
+			}}, core_xds.LocalHostAddresses)).
 			Build()
 
 		// then
@@ -36,6 +37,12 @@ filters:
           - name: envoy.filters.http.router
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+      internalAddressConfig:
+        cidrRanges:
+        - addressPrefix: 127.0.0.1
+          prefixLen: 32
+        - addressPrefix: ::1
+          prefixLen: 128
       routeConfig:
           virtualHosts:
               - domains:

--- a/pkg/xds/generator/testdata/dns/4-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/dns/4-envoy-config.golden.yaml
@@ -14,6 +14,12 @@ resources:
           - name: envoy.filters.http.router
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+            - addressPrefix: ::1
+              prefixLen: 128
           routeConfig:
             virtualHosts:
             - domains:


### PR DESCRIPTION
## Motivation

Fix a warning shown on Envoy:

```
[2025-05-19 09:41:07.450][20][warning][misc] [source/extensions/filters/network/http_connection_manager/config.cc:88] internal_address_config is not configured. The existing default behaviour will trust RFC1918 IP addresses, but this will be changed in next release. Please explictily config internal address config as the migration step or config the envoy.reloadable_features.explicit_internal_address_config to true to untrust all ips by default
```

## Implementation information

Add `internal_address_config` onto the HCM generated by the `DirectResponse` configurer based on CP config.

Listener name: `_kuma_dynamicconfig `

## Supporting documentation

A followup of https://github.com/kumahq/kuma/issues/12190

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
