### PR TITLE
fix(api-types): align port types in resources with Kubernetes guidelines

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -309,6 +309,7 @@ spec:
                       type: string
                     port:
                       description: Port of the endpoint
+                      format: int32
                       maximum: 65535
                       minimum: 1
                       type: integer
@@ -337,6 +338,7 @@ spec:
                 properties:
                   port:
                     description: Port defines a port to which a user does request.
+                    format: int32
                     maximum: 65535
                     minimum: 1
                     type: integer

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -309,6 +309,7 @@ spec:
                       type: string
                     port:
                       description: Port of the endpoint
+                      format: int32
                       maximum: 65535
                       minimum: 1
                       type: integer
@@ -337,6 +338,7 @@ spec:
                 properties:
                   port:
                     description: Port defines a port to which a user does request.
+                    format: int32
                     maximum: 65535
                     minimum: 1
                     type: integer

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -329,6 +329,7 @@ spec:
                       type: string
                     port:
                       description: Port of the endpoint
+                      format: int32
                       maximum: 65535
                       minimum: 1
                       type: integer
@@ -357,6 +358,7 @@ spec:
                 properties:
                   port:
                     description: Port defines a port to which a user does request.
+                    format: int32
                     maximum: 65535
                     minimum: 1
                     type: integer

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -2407,6 +2407,7 @@ spec:
                       type: string
                     port:
                       description: Port of the endpoint
+                      format: int32
                       maximum: 65535
                       minimum: 1
                       type: integer
@@ -2435,6 +2436,7 @@ spec:
                 properties:
                   port:
                     description: Port defines a port to which a user does request.
+                    format: int32
                     maximum: 65535
                     minimum: 1
                     type: integer

--- a/deployments/charts/kuma/crds/kuma.io_meshexternalservices.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshexternalservices.yaml
@@ -60,6 +60,7 @@ spec:
                       type: string
                     port:
                       description: Port of the endpoint
+                      format: int32
                       maximum: 65535
                       minimum: 1
                       type: integer
@@ -88,6 +89,7 @@ spec:
                 properties:
                   port:
                     description: Port defines a port to which a user does request.
+                    format: int32
                     maximum: 65535
                     minimum: 1
                     type: integer

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -16615,6 +16615,7 @@ components:
                     type: string
                   port:
                     description: Port of the endpoint
+                    format: int32
                     maximum: 65535
                     minimum: 1
                     type: integer
@@ -16643,6 +16644,7 @@ components:
               properties:
                 port:
                   description: Port defines a port to which a user does request.
+                  format: int32
                   maximum: 65535
                   minimum: 1
                   type: integer

--- a/docs/generated/raw/crds/kuma.io_meshexternalservices.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshexternalservices.yaml
@@ -60,6 +60,7 @@ spec:
                       type: string
                     port:
                       description: Port of the endpoint
+                      format: int32
                       maximum: 65535
                       minimum: 1
                       type: integer
@@ -88,6 +89,7 @@ spec:
                 properties:
                   port:
                     description: Port defines a port to which a user does request.
+                    format: int32
                     maximum: 65535
                     minimum: 1
                     type: integer

