### PR TITLE
feat(kuma-cp): fix missing unified naming for secret resources

### DIFF
--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels-unified-naming.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels-unified-naming.clusters.golden.yaml
@@ -21,12 +21,12 @@ resources:
                   exact: spiffe://default/backend
                 sanType: URI
             validationContextSdsSecretConfig:
-              name: mesh_ca:secret:default
+              name: system_mtls_ca_default
               sdsConfig:
                 ads: {}
                 resourceApiVersion: V3
           tlsCertificateSdsSecretConfigs:
-          - name: identity_cert:secret:default
+          - name: system_mtls_identity_default
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
@@ -59,12 +59,12 @@ resources:
                   exact: spiffe://default/backend
                 sanType: URI
             validationContextSdsSecretConfig:
-              name: mesh_ca:secret:default
+              name: system_mtls_ca_default
               sdsConfig:
                 ads: {}
                 resourceApiVersion: V3
           tlsCertificateSdsSecretConfigs:
-          - name: identity_cert:secret:default
+          - name: system_mtls_identity_default
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
@@ -97,12 +97,12 @@ resources:
                   exact: spiffe://default/backend
                 sanType: URI
             validationContextSdsSecretConfig:
-              name: mesh_ca:secret:default
+              name: system_mtls_ca_default
               sdsConfig:
                 ads: {}
                 resourceApiVersion: V3
           tlsCertificateSdsSecretConfigs:
-          - name: identity_cert:secret:default
+          - name: system_mtls_identity_default
             sdsConfig:
               ads: {}
               resourceApiVersion: V3

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice-unified-naming.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice-unified-naming.clusters.golden.yaml
@@ -21,12 +21,12 @@ resources:
                   exact: spiffe://default/backend
                 sanType: URI
             validationContextSdsSecretConfig:
-              name: mesh_ca:secret:default
+              name: system_mtls_ca_default
               sdsConfig:
                 ads: {}
                 resourceApiVersion: V3
           tlsCertificateSdsSecretConfigs:
-          - name: identity_cert:secret:default
+          - name: system_mtls_identity_default
             sdsConfig:
               ads: {}
               resourceApiVersion: V3

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings-unified-naming.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings-unified-naming.clusters.golden.yaml
@@ -21,12 +21,12 @@ resources:
                   exact: spiffe://default/zone-egress
                 sanType: URI
             validationContextSdsSecretConfig:
-              name: mesh_ca:secret:default
+              name: system_mtls_ca_default
               sdsConfig:
                 ads: {}
                 resourceApiVersion: V3
           tlsCertificateSdsSecretConfigs:
-          - name: identity_cert:secret:default
+          - name: system_mtls_identity_default
             sdsConfig:
               ads: {}
               resourceApiVersion: V3

