### PR TITLE
ci(renovate): add Makefile preset and simplify mise config

### DIFF
--- a/.renovate/makefile.json
+++ b/.renovate/makefile.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "customManagers": [
+    {
+      "description": "Custom dependency manager for updating tools defined in Makefiles",
+      "customType": "regex",
+      "fileMatch": [
+        "(?:^|\\/)(?:Makefile|[^\\/]+\\.mk)$"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?( registryUrl=(?<registryUrl>.*?))?\\s.*?_VERSION\\s?[:\\?]?=\\s?(?<currentValue>.*)\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchDepNames": ["kumahq/envoy-builds"],
+      "commitMessageTopic": "envoy"
+    }
+  ]
+}

--- a/.renovate/mise.json
+++ b/.renovate/mise.json
@@ -10,56 +10,18 @@
       "prFooter": "> Changelog: skip"
     },
     {
-      "description": "Allow protoc updates only within the 3.20.x version range",
-      "matchManagers": ["mise"],
-      "matchDepNames": ["protoc"],
-      "allowedVersions": "/^3\\.20\\.[0-9]+$/"
-    },
-    {
-      "description": "Disable updates for clang-format since we're using a legacy version and protobufs in Kuma are deprecated, so upgrading is not worth the effort",
-      "matchDepNames": ["clang-format"],
+      "description": "Disable updates for clang-format and protoc since we're using a legacy versions and protobufs in Kuma are deprecated, so upgrading is not worth the effort",
+      "matchDepNames": ["clang-format", "protoc"],
       "enabled": false
     },
     {
-      "matchDepNames": ["aqua:helm/chart-releaser"],
-      "overrideDepName": "helm-cr"
-    },
-    {
-      "matchDepNames": ["aqua:k3d-io/k3d"],
-      "overrideDepName": "k3d"
-    },
-    {
-      "matchDepNames": ["aqua:stackrox/kube-linter"],
-      "overrideDepName": "kube-linter"
-    },
-    {
-      "matchDepNames": ["aqua:protocolbuffers/protobuf-go/protoc-gen-go"],
-      "overrideDepName": "protoc-gen-go"
+      "description": "Simplify commit message topic for aqua and go packages by stripping namespace prefix",
+      "matchDepNames": ["/^(?:aqua|go):/"],
+      "commitMessageTopic": "{{{replace '([^\\/]*?\\/)*' '' depName}}}"
     },
     {
       "matchDepNames": ["aqua:grpc/grpc-go/protoc-gen-go-grpc"],
-      "overrideDepName": "protoc-gen-go-grpc",
       "extractVersion": "^cmd/protoc-gen-go-grpc/(?<version>.*)$"
-    },
-    {
-      "matchDepNames": ["aqua:bufbuild/protoc-gen-validate"],
-      "overrideDepName": "protoc-gen-validate"
-    },
-    {
-      "matchDepNames": ["go:github.com/chrusty/protoc-gen-jsonschema/cmd/protoc-gen-jsonschema"],
-      "overrideDepName": "protoc-gen-jsonschema"
-    },
-    {
-      "matchDepNames": ["go:github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen"],
-      "overrideDepName": "oapi-codegen"
-    },
-    {
-      "matchDepNames": ["go:sigs.k8s.io/controller-tools/cmd/controller-gen"],
-      "overrideDepName": "controller-gen"
-    },
-    {
-      "matchDepNames": ["go:sigs.k8s.io/controller-runtime/tools/setup-envtest"],
-      "overrideDepName": "setup-envtest"
     }
   ]
 }

--- a/mk/dev.mk
+++ b/mk/dev.mk
@@ -7,6 +7,7 @@ GIT_TAG = $(word 2, $(BUILD_INFO))
 GIT_COMMIT = $(word 3, $(BUILD_INFO))
 BUILD_DATE = $(word 4, $(BUILD_INFO))
 CI_TOOLS_VERSION = $(word 5, $(BUILD_INFO))
+# renovate: datasource=github-releases depName=kumahq/envoy-builds versioning=semver
 ENVOY_VERSION ?= 1.35.0
 KUMA_CHARTS_URL ?= https://kumahq.github.io/charts
 CHART_REPO_NAME ?= kuma

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,8 @@
   "extends": [
     "Kong/public-shared-renovate:backend",
     "kumahq/kuma//.renovate/go-control-plane",
-    "kumahq/kuma//.renovate/mise"
+    "kumahq/kuma//.renovate/mise",
+    "kumahq/kuma//.renovate/makefile"
   ],
   "enabledManagers": [
     "custom.regex",
@@ -14,6 +15,15 @@
     "kubernetes",
     "mise"
   ],
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "addLabels": [
+      "area/security"
+    ],
+    "assignees": [
+      "@kumahq/kuma-security-managers"
+    ]
+  },
   "ignorePaths": [],
   "kubernetes": {
     "description": "Update image versions in Kubernetes manifests from 'kumactl install demo|observability'",


### PR DESCRIPTION
### Motivation

The Renovate setup for `mise` and Makefile-based tools needed cleanup and improvements:

* `protoc` and `clang-format` are legacy tools in Kuma and not worth updating, so Renovate should not track them
* Some commit messages for tool updates were unnecessarily verbose due to long tool names; we want to simplify them
* We previously lacked support for updating tool versions defined in Makefiles (like `ENVOY_VERSION`)
* We also want to ensure that security-related vulnerabilities are labeled and assigned properly

### Implementation information

* Replaced `overrideDepName` with `commitMessageTopic` template for most aqua/go tools
* Merged `clang-format` and `protoc` disable rules into one
* Added `.renovate/makefile.json` with regex manager to detect versioned vars in `Makefile` or `.mk` files
* Annotated `ENVOY_VERSION` in `mk/dev.mk` to enable updates
* Added OSV security alert config with label `area/security`

> [!NOTE]
> I tested these changes on my fork:
> * https://github.com/bartsmykla/kuma/pull/472
> * https://github.com/bartsmykla/kuma/pull/473
> * https://github.com/bartsmykla/kuma/pull/474
> * https://github.com/bartsmykla/kuma/pull/471

### Supporting documentation

- Custom regex manager: https://docs.renovatebot.com/configuration-options/#custommanagers
- `commitMessageTopic` template: https://docs.renovatebot.com/configuration-options/#commitmessagetopic
- OSV security alerts config: https://docs.renovatebot.com/configuration-options/#osvvulnerabilityalerts