### PR TITLE
fix(tools): skip missing protoc-gen-go-grpc dependency in e2e tests

### DIFF
--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -37,7 +37,7 @@ jobs:
       - uses: jdx/mise-action@13abe502c30c1559a5c37dff303831bab82c9402 # v2.2.3
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          MISE_DISABLE_TOOLS: "clang-format,golangci-lint,skaffold"
+          MISE_DISABLE_TOOLS: "clang-format,golangci-lint,skaffold,protoc-gen-go-grpc"
       - name: "Free up disk space for the Runner"
         run: |
           echo "Disk usage before cleanup"


### PR DESCRIPTION
## Motivation

Skipping `protoc-gen-go-grpc` installation in e2e tests which is not used, and is causing errors since linux/arm version is missing in mise. This will fix: https://github.com/kumahq/kuma/actions/runs/16495964219/job/46644826561

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
