### PR TITLE
chore(targetRef): deprecate possibility to target MeshHTTPRoute in top level targetRef

### DIFF
--- a/pkg/plugins/policies/core/jsonpatch/validators/validator.go
+++ b/pkg/plugins/policies/core/jsonpatch/validators/validator.go
@@ -129,7 +129,12 @@ func TopLevelTargetRefDeprecations(targetRef *common_api.TargetRef) []string {
 	}
 	if _, ok := replacedByDataplane[targetRef.Kind]; ok {
 		return []string{
-			fmt.Sprintf("%s value for 'targetRef.kind' is deprecated, use %s with labels instead", common_api.MeshSubset, common_api.Dataplane),
+			fmt.Sprintf("%s value for 'targetRef.kind' is deprecated, use %s with labels instead", targetRef.Kind, common_api.Dataplane),
+		}
+	}
+	if targetRef.Kind == common_api.MeshHTTPRoute {
+		return []string{
+			fmt.Sprintf("%s value for 'targetRef.kind' is deprecated, use %s in spec.to[].targetRef", common_api.MeshHTTPRoute, common_api.MeshHTTPRoute),
 		}
 	}
 	return nil

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-route-deprecated.federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-route-deprecated.federated.golden.yaml
@@ -1,0 +1,8 @@
+Patches: null
+allowed: true
+status:
+  code: 200
+  metadata: {}
+uid: "12345"
+warnings:
+- MeshHTTPRoute value for 'targetRef.kind' is deprecated, use MeshHTTPRoute in spec.to[].targetRef

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-route-deprecated.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-route-deprecated.global.golden.yaml
@@ -1,0 +1,10 @@
+Patches: null
+allowed: false
+status:
+  code: 403
+  message: Operation not allowed. 'kuma.io/origin' label should have 'global' value,
+    got 'zone'
+  metadata: {}
+  reason: Forbidden
+  status: Failure
+uid: "12345"

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-route-deprecated.input.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-route-deprecated.input.yaml
@@ -1,0 +1,20 @@
+# user=cli-user,operation=CREATE,namespace=kuma-system
+apiVersion: kuma.io/v1alpha1
+kind: MeshTimeout
+metadata:
+  name: backend-v3
+  labels:
+    kuma.io/origin: zone
+    kuma.io/mesh: default
+    kuma.io/zone: zone-1
+spec:
+  targetRef:
+    kind: MeshHTTPRoute
+    name: test-route
+  to:
+    - targetRef:
+        kind: Mesh
+      default:
+        http:
+          requestTimeout: 19s
+          streamIdleTimeout: 1h

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-route-deprecated.non-federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-route-deprecated.non-federated.golden.yaml
@@ -1,0 +1,8 @@
+Patches: null
+allowed: true
+status:
+  code: 200
+  metadata: {}
+uid: "12345"
+warnings:
+- MeshHTTPRoute value for 'targetRef.kind' is deprecated, use MeshHTTPRoute in spec.to[].targetRef

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtlbs.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtlbs.global.golden.yaml
@@ -7,4 +7,5 @@ uid: "12345"
 warnings:
 - SourceIP type for 'spec.to[0].default.loadBalancer.ringHash.hashPolicies[0].type'
   is deprecated, use Connection instead
-- MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead
+- MeshService value for 'targetRef.kind' is deprecated, use Dataplane with labels
+  instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtlbs.non-federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtlbs.non-federated.golden.yaml
@@ -7,4 +7,5 @@ uid: "12345"
 warnings:
 - SourceIP type for 'spec.to[0].default.loadBalancer.ringHash.hashPolicies[0].type'
   is deprecated, use Connection instead
-- MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead
+- MeshService value for 'targetRef.kind' is deprecated, use Dataplane with labels
+  instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtp-zone-origin.federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtp-zone-origin.federated.golden.yaml
@@ -5,6 +5,7 @@ status:
   metadata: {}
 uid: "12345"
 warnings:
-- MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead
+- MeshService value for 'targetRef.kind' is deprecated, use Dataplane with labels
+  instead
 - MeshService value for 'from[].targetRef.kind' is deprecated, use MeshSubset with
   'kuma.io/service' instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtp-zone-origin.non-federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtp-zone-origin.non-federated.golden.yaml
@@ -5,6 +5,7 @@ status:
   metadata: {}
 uid: "12345"
 warnings:
-- MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead
+- MeshService value for 'targetRef.kind' is deprecated, use Dataplane with labels
+  instead
 - MeshService value for 'from[].targetRef.kind' is deprecated, use MeshSubset with
   'kuma.io/service' instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtp.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtp.global.golden.yaml
@@ -5,6 +5,7 @@ status:
   metadata: {}
 uid: "12345"
 warnings:
-- MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead
+- MeshService value for 'targetRef.kind' is deprecated, use Dataplane with labels
+  instead
 - MeshService value for 'from[].targetRef.kind' is deprecated, use MeshSubset with
   'kuma.io/service' instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtp.non-federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtp.non-federated.golden.yaml
@@ -5,6 +5,7 @@ status:
   metadata: {}
 uid: "12345"
 warnings:
-- MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead
+- MeshService value for 'targetRef.kind' is deprecated, use Dataplane with labels
+  instead
 - MeshService value for 'from[].targetRef.kind' is deprecated, use MeshSubset with
   'kuma.io/service' instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_zone-mtp.federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_zone-mtp.federated.golden.yaml
@@ -5,6 +5,7 @@ status:
   metadata: {}
 uid: "12345"
 warnings:
-- MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead
+- MeshService value for 'targetRef.kind' is deprecated, use Dataplane with labels
+  instead
 - MeshService value for 'from[].targetRef.kind' is deprecated, use MeshSubset with
   'kuma.io/service' instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_zone-mtp.non-federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_zone-mtp.non-federated.golden.yaml
@@ -5,6 +5,7 @@ status:
   metadata: {}
 uid: "12345"
 warnings:
-- MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead
+- MeshService value for 'targetRef.kind' is deprecated, use Dataplane with labels
+  instead
 - MeshService value for 'from[].targetRef.kind' is deprecated, use MeshSubset with
   'kuma.io/service' instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.federated.golden.yaml
@@ -7,4 +7,5 @@ uid: "12345"
 warnings:
 - SourceIP type for 'spec.to[0].default.loadBalancer.ringHash.hashPolicies[0].type'
   is deprecated, use Connection instead
-- MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead
+- MeshService value for 'targetRef.kind' is deprecated, use Dataplane with labels
+  instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.global.golden.yaml
@@ -7,4 +7,5 @@ uid: "12345"
 warnings:
 - SourceIP type for 'spec.to[0].default.loadBalancer.ringHash.hashPolicies[0].type'
   is deprecated, use Connection instead
-- MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead
+- MeshService value for 'targetRef.kind' is deprecated, use Dataplane with labels
+  instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.non-federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.non-federated.golden.yaml
@@ -7,4 +7,5 @@ uid: "12345"
 warnings:
 - SourceIP type for 'spec.to[0].default.loadBalancer.ringHash.hashPolicies[0].type'
   is deprecated, use Connection instead
-- MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead
+- MeshService value for 'targetRef.kind' is deprecated, use Dataplane with labels
+  instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mtp.federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mtp.federated.golden.yaml
@@ -5,6 +5,7 @@ status:
   metadata: {}
 uid: "12345"
 warnings:
-- MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead
+- MeshService value for 'targetRef.kind' is deprecated, use Dataplane with labels
+  instead
 - MeshService value for 'from[].targetRef.kind' is deprecated, use MeshSubset with
   'kuma.io/service' instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mtp.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mtp.global.golden.yaml
@@ -5,6 +5,7 @@ status:
   metadata: {}
 uid: "12345"
 warnings:
-- MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead
+- MeshService value for 'targetRef.kind' is deprecated, use Dataplane with labels
+  instead
 - MeshService value for 'from[].targetRef.kind' is deprecated, use MeshSubset with
   'kuma.io/service' instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mtp.non-federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mtp.non-federated.golden.yaml
@@ -5,6 +5,7 @@ status:
   metadata: {}
 uid: "12345"
 warnings:
-- MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead
+- MeshService value for 'targetRef.kind' is deprecated, use Dataplane with labels
+  instead
 - MeshService value for 'from[].targetRef.kind' is deprecated, use MeshSubset with
   'kuma.io/service' instead


### PR DESCRIPTION
## Motivation

We can now target MeshHTTPRoute in`to` section of policy, which should be used for targeting. Since this is now released, we can deprecate old way of targeting routes

Fix https://github.com/kumahq/kuma/issues/11001

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
