### PR TITLE
fix(vip): don't fail once previous address is out of range of new range

### DIFF
--- a/pkg/dns/vips/global_view.go
+++ b/pkg/dns/vips/global_view.go
@@ -15,6 +15,13 @@ type GlobalView struct {
 
 // Reserve add an ip/host to the list of reserved ips (useful when loading an existing view).
 func (g *GlobalView) Reserve(hostname HostnameEntry, ip string) error {
+	// When we have an existing map and the CIDR configuration changes,
+	// we may attempt to reserve an address that is no longer within the new CIDR range.
+	// In such cases, the operation fails, which is incorrect. Instead, we should skip reserving
+	// the out of range address, allowing new addresses to be allocated as needed.
+	if !g.ipam.CIDR.Contains(net.ParseIP(ip)) {
+		return nil
+	}
 	err := g.ipam.Reserve(net.ParseIP(ip))
 	if err != nil {
 		return err

--- a/pkg/dns/vips/global_view_test.go
+++ b/pkg/dns/vips/global_view_test.go
@@ -104,4 +104,22 @@ var _ = Describe("global view", func() {
 		// then
 		Expect(ip2).To(Equal(ip))
 	})
+
+	It("should allocate new range address if old is out of range", func() {
+		// given
+		host := vips.NewServiceEntry("foo.com")
+		gv, err := vips.NewGlobalView("240.0.0.0/4")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(gv).ToNot(BeNil())
+
+		err = gv.Reserve(host, "127.0.0.1")
+		Expect(err).ToNot(HaveOccurred())
+
+		// when
+		ip, err := gv.Allocate(host)
+		Expect(err).ToNot(HaveOccurred())
+
+		// then
+		Expect(ip).To(Equal("240.0.0.0"))
+	})
 })


### PR DESCRIPTION
## Motivation

When a user starts the control plane with the default IPAM configuration (CIDR 240.0.0.0/4), the control plane creates a ConfigMap containing service to VIP allocations. If the user later updates the CIDR range and redeploys the control plane, the control plane may fail with the error:

```
Address outside the CIDR
```

This happens because the control plane attempts to reallocate existing addresses that no longer fall within the updated CIDR range.

## Implementation information

Instead of failing when encountering an address outside the configured CIDR (e.g., for MeshService resources), the allocator will now skip reserving such addresses and allocate new ones instead. This ensures continued operation and proper IP assignment without failinf due to invalid IP reuse.
