### PR TITLE
chore(renovate): switch to shared security-extended preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,9 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     ":configMigration",
-    ":enableVulnerabilityAlerts",
     "customManagers:makefileVersions",
-    "Kong/public-shared-renovate:backend"
+    "Kong/public-shared-renovate:backend",
+    "Kong/public-shared-renovate:security-extended(area/security,team:kuma-security-managers)"
   ],
   "enabledManagers": [
     "custom.regex",
@@ -15,16 +15,6 @@
     "kubernetes",
     "mise"
   ],
-  "vulnerabilityAlerts": {
-    "extends": [
-      ":assignAndReview(team:kuma-security-managers)"
-    ],
-    "addLabels": [
-      "area/security"
-    ],
-    "commitMessageSuffix": ""
-  },
-  "osvVulnerabilityAlerts": true,
   "ignorePaths": [],
   "kubernetes": {
     "description": [
@@ -32,9 +22,7 @@
       " 'kumactl install demo|observability'. Limits matching to the generated YAML under",
       " app/kumactl/data/install/k8s/"
     ],
-    "managerFilePatterns": [
-      "/app/kumactl/data/install/k8s/.+\\.ya?ml$/"
-    ]
+    "managerFilePatterns": ["/app/kumactl/data/install/k8s/.+\\.ya?ml$/"]
   },
   "customManagers": [
     {
@@ -44,9 +32,7 @@
         " the 'go' datasource and rewrites the version string"
       ],
       "customType": "regex",
-      "managerFilePatterns": [
-        "/(^|/)go\\.mod$/"
-      ],
+      "managerFilePatterns": ["/(^|/)go\\.mod$/"],
       "matchStrings": [
         "(?<packageName>github.com\\/kumahq\\/(?<depName>go-control-plane)) (?<currentValue>[^\\s]+)",
         "(?<packageName>github.com\\/kumahq\\/go-control-plane\\/(?<depName>.+)) (?<currentValue>[^\\s]+)"
@@ -61,34 +47,12 @@
   "packageRules": [
     {
       "description": [
-        " Label and assign security managers to updates for '.../security-actions/**'. These PRs",
-        " are created immediately (no scheduling constraints) to prioritize security-related",
-        " changes"
-      ],
-      "matchPackageNames": [
-        "Kong/public-shared-actions/security-actions/**"
-      ],
-      "extends": [
-        ":assignAndReview(team:kuma-security-managers)",
-        ":prImmediately"
-      ],
-      "addLabels": [
-        "area/security"
-      ],
-      "schedule": []
-    },
-    {
-      "description": [
         " For GitHub Actions dependency updates, add a 'ci/skip-test' label and use a terse PR",
         " body/footer so these routine workflow bumps don't trigger full CI or clutter the",
         " changelog"
       ],
-      "matchManagers": [
-        "github-actions"
-      ],
-      "addLabels": [
-        "ci/skip-test"
-      ],
+      "matchManagers": ["github-actions"],
+      "addLabels": ["ci/skip-test"],
       "prBodyTemplate": "{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}{{{controls}}}{{{footer}}}",
       "prFooter": "> Changelog: skip"
     },
@@ -98,15 +62,9 @@
         " as other workflow bumps: apply 'ci/skip-test' and keep the PR body minimal to avoid",
         " unnecessary CI load and changelog noise"
       ],
-      "matchManagers": [
-        "custom.regex"
-      ],
-      "matchPackageNames": [
-        "Kong/public-shared-actions/**"
-      ],
-      "addLabels": [
-        "ci/skip-test"
-      ],
+      "matchManagers": ["custom.regex"],
+      "matchPackageNames": ["Kong/public-shared-actions/**"],
+      "addLabels": ["ci/skip-test"],
       "prBodyTemplate": "{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}{{{controls}}}{{{footer}}}",
       "prFooter": "> Changelog: skip"
     },
@@ -117,9 +75,7 @@
       ],
       "groupName": "kumactl install demo|observability container images",
       "groupSlug": "kumactl-install-k8s",
-      "matchFileNames": [
-        "app/kumactl/data/install/k8s/**"
-      ]
+      "matchFileNames": ["app/kumactl/data/install/k8s/**"]
     },
     {
       "description": [
@@ -127,9 +83,7 @@
         " Kuma-maintained builds of released Envoy versions and are handled by the Makefile",
         " regex manager. Using 'envoy' as the topic makes PR titles clearer"
       ],
-      "matchDepNames": [
-        "kumahq/envoy-builds"
-      ],
+      "matchDepNames": ["kumahq/envoy-builds"],
       "commitMessageTopic": "envoy"
     },
     {
@@ -138,16 +92,9 @@
         " version is not supported in our current setup and consistently fails, so we skip 'pin'",
         " and 'pinDigest' updates for it. Managed by the Makefile regex manager"
       ],
