### PR TITLE
chore(deps): bump setup-go version to 5.5.0

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: go.mod
           cache: false


### PR DESCRIPTION
## Motivation

Same as https://github.com/kumahq/kuma/pull/13695

## Implementation information

Same as https://github.com/kumahq/kuma/pull/13695
