### PR TITLE
fix(helm): remove `sh` usage in CRD install helm hook job

### DIFF
--- a/deployments/charts/kuma/templates/pre-upgrade-install-crds-job.yaml
+++ b/deployments/charts/kuma/templates/pre-upgrade-install-crds-job.yaml
@@ -72,16 +72,6 @@ metadata:
   labels:
   {{- include "kuma.labels" . | nindent 4 }}
 data:
-  install_crds.sh: |
-    #!/usr/bin/env sh
-    set -e
-
-    if [ -s /kuma/crds/crds.yaml ]; then
-      echo "/kuma/crds/crds.yaml found and is not empty, adding crds"
-      kubectl apply -f /kuma/crds/crds.yaml
-    else
-      echo "/kuma/crds/crds.yaml not found or empty, it looks like there is no crds to install"
-    fi
   save_crds.sh: |
     set -e
 
@@ -133,13 +123,10 @@ spec:
              limits:
                cpu: "100m"
                memory: "256Mi"
-          command: ["/kuma/scripts/install_crds.sh"]
+          args: ["apply", "--recursive", "--filename", "/kuma/crds"]
           volumeMounts:
             - mountPath: /kuma/crds
               name: crds
-              readOnly: true
-            - mountPath: /kuma/scripts
-              name: scripts
               readOnly: true
       initContainers:
         - name: pre-upgrade-job-init


### PR DESCRIPTION
## Motivation

Bitnami announced they will remove their `bitnami` registry soon. We currently rely on images from this registry that include a shell. When switching to other `kubectl` images (such as rancher) which do not ship with `sh`, the Helm hook Job responsible for installing CRDs breaks. We need to remove the shell dependency before the registry is removed.

## Implementation information

The Helm `pre-install,pre-upgrade` hook Job is updated so that the main container no longer executes a script via `sh`. Instead, it directly invokes `kubectl apply` on the CRD files generated by the init container. No new containers are introduced and the init container is unchanged. Since CRDs are generated with `kumactl install crds` without the `--only-missing` flag, the generated files always contain CRDs, so `kubectl apply` has resources to apply.

## Supporting documentation

- Related issue: https://github.com/bitnami/charts/issues/35164