### PR TITLE
chore(xds): mesh-aware (meshServices mode) unified naming switch in user resources

### DIFF
--- a/pkg/plugins/policies/core/xds/meshroute/clusters.go
+++ b/pkg/plugins/policies/core/xds/meshroute/clusters.go
@@ -8,11 +8,11 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/kri"
 	core_meta "github.com/kumahq/kuma/pkg/core/metadata"
+	"github.com/kumahq/kuma/pkg/core/naming/unified-naming"
 	meshmultizoneservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1"
 	meshservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
-	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
 	bldrs_common "github.com/kumahq/kuma/pkg/envoy/builders/common"
 	bldrs_matcher "github.com/kumahq/kuma/pkg/envoy/builders/matcher"
 	bldrs_tls "github.com/kumahq/kuma/pkg/envoy/builders/tls"
@@ -35,7 +35,7 @@ func GenerateClusters(
 ) (*core_xds.ResourceSet, error) {
 	resources := core_xds.NewResourceSet()
 
-	unifiedNaming := proxy.Metadata.HasFeature(xds_types.FeatureUnifiedResourceNaming)
+	unifiedNaming := unified_naming.Enabled(proxy.Metadata, meshCtx.Resource)
 
 	for _, serviceName := range services.Sorted() {
 		service := services[serviceName]

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
@@ -871,6 +871,7 @@ func otherServiceHTTPListener() core_xds.Resource {
 			},
 		}},
 		mesh_proto.MultiValueTagSet{"kuma.io/service": {"backend": true}},
+		false,
 	)
 	Expect(err).ToNot(HaveOccurred())
 	return *listener
@@ -892,6 +893,7 @@ func outboundServiceTCPListener(service string, port uint32) core_xds.Resource {
 		[]envoy_common.Split{
 			xds.NewSplitBuilder().WithClusterName(service).Build(),
 		},
+		false,
 	)
 	Expect(err).ToNot(HaveOccurred())
 	return *listener
@@ -913,6 +915,7 @@ func outboundRealServiceHTTPListener(serviceResourceKRI kri.Identifier, port int
 		},
 		routes,
 		mesh_proto.MultiValueTagSet{"kuma.io/service": {"backend": true}},
+		false,
 	)
 	Expect(err).ToNot(HaveOccurred())
 	return *listener

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
@@ -9,6 +9,7 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/kri"
 	core_meta "github.com/kumahq/kuma/pkg/core/metadata"
