### PR TITLE
feat(inbound-rules): stop merging inbound rules for internal representation

### DIFF
--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/inbounds/merged_inbound_policy.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/inbounds/merged_inbound_policy.golden.json
@@ -12,18 +12,20 @@
    ],
    "rules": [
     {
-     "conf": [
-      {
-       "connectionTimeout": "2s",
-       "idleTimeout": "1m0s",
-       "http": {
-        "requestTimeout": "10s",
-        "streamIdleTimeout": "1h0m0s",
-        "maxStreamDuration": "30m0s",
-        "maxConnectionDuration": "30m0s"
-       }
+     "conf": {
+      "http": {
+       "requestTimeout": "10s",
+       "streamIdleTimeout": "1h0m0s",
+       "maxStreamDuration": "30m0s",
+       "maxConnectionDuration": "30m0s"
       }
-     ]
+     }
+    },
+    {
+     "conf": {
+      "connectionTimeout": "2s",
+      "idleTimeout": "1m0s"
+     }
     }
    ]
   }

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/inbounds/multiple_inbound_policies.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/inbounds/multiple_inbound_policies.golden.json
@@ -9,23 +9,21 @@
    ],
    "rules": [
     {
-     "conf": [
-      {
-       "backends": [
-        {
-         "type": "File",
-         "file": {
-          "format": {
-           "type": "Plain",
-           "plain": "[%START_TIME%]",
-           "omitEmptyValues": false
-          },
-          "path": "/dev/stdout"
-         }
+     "conf": {
+      "backends": [
+       {
+        "type": "File",
+        "file": {
+         "format": {
+          "type": "Plain",
+          "plain": "[%START_TIME%]",
+          "omitEmptyValues": false
+         },
+         "path": "/dev/stdout"
         }
-       ]
-      }
-     ]
+       }
+      ]
+     }
     }
    ]
   },
@@ -38,29 +36,27 @@
    ],
    "rules": [
     {
-     "conf": [
-      {
-       "local": {
-        "http": {
-         "requestRate": {
-          "num": 5,
-          "interval": "10s"
-         },
-         "onRateLimit": {
-          "status": 423,
-          "headers": {
-           "set": [
-            {
-             "name": "x-kuma-rate-limited",
-             "value": "true"
-            }
-           ]
-          }
+     "conf": {
+      "local": {
+       "http": {
+        "requestRate": {
+         "num": 5,
+         "interval": "10s"
+        },
+        "onRateLimit": {
+         "status": 423,
+         "headers": {
+          "set": [
+           {
+            "name": "x-kuma-rate-limited",
+            "value": "true"
+           }
+          ]
          }
         }
        }
       }
-     ]
+     }
     }
    ]
   }

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/inbounds/single_inbound_policy.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/inbounds/single_inbound_policy.golden.json
@@ -9,23 +9,21 @@
    ],
    "rules": [
     {
-     "conf": [
-      {
-       "backends": [
-        {
-         "type": "File",
-         "file": {
-          "format": {
-           "type": "Plain",
-           "plain": "[%START_TIME%]",
-           "omitEmptyValues": false
-          },
-          "path": "/dev/stdout"
-         }
+     "conf": {
+      "backends": [
+       {
+        "type": "File",
+        "file": {
+         "format": {
+          "type": "Plain",
+          "plain": "[%START_TIME%]",
+          "omitEmptyValues": false
+         },
+         "path": "/dev/stdout"
         }
-       ]
-      }
-     ]
+       }
+      ]
+     }
     }
    ]
   }

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/dataplane_kind_meshtimeout_section_name.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/dataplane_kind_meshtimeout_section_name.golden.json
@@ -125,7 +125,7 @@
          "connectionTimeout": "7s",
          "idleTimeout": "7s",
          "http": {
-          "requestTimeout": "2s"
+          "requestTimeout": "7s"
          }
         }
        ],
@@ -138,7 +138,18 @@
           "type": "MeshTimeout"
          },
          "ruleIndex": 0
