### PR TITLE
fix(defaults): ensure that we use consistent store to retrive signing key

### DIFF
--- a/pkg/core/tokens/meshed_signing_key_manager.go
+++ b/pkg/core/tokens/meshed_signing_key_manager.go
@@ -60,7 +60,7 @@ func (s *meshedSigningKeyManager) CreateSigningKey(ctx context.Context, keyID Ke
 	}
 
 	owner := core_mesh.NewMeshResource()
-	if err := s.manager.Get(ctx, owner, store.GetByKey(s.mesh, model.NoMesh)); err != nil {
+	if err := s.manager.Get(ctx, owner, store.GetByKey(s.mesh, model.NoMesh), store.GetConsistent()); err != nil {
 		return manager.MeshNotFound(s.mesh)
 	}
 


### PR DESCRIPTION
## Motivation

closes https://github.com/Kong/kong-mesh/issues/7802

There can be a race condition where we wrote a mesh to a db and then tried to read it and it was read from a replica that did not have that mesh.

## Implementation information

Add get consistent.