### PR TITLE
ci(lint): enable httpNoBody rule from go-critic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -64,7 +64,6 @@ linters:
         - emptyStringTest
         - exposedSyncMutex
         - filepathJoin
-        - httpNoBody
         - hugeParam
         - importShadow
         - nestingReduce

--- a/app/kuma-dp/cmd/wait.go
+++ b/app/kuma-dp/cmd/wait.go
@@ -56,7 +56,7 @@ func newWaitCmd() *cobra.Command {
 }
 
 func checkIfEnvoyReady(client *http.Client, url string) error {
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, http.NoBody)
 	if err != nil {
 		return err
 	}

--- a/app/kuma-dp/pkg/dataplane/configfetcher/component.go
+++ b/app/kuma-dp/pkg/dataplane/configfetcher/component.go
@@ -125,7 +125,7 @@ func (cf *ConfigFetcher) Step() {
 func (cf *ConfigFetcher) stepForHandler(h *handlerInfo) (bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), cf.perHandlerTimeout)
 	defer cancel()
-	r, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("http://localhost%s", h.path), nil)
+	r, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("http://localhost%s", h.path), http.NoBody)
 	if err != nil {
 		return false, fmt.Errorf("failed to build request: %w", err)
 	}

--- a/app/kuma-dp/pkg/dataplane/metrics/metrics_producer.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/metrics_producer.go
@@ -90,7 +90,7 @@ func combineMetrics(metrics <-chan *metricdata.ScopeMetrics) []metricdata.ScopeM
 }
 
 func (ap *AggregatedProducer) fetchStats(ctx context.Context, app ApplicationToScrape) *metricdata.ScopeMetrics {
-	req, err := http.NewRequest("GET", rewriteMetricsURL(app.Address, app.Port, app.Path, app.QueryModifier, &url.URL{}), nil)
+	req, err := http.NewRequest("GET", rewriteMetricsURL(app.Address, app.Port, app.Path, app.QueryModifier, &url.URL{}), http.NoBody)
 	if err != nil {
 		log.Error(err, "failed to create request")
 		return nil

--- a/app/kuma-dp/pkg/dataplane/metrics/server.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/server.go
@@ -337,7 +337,7 @@ func selectContentType(contentTypes <-chan expfmt.Format, reqHeader http.Header)
 }
 
 func (s *Hijacker) getStats(ctx context.Context, initReq *http.Request, app ApplicationToScrape) ([]byte, expfmt.Format) {
-	req, err := http.NewRequest("GET", rewriteMetricsURL(app.Address, app.Port, app.Path, app.QueryModifier, initReq.URL), nil)
+	req, err := http.NewRequest("GET", rewriteMetricsURL(app.Address, app.Port, app.Path, app.QueryModifier, initReq.URL), http.NoBody)
 	if err != nil {
 		logger.Error(err, "failed to create request")
 		return nil, ""

--- a/app/kuma-dp/pkg/dataplane/probes/http.go
+++ b/app/kuma-dp/pkg/dataplane/probes/http.go
@@ -91,7 +91,7 @@ func buildUpstreamReq(downstreamReq *http.Request, upstreamScheme kube_core.URIS
 		Host:     net.JoinHostPort(podAddr, strconv.Itoa(port)),
 	}
 
-	upstreamReq, err := http.NewRequest(http.MethodGet, upstreamURL.String(), nil)
+	upstreamReq, err := http.NewRequest(http.MethodGet, upstreamURL.String(), http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/app/kuma-dp/pkg/dataplane/probes/probes_test.go
+++ b/app/kuma-dp/pkg/dataplane/probes/probes_test.go
@@ -99,7 +99,7 @@ var _ = Describe("Application probe proxy", func() {
 		})
 
 		It("should probe HTTP upstream when it's healthy", func() {
-			probeReq, err := http.NewRequest("GET", probeProxyURL("/8080/healthz", vProbePort), nil)
+			probeReq, err := http.NewRequest("GET", probeProxyURL("/8080/healthz", vProbePort), http.NoBody)
 			Expect(err).ToNot(HaveOccurred())
 			probeReq.Header.Set(kuma_probes.HeaderNameTimeout, "5")
 
@@ -110,7 +110,7 @@ var _ = Describe("Application probe proxy", func() {
 		})
 
 		It("should probe HTTP upstream when the port is not listening", func() {
-			probeReq, err := http.NewRequest("GET", probeProxyURL("/8081/healthz", vProbePort), nil)
+			probeReq, err := http.NewRequest("GET", probeProxyURL("/8081/healthz", vProbePort), http.NoBody)
 			Expect(err).ToNot(HaveOccurred())
 
 			response, err := http.DefaultClient.Do(probeReq)
@@ -121,7 +121,7 @@ var _ = Describe("Application probe proxy", func() {
 
 		It("should probe HTTP upstream when the application reports a failure and return application status code", func() {
 			// given a header set to trigger a failure
-			probeReq, err := http.NewRequest("GET", probeProxyURL("/8080/healthz", vProbePort), nil)
+			probeReq, err := http.NewRequest("GET", probeProxyURL("/8080/healthz", vProbePort), http.NoBody)
 			Expect(err).ToNot(HaveOccurred())
 			probeReq.Header.Set("x-custom-header-triggers-failure", "present")
 			probeReq.Header.Set(kuma_probes.HeaderNameTimeout, "5") // 5s is longer than the execution duration	(3s)
@@ -134,7 +134,7 @@ var _ = Describe("Application probe proxy", func() {
 
 		It("should probe HTTP upstream when path does not match", func() {
 			// given a header set to trigger a failure
-			probeReq, err := http.NewRequest("GET", probeProxyURL("/8080/bad-path", vProbePort), nil)
+			probeReq, err := http.NewRequest("GET", probeProxyURL("/8080/bad-path", vProbePort), http.NoBody)
 			Expect(err).ToNot(HaveOccurred())
 			probeReq.Header.Set(kuma_probes.HeaderNameTimeout, "5") // 5s is longer than the execution duration	(3s)
 
@@ -146,7 +146,7 @@ var _ = Describe("Application probe proxy", func() {
 
 		It("should fail with short timeout when probing", func() {
 			// given a timeout shorter than the execution duration
-			probeReq, err := http.NewRequest("GET", probeProxyURL("/8080/healthz", vProbePort), nil)
+			probeReq, err := http.NewRequest("GET", probeProxyURL("/8080/healthz", vProbePort), http.NoBody)
 			Expect(err).ToNot(HaveOccurred())
 			probeReq.Header.Set(kuma_probes.HeaderNameTimeout, "2") // 2s is shorter than the execution duration (3s)
 
@@ -198,7 +198,7 @@ var _ = Describe("Application probe proxy", func() {
 
 		It("should probe HTTPS upstream without verifying server certificates and keep query", func() {
 			// time.Sleep(100 * time.Second)
-			probeReq, err := http.NewRequest("GET", probeProxyURL("/18443/healthz?scheme=https", vProbePort), nil)
+			probeReq, err := http.NewRequest("GET", probeProxyURL("/18443/healthz?scheme=https", vProbePort), http.NoBody)
 			Expect(err).ToNot(HaveOccurred())
 			probeReq.Header.Set(kuma_probes.HeaderNameScheme, "HTTPS")
 
@@ -246,7 +246,7 @@ var _ = Describe("Application probe proxy", func() {
 		})
 
 		It("should probe TCP server when it's healthy", func() {
-			probeReq, err := http.NewRequest("GET", probeProxyURL("/tcp/6379", vProbePort), nil)
+			probeReq, err := http.NewRequest("GET", probeProxyURL("/tcp/6379", vProbePort), http.NoBody)
 			Expect(err).ToNot(HaveOccurred())
 
 			response, err := http.DefaultClient.Do(probeReq)
@@ -256,7 +256,7 @@ var _ = Describe("Application probe proxy", func() {
 		})
 
 		It("should probe TCP server when the port is not listening", func() {
-			probeReq, err := http.NewRequest("GET", probeProxyURL("/tcp/6000", vProbePort), nil)
+			probeReq, err := http.NewRequest("GET", probeProxyURL("/tcp/6000", vProbePort), http.NoBody)
 			Expect(err).ToNot(HaveOccurred())
 			probeReq.Header.Set(kuma_probes.HeaderNameTimeout, "3")
 
@@ -307,7 +307,7 @@ var _ = Describe("Application probe proxy", func() {
 		})
 
 		It("should probe gRPC server when it's healthy", func() {
-			probeReq, err := http.NewRequest("GET", probeProxyURL("/grpc/5678", vProbePort), nil)
+			probeReq, err := http.NewRequest("GET", probeProxyURL("/grpc/5678", vProbePort), http.NoBody)
 			Expect(err).ToNot(HaveOccurred())
 			probeReq.Header.Set(kuma_probes.HeaderNameGRPCService, "liveness")
 			probeReq.Header.Set(kuma_probes.HeaderNameTimeout, "5")
@@ -319,7 +319,7 @@ var _ = Describe("Application probe proxy", func() {
 		})
 
 		It("should fail with a short timeout when probing", func() {
-			probeReq, err := http.NewRequest("GET", probeProxyURL("/grpc/5678", vProbePort), nil)
+			probeReq, err := http.NewRequest("GET", probeProxyURL("/grpc/5678", vProbePort), http.NoBody)
 			Expect(err).ToNot(HaveOccurred())
 			probeReq.Header.Set(kuma_probes.HeaderNameGRPCService, "liveness")
 			probeReq.Header.Set(kuma_probes.HeaderNameTimeout, "2")
@@ -331,7 +331,7 @@ var _ = Describe("Application probe proxy", func() {
 		})
 
 		It("should probe gRPC server when the port is not listening", func() {
-			probeReq, err := http.NewRequest("GET", probeProxyURL("/grpc/5656", vProbePort), nil)
+			probeReq, err := http.NewRequest("GET", probeProxyURL("/grpc/5656", vProbePort), http.NoBody)
 			Expect(err).ToNot(HaveOccurred())
 			response, err := http.DefaultClient.Do(probeReq)
 
@@ -340,7 +340,7 @@ var _ = Describe("Application probe proxy", func() {
 		})
 
 		It("should probe gRPC server when the application reports a failure", func() {
-			probeReq, err := http.NewRequest("GET", probeProxyURL("/grpc/5678", vProbePort), nil)
+			probeReq, err := http.NewRequest("GET", probeProxyURL("/grpc/5678", vProbePort), http.NoBody)
 			Expect(err).ToNot(HaveOccurred())
 			probeReq.Header.Set(kuma_probes.HeaderNameGRPCService, "readiness")
 

--- a/app/kumactl/cmd/apply/apply.go
+++ b/app/kumactl/cmd/apply/apply.go
@@ -74,7 +74,7 @@ $ kumactl apply -f https://example.com/resource.yaml
 					client := &http.Client{
 						Timeout: timeout,
 					}
-					req, err := http.NewRequest("GET", ctx.args.file, nil)
+					req, err := http.NewRequest("GET", ctx.args.file, http.NoBody)
 					if err != nil {
 						return errors.Wrap(err, "error creating new http request")
 					}

--- a/app/kumactl/pkg/client/kube_resources_client.go
+++ b/app/kumactl/pkg/client/kube_resources_client.go
@@ -40,7 +40,7 @@ func (k *HTTPKubernetesResourcesClient) Get(ctx context.Context, descriptor mode
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest("GET", api.Item(mesh, name)+"?format=k8s", nil)
+	req, err := http.NewRequest("GET", api.Item(mesh, name)+"?format=k8s", http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/app/kumactl/pkg/client/resources_client.go
+++ b/app/kumactl/pkg/client/resources_client.go
@@ -29,7 +29,7 @@ func NewHTTPResourcesListClient(client util_http.Client) ResourcesListClient {
 }
 
 func (h HTTPResourcesListClient) List(ctx context.Context) (api_types.ResourceTypeDescriptionList, error) {
-	req, err := http.NewRequest("GET", "/_resources", nil)
+	req, err := http.NewRequest("GET", "/_resources", http.NoBody)
 	if err != nil {
 		return api_types.ResourceTypeDescriptionList{}, err
 	}

--- a/app/kumactl/pkg/resources/apiserver_client.go
+++ b/app/kumactl/pkg/resources/apiserver_client.go
@@ -22,7 +22,7 @@ func (fn ApiServerClientFn) GetVersion(ctx context.Context) (*types.IndexRespons
 
 func NewAPIServerClient(client util_http.Client) ApiServerClient {
 	return ApiServerClientFn(func(ctx context.Context) (*types.IndexResponse, error) {
-		req, err := http.NewRequest("GET", "/", nil)
+		req, err := http.NewRequest("GET", "/", http.NoBody)
 		if err != nil {
 			return nil, err
 		}

--- a/app/kumactl/pkg/resources/dataplane_inspect_client.go
+++ b/app/kumactl/pkg/resources/dataplane_inspect_client.go
@@ -34,7 +34,7 @@ func (h *httpDataplaneInspectClient) InspectPolicies(ctx context.Context, mesh, 
 	if err != nil {
 		return api_server_types.DataplaneInspectResponse{}, errors.Wrap(err, "could not construct the url")
 	}
-	req, err := http.NewRequest("GET", resUrl.String(), nil)
+	req, err := http.NewRequest("GET", resUrl.String(), http.NoBody)
 	if err != nil {
 		return api_server_types.DataplaneInspectResponse{}, err
 	}

--- a/app/kumactl/pkg/resources/dataplane_overview_client.go
+++ b/app/kumactl/pkg/resources/dataplane_overview_client.go
@@ -32,7 +32,7 @@ func (d *httpDataplaneOverviewClient) List(ctx context.Context, meshName string,
 	if err != nil {
 		return nil, errors.Wrap(err, "could not construct the url")
 	}
-	req, err := http.NewRequest("GET", resUrl.String(), nil)
+	req, err := http.NewRequest("GET", resUrl.String(), http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/app/kumactl/pkg/resources/inspect_envoy_proxy_client.go
+++ b/app/kumactl/pkg/resources/inspect_envoy_proxy_client.go
@@ -60,7 +60,7 @@ func (h *httpInspectEnvoyProxyClient) executeInspectRequest(ctx context.Context,
 		return nil, errors.Wrap(err, "could not construct the url")
 	}
 	resUrl.RawQuery = queryParams.Encode()
-	req, err := http.NewRequest("GET", resUrl.String(), nil)
+	req, err := http.NewRequest("GET", resUrl.String(), http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/app/kumactl/pkg/resources/meshgateway_inspect_client.go
+++ b/app/kumactl/pkg/resources/meshgateway_inspect_client.go
@@ -34,7 +34,7 @@ func (h *httpMeshGatewayInspectClient) InspectDataplanes(ctx context.Context, me
 	if err != nil {
 		return api_server_types.GatewayDataplanesInspectEntryList{}, errors.Wrap(err, "could not construct the url")
 	}
-	req, err := http.NewRequest("GET", resUrl.String(), nil)
+	req, err := http.NewRequest("GET", resUrl.String(), http.NoBody)
 	if err != nil {
 		return api_server_types.GatewayDataplanesInspectEntryList{}, err
 	}

--- a/app/kumactl/pkg/resources/policy_inspect_client.go
+++ b/app/kumactl/pkg/resources/policy_inspect_client.go
@@ -37,7 +37,7 @@ func (h *httpPolicyInspectClient) DataplanesForPolicy(ctx context.Context, polic
 	if err != nil {
 		return types.InspectDataplanesForPolicyResponse{}, errors.Wrap(err, "could not construct the url")
 	}
-	req, err := http.NewRequest("GET", resUrl.String(), nil)
+	req, err := http.NewRequest("GET", resUrl.String(), http.NoBody)
 	if err != nil {
 		return types.InspectDataplanesForPolicyResponse{}, err
 	}
@@ -60,7 +60,7 @@ func (h *httpPolicyInspectClient) Inspect(ctx context.Context, policyDesc core_m
 	if err != nil {
 		return nil, errors.Wrap(err, "could not construct the url")
 	}
-	req, err := http.NewRequest("GET", resUrl.String(), nil)
+	req, err := http.NewRequest("GET", resUrl.String(), http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/app/kumactl/pkg/resources/service_overview_client.go
+++ b/app/kumactl/pkg/resources/service_overview_client.go
@@ -27,7 +27,7 @@ type httpServiceOverviewClient struct {
 }
 
 func (d *httpServiceOverviewClient) List(ctx context.Context, meshName string) (*mesh.ServiceOverviewResourceList, error) {
-	req, err := http.NewRequest("GET", fmt.Sprintf("/meshes/%s/service-insights", meshName), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("/meshes/%s/service-insights", meshName), http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/app/kumactl/pkg/resources/zone_overview_client.go
+++ b/app/kumactl/pkg/resources/zone_overview_client.go
@@ -27,7 +27,7 @@ type httpZoneOverviewClient struct {
 }
 
 func (d *httpZoneOverviewClient) List(ctx context.Context) (*system.ZoneOverviewResourceList, error) {
-	req, err := http.NewRequest("GET", fmt.Sprintf("/%s/_overview", system.ZoneResourceTypeDescriptor.WsPath), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("/%s/_overview", system.ZoneResourceTypeDescriptor.WsPath), http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/app/kumactl/pkg/resources/zoneegressoverview_client.go
+++ b/app/kumactl/pkg/resources/zoneegressoverview_client.go
@@ -27,7 +27,7 @@ type httpZoneEgressOverviewClient struct {
 }
 
 func (d *httpZoneEgressOverviewClient) List(ctx context.Context) (*mesh.ZoneEgressOverviewResourceList, error) {
-	req, err := http.NewRequest("GET", fmt.Sprintf("/%s/_overview", mesh.ZoneEgressResourceTypeDescriptor.WsPath), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("/%s/_overview", mesh.ZoneEgressResourceTypeDescriptor.WsPath), http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/app/kumactl/pkg/resources/zoneingress_overview_client.go
+++ b/app/kumactl/pkg/resources/zoneingress_overview_client.go
@@ -27,7 +27,7 @@ type httpZoneIngressOverviewClient struct {
 }
 
 func (d *httpZoneIngressOverviewClient) List(ctx context.Context) (*mesh.ZoneIngressOverviewResourceList, error) {
-	req, err := http.NewRequest("GET", fmt.Sprintf("/%s/_overview", mesh.ZoneIngressResourceTypeDescriptor.WsPath), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("/%s/_overview", mesh.ZoneIngressResourceTypeDescriptor.WsPath), http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api-server/resource_endpoints_test.go
+++ b/pkg/api-server/resource_endpoints_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Resource Endpoints", func() {
 
 	It("should support CORS", func() {
 		// given
-		req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/meshes/%s/traffic-routes", apiServer.Address(), mesh), nil)
+		req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/meshes/%s/traffic-routes", apiServer.Address(), mesh), http.NoBody)
 		Expect(err).NotTo(HaveOccurred())
 		req.Header.Add(restful.HEADER_Origin, "test")
 
@@ -78,7 +78,7 @@ var _ = Describe("Resource Endpoints", func() {
 
 	It("should expose metrics", func() {
 		// given
-		req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/meshes/%s/traffic-routes", apiServer.Address(), mesh), nil)
+		req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/meshes/%s/traffic-routes", apiServer.Address(), mesh), http.NoBody)
 		Expect(err).NotTo(HaveOccurred())
 
 		// when

--- a/pkg/envoy/admin/client.go
+++ b/pkg/envoy/admin/client.go
@@ -111,7 +111,7 @@ func (a *envoyAdminClient) PostQuit(ctx context.Context, dataplane *core_mesh.Da
 	}
 
 	url := fmt.Sprintf("https://%s/%s", dataplane.AdminAddress(a.defaultAdminPort), quitquitquit)
-	request, err := http.NewRequestWithContext(ctx, "POST", url, nil)
+	request, err := http.NewRequestWithContext(ctx, "POST", url, http.NoBody)
 	if err != nil {
 		return err
 	}
@@ -199,7 +199,7 @@ func (a *envoyAdminClient) executeRequest(ctx context.Context, proxy core_model.
 	u.Host = proxy.AdminAddress(a.defaultAdminPort)
 	u.Path = path
 	u.RawQuery = query.Encode()
-	request, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
+	request, err := http.NewRequestWithContext(ctx, "GET", u.String(), http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/plugins/resources/remote/store.go
+++ b/pkg/plugins/resources/remote/store.go
@@ -119,7 +119,7 @@ func (s *remoteStore) Delete(ctx context.Context, res model.Resource, fs ...stor
 	if err != nil {
 		return errors.Wrapf(err, "failed to construct URI to delete a %q", res.Descriptor().Name)
 	}
-	req, err := http.NewRequest("DELETE", resourceApi.Item(opts.Mesh, opts.Name), nil)
+	req, err := http.NewRequest("DELETE", resourceApi.Item(opts.Mesh, opts.Name), http.NoBody)
 	if err != nil {
 		return err
 	}
@@ -146,7 +146,7 @@ func (s *remoteStore) Get(ctx context.Context, res model.Resource, fs ...store.G
 		return errors.Wrapf(err, "failed to construct URI to fetch a %q", res.Descriptor().Name)
 	}
 	opts := store.NewGetOptions(fs...)
-	req, err := http.NewRequest("GET", resourceApi.Item(opts.Mesh, opts.Name), nil)
+	req, err := http.NewRequest("GET", resourceApi.Item(opts.Mesh, opts.Name), http.NoBody)
 	if err != nil {
 		return err
 	}
@@ -179,7 +179,7 @@ func (s *remoteStore) List(ctx context.Context, rs model.ResourceList, fs ...sto
 		return errors.Wrapf(err, "failed to construct URI to fetch a list of %q", rs.GetItemType())
 	}
 	opts := store.NewListOptions(fs...)
-	req, err := http.NewRequest("GET", resourceApi.List(opts.Mesh), nil)
+	req, err := http.NewRequest("GET", resourceApi.List(opts.Mesh), http.NoBody)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/http/client_test.go
+++ b/pkg/util/http/client_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Http Util", func() {
 				Expect(client).ToNot(BeIdenticalTo(delegate))
 
 				// when
-				req, err := http.NewRequest("GET", given.requestURL, nil)
+				req, err := http.NewRequest("GET", given.requestURL, http.NoBody)
 				// then
 				Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e_env/kubernetes/api/api.go
+++ b/test/e2e_env/kubernetes/api/api.go
@@ -69,7 +69,7 @@ func Api() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(func(g Gomega) {
-				req, err := http.NewRequest("GET", kubernetes.Cluster.GetKuma().GetAPIServerAddress()+given.path, nil)
+				req, err := http.NewRequest("GET", kubernetes.Cluster.GetKuma().GetAPIServerAddress()+given.path, http.NoBody)
 				g.Expect(err).ToNot(HaveOccurred())
 				req.Header.Add("authorization", "Bearer "+token)
 				r, err := http.DefaultClient.Do(req)

--- a/test/e2e_env/universal/api/api.go
+++ b/test/e2e_env/universal/api/api.go
@@ -69,7 +69,7 @@ func Api() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(func(g Gomega) {
-				req, err := http.NewRequest("GET", universal.Cluster.GetKuma().GetAPIServerAddress()+given.path, nil)
+				req, err := http.NewRequest("GET", universal.Cluster.GetKuma().GetAPIServerAddress()+given.path, http.NoBody)
 				g.Expect(err).ToNot(HaveOccurred())
 				req.Header.Add("authorization", "Bearer "+token)
 				r, err := http.DefaultClient.Do(req)

--- a/test/e2e_env/universal/auth/user_auth.go
+++ b/test/e2e_env/universal/auth/user_auth.go
@@ -61,7 +61,7 @@ func UserAuth() {
 	DescribeTable("should ignore auth data on unauthorized endpoints",
 		func(endpoint string) {
 			// given
-			req, err := http.NewRequest("GET", universal.Cluster.GetKuma().GetAPIServerAddress()+endpoint, nil)
+			req, err := http.NewRequest("GET", universal.Cluster.GetKuma().GetAPIServerAddress()+endpoint, http.NoBody)
 			Expect(err).ToNot(HaveOccurred())
 			req.Header.Add("authorization", "Bearer invliddata")
 

--- a/test/framework/client/collect.go
+++ b/test/framework/client/collect.go
@@ -345,7 +345,7 @@ func MakeDirectRequest(
 ) (*http.Response, error) {
 	opts := CollectOptions(destination, fn...)
 
-	req, err := http.NewRequest(opts.Method, opts.URL, nil)
+	req, err := http.NewRequest(opts.Method, opts.URL, http.NoBody)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Motivation

Detects nil usages in http.NewRequest calls, suggesting http.NoBody as an alternative
Also switch from disable-all to enable-all and exclude so we pick up new linters as they are added

## Implementation information

https://go-critic.com/overview.html#httpnobody

> Changelog: skip
