### PR TITLE
ci(github): increase build timeout from 50 to 70 minutes

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -42,7 +42,7 @@ env:
   GH_REPO: "charts"
 jobs:
   build-binaries:
-    timeout-minutes: 50
+    timeout-minutes: 70
     runs-on: ubuntu-24.04
     outputs:
       BINARY_ARTIFACT_DIGEST_BASE64: ${{ steps.inspect-binary-output.outputs.binary_artifact_digest_base64 }}


### PR DESCRIPTION
## Motivation

`make build` in the parent project sometimes takes more time

## Implementation information

Increase `timeout-minutes` in `_build_publish.yaml` to 70 to account for longer build times when running `make build` in the parent project.

## Supporting documentation
