### PR TITLE
Revert "chore(deps): bump golang version from 1.24.2 to 1.24.3"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kumahq/kuma
 
-go 1.24.3
+go 1.24.2
 
 require (
 	cirello.io/pglock v1.16.0


### PR DESCRIPTION
Because of https://github.com/golang/go/issues/73617 we need to revert for now

> Changelog: skip