### PR TITLE
ci(docker): fix SKIP_PLATFORM not working

### DIFF
--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -7,7 +7,7 @@ DOCKER_USERNAME ?=
 DOCKER_API_KEY ?=
 
 define build_image
-$(addsuffix :$(BUILD_INFO_VERSION)$(if $(and $(filter-out true,$(SKIP_PLATFORM)),$(2)),-$(2)),$(addprefix $(DOCKER_REGISTRY)/,$(1)))
+$(addsuffix :$(BUILD_INFO_VERSION)$(if $(and $(2),$(if $(findstring true,$(SKIP_PLATFORM)),,1)),-$(2)),$(addprefix $(DOCKER_REGISTRY)/,$(1)))
 endef
 
 IMAGES_RELEASE += kuma-cp kuma-dp kumactl kuma-init kuma-cni


### PR DESCRIPTION
## Motivation

Our ECS tests started failing because there were no amd64 images.

You can see it here, they stopped being generated after the PR https://github.com/kumahq/kuma/commit/2584318b9f049bfc55c8ccf5cfeed212a1edf7ff

![image](https://github.com/user-attachments/assets/dcc0f9b7-60e9-487c-934e-3caf88182846)

Output of `make image/kuma-cp` on this branch:

```
> => naming to docker.io/kumahq/kuma-cp:0.0.0-preview.v07b48dead-arm64                                                                                                                                                                                                 0.0s
```

vs

main:

```
naming to docker.io/kumahq/kuma-cp:0.0.0-preview.vd514c07fa
```

Notice the suffix needed `-arm64`

Skaffold seems to also be working:

```
Starting deploy...
Loading images into k3d cluster nodes...
 - kumahq/kuma-cp:d51d317e6125dffba9607b448ed982c670bda1210632ab507a5a82cac8f50a43 -> Loaded
 - kumahq/kuma-dp:154897d21531b45db088c2bf6118810932fe570679d757da5aaf370c98194fdf -> Loaded
 - kumahq/kumactl:cd3cae2727d80284f718b5108ee2c766774809e066b7cc5e4ee572b079d7b7cc -> Loaded
 - kumahq/kuma-init:2c36cb3dfedd3a5c016889c23a276bdc5bb6574ebab1452d5ee1a78be372060a -> Loaded
Images loaded in 20.293 seconds
Helm release kuma not installed. Installing...
NAME: kuma
```

## Implementation information

Use `findstring` instead of `filter-out`. Not sure why filter-out was used in the first place.
