### PR TITLE
test(e2e): fix `should sync producer MeshRetry that targets producer route to other clusters`

### DIFF
--- a/test/e2e_env/multizone/producer/producer.go
+++ b/test/e2e_env/multizone/producer/producer.go
@@ -310,6 +310,7 @@ spec:
 				multizone.KubeZone1, "test-client", fmt.Sprintf("test-server.%s.svc.kuma-2.mesh.local", k8sZoneNamespace),
 				framework_client.FromKubernetesPod(k8sZoneNamespace, "test-client"),
 				framework_client.WithNumberOfRequests(100),
+				framework_client.WithMaxConcurrentRequests(1),
 			)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(responses).To(And(
@@ -344,6 +345,7 @@ spec:
 				multizone.KubeZone1, "test-client", fmt.Sprintf("test-server.%s.svc.kuma-2.mesh.local", k8sZoneNamespace),
 				framework_client.FromKubernetesPod(k8sZoneNamespace, "test-client"),
 				framework_client.WithNumberOfRequests(100),
+				framework_client.WithMaxConcurrentRequests(1),
 			)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(responses).To(And(

--- a/test/framework/client/collect.go
+++ b/test/framework/client/collect.go
@@ -517,6 +517,14 @@ func CountResponseCodes(statusCode int) func(responses []FailureResponse) int {
 	}
 }
 
+func IndexByResponseCode(responses []FailureResponse) map[int]int {
+	rv := map[int]int{}
+	for _, response := range responses {
+		rv[response.ResponseCode]++
+	}
+	return rv
+}
+
 func CollectResponses(cluster framework.Cluster, source, destination string, fn ...CollectResponsesOptsFn) ([]types.EchoResponse, error) {
 	res, err := callConcurrently(destination, func() (interface{}, error) {
 		return CollectEchoResponse(cluster, source, destination, fn...)


### PR DESCRIPTION
## Motivation

https://github.com/kumahq/kuma/actions/runs/15219190859/job/42812693611#step:12:16882
```
• [FAILED] [71.816 seconds]
Producer Policy Flow [It] should sync producer MeshRetry that targets producer route to other clusters
github.com/kumahq/kuma/test/e2e_env/multizone/producer/producer.go:240

Captured StdOut/StdErr Output

  [FAILED] Timed out after 30.000s.
  The function passed to Eventually failed at github.com/kumahq/kuma/test/e2e_env/multizone/producer/producer.go:349 with:
  Expected
      <int>: 89
  to be within 10 of ~
      <int>: 100
Error: It 05/23/25 21:53:28.69
------------------------------
```

## Implementation information

* replace MeshFaultInjection and MeshRetry code from 500 to 429
* change checker to see full responses map when it fails

