### PR TITLE
fix(meshexternalservice): allow 63 length k8s MeshExternalService resource creation

### DIFF
--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/testdata/name-length-63.input.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/testdata/name-length-63.input.yaml
@@ -1,0 +1,6 @@
+match:
+  port: 80
+  protocol: http
+endpoints:
+  - address: 1.1.1.1
+    port: 12345

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/validator.go
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/validator.go
@@ -9,6 +9,7 @@ import (
 
 	common_tls "github.com/kumahq/kuma/api/common/v1alpha1/tls"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/validators"
 	"github.com/kumahq/kuma/pkg/util/pointer"
 )
@@ -22,7 +23,7 @@ var (
 func (r *MeshExternalServiceResource) validate() error {
 	var verr validators.ValidationError
 
-	verr.Add(validators.ValidateLength(validators.RootedAt("name"), 63, r.Meta.GetName()))
+	verr.Add(validators.ValidateLength(validators.RootedAt("name"), 63, model.GetDisplayName(r.GetMeta())))
 
 	path := validators.RootedAt("spec")
 

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/validator_test.go
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/validator_test.go
@@ -80,6 +80,10 @@ var _ = Describe("MeshExternalService", func() {
 				name: "external-service-very-long-very-long-very-long-very-long-very-long-very-long-very-long",
 				file: "name-too-long",
 			}),
+			Entry("name length 63", testCase{
+				name: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+				file: "name-length-63",
+			}),
 		)
 	})
 })


### PR DESCRIPTION
## Motivation

Before the PR, we used the `("%s.%s", name, namespace)` combination string to verify its length. We should verify only name length

## Implementation information

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #13648

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
