### PR TITLE
chore(renovate): restrict go-control-plane replace to kong-specific builds

### DIFF
--- a/.renovate/go-control-plane.json
+++ b/.renovate/go-control-plane.json
@@ -14,7 +14,7 @@
       ],
       "datasourceTemplate": "go",
       "depTypeTemplate": "replace",
-      "extractVersionTemplate": "^(?:{{{depName}}}\\/)?(?<version>v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>.+))",
+      "extractVersionTemplate": "^(?:{{{depName}}}\\/)?(?<version>v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>kong-.+))",
       "autoReplaceStringTemplate": "{{{packageName}}} {{{newVersion}}}",
       "versioningTemplate": "loose"
     }


### PR DESCRIPTION
## Motivation & Implementation information

Updates `extractVersionTemplate` to only match versions with build suffixes starting with `kong-`, avoiding accidental upgrades to test builds like `v0.13.4-ld-delta-test-1` (https://github.com/kumahq/kuma/pull/13431).