### PR TITLE
fix(insights): don't compare cert time once managed externally

### DIFF
--- a/pkg/xds/server/callbacks/dataplane_status_sink.go
+++ b/pkg/xds/server/callbacks/dataplane_status_sink.go
@@ -271,7 +271,7 @@ func (s *dataplaneInsightStore) Upsert(
 			if secretsInfo == nil { // it means mTLS was disabled, we need to clear stats
 				insight.Spec.MTLS = nil
 			} else if insight.Spec.MTLS == nil ||
-				!insight.Spec.MTLS.CertificateExpirationTime.AsTime().Equal(secretsInfo.Expiration) ||
+				(!secretsInfo.ManagedExternally && !insight.Spec.MTLS.CertificateExpirationTime.AsTime().Equal(secretsInfo.Expiration)) ||
 				insight.Spec.MTLS.IssuedBackend != secretsInfo.IssuedBackend ||
 				!reflect.DeepEqual(insight.Spec.MTLS.SupportedBackends, secretsInfo.SupportedBackends) {
 				if err := insight.Spec.UpdateCert(secretsInfo.Generation, secretsInfo.Expiration, secretsInfo.IssuedBackend, secretsInfo.SupportedBackends, secretsInfo.ManagedExternally); err != nil {


### PR DESCRIPTION
## Motivation

While running a Kuma with SPIRE we noticed that certificate generation counter in `DataplaneInsights` is increasing

## Implementation information

I noticed that `insight.Spec.MTLS.CertificateExpirationTime` is nil, but `secretsInfo.Expiration` has a default value when not defined. This caused the comparison to detect a change and increment the counter.
