### PR TITLE
feat(inspect-api): make new api endpoint only available when MeshService mode is set to exclusive

### DIFF
--- a/pkg/api-server/dataplane_layout_endpoint.go
+++ b/pkg/api-server/dataplane_layout_endpoint.go
@@ -65,7 +65,7 @@ func (dle *dataplaneLayoutEndpoint) getLayout(request *restful.Request, response
 		rest_errors.HandleError(request.Request.Context(), response, err, "Failed to build MeshContext")
 	}
 
-	if baseMeshContext.Mesh.Spec.GetMeshServices().GetMode() == v1alpha1.Mesh_MeshServices_Disabled {
+	if baseMeshContext.Mesh.Spec.GetMeshServices().GetMode() != v1alpha1.Mesh_MeshServices_Exclusive {
 		rest_errors.HandleError(request.Request.Context(), response, rest_errors.NewBadRequestError("can't use _layout endpoint without meshService enabled"), "Bad Request")
 		return
 	}

--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -929,7 +929,7 @@ func (r *resourceEndpoints) getPoliciesConf(policies []core_plugins.PluginName, 
 			return
 		}
 
-		if baseMeshContext.Mesh.Spec.GetMeshServices().GetMode() == mesh_proto.Mesh_MeshServices_Disabled {
+		if baseMeshContext.Mesh.Spec.GetMeshServices().GetMode() != mesh_proto.Mesh_MeshServices_Exclusive {
 			rest_errors.HandleError(request.Request.Context(), response, rest_errors.NewBadRequestError("can't use _policies endpoint without meshService enabled"), "Bad Request")
 			return
 		}


### PR DESCRIPTION


## Motivation

This api does not make sense if MeshService mode is set to other than exclusive as we will be returning partial results

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
