### PR TITLE
test(e2e): cleanup namespaces in MeshPassthrough tests

### DIFF
--- a/test/e2e_env/kubernetes/meshpassthrough/meshpassthrough.go
+++ b/test/e2e_env/kubernetes/meshpassthrough/meshpassthrough.go
@@ -71,6 +71,7 @@ func MeshPassthrough() {
 
 	E2EAfterAll(func() {
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
+		Expect(kubernetes.Cluster.TriggerDeleteNamespace(mesNamespace)).To(Succeed())
 		Expect(kubernetes.Cluster.DeleteMesh(meshName)).To(Succeed())
 	})
 


### PR DESCRIPTION
## Motivation

Some MeshPassthrough tests were leaving namespaces behind after running. This could cause pollution in the test environment and make repeated runs less reliable. Cleaning up namespaces ensures tests are isolated and consistent.

## Implementation information

- Add cleanup steps to MeshPassthrough tests to remove created namespaces after execution
- Prevents leaking resources between test runs
- No changes to test logic or assertions, only environment hygiene