### PR TITLE
feat(kuma-cp): add proxyResourceName field to dataplane inbound and outbound

### DIFF
--- a/api/openapi/specs/common/resource.yaml
+++ b/api/openapi/specs/common/resource.yaml
@@ -156,7 +156,7 @@ components:
           type: integer
     DataplaneInbound:
       type: object
-      required: [ kri, port, protocol ]
+      required: [ kri, port, protocol, proxyResourceName ]
       properties:
         kri:
           type: string
@@ -164,10 +164,12 @@ components:
           type: integer
           x-go-type: 'int32'
         protocol:
+          type: string
+        proxyResourceName:
           type: string
     DataplaneOutbound:
       type: object
-      required: [ kri, port, protocol ]
+      required: [ kri, port, protocol, proxyResourceName ]
       properties:
         kri:
           type: string
@@ -175,6 +177,8 @@ components:
           type: integer
           x-go-type: 'int32'
         protocol:
+          type: string
+        proxyResourceName:
           type: string
     PoliciesList:
       type: object

--- a/api/openapi/types/common/zz_generated.resource.go
+++ b/api/openapi/types/common/zz_generated.resource.go
@@ -11,16 +11,18 @@ const (
 
 // DataplaneInbound defines model for DataplaneInbound.
 type DataplaneInbound struct {
-	Kri      string `json:"kri"`
-	Port     int32  `json:"port"`
-	Protocol string `json:"protocol"`
+	Kri               string `json:"kri"`
+	Port              int32  `json:"port"`
+	Protocol          string `json:"protocol"`
+	ProxyResourceName string `json:"proxyResourceName"`
 }
 
 // DataplaneOutbound defines model for DataplaneOutbound.
 type DataplaneOutbound struct {
-	Kri      string `json:"kri"`
-	Port     int32  `json:"port"`
-	Protocol string `json:"protocol"`
+	Kri               string `json:"kri"`
+	Port              int32  `json:"port"`
+	Protocol          string `json:"protocol"`
+	ProxyResourceName string `json:"proxyResourceName"`
 }
 
 // FromRule defines model for FromRule.

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -4286,6 +4286,7 @@ components:
         - kri
         - port
         - protocol
+        - proxyResourceName
       properties:
         kri:
           type: string
@@ -4293,6 +4294,8 @@ components:
           type: integer
           x-go-type: int32
         protocol:
+          type: string
+        proxyResourceName:
           type: string
     DataplaneOutbound:
       type: object
@@ -4300,6 +4303,7 @@ components:
         - kri
         - port
         - protocol
+        - proxyResourceName
       properties:
         kri:
           type: string
@@ -4307,6 +4311,8 @@ components:
           type: integer
           x-go-type: int32
         protocol:
+          type: string
+        proxyResourceName:
           type: string
     PolicyOrigin:
       type: object


### PR DESCRIPTION
## Motivation

Because of https://github.com/kumahq/kuma/blob/master/docs/madr/decisions/078-include-envoy-resource-name-tp-in-layout-endpoint.md#decision

## Implementation information

Add fields, regenerate.
