### PR TITLE
feat(kuma-cp): rename secret system resource to follow unified naming format

### DIFF
--- a/pkg/core/system_names/system_names.go
+++ b/pkg/core/system_names/system_names.go
@@ -44,8 +44,12 @@ func MustBeSystemName(name string) string {
 	return SystemPrefix + name
 }
 
-func Join(parts ...string) string {
-	return strings.Join(parts, sectionSeparator)
+func JoinSections(sections ...string) string {
+	return strings.Join(sections, sectionSeparator)
+}
+
+func JoinSectionParts(parts ...string) string {
+	return strings.Join(parts, sectionPartsSeparator)
 }
 
 func GetNameOrDefault(predicate bool) func(name string, defaultName string) string {

--- a/pkg/core/xds/types.go
+++ b/pkg/core/xds/types.go
@@ -213,6 +213,7 @@ type ServerSideTLSCertPaths struct {
 
 type IdentityCertRequest interface {
 	Name() string
+	MeshName() string
 }
 
 type CaRequest interface {

--- a/pkg/plugins/policies/core/xds/meshroute/clusters.go
+++ b/pkg/plugins/policies/core/xds/meshroute/clusters.go
@@ -1,6 +1,7 @@
 package meshroute
 
 import (
+	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
 	"github.com/pkg/errors"
 
 	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
@@ -59,6 +60,7 @@ func GenerateClusters(
 						Configure(envoy_clusters.EdsCluster()).
 						Configure(envoy_clusters.ClientSideMTLS(
 							proxy.SecretsTracker,
+							proxy.Metadata.HasFeature(xds_types.FeatureUnifiedResourceNaming),
 							meshCtx.Resource,
 							mesh_proto.ZoneEgressServiceName,
 							tlsReady,
@@ -120,9 +122,7 @@ func GenerateClusters(
 							ServiceTagIdentities(realResourceRef, meshCtx),
 						))
 					} else {
-						edsClusterBuilder.Configure(envoy_clusters.ClientSideMTLS(
-							proxy.SecretsTracker,
-							meshCtx.Resource, serviceName, tlsReady, clusterTags))
+						edsClusterBuilder.Configure(envoy_clusters.ClientSideMTLS(proxy.SecretsTracker, false, meshCtx.Resource, serviceName, tlsReady, clusterTags))
 					}
 				}
 			}

--- a/pkg/plugins/policies/core/xds/meshroute/clusters.go
+++ b/pkg/plugins/policies/core/xds/meshroute/clusters.go
@@ -1,7 +1,6 @@
 package meshroute
 
 import (
-	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
 	"github.com/pkg/errors"
 
 	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
@@ -12,6 +11,7 @@ import (
 	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/rules/resolve"
 	util_maps "github.com/kumahq/kuma/pkg/util/maps"
 	"github.com/kumahq/kuma/pkg/util/pointer"

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin_test.go
@@ -300,7 +300,7 @@ func getMeshServiceResources(secretsTracker core_xds.SecretsTracker, mesh *build
 			Name:   "outbound",
 			Origin: generator.OriginOutbound,
 			Resource: clusters.NewClusterBuilder(envoy_common.APIV3, "outgoing").
-				Configure(clusters.ClientSideMTLS(secretsTracker, mesh.Build(), "outgoing", true, nil)).
+				Configure(clusters.ClientSideMTLS(secretsTracker, false, mesh.Build(), "outgoing", true, nil)).
 				MustBuild(),
 			Protocol: core_mesh.ProtocolHTTP,
 			ResourceOrigin: &kri.Identifier{
@@ -350,7 +350,7 @@ func getResources(secretsTracker core_xds.SecretsTracker, mesh *builders.MeshBui
 			Name:   "outgoing",
 			Origin: generator.OriginOutbound,
 			Resource: clusters.NewClusterBuilder(envoy_common.APIV3, "outgoing").
-				Configure(clusters.ClientSideMTLS(secretsTracker, mesh.Build(), "outgoing", true, nil)).
+				Configure(clusters.ClientSideMTLS(secretsTracker, false, mesh.Build(), "outgoing", true, nil)).
 				MustBuild(),
 		},
 	}

--- a/pkg/plugins/runtime/gateway/cluster_generator.go
+++ b/pkg/plugins/runtime/gateway/cluster_generator.go
@@ -211,7 +211,7 @@ func (c *ClusterGenerator) generateMeshCluster(
 	builder := newClusterBuilder(info.Proxy.APIVersion, dest.Destination[mesh_proto.ServiceTag], protocol, dest).Configure(
 		clusters.EdsCluster(),
 		clusters.LB(nil /* TODO(jpeach) uses default Round Robin*/),
-		clusters.ClientSideMTLS(info.Proxy.SecretsTracker, meshCtx.Resource, upstreamServiceName, true, []tags.Tags{dest.Destination}),
+		clusters.ClientSideMTLS(info.Proxy.SecretsTracker, false, meshCtx.Resource, upstreamServiceName, true, []tags.Tags{dest.Destination}),
 		clusters.ConnectionBufferLimit(DefaultConnectionBuffer),
 	)
 

--- a/pkg/xds/dynconf/system_names/api.go
+++ b/pkg/xds/dynconf/system_names/api.go
@@ -5,9 +5,9 @@ import "github.com/kumahq/kuma/pkg/core/system_names"
 var SystemResourceNameDynamicConfigListener = system_names.MustBeSystemName("dynamicconfig")
 
 func SystemResourceNameDynamicConfigRoute(routeName string) string {
-	return system_names.MustBeSystemName(system_names.Join("dynamicconfig", routeName))
+	return system_names.MustBeSystemName(system_names.JoinSections("dynamicconfig", routeName))
 }
 
 func SystemResourceNameDynamicConfigRouteNotModified(routeName string) string {
-	return system_names.MustBeSystemName(system_names.Join("dynamicconfig", routeName, "not_modified"))
+	return system_names.MustBeSystemName(system_names.JoinSections("dynamicconfig", routeName, "not_modified"))
 }

--- a/pkg/xds/envoy/clusters/configurers.go
+++ b/pkg/xds/envoy/clusters/configurers.go
@@ -23,15 +23,16 @@ func CircuitBreaker(circuitBreaker *core_mesh.CircuitBreakerResource) ClusterBui
 	})
 }
 
-func ClientSideMTLS(tracker core_xds.SecretsTracker, mesh *core_mesh.MeshResource, upstreamService string, upstreamTLSReady bool, tags []envoy_tags.Tags) ClusterBuilderOpt {
+func ClientSideMTLS(tracker core_xds.SecretsTracker, unifiedResourceNaming bool, mesh *core_mesh.MeshResource, upstreamService string, upstreamTLSReady bool, tags []envoy_tags.Tags) ClusterBuilderOpt {
 	return ClusterBuilderOptFunc(func(builder *ClusterBuilder) {
 		builder.AddConfigurer(&v3.ClientSideMTLSConfigurer{
-			SecretsTracker:   tracker,
-			UpstreamMesh:     mesh,
-			UpstreamService:  upstreamService,
-			LocalMesh:        mesh,
-			Tags:             tags,
-			UpstreamTLSReady: upstreamTLSReady,
+			SecretsTracker:        tracker,
+			UnifiedResourceNaming: unifiedResourceNaming,
+			UpstreamMesh:          mesh,
+			UpstreamService:       upstreamService,
+			LocalMesh:             mesh,
+			Tags:                  tags,
+			UpstreamTLSReady:      upstreamTLSReady,
 		})
 	})
 }

--- a/pkg/xds/envoy/clusters/v3/client_side_mtls_configurer.go
+++ b/pkg/xds/envoy/clusters/v3/client_side_mtls_configurer.go
@@ -16,14 +16,15 @@ import (
 )
 
 type ClientSideMTLSConfigurer struct {
-	SecretsTracker   core_xds.SecretsTracker
-	UpstreamMesh     *core_mesh.MeshResource
-	UpstreamService  string
-	LocalMesh        *core_mesh.MeshResource
-	Tags             []tags.Tags
-	SNI              string
-	UpstreamTLSReady bool
-	VerifyIdentities []string
+	SecretsTracker        core_xds.SecretsTracker
+	UpstreamMesh          *core_mesh.MeshResource
+	UpstreamService       string
+	LocalMesh             *core_mesh.MeshResource
+	Tags                  []tags.Tags
+	SNI                   string
+	UpstreamTLSReady      bool
+	VerifyIdentities      []string
+	UnifiedResourceNaming bool
 }
 
 var _ ClusterConfigurer = &ClientSideMTLSConfigurer{}
@@ -85,7 +86,7 @@ func (c *ClientSideMTLSConfigurer) createTransportSocket(sni string) (*envoy_cor
 	if c.VerifyIdentities != nil {
 		verifyIdentities = c.VerifyIdentities
 	}
-	tlsContext, err := envoy_tls.CreateUpstreamTlsContext(identity, ca, c.UpstreamService, sni, verifyIdentities)
+	tlsContext, err := envoy_tls.CreateUpstreamTlsContext(identity, ca, c.UpstreamService, sni, verifyIdentities, c.UnifiedResourceNaming)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/xds/envoy/clusters/v3/client_side_mtls_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/client_side_mtls_configurer_test.go
@@ -1,6 +1,9 @@
 package clusters_test
 
 import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/test/matchers"
@@ -9,8 +12,6 @@ import (
 	"github.com/kumahq/kuma/pkg/xds/envoy"
 	"github.com/kumahq/kuma/pkg/xds/envoy/clusters"
 	"github.com/kumahq/kuma/pkg/xds/envoy/tags"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("EdsClusterConfigurer", func() {

--- a/pkg/xds/envoy/clusters/v3/client_side_mtls_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/client_side_mtls_configurer_test.go
@@ -28,7 +28,7 @@ var _ = Describe("EdsClusterConfigurer", func() {
 			tracker := envoy.NewSecretsTracker(given.mesh.GetMeta().GetName(), nil)
 			cluster, err := clusters.NewClusterBuilder(envoy.APIV3, given.clusterName).
 				Configure(clusters.EdsCluster()).
-				Configure(clusters.ClientSideMTLS(tracker, given.mesh, given.clientService, true, given.tags)).
+				Configure(clusters.ClientSideMTLS(tracker, false, given.mesh, given.clientService, true, given.tags)).
 				Configure(clusters.Timeout(DefaultTimeout(), core_mesh.ProtocolTCP)).
 				Build()
 

--- a/pkg/xds/envoy/clusters/v3/testdata/client_side_mtls_configurer/cluster-with-many-different-tag-sets.golden.yaml
+++ b/pkg/xds/envoy/clusters/v3/testdata/client_side_mtls_configurer/cluster-with-many-different-tag-sets.golden.yaml
@@ -1,0 +1,62 @@
+connectTimeout: 5s
+edsClusterConfig:
+  edsConfig:
+    ads: {}
+    resourceApiVersion: V3
+name: testCluster
+transportSocketMatches:
+- match:
+    cluster: "1"
+  name: backend{cluster=1,mesh=default}
+  transportSocket:
+    name: envoy.transport_sockets.tls
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+      commonTlsContext:
+        alpnProtocols:
+        - kuma
+        combinedValidationContext:
+          defaultValidationContext:
+            matchTypedSubjectAltNames:
+            - matcher:
+                exact: spiffe://default/backend
+              sanType: URI
+          validationContextSdsSecretConfig:
+            name: mesh_ca:secret:default
+            sdsConfig:
+              ads: {}
+              resourceApiVersion: V3
+        tlsCertificateSdsSecretConfigs:
+        - name: identity_cert:secret:default
+          sdsConfig:
+            ads: {}
+            resourceApiVersion: V3
+      sni: backend{cluster=1,mesh=default}
+- match:
+    cluster: "2"
+  name: backend{cluster=2,mesh=default}
+  transportSocket:
+    name: envoy.transport_sockets.tls
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+      commonTlsContext:
+        alpnProtocols:
+        - kuma
+        combinedValidationContext:
+          defaultValidationContext:
+            matchTypedSubjectAltNames:
+            - matcher:
+                exact: spiffe://default/backend
+              sanType: URI
+          validationContextSdsSecretConfig:
+            name: mesh_ca:secret:default
+            sdsConfig:
+              ads: {}
+              resourceApiVersion: V3
+        tlsCertificateSdsSecretConfigs:
+        - name: identity_cert:secret:default
+          sdsConfig:
+            ads: {}
+            resourceApiVersion: V3
+      sni: backend{cluster=2,mesh=default}
+type: EDS

--- a/pkg/xds/envoy/clusters/v3/testdata/client_side_mtls_configurer/cluster-with-mtls-and-credentials.golden.yaml
+++ b/pkg/xds/envoy/clusters/v3/testdata/client_side_mtls_configurer/cluster-with-mtls-and-credentials.golden.yaml
@@ -1,0 +1,31 @@
+connectTimeout: 5s
+edsClusterConfig:
+  edsConfig:
+    ads: {}
+    resourceApiVersion: V3
+name: testCluster
+transportSocket:
+  name: envoy.transport_sockets.tls
+  typedConfig:
+    '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+    commonTlsContext:
+      alpnProtocols:
+        - kuma
+      combinedValidationContext:
+        defaultValidationContext:
+          matchTypedSubjectAltNames:
+            - matcher:
+                exact: spiffe://default/backend
+              sanType: URI
+        validationContextSdsSecretConfig:
+          name: mesh_ca:secret:default
+          sdsConfig:
+            ads: {}
+            resourceApiVersion: V3
+      tlsCertificateSdsSecretConfigs:
+        - name: identity_cert:secret:default
+          sdsConfig:
+            ads: {}
+            resourceApiVersion: V3
+    sni: backend{mesh=default,version=v1}
+type: EDS

--- a/pkg/xds/envoy/clusters/v3/testdata/client_side_mtls_configurer/cluster-with-mtls-unified-naming.golden.yaml
+++ b/pkg/xds/envoy/clusters/v3/testdata/client_side_mtls_configurer/cluster-with-mtls-unified-naming.golden.yaml
@@ -1,0 +1,30 @@
+connectTimeout: 5s
+edsClusterConfig:
+  edsConfig:
+    ads: {}
+    resourceApiVersion: V3
+name: testCluster
+transportSocket:
+  name: envoy.transport_sockets.tls
+  typedConfig:
+    '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+    commonTlsContext:
+      alpnProtocols:
+      - kuma
+      combinedValidationContext:
+        defaultValidationContext:
+          matchTypedSubjectAltNames:
+          - matcher:
+              exact: spiffe://default/backend
+            sanType: URI
+        validationContextSdsSecretConfig:
+          name: system_mtls_ca_default
+          sdsConfig:
+            ads: {}
+            resourceApiVersion: V3
+      tlsCertificateSdsSecretConfigs:
+      - name: system_mtls_identity_default
+        sdsConfig:
+          ads: {}
+          resourceApiVersion: V3
+type: EDS

--- a/pkg/xds/envoy/clusters/v3/testdata/client_side_mtls_configurer/cluster-with-mtls.golden.yaml
+++ b/pkg/xds/envoy/clusters/v3/testdata/client_side_mtls_configurer/cluster-with-mtls.golden.yaml
@@ -1,0 +1,30 @@
+connectTimeout: 5s
+edsClusterConfig:
+  edsConfig:
+    ads: {}
+    resourceApiVersion: V3
+name: testCluster
+transportSocket:
+  name: envoy.transport_sockets.tls
+  typedConfig:
+    '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+    commonTlsContext:
+      alpnProtocols:
+      - kuma
+      combinedValidationContext:
+        defaultValidationContext:
+          matchTypedSubjectAltNames:
+          - matcher:
+              exact: spiffe://default/backend
+            sanType: URI
+        validationContextSdsSecretConfig:
+          name: mesh_ca:secret:default
+          sdsConfig:
+            ads: {}
+            resourceApiVersion: V3
+      tlsCertificateSdsSecretConfigs:
+      - name: identity_cert:secret:default
+        sdsConfig:
+          ads: {}
+          resourceApiVersion: V3
+type: EDS

--- a/pkg/xds/envoy/secrets.go
+++ b/pkg/xds/envoy/secrets.go
@@ -14,6 +14,10 @@ func (r identityCertRequest) Name() string {
 	return names.GetSecretName(xds_tls.IdentityCertResource, "secret", r.meshName)
 }
 
+func (r identityCertRequest) MeshName() string {
+	return r.meshName
+}
+
 type caRequest struct {
 	meshName string
 }

--- a/pkg/xds/envoy/tls/v3/tls.go
+++ b/pkg/xds/envoy/tls/v3/tls.go
@@ -4,6 +4,7 @@ import (
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	envoy_type_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+
 	core_system_names "github.com/kumahq/kuma/pkg/core/system_names"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/tls"
@@ -72,13 +73,13 @@ func createCommonTlsContext(ownMesh core_xds.IdentityCertRequest, targetMeshCa c
 	getNameOrDefault := core_system_names.GetNameOrDefault(unifiedResourceNaming)
 	meshCaSecret := NewSecretConfigSource(
 		getNameOrDefault(
-			core_system_names.AsSystemName("mtls_ca_" + core_system_names.JoinSectionParts(targetMeshCa.MeshName()...)),
+			core_system_names.AsSystemName("mtls_ca_"+core_system_names.JoinSectionParts(targetMeshCa.MeshName()...)),
 			targetMeshCa.Name(),
 		),
 	)
 	identitySecret := NewSecretConfigSource(
 		getNameOrDefault(
-			core_system_names.AsSystemName("mtls_identity_" + core_system_names.JoinSectionParts(targetMeshCa.MeshName()...)),
+			core_system_names.AsSystemName("mtls_identity_"+core_system_names.JoinSectionParts(targetMeshCa.MeshName()...)),
 			ownMesh.Name(),
 		),
 	)

--- a/pkg/xds/envoy/tls/v3/tls_test.go
+++ b/pkg/xds/envoy/tls/v3/tls_test.go
@@ -31,6 +31,10 @@ func (r *identityRequest) Name() string {
 	return "identity_cert:secret:" + r.mesh
 }
 
+func (r *identityRequest) MeshName() string {
+	return r.mesh
+}
+
 var _ = Describe("CreateDownstreamTlsContext()", func() {
 	Context("when mTLS is enabled on a given Mesh", func() {
 		type testCase struct {
@@ -109,13 +113,7 @@ var _ = Describe("CreateUpstreamTlsContext()", func() {
 				mesh := "default"
 
 				// when
-				snippet, err := v3.CreateUpstreamTlsContext(
-					&identityRequest{mesh: mesh},
-					&caRequest{mesh: mesh},
-					given.upstreamService,
-					"",
-					nil,
-				)
+				snippet, err := v3.CreateUpstreamTlsContext(&identityRequest{mesh: mesh}, &caRequest{mesh: mesh}, given.upstreamService, "", nil, false)
 				// then
 				Expect(err).ToNot(HaveOccurred())
 				// when

--- a/pkg/xds/generator/egress/generator.go
+++ b/pkg/xds/generator/egress/generator.go
@@ -112,7 +112,7 @@ func (g Generator) Generate(
 		resources.AddSet(rs)
 
 		rs, err = g.SecretGenerator.GenerateForZoneEgress(
-			ctx, xdsCtx, proxy.Id, proxy.ZoneEgressProxy.ZoneEgressResource, secretsTracker, meshResources.Mesh,
+			ctx, xdsCtx, proxy, secretsTracker, meshResources.Mesh,
 		)
 		if err != nil {
 			err := errors.Wrapf(

--- a/pkg/xds/generator/outbound_proxy_generator.go
+++ b/pkg/xds/generator/outbound_proxy_generator.go
@@ -215,13 +215,7 @@ func (g OutboundProxyGenerator) generateCDS(ctx xds_context.Context, services en
 				if ctx.Mesh.Resource.ZoneEgressEnabled() {
 					edsClusterBuilder.
 						Configure(envoy_clusters.EdsCluster()).
-						Configure(envoy_clusters.ClientSideMTLS(
-							proxy.SecretsTracker,
-							ctx.Mesh.Resource,
-							mesh_proto.ZoneEgressServiceName,
-							tlsReady,
-							clusterTags,
-						))
+						Configure(envoy_clusters.ClientSideMTLS(proxy.SecretsTracker, false, ctx.Mesh.Resource, mesh_proto.ZoneEgressServiceName, tlsReady, clusterTags))
 				} else {
 					endpoints := proxy.Routing.ExternalServiceOutboundTargets[serviceName]
 					isIPv6 := proxy.Dataplane.IsIPv6()
@@ -256,9 +250,7 @@ func (g OutboundProxyGenerator) generateCDS(ctx xds_context.Context, services en
 						}
 					}
 				} else {
-					edsClusterBuilder.Configure(envoy_clusters.ClientSideMTLS(
-						proxy.SecretsTracker,
-						ctx.Mesh.Resource, serviceName, tlsReady, clusterTags))
+					edsClusterBuilder.Configure(envoy_clusters.ClientSideMTLS(proxy.SecretsTracker, false, ctx.Mesh.Resource, serviceName, tlsReady, clusterTags))
 				}
 			}
 

--- a/pkg/xds/generator/secrets/generator.go
+++ b/pkg/xds/generator/secrets/generator.go
@@ -2,6 +2,8 @@ package secrets
 
 import (
 	"context"
+	"github.com/kumahq/kuma/pkg/core/system_names"
+	"github.com/kumahq/kuma/pkg/core/xds/types"
 
 	"github.com/pkg/errors"
 
@@ -42,17 +44,11 @@ func createIdentitySecretResource(name string, identity *core_xds.IdentitySecret
 
 // GenerateForZoneEgress generates whatever secrets were referenced in the
 // zone egress config generation.
-func (g Generator) GenerateForZoneEgress(
-	ctx context.Context,
-	xdsCtx xds_context.Context,
-	proxyId core_xds.ProxyId,
-	zoneEgressResource *core_mesh.ZoneEgressResource,
-	secretsTracker core_xds.SecretsTracker,
-	mesh *core_mesh.MeshResource,
-) (*core_xds.ResourceSet, error) {
+func (g Generator) GenerateForZoneEgress(ctx context.Context, xdsCtx xds_context.Context, proxy *core_xds.Proxy, secretsTracker core_xds.SecretsTracker, mesh *core_mesh.MeshResource, ) (*core_xds.ResourceSet, error) {
 	resources := core_xds.NewResourceSet()
+	zoneEgressResource := proxy.ZoneEgressProxy.ZoneEgressResource
 
-	log := generatorLogger.WithValues("proxyID", proxyId.String())
+	log := generatorLogger.WithValues("proxyID", proxy.Id.String())
 
 	if !mesh.MTLSEnabled() {
 		return nil, nil
@@ -67,14 +63,23 @@ func (g Generator) GenerateForZoneEgress(
 		return nil, errors.Wrap(err, "failed to generate ZoneEgress secrets")
 	}
 
+	getNameOrDefault := system_names.GetNameOrDefault(proxy.Metadata.HasFeature(types.FeatureUnifiedResourceNaming))
 	if usedIdentity {
 		log.V(1).Info("added identity", "mesh", meshName)
-		resources.Add(createIdentitySecretResource(secretsTracker.RequestIdentityCert().Name(), identity))
+		identitySecretName := getNameOrDefault(
+			system_names.AsSystemName("mtls_identity_" + proxy.SecretsTracker.RequestIdentityCert().MeshName()),
+			proxy.SecretsTracker.RequestIdentityCert().Name(),
+		)
+		resources.Add(createIdentitySecretResource(identitySecretName, identity))
 	}
 
 	if _, ok := secretsTracker.UsedCas()[meshName]; ok {
 		log.V(1).Info("added mesh CA resources", "mesh", meshName)
-		resources.Add(createCaSecretResource(secretsTracker.RequestCa(meshName).Name(), ca))
+		name := getNameOrDefault(
+			system_names.AsSystemName("mtls_ca_" + meshName),
+			secretsTracker.RequestCa(meshName).Name(),
+		)
+		resources.Add(createCaSecretResource(name, ca))
 	}
 
 	return resources, nil
@@ -95,6 +100,7 @@ func (g Generator) Generate(
 	if proxy.Dataplane != nil {
 		log = log.WithValues("mesh", xdsCtx.Mesh.Resource.GetMeta().GetName())
 	}
+	getNameOrDefault := system_names.GetNameOrDefault(proxy.Metadata.HasFeature(types.FeatureUnifiedResourceNaming))
 
 	usedIdentity := proxy.SecretsTracker.UsedIdentity()
 	usedCAs := proxy.SecretsTracker.UsedCas()
@@ -108,8 +114,16 @@ func (g Generator) Generate(
 			return nil, errors.Wrap(err, "failed to generate all in one CA")
 		}
 
-		resources.Add(createCaSecretResource(proxy.SecretsTracker.RequestAllInOneCa().Name(), allInOneCa))
-		resources.Add(createIdentitySecretResource(proxy.SecretsTracker.RequestIdentityCert().Name(), identity))
+		caSecretName := getNameOrDefault(
+			system_names.AsSystemName("mtls_ca_all_meshes"),
+			proxy.SecretsTracker.RequestAllInOneCa().Name(),
+		)
+		resources.Add(createCaSecretResource(caSecretName, allInOneCa))
+		identitySecretName := getNameOrDefault(
+			system_names.AsSystemName("mtls_identity_" + proxy.SecretsTracker.RequestIdentityCert().MeshName()),
+			proxy.SecretsTracker.RequestIdentityCert().Name(),
+		)
+		resources.Add(createIdentitySecretResource(identitySecretName, identity))
 		log.V(1).Info("added all in one CA resources")
 	}
 
@@ -125,17 +139,25 @@ func (g Generator) Generate(
 			return nil, errors.Wrap(err, "failed to generate dataplane identity cert and CAs")
 		}
 
-		resources.Add(createIdentitySecretResource(proxy.SecretsTracker.RequestIdentityCert().Name(), identity))
+		identitySecretName := getNameOrDefault(
+			system_names.AsSystemName("mtls_identity_" + proxy.SecretsTracker.RequestIdentityCert().MeshName()),
+			proxy.SecretsTracker.RequestIdentityCert().Name(),
+		)
+		resources.Add(createIdentitySecretResource(identitySecretName, identity))
 
 		var addedCas []string
 		for mesh := range usedCAs {
+			identityName := getNameOrDefault(
+				system_names.AsSystemName("mtls_ca_" + mesh),
+				proxy.SecretsTracker.RequestCa(mesh).Name(),
+			)
 			if ca, ok := generatedMeshCAs[mesh]; ok {
-				resources.Add(createCaSecretResource(proxy.SecretsTracker.RequestCa(mesh).Name(), ca))
+				resources.Add(createCaSecretResource(identityName, ca))
 			} else {
 				// We need to add _something_ here so that Envoy syncs the
 				// config
 				emptyCa := &core_xds.CaSecret{}
-				resources.Add(createCaSecretResource(proxy.SecretsTracker.RequestCa(mesh).Name(), emptyCa))
+				resources.Add(createCaSecretResource(identityName, emptyCa))
 			}
 			addedCas = append(addedCas, mesh)
 		}

--- a/pkg/xds/generator/secrets/generator.go
+++ b/pkg/xds/generator/secrets/generator.go
@@ -2,14 +2,14 @@ package secrets
 
 import (
 	"context"
-	"github.com/kumahq/kuma/pkg/core/system_names"
-	"github.com/kumahq/kuma/pkg/core/xds/types"
 
 	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/core"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/system_names"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+	"github.com/kumahq/kuma/pkg/core/xds/types"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_secrets "github.com/kumahq/kuma/pkg/xds/envoy/secrets/v3"
 	generator_core "github.com/kumahq/kuma/pkg/xds/generator/core"
@@ -44,7 +44,7 @@ func createIdentitySecretResource(name string, identity *core_xds.IdentitySecret
 
 // GenerateForZoneEgress generates whatever secrets were referenced in the
 // zone egress config generation.
-func (g Generator) GenerateForZoneEgress(ctx context.Context, xdsCtx xds_context.Context, proxy *core_xds.Proxy, secretsTracker core_xds.SecretsTracker, mesh *core_mesh.MeshResource, ) (*core_xds.ResourceSet, error) {
+func (g Generator) GenerateForZoneEgress(ctx context.Context, xdsCtx xds_context.Context, proxy *core_xds.Proxy, secretsTracker core_xds.SecretsTracker, mesh *core_mesh.MeshResource) (*core_xds.ResourceSet, error) {
 	resources := core_xds.NewResourceSet()
 	zoneEgressResource := proxy.ZoneEgressProxy.ZoneEgressResource
 
@@ -67,7 +67,7 @@ func (g Generator) GenerateForZoneEgress(ctx context.Context, xdsCtx xds_context
 	if usedIdentity {
 		log.V(1).Info("added identity", "mesh", meshName)
 		identitySecretName := getNameOrDefault(
-			system_names.AsSystemName("mtls_identity_" + proxy.SecretsTracker.RequestIdentityCert().MeshName()),
+			system_names.AsSystemName("mtls_identity_"+proxy.SecretsTracker.RequestIdentityCert().MeshName()),
 			proxy.SecretsTracker.RequestIdentityCert().Name(),
 		)
 		resources.Add(createIdentitySecretResource(identitySecretName, identity))
@@ -76,7 +76,7 @@ func (g Generator) GenerateForZoneEgress(ctx context.Context, xdsCtx xds_context
 	if _, ok := secretsTracker.UsedCas()[meshName]; ok {
 		log.V(1).Info("added mesh CA resources", "mesh", meshName)
 		name := getNameOrDefault(
-			system_names.AsSystemName("mtls_ca_" + meshName),
+			system_names.AsSystemName("mtls_ca_"+meshName),
 			secretsTracker.RequestCa(meshName).Name(),
 		)
 		resources.Add(createCaSecretResource(name, ca))
@@ -120,7 +120,7 @@ func (g Generator) Generate(
 		)
 		resources.Add(createCaSecretResource(caSecretName, allInOneCa))
 		identitySecretName := getNameOrDefault(
-			system_names.AsSystemName("mtls_identity_" + proxy.SecretsTracker.RequestIdentityCert().MeshName()),
+			system_names.AsSystemName("mtls_identity_"+proxy.SecretsTracker.RequestIdentityCert().MeshName()),
 			proxy.SecretsTracker.RequestIdentityCert().Name(),
 		)
 		resources.Add(createIdentitySecretResource(identitySecretName, identity))
@@ -140,7 +140,7 @@ func (g Generator) Generate(
 		}
 
 		identitySecretName := getNameOrDefault(
-			system_names.AsSystemName("mtls_identity_" + proxy.SecretsTracker.RequestIdentityCert().MeshName()),
+			system_names.AsSystemName("mtls_identity_"+proxy.SecretsTracker.RequestIdentityCert().MeshName()),
 			proxy.SecretsTracker.RequestIdentityCert().Name(),
 		)
 		resources.Add(createIdentitySecretResource(identitySecretName, identity))
@@ -148,7 +148,7 @@ func (g Generator) Generate(
 		var addedCas []string
 		for mesh := range usedCAs {
 			identityName := getNameOrDefault(
-				system_names.AsSystemName("mtls_ca_" + mesh),
+				system_names.AsSystemName("mtls_ca_"+mesh),
 				proxy.SecretsTracker.RequestCa(mesh).Name(),
 			)
 			if ca, ok := generatedMeshCAs[mesh]; ok {


### PR DESCRIPTION
## Motivation

In https://github.com/kumahq/kuma/issues/13973

## Implementation information

Had to expose mesh name to be able to construct new names.

## Supporting documentation

Fix https://github.com/kumahq/kuma/issues/13973
