### PR TITLE
feat(helm): switch kubectl image to `registry.k8s.io`

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -710,11 +710,11 @@ kumactl:
 kubectl:
   image:
     # -- The kubectl image registry
-    registry: docker.io
+    registry: registry.k8s.io
     # -- The kubectl image repository
-    repository: rancher/kubectl
+    repository: kubectl
     # -- The kubectl image tag
-    tag: "v1.32.7@sha256:9b97630d834879e76ad4ab2899deb9b600981bc2026fe0042f65006a5dfe415c"
+    tag: v1.32.8@sha256:54e66c42a1d3a11a1ed4f866ce9fff7e1e48f32a1cb147e3b98a05168a429917
 hooks:
   # -- Node selector for the HELM hooks
   nodeSelector:

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -212,9 +212,9 @@ A Helm chart for the Kuma Control Plane
 | egress.dns.config.searches | list | `[]` | A list of DNS search domains for hostname lookup in the Pod. |
 | kumactl.image.repository | string | `"kumactl"` | The kumactl image repository |
 | kumactl.image.tag | string | `nil` | The kumactl image tag. When not specified, the value is copied from global.tag |
-| kubectl.image.registry | string | `"docker.io"` | The kubectl image registry |
-| kubectl.image.repository | string | `"rancher/kubectl"` | The kubectl image repository |
-| kubectl.image.tag | string | `"v1.32.7@sha256:9b97630d834879e76ad4ab2899deb9b600981bc2026fe0042f65006a5dfe415c"` | The kubectl image tag |
+| kubectl.image.registry | string | `"registry.k8s.io"` | The kubectl image registry |
+| kubectl.image.repository | string | `"kubectl"` | The kubectl image repository |
+| kubectl.image.tag | string | `"v1.32.8@sha256:54e66c42a1d3a11a1ed4f866ce9fff7e1e48f32a1cb147e3b98a05168a429917"` | The kubectl image tag |
 | hooks.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selector for the HELM hooks |
 | hooks.tolerations | list | `[]` | Tolerations for the HELM hooks |
 | hooks.podSecurityContext | object | `{"runAsNonRoot":true}` | Security context at the pod level for crd/webhook/ns |

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -710,11 +710,11 @@ kumactl:
 kubectl:
   image:
     # -- The kubectl image registry
-    registry: docker.io
+    registry: registry.k8s.io
     # -- The kubectl image repository
-    repository: rancher/kubectl
+    repository: kubectl
     # -- The kubectl image tag
-    tag: "v1.32.7@sha256:9b97630d834879e76ad4ab2899deb9b600981bc2026fe0042f65006a5dfe415c"
+    tag: v1.32.8@sha256:54e66c42a1d3a11a1ed4f866ce9fff7e1e48f32a1cb147e3b98a05168a429917
 hooks:
   # -- Node selector for the HELM hooks
   nodeSelector:

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -710,11 +710,11 @@ kumactl:
 kubectl:
   image:
     # -- The kubectl image registry
-    registry: docker.io
+    registry: registry.k8s.io
     # -- The kubectl image repository
-    repository: rancher/kubectl
+    repository: kubectl
     # -- The kubectl image tag
-    tag: "v1.32.7@sha256:9b97630d834879e76ad4ab2899deb9b600981bc2026fe0042f65006a5dfe415c"
+    tag: v1.32.8@sha256:54e66c42a1d3a11a1ed4f866ce9fff7e1e48f32a1cb147e3b98a05168a429917
 hooks:
   # -- Node selector for the HELM hooks
   nodeSelector:


### PR DESCRIPTION
## Motivation

Use the official Kubernetes image for kubectl to reduce third-party dependencies, align with upstream defaults, and keep using a pinned digest. This also avoids surprises from images that change ownership or availability.

## Implementation information

- Switch `kubectl.image.registry` from `docker.io` to `registry.k8s.io`
- Switch `kubectl.image.repository` from `rancher/kubectl` to `kubectl`
- Bump `kubectl.image.tag` from `v1.32.7@sha256:9b9763...` to `v1.32.8@sha256:54e66c...`
- Update `values.yaml`, generated docs (`docs/generated/raw/helm-values.yaml`), test data (`install-control-plane.dump-values.yaml`), and README values table
- No changes to hooks, containers, or logic; charts will now pull the new image

## Supporting documentation

- Context: https://github.com/bitnami/charts/issues/35164