### PR TITLE
chore(kumactl): update kube-state-metrics image source and version

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-observability.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.defaults.golden.yaml
@@ -12111,7 +12111,7 @@ spec:
       serviceAccountName: prometheus-kube-state-metrics
       containers:
         - name: prometheus-kube-state-metrics
-          image: "bitnami/kube-state-metrics:2.16.0@sha256:afbc9cec92a6a9168430adf0576b464eac276568afae95031bcc8e802901d568"
+          image: "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.17.0@sha256:2bbc915567334b13632bf62c0a97084aff72a36e13c4dabd5f2f11c898c5bacd"
           imagePullPolicy: "IfNotPresent"
           ports:
             - name: metrics

--- a/app/kumactl/cmd/install/testdata/install-observability.no-grafana.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-grafana.golden.yaml
@@ -660,7 +660,7 @@ spec:
       serviceAccountName: prometheus-kube-state-metrics
       containers:
         - name: prometheus-kube-state-metrics
-          image: "bitnami/kube-state-metrics:2.16.0@sha256:afbc9cec92a6a9168430adf0576b464eac276568afae95031bcc8e802901d568"
+          image: "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.17.0@sha256:2bbc915567334b13632bf62c0a97084aff72a36e13c4dabd5f2f11c898c5bacd"
           imagePullPolicy: "IfNotPresent"
           ports:
             - name: metrics

--- a/app/kumactl/cmd/install/testdata/install-observability.no-jaeger.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-jaeger.golden.yaml
@@ -12111,7 +12111,7 @@ spec:
       serviceAccountName: prometheus-kube-state-metrics
       containers:
         - name: prometheus-kube-state-metrics
-          image: "bitnami/kube-state-metrics:2.16.0@sha256:afbc9cec92a6a9168430adf0576b464eac276568afae95031bcc8e802901d568"
+          image: "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.17.0@sha256:2bbc915567334b13632bf62c0a97084aff72a36e13c4dabd5f2f11c898c5bacd"
           imagePullPolicy: "IfNotPresent"
           ports:
             - name: metrics

--- a/app/kumactl/cmd/install/testdata/install-observability.no-loki.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-loki.golden.yaml
@@ -12111,7 +12111,7 @@ spec:
       serviceAccountName: prometheus-kube-state-metrics
       containers:
         - name: prometheus-kube-state-metrics
-          image: "bitnami/kube-state-metrics:2.16.0@sha256:afbc9cec92a6a9168430adf0576b464eac276568afae95031bcc8e802901d568"
+          image: "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.17.0@sha256:2bbc915567334b13632bf62c0a97084aff72a36e13c4dabd5f2f11c898c5bacd"
           imagePullPolicy: "IfNotPresent"
           ports:
             - name: metrics

--- a/app/kumactl/cmd/install/testdata/install-observability.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.overrides.golden.yaml
@@ -12111,7 +12111,7 @@ spec:
       serviceAccountName: prometheus-kube-state-metrics
       containers:
         - name: prometheus-kube-state-metrics
-          image: "bitnami/kube-state-metrics:2.16.0@sha256:afbc9cec92a6a9168430adf0576b464eac276568afae95031bcc8e802901d568"
+          image: "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.17.0@sha256:2bbc915567334b13632bf62c0a97084aff72a36e13c4dabd5f2f11c898c5bacd"
           imagePullPolicy: "IfNotPresent"
           ports:
             - name: metrics

--- a/app/kumactl/data/install/k8s/metrics/prometheus/kube-stats-metrics.yaml
+++ b/app/kumactl/data/install/k8s/metrics/prometheus/kube-stats-metrics.yaml
@@ -182,7 +182,7 @@ spec:
       serviceAccountName: prometheus-kube-state-metrics
       containers:
         - name: prometheus-kube-state-metrics
-          image: "bitnami/kube-state-metrics:2.16.0@sha256:afbc9cec92a6a9168430adf0576b464eac276568afae95031bcc8e802901d568"
+          image: "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.17.0@sha256:2bbc915567334b13632bf62c0a97084aff72a36e13c4dabd5f2f11c898c5bacd"
           imagePullPolicy: "IfNotPresent"
           ports:
             - name: metrics


### PR DESCRIPTION
## Motivation

We want to stop relying on the Bitnami-provided kube-state-metrics image and switch to the official upstream image. This ensures we are using a supported and secure source, while also taking advantage of the latest release. It also aligns our dependencies with the Kubernetes community standards.

## Implementation information

- Updated the kube-state-metrics image to use `registry.k8s.io/kube-state-metrics/kube-state-metrics`
- Bumped the version from 2.16.0 to 2.17.0
- Updated the digest to the upstream image’s published SHA256

## Result

Kuma now depends on the official kube-state-metrics image, gaining upstream fixes, security patches, and a more reliable source of updates.