### PR TITLE
ci(renovate): move security team assignment under vulnerabilityAlerts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    ":assignAndReview(team:kuma-security-managers)",
     ":configMigration",
     ":enableVulnerabilityAlerts",
     "customManagers:makefileVersions",
@@ -17,6 +16,9 @@
     "mise"
   ],
   "vulnerabilityAlerts": {
+    "extends": [
+      ":assignAndReview(team:kuma-security-managers)"
+    ],
     "addLabels": ["area/security"],
     "commitMessageSuffix": ""
   },


### PR DESCRIPTION
## Motivation

The `:assignAndReview(team:kuma-security-managers)` preset was previously applied at the top level of the Renovate configuration. This caused all Renovate PRs, including regular dependency updates, to be assigned to the security managers team. The intention was to assign only vulnerability alerts to the team.

## Implementation information

- Removed `:assignAndReview(team:kuma-security-managers)` from the top-level `extends`
- Added `:assignAndReview(team:kuma-security-managers)` under the `vulnerabilityAlerts` block so it only applies to security-related PRs