### PR TITLE
docs(CONTRIBUTING): removing Contributor Badge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -286,9 +286,3 @@ If you think your PR should be backported, please add the `backport` label. This
 
 You can indicate that you are reviewing a PR by using the `eyes` emoji on the PR description.
 If you give up on doing so please remove the emoji.
-
-### Contributor Badge
-
-If your Pull Request to [kumahq/kuma](https://github.com/kumahq/kuma) was accepted, and it fixes a bug, adds functionality, or makes it significantly easier to use or understand Kuma, congratulations! You are eligible to receive a digital Contributor Badge! Go ahead and fill out the [Contributor Submissions form](https://goo.gl/forms/5w6mxLaE4tz2YM0L2).
-
-*Badges expire after 1 year, at which point you may submit a new contribution to renew the badge.* 


### PR DESCRIPTION
We are no longer providing the Contributor Badge, removing it to avoid confusion.

## Motivation

<!-- Why are we doing this change -->

## Implementation information

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
