### PR TITLE
fix(oapi): fix generation of oapi schema by skipping not yaml files

### DIFF
--- a/mk/generate.mk
+++ b/mk/generate.mk
@@ -102,7 +102,7 @@ generate/policy-defaults:
 generate/policy-helm:
 	PATH=$(CI_TOOLS_BIN_DIR):$$PATH $(TOOLS_DIR)/policy-gen/generate-policy-helm.sh $(HELM_VALUES_FILE) $(HELM_CRD_DIR) $(HELM_VALUES_FILE_POLICY_PATH) $(POLICIES_DIR) $(policies)
 
-endpoints = $(foreach dir,$(shell find api/openapi/specs -type f | sort),$(basename $(dir)))
+endpoints?=$(foreach dir,$(shell find api/openapi/specs -type f -name "*.yaml" | sort),$(basename $(dir)))
 
 generate/oas: $(GENERATE_OAS_PREREQUISITES) $(RESOURCE_GEN)
 	for endpoint in $(endpoints); do \


### PR DESCRIPTION
## Motivation

Without this we are failing in Kong Mesh on: 
```
for endpoint in api/openapi/specs/common/ api/openapi/specs/common/error_schema api/openapi/specs/global_insight api/openapi/specs/tenants; do \
		DEST=${endpoint#"api/openapi/specs"}; \
		/Users/marcin.skalski@konghq.com/.kuma-dev/kong-mesh-master/bin/oapi-codegen -config api/openapi/openapi.cfg.yaml -o api/openapi/types/$(dirname ${DEST}})/zz_generated.$(basename ${DEST}).go ${endpoint}.yaml  || { echo "Failed to generate $endpoint"; exit 1; }; \
	done
error loading swagger spec in api/openapi/specs/common/.yaml
: failed to load OpenAPI specification: open api/openapi/specs/common/.yaml: no such file or directory
Failed to generate api/openapi/specs/common/
make: *** [generate/oas] Error 1
```

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
