### PR TITLE
refactor(xds): rework outbound route API, add SNI, helpers

### DIFF
--- a/pkg/core/naming/contextual.go
+++ b/pkg/core/naming/contextual.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	"golang.org/x/exp/constraints"
 
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_registry "github.com/kumahq/kuma/pkg/core/resources/registry"
 )
 
 type sectionName interface {
-	~string | ~uint32
+	~string | constraints.Unsigned
 }
 
 // MustContextualInboundName is a helper for code paths where you are certain the resource's

--- a/pkg/core/naming/naming.go
+++ b/pkg/core/naming/naming.go
@@ -1,0 +1,30 @@
+package naming
+
+// allow either a bool or a predicate func
+type boolOrFunc interface {
+	bool | func() bool
+}
+
+func eval[T boolOrFunc](p T) bool {
+	switch v := any(p).(type) {
+	case bool:
+		return v
+	case func() bool:
+		return v != nil && v()
+	default:
+		return false
+	}
+}
+
+func GetNameOrFallback[T boolOrFunc](pred T, name string, fallback string) string {
+	if eval(pred) {
+		return name
+	}
+	return fallback
+}
+
+func GetNameOrFallbackFunc[T boolOrFunc](pred T) func(value string, fallback string) string {
+	return func(name string, fallback string) string {
+		return GetNameOrFallback(pred, name, fallback)
+	}
+}

--- a/pkg/core/naming/naming_test.go
+++ b/pkg/core/naming/naming_test.go
@@ -1,0 +1,89 @@
+package naming_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/pkg/core/naming"
+)
+
+var _ = Describe("GetNameOrFallback", func() {
+	It("should return name when predicate is true (bool)", func() {
+		// when
+		got := naming.GetNameOrFallback(true, "name", "fallback")
+		// then
+		Expect(got).To(Equal("name"))
+	})
+
+	It("should return fallback when predicate is false (bool)", func() {
+		// when
+		got := naming.GetNameOrFallback(false, "name", "fallback")
+		// then
+		Expect(got).To(Equal("fallback"))
+	})
+
+	It("should return name when predicate func returns true", func() {
+		pred := func() bool { return true }
+		got := naming.GetNameOrFallback(pred, "name", "fallback")
+		Expect(got).To(Equal("name"))
+	})
+
+	It("should return fallback when predicate func returns false", func() {
+		pred := func() bool { return false }
+		got := naming.GetNameOrFallback(pred, "name", "fallback")
+		Expect(got).To(Equal("fallback"))
+	})
+
+	It("should return fallback when predicate func is nil", func() {
+		var pred func() bool // nil
+		got := naming.GetNameOrFallback(pred, "name", "fallback")
+		Expect(got).To(Equal("fallback"))
+	})
+})
+
+var _ = Describe("GetNameOrFallbackFunc", func() {
+	It("should return function that uses name when bool predicate true", func() {
+		fn := naming.GetNameOrFallbackFunc(true)
+		Expect(fn("name", "fallback")).To(Equal("name"))
+	})
+
+	It("should return function that uses fallback when bool predicate false", func() {
+		fn := naming.GetNameOrFallbackFunc(false)
+		Expect(fn("name", "fallback")).To(Equal("fallback"))
+	})
+
+	It("should return function that uses name when predicate func returns true", func() {
+		pred := func() bool { return true }
+		fn := naming.GetNameOrFallbackFunc(pred)
+		Expect(fn("name", "fallback")).To(Equal("name"))
+	})
+
+	It("should return function that uses fallback when predicate func returns false", func() {
+		pred := func() bool { return false }
+		fn := naming.GetNameOrFallbackFunc(pred)
+		Expect(fn("name", "fallback")).To(Equal("fallback"))
+	})
+
+	It("should evaluate predicate at call time (dynamic)", func() {
+		val := false
+		pred := func() bool { return val }
+		fn := naming.GetNameOrFallbackFunc(pred)
+
+		// initially false -> fallback
+		Expect(fn("name", "fallback")).To(Equal("fallback"))
+
+		// change underlying value -> should now return name
+		val = true
+		Expect(fn("name", "fallback")).To(Equal("name"))
+
+		// change back -> fallback again
+		val = false
+		Expect(fn("name", "fallback")).To(Equal("fallback"))
+	})
+
+	It("should return fallback when predicate func is nil", func() {
+		var pred func() bool // nil
+		fn := naming.GetNameOrFallbackFunc(pred)
+		Expect(fn("name", "fallback")).To(Equal("fallback"))
+	})
+})

