### PR TITLE
fix(dns): allow DNS traffic over TCP to bypass the mesh DNS

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-transparent-proxy.dns.no-conntrack.golden.txt
+++ b/app/kumactl/cmd/install/testdata/install-transparent-proxy.dns.no-conntrack.golden.txt
@@ -14,7 +14,6 @@
 -A KUMA_MESH_OUTBOUND -p tcp ! --dport 53 -o ifPlaceholder ! -d 127.0.0.1/32 -m owner --uid-owner 0 -j KUMA_MESH_INBOUND_REDIRECT
 -A KUMA_MESH_OUTBOUND -p tcp ! --dport 53 -o ifPlaceholder -m owner ! --uid-owner 0 -j RETURN
 -A KUMA_MESH_OUTBOUND -m owner --uid-owner 0 -j RETURN
--A KUMA_MESH_OUTBOUND -p tcp --dport 53 -j REDIRECT --to-ports 12345
 -A KUMA_MESH_OUTBOUND -d 127.0.0.1/32 -j RETURN
 -A KUMA_MESH_OUTBOUND -j KUMA_MESH_OUTBOUND_REDIRECT
 -A KUMA_MESH_INBOUND_REDIRECT -p tcp -j REDIRECT --to-ports 15006

--- a/pkg/transparentproxy/iptables/builder/builder_table_nat.go
+++ b/pkg/transparentproxy/iptables/builder/builder_table_nat.go
@@ -169,31 +169,6 @@ func buildMeshOutbound(cfg config.InitializedConfigIPvX) *Chain {
 				WithCommentf("return outbound traffic owned by UID %s (kuma-dp user)", cfg.KumaDPUser),
 		)
 
-	if cfg.Redirect.DNS.Enabled {
-		if cfg.Redirect.DNS.CaptureAll {
-			meshOutbound.AddRules(
-				rules.
-					NewAppendRule(
-						Protocol(Tcp(DestinationPort(consts.DNSPort))),
-						Jump(Redirect(ToPort(cfg.Redirect.DNS.Port))),
-					).
-					WithCommentf("redirect all DNS requests sent via TCP to kuma-dp DNS proxy (listening on port %d)", cfg.Redirect.DNS.Port),
-			)
-		} else {
-			for _, dnsIp := range cfg.Redirect.DNS.Servers {
-				meshOutbound.AddRules(
-					rules.
-						NewAppendRule(
-							Destination(dnsIp),
-							Protocol(Tcp(DestinationPort(consts.DNSPort))),
-							Jump(Redirect(ToPort(cfg.Redirect.DNS.Port))),
-						).
-						WithCommentf("redirect DNS requests sent via TCP to %s to kuma-dp DNS proxy (listening on port %d)", dnsIp, cfg.Redirect.DNS.Port),
-				)
-			}
-		}
-	}
-
 	meshOutbound.AddRules(
 		rules.
 			NewAppendRule(


### PR DESCRIPTION
## Motivation

Allow DNS over TCP to bypass the mesh DNS and go to cluster DNS directly since DNS over TCP is usually happened when UDP truncation and Mesh DNS response is small and never truncates.

## Implementation information

Exclude TCP traffic of DNS queries from transparent proxy rules

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

fixes https://github.com/kumahq/kuma/issues/14487

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
