### PR TITLE
chore(deps): bump golang from 1.24.6 to 1.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kumahq/kuma
 
-go 1.24.6
+go 1.25.0
 
 require (
 	cirello.io/pglock v1.16.1


### PR DESCRIPTION
## Motivation

upgrade golang from `1.24.6` to `1.25.0`