-      "matchManagers": [
-        "custom.regex"
-      ],
-      "matchDepNames": [
-        "kumahq/openapi-tool"
-      ],
-      "matchUpdateTypes": [
-        "pin",
-        "pinDigest"
-      ],
+      "matchManagers": ["custom.regex"],
+      "matchDepNames": ["kumahq/openapi-tool"],
+      "matchUpdateTypes": ["pin", "pinDigest"],
       "enabled": false
     },
     {
@@ -155,9 +102,7 @@
         " Enable PRs for all mise-managed dev tools and set a semantic commit scope of 'deps/dev'.",
         " This keeps these routine tool bumps out of the main changelog"
       ],
-      "matchManagers": [
-        "mise"
-      ],
+      "matchManagers": ["mise"],
       "semanticCommitScope": "deps/dev",
       "prBodyTemplate": "{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}{{{controls}}}{{{footer}}}",
       "prFooter": "> Changelog: skip"
@@ -168,10 +113,7 @@
         " versions, as protobuf usage in Kuma is deprecated, so upgrading would add churn without",
         " practical benefit"
       ],
-      "matchDepNames": [
-        "clang-format",
-        "protoc"
-      ],
+      "matchDepNames": ["clang-format", "protoc"],
       "enabled": false
     },
     {
@@ -180,9 +122,7 @@
         " namespace prefix from the dependency name. This makes commit titles shorter and easier",
         " to scan"
       ],
-      "matchDepNames": [
-        "/^(?:aqua|go):/"
-      ],
+      "matchDepNames": ["/^(?:aqua|go):/"],
       "commitMessageTopic": "{{{replace '([^\\/]*?\\/)*' '' depName}}}"
     },
     {
@@ -190,9 +130,7 @@
         " Extract the version for 'aqua:grpc/grpc-go/protoc-gen-go-grpc' from its command path",
         " so Renovate can correctly detect and propose updates for this tool"
       ],
-      "matchDepNames": [
-        "aqua:grpc/grpc-go/protoc-gen-go-grpc"
-      ],
+      "matchDepNames": ["aqua:grpc/grpc-go/protoc-gen-go-grpc"],
       "extractVersion": "^cmd/protoc-gen-go-grpc/(?<version>.*)$"
     },
     {
@@ -202,33 +140,19 @@
         " our custom regex manager instead"
       ],
       "groupName": "github.com/kumahq/go-control-plane*",
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchDepNames": [
-        "github.com/kumahq/go-control-plane{/,}**"
-      ],
-      "matchDepTypes": [
-        "replace"
-      ],
+      "matchManagers": ["gomod"],
+      "matchDepNames": ["github.com/kumahq/go-control-plane{/,}**"],
+      "matchDepTypes": ["replace"],
       "enabled": false
     },
     {
       "description": [
         " Route updates for 'github.com/kumahq/go-control-plane' through our custom manager"
       ],
-      "matchManagers": [
-        "custom.regex"
-      ],
-      "matchDatasources": [
-        "go"
-      ],
-      "matchDepTypes": [
-        "replace"
-      ],
-      "matchPackageNames": [
-        "github.com/kumahq/go-control-plane{/,}**"
-      ],
+      "matchManagers": ["custom.regex"],
+      "matchDatasources": ["go"],
+      "matchDepTypes": ["replace"],
+      "matchPackageNames": ["github.com/kumahq/go-control-plane{/,}**"],
       "commitMessageTopic": "{{{packageName}}}"
     },
     {
@@ -238,12 +162,8 @@
       ],
       "groupName": "github.com/envoyproxy/go-control-plane*",
       "groupSlug": "github.com-envoyproxy-go-control-plane",
-      "matchDatasources": [
-        "go"
-      ],
-      "matchPackageNames": [
-        "github.com/{envoyproxy,kumahq}/go-control-plane{/,}**"
-      ],
+      "matchDatasources": ["go"],
+      "matchPackageNames": ["github.com/{envoyproxy,kumahq}/go-control-plane{/,}**"],
       "prBodyDefinitions": {
         "Package": "[{{{packageName}}}]({{{sourceUrl}}}) ([source]({{{sourceUrl}}}/tree/{{#if newVersion}}{{{depName}}}/{{{newVersion}}}{{else}}main{{/if}}/{{{depName}}}))"
       }


### PR DESCRIPTION
## Motivation

The local Renovate configuration duplicated security-related rules. A shared preset now exists in `Kong/public-shared-renovate` that provides the same functionality with centralized management, making the local overrides unnecessary.

## Implementation information

### Switch to shared security preset

- Removed local `vulnerabilityAlerts` block and `osvVulnerabilityAlerts` setting  
- Removed local package rule for `Kong/public-shared-actions/security-actions/**`  
- Extended `Kong/public-shared-renovate:security-extended(area/security,team:kuma-security-managers)` instead, which applies the same behavior with consistent, centrally managed configuration  

### Formatting cleanup

- Removed unnecessary line breaks for fields with short values to keep formatting consistent across the file  

### Validation

Validated with:

```sh
npx --yes --package renovate@41.115.6 -- renovate-config-validator renovate.json
```

Result:

```
 INFO: Validating renovate.json
 INFO: Config validated successfully
```