### PR TITLE
ci(helm): fix release/helm.sh to properly find helm package

### DIFF
--- a/tools/releases/helm.sh
+++ b/tools/releases/helm.sh
@@ -99,7 +99,7 @@ function release {
 
   git clone --single-branch --branch "${GH_PAGES_BRANCH}" "$GH_REPO_URL"
 
-  CHART_TAR=$(find "${CHARTS_PACKAGE_PATH}/*.tgz" -type f)
+  CHART_TAR=$(find "${CHARTS_PACKAGE_PATH}" -name "*.tgz" -type f | head -n 1)
   CHART_FILE=$(tar -tf "${CHART_TAR}" | grep 'Chart.yaml')
   CHART_VERSION=$(tar -zxOf "${CHART_TAR}" "${CHART_FILE}" | yq .version)
 


### PR DESCRIPTION
## Motivation

Otherwise the job can't find the file: https://github.com/kumahq/kuma/actions/runs/15531336124/job/43730304100#step:10:19

```
PATH=/home/runner/work/kuma/kuma/.ci_tools/bin:$PATH ./tools/releases/helm.sh  --release
Cloning into 'charts'...
find: ‘.cr-release-packages/*.tgz’: No such file or directory
make: *** [mk/helm.mk:20: helm/release] Error 1
Error: Process completed with exit code 2.
```

This worked on my fork https://github.com/slonka/charts/releases/tag/kuma-2.11.0

## Implementation information

Find does not take a glob like that, fixed the syntax.

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

xrel https://github.com/Kong/team-mesh/issues/400
