### PR TITLE
test(e2e): define whole dns name and fix test description

### DIFF
--- a/test/e2e_env/kubernetes/meshidentity/spire.go
+++ b/test/e2e_env/kubernetes/meshidentity/spire.go
@@ -72,7 +72,7 @@ spec:
 		Expect(kubernetes.Cluster.DeleteMesh(meshName)).To(Succeed())
 	})
 
-	It("should use MeshHTTPRoute if no TrafficRoutes are present", func() {
+	It("should receive identity from Spire and traffic works", func() {
 		// when
 		yaml := fmt.Sprintf(`
 apiVersion: kuma.io/v1alpha1
@@ -116,7 +116,7 @@ spec:
 		// then
 		// traffic works
 		Eventually(func(g Gomega) {
-			resp, err := client.CollectEchoResponse(kubernetes.Cluster, "demo-client", fmt.Sprintf("test-server.%s:80", namespace), client.FromKubernetesPod(namespace, "demo-client"))
+			resp, err := client.CollectEchoResponse(kubernetes.Cluster, "demo-client", fmt.Sprintf("test-server.%s.svc.cluster.local:80", namespace), client.FromKubernetesPod(namespace, "demo-client"))
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(resp.Instance).To(Equal("test-server-spire"))
 		}, "30s", "1s", MustPassRepeatedly(5)).Should(Succeed())

--- a/test/e2e_env/kubernetes/meshidentity/spire.go
+++ b/test/e2e_env/kubernetes/meshidentity/spire.go
@@ -59,7 +59,7 @@ spec:
 	})
 
 	AfterEachFailure(func() {
-		DebugKube(kubernetes.Cluster, meshName, namespace)
+		DebugKube(kubernetes.Cluster, meshName, namespace, spireNamespace)
 	})
 
 	E2EAfterEach(func() {


### PR DESCRIPTION
## Motivation

I've noticed a failure of the test

## Implementation information

* Change the DNS name of the test server to use a full Kubernetes name. In some tests we are using custom HostnameGenerators which create a different domain name, maybe it has an impact on this since I've noticed in envoy config that we have a DNS entry `"{\"records\":[{\"name\":\"test-server.meshidentity-spire.default.meshcircuitbreaker\",\"ips\":[\"10.43.206.83\",\"::ffff:a2b:ce53\"]}],\"ttl\":30}"`
* Fixed a description of the test since it was incorrectly copied during the implementation
* Seems like it's some timeout on fetching secrets but we don't have logs from spire to know why, I've added a namespace of spire to `DebugKube`
