### PR TITLE
fix(k8s): fix validation of origin label on global

### DIFF
--- a/pkg/plugins/runtime/k8s/webhooks/defaulter_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/defaulter_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	admissionv1 "k8s.io/api/admission/v1"
+	v1 "k8s.io/api/authentication/v1"
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_runtime "k8s.io/apimachinery/pkg/runtime"
 	kube_types "k8s.io/apimachinery/pkg/types"
@@ -31,6 +32,7 @@ var _ = Describe("Defaulter", func() {
 		inputObject string
 		expected    string
 		kind        string
+		username    string
 		checker     ResourceAdmissionChecker
 	}
 
@@ -71,6 +73,9 @@ var _ = Describe("Defaulter", func() {
 					},
 					Kind: kube_meta.GroupVersionKind{
 						Kind: given.kind,
+					},
+					UserInfo: v1.UserInfo{
+						Username: given.username,
 					},
 				},
 			}
@@ -541,6 +546,8 @@ var _ = Describe("Defaulter", func() {
 		Entry("should not add namespace label when resource originates from universal zone", testCase{
 			checker: globalChecker(),
 			kind:    string(v1alpha1.MeshTrafficPermissionType),
+			// when resource originate from the zone it has username of kuma
+			username: "system:serviceaccount:kuma-system:kuma-control-plane",
 			inputObject: `
             {
               "apiVersion": "kuma.io/v1alpha1",

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-system-policy-role-label.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-system-policy-role-label.global.golden.yaml
@@ -1,18 +1,10 @@
 Patches: null
 allowed: false
 status:
-  code: 422
-  details:
-    causes:
-    - field: labels["kuma.io/origin"]
-      message: Operation not allowed. kuma.io/origin label should have global value,
-        got zone
-      reason: FieldValueInvalid
-    kind: MeshTimeout
-    name: backend-v3
-  message: 'labels["kuma.io/origin"]: Operation not allowed. kuma.io/origin label
-    should have global value, got zone'
+  code: 403
+  message: Operation not allowed. 'kuma.io/origin' label should have global value,
+    got 'zone'
   metadata: {}
-  reason: Invalid
+  reason: Forbidden
   status: Failure
 uid: "12345"

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-zone-label.federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-zone-label.federated.golden.yaml
@@ -2,8 +2,8 @@ Patches: null
 allowed: false
 status:
   code: 403
-  message: Operation not allowed. kuma.io/zone label should have zone-1 value, got
-    wrong-zone
+  message: Operation not allowed. 'kuma.io/zone' label should have zone-1 value, got
+    'wrong-zone'
   metadata: {}
   reason: Forbidden
   status: Failure

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtp-zone-origin.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtp-zone-origin.global.golden.yaml
@@ -1,18 +1,10 @@
 Patches: null
 allowed: false
 status:
-  code: 422
-  details:
-    causes:
-    - field: labels["kuma.io/origin"]
-      message: Operation not allowed. kuma.io/origin label should have global value,
-        got zone
-      reason: FieldValueInvalid
-    kind: MeshTrafficPermission
-    name: mtp-es
-  message: 'labels["kuma.io/origin"]: Operation not allowed. kuma.io/origin label
-    should have global value, got zone'
+  code: 403
+  message: Operation not allowed. 'kuma.io/origin' label should have global value,
+    got 'zone'
   metadata: {}
-  reason: Invalid
+  reason: Forbidden
   status: Failure
 uid: "12345"

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_unknown-origin-mtp.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_unknown-origin-mtp.global.golden.yaml
@@ -1,21 +1,10 @@
 Patches: null
 allowed: false
 status:
-  code: 422
-  details:
-    causes:
-    - field: labels["kuma.io/origin"]
-      message: unknown resource origin "unknownvalue"
-      reason: FieldValueInvalid
-    - field: labels["kuma.io/origin"]
-      message: Operation not allowed. kuma.io/origin label should have global value,
-        got unknownvalue
-      reason: FieldValueInvalid
-    kind: MeshTrafficPermission
-    name: mtp-es
-  message: 'labels["kuma.io/origin"]: unknown resource origin "unknownvalue"; labels["kuma.io/origin"]:
-    Operation not allowed. kuma.io/origin label should have global value, got unknownvalue'
+  code: 403
+  message: Operation not allowed. 'kuma.io/origin' label should have global value,
+    got 'unknownvalue'
   metadata: {}
-  reason: Invalid
+  reason: Forbidden
   status: Failure
 uid: "12345"

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_zone-mtp.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_zone-mtp.global.golden.yaml
@@ -1,18 +1,10 @@
 Patches: null
 allowed: false
 status:
-  code: 422
-  details:
-    causes:
-    - field: labels["kuma.io/origin"]
-      message: Operation not allowed. kuma.io/origin label should have global value,
-        got zone
-      reason: FieldValueInvalid
-    kind: MeshTrafficPermission
-    name: mtp-es
-  message: 'labels["kuma.io/origin"]: Operation not allowed. kuma.io/origin label
-    should have global value, got zone'
+  code: 403
+  message: Operation not allowed. 'kuma.io/origin' label should have global value,
+    got 'zone'
   metadata: {}
-  reason: Invalid
+  reason: Forbidden
   status: Failure
 uid: "12345"

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_delete_zone-mtp.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_delete_zone-mtp.global.golden.yaml
@@ -1,6 +1,10 @@
 Patches: null
-allowed: true
+allowed: false
 status:
-  code: 200
+  code: 403
+  message: Operation not allowed. 'kuma.io/origin' label should have global value,
+    got 'zone'
   metadata: {}
+  reason: Forbidden
+  status: Failure
 uid: "12345"

--- a/pkg/plugins/runtime/k8s/webhooks/validation.go
+++ b/pkg/plugins/runtime/k8s/webhooks/validation.go
@@ -10,7 +10,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	"github.com/kumahq/kuma/pkg/config/core"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_registry "github.com/kumahq/kuma/pkg/core/resources/registry"
@@ -58,7 +57,6 @@ func (h *validatingHandler) Handle(_ context.Context, req admission.Request) adm
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
-
 	if resp := h.IsOperationAllowed(req.UserInfo, coreRes, req.Namespace); !resp.Allowed {
 		return resp
 	}
@@ -120,12 +118,6 @@ func (h *validatingHandler) validateLabels(rm core_model.ResourceMeta) validator
 	if origin, ok := core_model.ResourceOrigin(rm); ok {
 		if err := origin.IsValid(); err != nil {
 			verr.AddViolationAt(labelsPath.Key(mesh_proto.ResourceOriginLabel), err.Error())
-		}
-		if h.Mode == core.Global && origin != mesh_proto.GlobalResourceOrigin {
-			verr.AddViolationAt(
-				labelsPath.Key(mesh_proto.ResourceOriginLabel),
-				labelsNotAllowedMsg(mesh_proto.ResourceOriginLabel, string(mesh_proto.GlobalResourceOrigin), string(origin)),
-			)
 		}
 	}
 	return verr


### PR DESCRIPTION
## Motivation

While testing we noticed that validation was rejecting resource synced from zone to global on k8s

## Implementation information

Rather than validating all resources, we only validate those intended for user creation and not managed administratively.

## Supporting documentation

Fix https://github.com/kumahq/kuma/issues/10590
