### PR TITLE
feat(kuma-cp): rename envoy admin system resource to follow unified naming format

### DIFF
--- a/app/kuma-dp/pkg/dataplane/metrics/profiles.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/profiles.go
@@ -167,6 +167,10 @@ var basicProfile = []selectorFunction{
 var basicProfileLabels = []selectorFunction{
 	selectorToFilterFunction(v1alpha1.Selector{
 		Type:  v1alpha1.PrefixSelectorType,
+		Match: names.SystemPrefix,
+	}),
+	selectorToFilterFunction(v1alpha1.Selector{
+		Type:  v1alpha1.PrefixSelectorType,
 		Match: names.GetInternalClusterNamePrefix(),
 	}),
 	selectorToFilterFunction(v1alpha1.Selector{

--- a/app/kuma-dp/pkg/dataplane/metrics/profiles.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/profiles.go
@@ -7,6 +7,7 @@ import (
 
 	io_prometheus_client "github.com/prometheus/client_model/go"
 
+	"github.com/kumahq/kuma/pkg/core/system_names"
 	"github.com/kumahq/kuma/pkg/plugins/policies/meshmetric/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/xds/envoy/names"
 )
@@ -167,7 +168,7 @@ var basicProfile = []selectorFunction{
 var basicProfileLabels = []selectorFunction{
 	selectorToFilterFunction(v1alpha1.Selector{
 		Type:  v1alpha1.PrefixSelectorType,
-		Match: names.SystemPrefix,
+		Match: system_names.SystemPrefix,
 	}),
 	selectorToFilterFunction(v1alpha1.Selector{
 		Type:  v1alpha1.PrefixSelectorType,

--- a/pkg/core/system_names/system_names.go
+++ b/pkg/core/system_names/system_names.go
@@ -1,0 +1,15 @@
+package system_names
+
+import (
+	"strings"
+)
+
+const SystemPrefix = "system_"
+
+func IsSystem(name string) bool {
+	return strings.HasPrefix(SystemPrefix, name)
+}
+
+func AsSystemName(name string) string {
+	return SystemPrefix + name
+}

--- a/pkg/hds/tracker/callbacks.go
+++ b/pkg/hds/tracker/callbacks.go
@@ -175,7 +175,7 @@ func (t *tracker) OnEndpointHealthResponse(streamID xds.StreamID, resp *envoy_se
 		status := clusterHealth.LocalityEndpointsHealth[0].EndpointsHealth[0].HealthStatus
 		health := status == envoy_core.HealthStatus_HEALTHY || status == envoy_core.HealthStatus_UNKNOWN
 
-		if clusterHealth.ClusterName == names.GetEnvoyAdminClusterName() {
+		if clusterHealth.ClusterName == names.GetEnvoyAdminClusterName() || clusterHealth.ClusterName == names.SystemGetAdminResourceName() {
 			envoyHealth = health
 		} else {
 			port, err := names.GetPortForLocalClusterName(clusterHealth.ClusterName)

--- a/pkg/hds/tracker/callbacks.go
+++ b/pkg/hds/tracker/callbacks.go
@@ -25,7 +25,7 @@ import (
 	"github.com/kumahq/kuma/pkg/util/watchdog"
 	util_xds_v3 "github.com/kumahq/kuma/pkg/util/xds/v3"
 	"github.com/kumahq/kuma/pkg/xds/envoy/names"
-	"github.com/kumahq/kuma/pkg/xds/generator"
+	"github.com/kumahq/kuma/pkg/xds/generator/system_names"
 )
 
 type streams struct {
@@ -176,7 +176,8 @@ func (t *tracker) OnEndpointHealthResponse(streamID xds.StreamID, resp *envoy_se
 		status := clusterHealth.LocalityEndpointsHealth[0].EndpointsHealth[0].HealthStatus
 		health := status == envoy_core.HealthStatus_HEALTHY || status == envoy_core.HealthStatus_UNKNOWN
 
-		if clusterHealth.ClusterName == names.GetEnvoyAdminClusterName() || clusterHealth.ClusterName == generator.AdminResourceName {
+		// TODO(unified-resource-naming): adjust when legacy naming is removed
+		if clusterHealth.ClusterName == names.GetEnvoyAdminClusterName() || clusterHealth.ClusterName == system_names.EnvoyAdminResourceName {
 			envoyHealth = health
 		} else {
 			port, err := names.GetPortForLocalClusterName(clusterHealth.ClusterName)

--- a/pkg/hds/tracker/callbacks.go
+++ b/pkg/hds/tracker/callbacks.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kumahq/kuma/pkg/util/watchdog"
 	util_xds_v3 "github.com/kumahq/kuma/pkg/util/xds/v3"
 	"github.com/kumahq/kuma/pkg/xds/envoy/names"
+	"github.com/kumahq/kuma/pkg/xds/generator"
 )
 
 type streams struct {
@@ -175,7 +176,7 @@ func (t *tracker) OnEndpointHealthResponse(streamID xds.StreamID, resp *envoy_se
 		status := clusterHealth.LocalityEndpointsHealth[0].EndpointsHealth[0].HealthStatus
 		health := status == envoy_core.HealthStatus_HEALTHY || status == envoy_core.HealthStatus_UNKNOWN
 
-		if clusterHealth.ClusterName == names.GetEnvoyAdminClusterName() || clusterHealth.ClusterName == names.SystemGetAdminResourceName() {
+		if clusterHealth.ClusterName == names.GetEnvoyAdminClusterName() || clusterHealth.ClusterName == generator.AdminResourceName {
 			envoyHealth = health
 		} else {
 			port, err := names.GetPortForLocalClusterName(clusterHealth.ClusterName)

--- a/pkg/hds/tracker/callbacks.go
+++ b/pkg/hds/tracker/callbacks.go
@@ -177,7 +177,7 @@ func (t *tracker) OnEndpointHealthResponse(streamID xds.StreamID, resp *envoy_se
 		health := status == envoy_core.HealthStatus_HEALTHY || status == envoy_core.HealthStatus_UNKNOWN
 
 		// TODO(unified-resource-naming): adjust when legacy naming is removed
-		if clusterHealth.ClusterName == names.GetEnvoyAdminClusterName() || clusterHealth.ClusterName == system_names.EnvoyAdminResourceName {
+		if clusterHealth.ClusterName == names.GetEnvoyAdminClusterName() || clusterHealth.ClusterName == system_names.SystemResourceNameEnvoyAdmin {
 			envoyHealth = health
 		} else {
 			port, err := names.GetPortForLocalClusterName(clusterHealth.ClusterName)

--- a/pkg/hds/tracker/healthcheck_generator.go
+++ b/pkg/hds/tracker/healthcheck_generator.go
@@ -63,7 +63,7 @@ func (g *SnapshotGenerator) GenerateSnapshot(ctx context.Context, node *envoy_co
 	unifiedNamingEnabled := md.HasFeature(xds_types.FeatureUnifiedResourceNaming)
 	clusterName := names.GetEnvoyAdminClusterName()
 	if unifiedNamingEnabled {
-		clusterName = system_names.EnvoyAdminResourceName
+		clusterName = system_names.SystemResourceNameEnvoyAdmin
 	}
 
 	healthChecks := []*envoy_service_health.ClusterHealthCheck{

--- a/pkg/hds/tracker/healthcheck_generator.go
+++ b/pkg/hds/tracker/healthcheck_generator.go
@@ -61,7 +61,7 @@ func (g *SnapshotGenerator) GenerateSnapshot(ctx context.Context, node *envoy_co
 	unifiedNamingEnabled := md.HasFeature(xds_types.FeatureUnifiedResourceNaming)
 	clusterName := names.GetEnvoyAdminClusterName()
 	if unifiedNamingEnabled {
-		clusterName = names.SystemGetAdminResourceName()
+		clusterName = generator.AdminResourceName
 	}
 
 	healthChecks := []*envoy_service_health.ClusterHealthCheck{

--- a/pkg/hds/tracker/healthcheck_generator.go
+++ b/pkg/hds/tracker/healthcheck_generator.go
@@ -26,6 +26,7 @@ import (
 	util_xds_v3 "github.com/kumahq/kuma/pkg/util/xds/v3"
 	"github.com/kumahq/kuma/pkg/xds/envoy/names"
 	"github.com/kumahq/kuma/pkg/xds/generator"
+	"github.com/kumahq/kuma/pkg/xds/generator/system_names"
 )
 
 type SnapshotGenerator struct {
@@ -57,11 +58,12 @@ func (g *SnapshotGenerator) GenerateSnapshot(ctx context.Context, node *envoy_co
 		return nil, err
 	}
 
+	// TODO(unified-resource-naming): adjust when legacy naming is removed
 	md := xds.DataplaneMetadataFromXdsMetadata(node.Metadata)
 	unifiedNamingEnabled := md.HasFeature(xds_types.FeatureUnifiedResourceNaming)
 	clusterName := names.GetEnvoyAdminClusterName()
 	if unifiedNamingEnabled {
-		clusterName = generator.AdminResourceName
+		clusterName = system_names.EnvoyAdminResourceName
 	}
 
 	healthChecks := []*envoy_service_health.ClusterHealthCheck{

--- a/pkg/hds/tracker/healthcheck_generator_test.go
+++ b/pkg/hds/tracker/healthcheck_generator_test.go
@@ -2,8 +2,6 @@ package tracker
 
 import (
 	"context"
-	"github.com/kumahq/kuma/pkg/core/xds"
-	"github.com/kumahq/kuma/pkg/core/xds/types"
 	"time"
 
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -18,6 +16,8 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
+	"github.com/kumahq/kuma/pkg/core/xds"
+	"github.com/kumahq/kuma/pkg/core/xds/types"
 	v3 "github.com/kumahq/kuma/pkg/hds/v3"
 	"github.com/kumahq/kuma/pkg/plugins/resources/memory"
 	"github.com/kumahq/kuma/pkg/test/matchers"

--- a/pkg/hds/tracker/testdata/hds.4.golden.yaml
+++ b/pkg/hds/tracker/testdata/hds.4.golden.yaml
@@ -1,0 +1,31 @@
+clusterHealthChecks:
+- clusterName: system_envoy_admin
+  healthChecks:
+  - healthyThreshold: 4
+    httpHealthCheck:
+      path: /ready
+    interval: 1s
+    noTrafficInterval: 2s
+    timeout: 3s
+    unhealthyThreshold: 5
+  localityEndpoints:
+  - endpoints:
+    - address:
+        socketAddress:
+          address: 127.0.0.1
+          portValue: 9901
+- clusterName: localhost:80
+  healthChecks:
+  - healthyThreshold: 4
+    interval: 1s
+    noTrafficInterval: 2s
+    tcpHealthCheck: {}
+    timeout: 3s
+    unhealthyThreshold: 5
+  localityEndpoints:
+  - endpoints:
+    - address:
+        socketAddress:
+          address: 192.168.0.1
+          portValue: 80
+interval: 8s

--- a/pkg/xds/envoy/names/system_names.go
+++ b/pkg/xds/envoy/names/system_names.go
@@ -1,9 +1,0 @@
-package names
-
-import "fmt"
-
-const SystemPrefix = "system_"
-
-func SystemGetAdminResourceName() string {
-	return fmt.Sprintf("%senvoy_admin", SystemPrefix)
-}

--- a/pkg/xds/envoy/names/system_names.go
+++ b/pkg/xds/envoy/names/system_names.go
@@ -1,0 +1,9 @@
+package names
+
+import "fmt"
+
+const SystemPrefix = "system_"
+
+func SystemGetAdminResourceName() string {
+	return fmt.Sprintf("%senvoy_admin", SystemPrefix)
+}

--- a/pkg/xds/generator/admin_proxy_generator.go
+++ b/pkg/xds/generator/admin_proxy_generator.go
@@ -70,7 +70,7 @@ func (g AdminProxyGenerator) Generate(ctx context.Context, _ *core_xds.ResourceS
 	// as a gateway to another host.
 	envoyAdminClusterName := envoy_names.GetEnvoyAdminClusterName()
 	if unifiedNamingEnabled {
-		envoyAdminClusterName = system_names.EnvoyAdminResourceName
+		envoyAdminClusterName = system_names.SystemResourceNameEnvoyAdmin
 	}
 	dppReadinessClusterName := envoy_names.GetDPPReadinessClusterName()
 	adminAddress := proxy.Metadata.GetAdminAddress()
@@ -127,7 +127,7 @@ func (g AdminProxyGenerator) Generate(ctx context.Context, _ *core_xds.ResourceS
 		// TODO(unified-resource-naming): adjust when legacy naming is removed
 		envoyAdminListenerName := envoy_names.GetAdminListenerName()
 		if unifiedNamingEnabled {
-			envoyAdminListenerName = system_names.EnvoyAdminResourceName
+			envoyAdminListenerName = system_names.SystemResourceNameEnvoyAdmin
 		}
 		filterChains := []envoy_listeners.ListenerBuilderOpt{
 			envoy_listeners.FilterChain(envoy_listeners.NewFilterChainBuilder(proxy.APIVersion, envoy_common.AnonymousResource).

--- a/pkg/xds/generator/admin_proxy_generator.go
+++ b/pkg/xds/generator/admin_proxy_generator.go
@@ -3,13 +3,13 @@ package generator
 import (
 	"context"
 	"fmt"
-	"github.com/kumahq/kuma/pkg/core/xds/types"
 	"strings"
 
 	"github.com/asaskevich/govalidator"
 	"github.com/pkg/errors"
 
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+	"github.com/kumahq/kuma/pkg/core/xds/types"
 	util_maps "github.com/kumahq/kuma/pkg/util/maps"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"

--- a/pkg/xds/generator/admin_proxy_generator.go
+++ b/pkg/xds/generator/admin_proxy_generator.go
@@ -8,6 +8,7 @@ import (
 	"github.com/asaskevich/govalidator"
 	"github.com/pkg/errors"
 
+	"github.com/kumahq/kuma/pkg/core/system_names"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/core/xds/types"
 	util_maps "github.com/kumahq/kuma/pkg/util/maps"
@@ -20,6 +21,8 @@ import (
 
 // OriginAdmin is a marker to indicate by which ProxyGenerator resources were generated.
 const OriginAdmin = "admin"
+
+var AdminResourceName = system_names.AsSystemName("envoy_admin")
 
 var staticEndpointPaths = []*envoy_common.StaticEndpointPath{
 	{
@@ -68,7 +71,7 @@ func (g AdminProxyGenerator) Generate(ctx context.Context, _ *core_xds.ResourceS
 	// as a gateway to another host.
 	envoyAdminClusterName := envoy_names.GetEnvoyAdminClusterName()
 	if unifiedNamingEnabled {
-		envoyAdminClusterName = envoy_names.SystemGetAdminResourceName()
+		envoyAdminClusterName = AdminResourceName
 	}
 	dppReadinessClusterName := envoy_names.GetDPPReadinessClusterName()
 	adminAddress := proxy.Metadata.GetAdminAddress()
@@ -124,7 +127,7 @@ func (g AdminProxyGenerator) Generate(ctx context.Context, _ *core_xds.ResourceS
 	if g.getAddress(proxy) != adminAddress {
 		adminListenerName := envoy_names.GetAdminListenerName()
 		if unifiedNamingEnabled {
-			adminListenerName = envoy_names.SystemGetAdminResourceName()
+			adminListenerName = AdminResourceName
 		}
 		filterChains := []envoy_listeners.ListenerBuilderOpt{
 			envoy_listeners.FilterChain(envoy_listeners.NewFilterChainBuilder(proxy.APIVersion, envoy_common.AnonymousResource).

--- a/pkg/xds/generator/admin_proxy_generator_test.go
+++ b/pkg/xds/generator/admin_proxy_generator_test.go
@@ -2,6 +2,7 @@ package generator_test
 
 import (
 	"context"
+	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
 	"os"
 	"path/filepath"
 
@@ -27,6 +28,7 @@ var _ = Describe("AdminProxyGenerator", func() {
 		expected      string
 		adminAddress  string
 		readinessPort uint32
+		features      xds_types.Features
 	}
 
 	DescribeTable("should generate envoy config",
@@ -55,6 +57,7 @@ var _ = Describe("AdminProxyGenerator", func() {
 					AdminPort:     9901,
 					AdminAddress:  given.adminAddress,
 					ReadinessPort: given.readinessPort,
+					Features:      given.features,
 				},
 				EnvoyAdminMTLSCerts: xds.ServerSideMTLSCerts{
 					CaPEM: []byte("caPEM"),
@@ -118,6 +121,14 @@ var _ = Describe("AdminProxyGenerator", func() {
 			expected:      "07.envoy-config.golden.yaml",
 			adminAddress:  "::1",
 			readinessPort: 9400,
+		}),
+		Entry("should generate admin resources, unified naming", testCase{
+			dataplaneFile: "08.dataplane.input.yaml",
+			expected:      "08.envoy-config.golden.yaml",
+			adminAddress:  "",
+			features: map[string]bool{
+				xds_types.FeatureUnifiedResourceNaming: true,
+			},
 		}),
 	)
 

--- a/pkg/xds/generator/admin_proxy_generator_test.go
+++ b/pkg/xds/generator/admin_proxy_generator_test.go
@@ -2,7 +2,6 @@ package generator_test
 
 import (
 	"context"
-	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
 	"os"
 	"path/filepath"
 
@@ -11,6 +10,7 @@ import (
 
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/xds"
+	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
 	. "github.com/kumahq/kuma/pkg/test/matchers"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
 	"github.com/kumahq/kuma/pkg/tls"

--- a/pkg/xds/generator/proxy_template_profile_source_test.go
+++ b/pkg/xds/generator/proxy_template_profile_source_test.go
@@ -2,7 +2,6 @@ package generator_test
 
 import (
 	"context"
-	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
 	"path/filepath"
 	"time"
 
@@ -12,6 +11,7 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
 	. "github.com/kumahq/kuma/pkg/test/matchers"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
 	test_xds "github.com/kumahq/kuma/pkg/test/xds"
@@ -172,7 +172,7 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
 							Version: "1.2.0",
 						},
 					},
-					WorkDir: "/tmp",
+					WorkDir:  "/tmp",
 					Features: given.features,
 				},
 				EnvoyAdminMTLSCerts: core_xds.ServerSideMTLSCerts{

--- a/pkg/xds/generator/proxy_template_profile_source_test.go
+++ b/pkg/xds/generator/proxy_template_profile_source_test.go
@@ -2,6 +2,7 @@ package generator_test
 
 import (
 	"context"
+	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
 	"path/filepath"
 	"time"
 
@@ -27,6 +28,7 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
 		dataplane string
 		profile   string
 		expected  string
+		features  xds_types.Features
 	}
 
 	DescribeTable("Generate Envoy xDS resources",
@@ -171,6 +173,7 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
 						},
 					},
 					WorkDir: "/tmp",
+					Features: given.features,
 				},
 				EnvoyAdminMTLSCerts: core_xds.ServerSideMTLSCerts{
 					CaPEM: []byte("caPEM"),
@@ -338,6 +341,36 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
 `,
 			profile:  core_mesh.ProfileDefaultProxy,
 			expected: "4-envoy-config.golden.yaml",
+		}),
+		Entry("should support pre-defined `default-proxy` profile; transparent_proxying=false; unified naming", testCase{
+			mesh: `
+            mtls:
+              enabledBackend: builtin
+              backends:
+              - type: builtin
+                name: builtin
+`,
+			dataplane: `
+            networking:
+              address: 192.168.0.1
+              inbound:
+                - port: 80
+                  servicePort: 8080
+                  tags:
+                    kuma.io/service: backend
+              outbound:
+              - port: 54321
+                tags:
+                  kuma.io/service: db
+              - port: 59200
+                tags:
+                  kuma.io/service: elastic
+`,
+			profile:  core_mesh.ProfileDefaultProxy,
+			expected: "5-envoy-config.golden.yaml",
+			features: map[string]bool{
+				xds_types.FeatureUnifiedResourceNaming: true,
+			},
 		}),
 	)
 })

--- a/pkg/xds/generator/system_names/api.go
+++ b/pkg/xds/generator/system_names/api.go
@@ -2,4 +2,4 @@ package system_names
 
 import "github.com/kumahq/kuma/pkg/core/system_names"
 
-var EnvoyAdminResourceName = system_names.AsSystemName("envoy_admin")
+var SystemResourceNameEnvoyAdmin = system_names.AsSystemName("envoy_admin")

--- a/pkg/xds/generator/system_names/api.go
+++ b/pkg/xds/generator/system_names/api.go
@@ -1,0 +1,5 @@
+package system_names
+
+import "github.com/kumahq/kuma/pkg/core/system_names"
+
+var EnvoyAdminResourceName = system_names.AsSystemName("envoy_admin")

--- a/pkg/xds/generator/testdata/admin/08.dataplane.input.yaml
+++ b/pkg/xds/generator/testdata/admin/08.dataplane.input.yaml
@@ -1,0 +1,9 @@
+type: Dataplane
+name: web-1
+mesh: default
+networking:
+  address: 192.168.0.1
+  inbound:
+    - port: 1234
+      tags:
+        kuma.io/service: web

--- a/pkg/xds/generator/testdata/admin/08.envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/admin/08.envoy-config.golden.yaml
@@ -1,0 +1,110 @@
+resources:
+- name: system_envoy_admin
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 5s
+    loadAssignment:
+      clusterName: system_envoy_admin
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 127.0.0.1
+                portValue: 9901
+    name: system_envoy_admin
+    type: STATIC
+- name: system_envoy_admin
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.1
+        portValue: 9901
+    enableReusePort: false
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          httpFilters:
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+            - addressPrefix: ::1
+              prefixLen: 128
+          routeConfig:
+            validateClusters: false
+            virtualHosts:
+            - domains:
+              - '*'
+              name: system_envoy_admin
+              routes:
+              - match:
+                  prefix: /ready
+                route:
+                  cluster: system_envoy_admin
+                  prefixRewrite: /ready
+          statPrefix: system_envoy_admin
+    - filterChainMatch:
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          httpFilters:
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+            - addressPrefix: ::1
+              prefixLen: 128
+          routeConfig:
+            validateClusters: false
+            virtualHosts:
+            - domains:
+              - '*'
+              name: system_envoy_admin
+              routes:
+              - match:
+                  prefix: /ready
+                route:
+                  cluster: system_envoy_admin
+                  prefixRewrite: /ready
+              - match:
+                  prefix: /
+                route:
+                  cluster: system_envoy_admin
+                  prefixRewrite: /
+          statPrefix: system_envoy_admin
+      transportSocket:
+        name: envoy.transport_sockets.tls
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          commonTlsContext:
+            tlsCertificates:
+            - certificateChain:
+                inlineBytes: Y2VydFBFTQ==
+              privateKey:
+                inlineBytes: a2V5UEVN
+            validationContext:
+              matchTypedSubjectAltNames:
+              - matcher:
+                  exact: kuma-cp
+                sanType: DNS
+              trustedCa:
+                inlineBytes: Y2FQRU0=
+          requireClientCertificate: true
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: system_envoy_admin
+    trafficDirection: INBOUND

--- a/pkg/xds/generator/testdata/profile-source/5-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/5-envoy-config.golden.yaml
@@ -1,0 +1,347 @@
+resources:
+- name: db
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+        resourceApiVersion: V3
+    name: db
+    transportSocket:
+      name: envoy.transport_sockets.tls
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        commonTlsContext:
+          alpnProtocols:
+          - kuma
+          combinedValidationContext:
+            defaultValidationContext:
+              matchTypedSubjectAltNames:
+              - matcher:
+                  exact: spiffe://demo/db
+                sanType: URI
+            validationContextSdsSecretConfig:
+              name: mesh_ca:secret:demo
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+          tlsCertificateSdsSecretConfigs:
+          - name: identity_cert:secret:demo
+            sdsConfig:
+              ads: {}
+              resourceApiVersion: V3
+        sni: db{mesh=demo}
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
+- name: elastic
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+        resourceApiVersion: V3
+    healthChecks:
+    - healthyThreshold: 2
+      interval: 5s
+      tcpHealthCheck: {}
+      timeout: 4s
+      unhealthyThreshold: 3
+    name: elastic
+    transportSocket:
+      name: envoy.transport_sockets.tls
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        commonTlsContext:
+          alpnProtocols:
+          - kuma
+          combinedValidationContext:
+            defaultValidationContext:
+              matchTypedSubjectAltNames:
+              - matcher:
+                  exact: spiffe://demo/elastic
+                sanType: URI
+            validationContextSdsSecretConfig:
+              name: mesh_ca:secret:demo
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+          tlsCertificateSdsSecretConfigs:
+          - name: identity_cert:secret:demo
+            sdsConfig:
+              ads: {}
+              resourceApiVersion: V3
+        sni: elastic{mesh=demo}
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
+- name: localhost:8080
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    altStatName: localhost_8080
+    connectTimeout: 10s
+    loadAssignment:
+      clusterName: localhost:8080
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.0.1
+                portValue: 8080
+    name: localhost:8080
+    type: STATIC
+- name: system_envoy_admin
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 5s
+    loadAssignment:
+      clusterName: system_envoy_admin
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 127.0.0.1
+                portValue: 9902
+    name: system_envoy_admin
+    type: STATIC
+- name: db
+  resource:
+    '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
+    clusterName: db
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.0.3
+              portValue: 5432
+        loadBalancingWeight: 1
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              role: master
+            envoy.transport_socket_match:
+              role: master
+- name: elastic
+  resource:
+    '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
+    clusterName: elastic
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.0.4
+              portValue: 9200
+        loadBalancingWeight: 1
+- name: inbound:192.168.0.1:80
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.1
+        portValue: 80
+    enableReusePort: false
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.rbac
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
+          rules: {}
+          statPrefix: inbound_192_168_0_1_80.
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: localhost:8080
+          idleTimeout: 7200s
+          statPrefix: localhost_8080
+      transportSocket:
+        name: envoy.transport_sockets.tls
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          commonTlsContext:
+            combinedValidationContext:
+              defaultValidationContext:
+                matchTypedSubjectAltNames:
+                - matcher:
+                    prefix: spiffe://demo/
+                  sanType: URI
+              validationContextSdsSecretConfig:
+                name: mesh_ca:secret:demo
+                sdsConfig:
+                  ads: {}
+                  resourceApiVersion: V3
+            tlsCertificateSdsSecretConfigs:
+            - name: identity_cert:secret:demo
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+          requireClientCertificate: true
+    metadata:
+      filterMetadata:
+        io.kuma.tags:
+          kuma.io/service: backend
+    name: inbound:192.168.0.1:80
+    trafficDirection: INBOUND
+- name: outbound:127.0.0.1:54321
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 127.0.0.1
+        portValue: 54321
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: db
+          idleTimeout: 0s
+          statPrefix: db
+    metadata:
+      filterMetadata:
+        io.kuma.tags:
+          kuma.io/service: db
+    name: outbound:127.0.0.1:54321
+    trafficDirection: OUTBOUND
+- name: outbound:127.0.0.1:59200
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 127.0.0.1
+        portValue: 59200
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: elastic
+          idleTimeout: 0s
+          statPrefix: elastic
+    metadata:
+      filterMetadata:
+        io.kuma.tags:
+          kuma.io/service: elastic
+    name: outbound:127.0.0.1:59200
+    trafficDirection: OUTBOUND
+- name: system_envoy_admin
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.1
+        portValue: 9902
+    enableReusePort: false
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          httpFilters:
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+            - addressPrefix: ::1
+              prefixLen: 128
+          routeConfig:
+            validateClusters: false
+            virtualHosts:
+            - domains:
+              - '*'
+              name: system_envoy_admin
+              routes:
+              - match:
+                  prefix: /ready
+                route:
+                  cluster: system_envoy_admin
+                  prefixRewrite: /ready
+          statPrefix: system_envoy_admin
+    - filterChainMatch:
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          httpFilters:
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+            - addressPrefix: ::1
+              prefixLen: 128
+          routeConfig:
+            validateClusters: false
+            virtualHosts:
+            - domains:
+              - '*'
+              name: system_envoy_admin
+              routes:
+              - match:
+                  prefix: /ready
+                route:
+                  cluster: system_envoy_admin
+                  prefixRewrite: /ready
+              - match:
+                  prefix: /
+                route:
+                  cluster: system_envoy_admin
+                  prefixRewrite: /
+          statPrefix: system_envoy_admin
+      transportSocket:
+        name: envoy.transport_sockets.tls
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          commonTlsContext:
+            tlsCertificates:
+            - certificateChain:
+                inlineBytes: Y2VydFBFTQ==
+              privateKey:
+                inlineBytes: a2V5UEVN
+            validationContext:
+              matchTypedSubjectAltNames:
+              - matcher:
+                  exact: kuma-cp
+                sanType: DNS
+              trustedCa:
+                inlineBytes: Y2FQRU0=
+          requireClientCertificate: true
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: system_envoy_admin
+    trafficDirection: INBOUND
+- name: identity_cert:secret:demo
+  resource:
+    '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
+    name: identity_cert:secret:demo
+    tlsCertificate:
+      certificateChain:
+        inlineBytes: Q0VSVA==
+      privateKey:
+        inlineBytes: S0VZ
+- name: mesh_ca:secret:demo
+  resource:
+    '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
+    name: mesh_ca:secret:demo
+    validationContext:
+      trustedCa:
+        inlineBytes: Q0E=

--- a/test/e2e_env/multizone/inspect/inspect.go
+++ b/test/e2e_env/multizone/inspect/inspect.go
@@ -26,6 +26,9 @@ func Inspect() {
 
 		err := multizone.UniZone1.Install(TestServerUniversal("test-server", meshName,
 			WithArgs([]string{"echo", "--instance", "echo"}),
+			WithDpEnvs(map[string]string{
+				"KUMA_DATAPLANE_RUNTIME_UNIFIED_RESOURCE_NAMING_ENABLED": "true",
+			}),
 		))
 		Expect(err).ToNot(HaveOccurred())
 		// remove default
@@ -98,7 +101,7 @@ func Inspect() {
 			Entry("of clusters for a dataplane using Zone CP", testCase{
 				cluster:     UniZone1Cluster,
 				args:        []string{"dataplane", "test-server", "--type", "clusters", "--mesh", meshName},
-				expectedOut: `kuma:envoy:admin::`,
+				expectedOut: `system_envoy_admin::`,
 			}),
 			Entry("of config dump for a zoneingress using Global CP", testCase{
 				cluster:     GlobalCluster,

--- a/test/e2e_env/multizone/inspect/inspect.go
+++ b/test/e2e_env/multizone/inspect/inspect.go
@@ -86,7 +86,7 @@ func Inspect() {
 			Entry("of clusters for a dataplane using Global CP", testCase{
 				cluster:     GlobalCluster,
 				args:        []string{"dataplane", testServerDPPName, "--type", "clusters", "--mesh", meshName},
-				expectedOut: `kuma:envoy:admin::`,
+				expectedOut: `system_envoy_admin::`,
 			}),
 			Entry("of config dump for a dataplane using Zone CP", testCase{
 				cluster:     UniZone1Cluster,


### PR DESCRIPTION
## Motivation

Best described in https://github.com/kumahq/kuma/issues/13903 and related MADRs

## Implementation information

Add a switch on top of a FF to rename envoy admin resources.

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

xrel https://github.com/kumahq/kuma/issues/13903
closes https://github.com/kumahq/kuma/issues/13966

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
