### PR TITLE
test(flake): disable `should route to only one instance` flaky test

### DIFF
--- a/test/e2e_env/kubernetes/gateway/gateway.go
+++ b/test/e2e_env/kubernetes/gateway/gateway.go
@@ -605,7 +605,8 @@ spec:
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("should route to only one instance", func() {
+		// disable until https://github.com/kumahq/kuma/issues/14072 is fixed
+		XIt("should route to only one instance", func() {
 			Eventually(func(g Gomega) {
 				responses, err := client.CollectResponsesByInstance(
 					kubernetes.Cluster, "demo-client",


### PR DESCRIPTION
## Motivation

https://github.com/kumahq/kuma/issues/14072

## Implementation information

disable test