### PR TITLE
ci(gha/pr-comments): allow `/format` comment to continue even if `make check` fails

### DIFF
--- a/.github/workflows/pr-comments.yaml
+++ b/.github/workflows/pr-comments.yaml
@@ -61,6 +61,7 @@ jobs:
       - name: "Auto-format code"
         if: contains(github.event.comment.body, '/format')
         run: make clean/generated check
+        continue-on-error: true
 
       # Update all golden files except transparent proxy tests if /golden_files is in the comment
       - name: "Update golden files (excluding transparent proxy)"


### PR DESCRIPTION
## Motivation

When someone comments `/format`, the job is supposed to fix formatting and commit the changes. But after [a53d0a6](https://github.com/kumahq/kuma/commit/a53d0a6f80ca46a8549964c16c30d9d4df6e8a7e), it fails if `make check` finds changes. This means the job stops before fixing anything, which is not what we want.

## Implementation information

This update adds `continue-on-error: true` to the step that runs `make check`. Now, even if there are formatting issues, the job will keep going and commit the changes.

## Supporting documentation

Here’s an example of a failing job that should have fixed formatting and pushed the result:
https://github.com/kumahq/kuma/actions/runs/16265189556/job/45919174757
