### PR TITLE
chore(deps): bump protoc-gen-go-grpc from 1.1.0 to 1.5.1

### DIFF
--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -37,7 +37,7 @@ jobs:
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          MISE_DISABLE_TOOLS: "clang-format,golangci-lint,skaffold,aqua:grpc/grpc-go/protoc-gen-go-grpc"
+          MISE_DISABLE_TOOLS: "clang-format,golangci-lint,skaffold"
       - name: "Free up disk space for the Runner"
         run: |
           echo "Disk usage before cleanup"

--- a/mise.toml
+++ b/mise.toml
@@ -35,4 +35,4 @@ clang-format = "13.0.0"
 golangci-lint = "2.2.2"
 skaffold = "2.16.1"
 # ⚠️ If you change this name, also update `MISE_DISABLE_TOOLS` in .github/workflows/_e2e.yaml
-"aqua:grpc/grpc-go/protoc-gen-go-grpc" = "1.1.0"
+"aqua:grpc/grpc-go/protoc-gen-go-grpc" = "1.5.1"


### PR DESCRIPTION
## Motivation

<!-- Why are we doing this change -->

## Implementation information

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
