### PR TITLE
feat(helm): switch kubectl image to `registry.k8s.io`

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -653,11 +653,11 @@ kumactl:
 kubectl:
   image:
     # -- The kubectl image registry
-    registry: docker.io
+    registry: registry.k8s.io
     # -- The kubectl image repository
-    repository: rancher/kubectl
+    repository: kubectl
     # -- The kubectl image tag
-    tag: "v1.27.16@sha256:51758d7dbafd9248757c11225ca6693f3cba570803431d0f0d6e917dd7667310"
+    tag: v1.28.15@sha256:498806b1515409c41d0d209fe2f5cd891fc571698ff19b1d3d9749f8b9b10f46
 hooks:
   # -- Node selector for the HELM hooks
   nodeSelector:

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -190,9 +190,9 @@ A Helm chart for the Kuma Control Plane
 | egress.automountServiceAccountToken | bool | `true` | Whether to automountServiceAccountToken for cp. Optionally set to false |
 | kumactl.image.repository | string | `"kumactl"` | The kumactl image repository |
 | kumactl.image.tag | string | `nil` | The kumactl image tag. When not specified, the value is copied from global.tag |
-| kubectl.image.registry | string | `"docker.io"` | The kubectl image registry |
-| kubectl.image.repository | string | `"rancher/kubectl"` | The kubectl image repository |
-| kubectl.image.tag | string | `"v1.27.16@sha256:51758d7dbafd9248757c11225ca6693f3cba570803431d0f0d6e917dd7667310"` | The kubectl image tag |
+| kubectl.image.registry | string | `"registry.k8s.io"` | The kubectl image registry |
+| kubectl.image.repository | string | `"kubectl"` | The kubectl image repository |
+| kubectl.image.tag | string | `"v1.28.15@sha256:498806b1515409c41d0d209fe2f5cd891fc571698ff19b1d3d9749f8b9b10f46"` | The kubectl image tag |
 | hooks.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selector for the HELM hooks |
 | hooks.tolerations | list | `[]` | Tolerations for the HELM hooks |
 | hooks.podSecurityContext | object | `{"runAsNonRoot":true}` | Security context at the pod level for crd/webhook/ns |

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -653,11 +653,11 @@ kumactl:
 kubectl:
   image:
     # -- The kubectl image registry
-    registry: docker.io
+    registry: registry.k8s.io
     # -- The kubectl image repository
-    repository: rancher/kubectl
+    repository: kubectl
     # -- The kubectl image tag
-    tag: "v1.27.16@sha256:51758d7dbafd9248757c11225ca6693f3cba570803431d0f0d6e917dd7667310"
+    tag: v1.28.15@sha256:498806b1515409c41d0d209fe2f5cd891fc571698ff19b1d3d9749f8b9b10f46
 hooks:
   # -- Node selector for the HELM hooks
   nodeSelector:

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -653,11 +653,11 @@ kumactl:
 kubectl:
   image:
     # -- The kubectl image registry
-    registry: docker.io
+    registry: registry.k8s.io
     # -- The kubectl image repository
-    repository: rancher/kubectl
+    repository: kubectl
     # -- The kubectl image tag
-    tag: "v1.27.16@sha256:51758d7dbafd9248757c11225ca6693f3cba570803431d0f0d6e917dd7667310"
+    tag: v1.28.15@sha256:498806b1515409c41d0d209fe2f5cd891fc571698ff19b1d3d9749f8b9b10f46
 hooks:
   # -- Node selector for the HELM hooks
   nodeSelector:


### PR DESCRIPTION
## Motivation

Switch to the official Kubernetes `kubectl` image from `registry.k8s.io` to align with upstream, reduce third-party risk, and keep using a pinned digest. v1.28 is the first version available in the official registry. We only use `kubectl` to install CRDs, so this bump is safe.

## Implementation information

- Change registry: `docker.io` → `registry.k8s.io`
- Change repository: `rancher/kubectl` → `kubectl`
- Bump tag: `v1.27.16@sha256:51758d...` → `v1.28.15@sha256:498806...`
- Update `values.yaml`, generated docs, test data, and README values table
- No changes to Helm hooks or logic; charts will pull the new image and tag

## Supporting documentation

- Context: https://github.com/bitnami/charts/issues/35164

> Changelog: feat(helm): switch kubectl image to registry.k8s.io