### PR TITLE
fix(meshratelimit): add warning log about status code

### DIFF
--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/deprecated.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"fmt"
+
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/jsonpatch/validators"
 	"github.com/kumahq/kuma/pkg/util/pointer"
 )
@@ -9,6 +11,35 @@ func (t *MeshRateLimitResource) Deprecations() []string {
 	var deprecations []string
 	if len(pointer.Deref(t.Spec.From)) > 0 {
 		deprecations = append(deprecations, "'from' field is deprecated, use 'rules' instead")
+		for i, rule := range pointer.Deref(t.Spec.From) {
+			if rule.Default.Local != nil && isStatusInvalid(pointer.Deref(rule.Default.Local)) {
+				deprecations = append(deprecations, fmt.Sprintf("'spec.from[%d].default.local.http.requestRate.status' must be 400 or higher. Please update your configuration.", i))
+			}
+		}
+	}
+	if len(pointer.Deref(t.Spec.Rules)) > 0 {
+		for i, rule := range pointer.Deref(t.Spec.Rules) {
+			if rule.Default.Local != nil && isStatusInvalid(pointer.Deref(rule.Default.Local)) {
+				deprecations = append(deprecations, fmt.Sprintf("'spec.rules[%d].default.local.http.requestRate.status' must be 400 or higher. Please update your configuration.", i))
+			}
+		}
+	}
+	if len(pointer.Deref(t.Spec.To)) > 0 {
+		for i, rule := range pointer.Deref(t.Spec.To) {
+			if rule.Default.Local != nil && isStatusInvalid(pointer.Deref(rule.Default.Local)) {
+				deprecations = append(deprecations, fmt.Sprintf("'spec.to[%d].default.local.http.requestRate.status' must be 400 or higher. Please update your configuration.", i))
+			}
+		}
 	}
 	return append(deprecations, validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)...)
+}
+
+func isStatusInvalid(local Local) bool {
+	if local.HTTP != nil &&
+		local.HTTP.OnRateLimit != nil &&
+		local.HTTP.OnRateLimit.Status != nil &&
+		pointer.Deref(local.HTTP.OnRateLimit.Status) < 400 {
+		return true
+	}
+	return false
 }

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/deprecated.go
@@ -12,21 +12,21 @@ func (t *MeshRateLimitResource) Deprecations() []string {
 	if len(pointer.Deref(t.Spec.From)) > 0 {
 		deprecations = append(deprecations, "'from' field is deprecated, use 'rules' instead")
 		for i, rule := range pointer.Deref(t.Spec.From) {
-			if rule.Default.Local != nil && isStatusInvalid(pointer.Deref(rule.Default.Local)) {
+			if rule.Default.Local != nil && isStatusInvalid(*rule.Default.Local) {
 				deprecations = append(deprecations, fmt.Sprintf("'spec.from[%d].default.local.http.requestRate.status' must be 400 or higher. Please update your configuration.", i))
 			}
 		}
 	}
 	if len(pointer.Deref(t.Spec.Rules)) > 0 {
 		for i, rule := range pointer.Deref(t.Spec.Rules) {
-			if rule.Default.Local != nil && isStatusInvalid(pointer.Deref(rule.Default.Local)) {
+			if rule.Default.Local != nil && isStatusInvalid(*rule.Default.Local) {
 				deprecations = append(deprecations, fmt.Sprintf("'spec.rules[%d].default.local.http.requestRate.status' must be 400 or higher. Please update your configuration.", i))
 			}
 		}
 	}
 	if len(pointer.Deref(t.Spec.To)) > 0 {
 		for i, rule := range pointer.Deref(t.Spec.To) {
-			if rule.Default.Local != nil && isStatusInvalid(pointer.Deref(rule.Default.Local)) {
+			if rule.Default.Local != nil && isStatusInvalid(*rule.Default.Local) {
 				deprecations = append(deprecations, fmt.Sprintf("'spec.to[%d].default.local.http.requestRate.status' must be 400 or higher. Please update your configuration.", i))
 			}
 		}


### PR DESCRIPTION
## Motivation

If the status is lower than 400 envoy fallback to 429. We shouldn't allow setting incorrect status

## Implementation information

Added log information that setting status lower than 400 is not supported

## Supporting documentation

part of: #https://github.com/kumahq/kuma/issues/13319
