### PR TITLE
ci(renovate): extract and expand security rules

### DIFF
--- a/.renovate/security.json
+++ b/.renovate/security.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Enable OSV-based vulnerability alerts and route them to the security team. Also label and assign updates for 'Kong/public-shared-actions/security-actions/**' as security-related to ensure proper visibility and handling",
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "addLabels": [
+      "area/security"
+    ],
+    "assignees": [
+      "@kumahq/kuma-security-managers"
+    ],
+    "commitMessageSuffix": ""
+  },
+  "packageRules": [
+    {
+      "description": "Add security label and assign security managers to updates for 'Kong/public-shared-actions/security-actions/**'",
+      "matchPackageNames": [
+        "Kong/public-shared-actions/security-actions/**"
+      ],
+      "addLabels": [
+        "area/security"
+      ],
+      "assignees": [
+        "@kumahq/kuma-security-managers"
+      ],
+      "prCreation": "immediate",
+      "schedule": []
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,8 @@
     "Kong/public-shared-renovate:backend",
     "Kong/public-shared-renovate:makefile",
     "kumahq/kuma//.renovate/go-control-plane",
-    "kumahq/kuma//.renovate/mise"
+    "kumahq/kuma//.renovate/mise",
+    "kumahq/kuma//.renovate/security"
   ],
   "enabledManagers": [
     "custom.regex",
@@ -15,16 +16,6 @@
     "kubernetes",
     "mise"
   ],
-  "osvVulnerabilityAlerts": true,
-  "vulnerabilityAlerts": {
-    "addLabels": [
-      "area/security"
-    ],
-    "assignees": [
-      "@kumahq/kuma-security-managers"
-    ],
-    "commitMessageSuffix": ""
-  },
   "ignorePaths": [],
   "kubernetes": {
     "description": "Update image versions in Kubernetes manifests from 'kumactl install demo|observability'",


### PR DESCRIPTION
### Motivation

The main `renovate.json` was becoming too large and harder to maintain. Security-related logic should be easier to find and reused across repositories. Also, updates to security-related actions were not explicitly marked or routed to the correct reviewers.

### Implementation information

This PR:
- Moves security-related configuration (OSV alerts, vulnerability PR labels and assignees) into a separate `.renovate/security.json` file
- Adds a rule to tag and assign updates to `Kong/public-shared-actions/security-actions/**` as security-related
- Ensures `area/security` label is added and `@kumahq/kuma-security-managers` are assigned
- Sets PRs for these updates to be created immediately with no schedule

Validated on my fork:
* https://github.com/bartsmykla/kuma/pull/475
* https://github.com/bartsmykla/kuma/pull/476

### Supporting documentation

- https://github.com/Kong/public-shared-actions/tree/main/security-actions