### PR TITLE
fix(accesslogstreamer): stop adding newline to the msg

### DIFF
--- a/app/kuma-dp/pkg/dataplane/accesslogs/streamer.go
+++ b/app/kuma-dp/pkg/dataplane/accesslogs/streamer.go
@@ -134,8 +134,6 @@ func (s *accessLogStreamer) streamAccessLogs(reader *bufio.Reader) error {
 					continue
 				}
 			}
-
-			accessLogMsg = append(accessLogMsg, '\n')
 		}
 
 		s.RLock()

--- a/test/e2e_env/universal/meshaccesslog/meshaccesslog.go
+++ b/test/e2e_env/universal/meshaccesslog/meshaccesslog.go
@@ -109,7 +109,7 @@ spec:
 		Eventually(func(g Gomega) {
 			makeRequest(g)
 
-			stdout, _, err := universal.Cluster.Exec("", "", AppModeTcpSink, "head", "-1", "/nc.out")
+			stdout, _, err := universal.Cluster.Exec("", "", AppModeTcpSink, "tail", "-1", "/nc.out")
 			g.Expect(err).ToNot(HaveOccurred())
 			parts := strings.Split(stdout, ",")
 			g.Expect(parts).To(HaveLen(3))
@@ -117,7 +117,7 @@ spec:
 			startTimeInt, err := strconv.Atoi(strings.TrimSpace(parts[0]))
 			Expect(err).ToNot(HaveOccurred())
 			startTime := time.Unix(int64(startTimeInt), 0)
-			Expect(startTime).To(BeTemporally("~", time.Now(), time.Hour))
+			Expect(startTime).To(BeTemporally("~", time.Now(), time.Minute))
 
 			src, dst = parts[1], parts[2]
 		}, "30s", "1s").Should(Succeed())


### PR DESCRIPTION
## Motivation

* e2e test for MeshAccessLog was incorrectly checking `head -1 nc.out` while new messages are written at the bottom
* AccessLogStreamer adds additional `\n` however we already add `\n` to the message in CP https://github.com/kumahq/kuma/blob/5bcced29dbb0ad857c78e5e6a2d6f75ef03d103d/pkg/plugins/policies/meshaccesslog/plugin/xds/configurer.go#L109

## Implementation information

* fixed the test to use `tail -1`
* stop adding `\n` in accesslogstreamer

