### PR TITLE
chore(deps): bump CoreDNS from v1.12.0 to v1.12.2

### DIFF
--- a/mk/build.mk
+++ b/mk/build.mk
@@ -20,7 +20,7 @@ export PATH := $(BUILD_KUMACTL_DIR):$(PATH)
 
 # An optional extension to the coredns packages
 COREDNS_EXT ?=
-COREDNS_VERSION = v1.12.1
+COREDNS_VERSION = v1.12.2
 
 # List of binaries that we have build/release build rules for.
 BUILD_RELEASE_BINARIES := kuma-cp kuma-dp kumactl coredns kuma-cni install-cni envoy


### PR DESCRIPTION
## Motivation

The current CoreDNS version (v1.12.0) includes vulnerabilities that are not exploitable in the context of Kuma but are still flagged by security scanners. Updating to v1.12.2 removes these false positives.

## Implementation information

The `COREDNS_VERSION` in `mk/build.mk` was updated from v1.12.0 to v1.12.2. No additional changes were required. CoreDNS usage in Kuma remains minimal and does not involve the affected functionality, but this update helps reduce noise in reports.

## Supporting documentation

Fixes included in CoreDNS v1.12.2:

* GHSA-v778-237x-gjrc
* GHSA-hcg3-q754-cr77

These were previously evaluated and confirmed as not exploitable.