### PR TITLE
feat(plugins): add ability to register core resources plugins

### DIFF
--- a/pkg/core/plugins/initializer.go
+++ b/pkg/core/plugins/initializer.go
@@ -25,3 +25,16 @@ func Init(enabledPlugins []string, plugins map[string]*PluginInitializer) {
 		}
 	}
 }
+
+func InitAllIf(enabledPlugins []string, pluginName string, plugins map[string]*PluginInitializer) {
+	for _, plugin := range enabledPlugins {
+		if plugin == pluginName {
+			for _, initializer := range plugins {
+				if !initializer.Initialized {
+					initializer.InitFn()
+					initializer.Initialized = true
+				}
+			}
+		}
+	}
+}

--- a/pkg/core/plugins/interfaces.go
+++ b/pkg/core/plugins/interfaces.go
@@ -131,3 +131,10 @@ type ProxyPlugin interface {
 	// Apply mutate the proxy as needed.
 	Apply(ctx context.Context, meshCtx xds_context.MeshContext, proxy *core_xds.Proxy) error
 }
+
+// CoreResourcePlugin a plugin to generate xDS resources based on core resources.
+type CoreResourcePlugin interface {
+	Plugin
+	// Apply to `rs` using `proxy` the mutation or new resources.
+	Generate(rs *core_xds.ResourceSet, xdsCtx xds_context.Context, proxy *core_xds.Proxy) error
+}

--- a/pkg/core/plugins/registry.go
+++ b/pkg/core/plugins/registry.go
@@ -48,6 +48,7 @@ type Registry interface {
 	AuthnAPIServer() map[PluginName]AuthnAPIServerPlugin
 	PolicyPlugins([]PluginName) []RegisteredPolicyPlugin
 	ProxyPlugins() map[PluginName]ProxyPlugin
+	CoreResourcePlugins() map[PluginName]CoreResourcePlugin
 }
 
 type RegistryMutator interface {
@@ -61,30 +62,32 @@ type MutableRegistry interface {
 
 func NewRegistry() MutableRegistry {
 	return &registry{
-		bootstrap:          make(map[PluginName]BootstrapPlugin),
-		resourceStore:      make(map[PluginName]ResourceStorePlugin),
-		secretStore:        make(map[PluginName]SecretStorePlugin),
-		configStore:        make(map[PluginName]ConfigStorePlugin),
-		runtime:            make(map[PluginName]RuntimePlugin),
-		ca:                 make(map[PluginName]CaPlugin),
-		authnAPIServer:     make(map[PluginName]AuthnAPIServerPlugin),
-		proxy:              make(map[PluginName]ProxyPlugin),
-		registeredPolicies: make(map[PluginName]PolicyPlugin),
+		bootstrap:           make(map[PluginName]BootstrapPlugin),
+		resourceStore:       make(map[PluginName]ResourceStorePlugin),
+		secretStore:         make(map[PluginName]SecretStorePlugin),
+		configStore:         make(map[PluginName]ConfigStorePlugin),
+		runtime:             make(map[PluginName]RuntimePlugin),
+		ca:                  make(map[PluginName]CaPlugin),
+		authnAPIServer:      make(map[PluginName]AuthnAPIServerPlugin),
+		proxy:               make(map[PluginName]ProxyPlugin),
+		registeredPolicies:  make(map[PluginName]PolicyPlugin),
+		registeredResources: make(map[PluginName]CoreResourcePlugin),
 	}
 }
 
 var _ MutableRegistry = &registry{}
 
 type registry struct {
-	bootstrap          map[PluginName]BootstrapPlugin
-	resourceStore      map[PluginName]ResourceStorePlugin
-	secretStore        map[PluginName]SecretStorePlugin
-	configStore        map[PluginName]ConfigStorePlugin
-	runtime            map[PluginName]RuntimePlugin
-	proxy              map[PluginName]ProxyPlugin
-	ca                 map[PluginName]CaPlugin
-	authnAPIServer     map[PluginName]AuthnAPIServerPlugin
-	registeredPolicies map[PluginName]PolicyPlugin
+	bootstrap           map[PluginName]BootstrapPlugin
+	resourceStore       map[PluginName]ResourceStorePlugin
+	secretStore         map[PluginName]SecretStorePlugin
+	configStore         map[PluginName]ConfigStorePlugin
+	runtime             map[PluginName]RuntimePlugin
+	proxy               map[PluginName]ProxyPlugin
+	ca                  map[PluginName]CaPlugin
+	authnAPIServer      map[PluginName]AuthnAPIServerPlugin
+	registeredPolicies  map[PluginName]PolicyPlugin
+	registeredResources map[PluginName]CoreResourcePlugin
 }
 
 func (r *registry) ResourceStore(name PluginName) (ResourceStorePlugin, error) {
@@ -136,6 +139,10 @@ func (r *registry) PolicyPlugins(ordered []PluginName) []RegisteredPolicyPlugin 
 		})
 	}
 	return plugins
