### PR TITLE
chore(deps): bump CoreDNS to v1.12.2

### DIFF
--- a/mk/build.mk
+++ b/mk/build.mk
@@ -20,7 +20,7 @@ export PATH := $(BUILD_KUMACTL_DIR):$(PATH)
 
 # An optional extension to the coredns packages
 COREDNS_EXT ?=
-COREDNS_VERSION = v1.12.1
+COREDNS_VERSION = v1.12.2
 
 # List of binaries that we have build/release build rules for.
 BUILD_RELEASE_BINARIES := kuma-cp kuma-dp kumactl coredns kuma-cni install-cni envoy


### PR DESCRIPTION
## Motivation

Other supported Kuma versions (e.g. 2.7.x, 2.9.x, 2.10.x) already use CoreDNS v1.12.2. This update aligns the current version with them for consistency and includes minor low-severity fixes.

## Implementation information

The `COREDNS_VERSION` value in `mk/build.mk` was updated from v1.12.1 to v1.12.2. The previously identified vulnerabilities were already addressed in v1.12.1, so this bump is only for consistency and minor improvements.