### PR TITLE
ci(gha): fix mise setup in PR comments workflow

### DIFF
--- a/.github/workflows/pr-comments.yaml
+++ b/.github/workflows/pr-comments.yaml
@@ -5,7 +5,6 @@ on:
 env:
   GH_USER: "github-actions[bot]"
   GH_EMAIL: "<41898282+github-actions[bot]@users.noreply.github.com>"
-  CI_TOOLS_DIR: /home/runner/work/kuma/kuma/.ci_tools
 permissions:
   contents: read
 jobs:
@@ -50,7 +49,7 @@ jobs:
       - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          MISE_DISABLE_TOOLS: "clang-format,golangci-lint,skaffold"
+          MISE_DISABLE_TOOLS: "golangci-lint,skaffold"
       # Automatically update code formatting if /format is in the comment
       - name: "Auto-format code"
         if: contains(github.event.comment.body, '/format')


### PR DESCRIPTION
## Motivation

The PR comments workflow is currently broken because `mise` is not set up correctly. This leads to failed runs and missing outputs in PRs, for example: https://github.com/kumahq/kuma/pull/13773/commits/33372c40b70ae6eae4de969ba00b08f49785524a. We need to fix the setup so the workflow works reliably.

## Implementation information

- Update PR comments workflow to set up `mise` properly
- Adjust steps so environment initialization works in CI
- No changes to other workflows or job logic