--- a/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin.go
@@ -11,6 +11,7 @@ import (
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	meshexternalservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/matchers"
 	core_rules "github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/rules/subsetutils"
@@ -132,6 +133,7 @@ func (p plugin) allowRules() core_rules.Rules {
 }
 
 func (p plugin) configureEgress(rs *core_xds.ResourceSet, proxy *core_xds.Proxy) error {
+	unifiedNaming := proxy.Metadata.HasFeature(xds_types.FeatureUnifiedResourceNaming)
 	listeners := policies_xds.GatherListeners(rs)
 	for _, resource := range proxy.ZoneEgressProxy.MeshResourcesList {
 		meshName := resource.Mesh.GetMeta().GetName()
@@ -158,7 +160,7 @@ func (p plugin) configureEgress(rs *core_xds.ResourceSet, proxy *core_xds.Proxy)
 		mesNames := []string{}
 		for _, mes := range resource.ListOrEmpty(meshexternalservice_api.MeshExternalServiceType).GetItems() {
 			meshExtSvc := mes.(*meshexternalservice_api.MeshExternalServiceResource)
-			mesNames = append(mesNames, destinationname.MustResolve(false, meshExtSvc, meshExtSvc.Spec.Match))
+			mesNames = append(mesNames, destinationname.MustResolve(unifiedNaming, meshExtSvc, meshExtSvc.Spec.Match))
 		}
 
 		for _, esName := range esNames {

--- a/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin_test.go
@@ -40,7 +40,7 @@ var _ = Describe("RBAC", func() {
 			listener, err := listeners.NewInboundListenerBuilder(envoy.APIV3, "192.168.0.1", 8080, core_xds.SocketAddressProtocolTCP).
 				WithOverwriteName("test_listener").
 				Configure(listeners.FilterChain(listeners.NewFilterChainBuilder(envoy.APIV3, envoy.AnonymousResource).
-					Configure(listeners.ServerSideMTLS(ctx.Mesh.Resource, envoy.NewSecretsTracker(ctx.Mesh.Resource.Meta.GetName(), nil), nil, nil)).
+					Configure(listeners.ServerSideMTLS(ctx.Mesh.Resource, envoy.NewSecretsTracker(ctx.Mesh.Resource.Meta.GetName(), nil), nil, nil, false)).
 					Configure(listeners.HttpConnectionManager("test_listener", false, nil)))).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
@@ -54,7 +54,7 @@ var _ = Describe("RBAC", func() {
 			listener2, err := listeners.NewInboundListenerBuilder(envoy.APIV3, "192.168.0.1", 8081, core_xds.SocketAddressProtocolTCP).
 				WithOverwriteName("test_listener2").
 				Configure(listeners.FilterChain(listeners.NewFilterChainBuilder(envoy.APIV3, envoy.AnonymousResource).
-					Configure(listeners.ServerSideMTLS(ctx.Mesh.Resource, envoy.NewSecretsTracker(ctx.Mesh.Resource.Meta.GetName(), nil), nil, nil)).
+					Configure(listeners.ServerSideMTLS(ctx.Mesh.Resource, envoy.NewSecretsTracker(ctx.Mesh.Resource.Meta.GetName(), nil), nil, nil, false)).
 					Configure(listeners.HttpConnectionManager("test_listener2", false, nil)))).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
@@ -68,7 +68,7 @@ var _ = Describe("RBAC", func() {
 			listener3, err := listeners.NewInboundListenerBuilder(envoy.APIV3, "192.168.0.1", 8082, core_xds.SocketAddressProtocolTCP).
 				WithOverwriteName("test_listener3").
 				Configure(listeners.FilterChain(listeners.NewFilterChainBuilder(envoy.APIV3, envoy.AnonymousResource).
-					Configure(listeners.ServerSideMTLS(ctx.Mesh.Resource, envoy.NewSecretsTracker(ctx.Mesh.Resource.Meta.GetName(), nil), nil, nil)).
+					Configure(listeners.ServerSideMTLS(ctx.Mesh.Resource, envoy.NewSecretsTracker(ctx.Mesh.Resource.Meta.GetName(), nil), nil, nil, false)).
 					Configure(listeners.HttpConnectionManager("test_listener3", false, nil)))).
 				Build()
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/plugins/runtime/gateway/cluster_generator.go
+++ b/pkg/plugins/runtime/gateway/cluster_generator.go
@@ -168,6 +168,7 @@ func (c *ClusterGenerator) generateRealBackendRefCluster(
 			clusters.LB(nil /* TODO(jpeach) uses default Round Robin*/),
 			clusters.ClientSideMultiIdentitiesMTLS(
 				proxy.SecretsTracker,
+				false,
 				meshCtx.Resource,
 				true, // TODO we just assume this atm?...
 				meshroute.SniForBackendRef(backendRef, meshCtx, systemNamespace),

--- a/pkg/plugins/runtime/gateway/filter_chain_generator.go
+++ b/pkg/plugins/runtime/gateway/filter_chain_generator.go
@@ -497,6 +497,7 @@ func configureTLS(
 		downstream, err = envoy_tls_v3.CreateDownstreamTlsContext(
 			listener.Proxy.SecretsTracker.RequestAllInOneCa(),
 			listener.Proxy.SecretsTracker.RequestIdentityCert(),
+			false,
 		)
 		if err != nil {
 			return nil, errors.Wrap(err, "couldn't generate downstream tls context for gateway")

--- a/pkg/xds/envoy/clusters/configurers.go
+++ b/pkg/xds/envoy/clusters/configurers.go
@@ -24,7 +24,14 @@ func CircuitBreaker(circuitBreaker *core_mesh.CircuitBreakerResource) ClusterBui
 	})
 }
 
-func ClientSideMTLS(tracker core_xds.SecretsTracker, unifiedResourceNaming bool, mesh *core_mesh.MeshResource, upstreamService string, upstreamTLSReady bool, tags []envoy_tags.Tags) ClusterBuilderOpt {
+func ClientSideMTLS(
+	tracker core_xds.SecretsTracker,
+	unifiedResourceNaming bool,
+	mesh *core_mesh.MeshResource,
+	upstreamService string,
+	upstreamTLSReady bool,
+	tags []envoy_tags.Tags,
+) ClusterBuilderOpt {
 	return ClusterBuilderOptFunc(func(builder *ClusterBuilder) {
 		builder.AddConfigurer(&v3.ClientSideMTLSConfigurer{
 			SecretsTracker:        tracker,
@@ -38,44 +45,69 @@ func ClientSideMTLS(tracker core_xds.SecretsTracker, unifiedResourceNaming bool,
 	})
 }
 
-func ClientSideMTLSCustomSNI(tracker core_xds.SecretsTracker, mesh *core_mesh.MeshResource, upstreamService string, upstreamTLSReady bool, sni string) ClusterBuilderOpt {
+func ClientSideMTLSCustomSNI(
+	tracker core_xds.SecretsTracker,
+	unifiedResourceNaming bool,
+	mesh *core_mesh.MeshResource,
+	upstreamService string,
+	upstreamTLSReady bool,
+	sni string,
+) ClusterBuilderOpt {
 	return ClusterBuilderOptFunc(func(builder *ClusterBuilder) {
 		builder.AddConfigurer(&v3.ClientSideMTLSConfigurer{
-			SecretsTracker:   tracker,
-			UpstreamMesh:     mesh,
-			UpstreamService:  upstreamService,
-			LocalMesh:        mesh,
-			Tags:             nil,
-			UpstreamTLSReady: upstreamTLSReady,
-			SNI:              sni,
+			SecretsTracker:        tracker,
+			UnifiedResourceNaming: unifiedResourceNaming,
+			UpstreamMesh:          mesh,
+			UpstreamService:       upstreamService,
+			LocalMesh:             mesh,
+			Tags:                  nil,
+			UpstreamTLSReady:      upstreamTLSReady,
+			SNI:                   sni,
 		})
 	})
 }
 
-func ClientSideMultiIdentitiesMTLS(tracker core_xds.SecretsTracker, mesh *core_mesh.MeshResource, upstreamTLSReady bool, sni string, identities []string) ClusterBuilderOpt {
+func ClientSideMultiIdentitiesMTLS(
+	tracker core_xds.SecretsTracker,
+	unifiedResourceNaming bool,
+	mesh *core_mesh.MeshResource,
+	upstreamTLSReady bool,
+	sni string,
+	identities []string,
+) ClusterBuilderOpt {
 	return ClusterBuilderOptFunc(func(builder *ClusterBuilder) {
 		builder.AddConfigurer(&v3.ClientSideMTLSConfigurer{
-			SecretsTracker:   tracker,
-			UpstreamMesh:     mesh,
-			UpstreamService:  "*",
-			LocalMesh:        mesh,
-			SNI:              sni,
-			Tags:             nil,
-			UpstreamTLSReady: upstreamTLSReady,
-			VerifyIdentities: identities,
+			SecretsTracker:        tracker,
+			UnifiedResourceNaming: unifiedResourceNaming,
+			UpstreamMesh:          mesh,
+			UpstreamService:       "*",
+			LocalMesh:             mesh,
+			SNI:                   sni,
+			Tags:                  nil,
+			UpstreamTLSReady:      upstreamTLSReady,
+			VerifyIdentities:      identities,
 		})
 	})
 }
 
-func CrossMeshClientSideMTLS(tracker core_xds.SecretsTracker, localMesh *core_mesh.MeshResource, upstreamMesh *core_mesh.MeshResource, upstreamService string, upstreamTLSReady bool, tags []envoy_tags.Tags) ClusterBuilderOpt {
+func CrossMeshClientSideMTLS(
+	tracker core_xds.SecretsTracker,
+	unifiedResourceNaming bool,
+	localMesh *core_mesh.MeshResource,
+	upstreamMesh *core_mesh.MeshResource,
+	upstreamService string,
+	upstreamTLSReady bool,
+	tags []envoy_tags.Tags,
+) ClusterBuilderOpt {
 	return ClusterBuilderOptFunc(func(builder *ClusterBuilder) {
 		builder.AddConfigurer(&v3.ClientSideMTLSConfigurer{
-			SecretsTracker:   tracker,
-			UpstreamMesh:     upstreamMesh,
-			UpstreamService:  upstreamService,
-			LocalMesh:        localMesh,
-			Tags:             tags,
-			UpstreamTLSReady: upstreamTLSReady,
+			SecretsTracker:        tracker,
+			UnifiedResourceNaming: unifiedResourceNaming,
+			UpstreamMesh:          upstreamMesh,
+			UpstreamService:       upstreamService,
+			LocalMesh:             localMesh,
+			Tags:                  tags,
+			UpstreamTLSReady:      upstreamTLSReady,
 		})
 	})
 }

--- a/pkg/xds/envoy/listeners/filter_chain_configurers.go
+++ b/pkg/xds/envoy/listeners/filter_chain_configurers.go
@@ -66,12 +66,19 @@ func NetworkDirectResponse(response string) FilterChainBuilderOpt {
 	})
 }
 
-func ServerSideMTLS(mesh *core_mesh.MeshResource, secrets core_xds.SecretsTracker, tlsVersion *common_tls.Version, tlsCiphers []common_tls.TlsCipher) FilterChainBuilderOpt {
+func ServerSideMTLS(
+	mesh *core_mesh.MeshResource,
+	secrets core_xds.SecretsTracker,
+	tlsVersion *common_tls.Version,
+	tlsCiphers []common_tls.TlsCipher,
+	unifiedResourceNaming bool,
+) FilterChainBuilderOpt {
 	return AddFilterChainConfigurer(&v3.ServerSideMTLSConfigurer{
-		Mesh:           mesh,
-		SecretsTracker: secrets,
-		TlsVersion:     tlsVersion,
-		TlsCiphers:     tlsCiphers,
+		Mesh:                  mesh,
+		SecretsTracker:        secrets,
+		TlsVersion:            tlsVersion,
+		TlsCiphers:            tlsCiphers,
+		UnifiedResourceNaming: unifiedResourceNaming,
 	})
 }
 

--- a/pkg/xds/envoy/listeners/v3/server_mtls_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/server_mtls_configurer.go
@@ -13,10 +13,11 @@ import (
 )
 
 type ServerSideMTLSConfigurer struct {
-	Mesh           *core_mesh.MeshResource
-	SecretsTracker core_xds.SecretsTracker
-	TlsVersion     *common_tls.Version
-	TlsCiphers     []common_tls.TlsCipher
+	Mesh                  *core_mesh.MeshResource
+	SecretsTracker        core_xds.SecretsTracker
+	TlsVersion            *common_tls.Version
+	TlsCiphers            []common_tls.TlsCipher
+	UnifiedResourceNaming bool
 }
 
 var _ FilterChainConfigurer = &ServerSideMTLSConfigurer{}
@@ -25,7 +26,11 @@ func (c *ServerSideMTLSConfigurer) Configure(filterChain *envoy_listener.FilterC
 	if !c.Mesh.MTLSEnabled() {
 		return nil
 	}
-	tlsContext, err := tls.CreateDownstreamTlsContext(c.SecretsTracker.RequestCa(c.Mesh.GetMeta().GetName()), c.SecretsTracker.RequestIdentityCert())
+	tlsContext, err := tls.CreateDownstreamTlsContext(
+		c.SecretsTracker.RequestCa(c.Mesh.GetMeta().GetName()),
+		c.SecretsTracker.RequestIdentityCert(),
+		c.UnifiedResourceNaming,
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/xds/envoy/listeners/v3/server_mtls_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/server_mtls_configurer_test.go
@@ -30,7 +30,7 @@ var _ = Describe("ServerMtlsConfigurer", func() {
 			tracker := envoy_common.NewSecretsTracker(given.mesh.GetMeta().GetName(), nil)
 			listener, err := NewInboundListenerBuilder(envoy_common.APIV3, given.listenerAddress, given.listenerPort, given.listenerProtocol).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3, envoy_common.AnonymousResource).
-					Configure(ServerSideMTLS(given.mesh, tracker, nil, nil)).
+					Configure(ServerSideMTLS(given.mesh, tracker, nil, nil, false)).
 					Configure(TcpProxyDeprecated(given.statsName, given.clusters...)))).
 				Build()
 			// then

--- a/pkg/xds/envoy/tls/v3/tls.go
+++ b/pkg/xds/envoy/tls/v3/tls.go
@@ -15,14 +15,18 @@ import (
 // CreateDownstreamTlsContext creates DownstreamTlsContext for incoming connections
 // It verifies that incoming connection has TLS certificate signed by Mesh CA with URI SAN of prefix spiffe://{mesh_name}/
 // It secures inbound listener with certificate of "identity_cert" that will be received from the SDS (it contains URI SANs of all inbounds).
-func CreateDownstreamTlsContext(downstreamMesh core_xds.CaRequest, mesh core_xds.IdentityCertRequest) (*envoy_tls.DownstreamTlsContext, error) {
+func CreateDownstreamTlsContext(
+	downstreamMesh core_xds.CaRequest,
+	mesh core_xds.IdentityCertRequest,
+	unifiedResourceNaming bool,
+) (*envoy_tls.DownstreamTlsContext, error) {
 	var validationSANMatchers []*envoy_tls.SubjectAltNameMatcher
 	meshNames := downstreamMesh.MeshName()
 	for _, meshName := range meshNames {
 		validationSANMatchers = append(validationSANMatchers, MeshSpiffeIDPrefixMatcher(meshName))
 	}
 
-	commonTlsContext := createCommonTlsContext(mesh, downstreamMesh, validationSANMatchers, false)
+	commonTlsContext := createCommonTlsContext(mesh, downstreamMesh, validationSANMatchers, unifiedResourceNaming)
 	return &envoy_tls.DownstreamTlsContext{
 		CommonTlsContext:         commonTlsContext,
 		RequireClientCertificate: util_proto.Bool(true),

--- a/pkg/xds/envoy/tls/v3/tls_test.go
+++ b/pkg/xds/envoy/tls/v3/tls_test.go
@@ -65,6 +65,7 @@ var _ = Describe("CreateDownstreamTlsContext()", func() {
 				snippet, err := v3.CreateDownstreamTlsContext(
 					&caRequest{mesh: mesh.GetMeta().GetName()},
 					&identityRequest{mesh: mesh.GetMeta().GetName()},
+					false,
 				)
 				// then
 				Expect(err).ToNot(HaveOccurred())

--- a/pkg/xds/generator/egress/external_services_generator.go
+++ b/pkg/xds/generator/egress/external_services_generator.go
@@ -6,6 +6,7 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	envoy_clusters "github.com/kumahq/kuma/pkg/xds/envoy/clusters"
@@ -43,14 +44,12 @@ func (g *ExternalServicesGenerator) Generate(
 	services := g.buildServices(endpointMap)
 
 	g.addFilterChains(
-		apiVersion,
-		proxy.InternalAddresses,
+		proxy,
 		destinations,
 		endpointMap,
 		meshResources,
 		listenerBuilder,
 		services,
-		proxy.SecretsTracker,
 	)
 
 	cds, err := g.generateCDS(
@@ -155,14 +154,12 @@ func (*ExternalServicesGenerator) buildServices(
 }
 
 func (g *ExternalServicesGenerator) addFilterChains(
-	apiVersion core_xds.APIVersion,
-	internalAddresses []core_xds.InternalAddress,
+	proxy *core_xds.Proxy,
 	meshDestinations zoneproxy.MeshDestinations,
 	endpointMap core_xds.EndpointMap,
 	meshResources *core_xds.MeshResources,
 	listenerBuilder *envoy_listeners.ListenerBuilder,
 	services map[string]bool,
-	secretsTracker core_xds.SecretsTracker,
 ) {
 	meshName := meshResources.Mesh.GetMeta().GetName()
 	sniUsed := map[string]bool{}
@@ -190,15 +187,13 @@ func (g *ExternalServicesGenerator) addFilterChains(
 
 			sniUsed[sni] = true
 			g.configureFilterChain(
-				apiVersion,
-				internalAddresses,
+				proxy,
 				esName,
 				sni,
 				meshName,
 				endpoints,
 				meshDestination,
 				meshResources,
-				secretsTracker,
 				listenerBuilder,
 			)
 		}
@@ -215,32 +210,29 @@ func (g *ExternalServicesGenerator) addFilterChains(
 		sniUsed[mes.SNI] = true
 		relevantTags := tags.Tags{}
 		g.configureFilterChain(
-			apiVersion,
-			internalAddresses,
+			proxy,
 			mes.DestinationName,
 			mes.SNI,
 			meshName,
 			endpoints,
 			relevantTags,
 			meshResources,
-			secretsTracker,
 			listenerBuilder,
 		)
 	}
 }
 
 func (*ExternalServicesGenerator) configureFilterChain(
-	apiVersion core_xds.APIVersion,
-	internalAddresses []core_xds.InternalAddress,
+	proxy *core_xds.Proxy,
 	esName string,
 	sni string,
 	meshName string,
 	endpoints []core_xds.Endpoint,
 	meshDestination tags.Tags,
 	meshResources *core_xds.MeshResources,
-	secretsTracker core_xds.SecretsTracker,
 	listenerBuilder *envoy_listeners.ListenerBuilder,
 ) {
+	unifiedNaming := proxy.Metadata.HasFeature(xds_types.FeatureUnifiedResourceNaming)
 	// There is a case where multiple meshes contain services with
 	// the same names, so we cannot use just "serviceName" as a cluster
 	// name as we would overwrite some clusters with the latest one
@@ -261,8 +253,8 @@ func (*ExternalServicesGenerator) configureFilterChain(
 		filterChainName = esName
 	}
 
-	filterChainBuilder := envoy_listeners.NewFilterChainBuilder(apiVersion, filterChainName).Configure(
-		envoy_listeners.ServerSideMTLS(meshResources.Mesh, secretsTracker, nil, nil),
+	filterChainBuilder := envoy_listeners.NewFilterChainBuilder(proxy.APIVersion, filterChainName).Configure(
+		envoy_listeners.ServerSideMTLS(meshResources.Mesh, proxy.SecretsTracker, nil, nil, unifiedNaming),
 		envoy_listeners.MatchTransportProtocol("tls"),
 		envoy_listeners.MatchServerNames(sni),
 		envoy_listeners.NetworkRBAC(
@@ -300,7 +292,7 @@ func (*ExternalServicesGenerator) configureFilterChain(
 		}
 
 		filterChainBuilder.
-			Configure(envoy_listeners.HttpConnectionManager(esName, false, internalAddresses)).
+			Configure(envoy_listeners.HttpConnectionManager(esName, false, proxy.InternalAddresses)).
 			Configure(envoy_listeners.FaultInjection(meshResources.ExternalServiceFaultInjections[esName]...)).
 			Configure(envoy_listeners.RateLimit(meshResources.ExternalServiceRateLimits[esName])).
 			Configure(envoy_listeners.AddFilterChainConfigurer(&v3.HttpOutboundRouteConfigurer{

--- a/pkg/xds/generator/outbound_proxy_generator.go
+++ b/pkg/xds/generator/outbound_proxy_generator.go
@@ -11,6 +11,7 @@ import (
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/user"
 	model "github.com/kumahq/kuma/pkg/core/xds"
+	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
 	util_protocol "github.com/kumahq/kuma/pkg/util/protocol"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
@@ -193,6 +194,8 @@ func (OutboundProxyGenerator) generateLDS(ctx xds_context.Context, proxy *model.
 func (g OutboundProxyGenerator) generateCDS(ctx xds_context.Context, services envoy_common.Services, proxy *model.Proxy) (*model.ResourceSet, error) {
 	resources := model.NewResourceSet()
 
+	unifiedNaming := proxy.Metadata.HasFeature(xds_types.FeatureUnifiedResourceNaming)
+
 	for _, serviceName := range services.Sorted() {
 		service := services[serviceName]
 		healthCheck := proxy.Policies.HealthChecks[serviceName]
@@ -215,7 +218,7 @@ func (g OutboundProxyGenerator) generateCDS(ctx xds_context.Context, services en
 				if ctx.Mesh.Resource.ZoneEgressEnabled() {
 					edsClusterBuilder.
 						Configure(envoy_clusters.EdsCluster()).
-						Configure(envoy_clusters.ClientSideMTLS(proxy.SecretsTracker, false, ctx.Mesh.Resource, mesh_proto.ZoneEgressServiceName, tlsReady, clusterTags))
+						Configure(envoy_clusters.ClientSideMTLS(proxy.SecretsTracker, unifiedNaming, ctx.Mesh.Resource, mesh_proto.ZoneEgressServiceName, tlsReady, clusterTags))
 				} else {
 					endpoints := proxy.Routing.ExternalServiceOutboundTargets[serviceName]
 					isIPv6 := proxy.Dataplane.IsIPv6()
@@ -243,14 +246,14 @@ func (g OutboundProxyGenerator) generateCDS(ctx xds_context.Context, services en
 						if otherMesh.GetMeta().GetName() == upstreamMeshName {
 							edsClusterBuilder.Configure(
 								envoy_clusters.CrossMeshClientSideMTLS(
-									proxy.SecretsTracker, ctx.Mesh.Resource, otherMesh, serviceName, tlsReady, clusterTags,
+									proxy.SecretsTracker, unifiedNaming, ctx.Mesh.Resource, otherMesh, serviceName, tlsReady, clusterTags,
 								),
 							)
 							break
 						}
 					}
 				} else {
-					edsClusterBuilder.Configure(envoy_clusters.ClientSideMTLS(proxy.SecretsTracker, false, ctx.Mesh.Resource, serviceName, tlsReady, clusterTags))
+					edsClusterBuilder.Configure(envoy_clusters.ClientSideMTLS(proxy.SecretsTracker, unifiedNaming, ctx.Mesh.Resource, serviceName, tlsReady, clusterTags))
 				}
 			}
 

--- a/pkg/xds/generator/prometheus_endpoint_generator.go
+++ b/pkg/xds/generator/prometheus_endpoint_generator.go
@@ -113,7 +113,7 @@ func (g PrometheusEndpointGenerator) Generate(ctx context.Context, _ *core_xds.R
 		case mesh_proto.PrometheusTlsConfig_activeMTLSBackend:
 			listenerBuilder = listenerBuilder.Configure(envoy_listeners.FilterChain(
 				envoy_listeners.NewFilterChainBuilder(proxy.APIVersion, envoy_common.AnonymousResource).Configure(
-					envoy_listeners.ServerSideMTLS(xdsCtx.Mesh.Resource, proxy.SecretsTracker, nil, nil),
+					envoy_listeners.ServerSideMTLS(xdsCtx.Mesh.Resource, proxy.SecretsTracker, nil, nil, false),
 					envoy_listeners.StaticEndpoints(prometheusListenerName,
 						[]*envoy_common.StaticEndpointPath{
 							{

--- a/pkg/xds/generator/testdata/profile-source/5-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/5-envoy-config.golden.yaml
@@ -22,12 +22,12 @@ resources:
                   exact: spiffe://demo/db
                 sanType: URI
             validationContextSdsSecretConfig:
-              name: mesh_ca:secret:demo
+              name: system_mtls_ca_demo
               sdsConfig:
                 ads: {}
                 resourceApiVersion: V3
           tlsCertificateSdsSecretConfigs:
-          - name: identity_cert:secret:demo
+          - name: system_mtls_identity_demo
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
@@ -67,12 +67,12 @@ resources:
                   exact: spiffe://demo/elastic
                 sanType: URI
             validationContextSdsSecretConfig:
-              name: mesh_ca:secret:demo
+              name: system_mtls_ca_demo
               sdsConfig:
                 ads: {}
                 resourceApiVersion: V3
           tlsCertificateSdsSecretConfigs:
-          - name: identity_cert:secret:demo
+          - name: system_mtls_identity_demo
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
@@ -191,12 +191,12 @@ resources:
                     prefix: spiffe://demo/
                   sanType: URI
               validationContextSdsSecretConfig:
-                name: mesh_ca:secret:demo
+                name: system_mtls_ca_demo
                 sdsConfig:
                   ads: {}
                   resourceApiVersion: V3
             tlsCertificateSdsSecretConfigs:
-            - name: identity_cert:secret:demo
+            - name: system_mtls_identity_demo
               sdsConfig:
                 ads: {}
                 resourceApiVersion: V3


### PR DESCRIPTION
## Motivation

Some code paths missed updating secret resource names to use the unified naming feature introduced in #14166. This caused inconsistencies in how secrets were referenced during mTLS and filter chain configuration.

## Implementation information

Added the `unifiedResourceNaming` flag to all relevant function calls and configurers that manage secrets, including server-side and client-side mTLS configurers. Updated inbound, outbound, gateway, and external service proxy generators to pass the flag consistently. Adjusted tests to account for the new parameter.

## Supporting documentation

Related to:
- #14166
- #13973