### PR TITLE
test(e2e): failing test `should create MeshRetry policy`

### DIFF
--- a/test/e2e_env/kubernetes/meshretry/api.go
+++ b/test/e2e_env/kubernetes/meshretry/api.go
@@ -9,23 +9,18 @@ import (
 	"github.com/kumahq/kuma/pkg/plugins/policies/meshretry/api/v1alpha1"
 	. "github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/framework/envs/kubernetes"
+	"github.com/kumahq/kuma/pkg/test/resources/builders"
 )
 
 func API() {
 	meshName := "meshretry-api"
 
 	BeforeAll(func() {
-		err := NewClusterSetup().
-			Install(MeshKubernetes(meshName)).
-			Setup(kubernetes.Cluster)
-		Expect(err).ToNot(HaveOccurred())
-
-		// Delete the default meshretry policy
-		Expect(DeleteMeshPolicyOrError(
-			kubernetes.Cluster,
-			v1alpha1.MeshRetryResourceTypeDescriptor,
-			fmt.Sprintf("mesh-retry-all-%s", meshName),
-		)).To(Succeed())
+		Expect(NewClusterSetup().
+			Install(Yaml(builders.Mesh().
+				WithName(meshName).
+				WithoutInitialPolicies())).
+			Setup(kubernetes.Cluster)).To(Succeed())
 	})
 
 	AfterEachFailure(func() {


### PR DESCRIPTION
## Motivation

https://github.com/kumahq/kuma/actions/runs/15238665779/job/42856597866#step:12:1147

```
• [FAILED] [3.942 seconds]
MeshRetry [It] should create MeshRetry policy
github.com/kumahq/kuma/test/e2e_env/kubernetes/meshretry/api.go:43

Captured StdOut/StdErr Output

  [FAILED] Expected
      <[]string | len:1, cap:1>: [
          "mesh-retry-all-meshretry-api.kuma-system",
      ]
  to be empty
Error: It 05/25/25 14:46:34.336
```

## Implementation information

Instead of creating mesh with default policies and removing them afterwards, we can simply create mesh without default policies.

