### PR TITLE
feat(kuma-cp): rename mesh metric and mesh trace from kri system to system

### DIFF
--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/otel_and_prometheus.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/otel_and_prometheus.clusters.golden.yaml
@@ -1,25 +1,11 @@
 resources:
-- name: system_kri_mm_default___meshmetric1_default-backend
-  resource:
-    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
-    loadAssignment:
-      clusterName: system_kri_mm_default___meshmetric1_default-backend
-      endpoints:
-      - lbEndpoints:
-        - endpoint:
-            address:
-              pipe:
-                path: /tmp/kuma-mh-backend-default.sock
-    name: system_kri_mm_default___meshmetric1_default-backend
-    type: STATIC
-- name: system_kri_mm_default___meshmetric1_otel-collector-observability-svc-4317
+- name: system_meshmetric_otel_otel-collector-observability-svc-4317
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     connectTimeout: 5s
     dnsLookupFamily: V4_ONLY
     loadAssignment:
-      clusterName: system_kri_mm_default___meshmetric1_otel-collector-observability-svc-4317
+      clusterName: system_meshmetric_otel_otel-collector-observability-svc-4317
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -27,10 +13,24 @@ resources:
               socketAddress:
                 address: otel-collector.observability.svc
                 portValue: 4317
-    name: system_kri_mm_default___meshmetric1_otel-collector-observability-svc-4317
+    name: system_meshmetric_otel_otel-collector-observability-svc-4317
     type: STRICT_DNS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         explicitHttpConfig:
           http2ProtocolOptions: {}
+- name: system_meshmetric_prometheus_default-backend
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 5s
+    loadAssignment:
+      clusterName: system_meshmetric_prometheus_default-backend
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              pipe:
+                path: /tmp/kuma-mh-backend-default.sock
+    name: system_meshmetric_prometheus_default-backend
+    type: STATIC

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/otel_and_prometheus.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/otel_and_prometheus.listeners.golden.yaml
@@ -49,45 +49,7 @@ resources:
                     value: 5237c55fc21d54360fbd4a6de06f58da55ea9255ee43f36c4e2f7103e273c2a7
           statPrefix: system_dynamicconfig
     name: system_dynamicconfig
-- name: system_kri_mm_default___meshmetric1_default-backend
-  resource:
-    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
-    address:
-      socketAddress:
-        address: 192.168.0.1
-        portValue: 5670
-    enableReusePort: false
-    filterChains:
-    - filters:
-      - name: envoy.filters.network.http_connection_manager
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-          httpFilters:
-          - name: envoy.filters.http.router
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-          internalAddressConfig:
-            cidrRanges:
-            - addressPrefix: 127.0.0.1
-              prefixLen: 32
-            - addressPrefix: ::1
-              prefixLen: 128
-          routeConfig:
-            validateClusters: false
-            virtualHosts:
-            - domains:
-              - '*'
-              name: system_kri_mm_default___meshmetric1_default-backend
-              routes:
-              - match:
-                  prefix: /metrics
-                route:
-                  cluster: system_kri_mm_default___meshmetric1_default-backend
-                  prefixRewrite: /meshmetric
-          statPrefix: system_kri_mm_default___meshmetric1_default-backend
-    name: system_kri_mm_default___meshmetric1_default-backend
-    trafficDirection: INBOUND
-- name: system_kri_mm_default___meshmetric1_otel-collector-observability-svc-4317
+- name: system_meshmetric_otel_otel-collector-observability-svc-4317
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener
     address:
@@ -117,11 +79,49 @@ resources:
             virtualHosts:
             - domains:
               - '*'
-              name: system_kri_mm_default___meshmetric1_otel-collector-observability-svc-4317
+              name: system_meshmetric_otel_otel-collector-observability-svc-4317
               routes:
               - match:
                   prefix: /
                 route:
