### PR TITLE
feat(skaffold): speedup redeploying kuma with Skaffold

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -61,6 +61,7 @@ deploy:
           kumactl.image.tag: "{{.IMAGE_TAG_kumahq_kumactl}}"
           controlPlane.resources.limits.memory: "1Gi"
           controlPlane.podSecurityContext.runAsNonRoot: "false"
+          installCrdsOnUpgrade.enabled: "false"
         setValues:
           controlPlane.podAnnotations:
             "debug\\.cloud\\.google\\.com/probe-timeouts": "skip"


### PR DESCRIPTION
## Motivation

We don't need to install crds on upgrade, this greatly speeds up Skaffold reload on k8s cluster

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
