### PR TITLE
ci(container-structure-tests): add missing platform flag

### DIFF
--- a/mk/test-container-structure.mk
+++ b/mk/test-container-structure.mk
@@ -5,6 +5,7 @@ define TEST_CONTAINER_STRUCTURES_BY_ARCH
 test/container-structure/$(1)/$(2): $(if $(CI),docker/load/$(1)/$(2),image/$(1)/$(2))
 	$(CONTAINER_STRUCTURE_TEST) test \
 		--config $(if $(RESOLVE_CONTAINER_TEST_FILE),$$(call RESOLVE_CONTAINER_TEST_FILE,$(1)),$(TEST_CONTAINER_TESTS_PATH)/$(1).yaml) \
+		--platform $(2) \
 		--image $(call build_image,$(1),$(2))
 endef
 $(foreach goarch,$(SUPPORTED_GOARCHES),$(foreach image,$(IMAGES_RELEASE),$(eval $(call TEST_CONTAINER_STRUCTURES_BY_ARCH,$(image),$(goarch)))))


### PR DESCRIPTION
## Motivation

Broken master

## Implementation information

Added missing `--platform` flag to container structure test command

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