--- a/pkg/plugins/policies/core/xds/cluster.go
+++ b/pkg/plugins/policies/core/xds/cluster.go
@@ -11,6 +11,7 @@ import (
 type Cluster struct {
 	service           string
 	name              string
+	sni               string
 	tags              tags.Tags
 	mesh              string
 	isExternalService bool
@@ -18,6 +19,7 @@ type Cluster struct {
 
 func (c *Cluster) Service() string { return c.service }
 func (c *Cluster) Name() string    { return c.name }
+func (c *Cluster) SNI() string     { return c.sni }
 func (c *Cluster) Tags() tags.Tags { return c.tags }
 
 // Mesh returns a non-empty string only if the cluster is in a different mesh
@@ -71,6 +73,13 @@ func (b *ClusterBuilder) WithName(name string) *ClusterBuilder {
 		if cluster.service == "" {
 			cluster.service = name
 		}
+	}))
+	return b
+}
+
+func (b *ClusterBuilder) WithSNI(sni string) *ClusterBuilder {
+	b.opts = append(b.opts, newClusterOptFunc(func(cluster *Cluster) {
+		cluster.sni = sni
 	}))
 	return b
 }

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
@@ -1174,6 +1174,7 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 							Configure(HttpConnectionManager("127.0.0.1:27777", false, nil)).
 							Configure(
 								HttpOutboundRoute(
+									envoy_names.GetOutboundRouteName("backend"),
 									"backend",
 									envoy_common.Routes{{
 										Clusters: []envoy_common.Cluster{
@@ -1791,6 +1792,7 @@ func paymentsListener() envoy_common.NamedResource {
 			Configure(HttpConnectionManager("127.0.0.1:27778", false, nil)).
 			Configure(
 				HttpOutboundRoute(
+					envoy_names.GetOutboundRouteName("backend"),
 					"backend",
 					envoy_common.Routes{{
 						Clusters: []envoy_common.Cluster{envoy_common.NewCluster(
@@ -1814,6 +1816,7 @@ func backendListener() envoy_common.NamedResource {
 			Configure(HttpConnectionManager("127.0.0.1:27777", false, nil)).
 			Configure(
 				HttpOutboundRoute(
+					envoy_names.GetOutboundRouteName("backend"),
 					"backend",
 					envoy_common.Routes{{
 						Clusters: []envoy_common.Cluster{envoy_common.NewCluster(

--- a/pkg/xds/envoy/clusters/cluster_builder.go
+++ b/pkg/xds/envoy/clusters/cluster_builder.go
@@ -36,7 +36,9 @@ type ClusterBuilder struct {
 // Configure configures ClusterBuilder by adding individual ClusterConfigurers.
 func (b *ClusterBuilder) Configure(opts ...ClusterBuilderOpt) *ClusterBuilder {
 	for _, opt := range opts {
-		opt.ApplyTo(b)
+		if opt != nil {
+			opt.ApplyTo(b)
+		}
 	}
 	return b
 }

--- a/pkg/xds/envoy/listeners/filter_chain_configurers.go
+++ b/pkg/xds/envoy/listeners/filter_chain_configurers.go
@@ -262,11 +262,17 @@ func HttpInboundRoutes(routeConfigName string, virtualHostName string, routes en
 	})
 }
 
-func HttpOutboundRoute(service string, routes envoy_common.Routes, dpTags mesh_proto.MultiValueTagSet) FilterChainBuilderOpt {
+func HttpOutboundRoute(
+	routeConfigName string,
+	virtualHostName string,
+	routes envoy_common.Routes,
+	dpTags mesh_proto.MultiValueTagSet,
+) FilterChainBuilderOpt {
 	return AddFilterChainConfigurer(&v3.HttpOutboundRouteConfigurer{
-		Service: service,
-		Routes:  routes,
-		DpTags:  dpTags,
+		RouteConfigName: routeConfigName,
+		VirtualHostName: virtualHostName,
+		Routes:          routes,
+		DpTags:          dpTags,
 	})
 }
 

--- a/pkg/xds/envoy/listeners/v3/http_outbound_route_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/http_outbound_route_configurer.go
@@ -5,34 +5,27 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
-	envoy_names "github.com/kumahq/kuma/pkg/xds/envoy/names"
 	envoy_routes "github.com/kumahq/kuma/pkg/xds/envoy/routes"
 	envoy_virtual_hosts "github.com/kumahq/kuma/pkg/xds/envoy/virtualhosts"
 )
 
 type HttpOutboundRouteConfigurer struct {
-	Name    string
-	Service string
-	Routes  envoy_common.Routes
-	DpTags  mesh_proto.MultiValueTagSet
+	VirtualHostName string
+	RouteConfigName string
+	Routes          envoy_common.Routes
+	DpTags          mesh_proto.MultiValueTagSet
 }
 
 var _ FilterChainConfigurer = &HttpOutboundRouteConfigurer{}
 
 func (c *HttpOutboundRouteConfigurer) Configure(filterChain *envoy_listener.FilterChain) error {
-	var name string
-	if c.Name == "" {
-		name = envoy_names.GetOutboundRouteName(c.Service)
-	} else {
-		name = c.Name
-	}
-	static := HttpStaticRouteConfigurer{
-		Builder: envoy_routes.NewRouteConfigurationBuilder(envoy_common.APIV3, name).
-			Configure(envoy_routes.CommonRouteConfiguration()).
-			Configure(envoy_routes.TagsHeader(c.DpTags)).
-			Configure(envoy_routes.VirtualHost(envoy_virtual_hosts.NewVirtualHostBuilder(envoy_common.APIV3, c.Service).
-				Configure(envoy_virtual_hosts.Routes(c.Routes)))),
-	}
+	virtualHost := envoy_virtual_hosts.NewVirtualHostBuilder(envoy_common.APIV3, c.VirtualHostName).
+		Configure(envoy_virtual_hosts.Routes(c.Routes))
 
-	return static.Configure(filterChain)
+	routeConfig := envoy_routes.NewRouteConfigurationBuilder(envoy_common.APIV3, c.RouteConfigName).
+		Configure(envoy_routes.CommonRouteConfiguration()).
+		Configure(envoy_routes.TagsHeader(c.DpTags)).
+		Configure(envoy_routes.VirtualHost(virtualHost))
+
+	return NewHttpStaticRouteConfigurer(routeConfig).Configure(filterChain)
 }

--- a/pkg/xds/envoy/listeners/v3/http_outbound_route_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_outbound_route_configurer_test.go
@@ -9,6 +9,7 @@ import (
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	. "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
+	envoy_names "github.com/kumahq/kuma/pkg/xds/envoy/names"
 )
 
 var _ = Describe("HttpOutboundRouteConfigurer", func() {
@@ -31,7 +32,7 @@ var _ = Describe("HttpOutboundRouteConfigurer", func() {
 				WithOverwriteName(given.listenerName).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3, envoy_common.AnonymousResource).
 					Configure(HttpConnectionManager(given.statsName, false, nil)).
-					Configure(HttpOutboundRoute(given.service, given.routes, given.dpTags)))).
+					Configure(HttpOutboundRoute(envoy_names.GetOutboundRouteName(given.service), given.service, given.routes, given.dpTags)))).
 				Build()
 			// then
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/xds/envoy/listeners/v3/http_route_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/http_route_configurer.go
@@ -10,13 +10,19 @@ import (
 	envoy_routes "github.com/kumahq/kuma/pkg/xds/envoy/routes"
 )
 
+var _ FilterChainConfigurer = &HttpStaticRouteConfigurer{}
+
 // HttpStaticRouteConfigurer configures a static set of routes into the
 // HttpConnectionManager in the filter chain.
 type HttpStaticRouteConfigurer struct {
 	Builder *envoy_routes.RouteConfigurationBuilder
 }
 
-var _ FilterChainConfigurer = &HttpStaticRouteConfigurer{}
+func NewHttpStaticRouteConfigurer(builder *envoy_routes.RouteConfigurationBuilder) *HttpStaticRouteConfigurer {
+	return &HttpStaticRouteConfigurer{
+		Builder: builder,
+	}
+}
 
 func (c *HttpStaticRouteConfigurer) Configure(filterChain *envoy_listener.FilterChain) error {
 	routeConfig, err := c.Builder.Build()
@@ -66,6 +72,6 @@ type HttpScopedRouteConfigurer struct{}
 
 var _ FilterChainConfigurer = &HttpScopedRouteConfigurer{}
 
-func (c *HttpScopedRouteConfigurer) Configure(filterChain *envoy_listener.FilterChain) error {
+func (c *HttpScopedRouteConfigurer) Configure(_ *envoy_listener.FilterChain) error {
 	return errors.New("scoped routes not implemented")
 }

--- a/pkg/xds/envoy/listeners/v3/util.go
+++ b/pkg/xds/envoy/listeners/v3/util.go
@@ -9,6 +9,7 @@ import (
 	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_tcp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	envoy_types "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -17,14 +18,34 @@ import (
 	"github.com/kumahq/kuma/pkg/core/validators"
 )
 
-func UpdateHTTPConnectionManager(filterChain *envoy_listener.FilterChain, updateFunc func(manager *envoy_hcm.HttpConnectionManager) error) error {
-	return UpdateFilterConfig(filterChain, "envoy.filters.network.http_connection_manager", func(filterConfig proto.Message) error {
-		hcm, ok := filterConfig.(*envoy_hcm.HttpConnectionManager)
-		if !ok {
-			return NewUnexpectedFilterConfigTypeError(filterConfig, (*envoy_hcm.HttpConnectionManager)(nil))
-		}
-		return updateFunc(hcm)
-	})
+type updater[T envoy_types.Resource] interface {
+	~func(T) error | ~func(T)
+}
+
+func UpdateHTTPConnectionManager[T updater[*envoy_hcm.HttpConnectionManager]](filterChain *envoy_listener.FilterChain, fn T) error {
+	return UpdateFilterConfig(
+		filterChain,
+		"envoy.filters.network.http_connection_manager",
+		func(filterConfig proto.Message) error {
+			hcm, ok := filterConfig.(*envoy_hcm.HttpConnectionManager)
+			if !ok {
+				return NewUnexpectedFilterConfigTypeError(filterConfig, (*envoy_hcm.HttpConnectionManager)(nil))
+			}
+
+			if fn == nil {
+				return nil
+			}
+
+			switch f := any(fn).(type) {
+			case func(*envoy_hcm.HttpConnectionManager) error:
+				return f(hcm)
+			case func(*envoy_hcm.HttpConnectionManager):
+				f(hcm)
+			}
+
+			return nil
+		},
+	)
 }
 
 func UpdateTCPProxy(filterChain *envoy_listener.FilterChain, updateFunc func(*envoy_tcp.TcpProxy) error) error {

--- a/pkg/xds/envoy/routes/v3/retry_configurer_test.go
+++ b/pkg/xds/envoy/routes/v3/retry_configurer_test.go
@@ -12,6 +12,7 @@ import (
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	. "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
+	envoy_names "github.com/kumahq/kuma/pkg/xds/envoy/names"
 )
 
 var _ = Describe("RetryConfigurer", func() {
@@ -35,6 +36,7 @@ var _ = Describe("RetryConfigurer", func() {
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3, envoy_common.AnonymousResource).
 					Configure(HttpConnectionManager(given.statsName, false, nil)).
 					Configure(HttpOutboundRoute(
+						envoy_names.GetOutboundRouteName(given.service),
 						given.service,
 						given.routes,
 						given.dpTags,

--- a/pkg/xds/generator/egress/external_services_generator.go
+++ b/pkg/xds/generator/egress/external_services_generator.go
@@ -297,10 +297,10 @@ func (*ExternalServicesGenerator) configureFilterChain(
 			Configure(envoy_listeners.FaultInjection(meshResources.ExternalServiceFaultInjections[esName]...)).
 			Configure(envoy_listeners.RateLimit(meshResources.ExternalServiceRateLimits[esName])).
 			Configure(envoy_listeners.AddFilterChainConfigurer(&v3.HttpOutboundRouteConfigurer{
-				Name:    routeConfigName,
-				Service: esName,
-				Routes:  routes,
-				DpTags:  nil,
+				RouteConfigName: routeConfigName,
+				VirtualHostName: esName,
+				Routes:          routes,
+				DpTags:          nil,
 			}))
 	default:
 		filterChainBuilder.Configure(

--- a/pkg/xds/generator/egress/internal_services_generator.go
+++ b/pkg/xds/generator/egress/internal_services_generator.go
@@ -17,7 +17,7 @@ type InternalServicesGenerator struct{}
 
 // Generate will generate envoy resources for one mesh (when mTLS enabled)
 func (g *InternalServicesGenerator) Generate(
-	ctx context.Context,
+	_ context.Context,
 	xdsCtx xds_context.Context,
 	proxy *core_xds.Proxy,
 	listenerBuilder *envoy_listeners.ListenerBuilder,

--- a/pkg/xds/generator/outbound_proxy_generator.go
+++ b/pkg/xds/generator/outbound_proxy_generator.go
@@ -118,7 +118,7 @@ func (OutboundProxyGenerator) generateLDS(ctx xds_context.Context, proxy *model.
 				)).
 				Configure(envoy_listeners.HttpAccessLog(meshName, envoy_common.TrafficDirectionOutbound, sourceService, serviceName,
 					ctx.Mesh.GetLoggingBackend(proxy.Policies.TrafficLogs[serviceName]), proxy)).
-				Configure(envoy_listeners.HttpOutboundRoute(serviceName, routes, dpTags)).
+				Configure(envoy_listeners.HttpOutboundRoute(envoy_names.GetOutboundRouteName(serviceName), serviceName, routes, dpTags)).
 				// backwards compatibility to support RateLimit for ExternalServices without ZoneEgress
 				ConfigureIf(!ctx.Mesh.Resource.ZoneEgressEnabled(), envoy_listeners.RateLimit(rateLimits)).
 				Configure(envoy_listeners.Retry(retryPolicy, protocol)).
@@ -143,7 +143,7 @@ func (OutboundProxyGenerator) generateLDS(ctx xds_context.Context, proxy *model.
 					ctx.Mesh.GetLoggingBackend(proxy.Policies.TrafficLogs[serviceName]),
 					proxy,
 				)).
-				Configure(envoy_listeners.HttpOutboundRoute(serviceName, routes, proxy.Dataplane.Spec.TagSet())).
+				Configure(envoy_listeners.HttpOutboundRoute(envoy_names.GetOutboundRouteName(serviceName), serviceName, routes, proxy.Dataplane.Spec.TagSet())).
 				Configure(envoy_listeners.Retry(retryPolicy, protocol))
 		case core_mesh.ProtocolKafka:
 			filterChainBuilder.


### PR DESCRIPTION
## Motivation

This change improves the outbound route configuration API and cluster handling in XDS to make it safer, clearer, and more flexible. The previous `HttpOutboundRoute` signature was prone to accidental name mismatches and lacked explicit parameters for route and virtual host names. Adding SNI support to the `Cluster` interface improves TLS interoperability, and new helpers like `naming.GetNameOrFallback` reduce boilerplate for safe name resolution.

## Implementation information

- Introduced `naming.GetNameOrFallback` and `GetNameOrFallbackFunc` with tests to simplify name resolution when primary values are missing
- Relaxed generic constraint on contextual `sectionName` to `constraints.Unsigned` for broader applicability
- Added `SNI` to `Cluster` interface and cluster builder (`WithSNI`) for explicit TLS server name configuration
- Updated `HttpOutboundRoute` to accept `routeConfigName` and `virtualHostName` for better clarity
- Switched to `NewHttpStaticRouteConfigurer` for static HTTP routes to unify route-building logic
- Optimized builders (`FilterChainBuilder`, `ClusterBuilder`) to append directly and skip nil checks internally
- Made `UpdateHTTPConnectionManager` generic and able to accept functions with or without error returns
- Hardened `routes_configurer` with safe type assertions for timeout and weights
- Cleaned up unused imports and parameters
