### PR TITLE
fix: fix loadbalancersourcerange templating

### DIFF
--- a/deployments/charts/kuma/templates/ingress-service.yaml
+++ b/deployments/charts/kuma/templates/ingress-service.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   type: {{ .Values.ingress.service.type }}
   {{- if .Values.ingress.service.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.ingress.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.ingress.service.loadBalancerIP | toYaml }}
   {{- end }}
   {{- if .Values.ingress.service.loadBalancerSourceRanges}}
   loadBalancerSourceRanges:


### PR DESCRIPTION
This fixes an issue that arises when the loadBalancerSourceRanges field is set with more than one value. Old behavior created a string with all the ranges in it which resulted in an invalid CIDR

## Motivation
helm chart is broken and I need to deploy stuff with loadbalancersourceranges

## Implementation information



## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
