### PR TITLE
feat(kuma-cp): exposed grpc reflection server in the intercp communication

### DIFF
--- a/pkg/intercp/server/server.go
+++ b/pkg/intercp/server/server.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"google.golang.org/grpc/reflection"
 	"net"
 	"net/http"
 	"sync/atomic"
@@ -85,6 +86,8 @@ func New(
 	)))
 
 	grpcServer := grpc.NewServer(grpcOptions...)
+
+	reflection.Register(grpcServer)
 
 	return &InterCpServer{
 		config:     config,


### PR DESCRIPTION
## Motivation
Can be useful in debugging the intercp sync issues using cli tools like grpcurl

## Implementation information
Added the reflection server using google.golang.org/grpc/reflection package

<!-- Is there a MADR? An Issue? A related PR? -->

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
