### PR TITLE
chore(helm): switch kubectl image from bitnami to rancher

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -740,9 +740,9 @@ kubectl:
     # -- The kubectl image registry
     registry: docker.io
     # -- The kubectl image repository
-    repository: bitnami/kubectl
+    repository: rancher/kubectl
     # -- The kubectl image tag
-    tag: "1.33.3@sha256:cd354d5b25562b195b277125439c23e4046902d7f1abc0dc3c75aad04d298c17"
+    tag: "1.33.3@sha256:26d09fcee6eb9a14b81c95e52dd90964a0a24263abb075f58651d2ac62651b59"
 hooks:
   # -- Node selector for the HELM hooks
   nodeSelector:

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -218,8 +218,8 @@ A Helm chart for the Kuma Control Plane
 | kumactl.image.repository | string | `"kumactl"` | The kumactl image repository |
 | kumactl.image.tag | string | `nil` | The kumactl image tag. When not specified, the value is copied from global.tag |
 | kubectl.image.registry | string | `"docker.io"` | The kubectl image registry |
-| kubectl.image.repository | string | `"bitnami/kubectl"` | The kubectl image repository |
-| kubectl.image.tag | string | `"1.33.3@sha256:cd354d5b25562b195b277125439c23e4046902d7f1abc0dc3c75aad04d298c17"` | The kubectl image tag |
+| kubectl.image.repository | string | `"rancher/kubectl"` | The kubectl image repository |
+| kubectl.image.tag | string | `"1.33.3@sha256:26d09fcee6eb9a14b81c95e52dd90964a0a24263abb075f58651d2ac62651b59"` | The kubectl image tag |
 | hooks.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selector for the HELM hooks |
 | hooks.tolerations | list | `[]` | Tolerations for the HELM hooks |
 | hooks.podSecurityContext | object | `{"runAsNonRoot":true}` | Security context at the pod level for crd/webhook/ns |

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -740,9 +740,9 @@ kubectl:
     # -- The kubectl image registry
     registry: docker.io
     # -- The kubectl image repository
-    repository: bitnami/kubectl
+    repository: rancher/kubectl
     # -- The kubectl image tag
-    tag: "1.33.3@sha256:cd354d5b25562b195b277125439c23e4046902d7f1abc0dc3c75aad04d298c17"
+    tag: "1.33.3@sha256:26d09fcee6eb9a14b81c95e52dd90964a0a24263abb075f58651d2ac62651b59"
 hooks:
   # -- Node selector for the HELM hooks
   nodeSelector:

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -740,9 +740,9 @@ kubectl:
     # -- The kubectl image registry
     registry: docker.io
     # -- The kubectl image repository
-    repository: bitnami/kubectl
+    repository: rancher/kubectl
     # -- The kubectl image tag
-    tag: "1.33.3@sha256:cd354d5b25562b195b277125439c23e4046902d7f1abc0dc3c75aad04d298c17"
+    tag: "1.33.3@sha256:26d09fcee6eb9a14b81c95e52dd90964a0a24263abb075f58651d2ac62651b59"
 hooks:
   # -- Node selector for the HELM hooks
   nodeSelector:

--- a/pkg/xds/envoy/clusters/v3/testdata/client_side_mtls_configurer/cluster-with-mtls-and-credentials.golden.yaml
+++ b/pkg/xds/envoy/clusters/v3/testdata/client_side_mtls_configurer/cluster-with-mtls-and-credentials.golden.yaml
@@ -10,22 +10,22 @@ transportSocket:
     '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
     commonTlsContext:
       alpnProtocols:
-        - kuma
+      - kuma
       combinedValidationContext:
         defaultValidationContext:
           matchTypedSubjectAltNames:
-            - matcher:
-                exact: spiffe://default/backend
-              sanType: URI
+          - matcher:
+              exact: spiffe://default/backend
+            sanType: URI
         validationContextSdsSecretConfig:
           name: mesh_ca:secret:default
           sdsConfig:
             ads: {}
             resourceApiVersion: V3
       tlsCertificateSdsSecretConfigs:
-        - name: identity_cert:secret:default
-          sdsConfig:
-            ads: {}
-            resourceApiVersion: V3
+      - name: identity_cert:secret:default
+        sdsConfig:
+          ads: {}
+          resourceApiVersion: V3
     sni: backend{mesh=default,version=v1}
 type: EDS


### PR DESCRIPTION
## Motivation

Bitnami will discontinue and remove the `bitnami/kubectl` image from their registry in 2 weeks. While kubectl is now available under the `bitnamisecure/kubectl` registry, it only contains new images, lacks tags corresponding to kubectl versions, and the publisher is not marked as verified. This makes it unsuitable for backporting changes to existing release branches.

To avoid disruption and ensure stability across versions, we are switching to a different image source.

## Implementation information

Updated the Helm chart to use the `rancher/kubectl` image instead of `bitnami/kubectl`, keeping the same version `1.33.3` and setting the corresponding image digest. Rancher provides versioned and tagged kubectl images, making it easier to align with our current and past releases.

## Supporting documentation

Reference: https://github.com/bitnami/charts/issues/35164