### PR TITLE
feat(kuma-cp): rename kube server bypass system resource to follow unified naming format

### DIFF
--- a/pkg/plugins/bootstrap/k8s/xds/hooks/api_server_bypass.go
+++ b/pkg/plugins/bootstrap/k8s/xds/hooks/api_server_bypass.go
@@ -3,7 +3,9 @@ package hooks
 import (
 	"github.com/pkg/errors"
 
+	"github.com/kumahq/kuma/pkg/core/system_names"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+	"github.com/kumahq/kuma/pkg/core/xds/types"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	envoy_clusters "github.com/kumahq/kuma/pkg/xds/envoy/clusters"
@@ -38,23 +40,30 @@ func (h ApiServerBypass) Modify(resources *core_xds.ResourceSet, ctx xds_context
 		return nil
 	}
 
+	getNameOrDefault := system_names.GetNameOrDefault(proxy.Metadata.HasFeature(types.FeatureUnifiedResourceNaming))
+
+	name := getNameOrDefault(
+		system_names.MustBeSystemName("kube_api_server_bypass"),
+		apiServerBypassHookResourcesName,
+	)
+
 	listener, err := envoy_listeners.NewOutboundListenerBuilder(proxy.APIVersion, h.Address, h.Port, core_xds.SocketAddressProtocolTCP).
-		WithOverwriteName(apiServerBypassHookResourcesName).
+		WithOverwriteName(name).
 		Configure(envoy_listeners.FilterChain(envoy_listeners.NewFilterChainBuilder(proxy.APIVersion, envoy_common.AnonymousResource).
-			Configure(envoy_listeners.TcpProxyDeprecated(apiServerBypassHookResourcesName, envoy_common.NewCluster(envoy_common.WithService(apiServerBypassHookResourcesName)))))).
+			Configure(envoy_listeners.TcpProxyDeprecated(name, envoy_common.NewCluster(envoy_common.WithService(name)))))).
 		Configure(envoy_listeners.NoBindToPort()).
 		Configure(envoy_listeners.OriginalDstForwarder()).
 		Build()
 	if err != nil {
-		return errors.Wrapf(err, "could not generate listener: %s", apiServerBypassHookResourcesName)
+		return errors.Wrapf(err, "could not generate listener: %s", name)
 	}
 
-	cluster, err := envoy_clusters.NewClusterBuilder(proxy.APIVersion, apiServerBypassHookResourcesName).
+	cluster, err := envoy_clusters.NewClusterBuilder(proxy.APIVersion, name).
 		Configure(envoy_clusters.PassThroughCluster()).
 		Configure(envoy_clusters.DefaultTimeout()).
 		Build()
 	if err != nil {
-		return errors.Wrapf(err, "could not generate cluster: %s", apiServerBypassHookResourcesName)
+		return errors.Wrapf(err, "could not generate cluster: %s", name)
 	}
 
 	resources.Add(&core_xds.Resource{

--- a/pkg/plugins/bootstrap/k8s/xds/hooks/api_server_bypass_test.go
+++ b/pkg/plugins/bootstrap/k8s/xds/hooks/api_server_bypass_test.go
@@ -10,6 +10,7 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/xds"
+	"github.com/kumahq/kuma/pkg/core/xds/types"
 	"github.com/kumahq/kuma/pkg/plugins/bootstrap/k8s/xds/hooks"
 	. "github.com/kumahq/kuma/pkg/test/matchers"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
@@ -51,5 +52,45 @@ var _ = Describe("ApiServerBypass", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(actual).To(MatchGoldenYAML(filepath.Join("testdata", "api-server-bypass.yaml")))
+	})
+
+	It("should generate configuration for API Server bypass with unified naming", func() {
+		// given
+		hook := hooks.NewApiServerBypass("1.1.1.1", 9090)
+		rs := xds.NewResourceSet()
+		ctx := xds_context.Context{
+			Mesh: xds_context.MeshContext{
+				Resource: &mesh.MeshResource{
+					Spec: &mesh_proto.Mesh{
+						Networking: &mesh_proto.Networking{
+							Outbound: &mesh_proto.Networking_Outbound{
+								Passthrough: wrapperspb.Bool(false),
+							},
+						},
+					},
+				},
+			},
+		}
+		proxy := &xds.Proxy{
+			APIVersion: envoy.APIV3,
+			Dataplane:  &mesh.DataplaneResource{},
+			Metadata: &xds.DataplaneMetadata{
+				Features: map[string]bool{
+					types.FeatureUnifiedResourceNaming: true,
+				},
+			},
+		}
+
+		// when
+		Expect(hook.Modify(rs, ctx, proxy)).To(Succeed())
+
+		// then
+		resp, err := rs.List().ToDeltaDiscoveryResponse()
+		Expect(err).ToNot(HaveOccurred())
+
+		actual, err := util_proto.ToYAML(resp)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(actual).To(MatchGoldenYAML(filepath.Join("testdata", "api-server-bypass-unified-naming.yaml")))
 	})
 })

--- a/pkg/plugins/bootstrap/k8s/xds/hooks/testdata/api-server-bypass-unified-naming.yaml
+++ b/pkg/plugins/bootstrap/k8s/xds/hooks/testdata/api-server-bypass-unified-naming.yaml
@@ -1,0 +1,26 @@
+resources:
+- name: system_kube_api_server_bypass
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 5s
+    lbPolicy: CLUSTER_PROVIDED
+    name: system_kube_api_server_bypass
+    type: ORIGINAL_DST
+- name: system_kube_api_server_bypass
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 1.1.1.1
+        portValue: 9090
+    bindToPort: false
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: system_kube_api_server_bypass
+          statPrefix: system_kube_api_server_bypass
+    name: system_kube_api_server_bypass
+    trafficDirection: OUTBOUND
+    useOriginalDst: true


### PR DESCRIPTION
## Motivation

In https://github.com/kumahq/kuma/issues/13975

## Implementation information

Nothing out of the ordinary.

## Supporting documentation

Fix https://github.com/kumahq/kuma/issues/13975
