### PR TITLE
chore(dev): remove ninja check from make install target

### DIFF
--- a/mk/dev.mk
+++ b/mk/dev.mk
@@ -96,7 +96,7 @@ cmd/check/%:
 
 # Install all dependencies on tools and protobuf files
 .PHONY: install
-install: cmd/check/curl cmd/check/git cmd/check/unzip cmd/check/make cmd/check/go cmd/check/ninja
+install: cmd/check/curl cmd/check/git cmd/check/unzip cmd/check/make cmd/check/go
 	$(MISE) install
 
 $(KUBECONFIG_DIR):


### PR DESCRIPTION
## Motivation

We removed the need for ninja when we moved from `clang-format` to `buf`. The install step still checked for `ninja`, which caused `make install` to fail on machines without it even though it is not used anymore. This updates the install target so it reflects the tools we actually need.

## Implementation information

I removed the `cmd/check/ninja` dependency from the install phony target in `mk/dev.mk`