### PR TITLE
chore(deps): automatically bump openapi-tool when a new release is out

### DIFF
--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -3,6 +3,9 @@ DOCS_CP_CONFIG ?= pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
 DOCS_EXTRA_TARGETS ?=
 DOCS_OPENAPI_PREREQUISITES ?=
 
+# renovate: datasource=github-tags depName=kumahq/ci-tools versioning=semver
+OAPI_TOOLS_VERSION ?= v1.1.6
+
 .PHONY: clean/docs
 clean/docs:
 	rm -rf docs/generated
@@ -53,7 +56,7 @@ docs/generated/openapi.yaml: $(DOCS_OPENAPI_PREREQUISITES)
 	for i in $$( find $(MESH_API_DIR) -name '*.yaml'); do DIR=$(OAPI_TMP_DIR)/protoresources/$$(echo $${i} | awk -F/ '{print $$(NF-1)}'); mkdir -p $${DIR}; cp $${i} $${DIR}/$$(echo $${i} | awk -F/ '{print $$(NF)}'); done
 
 ifdef BASE_API
-	docker run --rm -v $$PWD/$(dir $(BASE_API)):/base -v $(OAPI_TMP_DIR):/specs ghcr.io/kumahq/openapi-tool:v1.1.6 generate /base/$(notdir $(BASE_API)) '/specs/**/*.yaml'  '!/specs/kuma/**' > $@
+	docker run --rm -v $$PWD/$(dir $(BASE_API)):/base -v $(OAPI_TMP_DIR):/specs ghcr.io/kumahq/openapi-tool:$(OAPI_TOOLS_VERSION) generate /base/$(notdir $(BASE_API)) '/specs/**/*.yaml'  '!/specs/kuma/**' > $@
 else
-	docker run --rm -v $(OAPI_TMP_DIR):/specs ghcr.io/kumahq/openapi-tool:v1.1.6 generate '/specs/**/*.yaml' > $@
+	docker run --rm -v $(OAPI_TMP_DIR):/specs ghcr.io/kumahq/openapi-tool:$(OAPI_TOOLS_VERSION) generate '/specs/**/*.yaml' > $@
 endif


### PR DESCRIPTION
## Motivation

Because we had to do it manually https://github.com/kumahq/kuma/pull/14226 and it costed us hours of dev time because of that.

## Implementation information

Use makefile renovate updater.