### PR TITLE
ci(lint): enable exptostd linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
     - contextcheck
     - depguard
     - errcheck
+    - exptostd
     - ginkgolinter
     - gocritic
     - gomodguard

--- a/pkg/api-server/inspect_mesh_service.go
+++ b/pkg/api-server/inspect_mesh_service.go
@@ -2,11 +2,11 @@ package api_server
 
 import (
 	"fmt"
+	"maps"
 	"sort"
 	"strings"
 
 	"github.com/emicklei/go-restful/v3"
-	"golang.org/x/exp/maps"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/api/openapi/types"

--- a/pkg/core/kri/kri.go
+++ b/pkg/core/kri/kri.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"golang.org/x/exp/constraints"
+	"golang.org/x/exp/constraints" //nolint:exptostd // https://github.com/kumahq/kuma/pull/13810/files#r2179434552
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"

--- a/pkg/transparentproxy/config/dataplane/config_dataplane.go
+++ b/pkg/transparentproxy/config/dataplane/config_dataplane.go
@@ -2,7 +2,7 @@ package dataplane
 
 import (
 	"github.com/asaskevich/govalidator"
-	"golang.org/x/exp/constraints"
+	"golang.org/x/exp/constraints" //nolint:exptostd // https://github.com/kumahq/kuma/pull/13810/files#r2179434552
 
 	core_config "github.com/kumahq/kuma/pkg/config"
 	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"


### PR DESCRIPTION
## Motivation

Detects functions from golang.org/x/exp/ that can be replaced by std functions.

## Supporting documentation

https://golangci-lint.run/usage/linters/#exptostd

> Changelog: skip