-                  cluster: system_kri_mm_default___meshmetric1_otel-collector-observability-svc-4317
-          statPrefix: system_kri_mm_default___meshmetric1_otel-collector-observability-svc-4317
-    name: system_kri_mm_default___meshmetric1_otel-collector-observability-svc-4317
+                  cluster: system_meshmetric_otel_otel-collector-observability-svc-4317
+          statPrefix: system_meshmetric_otel_otel-collector-observability-svc-4317
+    name: system_meshmetric_otel_otel-collector-observability-svc-4317
+- name: system_meshmetric_prometheus_default-backend
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.1
+        portValue: 5670
+    enableReusePort: false
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          httpFilters:
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+            - addressPrefix: ::1
+              prefixLen: 128
+          routeConfig:
+            validateClusters: false
+            virtualHosts:
+            - domains:
+              - '*'
+              name: system_meshmetric_prometheus_default-backend
+              routes:
+              - match:
+                  prefix: /metrics
+                route:
+                  cluster: system_meshmetric_prometheus_default-backend
+                  prefixRewrite: /meshmetric
+          statPrefix: system_meshmetric_prometheus_default-backend
+    name: system_meshmetric_prometheus_default-backend
+    trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin.go
@@ -9,7 +9,6 @@ import (
 	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	"github.com/kumahq/kuma/pkg/core/kri"
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/core/destinationname"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
@@ -49,32 +48,26 @@ func (p plugin) Apply(rs *xds.ResourceSet, ctx xds_context.Context, proxy *xds.P
 	}
 
 	listeners := policies_xds.GatherListeners(rs)
-	var kriWithoutSection *kri.Identifier
-	// we only handle a case where there is one origin because
-	// we do not yet have a mechanism to name resources that have more than one origin https://github.com/kumahq/kuma/issues/13886
-	if len(policies.SingleItemRules.Rules[0].Origin) == 1 {
-		kriWithoutSection = pointer.To(kri.FromResourceMeta(policies.SingleItemRules.Rules[0].Origin[0], api.MeshTraceType))
-	}
-	if err := applyToInbounds(policies.SingleItemRules, listeners.Inbound, proxy, kriWithoutSection); err != nil {
+	if err := applyToInbounds(policies.SingleItemRules, listeners.Inbound, proxy); err != nil {
 		return err
 	}
-	if err := applyToOutbounds(policies.SingleItemRules, listeners.Outbound, proxy, kriWithoutSection); err != nil {
+	if err := applyToOutbounds(policies.SingleItemRules, listeners.Outbound, proxy); err != nil {
 		return err
 	}
-	if err := applyToClusters(policies.SingleItemRules, rs, proxy, kriWithoutSection); err != nil {
+	if err := applyToClusters(policies.SingleItemRules, rs, proxy); err != nil {
 		return err
 	}
-	if err := applyToGateway(policies.SingleItemRules, listeners.Gateway, ctx.Mesh.Resources.MeshLocalResources, proxy, kriWithoutSection); err != nil {
+	if err := applyToGateway(policies.SingleItemRules, listeners.Gateway, ctx.Mesh.Resources.MeshLocalResources, proxy); err != nil {
 		return err
 	}
-	if err := applyToRealResources(ctx, policies.SingleItemRules, rs, proxy, kriWithoutSection); err != nil {
+	if err := applyToRealResources(ctx, policies.SingleItemRules, rs, proxy); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func applyToGateway(rules core_rules.SingleItemRules, gatewayListeners map[core_rules.InboundListener]*envoy_listener.Listener, resources xds_context.ResourceMap, proxy *xds.Proxy, kriWithoutSection *kri.Identifier) error {
+func applyToGateway(rules core_rules.SingleItemRules, gatewayListeners map[core_rules.InboundListener]*envoy_listener.Listener, resources xds_context.ResourceMap, proxy *xds.Proxy) error {
 	var gateways *core_mesh.MeshGatewayResourceList
 	if rawList := resources[core_mesh.MeshGatewayType]; rawList != nil {
 		gateways = rawList.(*core_mesh.MeshGatewayResourceList)
@@ -100,7 +93,7 @@ func applyToGateway(rules core_rules.SingleItemRules, gatewayListeners map[core_
 			continue
 		}
 
-		if err := configureListener(rules, proxy, listener, "", kriWithoutSection); err != nil {
+		if err := configureListener(rules, proxy, listener, ""); err != nil {
 			return err
 		}
 	}
@@ -108,9 +101,9 @@ func applyToGateway(rules core_rules.SingleItemRules, gatewayListeners map[core_
 	return nil
 }
 
-func applyToInbounds(rules core_rules.SingleItemRules, inboundListeners map[core_rules.InboundListener]*envoy_listener.Listener, proxy *xds.Proxy, kriWithoutSection *kri.Identifier) error {
+func applyToInbounds(rules core_rules.SingleItemRules, inboundListeners map[core_rules.InboundListener]*envoy_listener.Listener, proxy *xds.Proxy) error {
 	for _, inboundListener := range inboundListeners {
-		if err := configureListener(rules, proxy, inboundListener, "", kriWithoutSection); err != nil {
+		if err := configureListener(rules, proxy, inboundListener, ""); err != nil {
 			return err
 		}
 	}
@@ -118,7 +111,7 @@ func applyToInbounds(rules core_rules.SingleItemRules, inboundListeners map[core
 	return nil
 }
 
-func applyToOutbounds(rules core_rules.SingleItemRules, outboundListeners map[mesh_proto.OutboundInterface]*envoy_listener.Listener, proxy *xds.Proxy, kriWithoutSection *kri.Identifier) error {
+func applyToOutbounds(rules core_rules.SingleItemRules, outboundListeners map[mesh_proto.OutboundInterface]*envoy_listener.Listener, proxy *xds.Proxy) error {
 	outbounds := proxy.Outbounds
 	dataplane := proxy.Dataplane
 	for _, outbound := range outbounds.Filter(xds_types.NonBackendRefFilter) {
@@ -131,7 +124,7 @@ func applyToOutbounds(rules core_rules.SingleItemRules, outboundListeners map[me
 
 		serviceName := outbound.LegacyOutbound.GetService()
 
-		if err := configureListener(rules, proxy, listener, serviceName, kriWithoutSection); err != nil {
+		if err := configureListener(rules, proxy, listener, serviceName); err != nil {
 			return err
 		}
 	}
@@ -139,7 +132,7 @@ func applyToOutbounds(rules core_rules.SingleItemRules, outboundListeners map[me
 	return nil
 }
 
-func applyToRealResources(ctx xds_context.Context, rules core_rules.SingleItemRules, rs *xds.ResourceSet, proxy *xds.Proxy, kriWithoutSection *kri.Identifier) error {
+func applyToRealResources(ctx xds_context.Context, rules core_rules.SingleItemRules, rs *xds.ResourceSet, proxy *xds.Proxy) error {
 	for uri, resType := range rs.IndexByOrigin(xds.NonMeshExternalService) {
 		service, port, found := meshroute.DestinationPortFromRef(ctx.Mesh, &resolve.RealResourceBackendRef{
 			Resource: uri,
@@ -151,7 +144,7 @@ func applyToRealResources(ctx xds_context.Context, rules core_rules.SingleItemRu
 			switch typ {
 			case envoy_resource.ListenerType:
 				for _, listener := range resources {
-					if err := configureListener(rules, proxy, listener.Resource.(*envoy_listener.Listener), destinationname.MustResolve(false, service, port), kriWithoutSection); err != nil {
+					if err := configureListener(rules, proxy, listener.Resource.(*envoy_listener.Listener), destinationname.MustResolve(false, service, port)); err != nil {
 						return err
 					}
 				}
@@ -161,7 +154,7 @@ func applyToRealResources(ctx xds_context.Context, rules core_rules.SingleItemRu
 	return nil
 }
 
-func configureListener(rules core_rules.SingleItemRules, proxy *xds.Proxy, listener *envoy_listener.Listener, destination string, kriWithoutSection *kri.Identifier) error {
+func configureListener(rules core_rules.SingleItemRules, proxy *xds.Proxy, listener *envoy_listener.Listener, destination string) error {
 	serviceName := proxy.Dataplane.Spec.GetIdentifyingService()
 	rawConf := rules.Rules[0].Conf
 	conf := rawConf.(api.Conf)
@@ -173,7 +166,6 @@ func configureListener(rules core_rules.SingleItemRules, proxy *xds.Proxy, liste
 		Destination:           destination,
 		IsGateway:             proxy.Dataplane.Spec.IsBuiltinGateway(),
 		UnifiedResourceNaming: proxy.Metadata.HasFeature(xds_types.FeatureUnifiedResourceNaming),
-		KriWithoutSection:     kriWithoutSection,
 	}
 
 	for _, chain := range listener.FilterChains {
@@ -185,7 +177,7 @@ func configureListener(rules core_rules.SingleItemRules, proxy *xds.Proxy, liste
 	return nil
 }
 
-func applyToClusters(rules core_rules.SingleItemRules, rs *xds.ResourceSet, proxy *xds.Proxy, kriWithoutSection *kri.Identifier) error {
+func applyToClusters(rules core_rules.SingleItemRules, rs *xds.ResourceSet, proxy *xds.Proxy) error {
 	rawConf := rules.Rules[0].Conf
 
 	conf := rawConf.(api.Conf)
@@ -200,28 +192,28 @@ func applyToClusters(rules core_rules.SingleItemRules, rs *xds.ResourceSet, prox
 	var endpoint *xds.Endpoint
 	var provider string
 
-	getNameOrDefault := core_system_names.GetNameOrDefault((proxy.Metadata.HasFeature(xds_types.FeatureUnifiedResourceNaming)) && kriWithoutSection != nil)
+	getNameOrDefault := core_system_names.GetNameOrDefault(proxy.Metadata.HasFeature(xds_types.FeatureUnifiedResourceNaming))
 	name := ""
 	switch {
 	case backend.Zipkin != nil:
 		endpoint = endpointForZipkin(backend.Zipkin)
 		provider = plugin_xds.ZipkinProviderName
 		name = getNameOrDefault(
-			core_system_names.AsSystemName(kri.WithSectionName(pointer.Deref(kriWithoutSection), core_system_names.CleanName(backend.Zipkin.Url))),
+			core_system_names.AsSystemName(core_system_names.JoinSections("meshtrace_zipkin", core_system_names.CleanName(backend.Zipkin.Url))),
 			plugin_xds.GetTracingClusterName(provider),
 		)
 	case backend.Datadog != nil:
 		endpoint = endpointForDatadog(backend.Datadog)
 		provider = plugin_xds.DatadogProviderName
 		name = getNameOrDefault(
-			core_system_names.AsSystemName(kri.WithSectionName(pointer.Deref(kriWithoutSection), core_system_names.CleanName(backend.Datadog.Url))),
+			core_system_names.AsSystemName(core_system_names.JoinSections("meshtrace_datadog", core_system_names.CleanName(backend.Datadog.Url))),
 			plugin_xds.GetTracingClusterName(provider),
 		)
 	case backend.OpenTelemetry != nil:
 		endpoint = endpointForOpenTelemetry(backend.OpenTelemetry)
 		provider = plugin_xds.OpenTelemetryProviderName
 		name = getNameOrDefault(
-			core_system_names.AsSystemName(kri.WithSectionName(pointer.Deref(kriWithoutSection), core_system_names.CleanName(backend.OpenTelemetry.Endpoint))),
+			core_system_names.AsSystemName(core_system_names.JoinSections("meshtrace_otel", core_system_names.CleanName(backend.OpenTelemetry.Endpoint))),
 			plugin_xds.GetTracingClusterName(provider),
 		)
 	}

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/inbound-outbound-zipkin-real-meshservice-unified-naming.cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/inbound-outbound-zipkin-real-meshservice-unified-naming.cluster.golden.yaml
@@ -5,7 +5,7 @@ resources:
     connectTimeout: 5s
     dnsLookupFamily: V4_ONLY
     loadAssignment:
-      clusterName: system_kri_mtr_default___mt-1_http---jaeger-collector-mesh-observability-9411-api-v2-spans
+      clusterName: system_meshtrace_zipkin_http---jaeger-collector-mesh-observability-9411-api-v2-spans
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -13,5 +13,5 @@ resources:
               socketAddress:
                 address: jaeger-collector.mesh-observability
                 portValue: 9411
-    name: system_kri_mtr_default___mt-1_http---jaeger-collector-mesh-observability-9411-api-v2-spans
+    name: system_meshtrace_zipkin_http---jaeger-collector-mesh-observability-9411-api-v2-spans
     type: STRICT_DNS

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/inbound-outbound-zipkin-real-meshservice-unified-naming.listener.golden.yaml
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/inbound-outbound-zipkin-real-meshservice-unified-naming.listener.golden.yaml
@@ -43,7 +43,7 @@ resources:
               name: envoy.tracers.zipkin
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.trace.v3.ZipkinConfig
-                collectorCluster: system_kri_mtr_default___mt-1_http---jaeger-collector-mesh-observability-9411-api-v2-spans
+                collectorCluster: system_meshtrace_zipkin_http---jaeger-collector-mesh-observability-9411-api-v2-spans
                 collectorEndpoint: /api/v2/spans
                 collectorEndpointVersion: HTTP_PROTO
                 collectorHostname: jaeger-collector.mesh-observability:9411
@@ -97,7 +97,7 @@ resources:
               name: envoy.tracers.zipkin
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.trace.v3.ZipkinConfig
-                collectorCluster: system_kri_mtr_default___mt-1_http---jaeger-collector-mesh-observability-9411-api-v2-spans
+                collectorCluster: system_meshtrace_zipkin_http---jaeger-collector-mesh-observability-9411-api-v2-spans
                 collectorEndpoint: /api/v2/spans
                 collectorEndpointVersion: HTTP_PROTO
                 collectorHostname: jaeger-collector.mesh-observability:9411

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/simple-gateway-with-unified-naming.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/simple-gateway-with-unified-naming.listeners.golden.yaml
@@ -56,7 +56,7 @@ filterChains:
           name: envoy.tracers.zipkin
           typedConfig:
             '@type': type.googleapis.com/envoy.config.trace.v3.ZipkinConfig
-            collectorCluster: system_kri_mtr_default___mt-2_http---jaeger-collector-mesh-observability-9411-api-v2-spans
+            collectorCluster: system_meshtrace_zipkin_http---jaeger-collector-mesh-observability-9411-api-v2-spans
             collectorEndpoint: /api/v2/spans
             collectorEndpointVersion: HTTP_JSON
             collectorHostname: jaeger-collector.mesh-observability:9411


### PR DESCRIPTION
## Motivation

Having the

```
if len(policies.SingleItemRules.Rules[0].Origin) == 1 {
```

check does not make sense. If we only have one origin means we most likely have 1 policy. As mentioned before when we have anything else that can be merged besides `backends` we can't rely on the last origin to actually be the backend (like here - last origin is `metrics-prom-1` but the backends are defined in other policy)

<details>
  <summary>policies</summary>
    
```
apiVersion: kuma.io/v1alpha1
kind: MeshMetric
metadata:
  name: metrics-prom-1
  namespace: kuma-demo
  labels:
    kuma.io/mesh: default
spec:
  default:
    sidecar:
      includeUnused: true
      profiles:
        appendProfiles:
        - name: Basic
---
apiVersion: kuma.io/v1alpha1
kind: MeshMetric
metadata:
  name: metrics-prom-2
  namespace: kuma-demo
  labels:
    kuma.io/mesh: default
spec:
  default:
    sidecar:
      includeUnused: true
      profiles:
        appendProfiles:
        - name: Basic
    backends:
    - type: Prometheus
      prometheus:
        port: 5670
        path: "/metrics"
---
apiVersion: kuma.io/v1alpha1
kind: MeshMetric
metadata:
  name: metrics-prom-3
  namespace: kuma-demo
  labels:
    kuma.io/mesh: default
spec:
  default:
    sidecar:
      includeUnused: true
      profiles:
        appendProfiles:
        - name: Basic
    backends:
    - type: Prometheus
      prometheus:
        clientId: prometheus-main
        port: 5671
        path: "/metrics"
```

</details>

## Implementation information

Removing the check and simply using `system_` name for it.

