### PR TITLE
chore(deps): bump lifecycle to 2e670e4083642dfa8f047fab84c6436d28ef81a4

### DIFF
--- a/.github/workflows/lifecycle.yml
+++ b/.github/workflows/lifecycle.yml
@@ -14,7 +14,7 @@ jobs:
   lifecycle:
     permissions:
       issues: write
-    uses: kumahq/.github/.github/workflows/wfc_lifecycle.yml@04e896dfccafc9d84d5ea8ac293beab0bbfc321d
+    uses: kumahq/.github/.github/workflows/wfc_lifecycle.yml@2e670e4083642dfa8f047fab84c6436d28ef81a4
     with:
       filesToIgnore: CONTRIBUTING.md
     secrets:


### PR DESCRIPTION
## Motivation

This version fixes issues with temporary skiping sha validation for slsa-framework/slsa-github-generator actions

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
