### PR TITLE
ci(lint): set smaller gomemlimit to combat OOMs

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -58,7 +58,7 @@ jobs:
           set -e
           mem_total_kb=$(grep MemTotal /proc/meminfo | awk '{print $2}')
           mem_total_bytes=$((mem_total_kb * 1024))
-          gomemlimit=$((mem_total_bytes * 9 / 10))
+          gomemlimit=$((mem_total_bytes * 8 / 10))
           echo "GOMEMLIMIT=${gomemlimit}" >> $GITHUB_ENV
           echo "Setting GOMEMLIMIT to $(numfmt --to=iec $gomemlimit)"
       - uses: jdx/mise-action@13abe502c30c1559a5c37dff303831bab82c9402 # v2.2.3
@@ -66,6 +66,8 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           MISE_DISABLE_TOOLS: "clang-format,golangci-lint,skaffold"
       - uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
+        env:
+          GOGC: "80" # run GC more aggressively
         with:
           args: --fix=false --verbose
           version: v2.2.2


### PR DESCRIPTION
## Motivation

We are still seeing golangci-lint OOMing:
- https://github.com/Kong/kong-mesh/actions/runs/16498801542/job/46651336957
- https://github.com/Kong/kong-mesh/actions/runs/16516391116/job/46708022916
- https://github.com/Kong/kong-mesh/actions/runs/16495938870/job/46641539526
- https://github.com/Kong/kong-mesh/actions/runs/16495938870/job/46641539526
- https://github.com/Kong/kong-mesh/actions/runs/16477097845/job/46581551551
- https://github.com/Kong/kong-mesh/actions/runs/16436573191/job/46447630542
- ...

In the parent project. 

## Implementation information

PromCI repo uses ratio of 0.8 so setting to that https://github.com/prometheus/promci/blob/37fc2faf8f611b1cffd38d86ba9f813b88c82750/actions/setup_environment/action.yml#L18

and also setting GOGC to 80 to make the GC run more often (saw this suggestion on another repo).