### PR TITLE
ci(backport): use env.USE_APP_TOKEN variable everywhere

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -184,6 +184,6 @@ jobs:
           delete-branch: true
           draft: ${{ contains(env.LABELS, 'conflict') }}
           labels: ${{ env.LABELS }}
-          token: ${{ secrets.APP_ID != '' && steps.github-app-token.outputs.token || steps.github-context-token.outputs.token }}
+          token: ${{env.USE_APP_TOKEN == 'true' && steps.github-app-token.outputs.token || steps.github-context-token.outputs.token }}
           committer: ${{ env.GH_USER }} ${{ env.GH_EMAIL }}
           author: ${{ env.GH_USER }} ${{ env.GH_EMAIL }}


### PR DESCRIPTION
## Motivation

Otherwise I have to override this in parent repo. We have a variable, let's use that variable and only overwrite in one place.