-        },
+        }
+       ]
+      },
+      {
+       "conf": [
+        {
+         "http": {
+          "requestTimeout": "2s"
+         }
+        }
+       ],
+       "origin": [
         {
          "resourceMeta": {
           "labels": {},

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/inboundrule_meshtimeout_section.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/inboundrule_meshtimeout_section.golden.json
@@ -60,7 +60,7 @@
          "connectionTimeout": "7s",
          "idleTimeout": "7s",
          "http": {
-          "requestTimeout": "2s"
+          "requestTimeout": "7s"
          }
         }
        ],
@@ -73,7 +73,18 @@
           "type": "MeshTimeout"
          },
          "ruleIndex": 0
-        },
+        }
+       ]
+      },
+      {
+       "conf": [
+        {
+         "http": {
+          "requestTimeout": "2s"
+         }
+        }
+       ],
+       "origin": [
         {
          "resourceMeta": {
           "labels": {},
@@ -99,7 +110,7 @@
       {
        "conf": [
         {
-         "connectionTimeout": "3s",
+         "connectionTimeout": "7s",
          "idleTimeout": "7s",
          "http": {
           "requestTimeout": "7s"
@@ -115,7 +126,16 @@
           "type": "MeshTimeout"
          },
          "ruleIndex": 0
-        },
+        }
+       ]
+      },
+      {
+       "conf": [
+        {
+         "connectionTimeout": "3s"
+        }
+       ],
+       "origin": [
         {
          "resourceMeta": {
           "labels": {},

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/overriding_meshtimeout.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/overriding_meshtimeout.golden.json
@@ -56,7 +56,7 @@
       {
        "conf": [
         {
-         "connectionTimeout": "20s",
+         "connectionTimeout": "2s",
          "idleTimeout": "20s",
          "http": {
           "requestTimeout": "5s"
@@ -72,7 +72,16 @@
           "type": "MeshTimeout"
          },
          "ruleIndex": 0
-        },
+        }
+       ]
+      },
+      {
+       "conf": [
+        {
+         "connectionTimeout": "20s"
+        }
+       ],
+       "origin": [
         {
          "resourceMeta": {
           "labels": {},

--- a/pkg/plugins/policies/core/matchers/testdata/egressmatchedpolicies/fromtorules/01.golden.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/egressmatchedpolicies/fromtorules/01.golden.yaml
@@ -1,18 +1,31 @@
 InboundRules:
   :0:
   - conf:
-    - connectionTimeout: 33s
-      http:
-        requestTimeout: 33s
+      BaseEntry:
+        default:
+          connectionTimeout: 22s
+          http:
+            requestTimeout: 22s
+        targetRef:
+          kind: Mesh
     origin:
-    - Resource:
+      Resource:
         creationTime: "0001-01-01T00:00:00Z"
         mesh: mesh-1
         modificationTime: "0001-01-01T00:00:00Z"
         name: mt-2
         type: MeshTimeout
       RuleIndex: 0
-    - Resource:
+  - conf:
+      BaseEntry:
+        default:
+          connectionTimeout: 33s
+          http:
+            requestTimeout: 33s
+        targetRef:
+          kind: Mesh
+    origin:
+      Resource:
         creationTime: "0001-01-01T00:00:00Z"
         mesh: mesh-1
         modificationTime: "0001-01-01T00:00:00Z"

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.golden.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.golden.yaml
@@ -44,12 +44,16 @@ FromRules:
 InboundRules:
   127.0.0.1:8080:
   - conf:
-    - backends:
-      - file:
-          path: /from-gateway
-        type: File
+      BaseEntry:
+        default:
+          backends:
+          - file:
+              path: /from-gateway
+            type: File
+        targetRef:
+          kind: Mesh
     origin:
-    - Resource:
+      Resource:
         creationTime: "0001-01-01T00:00:00Z"
         mesh: mesh-1
         modificationTime: "0001-01-01T00:00:00Z"
@@ -58,12 +62,16 @@ InboundRules:
       RuleIndex: 0
   127.0.0.1:8081:
   - conf:
-    - backends:
-      - file:
-          path: /from-gateway
-        type: File
+      BaseEntry:
+        default:
+          backends:
+          - file:
+              path: /from-gateway
+            type: File
+        targetRef:
+          kind: Mesh
     origin:
-    - Resource:
+      Resource:
         creationTime: "0001-01-01T00:00:00Z"
         mesh: mesh-1
         modificationTime: "0001-01-01T00:00:00Z"
@@ -72,12 +80,16 @@ InboundRules:
       RuleIndex: 0
   127.0.0.1:8082:
   - conf:
-    - backends:
-      - file:
-          path: /from-gateway
-        type: File
+      BaseEntry:
+        default:
+          backends:
+          - file:
+              path: /from-gateway
+            type: File
+        targetRef:
+          kind: Mesh
     origin:
-    - Resource:
+      Resource:
         creationTime: "0001-01-01T00:00:00Z"
         mesh: mesh-1
         modificationTime: "0001-01-01T00:00:00Z"

--- a/pkg/plugins/policies/core/rules/inbound/testdata/inboundrules/mt-from.golden.yaml
+++ b/pkg/plugins/policies/core/rules/inbound/testdata/inboundrules/mt-from.golden.yaml
@@ -1,18 +1,31 @@
 rules:
 - conf:
-  - connectionTimeout: 1m41s
-    http:
-      requestTimeout: 12s
-    idleTimeout: 10s
+    BaseEntry:
+      default:
+        connectionTimeout: 1m41s
+        http:
+          requestTimeout: 1m42s
+        idleTimeout: 1m40s
+      targetRef:
+        kind: Mesh
   origin:
-  - Resource:
+    Resource:
       creationTime: "0001-01-01T00:00:00Z"
       mesh: mesh-1
       modificationTime: "0001-01-01T00:00:00Z"
       name: matched-for-rules-mt-bbbbbb
       type: MeshTimeout
     RuleIndex: 0
-  - Resource:
+- conf:
+    BaseEntry:
+      default:
+        http:
+          requestTimeout: 12s
+        idleTimeout: 10s
+      targetRef:
+        kind: Mesh
+  origin:
+    Resource:
       creationTime: "0001-01-01T00:00:00Z"
       mesh: mesh-1
       modificationTime: "0001-01-01T00:00:00Z"

--- a/pkg/plugins/policies/core/rules/inbound/testdata/inboundrules/mt-mixed.golden.yaml
+++ b/pkg/plugins/policies/core/rules/inbound/testdata/inboundrules/mt-mixed.golden.yaml
@@ -1,25 +1,37 @@
 rules:
 - conf:
-  - connectionTimeout: 1m41s
-    http:
-      requestTimeout: 3m22s
-    idleTimeout: 10s
+    default:
+      http:
+        requestTimeout: 3m22s
+      idleTimeout: 3m20s
   origin:
-  - Resource:
+    Resource:
       creationTime: "0001-01-01T00:00:00Z"
       mesh: mesh-1
       modificationTime: "0001-01-01T00:00:00Z"
       name: matched-for-rules-mt-cccccc
       type: MeshTimeout
     RuleIndex: 0
-  - Resource:
+- conf:
+    BaseEntry:
+      default:
+        connectionTimeout: 1m41s
+        idleTimeout: 1m40s
+      targetRef:
+        kind: Mesh
+  origin:
+    Resource:
       creationTime: "0001-01-01T00:00:00Z"
       mesh: mesh-1
       modificationTime: "0001-01-01T00:00:00Z"
       name: matched-for-rules-mt-bbbbbb
       type: MeshTimeout
     RuleIndex: 0
-  - Resource:
+- conf:
+    default:
+      idleTimeout: 10s
+  origin:
+    Resource:
       creationTime: "0001-01-01T00:00:00Z"
       mesh: mesh-1
       modificationTime: "0001-01-01T00:00:00Z"

--- a/pkg/plugins/policies/core/rules/inbound/testdata/inboundrules/mt-order-by-origin.golden.yaml
+++ b/pkg/plugins/policies/core/rules/inbound/testdata/inboundrules/mt-order-by-origin.golden.yaml
@@ -1,11 +1,11 @@
 rules:
 - conf:
-  - connectionTimeout: 1m51s
-    http:
-      requestTimeout: 3m29s
-    idleTimeout: 1m49s
+    default:
+      connectionTimeout: 11s
+      http:
+        requestTimeout: 12s
   origin:
-  - Resource:
+    Resource:
       creationTime: "0001-01-01T00:00:00Z"
       labels:
         kuma.io/origin: global
@@ -14,14 +14,25 @@ rules:
       name: matched-for-rules-aaa
       type: MeshTimeout
     RuleIndex: 0
-  - Resource:
+- conf:
+    default:
+      connectionTimeout: 3m31s
+      http:
+        requestTimeout: 3m29s
+  origin:
+    Resource:
       creationTime: "0001-01-01T00:00:00Z"
       mesh: mesh-1
       modificationTime: "0001-01-01T00:00:00Z"
       name: matched-for-rules-bbb
       type: MeshTimeout
     RuleIndex: 0
-  - Resource:
+- conf:
+    default:
+      connectionTimeout: 1m51s
+      idleTimeout: 1m49s
+  origin:
+    Resource:
       creationTime: "0001-01-01T00:00:00Z"
       labels:
         kuma.io/origin: zone

--- a/pkg/plugins/policies/core/rules/inbound/testdata/inboundrules/mt-order-by-role.golden.yaml
+++ b/pkg/plugins/policies/core/rules/inbound/testdata/inboundrules/mt-order-by-role.golden.yaml
@@ -1,11 +1,11 @@
 rules:
 - conf:
-  - connectionTimeout: 1m51s
-    http:
-      requestTimeout: 3m29s
-    idleTimeout: 1m49s
+    default:
+      connectionTimeout: 11s
+      http:
+        requestTimeout: 12s
   origin:
-  - Resource:
+    Resource:
       creationTime: "0001-01-01T00:00:00Z"
       labels:
         kuma.io/policy-role: system
@@ -14,7 +14,13 @@ rules:
       name: matched-for-rules-aaa
       type: MeshTimeout
     RuleIndex: 0
-  - Resource:
+- conf:
+    default:
+      connectionTimeout: 3m31s
+      http:
+        requestTimeout: 3m29s
+  origin:
+    Resource:
       creationTime: "0001-01-01T00:00:00Z"
       labels:
         kuma.io/policy-role: producer
@@ -23,7 +29,12 @@ rules:
       name: matched-for-rules-bbb
       type: MeshTimeout
     RuleIndex: 0
-  - Resource:
+- conf:
+    default:
+      connectionTimeout: 1m51s
+      idleTimeout: 1m49s
+  origin:
+    Resource:
       creationTime: "0001-01-01T00:00:00Z"
       labels:
         kuma.io/policy-role: consumer

--- a/pkg/plugins/policies/core/rules/inbound/testdata/inboundrules/mt-rules.golden.yaml
+++ b/pkg/plugins/policies/core/rules/inbound/testdata/inboundrules/mt-rules.golden.yaml
@@ -1,18 +1,25 @@
 rules:
 - conf:
-  - connectionTimeout: 1m41s
-    http:
-      requestTimeout: 12s
-    idleTimeout: 10s
+    default:
+      connectionTimeout: 1m41s
+      http:
+        requestTimeout: 1m42s
+      idleTimeout: 1m40s
   origin:
-  - Resource:
+    Resource:
       creationTime: "0001-01-01T00:00:00Z"
       mesh: mesh-1
       modificationTime: "0001-01-01T00:00:00Z"
       name: matched-for-rules-mt-bbbbbb
       type: MeshTimeout
     RuleIndex: 0
-  - Resource:
+- conf:
+    default:
+      http:
+        requestTimeout: 12s
+      idleTimeout: 10s
+  origin:
+    Resource:
       creationTime: "0001-01-01T00:00:00Z"
       mesh: mesh-1
       modificationTime: "0001-01-01T00:00:00Z"

--- a/pkg/plugins/policies/core/rules/testdata/rules/from/04.golden.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/rules/from/04.golden.yaml
@@ -1,16 +1,33 @@
 InboundRules:
   127.0.0.1:80:
   - conf:
-    - backends: []
+      BaseEntry:
+        default:
+          backends:
+          - file:
+              path: /tmp/log/1
+            type: File
+          - file:
+              path: /tmp/log/2
+            type: File
+        targetRef:
+          kind: Mesh
     origin:
-    - Resource:
+      Resource:
         creationTime: "0001-01-01T00:00:00Z"
         mesh: mesh-1
         modificationTime: "0001-01-01T00:00:00Z"
         name: mal-1
         type: MeshAccessLog
       RuleIndex: 0
-    - Resource:
+  - conf:
+      BaseEntry:
+        default:
+          backends: []
+        targetRef:
+          kind: Mesh
+    origin:
+      Resource:
         creationTime: "0001-01-01T00:00:00Z"
         mesh: mesh-1
         modificationTime: "0001-01-01T00:00:00Z"

--- a/pkg/plugins/policies/core/rules/testdata/rules/from/05.golden.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/rules/from/05.golden.yaml
@@ -1,19 +1,36 @@
 InboundRules:
   127.0.0.1:80:
   - conf:
-    - backends:
-      - tcp:
-          address: logging:8080
-        type: Tcp
+      BaseEntry:
+        default:
+          backends:
+          - file:
+              path: /tmp/log/1
+            type: File
+          - file:
+              path: /tmp/log/2
+            type: File
+        targetRef:
+          kind: Mesh
     origin:
-    - Resource:
+      Resource:
         creationTime: "0001-01-01T00:00:00Z"
         mesh: mesh-1
         modificationTime: "0001-01-01T00:00:00Z"
         name: mal-1
         type: MeshAccessLog
       RuleIndex: 0
-    - Resource:
+  - conf:
+      BaseEntry:
+        default:
+          backends:
+          - tcp:
+              address: logging:8080
+            type: Tcp
+        targetRef:
+          kind: Mesh
+    origin:
+      Resource:
         creationTime: "0001-01-01T00:00:00Z"
         mesh: mesh-1
         modificationTime: "0001-01-01T00:00:00Z"

--- a/pkg/plugins/policies/core/rules/testdata/rules/from/meshtimeout.golden.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/rules/from/meshtimeout.golden.yaml
@@ -1,19 +1,30 @@
 InboundRules:
   127.0.0.1:80:
   - conf:
-    - connectionTimeout: 20s
-      http:
-        requestTimeout: 5s
-      idleTimeout: 20s
+      BaseEntry:
+        default:
+          connectionTimeout: 2s
+          http:
+            requestTimeout: 5s
+          idleTimeout: 20s
+        targetRef:
+          kind: Mesh
     origin:
-    - Resource:
+      Resource:
         creationTime: "0001-01-01T00:00:00Z"
         mesh: default
         modificationTime: "0001-01-01T00:00:00Z"
         name: default
         type: MeshTimeout
       RuleIndex: 0
-    - Resource:
+  - conf:
+      BaseEntry:
+        default:
+          connectionTimeout: 20s
+        targetRef:
+          kind: Mesh
+    origin:
+      Resource:
         creationTime: "0001-01-01T00:00:00Z"
         mesh: default
         modificationTime: "0001-01-01T00:00:00Z"

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
@@ -619,7 +619,7 @@ var _ = Describe("MeshAccessLog", func() {
 				},
 				InboundRules: map[core_rules.InboundListener][]*inbound.Rule{
 					{Address: "127.0.0.1", Port: 17777}: {{
-						Conf: []interface{}{api.Conf{
+						Conf: &api.Rule{Default: api.Conf{
 							Backends: &[]api.Backend{{
 								File: &api.FileBackend{
 									Path: "/tmp/log",
@@ -725,8 +725,8 @@ var _ = Describe("MeshAccessLog", func() {
 				},
 				InboundRules: map[core_rules.InboundListener][]*inbound.Rule{
 					{Address: "127.0.0.1", Port: 8080}: {
-						{Conf: []interface{}{
-							api.Conf{
+						{Conf: &api.Rule{
+							Default: api.Conf{
 								Backends: &[]api.Backend{{
 									File: &api.FileBackend{
 										Path: "/tmp/from-log",

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin_test.go
@@ -291,9 +291,7 @@ var _ = Describe("MeshCircuitBreaker", func() {
 				},
 				InboundRules: map[core_rules.InboundListener][]*inbound.Rule{
 					{Address: "127.0.0.1", Port: builders.FirstInboundPort}: {{
-						Conf: []interface{}{
-							api.Conf{ConnectionLimits: genConnectionLimits()},
-						},
+						Conf: &api.Rule{Default: api.Conf{ConnectionLimits: genConnectionLimits()}},
 					}},
 				},
 			},
@@ -318,9 +316,7 @@ var _ = Describe("MeshCircuitBreaker", func() {
 				},
 				InboundRules: map[core_rules.InboundListener][]*inbound.Rule{
 					{Address: "127.0.0.1", Port: builders.FirstInboundPort}: {{
-						Conf: []interface{}{
-							api.Conf{OutlierDetection: genOutlierDetection(false)},
-						},
+						Conf: &api.Rule{Default: api.Conf{OutlierDetection: genOutlierDetection(false)}},
 					}},
 				},
 			},
@@ -347,8 +343,8 @@ var _ = Describe("MeshCircuitBreaker", func() {
 				},
 				InboundRules: map[core_rules.InboundListener][]*inbound.Rule{
 					{Address: "127.0.0.1", Port: builders.FirstInboundPort}: {{
-						Conf: []interface{}{
-							api.Conf{
+						Conf: &api.Rule{
+							Default: api.Conf{
 								OutlierDetection: genOutlierDetection(true),
 							},
 						},
@@ -379,8 +375,8 @@ var _ = Describe("MeshCircuitBreaker", func() {
 				},
 				InboundRules: map[core_rules.InboundListener][]*inbound.Rule{
 					{Address: "127.0.0.1", Port: builders.FirstInboundPort}: {{
-						Conf: []interface{}{
-							api.Conf{
+						Conf: &api.Rule{
+							Default: api.Conf{
 								ConnectionLimits: genConnectionLimits(),
 								OutlierDetection: genOutlierDetection(false),
 							},
@@ -412,8 +408,8 @@ var _ = Describe("MeshCircuitBreaker", func() {
 				},
 				InboundRules: map[core_rules.InboundListener][]*inbound.Rule{
 					{Address: "127.0.0.1", Port: builders.FirstInboundPort}: {{
-						Conf: []interface{}{
-							api.Conf{
+						Conf: &api.Rule{
+							Default: api.Conf{
 								ConnectionLimits: genConnectionLimits(),
 								OutlierDetection: genOutlierDetection(true),
 							},

--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin_test.go
@@ -177,8 +177,8 @@ var _ = Describe("MeshRateLimit", func() {
 				},
 				InboundRules: map[core_rules.InboundListener][]*inbound.Rule{
 					{Address: "127.0.0.1", Port: 17777}: {{
-						Conf: []interface{}{
-							api.Conf{
+						Conf: &api.Rule{
+							Default: api.Conf{
 								Local: &api.Local{
 									HTTP: &api.LocalHTTP{
 										RequestRate: &api.Rate{Num: 100, Interval: *test.ParseDuration("10s")},
@@ -209,8 +209,8 @@ var _ = Describe("MeshRateLimit", func() {
 						},
 					}},
 					{Address: "127.0.0.1", Port: 17778}: {{
-						Conf: []interface{}{
-							api.Conf{
+						Conf: &api.Rule{
+							Default: api.Conf{
 								Local: &api.Local{
 									HTTP: &api.LocalHTTP{
 										RequestRate: &api.Rate{Num: 100, Interval: *test.ParseDuration("10s")},
@@ -307,8 +307,8 @@ var _ = Describe("MeshRateLimit", func() {
 				},
 				InboundRules: map[core_rules.InboundListener][]*inbound.Rule{
 					{Address: "127.0.0.1", Port: 17777}: {{
-						Conf: []interface{}{
-							api.Conf{
+						Conf: &api.Rule{
+							Default: api.Conf{
 								Local: &api.Local{
 									HTTP: &api.LocalHTTP{
 										RequestRate: &api.Rate{
@@ -399,8 +399,8 @@ var _ = Describe("MeshRateLimit", func() {
 				},
 				InboundRules: map[core_rules.InboundListener][]*inbound.Rule{
 					{Address: "127.0.0.1", Port: 17778}: {{
-						Conf: []interface{}{
-							api.Conf{
+						Conf: &api.Rule{
+							Default: api.Conf{
 								Local: &api.Local{
 									TCP: &api.LocalTCP{
 										Disabled:       pointer.To(true),
@@ -453,8 +453,8 @@ var _ = Describe("MeshRateLimit", func() {
 				},
 				InboundRules: map[core_rules.InboundListener][]*inbound.Rule{
 					{Address: "127.0.0.1", Port: 17777}: {{
-						Conf: []interface{}{
-							api.Conf{
+						Conf: &api.Rule{
+							Default: api.Conf{
 								Local: &api.Local{
 									HTTP: &api.LocalHTTP{
 										Disabled:    pointer.To(true),
@@ -493,8 +493,8 @@ var _ = Describe("MeshRateLimit", func() {
 				},
 				InboundRules: map[core_rules.InboundListener][]*inbound.Rule{
 					{Address: "127.0.0.1", Port: 17778}: {{
-						Conf: []interface{}{
-							api.Conf{
+						Conf: &api.Rule{
+							Default: api.Conf{
 								Local: &api.Local{
 									TCP: &api.LocalTCP{
 										ConnectionRate: nil,
@@ -545,8 +545,8 @@ var _ = Describe("MeshRateLimit", func() {
 				},
 				InboundRules: map[core_rules.InboundListener][]*inbound.Rule{
 					{Address: "127.0.0.1", Port: 17777}: {{
-						Conf: []interface{}{
-							api.Conf{
+						Conf: &api.Rule{
+							Default: api.Conf{
 								Local: &api.Local{
 									HTTP: &api.LocalHTTP{
 										RequestRate: nil,

--- a/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin_test.go
@@ -250,7 +250,7 @@ var _ = Describe("MeshTimeout", func() {
 						Address: "127.0.0.1",
 						Port:    80,
 					}: {{
-						Conf: []interface{}{api.Conf{
+						Conf: &api.Rule{Default: api.Conf{
 							ConnectionTimeout: test.ParseDuration("10s"),
 							IdleTimeout:       test.ParseDuration("1h"),
 							Http: &api.Http{
@@ -413,7 +413,7 @@ var _ = Describe("MeshTimeout", func() {
 						Address: "127.0.0.1",
 						Port:    80,
 					}: {{
-						Conf: []interface{}{api.Conf{
+						Conf: &api.Rule{Default: api.Conf{
 							ConnectionTimeout: test.ParseDuration("10s"),
 							IdleTimeout:       test.ParseDuration("1h"),
 							Http: &api.Http{
@@ -696,8 +696,8 @@ var _ = Describe("MeshTimeout", func() {
 				},
 				InboundRules: map[core_rules.InboundListener][]*inbound.Rule{
 					{Address: "192.168.0.1", Port: 8080}: {
-						{Conf: []interface{}{
-							api.Conf{
+						{Conf: &api.Rule{
+							Default: api.Conf{
 								IdleTimeout: test.ParseDuration("1h"),
 								Http: &api.Http{
 									RequestTimeout:        test.ParseDuration("311s"),

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin_test.go
@@ -20,6 +20,7 @@ import (
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
 	core_rules "github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
+	"github.com/kumahq/kuma/pkg/plugins/policies/core/rules/common"
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/rules/inbound"
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/rules/subsetutils"
 	meshhttproute_api "github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
@@ -377,49 +378,55 @@ func getPolicy(caseName string) *api.MeshTLSResource {
 }
 
 func getFromRules(froms []api.From) core_rules.FromRules {
-	var rules []*core_rules.Rule
-	var confs []interface{}
+	var legacyRules []*core_rules.Rule
+	var rules []*inbound.Rule
 
 	for _, from := range froms {
-		rules = append(rules, &core_rules.Rule{
+		legacyRules = append(legacyRules, &core_rules.Rule{
 			Subset: subsetutils.Subset{},
 			Conf:   from.Default,
 		})
-		confs = append(confs, from.Default)
+		rules = append(rules, &inbound.Rule{
+			Conf:   &from,
+			Origin: common.Origin{},
+		})
 	}
 
 	return core_rules.FromRules{
 		Rules: map[core_rules.InboundListener]core_rules.Rules{
-			{Address: "127.0.0.1", Port: 17777}: rules,
-			{Address: "127.0.0.1", Port: 17778}: rules,
+			{Address: "127.0.0.1", Port: 17777}: legacyRules,
+			{Address: "127.0.0.1", Port: 17778}: legacyRules,
 		},
 		InboundRules: map[core_rules.InboundListener][]*inbound.Rule{
-			{Address: "127.0.0.1", Port: 17777}: {{Conf: confs}},
-			{Address: "127.0.0.1", Port: 17778}: {{Conf: confs}},
+			{Address: "127.0.0.1", Port: 17777}: rules,
+			{Address: "127.0.0.1", Port: 17778}: rules,
 		},
 	}
 }
 
 func getGatewayRules(froms []api.From) core_rules.GatewayRules {
-	var rules []*core_rules.Rule
-	var confs []interface{}
+	var legacyRules []*core_rules.Rule
+	var rules []*inbound.Rule
 
 	for _, from := range froms {
-		rules = append(rules, &core_rules.Rule{
+		legacyRules = append(legacyRules, &core_rules.Rule{
 			Subset: subsetutils.Subset{},
 			Conf:   from.Default,
 		})
-		confs = append(confs, from.Default)
+		rules = append(rules, &inbound.Rule{
+			Conf:   &from,
+			Origin: common.Origin{},
+		})
 	}
 
 	return core_rules.GatewayRules{
 		FromRules: map[core_rules.InboundListener]core_rules.Rules{
-			{Address: "127.0.0.1", Port: 17777}: rules,
-			{Address: "127.0.0.1", Port: 17778}: rules,
+			{Address: "127.0.0.1", Port: 17777}: legacyRules,
+			{Address: "127.0.0.1", Port: 17778}: legacyRules,
 		},
 		InboundRules: map[core_rules.InboundListener][]*inbound.Rule{
-			{Address: "127.0.0.1", Port: 17777}: {{Conf: confs}},
-			{Address: "127.0.0.1", Port: 17778}: {{Conf: confs}},
+			{Address: "127.0.0.1", Port: 17777}: rules,
+			{Address: "127.0.0.1", Port: 17778}: rules,
 		},
 	}
 }


### PR DESCRIPTION
## Motivation

We need to stop merging inbound rules to be able to implement SpiffeId support in MeshTrafficPermission. Rest of the policies that utilize rules will work as previosly 

## Implementation information

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
