### PR TITLE
chore(deps): bump golang from 1.24.4 to 1.24.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kumahq/kuma
 
-go 1.24.4
+go 1.24.5
 
 require (
 	cirello.io/pglock v1.16.1


### PR DESCRIPTION
## Motivation

upgrade golang from `1.24.4` to `1.24.5`

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
