### PR TITLE
chore(ci): bump timeout for tests

### DIFF
--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -16,7 +16,7 @@ env:
   K8S_MAX_VERSION: v1.30.0-k3s1
 jobs:
   test_unit:
-    timeout-minutes: 20
+    timeout-minutes: 30
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
## Motivation

bump timeout as we always timeout recently on release-2.8

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
