### PR TITLE
fix(e2e): do not setup MADS port forward on global

### DIFF
--- a/test/framework/k8s_controlplane.go
+++ b/test/framework/k8s_controlplane.go
@@ -94,8 +94,10 @@ func (c *K8sControlPlane) PortForwardKumaCP() error {
 		return errors.Wrapf(err, "failed to start port-forward to API Server (port %d)", 5681)
 	}
 
-	if c.madsFwd, err = c.cluster.PortForward(k8s.ResourceTypeService, kumaCpSvc.Name, kumaCpSvc.Namespace, 5676); err != nil {
-		return errors.Wrapf(err, "failed to start port-forward to MADS (port: %d)", 5676)
+	if c.mode != core.Global {
+		if c.madsFwd, err = c.cluster.PortForward(k8s.ResourceTypeService, kumaCpSvc.Name, kumaCpSvc.Namespace, 5676); err != nil {
+			return errors.Wrapf(err, "failed to start port-forward to MADS (port: %d)", 5676)
+		}
 	}
 
 	return nil
@@ -103,7 +105,9 @@ func (c *K8sControlPlane) PortForwardKumaCP() error {
 
 func (c *K8sControlPlane) ClosePortForwards() {
 	c.portFwd.Close()
-	c.madsFwd.Close()
+	if c.mode != core.Global {
+		c.madsFwd.Close()
+	}
 }
 
 func (c *K8sControlPlane) GetKumaCPPods() []v1.Pod {


### PR DESCRIPTION
## Motivation

On global we don't expose MADS server. This fails in our synthetic tests on global control plane setup https://github.com/Kong/kong-mesh-smoke/actions/runs/17552760437/job/49854161643 

It didn't fail in our regular e2e after updating this logic because we don't set up global control plane on Kubernetes in our tests. 

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
