### PR TITLE
refactor(kubernetes/rbac): rename control-plane-writer to control-plane-workloads

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -262,7 +262,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -388,7 +388,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -396,7 +396,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
 subjects:
   - kind: ServiceAccount
     name: kuma-control-plane

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -10605,7 +10605,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -10706,7 +10706,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -10714,7 +10714,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
 subjects:
   - kind: ServiceAccount
     name: kuma-control-plane

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -10605,7 +10605,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -10706,7 +10706,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -10714,7 +10714,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
 subjects:
   - kind: ServiceAccount
     name: kuma-control-plane

--- a/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
@@ -190,7 +190,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -291,7 +291,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -299,7 +299,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
 subjects:
   - kind: ServiceAccount
     name: kuma-control-plane

--- a/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
@@ -190,7 +190,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -291,7 +291,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -299,7 +299,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
 subjects:
   - kind: ServiceAccount
     name: kuma-control-plane

--- a/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
@@ -190,7 +190,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -291,7 +291,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -299,7 +299,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
 subjects:
   - kind: ServiceAccount
     name: kuma-control-plane

--- a/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
@@ -190,7 +190,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -291,7 +291,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -299,7 +299,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
 subjects:
   - kind: ServiceAccount
     name: kuma-control-plane

--- a/app/kumactl/cmd/install/testdata/install-control-plane.tproxy-ebpf-experimental-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.tproxy-ebpf-experimental-enabled.golden.yaml
@@ -190,7 +190,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -291,7 +291,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -299,7 +299,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
 subjects:
   - kind: ServiceAccount
     name: kuma-control-plane

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
@@ -200,7 +200,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -301,7 +301,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -309,7 +309,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
 subjects:
   - kind: ServiceAccount
     name: kuma-control-plane

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -10625,7 +10625,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -10726,7 +10726,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -10734,7 +10734,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
 subjects:
   - kind: ServiceAccount
     name: kuma-control-plane

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
@@ -190,7 +190,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -291,7 +291,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -299,7 +299,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
 subjects:
   - kind: ServiceAccount
     name: kuma-control-plane

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -200,7 +200,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -301,7 +301,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -309,7 +309,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
 subjects:
   - kind: ServiceAccount
     name: kuma-control-plane

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
@@ -190,7 +190,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -291,7 +291,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -299,7 +299,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
 subjects:
   - kind: ServiceAccount
     name: kuma-control-plane

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/dnsConfigOption.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/dnsConfigOption.golden.yaml
@@ -210,7 +210,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -311,7 +311,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -319,7 +319,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
 subjects:
   - kind: ServiceAccount
     name: kuma-control-plane

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/doNotChangeTlsChecksum.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/doNotChangeTlsChecksum.golden.yaml
@@ -190,7 +190,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -291,7 +291,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -299,7 +299,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
 subjects:
   - kind: ServiceAccount
     name: kuma-control-plane

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
@@ -190,7 +190,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -291,7 +291,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -299,7 +299,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
 subjects:
   - kind: ServiceAccount
     name: kuma-control-plane

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/envVarsDownwardApi.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/envVarsDownwardApi.golden.yaml
@@ -190,7 +190,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -291,7 +291,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -299,7 +299,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
 subjects:
   - kind: ServiceAccount
     name: kuma-control-plane

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix12847.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix12847.golden.yaml
@@ -262,7 +262,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -388,7 +388,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -396,7 +396,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
 subjects:
   - kind: ServiceAccount
     name: kuma-control-plane

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix13029.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix13029.golden.yaml
@@ -262,7 +262,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -388,7 +388,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -396,7 +396,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
 subjects:
   - kind: ServiceAccount
     name: kuma-control-plane

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
@@ -207,7 +207,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     "foo": "baz"
@@ -310,7 +310,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     "foo": "baz"
@@ -319,7 +319,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
 subjects:
   - kind: ServiceAccount
     name: kuma-control-plane

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
@@ -204,7 +204,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     "foo": "bar"
@@ -307,7 +307,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     "foo": "bar"
@@ -316,7 +316,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
 subjects:
   - kind: ServiceAccount
     name: kuma-control-plane

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
@@ -282,7 +282,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -408,7 +408,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -416,7 +416,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
 subjects:
   - kind: ServiceAccount
     name: kuma-control-plane

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix5978.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix5978.golden.yaml
@@ -210,7 +210,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -311,7 +311,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -319,7 +319,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
 subjects:
   - kind: ServiceAccount
     name: kuma-control-plane

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix7724.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix7724.golden.yaml
@@ -193,7 +193,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -294,7 +294,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -302,7 +302,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
 subjects:
   - kind: ServiceAccount
     name: kuma-control-plane

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix7824.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix7824.golden.yaml
@@ -225,7 +225,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -326,7 +326,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -334,7 +334,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
 subjects:
   - kind: ServiceAccount
     name: kuma-control-plane

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/minReadySeconds.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/minReadySeconds.golden.yaml
@@ -190,7 +190,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -291,7 +291,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -299,7 +299,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
 subjects:
   - kind: ServiceAccount
     name: kuma-control-plane

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/roleBindingInNamespaces.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/roleBindingInNamespaces.golden.yaml
@@ -190,7 +190,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -364,7 +364,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -373,7 +373,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
 subjects:
   - kind: ServiceAccount
     name: kuma-control-plane
