### PR TITLE
test(framework): migrate to `portforward` API and add `ConfigDump` support

### DIFF
--- a/test/framework/envoy_admin/config_dump/config_dump.go
+++ b/test/framework/envoy_admin/config_dump/config_dump.go
@@ -1,0 +1,71 @@
+package config_dump
+
+import (
+	envoy_admin_v3 "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
+
+	xds_types "github.com/kumahq/kuma/pkg/core/xds/types"
+	"github.com/kumahq/kuma/pkg/util/proto"
+)
+
+type EnvoyConfig struct {
+	Boostrap     envoy_admin_v3.BootstrapConfigDump
+	Cluster      envoy_admin_v3.ClustersConfigDump
+	Endpoints    envoy_admin_v3.EndpointsConfigDump
+	Listeners    envoy_admin_v3.ListenersConfigDump
+	ScopedRoutes envoy_admin_v3.ScopedRoutesConfigDump
+	Routes       envoy_admin_v3.RoutesConfigDump
+}
+
+func ParseEnvoyConfig(bs []byte) (*EnvoyConfig, error) {
+	var cd envoy_admin_v3.ConfigDump
+	if err := proto.FromJSON(bs, &cd); err != nil {
+		return nil, err
+	}
+
+	var config EnvoyConfig
+
+	for _, raw := range cd.GetConfigs() {
+		var err error
+
+		switch {
+		case raw.MessageIs(&config.Boostrap):
+			err = raw.UnmarshalTo(&config.Boostrap)
+		case raw.MessageIs(&config.Cluster):
+			err = raw.UnmarshalTo(&config.Cluster)
+		case raw.MessageIs(&config.Endpoints):
+			err = raw.UnmarshalTo(&config.Endpoints)
+		case raw.MessageIs(&config.Listeners):
+			err = raw.UnmarshalTo(&config.Listeners)
+		case raw.MessageIs(&config.ScopedRoutes):
+			err = raw.UnmarshalTo(&config.ScopedRoutes)
+		case raw.MessageIs(&config.Routes):
+			err = raw.UnmarshalTo(&config.Routes)
+		}
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &config, nil
+}
+
+type Metadata struct {
+	features xds_types.Features
+}
+
+func (m *Metadata) HasFeature(feature string) bool {
+	return m.features[feature]
+}
+
+func (c *EnvoyConfig) Metadata() *Metadata {
+	meta := Metadata{features: xds_types.Features{}}
+
+	if raw, ok := c.Boostrap.GetBootstrap().GetNode().GetMetadata().Fields["features"]; ok {
+		for _, value := range raw.GetListValue().GetValues() {
+			meta.features[value.GetStringValue()] = true
+		}
+	}
+
+	return &meta
+}

--- a/test/framework/envoy_admin/interface.go
+++ b/test/framework/envoy_admin/interface.go
@@ -2,11 +2,13 @@ package envoy_admin
 
 import (
 	"github.com/kumahq/kuma/test/framework/envoy_admin/clusters"
+	"github.com/kumahq/kuma/test/framework/envoy_admin/config_dump"
 	"github.com/kumahq/kuma/test/framework/envoy_admin/stats"
 )
 
 type Tunnel interface {
 	GetStats(name string) (*stats.Stats, error)
 	GetClusters() (*clusters.Clusters, error)
+	GetConfigDump() (*config_dump.EnvoyConfig, error)
 	ResetCounters() error
 }

--- a/test/framework/envoy_admin/tunnel/universal.go
+++ b/test/framework/envoy_admin/tunnel/universal.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kumahq/kuma/test/framework/envoy_admin"
 	"github.com/kumahq/kuma/test/framework/envoy_admin/clusters"
+	"github.com/kumahq/kuma/test/framework/envoy_admin/config_dump"
 	"github.com/kumahq/kuma/test/framework/envoy_admin/stats"
 )
 
@@ -45,6 +46,15 @@ func (t *UniversalTunnel) GetClusters() (*clusters.Clusters, error) {
 	}
 
 	return &c, nil
+}
+
+func (t *UniversalTunnel) GetConfigDump() (*config_dump.EnvoyConfig, error) {
+	stdout, err := t.remoteExec("getconfig_dump", "curl -s --max-time 3 --fail http://localhost:9901/config_dump?format=json")
+	if err != nil {
+		return nil, err
+	}
+
+	return config_dump.ParseEnvoyConfig([]byte(stdout))
 }
 
 func (t *UniversalTunnel) ResetCounters() error {

--- a/test/framework/k8s_controlplane.go
+++ b/test/framework/k8s_controlplane.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/test/framework/kumactl"
+	"github.com/kumahq/kuma/test/framework/portforward"
 )
 
 var _ ControlPlane = &K8sControlPlane{}
