### PR TITLE
chore(kuma-cp): add info why we need to watch dataplane in configmap controller

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/configmap_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/configmap_controller.go
@@ -88,6 +88,7 @@ func (r *ConfigMapReconciler) SetupWithManager(mgr kube_ctrl.Manager) error {
 		Named("kuma-configmap-controller").
 		For(&kube_core.ConfigMap{}).
 		Watches(&kube_core.Service{}, kube_handler.EnqueueRequestsFromMapFunc(ServiceToConfigMapsMapper(mgr.GetClient(), r.Log, r.SystemNamespace))).
+		// Dataplane is needed because we can add labels (converted to tags) in runtime that are then picked by VirtualOutbounds
 		Watches(&mesh_k8s.Dataplane{}, kube_handler.EnqueueRequestsFromMapFunc(DataplaneToMeshMapper(r.Log, r.SystemNamespace, r.ResourceConverter))).
 		Watches(&mesh_k8s.ZoneIngress{}, kube_handler.EnqueueRequestsFromMapFunc(ZoneIngressToMeshMapper(r.Log, r.SystemNamespace, r.ResourceConverter))).
 		Watches(&mesh_k8s.VirtualOutbound{}, kube_handler.EnqueueRequestsFromMapFunc(VirtualOutboundToConfigMapsMapper(r.Log, r.SystemNamespace))).


### PR DESCRIPTION
## Motivation

closses https://github.com/kumahq/kuma/issues/8749

## Implementation information

none