### PR TITLE
ci(gha): update disabled tool name in mise action to match full registry name

### DIFF
--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -37,7 +37,7 @@ jobs:
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          MISE_DISABLE_TOOLS: "clang-format,golangci-lint,skaffold,protoc-gen-go-grpc"
+          MISE_DISABLE_TOOLS: "clang-format,golangci-lint,skaffold,aqua:grpc/grpc-go/protoc-gen-go-grpc"
       - name: "Free up disk space for the Runner"
         run: |
           echo "Disk usage before cleanup"

--- a/mise.toml
+++ b/mise.toml
@@ -2,10 +2,8 @@
 experimental = true # To enable installation of Go tools from source with mise.
 
 [tools]
-clang-format = "13.0.0"
 container-structure-test = "1.15.0"
 ginkgo = "2.23.4"
-golangci-lint = "2.2.2"
 hadolint = "2.12.0"
 helm = "3.18.4"
 helm-docs = "1.11.0"
@@ -13,10 +11,8 @@ kind = "0.24.0"
 kubectl = "1.32.6"
 protoc = "3.20.0"
 shellcheck = "0.8.0"
-skaffold = "2.16.1"
 yq = "4.47.1"
 "aqua:bufbuild/protoc-gen-validate" = "1.2.1"
-"aqua:grpc/grpc-go/protoc-gen-go-grpc" = "1.1.0"
 "aqua:helm/chart-releaser" = "1.7.0"
 "aqua:k3d-io/k3d" = "5.8.1"
 "aqua:protocolbuffers/protobuf-go/protoc-gen-go" = "1.28.1"
@@ -25,3 +21,17 @@ yq = "4.47.1"
 "go:github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen" = "v2.4.1"
 "go:sigs.k8s.io/controller-tools/cmd/controller-gen" = "v0.18.0"
 "go:sigs.k8s.io/controller-runtime/tools/setup-envtest" = "v0.0.0-20250630142431-4c2e9cec2954"
+# === tools excluded from GitHub Actions installs ===
+# ⚠️ If you change any tool name below, update `MISE_DISABLE_TOOLS` in:
+#     .github/workflows/_build_publish.yaml
+#     .github/workflows/_e2e.yaml
+#     .github/workflows/_test.yaml
+#     .github/workflows/build-test-distribute.yaml
+#     .github/workflows/merge-release-to-master.yaml
+#     .github/workflows/pr-comments.yaml
+#     .github/workflows/transparentproxy-tests.yaml
+clang-format = "13.0.0"
+golangci-lint = "2.2.2"
+skaffold = "2.16.1"
+# ⚠️ If you change this name, also update `MISE_DISABLE_TOOLS` in .github/workflows/_e2e.yaml
+"aqua:grpc/grpc-go/protoc-gen-go-grpc" = "1.1.0"


### PR DESCRIPTION
### Motivation

After updating `mise.toml` to use full tool names supported by Renovate (see #14051), the name of `protoc-gen-go-grpc` changed to `aqua:grpc/grpc-go/protoc-gen-go-grpc`.

This PR updates the `_e2e.yaml` workflow to match the new name so the tool doesn't get installed during GitHub Actions runs.

To prevent similar issues in the future, the excluded tools in `mise.toml` were moved to the bottom and grouped under a dedicated comment that clearly lists which workflows use the `MISE_DISABLE_TOOLS` variable and should be updated if tool names change.

### Implementation information

* Updated `_e2e.yaml` to use the new full tool name
* Moved excluded tools to the bottom of `mise.toml`
* Added a comment block listing all affected GitHub Actions workflows to keep `MISE_DISABLE_TOOLS` in sync

### Supporting documentation

* Related PR: #14051