### PR TITLE
feat(tools): move clang-format from `make check` to action

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -65,6 +65,10 @@ jobs:
         with:
           args: --fix=false --verbose
           version: v2.2.2
+      - name: Run clang-format style check for Protobuf
+        uses: jidicula/clang-format-action@4726374d1aa3c6aecf132e5197e498979588ebc8 # v4.15.0
+        with:
+          clang-format-version: '13'
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: |

--- a/api/mesh/v1alpha1/dataplane.proto
+++ b/api/mesh/v1alpha1/dataplane.proto
@@ -113,9 +113,11 @@ message Dataplane {
       // ServiceProbe defines parameters for probing service's port
       message ServiceProbe {
         // Interval between consecutive health checks.
-        google.protobuf.Duration interval=1;
+        google.protobuf.Duration interval = 1;
+
         // Maximum time to wait for a health check response.
-        google.protobuf.Duration timeout=2;
+        google.protobuf.Duration timeout = 2;
+
         // Number of consecutive unhealthy checks before considering a host
         // unhealthy.
         google.protobuf.UInt32Value unhealthy_threshold = 3;
@@ -156,6 +158,7 @@ message Dataplane {
       // Name adds another way of referencing this port, usable with MeshService
       string name = 10;
     }
+
     // Outbound describes a service consumed by the data plane proxy.
     // For every defined Outbound there is a corresponding Envoy Listener.
     message Outbound {

--- a/api/mesh/v1alpha1/dataplane.proto
+++ b/api/mesh/v1alpha1/dataplane.proto
@@ -113,11 +113,9 @@ message Dataplane {
       // ServiceProbe defines parameters for probing service's port
       message ServiceProbe {
         // Interval between consecutive health checks.
-        google.protobuf.Duration interval = 1;
-
+        google.protobuf.Duration interval=1;
         // Maximum time to wait for a health check response.
-        google.protobuf.Duration timeout = 2;
-
+        google.protobuf.Duration timeout=2;
         // Number of consecutive unhealthy checks before considering a host
         // unhealthy.
         google.protobuf.UInt32Value unhealthy_threshold = 3;
@@ -158,7 +156,6 @@ message Dataplane {
       // Name adds another way of referencing this port, usable with MeshService
       string name = 10;
     }
-
     // Outbound describes a service consumed by the data plane proxy.
     // For every defined Outbound there is a corresponding Envoy Listener.
     message Outbound {

--- a/mk/check.mk
+++ b/mk/check.mk
@@ -1,6 +1,10 @@
 .PHONY: fmt/proto
 fmt/proto: ## Dev: Run clang-format on .proto files
+ifndef CI
 	find . -name '*.proto' | xargs -L 1 $(CLANG_FORMAT) -i
+else
+	@echo "skipping clang-format as it's done as a github action"
+endif
 
 .PHONY: tidy
 tidy:


### PR DESCRIPTION
## Motivation

Move clang-format from `make check` to separate action as `golangci-lint`. This will allow us to speed up `mise` tools installation as we won't rely on clang-format any more. This will fail like this if not properly formatted:

https://github.com/kumahq/kuma/actions/runs/16418589385/job/46390718639?pr=14012
```
Ubuntu clang-format version 13.0.1-2ubuntu2.2
./api/mesh/v1alpha1/dataplane.proto:116:[42](https://github.com/kumahq/kuma/actions/runs/16418589385/job/46390718639?pr=14012#step:7:44): error: code should be clang-formatted [-Wclang-format-violations]
        google.protobuf.Duration interval=1;
                                         ^
./api/mesh/v1alpha1/dataplane.proto:116:[43](https://github.com/kumahq/kuma/actions/runs/16418589385/job/46390718639?pr=14012#step:7:45): error: code should be clang-formatted [-Wclang-format-violations]
        google.protobuf.Duration interval=1;
                                          ^
./api/mesh/v1alpha1/dataplane.proto:118:41: error: code should be clang-formatted [-Wclang-format-violations]
        google.protobuf.Duration timeout=2;
                                        ^
./api/mesh/v1alpha1/dataplane.proto:118:42: error: code should be clang-formatted [-Wclang-format-violations]
        google.protobuf.Duration timeout=2;
                                         ^
Failed on file: ./api/mesh/v1alpha1/dataplane.proto
```

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
