### PR TITLE
fix(inspect-api): fix new inspect api endpoints paths to match oapi schema

### DIFF
--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -152,19 +152,19 @@ func (r *resourceEndpoints) addFindEndpoint(ws *restful.WebService, pathPrefix s
 			Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.descriptor.Name)).DataType("string")).
 			Returns(200, "OK", nil).
 			Returns(404, "Not found", nil))
-		ws.Route(ws.GET(pathPrefix+"/{name}/inbounds/{inbound_kri}/_policies").To(r.getPoliciesConf(ordered.Policies, matchedPoliciesToInboundConfig)).
+		ws.Route(ws.GET(pathPrefix+"/{name}/_inbounds/{inbound_kri}/_policies").To(r.getPoliciesConf(ordered.Policies, matchedPoliciesToInboundConfig)).
 			Doc("Get policy config for inbound").
 			Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.descriptor.Name)).DataType("string")).
 			Param(ws.PathParameter("inbound_kri", "KRI of a inbound").DataType("string")).
 			Returns(200, "OK", nil).
 			Returns(404, "Not found", nil))
-		ws.Route(ws.GET(pathPrefix+"/{name}/outbounds/{outbound_kri}/_policies").To(r.getPoliciesConf(ordered.Policies, matchedPoliciesToOutboundPolicy)).
+		ws.Route(ws.GET(pathPrefix+"/{name}/_outbounds/{outbound_kri}/_policies").To(r.getPoliciesConf(ordered.Policies, matchedPoliciesToOutboundPolicy)).
 			Doc("Get policy config for outbound").
 			Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.descriptor.Name)).DataType("string")).
 			Param(ws.PathParameter("outbound_kri", "KRI of a outbound").DataType("string")).
 			Returns(200, "OK", nil).
 			Returns(404, "Not found", nil))
