### PR TITLE
fix(kds): don't override status field

### DIFF
--- a/pkg/kds/context/context.go
+++ b/pkg/kds/context/context.go
@@ -23,7 +23,6 @@ import (
 	config_manager "github.com/kumahq/kuma/pkg/core/config/manager"
 	"github.com/kumahq/kuma/pkg/core/kri"
 	hostnamegenerator_api "github.com/kumahq/kuma/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1"
-	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
@@ -86,7 +85,8 @@ func DefaultContext(
 			reconcile_v2.IsKubernetes(cfg.Store.Type),
 			RemoveK8sSystemNamespaceSuffixMapper(cfg.Store.Kubernetes.SystemNamespace)),
 		reconcile_v2.If(
-			reconcile_v2.TypeIs(meshservice_api.MeshServiceType),
+			// we don't want status field on the global
+			reconcile_v2.HasStatus(),
 			RemoveStatus()),
 		reconcile_v2.If(func(resource core_model.Resource) bool {
 			// There's a handful of resource types for which we keep the name unchanged

--- a/pkg/kds/v2/reconcile/snapshot_generator.go
+++ b/pkg/kds/v2/reconcile/snapshot_generator.go
@@ -47,6 +47,12 @@ func IsKubernetes(storeType config_store.StoreType) func(model.Resource) bool {
 	}
 }
 
+func HasStatus() func(model.Resource) bool {
+	return func(r model.Resource) bool {
+		return r.Descriptor().HasStatus
+	}
+}
+
 func NameHasPrefix(prefix string) func(model.Resource) bool {
 	return func(r model.Resource) bool {
 		return strings.HasPrefix(r.GetMeta().GetName(), prefix)


### PR DESCRIPTION
## Motivation

In a multizone setup using MeshService mode, we synchronize objects across zones. Each object contains a status field, which is intentionally removed during synchronization on the global control plane. This allows a remote zone to allocate a VIP and hostname for the MeshService based on its local configuration.

However, when the connection to the global control plane is reestablished, the system detects a change in the resource and overrides the object in the zone, even when there are no actual changes. This happens because the global control plane has a version of the MeshService with an empty status field, while the zone contains an updated status. As a result, the objects appear to differ and trigger an unnecessary update.

The override of MeshService status field was casuing multiple IP allocations and could cause more frequent updates of XDS snapshots.

## Implementation information

First of all, we don't need to compare the status field of synchronized resources, since only the zone runs a generator that sets the status, while the global control plane always has it empty. Additionally, we should ensure that the status field is removed from all resources when syncing them to the global control plane. Since the status shouldn't change, we should set the status of the existing object instead of overriding it.

## Supporting documentation

Fix https://github.com/kumahq/kuma/issues/13592
