### PR TITLE
ci(lint): dynamically set gomemlimit to avoid OOMs

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -51,6 +51,15 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false
+      - name: Set GOMEMLIMIT dynamically based on available memory
+        id: set-gomemlimit
+        run: |
+          # Get total memory in bytes
+          mem_total_kb=$(grep MemTotal /proc/meminfo | awk '{print $2}')
+          mem_total_bytes=$((mem_total_kb * 1024))
+          gomemlimit=$((mem_total_bytes * 0.9))
+          echo "GOMEMLIMIT=${gomemlimit}" >> $GITHUB_ENV
+          echo "Setting GOMEMLIMIT to $(numfmt --to=iec $gomemlimit)"
       - uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
           args: --fix=false --verbose


### PR DESCRIPTION
## Motivation

We're getting 137 kills in parent project:
- https://github.com/Kong/kong-mesh/actions/runs/15329220091/job/43131542029#step:10:55
- https://github.com/Kong/kong-mesh/actions/runs/15314182872/job/43084808674#step:10:49
- https://github.com/Kong/kong-mesh/actions/runs/15305625856/job/43057467065#step:10:55

<!-- Why are we doing this change -->

## Implementation information

Add a step that sets `GOMEMLIMIT` to 90% of available memory

