### PR TITLE
chore(helm): switch kubectl image to rancher and bump patch

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -695,9 +695,9 @@ kubectl:
     # -- The kubectl image registry
     registry: docker.io
     # -- The kubectl image repository
-    repository: bitnami/kubectl
+    repository: rancher/kubectl
     # -- The kubectl image tag
-    tag: "1.27.5"
+    tag: "v1.27.16@sha256:51758d7dbafd9248757c11225ca6693f3cba570803431d0f0d6e917dd7667310"
 hooks:
   # -- Node selector for the HELM hooks
   nodeSelector:

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -207,8 +207,8 @@ A Helm chart for the Kuma Control Plane
 | kumactl.image.repository | string | `"kumactl"` | The kumactl image repository |
 | kumactl.image.tag | string | `nil` | The kumactl image tag. When not specified, the value is copied from global.tag |
 | kubectl.image.registry | string | `"docker.io"` | The kubectl image registry |
-| kubectl.image.repository | string | `"bitnami/kubectl"` | The kubectl image repository |
-| kubectl.image.tag | string | `"1.27.5"` | The kubectl image tag |
+| kubectl.image.repository | string | `"rancher/kubectl"` | The kubectl image repository |
+| kubectl.image.tag | string | `"v1.27.16@sha256:51758d7dbafd9248757c11225ca6693f3cba570803431d0f0d6e917dd7667310"` | The kubectl image tag |
 | hooks.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selector for the HELM hooks |
 | hooks.tolerations | list | `[]` | Tolerations for the HELM hooks |
 | hooks.podSecurityContext | object | `{"runAsNonRoot":true}` | Security context at the pod level for crd/webhook/ns |

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -695,9 +695,9 @@ kubectl:
     # -- The kubectl image registry
     registry: docker.io
     # -- The kubectl image repository
-    repository: bitnami/kubectl
+    repository: rancher/kubectl
     # -- The kubectl image tag
-    tag: "1.27.5"
+    tag: "v1.27.16@sha256:51758d7dbafd9248757c11225ca6693f3cba570803431d0f0d6e917dd7667310"
 hooks:
   # -- Node selector for the HELM hooks
   nodeSelector:

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -695,9 +695,9 @@ kubectl:
     # -- The kubectl image registry
     registry: docker.io
     # -- The kubectl image repository
-    repository: bitnami/kubectl
+    repository: rancher/kubectl
     # -- The kubectl image tag
-    tag: "1.27.5"
+    tag: "v1.27.16@sha256:51758d7dbafd9248757c11225ca6693f3cba570803431d0f0d6e917dd7667310"
 hooks:
   # -- Node selector for the HELM hooks
   nodeSelector:


### PR DESCRIPTION
## Motivation

Bitnami will discontinue and remove the `bitnami/kubectl` image from their registry in 2 weeks. While kubectl is now available under the `bitnamisecure/kubectl` registry, it only contains new images, lacks tags corresponding to kubectl versions, and the publisher is not marked as verified. This makes it unsuitable for backporting changes to existing release branches.

## Implementation information

Updated the Helm chart and generated documentation to use the `rancher/kubectl` image instead of `bitnami/kubectl`. Increased the patch version from `1.27.5` to `1.27.16` and set the corresponding image digest. Rancher provides versioned and tagged kubectl images, making it easier to align with our current and past releases.

## Supporting documentation

Reference: https://github.com/bitnami/charts/issues/35164
Related: https://github.com/kumahq/kuma/issues/14035