### PR TITLE
chore(deps): update renovate config for openapi-tool

### DIFF
--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -3,7 +3,7 @@ DOCS_CP_CONFIG ?= pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
 DOCS_EXTRA_TARGETS ?=
 DOCS_OPENAPI_PREREQUISITES ?=
 
-# renovate: datasource=github-tags depName=kumahq/ci-tools versioning=semver
+# renovate: datasource=docker depName=kumahq/openapi-tool versioning=semver-coerced registryUrl=https://ghcr.io
 OAPI_TOOLS_VERSION ?= v1.1.6
 
 .PHONY: clean/docs

--- a/renovate.json
+++ b/renovate.json
@@ -59,6 +59,20 @@
         "kumahq/envoy-builds"
       ],
       "commitMessageTopic": "envoy"
+    },
+    {
+      "description": "Disable pinning of openapi-tool which won't work and always will result in pailures. This dependency is managed by the custom regex manager for Makefiles",
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDepNames": [
+        "kumahq/openapi-tool"
+      ],
+      "matchUpdateTypes": [
+        "pin",
+        "pinDigest"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Motivation

`kumahq/openapi-tool` in `mk/docs.mk` was still configured to use the `github-tags` datasource in renovate metadata, even though the image is hosted on GitHub Container Registry. This caused renovate to misdetect updates. Additionally, renovate was attempting to pin this dependency, but pinning does not work and always fails because the dependency is managed by a custom regex manager for Makefiles.

## Implementation information

Updated the renovate metadata in `mk/docs.mk` to use the `docker` datasource with `semver-coerced` versioning and the correct `ghcr.io` registry. Added a renovate package rule in `renovate.json` to disable pinning for `kumahq/openapi-tool`, preventing renovate from creating invalid pin PRs. This ensures only version bumps are attempted, managed through the custom regex manager.
