### PR TITLE
feat(MeshTrafficPermission): implement new inspect api support

### DIFF
--- a/api/openapi/specs/common/resource.yaml
+++ b/api/openapi/specs/common/resource.yaml
@@ -238,6 +238,8 @@ components:
           type: object
           additionalProperties: true
           x-go-type: 'interface{}'
+        kri:
+          type: string
     RoutesList:
       type: object
       required: [ routes ]

--- a/api/openapi/types/common/zz_generated.resource.go
+++ b/api/openapi/types/common/zz_generated.resource.go
@@ -155,6 +155,7 @@ type PolicyOrigin struct {
 type PolicyRule struct {
 	// Conf The final computed configuration for the data plane proxy, derived by merging all policies whose 'targetRef' field matches the proxy. The merging process follows [RFC 7396 (JSON Merge Patch)](https://datatracker.ietf.org/doc/html/rfc7396), with the order of merging influenced by factors such as where the policy was applied (e.g., custom namespace, system, or global control plane), policy role, and targetRef specificity.
 	Conf interface{} `json:"conf"`
+	Kri  *string     `json:"kri,omitempty"`
 }
 
 // ProxyRule a rule that affects the entire proxy

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -4522,6 +4522,8 @@ components:
           type: object
           additionalProperties: true
           x-go-type: interface{}
+        kri:
+          type: string
     InboundPolicyConf:
       type: object
       required:

--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -1026,6 +1026,7 @@ func matchedPoliciesToInboundConfig(matchedPolicies []core_xds.TypedMatchingPoli
 		var policyRules []api_common.PolicyRule
 		for _, rule := range rules {
 			policyRules = append(policyRules, api_common.PolicyRule{
+				Kri:  pointer.To(originToKRI(rule.Origin.Resource, matched.Type).Kri),
 				Conf: rule.Conf.GetDefault(),
 			})
 		}

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/inbounds/merged_inbound_policy.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/inbounds/merged_inbound_policy.golden.json
@@ -19,13 +19,15 @@
        "maxStreamDuration": "30m0s",
        "maxConnectionDuration": "30m0s"
       }
-     }
+     },
+     "kri": "kri_mt_default___inbound-timeout-1_"
     },
     {
      "conf": {
       "connectionTimeout": "2s",
       "idleTimeout": "1m0s"
-     }
+     },
+     "kri": "kri_mt_default___inbound-timeout_"
     }
    ]
   }

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/inbounds/merged_mtp.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/inbounds/merged_mtp.golden.json
@@ -1,0 +1,43 @@
+{
+ "policies": [
+  {
+   "kind": "MeshTrafficPermission",
+   "origins": [
+    {
+     "kri": "kri_mtp_default___mtp-2_"
+    },
+    {
+     "kri": "kri_mtp_default___mtp-1_"
+    }
+   ],
+   "rules": [
+    {
+     "conf": {
+      "allow": [
+       {
+        "spiffeId": {
+         "type": "Prefix",
+         "value": "spiffe://trust-domain.mesh/ns/backend"
+        }
+       }
+      ]
+     },
+     "kri": "kri_mtp_default___mtp-2_"
+    },
+    {
+     "conf": {
+      "deny": [
+       {
+        "spiffeId": {
+         "type": "Exact",
+         "value": "spiffe://trust-domain.mesh/ns/backend/v1"
+        }
+       }
+      ]
+     },
+     "kri": "kri_mtp_default___mtp-1_"
+    }
+   ]
+  }
+ ]
+}

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/inbounds/merged_mtp.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/inbounds/merged_mtp.input.yaml
@@ -1,0 +1,38 @@
+#/meshes/default/dataplanes/dp-1/inbounds/kri_dp_default_test-zone__dp-1_main-port/_policies 200
+type: Mesh
+name: default
+meshServices:
+  mode: Exclusive
+---
+type: Dataplane
+name: dp-1
+mesh: default
+networking:
+  address: 127.0.0.1
+  inbound:
+    - port: 8080
+      name: main-port
+      tags:
+        kuma.io/service: foo
+---
+type: MeshTrafficPermission
+name: mtp-1
+mesh: default
+spec:
+  rules:
+    - default:
+        deny:
+          - spiffeId:
+              type: Exact
+              value: spiffe://trust-domain.mesh/ns/backend/v1
+---
+type: MeshTrafficPermission
+name: mtp-2
+mesh: default
+spec:
+  rules:
+    - default:
+        allow:
+          - spiffeId:
+              type: Prefix
+              value: spiffe://trust-domain.mesh/ns/backend

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/inbounds/multiple_inbound_policies.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/inbounds/multiple_inbound_policies.golden.json
@@ -23,7 +23,8 @@
         }
        }
       ]
-     }
+     },
+     "kri": "kri_mal_default___multiple-backends_"
     }
    ]
   },
@@ -56,7 +57,8 @@
         }
        }
       }
-     }
+     },
+     "kri": "kri_mrl_default___backend-rate-limit_"
     }
    ]
   }

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/inbounds/single_inbound_policy.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/inbounds/single_inbound_policy.golden.json
@@ -23,7 +23,8 @@
         }
        }
       ]
-     }
+     },
+     "kri": "kri_mal_default___multiple-backends_"
     }
    ]
   }


### PR DESCRIPTION
## Motivation

Adding support for origin per rule needed for MeshTrafficPermission spiffeId support

Fix https://github.com/kumahq/kuma/issues/14030

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