-		ws.Route(ws.GET(pathPrefix+"/{name}/outbounds/{outbound_kri}/_routes").To(r.getPoliciesConf(
+		ws.Route(ws.GET(pathPrefix+"/{name}/_outbounds/{outbound_kri}/_routes").To(r.getPoliciesConf(
 			[]core_plugins.PluginName{
 				core_plugins.PluginName(meshhttproute_api.MeshHTTPRouteResourceTypeDescriptor.KumactlArg),
 				core_plugins.PluginName(meshtcproute_api.MeshTCPRouteResourceTypeDescriptor.KumactlArg),
@@ -176,7 +176,7 @@ func (r *resourceEndpoints) addFindEndpoint(ws *restful.WebService, pathPrefix s
 			Param(ws.PathParameter("outbound_kri", "KRI of a outbound").DataType("string")).
 			Returns(200, "OK", nil).
 			Returns(404, "Not found", nil))
-		ws.Route(ws.GET(pathPrefix+"/{name}/outbounds/{outbound_kri}/_routes/{route_kri}/_policies").To(r.getPoliciesConf(
+		ws.Route(ws.GET(pathPrefix+"/{name}/_outbounds/{outbound_kri}/_routes/{route_kri}/_policies").To(r.getPoliciesConf(
 			util_slices.Filter(ordered.Policies, func(name core_plugins.PluginName) bool {
 				return name != core_plugins.PluginName(meshhttproute_api.MeshHTTPRouteResourceTypeDescriptor.KumactlArg) && name != core_plugins.PluginName(meshtcproute_api.MeshTCPRouteResourceTypeDescriptor.KumactlArg)
 			}), matchedPoliciesToRouteConfig)).

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/inbounds/merged_inbound_policy.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/inbounds/merged_inbound_policy.input.yaml
@@ -1,4 +1,4 @@
-#/meshes/default/dataplanes/dp-1/inbounds/kri_dp_default_test-zone__dp-1_main-port/_policies 200
+#/meshes/default/dataplanes/dp-1/_inbounds/kri_dp_default_test-zone__dp-1_main-port/_policies 200
 type: Mesh
 name: default
 meshServices:

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/inbounds/merged_mtp.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/inbounds/merged_mtp.input.yaml
@@ -1,4 +1,4 @@
-#/meshes/default/dataplanes/dp-1/inbounds/kri_dp_default_test-zone__dp-1_main-port/_policies 200
+#/meshes/default/dataplanes/dp-1/_inbounds/kri_dp_default_test-zone__dp-1_main-port/_policies 200
 type: Mesh
 name: default
 meshServices:

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/inbounds/multiple_inbound_policies.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/inbounds/multiple_inbound_policies.input.yaml
@@ -1,4 +1,4 @@
-#/meshes/default/dataplanes/dp-1/inbounds/kri_dp_default_test-zone__dp-1_main-port/_policies 200
+#/meshes/default/dataplanes/dp-1/_inbounds/kri_dp_default_test-zone__dp-1_main-port/_policies 200
 type: Mesh
 name: default
 meshServices:

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/inbounds/no_policies.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/inbounds/no_policies.input.yaml
@@ -1,4 +1,4 @@
-#/meshes/default/dataplanes/dp-1/inbounds/kri_dp_default_test-zone__dp-1_main-port/_policies 200
+#/meshes/default/dataplanes/dp-1/_inbounds/kri_dp_default_test-zone__dp-1_main-port/_policies 200
 type: Mesh
 name: default
 meshServices:

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/inbounds/single_inbound_policy.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/inbounds/single_inbound_policy.input.yaml
@@ -1,4 +1,4 @@
-#/meshes/default/dataplanes/dp-1/inbounds/kri_dp_default_test-zone__dp-1_main-port/_policies 200
+#/meshes/default/dataplanes/dp-1/_inbounds/kri_dp_default_test-zone__dp-1_main-port/_policies 200
 type: Mesh
 name: default
 meshServices:

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/outbounds/merged_outbound_policies.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/outbounds/merged_outbound_policies.input.yaml
@@ -1,4 +1,4 @@
-#/meshes/default/dataplanes/dp-1/outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_policies 200
+#/meshes/default/dataplanes/dp-1/_outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_policies 200
 type: Mesh
 name: default
 meshServices:

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/outbounds/multiple_outbound_polices.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/outbounds/multiple_outbound_polices.input.yaml
@@ -1,4 +1,4 @@
-#/meshes/default/dataplanes/dp-1/outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_policies 200
+#/meshes/default/dataplanes/dp-1/_outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_policies 200
 type: Mesh
 name: default
 meshServices:

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/outbounds/no_policies.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/outbounds/no_policies.input.yaml
@@ -1,4 +1,4 @@
-#/meshes/default/dataplanes/dp-1/outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_policies 200
+#/meshes/default/dataplanes/dp-1/_outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_policies 200
 type: Mesh
 name: default
 meshServices:

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/outbounds/single_outbound_policy_selecting_mesh.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/outbounds/single_outbound_policy_selecting_mesh.input.yaml
@@ -1,4 +1,4 @@
-#/meshes/default/dataplanes/dp-1/outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_policies 200
+#/meshes/default/dataplanes/dp-1/_outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_policies 200
 type: Mesh
 name: default
 meshServices:

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/outbounds/single_outbound_policy_selecting_ms.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/outbounds/single_outbound_policy_selecting_ms.input.yaml
@@ -1,4 +1,4 @@
-#/meshes/default/dataplanes/dp-1/outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_policies 200
+#/meshes/default/dataplanes/dp-1/_outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_policies 200
 type: Mesh
 name: default
 meshServices:

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/outbounds/single_outbound_policy_selecting_port.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/outbounds/single_outbound_policy_selecting_port.input.yaml
@@ -1,4 +1,4 @@
-#/meshes/default/dataplanes/dp-1/outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_policies 200
+#/meshes/default/dataplanes/dp-1/_outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_policies 200
 type: Mesh
 name: default
 meshServices:

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/routes/fallback_route_conf_to_mesh.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/routes/fallback_route_conf_to_mesh.input.yaml
@@ -1,4 +1,4 @@
-#/meshes/default/dataplanes/dp-1/outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_routes/kri_mhttpr_default___the-http-route_/_policies 200
+#/meshes/default/dataplanes/dp-1/_outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_routes/kri_mhttpr_default___the-http-route_/_policies 200
 type: Mesh
 name: default
 meshServices:

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/routes/fallback_route_conf_to_ms.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/routes/fallback_route_conf_to_ms.input.yaml
@@ -1,4 +1,4 @@
-#/meshes/default/dataplanes/dp-1/outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_routes/kri_mhttpr_default___the-http-route_/_policies 200
+#/meshes/default/dataplanes/dp-1/_outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_routes/kri_mhttpr_default___the-http-route_/_policies 200
 type: Mesh
 name: default
 meshServices:

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/routes/multiple_different_policies.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/routes/multiple_different_policies.input.yaml
@@ -1,4 +1,4 @@
-#/meshes/default/dataplanes/dp-1/outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_routes/kri_mhttpr_default___the-http-route_/_policies 200
+#/meshes/default/dataplanes/dp-1/_outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_routes/kri_mhttpr_default___the-http-route_/_policies 200
 type: Mesh
 name: default
 meshServices:

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/routes/multiple_merged_policies_different_to.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/routes/multiple_merged_policies_different_to.input.yaml
@@ -1,4 +1,4 @@
-#/meshes/default/dataplanes/dp-1/outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_routes/kri_mhttpr_default___the-http-route_/_policies 200
+#/meshes/default/dataplanes/dp-1/_outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_routes/kri_mhttpr_default___the-http-route_/_policies 200
 type: Mesh
 name: default
 meshServices:

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/routes/multiple_merged_policies_targeting_route.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/routes/multiple_merged_policies_targeting_route.input.yaml
@@ -1,4 +1,4 @@
-#/meshes/default/dataplanes/dp-1/outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_routes/kri_mhttpr_default___the-http-route_/_policies 200
+#/meshes/default/dataplanes/dp-1/_outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_routes/kri_mhttpr_default___the-http-route_/_policies 200
 type: Mesh
 name: default
 meshServices:

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/routes/no_policies.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/routes/no_policies.input.yaml
@@ -1,4 +1,4 @@
-#/meshes/default/dataplanes/dp-1/outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_routes/kri_mhttpr_default___the-http-route_/_policies 200
+#/meshes/default/dataplanes/dp-1/_outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_routes/kri_mhttpr_default___the-http-route_/_policies 200
 type: Mesh
 name: default
 meshServices:

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/routes/single_policy.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_policies/routes/single_policy.input.yaml
@@ -1,4 +1,4 @@
-#/meshes/default/dataplanes/dp-1/outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_routes/kri_mhttpr_default___the-http-route_/_policies 200
+#/meshes/default/dataplanes/dp-1/_outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_routes/kri_mhttpr_default___the-http-route_/_policies 200
 type: Mesh
 name: default
 meshServices:

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_routes/meshservice_meshhttproute.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_routes/meshservice_meshhttproute.input.yaml
@@ -1,4 +1,4 @@
-#/meshes/default/dataplanes/dp-1/outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_routes 200
+#/meshes/default/dataplanes/dp-1/_outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_routes 200
 type: Mesh
 name: default
 meshServices:

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_routes/meshservice_meshtcproute.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_routes/meshservice_meshtcproute.input.yaml
@@ -1,4 +1,4 @@
-#/meshes/default/dataplanes/dp-1/outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_routes 200
+#/meshes/default/dataplanes/dp-1/_outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_routes 200
 type: Mesh
 name: default
 meshServices:

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_routes/meshservice_mixed_routes.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_routes/meshservice_mixed_routes.input.yaml
@@ -1,4 +1,4 @@
-#/meshes/default/dataplanes/dp-1/outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_routes 200
+#/meshes/default/dataplanes/dp-1/_outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_routes 200
 type: Mesh
 name: default
 meshServices:

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_routes/meshservice_multiple_meshhttproute.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_routes/meshservice_multiple_meshhttproute.input.yaml
@@ -1,4 +1,4 @@
-#/meshes/default/dataplanes/dp-1/outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_routes 200
+#/meshes/default/dataplanes/dp-1/_outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_routes 200
 type: Mesh
 name: default
 meshServices:

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_routes/meshservice_multiple_meshhttproute_same_match.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_routes/meshservice_multiple_meshhttproute_same_match.input.yaml
@@ -1,4 +1,4 @@
-#/meshes/default/dataplanes/dp-1/outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_routes 200
+#/meshes/default/dataplanes/dp-1/_outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_routes 200
 type: Mesh
 name: default
 meshServices:

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_routes/meshservice_multiple_meshtcproute.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_routes/meshservice_multiple_meshtcproute.input.yaml
@@ -1,4 +1,4 @@
-#/meshes/default/dataplanes/dp-1/outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_routes 200
+#/meshes/default/dataplanes/dp-1/_outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_routes 200
 type: Mesh
 name: default
 meshServices:

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_routes/no_policies.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_routes/no_policies.input.yaml
@@ -1,4 +1,4 @@
-#/meshes/default/dataplanes/dp-1/outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_routes 200
+#/meshes/default/dataplanes/dp-1/_outbounds/kri_msvc_default_test-zone__test-server-1_main-port/_routes 200
 type: Mesh
 name: default
 meshServices:


### PR DESCRIPTION
## Motivation
Original endpoints that were created were different from schema

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
