### PR TITLE
ci(gha): bump timeout for check job to 40 minutes

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: read
       checks: write # needed for golangci/golangci-lint-action to add code annotations in PRs
-    timeout-minutes: 30
+    timeout-minutes: 40
     runs-on: ubuntu-24.04
     env:
       FULL_MATRIX: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') }}


### PR DESCRIPTION
## Motivation

Sometimes this job timeout just before finishing, so bumping it to 40 minutes should solve the issue until we'll figure ouft how to improve it so it doesn't take that long to finish

Example: https://github.com/kumahq/kuma/actions/runs/16871021503/job/47785804370?pr=14191

## Implementation information

Bumping job's timeout to 40 minutes