### PR TITLE
feat(kuma-cp/xds): support unified naming in MeshTLS

### DIFF
--- a/api/common/v1alpha1/tls/tls.go
+++ b/api/common/v1alpha1/tls/tls.go
@@ -83,6 +83,8 @@ func ToTlsVersion(version *TlsVersion) tlsv3.TlsParameters_TlsProtocol {
 // +kubebuilder:validation:Enum=ECDHE-ECDSA-AES128-GCM-SHA256;ECDHE-ECDSA-AES256-GCM-SHA384;ECDHE-ECDSA-CHACHA20-POLY1305;ECDHE-RSA-AES128-GCM-SHA256;ECDHE-RSA-AES256-GCM-SHA384;ECDHE-RSA-CHACHA20-POLY1305
 type TlsCipher string
 
+func (c TlsCipher) String() string { return string(c) }
+
 const (
 	EcdheEcdsaAes128GcmSha256  TlsCipher = "ECDHE-ECDSA-AES128-GCM-SHA256"
 	EcdheEcdsaAes256GcmSha384  TlsCipher = "ECDHE-ECDSA-AES256-GCM-SHA384"

--- a/pkg/core/metadata/protocol.go
+++ b/pkg/core/metadata/protocol.go
@@ -11,14 +11,15 @@ import (
 type Protocol string
 
 const (
-	ProtocolUnknown Protocol = "<unknown>"
-	ProtocolTCP     Protocol = "tcp"
-	ProtocolTLS     Protocol = "tls"
-	ProtocolHTTP    Protocol = "http"
-	ProtocolHTTP2   Protocol = "http2"
-	ProtocolGRPC    Protocol = "grpc"
-	ProtocolKafka   Protocol = "kafka"
-	ProtocolMysql   Protocol = "mysql"
+	ProtocolUnknown   Protocol = "<unknown>"
+	ProtocolTCP       Protocol = "tcp"
+	ProtocolTLS       Protocol = "tls"
+	ProtocolHTTP      Protocol = "http"
+	ProtocolHTTP2     Protocol = "http2"
+	ProtocolGRPC      Protocol = "grpc"
+	ProtocolKafka     Protocol = "kafka"
+	ProtocolMysql     Protocol = "mysql"
+	ProtocolRawBuffer Protocol = "raw_buffer"
 )
 
 func (p Protocol) String() string { return string(p) }


### PR DESCRIPTION
## Motivation

Make `MeshTLS` work with unified resource naming so clusters, routes, listeners, SNI, and SAN matchers use new naming formats when the feature is enabled.

## Implementation information

- Resolve names from full `kri.Identifier` including `SectionName`
- Read `SectionName` from `BackendRef` when present, otherwise derive it from the port
- Apply section-aware names to SNI, SAN matchers, cluster names, and related MeshTLS wiring
- Keep legacy behavior when unified naming is off to maintain backward compatibility
- Refactor helpers and split functions to improve readability without changing behavior outside of naming
- Update and align tests with the new naming flow

## Supporting documentation

Closes: https://github.com/kumahq/kuma/issues/13961