### PR TITLE
chore(MeshLoadBalancingStrategy): deprecate default.*.hashPolicies in favour of default.hashPolicies

### DIFF
--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/deprecated.go
@@ -25,6 +25,9 @@ func validateHashPoliciesType(confs []To) []string {
 			if conf.Default.LoadBalancer.RingHash == nil || conf.Default.LoadBalancer.RingHash.HashPolicies == nil {
 				continue
 			}
+			if conf.Default.LoadBalancer.RingHash.HashPolicies != nil {
+				deprecations = append(deprecations, fmt.Sprintf("configuration 'spec.to[%d].default.loadBalancer.ringHash.hashPolicies' is deprecated, use 'spec.to[%d].default.hashPolicies' instead", ruleIdx, ruleIdx))
+			}
 			for lbIdx, lbConf := range *conf.Default.LoadBalancer.RingHash.HashPolicies {
 				if lbConf.Type == SourceIPType {
 					deprecations = append(deprecations, fmt.Sprintf("%s type for 'spec.to[%d].default.loadBalancer.ringHash.hashPolicies[%d].type' is deprecated, use %s instead", SourceIPType, ruleIdx, lbIdx, ConnectionType))
@@ -33,6 +36,9 @@ func validateHashPoliciesType(confs []To) []string {
 		case MaglevType:
 			if conf.Default.LoadBalancer.Maglev == nil || conf.Default.LoadBalancer.Maglev.HashPolicies == nil {
 				continue
+			}
+			if conf.Default.LoadBalancer.Maglev.HashPolicies != nil {
+				deprecations = append(deprecations, fmt.Sprintf("configuration 'spec.to[%d].default.loadBalancer.maglev.hashPolicies' is deprecated, use 'spec.to[%d].default.hashPolicies' instead", ruleIdx, ruleIdx))
 			}
 			for lbIdx, lbConf := range *conf.Default.LoadBalancer.Maglev.HashPolicies {
 				if lbConf.Type == SourceIPType {

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtlbs.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtlbs.global.golden.yaml
@@ -5,6 +5,8 @@ status:
   metadata: {}
 uid: "12345"
 warnings:
+- configuration 'spec.to[0].default.loadBalancer.ringHash.hashPolicies' is deprecated,
+  use 'spec.to[0].default.hashPolicies' instead
 - SourceIP type for 'spec.to[0].default.loadBalancer.ringHash.hashPolicies[0].type'
   is deprecated, use Connection instead
 - MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtlbs.non-federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtlbs.non-federated.golden.yaml
@@ -5,6 +5,8 @@ status:
   metadata: {}
 uid: "12345"
 warnings:
+- configuration 'spec.to[0].default.loadBalancer.ringHash.hashPolicies' is deprecated,
+  use 'spec.to[0].default.hashPolicies' instead
 - SourceIP type for 'spec.to[0].default.loadBalancer.ringHash.hashPolicies[0].type'
   is deprecated, use Connection instead
 - MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.federated.golden.yaml
@@ -5,6 +5,8 @@ status:
   metadata: {}
 uid: "12345"
 warnings:
+- configuration 'spec.to[0].default.loadBalancer.ringHash.hashPolicies' is deprecated,
+  use 'spec.to[0].default.hashPolicies' instead
 - SourceIP type for 'spec.to[0].default.loadBalancer.ringHash.hashPolicies[0].type'
   is deprecated, use Connection instead
 - MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.global.golden.yaml
@@ -5,6 +5,8 @@ status:
   metadata: {}
 uid: "12345"
 warnings:
+- configuration 'spec.to[0].default.loadBalancer.ringHash.hashPolicies' is deprecated,
+  use 'spec.to[0].default.hashPolicies' instead
 - SourceIP type for 'spec.to[0].default.loadBalancer.ringHash.hashPolicies[0].type'
   is deprecated, use Connection instead
 - MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.non-federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.non-federated.golden.yaml
@@ -5,6 +5,8 @@ status:
   metadata: {}
 uid: "12345"
 warnings:
+- configuration 'spec.to[0].default.loadBalancer.ringHash.hashPolicies' is deprecated,
+  use 'spec.to[0].default.hashPolicies' instead
 - SourceIP type for 'spec.to[0].default.loadBalancer.ringHash.hashPolicies[0].type'
   is deprecated, use Connection instead
 - MeshSubset value for 'targetRef.kind' is deprecated, use Dataplane with labels instead


### PR DESCRIPTION
## Motivation
The change to the api is already released so we can safely deprecate it

Fix https://github.com/kumahq/kuma/issues/13793

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
