### PR TITLE
feat(kuma-cp): rename readiness resources

### DIFF
--- a/pkg/xds/generator/admin_proxy_generator.go
+++ b/pkg/xds/generator/admin_proxy_generator.go
@@ -8,6 +8,7 @@ import (
 	"github.com/asaskevich/govalidator"
 	"github.com/pkg/errors"
 
+	core_system_names "github.com/kumahq/kuma/pkg/core/system_names"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/core/xds/types"
 	util_maps "github.com/kumahq/kuma/pkg/util/maps"
@@ -75,7 +76,12 @@ func (g AdminProxyGenerator) Generate(ctx context.Context, _ *core_xds.ResourceS
 	if unifiedNamingEnabled {
 		envoyAdminClusterName = system_names.SystemResourceNameEnvoyAdmin
 	}
-	dppReadinessClusterName := envoy_names.GetDPPReadinessClusterName()
+
+	getNameOrDefault := core_system_names.GetNameOrDefault(proxy.Metadata.HasFeature(types.FeatureUnifiedResourceNaming))
+	dppReadinessClusterName := getNameOrDefault(
+		system_names.SystemResourceNameReadiness,
+		envoy_names.GetDPPReadinessClusterName(),
+	)
 	adminAddress := proxy.Metadata.GetAdminAddress()
 	if _, ok := adminAddressAllowedValues[adminAddress]; !ok {
 		var allowedAddresses []string

--- a/pkg/xds/generator/system_names/api.go
+++ b/pkg/xds/generator/system_names/api.go
@@ -2,4 +2,7 @@ package system_names
 
 import "github.com/kumahq/kuma/pkg/core/system_names"
 
-var SystemResourceNameEnvoyAdmin = system_names.MustBeSystemName("envoy_admin")
+var (
+	SystemResourceNameEnvoyAdmin = system_names.MustBeSystemName("envoy_admin")
+	SystemResourceNameReadiness  = system_names.MustBeSystemName("probe_readiness")
+)

--- a/pkg/xds/generator/testdata/admin/07.envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/admin/07.envoy-config.golden.yaml
@@ -1,20 +1,4 @@
 resources:
-- name: kuma:readiness
-  resource:
-    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    altStatName: kuma_readiness
-    connectTimeout: 5s
-    loadAssignment:
-      clusterName: kuma:readiness
-      endpoints:
-      - lbEndpoints:
-        - endpoint:
-            address:
-              socketAddress:
-                address: 127.0.0.1
-                portValue: 9902
-    name: kuma:readiness
-    type: STATIC
 - name: system_envoy_admin
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
@@ -29,6 +13,21 @@ resources:
                 address: 127.0.0.1
                 portValue: 9901
     name: system_envoy_admin
+    type: STATIC
+- name: system_probe_readiness
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 5s
+    loadAssignment:
+      clusterName: system_probe_readiness
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 127.0.0.1
+                portValue: 9902
+    name: system_probe_readiness
     type: STATIC
 - name: system_envoy_admin
   resource:
@@ -63,7 +62,7 @@ resources:
               - match:
                   prefix: /ready
                 route:
-                  cluster: kuma:readiness
+                  cluster: system_probe_readiness
                   prefixRewrite: /ready
           statPrefix: system_envoy_admin
     - filterChainMatch:
@@ -92,7 +91,7 @@ resources:
               - match:
                   prefix: /ready
                 route:
-                  cluster: kuma:readiness
+                  cluster: system_probe_readiness
                   prefixRewrite: /ready
               - match:
                   prefix: /

--- a/pkg/xds/generator/testdata/admin/08.envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/admin/08.envoy-config.golden.yaml
@@ -1,19 +1,4 @@
 resources:
-- name: kuma:readiness
-  resource:
-    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    altStatName: kuma_readiness
-    connectTimeout: 5s
-    loadAssignment:
-      clusterName: kuma:readiness
-      endpoints:
-      - lbEndpoints:
-        - endpoint:
-            address:
-              pipe:
-                path: kuma-readiness-reporter.sock
-    name: kuma:readiness
-    type: STATIC
 - name: system_envoy_admin
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
@@ -28,6 +13,20 @@ resources:
                 address: 127.0.0.1
                 portValue: 9901
     name: system_envoy_admin
+    type: STATIC
+- name: system_probe_readiness
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 5s
+    loadAssignment:
+      clusterName: system_probe_readiness
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              pipe:
+                path: kuma-readiness-reporter.sock
+    name: system_probe_readiness
     type: STATIC
 - name: system_envoy_admin
   resource:
@@ -62,7 +61,7 @@ resources:
               - match:
                   prefix: /ready
                 route:
-                  cluster: kuma:readiness
+                  cluster: system_probe_readiness
                   prefixRewrite: /ready
           statPrefix: system_envoy_admin
     - filterChainMatch:
@@ -91,7 +90,7 @@ resources:
               - match:
                   prefix: /ready
                 route:
-                  cluster: kuma:readiness
+                  cluster: system_probe_readiness
                   prefixRewrite: /ready
               - match:
                   prefix: /

--- a/pkg/xds/generator/testdata/profile-source/5-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/5-envoy-config.golden.yaml
@@ -83,21 +83,6 @@ resources:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         explicitHttpConfig:
           http2ProtocolOptions: {}
-- name: kuma:readiness
-  resource:
-    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    altStatName: kuma_readiness
-    connectTimeout: 5s
-    loadAssignment:
-      clusterName: kuma:readiness
-      endpoints:
-      - lbEndpoints:
-        - endpoint:
-            address:
-              pipe:
-                path: /tmp/kuma-readiness-reporter.sock
-    name: kuma:readiness
-    type: STATIC
 - name: localhost:8080
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
@@ -128,6 +113,20 @@ resources:
                 address: 127.0.0.1
                 portValue: 9902
     name: system_envoy_admin
+    type: STATIC
+- name: system_probe_readiness
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 5s
+    loadAssignment:
+      clusterName: system_probe_readiness
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              pipe:
+                path: /tmp/kuma-readiness-reporter.sock
+    name: system_probe_readiness
     type: STATIC
 - name: db
   resource:
@@ -283,7 +282,7 @@ resources:
               - match:
                   prefix: /ready
                 route:
-                  cluster: kuma:readiness
+                  cluster: system_probe_readiness
                   prefixRewrite: /ready
           statPrefix: system_envoy_admin
     - filterChainMatch:
@@ -312,7 +311,7 @@ resources:
               - match:
                   prefix: /ready
                 route:
-                  cluster: kuma:readiness
+                  cluster: system_probe_readiness
                   prefixRewrite: /ready
               - match:
                   prefix: /


### PR DESCRIPTION
## Motivation

Explained in https://github.com/kumahq/kuma/issues/13972

## Implementation information

Use exiting system naming API.

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix https://github.com/kumahq/kuma/issues/13972
