### PR TITLE
chore(deps): bump setup-go version to 5.5.0

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: go.mod
           cache: false


### PR DESCRIPTION
## Motivation

The old action is using a decommissioned GH cache service that makes the workflow time out - https://github.com/kumahq/kuma/actions/runs/15321628714 . Skipping tests, they will have to pass on the PR - https://github.com/kumahq/kuma/pull/13651

## Implementation information

Bump version