### PR TITLE
ci(gha): automate golangci-lint version with Renovate

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -14,6 +14,8 @@ env:
   # of the code checkout path (typically /home/runner/work/<repo-name>/<repo-name>
   # on the runner).
   CI_TOOLS_DIR: "/home/runner/work/kuma/.ci_tools"
+  # renovate: datasource=github-tags depName=golangci/golangci-lint versioning=semver-coerced
+  GOLANGCI_LINT_VERSION: "v2.4.0"
 concurrency:
   group: ${{ format('{0}-{1}-{2}', github.workflow, github.event_name, github.event_name == 'push' && github.sha || github.event_name == 'pull_request' && github.event.pull_request.number || github.event_name == 'workflow_dispatch' && github.ref_name) }}
   cancel-in-progress: ${{ github.event_name == 'push' && false || true }}
@@ -70,7 +72,7 @@ jobs:
           GOGC: "80" # run GC more aggressively
         with:
           args: --fix=false --verbose
-          version: v2.4.0 # TODO: automate this version update via Renovate
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
       - name: Run clang-format style check for Protobuf
         uses: jidicula/clang-format-action@4726374d1aa3c6aecf132e5197e498979588ebc8 # v4.15.0
         with:

--- a/mk/check.mk
+++ b/mk/check.mk
@@ -28,7 +28,6 @@ endif
 .PHONY: fmt/ci
 fmt/ci:
 	$(YQ) -i '.env.K8S_MIN_VERSION = "$(K8S_MIN_VERSION)" | .env.K8S_MAX_VERSION = "$(K8S_MAX_VERSION)"' .github/workflows/"$(ACTION_PREFIX)"_test.yaml
-	grep -r "golangci/golangci-lint-action" .github/workflows --include \*ml | cut -d ':' -f 1 | xargs -n 1 $(YQ) -i '(.jobs.* | select(. | has("steps")) | .steps[] | select(.uses == "golangci/golangci-lint-action*") | .with.version) |= "$(GOLANGCI_LINT_VERSION)"'
 
 .PHONY: helm-lint
 helm-lint:

--- a/mk/dev.mk
+++ b/mk/dev.mk
@@ -33,7 +33,7 @@ K8S_MAX_VERSION=v1.33.4-k3s1
 KUBEBUILDER_ASSETS_VERSION=1.33
 
 export GO_VERSION=$(shell go mod edit -json | jq -r .Go)
-# renovate: datasource=github-releases depName=golangci/golangci-lint versioning=semver-coerced
+# renovate: datasource=github-tags depName=golangci/golangci-lint versioning=semver-coerced
 export GOLANGCI_LINT_VERSION=v2.4.0
 GOOS := $(shell go env GOOS)
 GOARCH := $(shell go env GOARCH)


### PR DESCRIPTION
## Motivation

The golangci-lint version in the workflow was hardcoded, which meant it needed manual updates. This was easy to miss and left the workflow using outdated versions. The goal was to make this version update automatic.

## Implementation information

- Introduced an environment variable `GOLANGCI_LINT_VERSION` annotated for Renovate so it can track and update the version automatically
- Changed the golangci-lint job to use the environment variable instead of a hardcoded version

## Result

The workflow now benefits from automated golangci-lint updates managed by Renovate. Automated tracking and updates will start working once https://github.com/Kong/public-shared-renovate/pull/56 is merged, a new version of `Kong/public-shared-renovate` is released, and Renovate updates the pinned preset version in this repository.