### PR TITLE
ci(gha/pr-comments): split transparent proxy golden file updates

### DIFF
--- a/.github/workflows/pr-comments.yaml
+++ b/.github/workflows/pr-comments.yaml
@@ -56,15 +56,22 @@ jobs:
             ${{ runner.os }}-${{ runner.arch }}-devtools
       - run: |
           make dev/tools
-      - name: format
-        if: contains(github.event.comment.body, '/format') # check the comment if it contains the keywords
-        run: |
-          make clean/generated check
-      - name: run golden_files
-        if: contains(github.event.comment.body, '/golden_files') # check the comment if it contains the keywords
-        run: |
-          make test UPDATE_GOLDEN_FILES=true
-          make test/transparentproxy UPDATE_GOLDEN_FILES=true
+
+      # Automatically update code formatting if /format is in the comment
+      - name: "Auto-format code"
+        if: contains(github.event.comment.body, '/format')
+        run: make clean/generated check
+
+      # Update all golden files except transparent proxy tests if /golden_files is in the comment
+      - name: "Update golden files (excluding transparent proxy)"
+        if: contains(github.event.comment.body, '/golden_files')
+        run: make test UPDATE_GOLDEN_FILES=true
+
+      # Update only transparent proxy golden files if /golden_files_tproxy is in the comment
+      - name: "Update transparent proxy golden files"
+        if: contains(github.event.comment.body, '/golden_files_tproxy')
+        run: make test/transparentproxy UPDATE_GOLDEN_FILES=true
+
       - name: commit and push fixes
         env:
           GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}


### PR DESCRIPTION
## Motivation

Updating transparent proxy golden files can take over 30 minutes, which often causes the GitHub Action to hit the 45-minute timeout. These files rarely change and are usually updated manually during larger reworks. Including them in the regular `/golden_files` command makes it inconvenient and slow when only normal golden files need to be updated.

## Implementation information

The `/golden_files` comment now updates all golden files except transparent proxy tests. A new `/golden_files_tproxy` comment was added to update only the transparent proxy golden files. This split makes the action faster and avoids unnecessary long runs during routine updates.

## Supporting documentation

Example of timing out workflow: https://github.com/kumahq/kuma/actions/runs/16110511865/job/45458764328