@@ -382,7 +382,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -391,7 +391,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
 subjects:
   - kind: ServiceAccount
     name: kuma-control-plane

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/securityContext.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/securityContext.golden.yaml
@@ -190,7 +190,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -291,7 +291,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
   labels: 
     app: kuma-control-plane
     app.kubernetes.io/name: kuma
@@ -299,7 +299,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
 subjects:
   - kind: ServiceAccount
     name: kuma-control-plane

--- a/deployments/charts/kuma/templates/cp-rbac.yaml
+++ b/deployments/charts/kuma/templates/cp-rbac.yaml
@@ -208,7 +208,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "kuma.name" . }}-control-plane-writer
+  name: {{ include "kuma.name" . }}-control-plane-workloads
   labels: {{ include "kuma.cpLabels" . | nindent 4 }}
 rules:
   - apiGroups:
@@ -302,13 +302,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "kuma.name" $root }}-control-plane-writer
+  name: {{ include "kuma.name" $root }}-control-plane-workloads
   labels: {{ include "kuma.cpLabels" $root | nindent 4 }}
   namespace: {{ $element }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "kuma.name" $root }}-control-plane-writer
+  name: {{ include "kuma.name" $root }}-control-plane-workloads
 subjects:
   - kind: ServiceAccount
     name: {{ include "kuma.name" $root }}-control-plane
@@ -320,12 +320,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "kuma.name" . }}-control-plane-writer
+  name: {{ include "kuma.name" . }}-control-plane-workloads
   labels: {{ include "kuma.cpLabels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "kuma.name" . }}-control-plane-writer
+  name: {{ include "kuma.name" . }}-control-plane-workloads
 subjects:
   - kind: ServiceAccount
     name: {{ include "kuma.name" . }}-control-plane

--- a/docs/generated/raw/rbac.yaml
+++ b/docs/generated/raw/rbac.yaml
@@ -150,7 +150,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
 rules:
   - apiGroups:
       - ""
@@ -240,11 +240,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kuma-control-plane-writer
+  name: kuma-control-plane-workloads
 subjects:
   - kind: ServiceAccount
     name: kuma-control-plane


### PR DESCRIPTION
## Motivation

Regular `kuma-control-plane` role also contains write permissions so `kuma-control-plane-write` is not appropriate name.

## Implementation information

Update all golden test fixtures and Helm templates to rename `kuma-control-plane-writer` to `kuma-control-plane-workloads`. This aligns the name with its actual use and intent: granting permissions for the control plane to manage workloads across namespaces.

## Supporting documentation

Solves issue mentioned during test Friday and:
- https://github.com/kumahq/kuma-website/pull/2305#discussion_r2095328543
- https://github.com/kumahq/kuma-website/pull/2305#discussion_r2095570218