--- a/pkg/api-server/resource_endpoints_test.go
+++ b/pkg/api-server/resource_endpoints_test.go
@@ -324,7 +324,7 @@ var _ = Describe("Resource Endpoints on Zone, label origin", func() {
 				Endpoints: &[]meshexternalservice_api.Endpoint{
 					{
 						Address: "192.168.0.1",
-						Port:    meshexternalservice_api.Port(27017),
+						Port:    27017,
 					},
 				},
 			},

--- a/pkg/core/resources/apis/core/destinationname/destinationname.go
+++ b/pkg/core/resources/apis/core/destinationname/destinationname.go
@@ -8,6 +8,6 @@ import (
 
 // LegacyName is a current way of naming envoy resources until https://github.com/kumahq/kuma/pull/12756
 // is fully implemented
-func LegacyName(id kri.Identifier, shortName string, port uint32) string {
+func LegacyName(id kri.Identifier, shortName string, port int32) string {
 	return fmt.Sprintf("%s_%s_%s_%s_%s_%d", id.Mesh, id.Name, id.Namespace, id.Zone, shortName, port)
 }

--- a/pkg/core/resources/apis/core/interfaces.go
+++ b/pkg/core/resources/apis/core/interfaces.go
@@ -2,6 +2,6 @@ package core
 
 type Port interface {
 	GetName() string
-	GetValue() uint32
+	GetValue() int32
 	GetNameOrStringifyPort() string
 }

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/helpers.go
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/helpers.go
@@ -9,9 +9,9 @@ import (
 	"github.com/kumahq/kuma/pkg/util/pointer"
 )
 
-func (m *MeshExternalServiceResource) DestinationName(port uint32) string {
+func (m *MeshExternalServiceResource) DestinationName(port int32) string {
 	if port == 0 {
-		port = uint32(m.Spec.Match.Port)
+		port = m.Spec.Match.Port
 	}
 	return destinationname.LegacyName(kri.From(m, ""), MeshExternalServiceResourceTypeDescriptor.ShortName, port)
 }

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/meshexternalservice.go
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/meshexternalservice.go
@@ -43,7 +43,9 @@ type Match struct {
 	// +kubebuilder:default=HostnameGenerator
 	Type MatchType `json:"type"`
 	// Port defines a port to which a user does request.
-	Port Port `json:"port"`
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=65535
+	Port int32 `json:"port"`
 	// Protocol defines a protocol of the communication. Possible values: `tcp`, `grpc`, `http`, `http2`.
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=tcp
@@ -58,10 +60,6 @@ type Extension struct {
 	Config *apiextensionsv1.JSON `json:"config,omitempty"`
 }
 
-// +kubebuilder:validation:Minimum=1
-// +kubebuilder:validation:Maximum=65535
-type Port int
-
 type Endpoint struct {
 	// Address defines an address to which a user want to send a request. Is possible to provide `domain`, `ip`.
 	// +kubebuilder:example="127.0.0.1"
@@ -69,7 +67,9 @@ type Endpoint struct {
 	// +kubebuilder:validation:MinLength=1
 	Address string `json:"address"`
 	// Port of the endpoint
-	Port Port `json:"port"`
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=65535
+	Port int32 `json:"port"`
 }
 
 type Tls struct {

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/schema.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/schema.yaml
@@ -32,6 +32,7 @@ properties:
               type: string
             port:
               description: Port of the endpoint
+              format: int32
               maximum: 65535
               minimum: 1
               type: integer
@@ -57,6 +58,7 @@ properties:
         properties:
           port:
             description: Port defines a port to which a user does request.
+            format: int32
             maximum: 65535
             minimum: 1
             type: integer

--- a/pkg/core/resources/apis/meshexternalservice/k8s/crd/kuma.io_meshexternalservices.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/k8s/crd/kuma.io_meshexternalservices.yaml
@@ -60,6 +60,7 @@ spec:
                       type: string
                     port:
                       description: Port of the endpoint
+                      format: int32
                       maximum: 65535
                       minimum: 1
                       type: integer
@@ -88,6 +89,7 @@ spec:
                 properties:
                   port:
                     description: Port defines a port to which a user does request.
+                    format: int32
                     maximum: 65535
                     minimum: 1
                     type: integer

--- a/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/helpers.go
+++ b/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/helpers.go
@@ -28,7 +28,7 @@ func (t *MeshMultiZoneServiceResource) AllocateVIP(vip string) {
 	})
 }
 
-func (m *MeshMultiZoneServiceResource) findPort(port uint32) (Port, bool) {
+func (m *MeshMultiZoneServiceResource) findPort(port int32) (Port, bool) {
 	for _, p := range m.Spec.Ports {
 		if p.Port == port {
 			return p, true
@@ -37,7 +37,7 @@ func (m *MeshMultiZoneServiceResource) findPort(port uint32) (Port, bool) {
 	return Port{}, false
 }
 
-func (m *MeshMultiZoneServiceResource) FindSectionNameByPort(port uint32) (string, bool) {
+func (m *MeshMultiZoneServiceResource) FindSectionNameByPort(port int32) (string, bool) {
 	if port, found := m.findPort(port); found {
 		return port.GetNameOrStringifyPort(), true
 	}
@@ -56,7 +56,7 @@ func (m *MeshMultiZoneServiceResource) FindPortByName(name string) (Port, bool) 
 	return Port{}, false
 }
 
-func (m *MeshMultiZoneServiceResource) DestinationName(port uint32) string {
+func (m *MeshMultiZoneServiceResource) DestinationName(port int32) string {
 	return destinationname.LegacyName(kri.From(m, ""), MeshMultiZoneServiceResourceTypeDescriptor.ShortName, port)
 }
 
@@ -66,7 +66,7 @@ func (m *MeshMultiZoneServiceResource) AsOutbounds() xds_types.Outbounds {
 		for _, port := range m.Spec.Ports {
 			outbounds = append(outbounds, &xds_types.Outbound{
 				Address:  vip.IP,
-				Port:     port.Port,
+				Port:     uint32(port.Port),
 				Resource: pointer.To(kri.From(m, port.GetNameOrStringifyPort())),
 			})
 		}
@@ -107,6 +107,6 @@ func (p Port) GetName() string {
 	return pointer.Deref(p.Name)
 }
 
-func (p Port) GetValue() uint32 {
+func (p Port) GetValue() int32 {
 	return p.Port
 }

--- a/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/meshmultizoneservice.go
+++ b/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/meshmultizoneservice.go
@@ -28,7 +28,7 @@ type MeshMultiZoneService struct {
 
 type Port struct {
 	Name *string `json:"name,omitempty"`
-	Port uint32  `json:"port"`
+	Port int32   `json:"port"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=tcp
 	AppProtocol core_mesh.Protocol `json:"appProtocol"`

--- a/pkg/core/resources/apis/meshmultizoneservice/status_updater.go
+++ b/pkg/core/resources/apis/meshmultizoneservice/status_updater.go
@@ -94,7 +94,7 @@ func (s *StatusUpdater) updateStatus(ctx context.Context) error {
 
 	for _, mzSvc := range mzSvcList.Items {
 		var matched []meshmzservice_api.MatchedMeshService
-		ports := map[uint32]meshservice_api.Port{}
+		ports := map[int32]meshservice_api.Port{}
 		for _, svc := range msList.Items {
 			if matchesService(mzSvc, svc) {
 				ri := kri.From(svc, "")

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/helpers.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/helpers.go
@@ -12,11 +12,11 @@ import (
 	"github.com/kumahq/kuma/pkg/util/pointer"
 )
 
-func (m *MeshServiceResource) DestinationName(port uint32) string {
+func (m *MeshServiceResource) DestinationName(port int32) string {
 	return destinationname.LegacyName(kri.From(m, ""), MeshServiceResourceTypeDescriptor.ShortName, port)
 }
 
-func (m *MeshServiceResource) findPort(port uint32) (Port, bool) {
+func (m *MeshServiceResource) findPort(port int32) (Port, bool) {
 	for _, p := range m.Spec.Ports {
 		if p.Port == port {
 			return p, true
@@ -25,7 +25,7 @@ func (m *MeshServiceResource) findPort(port uint32) (Port, bool) {
 	return Port{}, false
 }
 
-func (m *MeshServiceResource) FindSectionNameByPort(port uint32) (string, bool) {
+func (m *MeshServiceResource) FindSectionNameByPort(port int32) (string, bool) {
 	if port, found := m.findPort(port); found {
 		return port.GetNameOrStringifyPort(), true
 	}
@@ -100,7 +100,7 @@ func (t *MeshServiceResource) AsOutbounds() xds_types.Outbounds {
 		for _, port := range t.Spec.Ports {
 			outbounds = append(outbounds, &xds_types.Outbound{
 				Address:  vip.IP,
-				Port:     port.Port,
+				Port:     uint32(port.Port),
 				Resource: pointer.To(kri.From(t, port.GetNameOrStringifyPort())),
 			})
 		}
@@ -141,6 +141,6 @@ func (p Port) GetName() string {
 	return p.Name
 }
 
-func (p Port) GetValue() uint32 {
+func (p Port) GetValue() int32 {
 	return p.Port
 }

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/meshservice.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/meshservice.go
@@ -21,7 +21,7 @@ type DataplaneRef struct {
 
 type Port struct {
 	Name       string             `json:"name,omitempty"`
-	Port       uint32             `json:"port"`
+	Port       int32              `json:"port"`
 	TargetPort intstr.IntOrString `json:"targetPort,omitempty"`
 	// +kubebuilder:default=tcp
 	AppProtocol core_mesh.Protocol `json:"appProtocol,omitempty"`

--- a/pkg/core/resources/apis/meshservice/generate/generator.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator.go
@@ -94,7 +94,7 @@ func (g *Generator) meshServicesForDataplane(dataplane *core_mesh.DataplaneResou
 		}
 		port := meshservice_api.Port{
 			Name:        portName,
-			Port:        inbound.Port,
+			Port:        int32(inbound.Port),
 			TargetPort:  intstr.FromInt(int(inbound.Port)),
 			AppProtocol: core_mesh.Protocol(appProtocol),
 		}

--- a/pkg/core/resources/apis/meshservice/status/updater_test.go
+++ b/pkg/core/resources/apis/meshservice/status/updater_test.go
@@ -233,7 +233,7 @@ var _ = Describe("Updater", func() {
 		Entry("should count healthy DPPs and use MeshService.ports[].targetPort to select DP inbound", dpProxiesTestCase{
 			meshService: samples.MeshServiceBackendBuilder().
 				WithDataplaneTagsSelectorKV("app", "backend").
-				AddIntPort(builders.FirstInboundServicePort+1, builders.FirstInboundPort+1, core_mesh.ProtocolHTTP),
+				AddIntPort(int32(builders.FirstInboundServicePort+1), int32(builders.FirstInboundPort+1), core_mesh.ProtocolHTTP),
 			dpps: []*builders.DataplaneBuilder{
 				builders.Dataplane().
 					WithName("dp-all-inbounds-healthy").

--- a/pkg/plugins/policies/core/rules/resolve/targetref.go
+++ b/pkg/plugins/policies/core/rules/resolve/targetref.go
@@ -31,7 +31,7 @@ type ResourceWithPorts interface {
 type query struct {
 	byIdentifier *kri.Identifier
 	byLabels     map[string]string
-	port         uint32
+	port         int32
 	sectionName  string
 }
 
@@ -139,30 +139,30 @@ func TargetRef(targetRef common_api.TargetRef, tMeta core_model.ResourceMeta, re
 	return result
 }
 
-func tryParsePort(s string) (uint32, bool) {
-	u, err := strconv.ParseUint(s, 10, 32)
+func tryParsePort(s string) (int32, bool) {
+	u, err := strconv.ParseInt(s, 10, 32)
 	if err != nil {
 		return 0, false
 	}
-	return uint32(u), true
+	return int32(u), true
 }
 
 // parseService is copied from pkg/plugins/runtime/k8s/controllers/outbound_converter.go
 // but when port is not specified it returns 0 instead of IANA Reserved port 49151.
 // We don't need reserved port in the original 'parseService',
 // there is an issue to fix it https://github.com/kumahq/kuma/issues/12834
-func parseService(host string) (string, string, uint32, error) {
+func parseService(host string) (string, string, int32, error) {
 	// split host into <name>_<namespace>_svc_<port>
 	segments := strings.Split(host, "_")
 
-	var port uint32
+	var port int32
 	switch len(segments) {
 	case 4:
 		p, err := strconv.ParseInt(segments[3], 10, 32)
 		if err != nil {
 			return "", "", 0, err
 		}
-		port = uint32(p)
+		port = int32(p)
 	case 3:
 		// service less service names have no port, so we just put the reserved
 		// one here to note that this service is actually

--- a/pkg/plugins/policies/core/xds/meshroute/clusters.go
+++ b/pkg/plugins/policies/core/xds/meshroute/clusters.go
@@ -149,7 +149,7 @@ func SniForBackendRef(
 ) string {
 	var resource core_model.Resource
 	var name string
-	var port uint32
+	var port int32
 	switch common_api.TargetRefKind(backendRef.Resource.ResourceType) {
 	case common_api.MeshService:
 		ms := meshCtx.GetMeshServiceByKRI(pointer.Deref(backendRef.Resource))
@@ -162,7 +162,7 @@ func SniForBackendRef(
 		mes := meshCtx.GetMeshExternalServiceByKRI(pointer.Deref(backendRef.Resource))
 		resource = mes
 		name = core_model.GetDisplayName(resource.GetMeta())
-		port = uint32(mes.Spec.Match.Port)
+		port = mes.Spec.Match.Port
 	case common_api.MeshMultiZoneService:
 		mzms := meshCtx.GetMeshMultiZoneServiceByKRI(pointer.Deref(backendRef.Resource))
 		resource = mzms

--- a/pkg/plugins/policies/core/xds/meshroute/listeners.go
+++ b/pkg/plugins/policies/core/xds/meshroute/listeners.go
@@ -148,7 +148,7 @@ func collectMeshExternalService(
 	return &DestinationService{
 		Outbound:    outbound,
 		Protocol:    protocol,
-		ServiceName: mes.DestinationName(uint32(mes.Spec.Match.Port)),
+		ServiceName: mes.DestinationName(mes.Spec.Match.Port),
 	}
 }
 
@@ -190,14 +190,14 @@ func collectServiceTagService(
 func GetServiceProtocolPortFromRef(
 	meshCtx xds_context.MeshContext,
 	ref *resolve.RealResourceBackendRef,
-) (string, core_mesh.Protocol, uint32, bool) {
+) (string, core_mesh.Protocol, int32, bool) {
 	switch common_api.TargetRefKind(ref.Resource.ResourceType) {
 	case common_api.MeshExternalService:
 		mes := meshCtx.GetMeshExternalServiceByKRI(pointer.Deref(ref.Resource))
 		if mes == nil {
 			return "", "", 0, false
 		}
-		port := uint32(mes.Spec.Match.Port)
+		port := mes.Spec.Match.Port
 		service := mes.DestinationName(port)
 		protocol := mes.Spec.Match.Protocol
 		return service, protocol, port, true

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
@@ -807,13 +807,13 @@ func outboundServiceTCPListener(service string, port uint32) core_xds.Resource {
 	return *listener
 }
 
-func outboundRealServiceHTTPListener(serviceResourceKRI kri.Identifier, port uint32, routes []meshhttproute_xds.OutboundRoute) core_xds.Resource {
+func outboundRealServiceHTTPListener(serviceResourceKRI kri.Identifier, port int32, routes []meshhttproute_xds.OutboundRoute) core_xds.Resource {
 	listener, err := meshhttproute_plugin.GenerateOutboundListener(
 		envoy_common.APIV3,
 		meshroute_xds.DestinationService{
 			Outbound: &xds_types.Outbound{
 				Address:  "127.0.0.1",
-				Port:     port,
+				Port:     uint32(port),
 				Resource: &serviceResourceKRI,
 			},
 			Protocol:    core_mesh.ProtocolHTTP,
@@ -828,7 +828,7 @@ func outboundRealServiceHTTPListener(serviceResourceKRI kri.Identifier, port uin
 	return *listener
 }
 
-func serviceName(id kri.Identifier, port uint32) string {
+func serviceName(id kri.Identifier, port int32) string {
 	desc, err := registry.Global().DescriptorFor(id.ResourceType)
 	Expect(err).ToNot(HaveOccurred())
 	return destinationname.LegacyName(id, desc.ShortName, port)

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin.go
@@ -208,7 +208,7 @@ func applyToEgressRealResources(rs *core_xds.ResourceSet, proxy *core_xds.Proxy)
 		meshExternalServices := meshResources.ListOrEmpty(meshexternalservice_api.MeshExternalServiceType)
 		for _, mes := range meshExternalServices.GetItems() {
 			meshExtSvc := mes.(*meshexternalservice_api.MeshExternalServiceResource)
-			policies, ok := meshResources.Dynamic[meshExtSvc.DestinationName(uint32(meshExtSvc.Spec.Match.Port))]
+			policies, ok := meshResources.Dynamic[meshExtSvc.DestinationName(meshExtSvc.Spec.Match.Port)]
 			if !ok {
 				continue
 			}

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin.go
@@ -194,7 +194,7 @@ func applyToEgressRealResources(rs *core_xds.ResourceSet, proxy *core_xds.Proxy)
 		meshExternalServices := meshResources.ListOrEmpty(meshexternalservice_api.MeshExternalServiceType)
 		for _, mes := range meshExternalServices.GetItems() {
 			meshExtSvc := mes.(*meshexternalservice_api.MeshExternalServiceResource)
-			policies, ok := meshResources.Dynamic[meshExtSvc.DestinationName(uint32(meshExtSvc.Spec.Match.Port))]
+			policies, ok := meshResources.Dynamic[meshExtSvc.DestinationName(meshExtSvc.Spec.Match.Port)]
 			if !ok {
 				continue
 			}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
@@ -369,7 +369,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 					Endpoints: &[]meshexternalservice_api.Endpoint{
 						{
 							Address: "example.com",
-							Port:    meshexternalservice_api.Port(10000),
+							Port:    10000,
 						},
 					},
 				},
@@ -401,7 +401,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 					Endpoints: &[]meshexternalservice_api.Endpoint{
 						{
 							Address: "example.com",
-							Port:    meshexternalservice_api.Port(10000),
+							Port:    10000,
 						},
 					},
 				},
@@ -487,7 +487,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 					Endpoints: &[]meshexternalservice_api.Endpoint{
 						{
 							Address: "example.com",
-							Port:    meshexternalservice_api.Port(10000),
+							Port:    10000,
 						},
 					},
 				},
@@ -548,7 +548,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 					Endpoints: &[]meshexternalservice_api.Endpoint{
 						{
 							Address: "example.com",
-							Port:    meshexternalservice_api.Port(10000),
+							Port:    10000,
 						},
 					},
 					Tls: &meshexternalservice_api.Tls{
@@ -583,7 +583,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 					Endpoints: &[]meshexternalservice_api.Endpoint{
 						{
 							Address: "example.com",
-							Port:    meshexternalservice_api.Port(10000),
+							Port:    10000,
 						},
 					},
 					Tls: &meshexternalservice_api.Tls{
@@ -621,11 +621,11 @@ var _ = Describe("MeshHTTPRoute", func() {
 					Endpoints: &[]meshexternalservice_api.Endpoint{
 						{
 							Address: "example.com",
-							Port:    meshexternalservice_api.Port(10000),
+							Port:    10000,
 						},
 						{
 							Address: "example2.com",
-							Port:    meshexternalservice_api.Port(11111),
+							Port:    11111,
 						},
 					},
 					Tls: &meshexternalservice_api.Tls{

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
@@ -486,7 +486,7 @@ func (p plugin) configureEgress(rs *core_xds.ResourceSet, proxy *core_xds.Proxy)
 		meshExternalServices := meshResources.ListOrEmpty(meshexternalservice_api.MeshExternalServiceType)
 		for _, mes := range meshExternalServices.GetItems() {
 			meshExtSvc := mes.(*meshexternalservice_api.MeshExternalServiceResource)
-			destinationName := meshExtSvc.DestinationName(uint32(meshExtSvc.Spec.Match.Port))
+			destinationName := meshExtSvc.DestinationName(meshExtSvc.Spec.Match.Port)
 			policies, ok := meshResources.Dynamic[destinationName]
 			if !ok {
 				continue

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
@@ -363,11 +363,11 @@ var _ = Describe("MeshTCPRoute", func() {
 					Endpoints: &[]meshexternalservice_api.Endpoint{
 						{
 							Address: "example.com",
-							Port:    meshexternalservice_api.Port(10000),
+							Port:    10000,
 						},
 						{
 							Address: "192.168.1.1",
-							Port:    meshexternalservice_api.Port(10000),
+							Port:    10000,
 						},
 					},
 					Tls: &meshexternalservice_api.Tls{
@@ -402,11 +402,11 @@ var _ = Describe("MeshTCPRoute", func() {
 					Endpoints: &[]meshexternalservice_api.Endpoint{
 						{
 							Address: "example.com",
-							Port:    meshexternalservice_api.Port(10000),
+							Port:    10000,
 						},
 						{
 							Address: "192.168.1.1",
-							Port:    meshexternalservice_api.Port(10000),
+							Port:    10000,
 						},
 					},
 					Tls: &meshexternalservice_api.Tls{
@@ -430,11 +430,11 @@ var _ = Describe("MeshTCPRoute", func() {
 					Endpoints: &[]meshexternalservice_api.Endpoint{
 						{
 							Address: "example.com",
-							Port:    meshexternalservice_api.Port(10000),
+							Port:    10000,
 						},
 						{
 							Address: "192.168.1.1",
-							Port:    meshexternalservice_api.Port(10000),
+							Port:    10000,
 						},
 					},
 					Tls: &meshexternalservice_api.Tls{

--- a/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin.go
@@ -145,7 +145,7 @@ func (p plugin) configureEgress(rs *core_xds.ResourceSet, proxy *core_xds.Proxy)
 		mesNames := []string{}
 		for _, mes := range resource.ListOrEmpty(meshexternalservice_api.MeshExternalServiceType).GetItems() {
 			meshExtSvc := mes.(*meshexternalservice_api.MeshExternalServiceResource)
-			mesNames = append(mesNames, meshExtSvc.DestinationName(uint32(meshExtSvc.Spec.Match.Port)))
+			mesNames = append(mesNames, meshExtSvc.DestinationName(meshExtSvc.Spec.Match.Port))
 		}
 
 		for _, esName := range esNames {

--- a/pkg/plugins/runtime/k8s/controllers/meshservice_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/meshservice_controller.go
@@ -399,7 +399,7 @@ func (r *MeshServiceReconciler) manageMeshService(
 			}
 			ms.Spec.Ports = append(ms.Spec.Ports, meshservice_api.Port{
 				Name:        portName,
-				Port:        uint32(port.Port),
+				Port:        port.Port,
 				TargetPort:  port.TargetPort,
 				AppProtocol: core_mesh.Protocol(pointer.DerefOr(port.AppProtocol, "tcp")),
 			})

--- a/pkg/test/resources/builders/meshexternalservice_builder.go
+++ b/pkg/test/resources/builders/meshexternalservice_builder.go
@@ -30,7 +30,7 @@ func MeshExternalService() *MeshExternalServiceBuilder {
 				Endpoints: &[]v1alpha1.Endpoint{
 					{
 						Address: "192.168.0.1",
-						Port:    v1alpha1.Port(27017),
+						Port:    27017,
 					},
 				},
 			},

--- a/pkg/test/resources/builders/meshmultizoneservice_builder.go
+++ b/pkg/test/resources/builders/meshmultizoneservice_builder.go
@@ -64,7 +64,7 @@ func (m *MeshMultiZoneServiceBuilder) AddPort(port meshmzservice_api.Port) *Mesh
 	return m
 }
 
-func (m *MeshMultiZoneServiceBuilder) AddIntPort(port uint32, protocol core_mesh.Protocol) *MeshMultiZoneServiceBuilder {
+func (m *MeshMultiZoneServiceBuilder) AddIntPort(port int32, protocol core_mesh.Protocol) *MeshMultiZoneServiceBuilder {
 	m.res.Spec.Ports = append(m.res.Spec.Ports, meshmzservice_api.Port{
 		Port:        port,
 		AppProtocol: protocol,
@@ -72,7 +72,7 @@ func (m *MeshMultiZoneServiceBuilder) AddIntPort(port uint32, protocol core_mesh
 	return m
 }
 
-func (m *MeshMultiZoneServiceBuilder) AddIntPortWithName(port uint32, protocol core_mesh.Protocol, name string) *MeshMultiZoneServiceBuilder {
+func (m *MeshMultiZoneServiceBuilder) AddIntPortWithName(port int32, protocol core_mesh.Protocol, name string) *MeshMultiZoneServiceBuilder {
 	m.res.Spec.Ports = append(m.res.Spec.Ports, meshmzservice_api.Port{
 		Port:        port,
 		AppProtocol: protocol,

--- a/pkg/test/resources/builders/meshservice_builder.go
+++ b/pkg/test/resources/builders/meshservice_builder.go
@@ -64,24 +64,24 @@ func (m *MeshServiceBuilder) WithDataplaneTagsSelectorKV(selectorKV ...string) *
 	return m.WithDataplaneTagsSelector(TagsKVToMap(selectorKV))
 }
 
-func (m *MeshServiceBuilder) AddIntPort(port, target uint32, protocol core_mesh.Protocol) *MeshServiceBuilder {
+func (m *MeshServiceBuilder) AddIntPort(port, target int32, protocol core_mesh.Protocol) *MeshServiceBuilder {
 	m.res.Spec.Ports = append(m.res.Spec.Ports, v1alpha1.Port{
 		Port: port,
 		TargetPort: intstr.IntOrString{
 			Type:   intstr.Int,
-			IntVal: int32(target),
+			IntVal: target,
 		},
 		AppProtocol: protocol,
 	})
 	return m
 }
 
-func (m *MeshServiceBuilder) AddIntPortWithName(port, target uint32, protocol core_mesh.Protocol, name string) *MeshServiceBuilder {
+func (m *MeshServiceBuilder) AddIntPortWithName(port, target int32, protocol core_mesh.Protocol, name string) *MeshServiceBuilder {
 	m.res.Spec.Ports = append(m.res.Spec.Ports, v1alpha1.Port{
 		Port: port,
 		TargetPort: intstr.IntOrString{
 			Type:   intstr.Int,
-			IntVal: int32(target),
+			IntVal: target,
 		},
 		AppProtocol: protocol,
 		Name:        name,

--- a/pkg/test/resources/samples/meshmultizoneservice_samples.go
+++ b/pkg/test/resources/samples/meshmultizoneservice_samples.go
@@ -11,7 +11,7 @@ func MeshMultiZoneServiceBackendBuilder() *builders.MeshMultiZoneServiceBuilder 
 		WithServiceLabelSelector(map[string]string{
 			mesh_proto.DisplayName: "backend",
 		}).
-		AddIntPort(builders.FirstInboundPort, "http")
+		AddIntPort(int32(builders.FirstInboundPort), "http")
 }
 
 func MeshMultiZoneServiceBackend() *meshmzservice_api.MeshMultiZoneServiceResource {

--- a/pkg/test/resources/samples/meshservice_samples.go
+++ b/pkg/test/resources/samples/meshservice_samples.go
@@ -16,7 +16,7 @@ func MeshServiceBackendBuilder() *builders.MeshServiceBuilder {
 			mesh_proto.ServiceTag: "backend",
 		}).
 		WithKumaVIP("240.0.0.1").
-		AddIntPort(builders.FirstInboundPort, builders.FirstInboundPort, "http")
+		AddIntPort(int32(builders.FirstInboundPort), int32(builders.FirstInboundPort), "http")
 }
 
 func MeshServiceBackend() *v1alpha1.MeshServiceResource {
@@ -30,7 +30,7 @@ func MeshServiceWebBuilder() *builders.MeshServiceBuilder {
 			mesh_proto.ServiceTag: "web",
 		}).
 		WithKumaVIP("240.0.0.2").
-		AddIntPort(builders.FirstInboundPort, builders.FirstInboundPort, "http")
+		AddIntPort(int32(builders.FirstInboundPort), int32(builders.FirstInboundPort), "http")
 }
 
 func MeshServiceWeb() *v1alpha1.MeshServiceResource {

--- a/pkg/xds/context/context.go
+++ b/pkg/xds/context/context.go
@@ -163,7 +163,7 @@ func (mc *MeshContext) GetReachableBackends(dataplane *core_mesh.DataplaneResour
 		if len(reachableBackend.Labels) > 0 {
 			for _, tri := range mc.resolveResourceIdentifiersForLabels(reachableBackend.Kind, reachableBackend.Labels) {
 				if port := reachableBackend.Port; port != nil {
-					tri.SectionName = mc.getSectionName(tri.ResourceType, tri, reachableBackend.Port.GetValue())
+					tri.SectionName = mc.getSectionName(tri.ResourceType, tri, int32(reachableBackend.Port.GetValue()))
 				}
 				out[tri] = true
 			}
@@ -174,7 +174,7 @@ func (mc *MeshContext) GetReachableBackends(dataplane *core_mesh.DataplaneResour
 				Namespace: &reachableBackend.Namespace,
 			})
 			if port := reachableBackend.Port; port != nil {
-				key.SectionName = mc.getSectionName(key.ResourceType, key, reachableBackend.Port.GetValue())
+				key.SectionName = mc.getSectionName(key.ResourceType, key, int32(reachableBackend.Port.GetValue()))
 			}
 			out[key] = true
 		}
@@ -193,7 +193,7 @@ func (mc *MeshContext) resolveResourceIdentifiersForLabels(kind string, labels m
 	return result
 }
 
-func (mc *MeshContext) getSectionName(kind core_model.ResourceType, key kri.Identifier, port uint32) string {
+func (mc *MeshContext) getSectionName(kind core_model.ResourceType, key kri.Identifier, port int32) string {
 	switch kind {
 	case meshservice_api.MeshServiceType:
 		ms := mc.GetMeshServiceByKRI(key)

--- a/pkg/xds/envoy/tls/sni.go
+++ b/pkg/xds/envoy/tls/sni.go
@@ -47,7 +47,7 @@ const (
 	dnsLabelLimit    = 63
 )
 
-func SNIForResource(resName string, meshName string, resType model.ResourceType, port uint32, additionalData map[string]string) string {
+func SNIForResource(resName string, meshName string, resType model.ResourceType, port int32, additionalData map[string]string) string {
 	var mapStrings []string
 	for _, key := range maps.SortedKeys(additionalData) {
 		mapStrings = append(mapStrings, fmt.Sprintf("%s=%s", key, additionalData[key]))

--- a/pkg/xds/envoy/tls/sni_test.go
+++ b/pkg/xds/envoy/tls/sni_test.go
@@ -98,7 +98,7 @@ var _ = Describe("SNI", func() {
 		resName        string
 		meshName       string
 		resType        model.ResourceType
-		port           uint32
+		port           int32
 		additionalData map[string]string
 		expected       string
 	}

--- a/pkg/xds/generator/zoneproxy/destinations.go
+++ b/pkg/xds/generator/zoneproxy/destinations.go
@@ -83,7 +83,7 @@ func buildMeshServiceDestinations(
 	return msDestinations
 }
 
-func resourceToBackendRef(r core_model.Resource, resType core_model.ResourceType, port uint32) common_api.BackendRef {
+func resourceToBackendRef(r core_model.Resource, resType core_model.ResourceType, port int32) common_api.BackendRef {
 	id := kri.From(r, "")
 	return common_api.BackendRef{
 		TargetRef: common_api.TargetRef{
@@ -91,7 +91,7 @@ func resourceToBackendRef(r core_model.Resource, resType core_model.ResourceType
 			Name:      pointer.To(id.Name),
 			Namespace: pointer.To(id.Namespace),
 		},
-		Port: pointer.To(port),
+		Port: pointer.To(uint32(port)),
 	}
 }
 
@@ -105,16 +105,16 @@ func buildMeshExternalServiceDestinations(
 			core_model.GetDisplayName(mes.GetMeta()),
 			mes.GetMeta().GetMesh(),
 			meshexternalservice_api.MeshExternalServiceType,
-			uint32(mes.Spec.Match.Port),
+			mes.Spec.Match.Port,
 			nil,
 		)
 		mesDestinations = append(mesDestinations, BackendRefDestination{
 			Mesh:            mes.GetMeta().GetMesh(),
-			DestinationName: mes.DestinationName(uint32(mes.Spec.Match.Port)),
+			DestinationName: mes.DestinationName(mes.Spec.Match.Port),
 			SNI:             sni,
 			Resource: resolve.BackendRefOrNil(
 				mes.Meta,
-				resourceToBackendRef(mes, meshexternalservice_api.MeshExternalServiceType, uint32(mes.Spec.Match.Port)),
+				resourceToBackendRef(mes, meshexternalservice_api.MeshExternalServiceType, mes.Spec.Match.Port),
 				resolveResourceIdentifier,
 			),
 		})

--- a/pkg/xds/topology/outbound.go
+++ b/pkg/xds/topology/outbound.go
@@ -672,7 +672,7 @@ func createMeshExternalServiceEndpoint(
 			Tags:            tags,
 			Locality:        GetLocality(zone, getZone(tags), mesh.LocalityAwareLbEnabled()),
 		}
-		outbounds[mes.DestinationName(uint32(mes.Spec.Match.Port))] = append(outbounds[mes.DestinationName(uint32(mes.Spec.Match.Port))], *outboundEndpoint)
+		outbounds[mes.DestinationName(mes.Spec.Match.Port)] = append(outbounds[mes.DestinationName(int32(mes.Spec.Match.Port))], *outboundEndpoint)
 	}
 	return nil
 }
@@ -801,7 +801,7 @@ func fillExternalServicesOutboundsThroughEgress(
 	for _, mes := range meshExternalServices {
 		// deep copy map to not modify tags in ExternalService.
 		serviceTags := maps.Clone(mes.Meta.GetLabels())
-		serviceName := mes.DestinationName(uint32(mes.Spec.Match.Port))
+		serviceName := mes.DestinationName(mes.Spec.Match.Port)
 		locality := GetLocality(localZone, getZone(serviceTags), mesh.LocalityAwareLbEnabled())
 		tls := mes.Spec.Tls
 		es := &core_xds.ExternalService{

--- a/pkg/xds/topology/outbound.go
+++ b/pkg/xds/topology/outbound.go
@@ -672,7 +672,7 @@ func createMeshExternalServiceEndpoint(
 			Tags:            tags,
 			Locality:        GetLocality(zone, getZone(tags), mesh.LocalityAwareLbEnabled()),
 		}
-		outbounds[mes.DestinationName(mes.Spec.Match.Port)] = append(outbounds[mes.DestinationName(int32(mes.Spec.Match.Port))], *outboundEndpoint)
+		outbounds[mes.DestinationName(mes.Spec.Match.Port)] = append(outbounds[mes.DestinationName(mes.Spec.Match.Port)], *outboundEndpoint)
 	}
 	return nil
 }

--- a/pkg/xds/topology/outbound_test.go
+++ b/pkg/xds/topology/outbound_test.go
@@ -1334,7 +1334,7 @@ var _ = Describe("TrafficRoute", func() {
 							Endpoints: &[]meshexternalservice_api.Endpoint{
 								{
 									Address: "example.com",
-									Port:    meshexternalservice_api.Port(443),
+									Port:    443,
 								},
 							},
 							Tls: &meshexternalservice_api.Tls{
@@ -1387,7 +1387,7 @@ var _ = Describe("TrafficRoute", func() {
 							Endpoints: &[]meshexternalservice_api.Endpoint{
 								{
 									Address: "example.com",
-									Port:    meshexternalservice_api.Port(443),
+									Port:    443,
 								},
 							},
 							Tls: &meshexternalservice_api.Tls{
@@ -1503,7 +1503,7 @@ var _ = Describe("TrafficRoute", func() {
 							Endpoints: &[]meshexternalservice_api.Endpoint{
 								{
 									Address: "example.com",
-									Port:    meshexternalservice_api.Port(443),
+									Port:    443,
 								},
 							},
 							Tls: &meshexternalservice_api.Tls{
@@ -1687,7 +1687,7 @@ var _ = Describe("TrafficRoute", func() {
 								Endpoints: &[]meshexternalservice_api.Endpoint{
 									{
 										Address: "192.168.1.1",
-										Port:    meshexternalservice_api.Port(10000),
+										Port:    10000,
 									},
 								},
 							},
@@ -1756,7 +1756,7 @@ var _ = Describe("TrafficRoute", func() {
 								Endpoints: &[]meshexternalservice_api.Endpoint{
 									{
 										Address: "192.168.1.1",
-										Port:    meshexternalservice_api.Port(10000),
+										Port:    10000,
 									},
 								},
 							},
@@ -1772,7 +1772,7 @@ var _ = Describe("TrafficRoute", func() {
 								Endpoints: &[]meshexternalservice_api.Endpoint{
 									{
 										Address: "192.168.1.1",
-										Port:    meshexternalservice_api.Port(10000),
+										Port:    10000,
 									},
 								},
 								Tls: &meshexternalservice_api.Tls{

--- a/test/e2e_env/universal/meshexternalservice/meshexternalservice.go
+++ b/test/e2e_env/universal/meshexternalservice/meshexternalservice.go
@@ -44,7 +44,7 @@ networking:
 `, meshName))
 	}
 
-	meshExternalService := func(service, host, meshName string, port int, tls bool, caCert []byte) *meshexternalservice_api.MeshExternalServiceResource {
+	meshExternalService := func(service, host, meshName string, port int32, tls bool, caCert []byte) *meshexternalservice_api.MeshExternalServiceResource {
 		mes := &meshexternalservice_api.MeshExternalServiceResource{
 			Meta: &test_model.ResourceMeta{
 				Mesh: meshName,
@@ -61,7 +61,7 @@ networking:
 				},
 				Endpoints: &[]meshexternalservice_api.Endpoint{{
 					Address: host,
-					Port:    meshexternalservice_api.Port(port),
+					Port:    port,
 				}},
 			},
 			Status: &meshexternalservice_api.MeshExternalServiceStatus{},


### PR DESCRIPTION
## Motivation

We should always use `int32` or `int64` type for integer values: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#primitive-types

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
