### PR TITLE
feat(k8s): propagate service account in the annotation

### DIFF
--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -448,11 +448,11 @@ func (r *resourceEndpoints) createResource(
 		res.Descriptor(),
 		res.GetSpec(),
 		res.GetMeta().GetLabels(),
-		core_model.GetNamespace(res.GetMeta(), r.systemNamespace),
 		meshName,
-		r.mode,
-		r.isK8s,
-		r.zoneName,
+		core_model.WithNamespace(core_model.GetNamespace(res.GetMeta(), r.systemNamespace)),
+		core_model.WithMode(r.mode),
+		core_model.WithK8s(r.isK8s),
+		core_model.WithZone(r.zoneName),
 	)
 	if err != nil {
 		rest_errors.HandleError(ctx, response, err, "Could not compute labels for a resource")
@@ -494,11 +494,11 @@ func (r *resourceEndpoints) updateResource(
 		currentRes.Descriptor(),
 		currentRes.GetSpec(),
 		newResRest.GetMeta().GetLabels(),
-		core_model.GetNamespace(newResRest.GetMeta(), r.systemNamespace),
 		meshName,
-		r.mode,
-		r.isK8s,
-		r.zoneName,
+		core_model.WithNamespace(core_model.GetNamespace(newResRest.GetMeta(), r.systemNamespace)),
+		core_model.WithMode(r.mode),
+		core_model.WithK8s(r.isK8s),
+		core_model.WithZone(r.zoneName),
 	)
 	if err != nil {
 		rest_errors.HandleError(ctx, response, err, "Could not compute labels for a resource")

--- a/pkg/core/managers/apis/dataplane/dataplane_manager.go
+++ b/pkg/core/managers/apis/dataplane/dataplane_manager.go
@@ -59,11 +59,11 @@ func (m *dataplaneManager) Create(ctx context.Context, resource core_model.Resou
 		resource.Descriptor(),
 		resource.GetSpec(),
 		opts.Labels,
-		core_model.UnsetNamespace,
 		opts.Mesh,
-		m.mode,
-		m.isK8s,
-		m.zone,
+		core_model.WithNamespace(core_model.UnsetNamespace),
+		core_model.WithMode(m.mode),
+		core_model.WithK8s(m.isK8s),
+		core_model.WithZone(m.zone),
 	)
 	if err != nil {
 		return err
@@ -100,11 +100,11 @@ func (m *dataplaneManager) Update(ctx context.Context, resource core_model.Resou
 		resource.Descriptor(),
 		resource.GetSpec(),
 		opts.Labels,
-		core_model.GetNamespace(resource.GetMeta(), m.systemNamespace),
 		resource.GetMeta().GetMesh(),
-		m.mode,
-		m.isK8s,
-		m.zone,
+		core_model.WithNamespace(core_model.GetNamespace(resource.GetMeta(), m.systemNamespace)),
+		core_model.WithMode(m.mode),
+		core_model.WithK8s(m.isK8s),
+		core_model.WithZone(m.zone),
 	)
 	if err != nil {
 		return err

--- a/pkg/core/resources/model/labels/labels.go
+++ b/pkg/core/resources/model/labels/labels.go
@@ -15,4 +15,5 @@ var AllComputedLabels = map[string]struct{}{
 	mesh_proto.KubeNamespaceTag:    {},
 	mesh_proto.PolicyRoleLabel:     {},
 	mesh_proto.ProxyTypeLabel:      {},
+	metadata.KumaServiceAccount:    {},
 }

--- a/pkg/core/resources/model/resource_test.go
+++ b/pkg/core/resources/model/resource_test.go
@@ -346,11 +346,11 @@ var _ = Describe("ComputeLabels", func() {
 				given.r.Descriptor(),
 				given.r.GetSpec(),
 				given.r.GetMeta().GetLabels(),
-				core_model.GetNamespace(given.r.GetMeta(), "kuma-system"),
 				given.r.GetMeta().GetMesh(),
-				given.mode,
-				given.isK8s,
-				given.localZone,
+				core_model.WithNamespace(core_model.GetNamespace(given.r.GetMeta(), "kuma-system")),
+				core_model.WithMode(given.mode),
+				core_model.WithK8s(given.isK8s),
+				core_model.WithZone(given.localZone),
 			)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(labels).To(Equal(given.expectedLabels))

--- a/pkg/plugins/resources/k8s/store_test.go
+++ b/pkg/plugins/resources/k8s/store_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s"
 	mesh_k8s "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/api/v1alpha1"
 	k8s_registry "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
+	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/metadata"
 	. "github.com/kumahq/kuma/pkg/test/matchers"
 )
 
@@ -542,6 +543,7 @@ var _ = Describe("KubernetesStore", func() {
             metadata:
               annotations:
                 kuma.io/display-name: dn
+                k8s.kuma.io/service-account: default
               name: %s
             spec:
               conf:
@@ -559,6 +561,7 @@ var _ = Describe("KubernetesStore", func() {
 			// then
 			Expect(err).ToNot(HaveOccurred())
 			Expect(actual.Meta.GetLabels()[mesh_proto.DisplayName]).To(Equal("dn"))
+			Expect(actual.Meta.GetLabels()[metadata.KumaServiceAccount]).To(Equal("default"))
 		})
 	})
 

--- a/pkg/plugins/runtime/k8s/controllers/pod_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller.go
@@ -179,7 +179,7 @@ func (r *PodReconciler) reconcileBuiltinGatewayDataplane(ctx context.Context, po
 	if err := r.Get(ctx, kube_types.NamespacedName{Name: pod.Namespace}, &ns); err != nil {
 		return errors.Wrap(err, "unable to get Namespace for Pod")
 	}
-	return r.createorUpdateBuiltinGatewayDataplane(ctx, pod, &ns)
+	return r.createOrUpdateBuiltinGatewayDataplane(ctx, pod, &ns)
 }
 
 func (r *PodReconciler) reconcileZoneIngress(ctx context.Context, pod *kube_core.Pod, log logr.Logger) error {

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter.go
@@ -64,11 +64,12 @@ func (p *PodConverter) PodToDataplane(
 		core_mesh.DataplaneResourceTypeDescriptor,
 		currentSpec,
 		mergeLabels(dataplane.GetLabels(), pod.Labels),
-		model.NewNamespace(pod.Namespace, pod.Namespace == p.SystemNamespace),
 		dataplane.Mesh,
-		p.Mode,
-		true,
-		p.Zone,
+		model.WithNamespace(model.NewNamespace(pod.Namespace, pod.Namespace == p.SystemNamespace)),
+		model.WithMode(p.Mode),
+		model.WithK8s(true),
+		model.WithZone(p.Zone),
+		model.WithServiceAccount(pod.Spec.ServiceAccountName),
 	)
 	if err != nil {
 		return err
@@ -104,11 +105,12 @@ func (p *PodConverter) PodToIngress(ctx context.Context, zoneIngress *mesh_k8s.Z
 		core_mesh.ZoneIngressResourceTypeDescriptor,
 		currentSpec,
 		mergeLabels(zoneIngress.GetLabels(), pod.Labels),
-		model.NewNamespace(pod.Namespace, pod.Namespace == p.SystemNamespace),
 		model.NoMesh,
-		p.Mode,
-		true,
-		p.Zone,
+		model.WithNamespace(model.NewNamespace(pod.Namespace, pod.Namespace == p.SystemNamespace)),
+		model.WithMode(p.Mode),
+		model.WithK8s(true),
+		model.WithZone(p.Zone),
+		model.WithServiceAccount(pod.Spec.ServiceAccountName),
 	)
 	if err != nil {
 		return err
@@ -144,11 +146,12 @@ func (p *PodConverter) PodToEgress(ctx context.Context, zoneEgress *mesh_k8s.Zon
 		core_mesh.ZoneEgressResourceTypeDescriptor,
 		currentSpec,
 		mergeLabels(zoneEgress.GetLabels(), pod.Labels),
-		model.NewNamespace(pod.Namespace, pod.Namespace == p.SystemNamespace),
 		model.NoMesh,
-		p.Mode,
-		true,
-		p.Zone,
+		model.WithNamespace(model.NewNamespace(pod.Namespace, pod.Namespace == p.SystemNamespace)),
+		model.WithMode(p.Mode),
+		model.WithK8s(true),
+		model.WithZone(p.Zone),
+		model.WithServiceAccount(pod.Spec.ServiceAccountName),
 	)
 	if err != nil {
 		return err

--- a/pkg/plugins/runtime/k8s/controllers/testdata/30.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/30.dataplane.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app: example
     k8s.kuma.io/namespace: demo
+    k8s.kuma.io/service-account: test-sa
     kuma.io/mesh: default
     kuma.io/proxy-type: sidecar
     version: "0.1"

--- a/pkg/plugins/runtime/k8s/controllers/testdata/30.pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/30.pod.yaml
@@ -9,6 +9,7 @@ metadata:
     kuma.io/virtual-probes-port: 19000
     kuma.io/application-probe-proxy-port: "8662"
 spec:
+  serviceAccountName: test-sa
   containers:
     - readinessProbe:
         httpGet:

--- a/pkg/plugins/runtime/k8s/metadata/annotations.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations.go
@@ -138,6 +138,9 @@ const (
 	// KumaXdsTransportProtocolVariant allows to specify mode in which control-plane exchange configuration with the sidecar.
 	// Available value is DELTA_GRPC
 	KumaXdsTransportProtocolVariant = "kuma.io/xds-transport-protocol-variant"
+
+	// KumaServiceAccount specifies the ServiceAccount associated with the pod.
+	KumaServiceAccount = "k8s.kuma.io/service-account"
 )
 
 var PodAnnotationDeprecations = []Deprecation{

--- a/pkg/plugins/runtime/k8s/webhooks/defaulter.go
+++ b/pkg/plugins/runtime/k8s/webhooks/defaulter.go
@@ -70,11 +70,11 @@ func (h *defaultingHandler) Handle(_ context.Context, req admission.Request) adm
 		resource.Descriptor(),
 		resource.GetSpec(),
 		resource.GetMeta().GetLabels(),
-		core_model.GetNamespace(resource.GetMeta(), h.SystemNamespace),
 		resource.GetMeta().GetMesh(),
-		h.Mode,
-		true,
-		h.ZoneName,
+		core_model.WithNamespace(core_model.GetNamespace(resource.GetMeta(), h.SystemNamespace)),
+		core_model.WithMode(h.Mode),
+		core_model.WithK8s(true),
+		core_model.WithZone(h.ZoneName),
 	)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)


### PR DESCRIPTION
## Motivation

Support of MeshIdentity requires access to ServiceAccount of pod.

## Implementation information

* propagate ServiceAccount in the annotation - service account might be longer than 63 characters so we cannot store it in the label
* refactor `ComputeLabels` to accept function instead of another parameter
* ComputeLabels for builtin gateway

## Supporting documentation

Part of #13876 
