### PR TITLE
feat(kuma-cp): do not run policies code if policy is not configured

### DIFF
--- a/pkg/plugins/policies/core/rules/rules.go
+++ b/pkg/plugins/policies/core/rules/rules.go
@@ -55,9 +55,17 @@ type FromRules struct {
 	InboundRules map[InboundListener][]*inbound.Rule
 }
 
+func (f FromRules) Configured() bool {
+	return len(f.Rules) > 0 || len(f.InboundRules) > 0
+}
+
 type ToRules struct {
 	Rules         Rules
 	ResourceRules outbound.ResourceRules
+}
+
+func (t ToRules) Configured() bool {
+	return len(t.Rules) > 0 || len(t.ResourceRules) > 0
 }
 
 type InboundListenerHostname struct {
@@ -104,8 +112,16 @@ type GatewayRules struct {
 	InboundRules map[InboundListener][]*inbound.Rule
 }
 
+func (g GatewayRules) Configured() bool {
+	return len(g.FromRules) > 0 || len(g.InboundRules) > 0 || len(g.ToRules.ByListener) > 0 || len(g.ToRules.ByListenerAndHostname) > 0
+}
+
 type SingleItemRules struct {
 	Rules Rules
+}
+
+func (s SingleItemRules) Configured() bool {
+	return len(s.Rules) > 0
 }
 
 // Deprecated: use common.WithPolicyAttributes instead

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin.go
@@ -60,7 +60,7 @@ func (p plugin) MatchedPolicies(dataplane *core_mesh.DataplaneResource, resource
 
 func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *core_xds.Proxy) error {
 	policies, ok := proxy.Policies.Dynamic[api.MeshAccessLogType]
-	if !ok {
+	if !ok || (!policies.FromRules.Configured() && !policies.ToRules.Configured() && !policies.GatewayRules.Configured()) {
 		return nil
 	}
 

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin.go
@@ -54,7 +54,7 @@ func (p plugin) Apply(
 		return applyToEgressRealResources(rs, proxy)
 	}
 	policies, ok := proxy.Policies.Dynamic[api.MeshCircuitBreakerType]
-	if !ok {
+	if !ok || (!policies.FromRules.Configured() && !policies.ToRules.Configured() && !policies.GatewayRules.Configured()) {
 		return nil
 	}
 

--- a/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin.go
@@ -49,7 +49,7 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 		return nil
 	}
 	policies, ok := proxy.Policies.Dynamic[api.MeshFaultInjectionType]
-	if !ok {
+	if !ok || (!policies.FromRules.Configured() && !policies.GatewayRules.Configured()) {
 		return nil
 	}
 	listeners := policies_xds.GatherListeners(rs)

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin.go
@@ -45,7 +45,7 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 		return applyToEgressRealResources(rs, proxy)
 	}
 	policies, ok := proxy.Policies.Dynamic[api.MeshHealthCheckType]
-	if !ok {
+	if !ok || (!policies.ToRules.Configured() && !policies.GatewayRules.Configured()) {
 		return nil
 	}
 

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
@@ -66,7 +66,7 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 	}
 
 	policies, ok := proxy.Policies.Dynamic[api.MeshLoadBalancingStrategyType]
-	if !ok {
+	if !ok || (!policies.ToRules.Configured() && !policies.GatewayRules.Configured()) {
 		return nil
 	}
 

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin.go
@@ -59,7 +59,7 @@ func (p plugin) MatchedPolicies(dataplane *core_mesh.DataplaneResource, resource
 
 func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *core_xds.Proxy) error {
 	policies, ok := proxy.Policies.Dynamic[api.MeshMetricType]
-	if !ok || len(policies.SingleItemRules.Rules) == 0 {
+	if !ok || !policies.SingleItemRules.Configured() {
 		return nil
 	}
 

--- a/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/plugin.go
@@ -38,7 +38,7 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 		return nil
 	}
 	policies, ok := proxy.Policies.Dynamic[api.MeshPassthroughType]
-	if !ok {
+	if !ok || !policies.SingleItemRules.Configured() {
 		return nil
 	}
 	if proxy.Dataplane.Spec.GetNetworking().GetGateway().GetType() == v1alpha1.Dataplane_Networking_Gateway_BUILTIN {

--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/plugin.go
@@ -31,10 +31,7 @@ func (p plugin) MatchedPolicies(dataplane *core_mesh.DataplaneResource, resource
 
 func (p plugin) Apply(rs *core_xds.ResourceSet, _ xds_context.Context, proxy *core_xds.Proxy) error {
 	policies, ok := proxy.Policies.Dynamic[api.MeshProxyPatchType]
-	if !ok {
-		return nil
-	}
-	if len(policies.SingleItemRules.Rules) == 0 {
+	if !ok || !policies.SingleItemRules.Configured() {
 		return nil
 	}
 	rule := policies.SingleItemRules.Rules.Compute(subsetutils.MeshElement())

--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin.go
@@ -48,7 +48,7 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 		return nil
 	}
 	policies, ok := proxy.Policies.Dynamic[api.MeshRateLimitType]
-	if !ok {
+	if !ok || (!policies.FromRules.Configured() && !policies.GatewayRules.Configured()) {
 		return nil
 	}
 	listeners := xds.GatherListeners(rs)

--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin.go
@@ -40,7 +40,7 @@ func (p plugin) MatchedPolicies(dataplane *core_mesh.DataplaneResource, resource
 
 func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *core_xds.Proxy) error {
 	policies, ok := proxy.Policies.Dynamic[api.MeshRetryType]
-	if !ok {
+	if !ok || (!policies.ToRules.Configured() && !policies.GatewayRules.Configured()) {
 		return nil
 	}
 

--- a/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
@@ -43,6 +43,7 @@ func (p plugin) MatchedPolicies(dataplane *core_mesh.DataplaneResource, resource
 
 func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *core_xds.Proxy) error {
 	policies, ok := proxy.Policies.Dynamic[api.MeshTimeoutType]
+	// We don't check if any policies were actually configured because we want to apply default timeouts
 	if !ok {
 		return nil
 	}

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin.go
@@ -44,7 +44,7 @@ func (p plugin) MatchedPolicies(dataplane *core_mesh.DataplaneResource, resource
 
 func (p plugin) Apply(rs *xds.ResourceSet, ctx xds_context.Context, proxy *xds.Proxy) error {
 	policies, ok := proxy.Policies.Dynamic[api.MeshTraceType]
-	if !ok || len(policies.SingleItemRules.Rules) == 0 {
+	if !ok || !policies.SingleItemRules.Configured() {
 		return nil
 	}
 


### PR DESCRIPTION
## Motivation

We don't want to run policies code if no policy was configured. The only exception is MeshTimeout where we want to configure defaults even if no policies were configured. This should have positive impact on performance as we won't run code that we know won't produce any result

Fix https://github.com/kumahq/kuma/issues/13941

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
