### PR TITLE
fix(autoreachableservices): fix nil pointer by skipping policies with targetRef.kind Dataplane

### DIFF
--- a/pkg/plugins/policies/meshtrafficpermission/graph/util/rule_builder.go
+++ b/pkg/plugins/policies/meshtrafficpermission/graph/util/rule_builder.go
@@ -50,8 +50,8 @@ func ComputeMtpRulesForTags(
 }
 
 // TODO Currently autoreachable services functionality is based on tags. When MTP selects dataplanes by Dataplane kind
-// we don't have tags to work with. We should rethink how to implement autoreachable services with Dataplane kind and new spec.rules
-// This should be covered by: https://github.com/kumahq/kuma/issues/12403
+// we don't have tags to work with. We should rethink how to implement autoreachable services with new workload identity
+// after we design it
 func filterMTPsWithKindDataplane(mtps []*mtp_api.MeshTrafficPermissionResource) []*mtp_api.MeshTrafficPermissionResource {
 	var filteredMtps []*mtp_api.MeshTrafficPermissionResource
 	for _, mtp := range mtps {

--- a/pkg/plugins/policies/meshtrafficpermission/graph/util/rule_builder.go
+++ b/pkg/plugins/policies/meshtrafficpermission/graph/util/rule_builder.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
@@ -17,7 +18,7 @@ func ComputeMtpRulesForTags(
 	resources := context.Resources{
 		MeshLocalResources: map[core_model.ResourceType]core_model.ResourceList{
 			mtp_api.MeshTrafficPermissionType: &mtp_api.MeshTrafficPermissionResourceList{
-				Items: mtpsWithTrimmedTags,
+				Items: filterMTPsWithKindDataplane(mtpsWithTrimmedTags),
 			},
 		},
 	}
@@ -46,4 +47,18 @@ func ComputeMtpRulesForTags(
 		Port:    1234,
 	}]
 	return rl, ok, nil
+}
+
+// TODO Currently autoreachable services functionality is based on tags. When MTP selects dataplanes by Dataplane kind
+// we don't have tags to work with. We should rethink how to implement autoreachable services with Dataplane kind and new spec.rules
+// This should be covered by: https://github.com/kumahq/kuma/issues/12403
+func filterMTPsWithKindDataplane(mtps []*mtp_api.MeshTrafficPermissionResource) []*mtp_api.MeshTrafficPermissionResource {
+	var filteredMtps []*mtp_api.MeshTrafficPermissionResource
+	for _, mtp := range mtps {
+		if mtp.Spec != nil && mtp.Spec.GetTargetRef().Kind == common_api.Dataplane {
+			continue
+		}
+		filteredMtps = append(filteredMtps, mtp)
+	}
+	return filteredMtps
 }

--- a/pkg/plugins/policies/meshtrafficpermission/graph/util/rule_builder.go
+++ b/pkg/plugins/policies/meshtrafficpermission/graph/util/rule_builder.go
@@ -18,7 +18,7 @@ func ComputeMtpRulesForTags(
 	resources := context.Resources{
 		MeshLocalResources: map[core_model.ResourceType]core_model.ResourceList{
 			mtp_api.MeshTrafficPermissionType: &mtp_api.MeshTrafficPermissionResourceList{
-				Items: filterMTPsWithKindDataplane(mtpsWithTrimmedTags),
+				Items: filterOutMTPsWithKindDataplane(mtpsWithTrimmedTags),
 			},
 		},
 	}
@@ -52,7 +52,7 @@ func ComputeMtpRulesForTags(
 // TODO Currently autoreachable services functionality is based on tags. When MTP selects dataplanes by Dataplane kind
 // we don't have tags to work with. We should rethink how to implement autoreachable services with new workload identity
 // after we design it
-func filterMTPsWithKindDataplane(mtps []*mtp_api.MeshTrafficPermissionResource) []*mtp_api.MeshTrafficPermissionResource {
+func filterOutMTPsWithKindDataplane(mtps []*mtp_api.MeshTrafficPermissionResource) []*mtp_api.MeshTrafficPermissionResource {
 	var filteredMtps []*mtp_api.MeshTrafficPermissionResource
 	for _, mtp := range mtps {
 		if mtp.Spec != nil && mtp.Spec.GetTargetRef().Kind == common_api.Dataplane {


### PR DESCRIPTION
## Motivation
Because autoreachable services are based on tags, and we create fake dp without any meta, we cannot match policies with `targetRef.kind: Dataplane` ending in nil pointer, this is just temporary fix. We should update it after we design new workload identity 

Fix https://github.com/kumahq/kuma/issues/13584

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
