### PR TITLE
chore(renovate): enable updates for `mise` plugins and tools

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,8 @@
     "github-actions",
     "gomod",
     "helm-values",
-    "kubernetes"
+    "kubernetes",
+    "mise"
   ],
   "ignorePaths": [],
   "kubernetes": {


### PR DESCRIPTION
## Motivation

We want Renovate to keep our dev tools like `mise` up to date.  Now that support for `mise` was added in #14027, we can enable this in our config.

## Implementation information

Added `mise` to the list of enabled Renovate managers in `renovate.json`.

## Supporting documentation

* https://docs.renovatebot.com/modules/manager/mise/
* #11770
* #14027