@@ -31,8 +32,8 @@ type K8sControlPlane struct {
 	kubeconfig string
 	kumactl    *kumactl.KumactlOptions
 	cluster    *K8sCluster
-	portFwd    PortFwd
-	madsFwd    PortFwd
+	portFwd    portforward.Tunnel
+	madsFwd    portforward.Tunnel
 	verbose    bool
 	replicas   int
 	apiHeaders []string
@@ -177,11 +178,11 @@ func (c *K8sControlPlane) VerifyKumaGUI() error {
 	)
 }
 
-func (c *K8sControlPlane) PortFwd() PortFwd {
+func (c *K8sControlPlane) PortFwd() portforward.Tunnel {
 	return c.portFwd
 }
 
-func (c *K8sControlPlane) MadsPortFwd() PortFwd {
+func (c *K8sControlPlane) MadsPortFwd() portforward.Tunnel {
 	return c.madsFwd
 }
 
@@ -193,7 +194,10 @@ func (c *K8sControlPlane) FinalizeAdd() error {
 	return c.FinalizeAddWithPortFwd(c.portFwd, c.madsFwd)
 }
 
-func (c *K8sControlPlane) FinalizeAddWithPortFwd(portFwd PortFwd, madsPortForward PortFwd) error {
+func (c *K8sControlPlane) FinalizeAddWithPortFwd(
+	portFwd portforward.Tunnel,
+	madsPortForward portforward.Tunnel,
+) error {
 	c.portFwd = portFwd
 	c.madsFwd = madsPortForward
 	if !c.cluster.opts.setupKumactl {

--- a/test/framework/portforward/portforward.go
+++ b/test/framework/portforward/portforward.go
@@ -1,0 +1,101 @@
+package portforward
+
+import (
+	"errors"
+	"math"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
+)
+
+var EnvoyAdminDefaultSpec = Spec{RemotePort: 9901}
+
+type Tunnel struct {
+	tunnel   *k8s.Tunnel
+	Endpoint string `json:"endpoint"`
+}
+
+func NewTunnel(tunnel *k8s.Tunnel, endpoint string) Tunnel {
+	return Tunnel{
+		tunnel:   tunnel,
+		Endpoint: endpoint,
+	}
+}
+
+func (p Tunnel) Close() {
+	if p.tunnel != nil {
+		p.tunnel.Close()
+	}
+}
+
+type Spec struct {
+	AppName    string
+	Namespace  string
+	RemotePort int
+}
+
+func (a Spec) WithDefaults(def Spec) Spec {
+	if a.AppName == "" {
+		a.AppName = def.AppName
+	}
+
+	if a.Namespace == "" {
+		a.Namespace = def.Namespace
+	}
+
+	if a.RemotePort == 0 {
+		a.RemotePort = def.RemotePort
+	}
+
+	return a
+}
+
+func (a Spec) ValidateFullSpec() error {
+	var errs []error
+
+	if a.AppName == "" {
+		errs = append(errs, errors.New(".AppName is required"))
+	}
+
+	if a.Namespace == "" {
+		errs = append(errs, errors.New(".Namespace is required"))
+	}
+
+	if a.RemotePort < 1 || a.RemotePort > math.MaxUint16 {
+		errs = append(errs, errors.New(".Port must be between 1 and 65535"))
+	}
+
+	return errors.Join(errs...)
+}
+
+// Matches reports whether 'args' matches the receiver
+// Matching semantics:
+//   - Zero value in 'args' means "don't care" (wildcard) for that field.
+//   - All non-zero fields in 'args' must equal the corresponding fields in the
+//     defaulted receiver
+//   - An entirely zero 'args' acts as a catch‑all (matches everything)
+func (a Spec) Matches(args Spec) bool {
+	// Catch‑all: no specific properties requested.
+	if args == (Spec{}) {
+		return true
+	}
+
+	// Exact match fast-path.
+	if args == a {
+		return true
+	}
+
+	// Field-wise matching (wildcard on zero values).
+	if args.Namespace != "" && args.Namespace != a.Namespace {
+		return false
+	}
+
+	if args.AppName != "" && args.AppName != a.AppName {
+		return false
+	}
+
+	if args.RemotePort != 0 && args.RemotePort != a.RemotePort {
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
## Motivation

The old `tunnel.NewK8sEnvoyAdminTunnel` API was limited and required manual port-forward handling. We are moving to the new `portforward` API which provides a simpler and unified way of creating and reusing admin tunnels. Additionally, we add `GetConfigDump` support to improve envoy config validation in tests.

## Implementation information

- replaced all usages of `tunnel.NewK8sEnvoyAdminTunnel` with `Cluster.GetOrCreateAdminTunnel` using `portforward.Spec`
- removed old `tunnel` import and added new `portforward` import
- updated e2e tests in `spire` and multizone `meshservice` to use the new API
- extended the admin tunnel with a `GetConfigDump` function for easier envoy configuration checks