### PR TITLE
chore(deps/dev): bump hadolint to 2.12.1-beta to fix macOS crash

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -4,7 +4,7 @@ experimental = true # To enable installation of Go tools from source with mise.
 [tools]
 container-structure-test = "1.19.3"
 ginkgo = "2.23.4"
-hadolint = "2.12.0"
+hadolint = "2.12.1-beta"
 helm = "3.18.4"
 helm-docs = "1.11.0"
 kind = "0.24.0"


### PR DESCRIPTION
## Motivation

Hadolint 2.12.0 crashes on macOS with a segmentation fault when run, making it unusable for local development. The issue is tracked here: https://github.com/hadolint/hadolint/issues/919

## Implementation information

Bumped hadolint to 2.12.1-beta in `mise.toml`. This version includes a fix for the macOS crash and is the latest officially released version, even though it was published almost 3 years ago.

No other changes were needed.

## Supporting documentation

Issue: https://github.com/hadolint/hadolint/issues/919