+	"github.com/kumahq/kuma/pkg/core/naming/unified-naming"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
@@ -35,8 +36,8 @@ func GenerateOutboundListener(
 	svc meshroute_xds.DestinationService,
 	routes []xds.OutboundRoute,
 	originDPPTags mesh_proto.MultiValueTagSet,
+	unifiedNaming bool,
 ) (*core_xds.Resource, error) {
-	unifiedNamingEnabled := proxy.Metadata.HasFeature(xds_types.FeatureUnifiedResourceNaming)
 	transparentProxyEnabled := !proxy.Metadata.HasFeature(xds_types.FeatureBindOutbounds) && proxy.GetTransparentProxy().Enabled()
 
 	address := svc.Outbound.GetAddressWithFallback("127.0.0.1")
@@ -46,9 +47,9 @@ func GenerateOutboundListener(
 	legacyListenerName := envoy_names.GetOutboundListenerName(address, port)
 
 	routeConfigName := svc.ConditionallyResolveKRIWithFallback(true, legacyRouteConfigName)
-	virtualHostName := svc.ConditionallyResolveKRIWithFallback(unifiedNamingEnabled, svc.KumaServiceTagValue)
-	listenerStatPrefix := svc.ConditionallyResolveKRIWithFallback(unifiedNamingEnabled, "")
-	listenerName := svc.ConditionallyResolveKRIWithFallback(unifiedNamingEnabled, legacyListenerName)
+	virtualHostName := svc.ConditionallyResolveKRIWithFallback(unifiedNaming, svc.KumaServiceTagValue)
+	listenerStatPrefix := svc.ConditionallyResolveKRIWithFallback(unifiedNaming, "")
+	listenerName := svc.ConditionallyResolveKRIWithFallback(unifiedNaming, legacyListenerName)
 
 	route := &xds.HttpOutboundRouteConfigurer{
 		RouteConfigName: routeConfigName,
@@ -100,7 +101,7 @@ func generateFromService(
 ) (*core_xds.ResourceSet, error) {
 	var routes []xds.OutboundRoute
 
-	unifiedNaming := proxy.Metadata.HasFeature(xds_types.FeatureUnifiedResourceNaming)
+	unifiedNaming := unified_naming.Enabled(proxy.Metadata, meshCtx.Resource)
 
 	for _, route := range prepareRoutes(rules, svc, meshCtx, unifiedNaming) {
 		split := meshroute_xds.MakeHTTPSplit(clusterCache, servicesAcc, route.BackendRefs, meshCtx, unifiedNaming)
@@ -136,7 +137,7 @@ func generateFromService(
 		dpTags = proxy.Dataplane.Spec.TagSet()
 	}
 
-	listener, err := GenerateOutboundListener(proxy, svc, routes, dpTags)
+	listener, err := GenerateOutboundListener(proxy, svc, routes, dpTags, unifiedNaming)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
@@ -308,9 +308,15 @@ var _ = Describe("MeshHTTPRoute", func() {
 			resources.MeshLocalResources[meshservice_api.MeshServiceType] = &meshservice_api.MeshServiceResourceList{
 				Items: []*meshservice_api.MeshServiceResource{&meshSvc},
 			}
+
+			mesh := builders.Mesh().
+				WithBuiltinMTLSBackend("builtin").
+				WithEnabledMTLSBackend("builtin").
+				WithMeshServicesEnabled(mesh_proto.Mesh_MeshServices_Exclusive)
+
 			return outboundsTestCase{
 				xdsContext: *xds_builders.Context().
-					WithMeshBuilder(builders.Mesh().WithBuiltinMTLSBackend("builtin").WithEnabledMTLSBackend("builtin")).
+					WithMeshBuilder(mesh).
 					WithEndpointMap(outboundTargets).
 					WithResources(resources).
 					AddServiceProtocol("default_backend___svc_80", core_meta.ProtocolHTTP).
@@ -422,7 +428,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 				WithAddress("192.168.0.2").
 				WithInboundOfTags(mesh_proto.ServiceTag, "web", mesh_proto.ProtocolTag, "http").
 				Build()
-			mc := meshContextWithResources(dp, backendDP, &meshSvc, &meshMZSvc)
+			mc := meshContextWithResources(builders.Mesh(), dp, backendDP, &meshSvc, &meshMZSvc)
 
 			builder := &sync.DataplaneProxyBuilder{
 				Zone:       "zone-1",
@@ -467,7 +473,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 
 			dp, proxy := dppForMeshExternalService(&meshExtSvc)
 			egress := builders.ZoneEgress().WithPort(10002).Build()
-			mc := meshContextWithResources(dp.Build(), &meshExtSvc, egress)
+			mc := meshContextWithResources(builders.Mesh(), dp.Build(), &meshExtSvc, egress)
 
 			return outboundsTestCase{
 				xdsContext: *xds_builders.Context().WithMeshContext(mc).Build(),
@@ -553,7 +559,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 
 			dp, proxy := dppForMeshExternalService(&meshExtSvc)
 			egress := builders.ZoneEgress().WithPort(10002).Build()
-			mc := meshContextWithResources(dp.Build(), &meshExtSvc, egress, gateway, &meshHttpRoute)
+			mc := meshContextWithResources(builders.Mesh(), dp.Build(), &meshExtSvc, egress, gateway, &meshHttpRoute)
 
 			return outboundsTestCase{
 				xdsContext: *xds_builders.Context().WithMeshContext(mc).Build(),
@@ -614,7 +620,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 			}
 
 			egress := builders.ZoneEgress().WithPort(10002).Build()
-			mc := meshContextWithResources(dp.Build(), &meshExtSvc, egress)
+			mc := meshContextWithResources(builders.Mesh(), dp.Build(), &meshExtSvc, egress)
 
 			return outboundsTestCase{
 				xdsContext: *xds_builders.Context().WithMeshContext(mc).Build(),
@@ -649,7 +655,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 
 			dp, proxy := dppForMeshExternalService(&meshExtSvc)
 			egress := builders.ZoneEgress().WithPort(10002).Build()
-			mc := meshContextWithResources(dp.Build(), &meshExtSvc, egress)
+			mc := meshContextWithResources(builders.Mesh(), dp.Build(), &meshExtSvc, egress)
 
 			return outboundsTestCase{
 				xdsContext: *xds_builders.Context().WithMeshContext(mc).Build(),
@@ -687,7 +693,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 
 			dp, proxy := dppForMeshExternalService(&meshExtSvc)
 			egress := builders.ZoneEgress().WithPort(10002).Build()
-			mc := meshContextWithResources(dp.Build(), &meshExtSvc, egress)
+			mc := meshContextWithResources(builders.Mesh(), dp.Build(), &meshExtSvc, egress)
 
 			return outboundsTestCase{
 				xdsContext: *xds_builders.Context().WithMeshContext(mc).Build(),
@@ -745,7 +751,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 
 			dp, proxy := dppForMeshExternalService(&meshExtSvc)
 			egress := builders.ZoneEgress().WithPort(10002).Build()
-			mc := meshContextWithResources(dp.Build(), &meshExtSvc, egress)
+			mc := meshContextWithResources(builders.Mesh(), dp.Build(), &meshExtSvc, egress)
 
 			return outboundsTestCase{
 				xdsContext: *xds_builders.Context().WithMeshContext(mc).Build(),
@@ -806,7 +812,13 @@ var _ = Describe("MeshHTTPRoute", func() {
 
 			dp, proxy := dppForMeshExternalService(&meshExtSvc, xds_types.FeatureUnifiedResourceNaming)
 			egress := builders.ZoneEgress().WithPort(10002).Build()
-			mc := meshContextWithResources(dp.Build(), &meshExtSvc, egress)
+
+			mc := meshContextWithResources(
+				builders.Mesh().WithMeshServicesEnabled(mesh_proto.Mesh_MeshServices_Exclusive),
+				dp.Build(),
+				&meshExtSvc,
+				egress,
+			)
 
 			return outboundsTestCase{
 				xdsContext: *xds_builders.Context().WithMeshContext(mc).Build(),
@@ -1094,7 +1106,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 				WithName("web-01").
 				WithAddress("192.168.0.2").
 				WithInboundOfTags(mesh_proto.ServiceTag, "web", mesh_proto.ProtocolTag, "http")
-			mc := meshContextWithResources(dpBuilder.Build(), &meshSvc, &meshSvc2)
+			mc := meshContextWithResources(builders.Mesh(), dpBuilder.Build(), &meshSvc, &meshSvc2)
 
 			outboundTargets := xds_builders.EndpointMap().
 				AddEndpoint("backend_msvc_80", xds_builders.Endpoint().
@@ -1270,7 +1282,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 				WithName("web-01").
 				WithAddress("192.168.0.2").
 				WithInboundOfTags(mesh_proto.ServiceTag, "web", mesh_proto.ProtocolTag, "http")
-			mc := meshContextWithResources(dpBuilder.Build(), &meshSvc, &meshMZSvc)
+			mc := meshContextWithResources(builders.Mesh(), dpBuilder.Build(), &meshSvc, &meshMZSvc)
 
 			outboundTargets := xds_builders.EndpointMap().
 				AddEndpoint("backend_msvc_80", xds_builders.Endpoint().
@@ -1431,7 +1443,13 @@ var _ = Describe("MeshHTTPRoute", func() {
 				WithName("web-01").
 				WithAddress("192.168.0.2").
 				WithInboundOfTags(mesh_proto.ServiceTag, "web", mesh_proto.ProtocolTag, "http")
-			mc := meshContextWithResources(dpBuilder.Build(), &meshSvc, &meshMZSvc)
+
+			mc := meshContextWithResources(
+				builders.Mesh().WithMeshServicesEnabled(mesh_proto.Mesh_MeshServices_Exclusive),
+				dpBuilder.Build(),
+				&meshSvc,
+				&meshMZSvc,
+			)
 
 			outboundTargets := xds_builders.EndpointMap().
 				AddEndpoint("backend_msvc_80", xds_builders.Endpoint().
@@ -2866,10 +2884,17 @@ oESyXXAeWPJX3e7ZgdjUHomwhAZpUmqIWribTioaHZTb1I6OpsD+eF6USSayxUaL
 -----END CERTIFICATE-----
 `
 
-func meshContextWithResources(resources ...core_model.Resource) *xds_context.MeshContext {
+func meshContextWithResources(
+	meshBuilder *builders.MeshBuilder,
+	resources ...core_model.Resource,
+) *xds_context.MeshContext {
 	resourceStore := memory.NewStore()
 
-	mesh := builders.Mesh().WithBuiltinMTLSBackend("ca-1").WithEgressRoutingEnabled().WithEnabledMTLSBackend("ca-1").Build()
+	if meshBuilder == nil {
+		meshBuilder = builders.Mesh()
+	}
+
+	mesh := meshBuilder.WithBuiltinMTLSBackend("ca-1").WithEgressRoutingEnabled().WithEnabledMTLSBackend("ca-1").Build()
 	err := resourceStore.Create(context.Background(), mesh, store.CreateByKey("default", core_model.NoMesh))
 	Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
@@ -1851,6 +1851,7 @@ func outboundRealServiceHTTPListener(serviceResourceKRI kri.Identifier, port int
 		},
 		routes,
 		mesh_proto.MultiValueTagSet{"kuma.io/service": {"backend": true}},
+		false,
 	)
 	Expect(err).ToNot(HaveOccurred())
 	return *listener

--- a/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/plugin.go
@@ -6,6 +6,7 @@ import (
 	"github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_meta "github.com/kumahq/kuma/pkg/core/metadata"
 	"github.com/kumahq/kuma/pkg/core/naming"
+	unified_naming "github.com/kumahq/kuma/pkg/core/naming/unified-naming"
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
@@ -72,7 +73,7 @@ func applyToOutboundPassthrough(
 	if pointer.Deref(conf.PassthroughMode) == "" {
 		conf.PassthroughMode = pointer.To[api.PassthroughMode]("Matched")
 	}
-	unifiedNaming := proxy.Metadata.HasFeature(xds_types.FeatureUnifiedResourceNaming)
+	unifiedNaming := unified_naming.Enabled(proxy.Metadata, ctx.Mesh.Resource)
 
 	if disableDefaultPassthrough(conf, ctx.Mesh.Resource.Spec.IsPassthrough()) {
 		// remove clusters because they were added in TransparentProxyGenerator

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners.go
@@ -4,6 +4,7 @@ import (
 	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_meta "github.com/kumahq/kuma/pkg/core/metadata"
+	"github.com/kumahq/kuma/pkg/core/naming/unified-naming"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/core/xds/types"
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
@@ -21,8 +22,8 @@ func GenerateOutboundListener(
 	proxy *core_xds.Proxy,
 	svc meshroute_xds.DestinationService,
 	splits []envoy_common.Split,
+	unifiedNaming bool,
 ) (*core_xds.Resource, error) {
-	unifiedNaming := proxy.Metadata.HasFeature(types.FeatureUnifiedResourceNaming)
 	bindOutbounds := proxy.Metadata.HasFeature(types.FeatureBindOutbounds)
 	transparentProxy := !bindOutbounds && proxy.GetTransparentProxy().Enabled()
 
@@ -74,7 +75,7 @@ func generateFromService(
 	svc meshroute_xds.DestinationService,
 ) (*core_xds.ResourceSet, error) {
 	toRulesHTTP := proxy.Policies.Dynamic[meshhttproute_api.MeshHTTPRouteType].ToRules
-	unifiedNaming := proxy.Metadata.HasFeature(types.FeatureUnifiedResourceNaming)
+	unifiedNaming := unified_naming.Enabled(proxy.Metadata, meshCtx.Resource)
 
 	backendRefs := getBackendRefs(toRulesTCP, toRulesHTTP, svc, meshCtx)
 	if len(backendRefs) == 0 {
@@ -83,7 +84,7 @@ func generateFromService(
 
 	splits := meshroute_xds.MakeTCPSplit(clusterCache, servicesAccumulator, backendRefs, meshCtx, unifiedNaming)
 
-	listener, err := GenerateOutboundListener(proxy, svc, splits)
+	listener, err := GenerateOutboundListener(proxy, svc, splits, unifiedNaming)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/kri"
 	core_meta "github.com/kumahq/kuma/pkg/core/metadata"
 	"github.com/kumahq/kuma/pkg/core/naming"
+	"github.com/kumahq/kuma/pkg/core/naming/unified-naming"
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
@@ -279,7 +280,7 @@ func configureListener(
 	inbound *mesh_proto.Dataplane_Networking_Inbound,
 	conf api.Conf,
 ) (envoy_common.NamedResource, error) {
-	unifiedNaming := proxy.Metadata.HasFeature(xds_types.FeatureUnifiedResourceNaming)
+	unifiedNaming := unified_naming.Enabled(proxy.Metadata, xdsCtx.Mesh.Resource)
 	getName := naming.GetNameOrFallbackFunc(unifiedNaming)
 
 	inboundID := kri.WithSectionName(kri.From(proxy.Dataplane), iface.WorkloadPort).String()

--- a/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin.go
@@ -6,12 +6,12 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 
 	"github.com/kumahq/kuma/pkg/core"
+	"github.com/kumahq/kuma/pkg/core/naming/unified-naming"
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/core/destinationname"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	meshexternalservice_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
-	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/matchers"
 	core_rules "github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/rules/subsetutils"
@@ -44,7 +44,7 @@ func (p plugin) EgressMatchedPolicies(tags map[string]string, resources xds_cont
 
 func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *core_xds.Proxy) error {
 	if proxy.ZoneEgressProxy != nil {
-		return p.configureEgress(rs, proxy)
+		return p.configureEgress(rs, proxy, unified_naming.Enabled(proxy.Metadata, ctx.Mesh.Resource))
 	}
 
 	if proxy.Dataplane == nil || proxy.Dataplane.Spec.IsBuiltinGateway() {
@@ -145,8 +145,7 @@ func (p plugin) allowRules() core_rules.Rules {
 	}
 }
 
-func (p plugin) configureEgress(rs *core_xds.ResourceSet, proxy *core_xds.Proxy) error {
-	unifiedNaming := proxy.Metadata.HasFeature(xds_types.FeatureUnifiedResourceNaming)
+func (p plugin) configureEgress(rs *core_xds.ResourceSet, proxy *core_xds.Proxy, unifiedNaming bool) error {
 	listeners := policies_xds.GatherListeners(rs)
 	for _, resource := range proxy.ZoneEgressProxy.MeshResourcesList {
 		meshName := resource.Mesh.GetMeta().GetName()

--- a/pkg/plugins/runtime/gateway/cluster_generator.go
+++ b/pkg/plugins/runtime/gateway/cluster_generator.go
@@ -8,10 +8,10 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_meta "github.com/kumahq/kuma/pkg/core/metadata"
+	"github.com/kumahq/kuma/pkg/core/naming/unified-naming"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/core/destinationname"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
-	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/rules/resolve"
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/xds/meshroute"
 	"github.com/kumahq/kuma/pkg/plugins/runtime/gateway/match"
@@ -159,7 +159,7 @@ func (c *ClusterGenerator) generateRealBackendRefCluster(
 	if !ok {
 		return nil, "", nil
 	}
-	unifiedNaming := proxy.Metadata.HasFeature(xds_types.FeatureUnifiedResourceNaming)
+	unifiedNaming := unified_naming.Enabled(proxy.Metadata, meshCtx.Resource)
 
 	protocol := route.InferServiceProtocol(port.GetProtocol(), routeProtocol)
 

--- a/pkg/xds/generator/inbound_proxy_generator.go
+++ b/pkg/xds/generator/inbound_proxy_generator.go
@@ -9,9 +9,9 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_meta "github.com/kumahq/kuma/pkg/core/metadata"
 	"github.com/kumahq/kuma/pkg/core/naming"
+	"github.com/kumahq/kuma/pkg/core/naming/unified-naming"
 	"github.com/kumahq/kuma/pkg/core/validators"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
-	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
 	defaults_mesh "github.com/kumahq/kuma/pkg/defaults/mesh"
 	plugins_xds "github.com/kumahq/kuma/pkg/plugins/policies/core/xds"
 	"github.com/kumahq/kuma/pkg/util/net"
@@ -29,7 +29,7 @@ type InboundProxyGenerator struct{}
 
 func (g InboundProxyGenerator) Generate(_ context.Context, _ *core_xds.ResourceSet, xdsCtx xds_context.Context, proxy *core_xds.Proxy) (*core_xds.ResourceSet, error) {
 	resources := core_xds.NewResourceSet()
-	unifiedNaming := proxy.Metadata.HasFeature(xds_types.FeatureUnifiedResourceNaming)
+	unifiedNaming := unified_naming.Enabled(proxy.Metadata, xdsCtx.Mesh.Resource)
 	for i, endpoint := range proxy.Dataplane.Spec.Networking.GetInboundInterfaces() {
 		// we do not create inbounds for serviceless
 		if endpoint.IsServiceLess() {
@@ -150,7 +150,7 @@ func FilterChainBuilder(
 	tlsVersion *tls.Version,
 	ciphers []tls.TlsCipher,
 ) *envoy_listeners.FilterChainBuilder {
-	unifiedNaming := proxy.Metadata.HasFeature(xds_types.FeatureUnifiedResourceNaming)
+	unifiedNaming := unified_naming.Enabled(proxy.Metadata, xdsCtx.Mesh.Resource)
 	getName := naming.GetNameOrFallbackFunc(unifiedNaming)
 	contextualName := naming.MustContextualInboundName(proxy.Dataplane, endpoint.WorkloadPort)
 	routeConfigName := getName(contextualName, envoy_names.GetInboundRouteName(service))

--- a/pkg/xds/generator/outbound_proxy_generator.go
+++ b/pkg/xds/generator/outbound_proxy_generator.go
@@ -9,10 +9,10 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core"
 	core_meta "github.com/kumahq/kuma/pkg/core/metadata"
+	"github.com/kumahq/kuma/pkg/core/naming/unified-naming"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/user"
 	model "github.com/kumahq/kuma/pkg/core/xds"
-	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	envoy_clusters "github.com/kumahq/kuma/pkg/xds/envoy/clusters"
@@ -192,7 +192,7 @@ func (OutboundProxyGenerator) generateLDS(ctx xds_context.Context, proxy *model.
 func (g OutboundProxyGenerator) generateCDS(ctx xds_context.Context, services envoy_common.Services, proxy *model.Proxy) (*model.ResourceSet, error) {
 	resources := model.NewResourceSet()
 
-	unifiedNaming := proxy.Metadata.HasFeature(xds_types.FeatureUnifiedResourceNaming)
+	unifiedNaming := unified_naming.Enabled(proxy.Metadata, ctx.Mesh.Resource)
 
 	for _, serviceName := range services.Sorted() {
 		service := services[serviceName]

--- a/pkg/xds/generator/prometheus_endpoint_generator.go
+++ b/pkg/xds/generator/prometheus_endpoint_generator.go
@@ -8,9 +8,9 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core"
+	"github.com/kumahq/kuma/pkg/core/naming/unified-naming"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
-	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	envoy_clusters "github.com/kumahq/kuma/pkg/xds/envoy/clusters"
@@ -32,7 +32,7 @@ var prometheusLog = core.Log.WithName("xds").WithName("prometheus-endpoint-gener
 type PrometheusEndpointGenerator struct{}
 
 func (g PrometheusEndpointGenerator) Generate(_ context.Context, _ *core_xds.ResourceSet, xdsCtx xds_context.Context, proxy *core_xds.Proxy) (*core_xds.ResourceSet, error) {
-	unifiedNaming := proxy.Metadata.HasFeature(xds_types.FeatureUnifiedResourceNaming)
+	unifiedNaming := unified_naming.Enabled(proxy.Metadata, xdsCtx.Mesh.Resource)
 	prometheusEndpoint, err := proxy.Dataplane.GetPrometheusConfig(xdsCtx.Mesh.Resource)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get prometheus endpoint")

--- a/pkg/xds/generator/proxy_template_profile_source_test.go
+++ b/pkg/xds/generator/proxy_template_profile_source_test.go
@@ -104,6 +104,12 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
 				},
 			}
 
+			if given.features.HasFeature(xds_types.FeatureUnifiedResourceNaming) {
+				ctx.Mesh.Resource.Spec.MeshServices = &mesh_proto.Mesh_MeshServices{
+					Mode: mesh_proto.Mesh_MeshServices_Exclusive,
+				}
+			}
+
 			Expect(util_proto.FromYAML([]byte(given.mesh), ctx.Mesh.Resource.Spec)).To(Succeed())
 
 			dataplane := &mesh_proto.Dataplane{}

--- a/pkg/xds/generator/transparent_proxy_generator.go
+++ b/pkg/xds/generator/transparent_proxy_generator.go
@@ -7,6 +7,7 @@ import (
 
 	core_meta "github.com/kumahq/kuma/pkg/core/metadata"
 	"github.com/kumahq/kuma/pkg/core/naming"
+	"github.com/kumahq/kuma/pkg/core/naming/unified-naming"
 	model "github.com/kumahq/kuma/pkg/core/xds"
 	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
@@ -127,7 +128,8 @@ func (TransparentProxyGenerator) generate(ctx xds_context.Context, proxy *model.
 }
 
 func (tpg TransparentProxyGenerator) generateIPv4(ctx xds_context.Context, proxy *model.Proxy) (*model.ResourceSet, error) {
-	nameOrDefault := naming.GetNameOrFallbackFunc(proxy.Metadata.HasFeature(xds_types.FeatureUnifiedResourceNaming))
+	unifiedNaming := unified_naming.Enabled(proxy.Metadata, ctx.Mesh.Resource)
+	nameOrDefault := naming.GetNameOrFallbackFunc(unifiedNaming)
 	return tpg.generate(
 		ctx,
 		proxy,
@@ -139,7 +141,8 @@ func (tpg TransparentProxyGenerator) generateIPv4(ctx xds_context.Context, proxy
 }
 
 func (tpg TransparentProxyGenerator) generateIPv6(ctx xds_context.Context, proxy *model.Proxy) (*model.ResourceSet, error) {
-	nameOrDefault := naming.GetNameOrFallbackFunc(proxy.Metadata.HasFeature(xds_types.FeatureUnifiedResourceNaming))
+	unifiedNaming := unified_naming.Enabled(proxy.Metadata, ctx.Mesh.Resource)
+	nameOrDefault := naming.GetNameOrFallbackFunc(unifiedNaming)
 	return tpg.generate(
 		ctx,
 		proxy,

--- a/pkg/xds/generator/transparent_proxy_generator_test.go
+++ b/pkg/xds/generator/transparent_proxy_generator_test.go
@@ -21,8 +21,9 @@ import (
 
 var _ = Describe("TransparentProxyGenerator", func() {
 	type testCase struct {
-		proxy    *model.Proxy
-		expected string
+		proxy            *model.Proxy
+		meshServicesMode mesh_proto.Mesh_MeshServices_Mode
+		expected         string
 	}
 
 	DescribeTable("Generate Envoy xDS resources",
@@ -36,6 +37,9 @@ var _ = Describe("TransparentProxyGenerator", func() {
 							Name: "default",
 						},
 						Spec: &mesh_proto.Mesh{
+							MeshServices: &mesh_proto.Mesh_MeshServices{
+								Mode: given.meshServicesMode,
+							},
 							Logging: &mesh_proto.Logging{
 								Backends: []*mesh_proto.LoggingBackend{
 									{
@@ -199,7 +203,8 @@ var _ = Describe("TransparentProxyGenerator", func() {
 				},
 				InternalAddresses: DummyInternalAddresses,
 			},
-			expected: "05.envoy.golden.yaml",
+			meshServicesMode: mesh_proto.Mesh_MeshServices_Exclusive,
+			expected:         "05.envoy.golden.yaml",
 		}),
 	)
 })

--- a/pkg/xds/generator/zoneproxy/generator.go
+++ b/pkg/xds/generator/zoneproxy/generator.go
@@ -8,7 +8,6 @@ import (
 	"github.com/kumahq/kuma/pkg/core/naming"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/core/xds/origin"
-	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/rules/resolve"
 	plugins_xds "github.com/kumahq/kuma/pkg/plugins/policies/core/xds"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
@@ -26,10 +25,10 @@ func GenerateCDS(
 	services envoy_common.Services,
 	meshName string,
 	origin origin.Origin,
+	unifiedNaming bool,
 ) (*core_xds.ResourceSet, error) {
 	rs := core_xds.NewResourceSet()
 
-	unifiedNaming := proxy.Metadata.HasFeature(xds_types.FeatureUnifiedResourceNaming)
 	matchAll := destinations.KumaIoServices[mesh_proto.MatchAllTag]
 
 	for _, serviceName := range services.Sorted() {
@@ -71,10 +70,9 @@ func GenerateEDS(
 	services envoy_common.Services,
 	meshName string,
 	origin origin.Origin,
+	unifiedNaming bool,
 ) (*core_xds.ResourceSet, error) {
 	rs := core_xds.NewResourceSet()
-
-	unifiedNaming := proxy.Metadata.HasFeature(xds_types.FeatureUnifiedResourceNaming)
 
 	for _, serviceName := range services.Sorted() {
 		service := services[serviceName]
@@ -114,14 +112,13 @@ func CreateFilterChain(
 }
 
 func GetServices(
-	proxy *core_xds.Proxy,
 	destinations MeshDestinations,
 	endpointMap core_xds.EndpointMap,
 	availableServices []*mesh_proto.ZoneIngress_AvailableService,
+	unifiedNaming bool,
 ) envoy_common.Services {
 	acc := envoy_common.NewServicesAccumulator(nil)
 
-	unifiedNaming := proxy.Metadata.HasFeature(xds_types.FeatureUnifiedResourceNaming)
 	getName := naming.GetNameOrFallbackFunc(unifiedNaming)
 	matchAll := destinations.KumaIoServices[mesh_proto.MatchAllTag]
 	sniUsed := map[string]struct{}{}


### PR DESCRIPTION
## Motivation

Unified naming can't depend only on proxy features. It also needs to check mesh-level configuration. Unified naming currently can only work properly when the mesh is configured with `meshServices: Exclusive`. In other cases our GUI and inspect API are not ready to support unified names, so we must fall back to legacy naming.

## Implementation information

- Add a `unifiedNaming` flag resolved from both proxy metadata and mesh configuration
- Check if the mesh is configured with `meshServices: Exclusive`; only then enable unified naming
- Replace direct calls to `proxy.Metadata.HasFeature(FeatureUnifiedResourceNaming)` with `unified_naming.Enabled(metadata, mesh)`
- Pass the `unifiedNaming` flag into listeners, clusters, and routes
- Use `naming.GetNameOrFallbackFunc(unifiedNaming)` in generators
- Update tests to allow building meshes in helpers and to check the mesh-aware exclusive mode
- Remove unused imports and simplify code paths

Legacy behavior is unchanged when unified naming is off, and now unified naming is only active in meshes that use `meshServices: Exclusive`.