### PR TITLE
chore(helm): disable unified naming for zone proxies

### DIFF
--- a/deployments/charts/kuma/templates/egress-deployment.yaml
+++ b/deployments/charts/kuma/templates/egress-deployment.yaml
@@ -75,10 +75,6 @@ spec:
               value: /var/run/secrets/kubernetes.io/serviceaccount/token
             - name: KUMA_DATAPLANE_PROXY_TYPE
               value: "egress"
-            {{- if .Values.dataPlane.features.unifiedResourceNaming }}
-            - name: KUMA_DATAPLANE_RUNTIME_UNIFIED_RESOURCE_NAMING_ENABLED
-              value: "true"
-            {{- end }}
           args:
             - run
             - --log-level={{ .Values.egress.logLevel | default "info" }}

--- a/deployments/charts/kuma/templates/ingress-deployment.yaml
+++ b/deployments/charts/kuma/templates/ingress-deployment.yaml
@@ -76,10 +76,6 @@ spec:
               value: /var/run/secrets/kubernetes.io/serviceaccount/token
             - name: KUMA_DATAPLANE_PROXY_TYPE
               value: "ingress"
-            {{- if .Values.dataPlane.features.unifiedResourceNaming }}
-            - name: KUMA_DATAPLANE_RUNTIME_UNIFIED_RESOURCE_NAMING_ENABLED
-              value: "true"
-            {{- end }}
           args:
             - run
             - --log-level={{ .Values.ingress.logLevel | default "info" }}


### PR DESCRIPTION
## Motivation

Unified naming is enabled across most components, but zone proxies (egress and ingress) are not yet ready to expose these names in the GUI. We lack inspect API endpoints for zone proxies, so enabling unified naming there would lead to incomplete or confusing information. We temporarily disable unified naming for these deployments until GUI and API support is available.

## Implementation information

- Disable unified naming in Helm templates for zone egress and zone ingress deployments
- No changes in control plane logic; only deployment values are adjusted
- This is a temporary measure and will be reverted once GUI and inspect APIs for zone proxies are implemented