### PR TITLE
fix(kuma-cp): cert regeneration counter constantly increasing

### DIFF
--- a/pkg/xds/server/callbacks/dataplane_status_sink.go
+++ b/pkg/xds/server/callbacks/dataplane_status_sink.go
@@ -158,6 +158,8 @@ func (s *dataplaneInsightSink) Start(stop <-chan struct{}) {
 		currentState.Generation = generation
 
 		if proto.Equal(currentState, lastStoredState) && secretsInfo == lastStoredSecretsInfo {
+			// We compare secretsInfo and lastStoredSecretsInfo as pointers. It makes sense to short-circuit if flush() runs
+			// on tick without events and we're picking exactly the same secreetsInfo structure from the cachedCerts cache.
 			return
 		}
 


### PR DESCRIPTION
## Motivation

TLDR we were comparing `time.Time` incorrectly:

> Note that the Go == operator compares not just the time instant but also the Location and the monotonic clock reading. Therefore, Time values should not be used as map or database keys without first guaranteeing that the identical Location has been set for all values, which can be achieved through use of the UTC or Local method, and that the monotonic clock reading has been stripped by setting t = t.Round(0). In general, prefer t.Equal(u) to t == u, since t.Equal uses the most accurate comparison available and correctly handles the case when only one of its arguments has a monotonic clock reading.

BUT we were doing that since 2021! So I tried to figure out why did it break only now in the master.

It turns out, previously we were protected by the preceding if-condition https://github.com/kumahq/kuma/blob/ec6c6231cb5b8ae6272c52b6f13f3232ea92f7ce/pkg/xds/server/callbacks/dataplane_status_sink.go#L160

This condition compares `secretsInfo` and `lastStoredSecretsInfo` as pointers. Which makes sense if you're getting `secretInfo` as `s.secrets.Info(...)`, but the condition doesn't stop us anymore if `secretsInfo` was constructed based on the event (that we introduced recently) https://github.com/kumahq/kuma/blob/ec6c6231cb5b8ae6272c52b6f13f3232ea92f7ce/pkg/xds/server/callbacks/dataplane_status_sink.go#L139-L148

## Implementation information

The correct fix in my opinion is just compare `time.Time` correctly. I think comparing `secretsInfo` as pointers still makes sense, we short-circuit when `flush` runs on tick and nothing changed since the previous run.

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix https://github.com/kumahq/kuma/issues/14342
