### PR TITLE
chore(helm): add v prefix to the kubectl image tag for consistency

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -742,7 +742,7 @@ kubectl:
     # -- The kubectl image repository
     repository: rancher/kubectl
     # -- The kubectl image tag
-    tag: "1.33.3@sha256:26d09fcee6eb9a14b81c95e52dd90964a0a24263abb075f58651d2ac62651b59"
+    tag: "v1.33.3@sha256:26d09fcee6eb9a14b81c95e52dd90964a0a24263abb075f58651d2ac62651b59"
 hooks:
   # -- Node selector for the HELM hooks
   nodeSelector:

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -219,7 +219,7 @@ A Helm chart for the Kuma Control Plane
 | kumactl.image.tag | string | `nil` | The kumactl image tag. When not specified, the value is copied from global.tag |
 | kubectl.image.registry | string | `"docker.io"` | The kubectl image registry |
 | kubectl.image.repository | string | `"rancher/kubectl"` | The kubectl image repository |
-| kubectl.image.tag | string | `"1.33.3@sha256:26d09fcee6eb9a14b81c95e52dd90964a0a24263abb075f58651d2ac62651b59"` | The kubectl image tag |
+| kubectl.image.tag | string | `"v1.33.3@sha256:26d09fcee6eb9a14b81c95e52dd90964a0a24263abb075f58651d2ac62651b59"` | The kubectl image tag |
 | hooks.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selector for the HELM hooks |
 | hooks.tolerations | list | `[]` | Tolerations for the HELM hooks |
 | hooks.podSecurityContext | object | `{"runAsNonRoot":true}` | Security context at the pod level for crd/webhook/ns |

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -742,7 +742,7 @@ kubectl:
     # -- The kubectl image repository
     repository: rancher/kubectl
     # -- The kubectl image tag
-    tag: "1.33.3@sha256:26d09fcee6eb9a14b81c95e52dd90964a0a24263abb075f58651d2ac62651b59"
+    tag: "v1.33.3@sha256:26d09fcee6eb9a14b81c95e52dd90964a0a24263abb075f58651d2ac62651b59"
 hooks:
   # -- Node selector for the HELM hooks
   nodeSelector:

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -742,7 +742,7 @@ kubectl:
     # -- The kubectl image repository
     repository: rancher/kubectl
     # -- The kubectl image tag
-    tag: "1.33.3@sha256:26d09fcee6eb9a14b81c95e52dd90964a0a24263abb075f58651d2ac62651b59"
+    tag: "v1.33.3@sha256:26d09fcee6eb9a14b81c95e52dd90964a0a24263abb075f58651d2ac62651b59"
 hooks:
   # -- Node selector for the HELM hooks
   nodeSelector:


### PR DESCRIPTION
## Motivation

Rancher tags their `kubectl` images with a `v` prefix (e.g., `v1.33.3`). Our Helm chart was using the tag without the prefix, which is inconsistent with Rancher’s convention and with the release branches where we already include the `v` prefix. While this is a cosmetic change only (the image digest is provided and takes precedence over the tag), keeping tags consistent improves clarity and avoids confusion.

## Implementation information

Updated all references to the `rancher/kubectl` image tag from `1.33.3` to `v1.33.3` across Helm chart values, generated documentation, and related test data. The image digest remains unchanged.