### PR TITLE
chore(helm): switch kubectl image to rancher and bump patch

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -727,9 +727,9 @@ kubectl:
     # -- The kubectl image registry
     registry: docker.io
     # -- The kubectl image repository
-    repository: bitnami/kubectl
+    repository: rancher/kubectl
     # -- The kubectl image tag
-    tag: "1.33.1@sha256:35f792b0f0b8b3072bb01cd50a23d2dc1ba2488eed70a1a951a1789a8e3bc994"
+    tag: "v1.33.3@sha256:26d09fcee6eb9a14b81c95e52dd90964a0a24263abb075f58651d2ac62651b59"
 hooks:
   # -- Node selector for the HELM hooks
   nodeSelector:

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -217,8 +217,8 @@ A Helm chart for the Kuma Control Plane
 | kumactl.image.repository | string | `"kumactl"` | The kumactl image repository |
 | kumactl.image.tag | string | `nil` | The kumactl image tag. When not specified, the value is copied from global.tag |
 | kubectl.image.registry | string | `"docker.io"` | The kubectl image registry |
-| kubectl.image.repository | string | `"bitnami/kubectl"` | The kubectl image repository |
-| kubectl.image.tag | string | `"1.33.1@sha256:35f792b0f0b8b3072bb01cd50a23d2dc1ba2488eed70a1a951a1789a8e3bc994"` | The kubectl image tag |
+| kubectl.image.repository | string | `"rancher/kubectl"` | The kubectl image repository |
+| kubectl.image.tag | string | `"v1.33.3@sha256:26d09fcee6eb9a14b81c95e52dd90964a0a24263abb075f58651d2ac62651b59"` | The kubectl image tag |
 | hooks.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selector for the HELM hooks |
 | hooks.tolerations | list | `[]` | Tolerations for the HELM hooks |
 | hooks.podSecurityContext | object | `{"runAsNonRoot":true}` | Security context at the pod level for crd/webhook/ns |

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -727,9 +727,9 @@ kubectl:
     # -- The kubectl image registry
     registry: docker.io
     # -- The kubectl image repository
-    repository: bitnami/kubectl
+    repository: rancher/kubectl
     # -- The kubectl image tag
-    tag: "1.33.1@sha256:35f792b0f0b8b3072bb01cd50a23d2dc1ba2488eed70a1a951a1789a8e3bc994"
+    tag: "v1.33.3@sha256:26d09fcee6eb9a14b81c95e52dd90964a0a24263abb075f58651d2ac62651b59"
 hooks:
   # -- Node selector for the HELM hooks
   nodeSelector:

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -727,9 +727,9 @@ kubectl:
     # -- The kubectl image registry
     registry: docker.io
     # -- The kubectl image repository
-    repository: bitnami/kubectl
+    repository: rancher/kubectl
     # -- The kubectl image tag
-    tag: "1.33.1@sha256:35f792b0f0b8b3072bb01cd50a23d2dc1ba2488eed70a1a951a1789a8e3bc994"
+    tag: "v1.33.3@sha256:26d09fcee6eb9a14b81c95e52dd90964a0a24263abb075f58651d2ac62651b59"
 hooks:
   # -- Node selector for the HELM hooks
   nodeSelector:


### PR DESCRIPTION
## Motivation

Bitnami will discontinue and remove the `bitnami/kubectl` image from their registry in 2 weeks. While kubectl is now available under the `bitnamisecure/kubectl` registry, it only contains new images, lacks tags corresponding to kubectl versions, and the publisher is not marked as verified. This makes it unsuitable for backporting changes to existing release branches.

## Implementation information

Updated the Helm chart and generated documentation to use the `rancher/kubectl` image instead of `bitnami/kubectl`. Increased the patch version from `1.33.1` to `1.33.3` and set the corresponding image digest. Rancher provides versioned and tagged kubectl images, making it easier to align with our current and past releases.

## Supporting documentation

Reference: https://github.com/bitnami/charts/issues/35164
Related: https://github.com/kumahq/kuma/issues/14035

> Changelog: feat(helm): switch kubectl image from `bitnami` to `registry.k8s.io`