### PR TITLE
chore(ci): bump pr-comments timeout because its timing out on golden files

### DIFF
--- a/.github/workflows/pr-comments.yaml
+++ b/.github/workflows/pr-comments.yaml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 jobs:
   pr_comments:
-    timeout-minutes: 30
+    timeout-minutes: 45
     if: github.event.issue.pull_request != '' && (contains(github.event.comment.body, '/format') || contains(github.event.comment.body, '/golden_files'))
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
## Motivation

Not sure why it takes longer https://github.com/kumahq/kuma/actions/runs/15966690639/job/45028491974#step:10:2603 but it is timing out.

## Implementation information

Prolong timeout