### PR TITLE
feat(kuma-cp): implement dataplane layout endpoint

### DIFF
--- a/api/openapi/specs/common/resource.yaml
+++ b/api/openapi/specs/common/resource.yaml
@@ -162,6 +162,7 @@ components:
           type: string
         port:
           type: integer
+          x-go-type: 'int32'
         protocol:
           type: string
     DataplaneOutbound:
@@ -172,6 +173,7 @@ components:
           type: string
         port:
           type: integer
+          x-go-type: 'int32'
         protocol:
           type: string
     PoliciesList:

--- a/api/openapi/types/common/zz_generated.resource.go
+++ b/api/openapi/types/common/zz_generated.resource.go
@@ -12,14 +12,14 @@ const (
 // DataplaneInbound defines model for DataplaneInbound.
 type DataplaneInbound struct {
 	Kri      string `json:"kri"`
-	Port     int    `json:"port"`
+	Port     int32  `json:"port"`
 	Protocol string `json:"protocol"`
 }
 
 // DataplaneOutbound defines model for DataplaneOutbound.
 type DataplaneOutbound struct {
 	Kri      string `json:"kri"`
-	Port     int    `json:"port"`
+	Port     int32  `json:"port"`
 	Protocol string `json:"protocol"`
 }
 

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -4291,6 +4291,7 @@ components:
           type: string
         port:
           type: integer
+          x-go-type: int32
         protocol:
           type: string
     DataplaneOutbound:
@@ -4304,6 +4305,7 @@ components:
           type: string
         port:
           type: integer
+          x-go-type: int32
         protocol:
           type: string
     PolicyOrigin:

--- a/pkg/api-server/dataplane_layout_endpoint.go
+++ b/pkg/api-server/dataplane_layout_endpoint.go
@@ -1,0 +1,186 @@
+package api_server
+
+import (
+	"context"
+	"net/http"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/emicklei/go-restful/v3"
+
+	"github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/api/openapi/types"
+	api_common "github.com/kumahq/kuma/api/openapi/types/common"
+	"github.com/kumahq/kuma/pkg/core/kri"
+	"github.com/kumahq/kuma/pkg/core/resources/access"
+	"github.com/kumahq/kuma/pkg/core/resources/apis/core"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/resources/manager"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/core/resources/store"
+	rest_errors "github.com/kumahq/kuma/pkg/core/rest/errors"
+	"github.com/kumahq/kuma/pkg/core/user"
+	util_slices "github.com/kumahq/kuma/pkg/util/slices"
+	xds_context "github.com/kumahq/kuma/pkg/xds/context"
+)
+
+type dataplaneLayoutEndpoint struct {
+	resManager         manager.ResourceManager
+	meshContextBuilder xds_context.MeshContextBuilder
+	resourceAccess     access.ResourceAccess
+}
+
+func newDataplaneLayoutEndpoint(resManager manager.ResourceManager, meshContextBuilder xds_context.MeshContextBuilder, resourceAccess access.ResourceAccess) *dataplaneLayoutEndpoint {
+	return &dataplaneLayoutEndpoint{
+		resManager:         resManager,
+		meshContextBuilder: meshContextBuilder,
+		resourceAccess:     resourceAccess,
+	}
+}
+
+func (dle *dataplaneLayoutEndpoint) addEndpoint(ws *restful.WebService) {
+	ws.Route(
+		ws.GET("/meshes/{mesh}/dataplanes/{name}/_layout").
+			To(dle.getLayout).
+			Doc("Get Dataplane Layout").
+			Returns(http.StatusOK, "OK", nil),
+	)
+}
+
+func (dle *dataplaneLayoutEndpoint) getLayout(request *restful.Request, response *restful.Response) {
+	meshName := request.PathParameter("mesh")
+	dataplaneName := request.PathParameter("name")
+
+	if err := dle.resourceAccess.ValidateGet(
+		request.Request.Context(),
+		core_model.ResourceKey{Mesh: meshName, Name: dataplaneName},
+		core_mesh.DataplaneResourceTypeDescriptor,
+		user.FromCtx(request.Request.Context()),
+	); err != nil {
+		rest_errors.HandleError(request.Request.Context(), response, err, "Access Denied")
+		return
+	}
+
+	mesh, err := dle.getMeshResource(request.Request.Context(), meshName)
+	if err != nil {
+		rest_errors.HandleError(request.Request.Context(), response, err, "Failed to retrieve Mesh")
+		return
+	}
+
+	if mesh.Spec.GetMeshServices().GetMode() == v1alpha1.Mesh_MeshServices_Disabled {
+		response.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	dataplane, err := dle.getDataplaneResource(request.Request.Context(), meshName, dataplaneName)
+	if err != nil {
+		rest_errors.HandleError(request.Request.Context(), response, err, "Failed to retrieve Dataplane")
+		return
+	}
+
+	baseMeshContext, err := dle.meshContextBuilder.BuildBaseMeshContextIfChanged(request.Request.Context(), meshName, nil)
+	if err != nil {
+		rest_errors.HandleError(request.Request.Context(), response, err, "Failed to build MeshContext")
+	}
+
+	inbounds := util_slices.Map(dataplane.Spec.GetNetworking().GetInbound(), func(inbound *v1alpha1.Dataplane_Networking_Inbound) api_common.DataplaneInbound {
+		sectionName := inbound.GetName()
+		if sectionName == "" {
+			sectionName = strconv.Itoa(int(inbound.GetPort()))
+		}
+
+		return api_common.DataplaneInbound{
+			Kri:      kri.From(dataplane, sectionName).String(),
+			Port:     int32(inbound.GetPort()),
+			Protocol: inbound.GetProtocol(),
+		}
+	})
+
+	var outbounds []api_common.DataplaneOutbound
+	if dataplane.Spec.GetNetworking().GetOutbound() != nil {
+		// TODO handle user defined outbounds on universal without transparent proxy
+	} else {
+		// handle reachable backend and outbounds when using transparent proxy
+		reachableBackends := baseMeshContext.DestinationIndex.GetReachableBackends(mesh, dataplane)
+		outbounds = dle.getOutbounds(baseMeshContext.DestinationIndex, reachableBackends)
+	}
+
+	slices.SortStableFunc(outbounds, func(a, b api_common.DataplaneOutbound) int {
+		return strings.Compare(a.Kri, b.Kri)
+	})
+
+	networkingLayout := types.DataplaneNetworkingLayout{
+		Inbounds:  inbounds,
+		Kri:       kri.From(dataplane, "").String(),
+		Labels:    dataplane.GetMeta().GetLabels(),
+		Outbounds: outbounds,
+	}
+
+	err = response.WriteHeaderAndJson(http.StatusOK, networkingLayout, "application/json")
+	if err != nil {
+		log.Error(err, "Could not write response")
+	}
+}
+
+func (dle *dataplaneLayoutEndpoint) getMeshResource(ctx context.Context, meshName string) (*core_mesh.MeshResource, error) {
+	meshResource := core_mesh.NewMeshResource()
+	err := dle.resManager.Get(ctx, meshResource, store.GetByKey(meshName, core_model.NoMesh))
+	if err != nil {
+		return nil, err
+	}
+	return meshResource, nil
+}
+
+func (dle *dataplaneLayoutEndpoint) getDataplaneResource(ctx context.Context, meshName string, dataplaneName string) (*core_mesh.DataplaneResource, error) {
+	dataplaneResource := core_mesh.NewDataplaneResource()
+	err := dle.resManager.Get(ctx, dataplaneResource, store.GetByKey(dataplaneName, meshName))
+	if err != nil {
+		return nil, err
+	}
+	return dataplaneResource, nil
+}
+
+func (dle *dataplaneLayoutEndpoint) getOutbounds(destinationContext *xds_context.DestinationIndex, reachableBackends *xds_context.ReachableBackends) []api_common.DataplaneOutbound {
+	var outbounds []api_common.DataplaneOutbound
+	if reachableBackends == nil {
+		for destinationKri, destination := range destinationContext.GetAllDestinations() {
+			outbounds = append(outbounds, expandDestination(destinationKri, destination)...)
+		}
+		return outbounds
+	}
+
+	for destinationKri := range *reachableBackends {
+		dest := destinationContext.GetDestinationByKri(destinationKri)
+		if dest == nil {
+			continue
+		}
+		if destinationKri.HasSectionName() {
+			port, ok := dest.FindPortByName(destinationKri.SectionName)
+			if !ok {
+				continue
+			}
+			outbounds = append(outbounds, api_common.DataplaneOutbound{
+				Kri:      destinationKri.String(),
+				Port:     port.GetValue(),
+				Protocol: string(port.GetProtocol()),
+			})
+		} else {
+			outbounds = append(outbounds, expandDestination(destinationKri, dest)...)
+		}
+	}
+
+	return outbounds
+}
+
+func expandDestination(destinationKri kri.Identifier, dest core.Destination) []api_common.DataplaneOutbound {
+	var outbounds []api_common.DataplaneOutbound
+	for _, port := range dest.GetPorts() {
+		outbounds = append(outbounds, api_common.DataplaneOutbound{
+			Kri:      kri.WithSectionNameFromPort(destinationKri, port.GetName()).String(),
+			Port:     port.GetValue(),
+			Protocol: string(port.GetProtocol()),
+		})
+	}
+	return outbounds
+}

--- a/pkg/api-server/endpoints_table_test.go
+++ b/pkg/api-server/endpoints_table_test.go
@@ -45,6 +45,10 @@ var _ = Describe("Endpoints", func() {
 		apiTest(inputFile, apiServer, resourceStore)
 	}, test.EntriesForFolder("resources/inspect/meshgateways/_rules"))
 
+	DescribeTable("inspect dataplane layout /meshes/{mesh}/dataplanes/{dpName}/_layout", func(inputFile string) {
+		apiTest(inputFile, apiServer, resourceStore)
+	}, test.EntriesForFolder("resources/inspect/dataplanes/_layout"))
+
 	DescribeTable("resources CRUD", func(inputFile string) {
 		apiTest(inputFile, apiServer, resourceStore)
 	}, test.EntriesForFolder("resources/crud"))

--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -268,6 +268,8 @@ func addResourcesEndpoints(
 	}
 	globalInsightEndpoint.addEndpoint(ws)
 
+	newDataplaneLayoutEndpoint(resManager, meshContextBuilder, resourceAccess).addEndpoint(ws)
+
 	var k8sMapper k8s.ResourceMapperFunc
 	var k8sSecretMapper k8s.ResourceMapperFunc
 	switch cfg.Store.Type {

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/empty_reachable_backend.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/empty_reachable_backend.golden.json
@@ -1,0 +1,19 @@
+{
+ "inbounds": [
+  {
+   "kri": "kri_dp_default_test-zone__dp-1_main-port",
+   "port": 8080,
+   "protocol": "http"
+  },
+  {
+   "kri": "kri_dp_default_test-zone__dp-1_secondary-port",
+   "port": 8081,
+   "protocol": "tcp"
+  }
+ ],
+ "kri": "kri_dp_default_test-zone__dp-1_",
+ "labels": {
+  "kuma.io/zone": "test-zone"
+ },
+ "outbounds": null
+}

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/empty_reachable_backend.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/empty_reachable_backend.input.yaml
@@ -1,0 +1,29 @@
+#/meshes/default/dataplanes/dp-1/_layout 200
+type: Mesh
+name: default
+meshServices:
+  mode: Exclusive
+---
+type: Dataplane
+name: dp-1
+mesh: default
+labels:
+  kuma.io/zone: test-zone
+networking:
+  address: 127.0.0.1
+  inbound:
+    - port: 8080
+      name: main-port
+      tags:
+        kuma.io/service: foo
+        kuma.io/protocol: http
+    - port: 8081
+      name: secondary-port
+      tags:
+        kuma.io/service: foo
+        kuma.io/protocol: tcp
+  transparentProxying:
+    redirectPortInbound: 15006
+    redirectPortOutbound: 15001
+    reachableBackends:
+      refs: []

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/meshservice_disabled.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/meshservice_disabled.input.yaml
@@ -1,0 +1,13 @@
+#/meshes/default/dataplanes/dp-1/_layout 400
+type: Mesh
+name: default
+---
+type: Dataplane
+name: dp-1
+mesh: default
+networking:
+  address: 127.0.0.1
+  inbound:
+    - port: 8080
+      tags:
+        kuma.io/service: foo

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/missing_reachable_backend.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/missing_reachable_backend.golden.json
@@ -1,0 +1,19 @@
+{
+ "inbounds": [
+  {
+   "kri": "kri_dp_default_test-zone__dp-1_main-port",
+   "port": 8080,
+   "protocol": "http"
+  },
+  {
+   "kri": "kri_dp_default_test-zone__dp-1_secondary-port",
+   "port": 8081,
+   "protocol": "tcp"
+  }
+ ],
+ "kri": "kri_dp_default_test-zone__dp-1_",
+ "labels": {
+  "kuma.io/zone": "test-zone"
+ },
+ "outbounds": null
+}

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/missing_reachable_backend.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/missing_reachable_backend.input.yaml
@@ -1,0 +1,34 @@
+#/meshes/default/dataplanes/dp-1/_layout 200
+type: Mesh
+name: default
+meshServices:
+  mode: Exclusive
+---
+type: Dataplane
+name: dp-1
+mesh: default
+labels:
+  kuma.io/zone: test-zone
+networking:
+  address: 127.0.0.1
+  inbound:
+    - port: 8080
+      name: main-port
+      tags:
+        kuma.io/service: foo
+        kuma.io/protocol: http
+    - port: 8081
+      name: secondary-port
+      tags:
+        kuma.io/service: foo
+        kuma.io/protocol: tcp
+  transparentProxying:
+    redirectPortInbound: 15006
+    redirectPortOutbound: 15001
+    reachableBackends:
+      refs:
+        - kind: MeshService
+          name: test-server-1
+          port: 80
+        - kind: MeshService
+          name: test-server-2

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/multiple_mixed_destinations.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/multiple_mixed_destinations.golden.json
@@ -1,0 +1,40 @@
+{
+ "inbounds": [
+  {
+   "kri": "kri_dp_default_test-zone__dp-1_main-port",
+   "port": 8080,
+   "protocol": "http"
+  },
+  {
+   "kri": "kri_dp_default_test-zone__dp-1_secondary-port",
+   "port": 8081,
+   "protocol": "tcp"
+  }
+ ],
+ "kri": "kri_dp_default_test-zone__dp-1_",
+ "labels": {
+  "kuma.io/zone": "test-zone"
+ },
+ "outbounds": [
+  {
+   "kri": "kri_extsvc_default___mes-1_9090",
+   "port": 9090,
+   "protocol": "http"
+  },
+  {
+   "kri": "kri_msvc_default_test-zone__test-server-1_main-port",
+   "port": 80,
+   "protocol": "http"
+  },
+  {
+   "kri": "kri_msvc_default_test-zone__test-server-1_secondary-port",
+   "port": 8080,
+   "protocol": "tcp"
+  },
+  {
+   "kri": "kri_mzsvc_default___multizone-test-server_80",
+   "port": 80,
+   "protocol": "http"
+  }
+ ]
+}

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/multiple_mixed_destinations.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/multiple_mixed_destinations.input.yaml
@@ -1,0 +1,68 @@
+#/meshes/default/dataplanes/dp-1/_layout 200
+type: Mesh
+name: default
+meshServices:
+  mode: Exclusive
+---
+type: Dataplane
+name: dp-1
+mesh: default
+labels:
+  kuma.io/zone: test-zone
+networking:
+  address: 127.0.0.1
+  inbound:
+    - port: 8080
+      name: main-port
+      tags:
+        kuma.io/service: foo
+        kuma.io/protocol: http
+    - port: 8081
+      name: secondary-port
+      tags:
+        kuma.io/service: foo
+        kuma.io/protocol: tcp
+---
+type: MeshService
+name: test-server-1
+mesh: default
+labels:
+  kuma.io/display-name: test-server-1
+  kuma.io/zone: test-zone
+spec:
+  selector:
+    dataplaneTags:
+      kuma.io/service: test-server
+  ports:
+    - port: 80
+      targetPort: 80
+      appProtocol: http
+      name: main-port
+    - port: 8080
+      targetPort: 8080
+      appProtocol: tcp
+      name: secondary-port
+---
+type: MeshMultiZoneService
+name: multizone-test-server
+mesh: default
+spec:
+  selector:
+    meshService:
+      matchLabels:
+        kuma.io/display-name: test-server
+  ports:
+    - port: 80
+      appProtocol: http
+---
+type: MeshExternalService
+name: mes-1
+mesh: default
+spec:
+  match:
+    type: HostnameGenerator
+    port: 9090
+    protocol: http
+  endpoints:
+    - address: 127.0.0.1
+      port: 8080

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/multiple_ms_destinations.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/multiple_ms_destinations.golden.json
@@ -1,0 +1,35 @@
+{
+ "inbounds": [
+  {
+   "kri": "kri_dp_default_test-zone__dp-1_main-port",
+   "port": 8080,
+   "protocol": "http"
+  },
+  {
+   "kri": "kri_dp_default_test-zone__dp-1_secondary-port",
+   "port": 8081,
+   "protocol": "tcp"
+  }
+ ],
+ "kri": "kri_dp_default_test-zone__dp-1_",
+ "labels": {
+  "kuma.io/zone": "test-zone"
+ },
+ "outbounds": [
+  {
+   "kri": "kri_msvc_default_test-zone__test-server-1_main-port",
+   "port": 80,
+   "protocol": "http"
+  },
+  {
+   "kri": "kri_msvc_default_test-zone__test-server-2_main-port",
+   "port": 80,
+   "protocol": "http"
+  },
+  {
+   "kri": "kri_msvc_default_test-zone__test-server-3_main-port",
+   "port": 80,
+   "protocol": "http"
+  }
+ ]
+}

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/multiple_ms_destinations.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/multiple_ms_destinations.input.yaml
@@ -1,0 +1,72 @@
+#/meshes/default/dataplanes/dp-1/_layout 200
+type: Mesh
+name: default
+meshServices:
+  mode: Exclusive
+---
+type: Dataplane
+name: dp-1
+mesh: default
+labels:
+  kuma.io/zone: test-zone
+networking:
+  address: 127.0.0.1
+  inbound:
+    - port: 8080
+      name: main-port
+      tags:
+        kuma.io/service: foo
+        kuma.io/protocol: http
+    - port: 8081
+      name: secondary-port
+      tags:
+        kuma.io/service: foo
+        kuma.io/protocol: tcp
+---
+type: MeshService
+name: test-server-1
+mesh: default
+labels:
+  kuma.io/display-name: test-server-1
+  kuma.io/zone: test-zone
+spec:
+  selector:
+    dataplaneTags:
+      kuma.io/service: test-server
+  ports:
+    - port: 80
+      targetPort: 80
+      appProtocol: http
+      name: main-port
+---
+type: MeshService
+name: test-server-2
+mesh: default
+labels:
+  kuma.io/display-name: test-server-2
+  kuma.io/zone: test-zone
+spec:
+  selector:
+    dataplaneTags:
+      kuma.io/service: test-server
+  ports:
+    - port: 80
+      targetPort: 80
+      appProtocol: http
+      name: main-port
+---
+type: MeshService
+name: test-server-3
+mesh: default
+labels:
+  kuma.io/display-name: test-server-3
+  kuma.io/zone: test-zone
+spec:
+  selector:
+    dataplaneTags:
+      kuma.io/service: test-server
+  ports:
+    - port: 80
+      targetPort: 80
+      appProtocol: http
+      name: main-port

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/multiple_ms_destinations_reachable_backend.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/multiple_ms_destinations_reachable_backend.golden.json
@@ -1,0 +1,35 @@
+{
+ "inbounds": [
+  {
+   "kri": "kri_dp_default_test-zone__dp-1_main-port",
+   "port": 8080,
+   "protocol": "http"
+  },
+  {
+   "kri": "kri_dp_default_test-zone__dp-1_secondary-port",
+   "port": 8081,
+   "protocol": "tcp"
+  }
+ ],
+ "kri": "kri_dp_default_test-zone__dp-1_",
+ "labels": {
+  "kuma.io/zone": "test-zone"
+ },
+ "outbounds": [
+  {
+   "kri": "kri_msvc_default_test-zone__test-server-1_main-port",
+   "port": 80,
+   "protocol": "http"
+  },
+  {
+   "kri": "kri_msvc_default_test-zone__test-server-2_main-port",
+   "port": 80,
+   "protocol": "http"
+  },
+  {
+   "kri": "kri_msvc_default_test-zone__test-server-2_secondary-port",
+   "port": 8080,
+   "protocol": "http"
+  }
+ ]
+}

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/multiple_ms_destinations_reachable_backend.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/multiple_ms_destinations_reachable_backend.input.yaml
@@ -1,0 +1,90 @@
+#/meshes/default/dataplanes/dp-1/_layout 200
+type: Mesh
+name: default
+meshServices:
+  mode: Exclusive
+---
+type: Dataplane
+name: dp-1
+mesh: default
+labels:
+  kuma.io/zone: test-zone
+networking:
+  address: 127.0.0.1
+  inbound:
+    - port: 8080
+      name: main-port
+      tags:
+        kuma.io/service: foo
+        kuma.io/protocol: http
+    - port: 8081
+      name: secondary-port
+      tags:
+        kuma.io/service: foo
+        kuma.io/protocol: tcp
+  transparentProxying:
+    redirectPortInbound: 15006
+    redirectPortOutbound: 15001
+    reachableBackends:
+      refs:
+        - kind: MeshService
+          name: test-server-1
+          port: 80
+        - kind: MeshService
+          name: test-server-2
+---
+type: MeshService
+name: test-server-1
+mesh: default
+labels:
+  kuma.io/display-name: test-server-1
+  kuma.io/zone: test-zone
+spec:
+  selector:
+    dataplaneTags:
+      kuma.io/service: test-server
+  ports:
+    - port: 80
+      targetPort: 80
+      appProtocol: http
+      name: main-port
+    - port: 8080
+      targetPort: 8080
+      appProtocol: tcp
+      name: secondary-port
+---
+type: MeshService
+name: test-server-2
+mesh: default
+labels:
+  kuma.io/display-name: test-server-2
+  kuma.io/zone: test-zone
+spec:
+  selector:
+    dataplaneTags:
+      kuma.io/service: test-server
+  ports:
+    - port: 80
+      targetPort: 80
+      appProtocol: http
+      name: main-port
+    - port: 8080
+      targetPort: 8080
+      appProtocol: http
+      name: secondary-port
+---
+type: MeshService
+name: test-server-3
+mesh: default
+labels:
+  kuma.io/display-name: test-server-3
+  kuma.io/zone: test-zone
+spec:
+  selector:
+    dataplaneTags:
+      kuma.io/service: test-server
+  ports:
+    - port: 80
+      targetPort: 80
+      appProtocol: http
+      name: main-port

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/single_dp.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/single_dp.golden.json
@@ -1,0 +1,19 @@
+{
+ "inbounds": [
+  {
+   "kri": "kri_dp_default_test-zone__dp-1_main-port",
+   "port": 8080,
+   "protocol": "http"
+  },
+  {
+   "kri": "kri_dp_default_test-zone__dp-1_secondary-port",
+   "port": 8081,
+   "protocol": "tcp"
+  }
+ ],
+ "kri": "kri_dp_default_test-zone__dp-1_",
+ "labels": {
+  "kuma.io/zone": "test-zone"
+ },
+ "outbounds": null
+}

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/single_dp.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/single_dp.input.yaml
@@ -1,0 +1,24 @@
+#/meshes/default/dataplanes/dp-1/_layout 200
+type: Mesh
+name: default
+meshServices:
+  mode: Exclusive
+---
+type: Dataplane
+name: dp-1
+mesh: default
+labels:
+  kuma.io/zone: test-zone
+networking:
+  address: 127.0.0.1
+  inbound:
+    - port: 8080
+      name: main-port
+      tags:
+        kuma.io/service: foo
+        kuma.io/protocol: http
+    - port: 8081
+      name: secondary-port
+      tags:
+        kuma.io/service: foo
+        kuma.io/protocol: tcp

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/single_ms_destination.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/single_ms_destination.golden.json
@@ -1,0 +1,25 @@
+{
+ "inbounds": [
+  {
+   "kri": "kri_dp_default_test-zone__dp-1_main-port",
+   "port": 8080,
+   "protocol": "http"
+  },
+  {
+   "kri": "kri_dp_default_test-zone__dp-1_secondary-port",
+   "port": 8081,
+   "protocol": "tcp"
+  }
+ ],
+ "kri": "kri_dp_default_test-zone__dp-1_",
+ "labels": {
+  "kuma.io/zone": "test-zone"
+ },
+ "outbounds": [
+  {
+   "kri": "kri_msvc_default_test-zone__test-server_main-port",
+   "port": 80,
+   "protocol": "http"
+  }
+ ]
+}

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/single_ms_destination.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/single_ms_destination.input.yaml
@@ -1,0 +1,40 @@
+#/meshes/default/dataplanes/dp-1/_layout 200
+type: Mesh
+name: default
+meshServices:
+  mode: Exclusive
+---
+type: Dataplane
+name: dp-1
+mesh: default
+labels:
+  kuma.io/zone: test-zone
+networking:
+  address: 127.0.0.1
+  inbound:
+    - port: 8080
+      name: main-port
+      tags:
+        kuma.io/service: foo
+        kuma.io/protocol: http
+    - port: 8081
+      name: secondary-port
+      tags:
+        kuma.io/service: foo
+        kuma.io/protocol: tcp
+---
+type: MeshService
+name: test-server-syncedhash
+mesh: default
+labels:
+  kuma.io/display-name: test-server
+  kuma.io/zone: test-zone
+spec:
+  selector:
+    dataplaneTags:
+      kuma.io/service: test-server
+  ports:
+    - port: 80
+      targetPort: 80
+      appProtocol: http
+      name: main-port

--- a/pkg/core/kri/kri.go
+++ b/pkg/core/kri/kri.go
@@ -100,3 +100,13 @@ func IsValid(s string) bool {
 func Compare(a, b Identifier) int {
 	return strings.Compare(a.String(), b.String())
 }
+
+func (i Identifier) HasSectionName() bool {
+	return i.SectionName != ""
+}
+
+func WithSectionNameFromPort(id Identifier, sectionName string) Identifier {
+	idCopy := id
+	idCopy.SectionName = sectionName
+	return idCopy
+}


### PR DESCRIPTION
## Motivation

Implementing new `_layout` endpoint as described in MADR: https://docs.google.com/document/d/1EzZpk3wwneIxQNPK7WXJqhW3Y3CS1AWMXIcXix9LEoc/edit?tab=t.g7ooo2ntj4jj

Fix https://github.com/kumahq/kuma/issues/13753

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
