### PR TITLE
refactor(xds/zoneproxy): add DestinationList and rework refs and SNI

### DIFF
--- a/pkg/core/resources/apis/core/interfaces.go
+++ b/pkg/core/resources/apis/core/interfaces.go
@@ -27,3 +27,13 @@ type Destination interface {
 	// and reachableBackendRef where you can only specify port value. More on this in issue: https://github.com/kumahq/kuma/issues/11738
 	FindPortByName(name string) (Port, bool)
 }
+
+// DestinationList is a list wrapper for Destination resources. Implementations should embed
+// `core_model.ResourceList` and provide items via `GetDestinations`. All items must be the same
+// destination kind, for example all MeshService or all MeshExternalService. The order should
+// be stable for a single read to make indexing and hashing predictable
+type DestinationList interface {
+	core_model.ResourceList
+	// GetDestinations returns all Destination resources in the list.
+	GetDestinations() []Destination
+}

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/helpers.go
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/helpers.go
@@ -73,3 +73,11 @@ func (m Match) GetValue() int32 {
 func (m Match) GetProtocol() core_meta.Protocol {
 	return m.Protocol
 }
+
+func (l *MeshExternalServiceResourceList) GetDestinations() []core.Destination {
+	var result []core.Destination
+	for _, item := range l.Items {
+		result = append(result, item)
+	}
+	return result
+}

--- a/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/helpers.go
+++ b/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/helpers.go
@@ -90,3 +90,11 @@ func (p Port) GetValue() int32 {
 func (p Port) GetProtocol() core_meta.Protocol {
 	return p.AppProtocol
 }
+
+func (l *MeshMultiZoneServiceResourceList) GetDestinations() []core.Destination {
+	var result []core.Destination
+	for _, item := range l.Items {
+		result = append(result, item)
+	}
+	return result
+}

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/helpers.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/helpers.go
@@ -122,3 +122,11 @@ func (p Port) GetValue() int32 {
 func (p Port) GetProtocol() core_meta.Protocol {
 	return p.AppProtocol
 }
+
+func (l *MeshServiceResourceList) GetDestinations() []core.Destination {
+	var result []core.Destination
+	for _, item := range l.Items {
+		result = append(result, item)
+	}
+	return result
+}

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin.go
@@ -278,7 +278,7 @@ func configure(
 	mode := pointer.DerefOr(conf.Mode, getMeshTLSMode(mesh))
 	protocol := core_meta.ParseProtocol(inbound.GetProtocol())
 	localClusterName := envoy_names.GetLocalClusterName(iface.WorkloadPort)
-	cluster := envoy_common.NewCluster(envoy_common.WithService(localClusterName))
+	cluster := policies_xds.NewClusterBuilder().WithName(localClusterName).Build()
 	service := inbound.GetService()
 	routes := generator.GenerateRoutes(proxy, iface, cluster)
 	listenerBuilder := envoy_listeners.NewInboundListenerBuilder(proxy.APIVersion, iface.DataplaneIP, iface.DataplanePort, core_xds.SocketAddressProtocolTCP).

--- a/pkg/xds/envoy/clusters/cluster_builder.go
+++ b/pkg/xds/envoy/clusters/cluster_builder.go
@@ -1,6 +1,8 @@
 package clusters
 
 import (
+	"slices"
+
 	envoy_api "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	"github.com/pkg/errors"
 
@@ -30,49 +32,48 @@ type ClusterBuilder struct {
 	apiVersion core_xds.APIVersion
 	// A series of ClusterConfigurers to apply to Envoy cluster.
 	configurers []v3.ClusterConfigurer
+	opts        []ClusterBuilderOpt
 	name        string
 }
 
 // Configure configures ClusterBuilder by adding individual ClusterConfigurers.
 func (b *ClusterBuilder) Configure(opts ...ClusterBuilderOpt) *ClusterBuilder {
-	for _, opt := range opts {
-		if opt != nil {
-			opt.ApplyTo(b)
-		}
-	}
+	b.opts = slices.Concat(b.opts, opts)
 	return b
 }
 
 func (b *ClusterBuilder) ConfigureIf(condition bool, opts ...ClusterBuilderOpt) *ClusterBuilder {
-	if !condition {
-		return b
+	if condition {
+		return b.Configure(opts...)
 	}
-	for _, opt := range opts {
-		opt.ApplyTo(b)
-	}
-
 	return b
 }
 
 // Build generates an Envoy cluster by applying a series of ClusterConfigurers.
 func (b *ClusterBuilder) Build() (envoy.NamedResource, error) {
-	switch b.apiVersion {
-	case envoy.APIV3:
-		cluster := envoy_api.Cluster{
-			Name: b.name,
-		}
-		for _, configurer := range b.configurers {
-			if err := configurer.Configure(&cluster); err != nil {
-				return nil, err
-			}
-		}
-		if cluster.GetName() == "" {
-			return nil, errors.New("cluster name is undefined")
-		}
-		return &cluster, nil
-	default:
+	if b.apiVersion != envoy.APIV3 {
 		return nil, errors.New("unknown API")
 	}
+
+	for _, opt := range b.opts {
+		opt.ApplyTo(b)
+	}
+
+	cluster := envoy_api.Cluster{
+		Name: b.name,
+	}
+
+	for _, configurer := range b.configurers {
+		if err := configurer.Configure(&cluster); err != nil {
+			return nil, err
+		}
+	}
+
+	if cluster.GetName() == "" {
+		return nil, errors.New("cluster name is undefined")
+	}
+
+	return &cluster, nil
 }
 
 func (b *ClusterBuilder) MustBuild() envoy.NamedResource {

--- a/pkg/xds/envoy/listeners/listener_configurers.go
+++ b/pkg/xds/envoy/listeners/listener_configurers.go
@@ -61,7 +61,7 @@ func TransparentProxying[T *tproxy_dp.DataplaneConfig | *core_xds.Proxy | bool](
 		return AddListenerConfigurer(&v3.TransparentProxyingConfigurer{})
 	}
 
-	return ListenerBuilderOptFunc(nil)
+	return listenerBuilderOptFunc(nil)
 }
 
 func NoBindToPort() ListenerBuilderOpt {

--- a/pkg/xds/generator/egress/generator_test.go
+++ b/pkg/xds/generator/egress/generator_test.go
@@ -134,7 +134,7 @@ var _ = Describe("EgressGenerator", func() {
 			loader := fakeLoader{}
 
 			for _, meshResources := range meshResourcesMap {
-				mes := []*meshexternalservice_api.MeshExternalServiceResource{}
+				var mes []*meshexternalservice_api.MeshExternalServiceResource
 				if _, found := meshResources.Resources[meshexternalservice_api.MeshExternalServiceType]; found {
 					for _, m := range meshResources.Resources[meshexternalservice_api.MeshExternalServiceType].GetItems() {
 						mes = append(mes, m.(*meshexternalservice_api.MeshExternalServiceResource))

--- a/pkg/xds/generator/egress/internal_services_generator.go
+++ b/pkg/xds/generator/egress/internal_services_generator.go
@@ -36,12 +36,8 @@ func (g *InternalServicesGenerator) Generate(
 	availableServices := g.distinctAvailableServices(proxy.ZoneEgressProxy.ZoneIngresses, meshName, servicesMap)
 	destinations := zoneproxy.BuildMeshDestinations(
 		availableServices,
-		xds_context.Resources{MeshLocalResources: meshResources.Resources},
-		nil, // todo(jakubdyszkiewicz) add support for MeshService + egress
-		nil, // todo(jakubdyszkiewicz) add support for MeshService + egress
-		nil,
 		"",
-		xdsCtx.Mesh.ResolveResourceIdentifier,
+		xds_context.Resources{MeshLocalResources: meshResources.Resources},
 	)
 
 	services := zoneproxy.AddFilterChains(availableServices, proxy.APIVersion, listenerBuilder, destinations, meshResources.EndpointMap)

--- a/pkg/xds/generator/zoneproxy/generator.go
+++ b/pkg/xds/generator/zoneproxy/generator.go
@@ -190,8 +190,8 @@ func AddFilterChains(
 		// Destination name usually equals to kuma.io/service so we will add already existing cluster which will be
 		// then deduplicated in later steps
 		cluster := envoy_common.NewCluster(
-			envoy_common.WithName(refDest.DestinationName),
-			envoy_common.WithService(refDest.DestinationName),
+			envoy_common.WithName(refDest.LegacyServiceName),
+			envoy_common.WithService(refDest.LegacyServiceName),
 			envoy_common.WithTags(relevantTags),
 		)
 		cluster.SetMesh(refDest.Mesh)
@@ -201,14 +201,14 @@ func AddFilterChains(
 				envoy_listeners.MatchTransportProtocol("tls"),
 				envoy_listeners.MatchServerNames(refDest.SNI),
 				envoy_listeners.TcpProxyDeprecatedWithMetadata(
-					refDest.DestinationName,
+					refDest.LegacyServiceName,
 					cluster,
 				),
 			),
 		)
 
 		listenerBuilder.Configure(filterChain)
-		servicesAcc.AddBackendRef(refDest.Resource, cluster)
+		servicesAcc.AddBackendRef(&refDest.ResolvedBackendRef, cluster)
 	}
 
 	return servicesAcc.Services()


### PR DESCRIPTION
## Motivation

This change simplifies and modernizes how destinations and clusters are managed in zone proxy xDS code. The previous `BackendRefDestination` design mixed responsibilities and used legacy fields that caused confusion. Cluster creation relied on deprecated APIs, and option handling was immediate rather than lazy, which limited flexibility. Deduplication of SNI and route naming were also inconsistent across generators. The goal is to make the code clearer, safer, and easier to extend in the future.

## Implementation information

- Introduced `core.DestinationList` and implemented `GetDestinations` on `MeshServiceResourceList`, `MeshMultiZoneServiceResourceList`, and `MeshExternalServiceResourceList` to unify how destinations are extracted
- Refactored `BackendRefDestination` to embed `resolve.ResolvedBackendRef` and replaced `DestinationName` with `LegacyServiceName` for clearer semantics
- Replaced `envoy_common.NewCluster(...)` with `plugins_xds.NewClusterBuilder().WithName(...).Build()` to move away from deprecated cluster construction
- Changed `envoy_clusters.ClusterBuilder.Configure{If}` to collect options for lazy evaluation during `Build()`, making option ordering predictable and safer
- Updated egress and ingress generators to use `map[string]struct{}` for SNI deduplication and to compute names with `naming.GetNameOrFallback{,Func}` and `naming.MustContextualInboundName`
- Simplified `ExternalServicesGenerator` flow and reduced parameter surface for `addFilterChains`
- Unexported `ListenerBuilderOptFunc` since it is not used outside of the package
- Removed unused `IngressProxy` constant and applied minor cleanups in tests and generators