### PR TITLE
ci(gha): remove tag pushing triggering behavior for docs updating

### DIFF
--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -7,7 +7,6 @@ on:
       - UPGRADE.md
       - docs/generated/raw/**
     branches: ["master"]
-    tags: ["*"]
   workflow_dispatch: {}
   schedule:
     - cron: 0 8 * * *


### PR DESCRIPTION
## Motivation

Before this PR, we could trigger docs updating by pushing a tag. Sometimes, this CI action might fail and make the release manager feel confused when releasing. So, we should separate this behavior and once all of the tag pushed actions succeed, then we can trigger this docs updating manually.


<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
