### PR TITLE
fix(kuma-cp): fix match MeshHTTPRoute in policy targets with unified naming

### DIFF
--- a/pkg/core/kri/kri.go
+++ b/pkg/core/kri/kri.go
@@ -62,7 +62,7 @@ func FromResourceMeta(rm core_model.ResourceMeta, resourceType core_model.Resour
 
 func FromString(s string) (Identifier, error) {
 	parts := strings.Split(s, "_")
-	if len(parts) != 7 {
+	if len(parts) < 7 {
 		return Identifier{}, errors.Errorf("invalid identifier string: %q", s)
 	}
 	if parts[0] != "kri" {
@@ -80,7 +80,7 @@ func FromString(s string) (Identifier, error) {
 		Zone:         parts[3],
 		Namespace:    parts[4],
 		Name:         parts[5],
-		SectionName:  parts[6],
+		SectionName:  strings.Join(parts[6:], ""),
 	}, nil
 }
 
@@ -100,7 +100,7 @@ func NoSectionName(id Identifier) Identifier {
 
 func IsValid(s string) bool {
 	parts := strings.Split(s, "_")
-	if len(parts) != 7 {
+	if len(parts) < 7 {
 		return false
 	}
 	if parts[0] != "kri" {

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin.go
@@ -402,8 +402,14 @@ func buildRoutesMap(l *envoy_listener.Listener, svcCtx *outbound.ResourceContext
 		if !kri.IsValid(route.Name) {
 			return
 		}
+
 		id, _ := kri.FromString(route.Name)
-		if conf, isDirect := svcCtx.WithID(id).DirectConf(); isDirect {
+
+		routeCtx := svcCtx.
+			WithID(kri.NoSectionName(id)).
+			WithID(id)
+
+		if conf, isDirect := routeCtx.DirectConf(); isDirect {
 			routes[id] = conf
 		}
 	}); err != nil {

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
@@ -208,7 +208,9 @@ func filterChainConfigurer(rctx *rules_outbound.ResourceContext[api.Conf]) Confi
 	return bldrs_listener.RoutesOnFilterChain(func(route *envoy_route.Route) error {
 		var routeCtx *rules_outbound.ResourceContext[api.Conf]
 		if routeID, err := kri.FromString(route.Name); err == nil {
-			routeCtx = rctx.WithID(routeID)
+			routeCtx = rctx.
+				WithID(kri.NoSectionName(routeID)).
+				WithID(routeID)
 		} else {
 			routeCtx = rctx
 		}

--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin.go
@@ -171,7 +171,11 @@ func applyToRealResource(rctx *outbound.ResourceContext[api.Conf], r *core_xds.R
 							return err
 						}
 
-						if err := configureRoute(rctx.WithID(id), route, r.Protocol); err != nil {
+						routeCtx := rctx.
+							WithID(kri.NoSectionName(id)).
+							WithID(id)
+
+						if err := configureRoute(routeCtx, route, r.Protocol); err != nil {
 							return err
 						}
 					}

--- a/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
@@ -293,7 +293,9 @@ func applyToRealResource(rctx *outbound.ResourceContext[api.Conf], r *core_xds.R
 							return err
 						}
 
-						routeCtx := rctx.WithID(id)
+						routeCtx := rctx.
+							WithID(kri.NoSectionName(id)).
+							WithID(id)
 
 						plugin_xds.ConfigureRouteAction(
 							route.GetRoute(),

--- a/test/framework/config.go
+++ b/test/framework/config.go
@@ -239,7 +239,9 @@ var defaultConf = E2eConfig{
 				AdditionalYamlConfig: "",
 			},
 			KubeZone1: ControlPlaneConfig{
-				Envs:                 map[string]string{},
+				Envs: map[string]string{
+					"KUMA_RUNTIME_KUBERNETES_INJECTOR_UNIFIED_RESOURCE_NAMING_ENABLED": "true",
+				},
 				AdditionalYamlConfig: "",
 			},
 			KubeZone2: ControlPlaneConfig{


### PR DESCRIPTION
## Motivation

With unified naming enabled, generated Envoy route names for a `MeshHTTPRoute` include the full KRI with a `SectionName` (the rule index that produced the route). Policies like `MeshTimeout` and `MeshRetry` target the whole `MeshHTTPRoute`, so their `ToRules` carry the base KRI without a `SectionName`. This mismatch caused the policy wiring to skip those routes because the names did not match. We found this while enabling unified naming for one zone in our multizone e2e tests.

## Implementation information

- Make route lookups section-aware: when a policy targets a `MeshHTTPRoute` by its base KRI, match routes derived from that resource even if their names include a `SectionName`
- Keep behavior unchanged when unified naming is off
- Add e2e coverage by enabling unified naming in one zone of the multizone suite
  - Rationale: we do not have a good unit or integration test seam that exercises the full path from policy targets to Envoy route names with sectioned KRIs
  - Enabling unified naming in one zone validates the fix end-to-end with minimal churn, while leaving other zones on legacy naming for stability

## Supporting documentation

Related to: https://github.com/kumahq/kuma/issues/13799