+}
+
+func (r *registry) CoreResourcePlugins() map[PluginName]CoreResourcePlugin {
+	return r.registeredResources
 }
 
 func (r *registry) BootstrapPlugins() []BootstrapPlugin {
@@ -212,6 +219,12 @@ func (r *registry) Register(name PluginName, plugin Plugin) error {
 			return pluginAlreadyRegisteredError(proxyPlugin, name, old, proxy)
 		}
 		r.proxy[name] = proxy
+	}
+	if coreRes, ok := plugin.(CoreResourcePlugin); ok {
+		if old, exists := r.registeredResources[name]; exists {
+			return pluginAlreadyRegisteredError(proxyPlugin, name, old, coreRes)
+		}
+		r.registeredResources[name] = coreRes
 	}
 	return nil
 }

--- a/pkg/core/resources/apis/core/generator/generator.go
+++ b/pkg/core/resources/apis/core/generator/generator.go
@@ -1,0 +1,27 @@
+package generator
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/kumahq/kuma/pkg/core/plugins"
+	"github.com/kumahq/kuma/pkg/core/xds"
+	xds_context "github.com/kumahq/kuma/pkg/xds/context"
+	generator_core "github.com/kumahq/kuma/pkg/xds/generator/core"
+)
+
+func NewGenerator() generator_core.ResourceGenerator {
+	return generator{}
+}
+
+type generator struct{}
+
+func (g generator) Generate(ctx context.Context, rs *xds.ResourceSet, xdsCtx xds_context.Context, proxy *xds.Proxy) (*xds.ResourceSet, error) {
+	for pluginName, plugin := range plugins.Plugins().CoreResourcePlugins() {
+		if err := plugin.Generate(rs, xdsCtx, proxy); err != nil {
+			return nil, errors.Wrapf(err, "could not apply core resource plugin %s", pluginName)
+		}
+	}
+	return rs, nil
+}

--- a/pkg/xds/generator/proxy_template.go
+++ b/pkg/xds/generator/proxy_template.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	core_generator "github.com/kumahq/kuma/pkg/core/resources/apis/core/generator"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	model "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/generator"
@@ -89,6 +90,7 @@ func NewDefaultProxyProfile() core.ResourceGenerator {
 		DNSGenerator{},
 		generator.NewGenerator(),
 		generator_secrets.Generator{},
+		core_generator.NewGenerator(),
 	}
 }
 

--- a/tools/policy-gen/generator/pkg/parse/policyconfig.go
+++ b/tools/policy-gen/generator/pkg/parse/policyconfig.go
@@ -47,6 +47,7 @@ type PolicyConfig struct {
 	IsReferenceableInTo          bool
 	KubebuilderMarkers           []string
 	IsFromAsRules                bool
+	RegisterGenerator            bool
 }
 
 func Policy(path string) (PolicyConfig, error) {
@@ -175,6 +176,9 @@ func newPolicyConfig(pkg, name string, markers map[string]string, fields map[str
 	}
 	if v, ok := parseBool(markers, "kuma:policy:is_from_as_rules"); ok {
 		res.IsFromAsRules = v
+	}
+	if v, ok := parseBool(markers, "kuma:policy:register_generator"); ok {
+		res.RegisterGenerator = v
 	}
 	if v, ok := markers["kuma:policy:kds_flags"]; ok {
 		res.KDSFlags = v


### PR DESCRIPTION
## Motivation

Once MeshIdentity is implemented we need to create some resources (Secrets, Cluster - Spire agent) it makes sense to have specific generator for them.

## Implementation information

* Add tag which allows registering generators in core resources
* Add option to distinguish between specific plugins 

## Supporting documentation

Part of #13876 
