### PR TITLE
docs(bootstrap): document app probe proxy wire key to prevent upgrade flips

### DIFF
--- a/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap.go
@@ -188,6 +188,30 @@ func (b *remoteBootstrapClient) requestForBootstrap(ctx context.Context, client 
 		DynamicMetadata:      metadata,
 		DNSPort:              opts.Config.DNS.EnvoyDNSPort,
 		ReadinessPort:        opts.Config.Dataplane.ReadinessPort,
+		// AppProbeProxyEnabled controls whether the per-pod HTTP probe proxy is enabled.
+		//
+		// IMPORTANT: The BootstrapRequest JSON tag for this field is intentionally
+		// "appProbeProxyDisabled".
+		//
+		// This DP request mirrors the CP contract. Since v2.9.0 the JSON wire key for
+		// this setting has been "appProbeProxyDisabled". Both CP and DP rely on this
+		// shape. Renaming the field to AppProbeProxyDisabled or changing the tag to
+		// "appProbeProxyEnabled" will cause behavior inversions with mixed versions.
+		//
+		// Upgrade pitfalls if changed:
+		//   - New DP -> Old CP:
+		//       Old CP reads "appProbeProxyDisabled: true" into
+		//       AppProbeProxyEnabled = true, which treats the proxy as enabled.
+		//   - Old DP -> New CP:
+		//       Old DP still sends the "disabled" wire key. A new CP expecting a
+		//       different field/tag will flip the meaning.
+		//
+		// These flips can break probes and traffic during rolling upgrades. We avoid
+		// that by keeping this exact JSON tag and the current semantics.
+		//
+		// DO NOT rename, DO NOT change the JSON tag, and DO NOT invert the meaning.
+		//
+		// Context: https://github.com/kumahq/kuma/issues/13885
 		AppProbeProxyEnabled: opts.Config.ApplicationProbeProxyServer.Port > 0,
 		OperatingSystem:      b.operatingSystem,
 		Features:             features,

--- a/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap.go
@@ -185,9 +185,9 @@ func (b *remoteBootstrapClient) requestForBootstrap(ctx context.Context, client 
 				KumaDpCompatible: envoyVersion.KumaDpCompatible,
 			},
 		},
-		DynamicMetadata:      metadata,
-		DNSPort:              opts.Config.DNS.EnvoyDNSPort,
-		ReadinessPort:        opts.Config.Dataplane.ReadinessPort,
+		DynamicMetadata: metadata,
+		DNSPort:         opts.Config.DNS.EnvoyDNSPort,
+		ReadinessPort:   opts.Config.Dataplane.ReadinessPort,
 		// AppProbeProxyEnabled controls whether the per-pod HTTP probe proxy is enabled.
 		//
 		// IMPORTANT: The BootstrapRequest JSON tag for this field is intentionally

--- a/pkg/xds/bootstrap/parameters.go
+++ b/pkg/xds/bootstrap/parameters.go
@@ -27,11 +27,11 @@ type AggregateMetricsConfig struct {
 }
 
 type configParameters struct {
-	Id                   string
-	Service              string
-	AdminAddress         string
-	AdminPort            uint32
-	ReadinessPort        uint32
+	Id            string
+	Service       string
+	AdminAddress  string
+	AdminPort     uint32
+	ReadinessPort uint32
 	// AppProbeProxyEnabled controls whether the per-pod HTTP probe proxy is enabled.
 	//
 	// IMPORTANT: Backward compatibility trap

--- a/pkg/xds/bootstrap/parameters.go
+++ b/pkg/xds/bootstrap/parameters.go
@@ -32,6 +32,41 @@ type configParameters struct {
 	AdminAddress         string
 	AdminPort            uint32
 	ReadinessPort        uint32
+	// AppProbeProxyEnabled controls whether the per-pod HTTP probe proxy is enabled.
+	//
+	// IMPORTANT: Backward compatibility trap
+	//
+	// The BootstrapRequest JSON tag for this setting is intentionally
+	// "appProbeProxyDisabled". The mismatch between the field name and the JSON
+	// wire key is historical and has been part of the CP↔DP contract since v2.9.0.
+	//
+	// Why we cannot "fix" this by renaming the field to AppProbeProxyDisabled
+	// or by changing the JSON tag:
+	//
+	// - Mixed-version upgrades are supported. During rolling upgrades there can
+	//   be version skew between CP and DP.
+	// - If we flip the field name or the JSON tag to match the semantics, the
+	//   interpretation in version-skew combinations will invert:
+	//     * New DP -> Old CP:
+	//         Old CP deserializes "appProbeProxyDisabled: true" into its
+	//         AppProbeProxyEnabled = true and will treat the proxy as enabled,
+	//         which is the opposite of what the new DP intended.
+	//     * Old DP -> New CP:
+	//         Old DPs still send the "disabled" wire key. A new CP that expects
+	//         a renamed field would read the opposite meaning, again flipping
+	//         behavior.
+	// - Either case can break probes during upgrades. This violates our
+	//   backward-compatibility expectations for rolling upgrades.
+	//
+	// Possible alternatives like adding a second field, precedence rules, or
+	// versioning the bootstrap endpoint would add long-lived complexity and
+	// still risk behavior flips mid-upgrade.
+	//
+	// Therefore, DO NOT rename this field, DO NOT change the JSON tag, and DO
+	// NOT invert its meaning. Any attempt to "correct" it will break existing
+	// data planes during upgrades.
+	//
+	// Context: https://github.com/kumahq/kuma/issues/13885
 	AppProbeProxyEnabled bool
 	AdminAccessLogPath   string
 	XdsHost              string

--- a/pkg/xds/bootstrap/template_v3.go
+++ b/pkg/xds/bootstrap/template_v3.go
@@ -367,7 +367,13 @@ func genConfig(parameters configParameters, proxyConfig xds.Proxy, enableReloada
 	if parameters.ReadinessPort != 0 {
 		res.Node.Metadata.Fields[core_xds.FieldDataplaneReadinessPort] = util_proto.MustNewValueForStruct(strconv.Itoa(int(parameters.ReadinessPort)))
 	}
-	// a request from an old DP will not include this field, so defaults to false
+	// NOTE: parameters.AppProbeProxyEnabled originates from BootstrapRequest where
+	// the JSON wire key for this setting is "appProbeProxyDisabled" for backward
+	// compatibility. Do not try to auto-invert or post-process this value here
+	// based on names. Any such logic would diverge CP and DP behavior under
+	// version skew and can break rolling upgrades. If you think this should
+	// change, read https://github.com/kumahq/kuma/issues/13885 first and propose
+	// a versioned endpoint plan with a deprecation window
 	if parameters.AppProbeProxyEnabled {
 		res.Node.Metadata.Fields[core_xds.FieldDataplaneAppProbeProxyEnabled] = util_proto.MustNewValueForStruct("true")
 	}

--- a/pkg/xds/bootstrap/types/bootstrap_request.go
+++ b/pkg/xds/bootstrap/types/bootstrap_request.go
@@ -14,10 +14,10 @@ type BootstrapRequest struct {
 	Host               string  `json:"-"`
 	Version            Version `json:"version"`
 	// CaCert is a PEM-encoded CA cert that DP uses to verify CP
-	CaCert               string                     `json:"caCert"`
-	DynamicMetadata      map[string]string          `json:"dynamicMetadata"`
-	DNSPort              uint32                     `json:"dnsPort,omitempty"`
-	ReadinessPort        uint32                     `json:"readinessPort,omitempty"`
+	CaCert          string            `json:"caCert"`
+	DynamicMetadata map[string]string `json:"dynamicMetadata"`
+	DNSPort         uint32            `json:"dnsPort,omitempty"`
+	ReadinessPort   uint32            `json:"readinessPort,omitempty"`
 	// AppProbeProxyEnabled controls whether the per-pod HTTP probe proxy is enabled.
 	//
 	// IMPORTANT: Backward compatibility trap

--- a/pkg/xds/bootstrap/types/bootstrap_request.go
+++ b/pkg/xds/bootstrap/types/bootstrap_request.go
@@ -18,6 +18,41 @@ type BootstrapRequest struct {
 	DynamicMetadata      map[string]string          `json:"dynamicMetadata"`
 	DNSPort              uint32                     `json:"dnsPort,omitempty"`
 	ReadinessPort        uint32                     `json:"readinessPort,omitempty"`
+	// AppProbeProxyEnabled controls whether the per-pod HTTP probe proxy is enabled.
+	//
+	// IMPORTANT: Backward compatibility trap
+	//
+	// The JSON tag for this field is intentionally "appProbeProxyDisabled".
+	// The mismatch between the field name and the JSON wire key is historical
+	// and has been part of the CP↔DP contract since v2.9.0.
+	//
+	// Why we cannot "fix" this by renaming the field to AppProbeProxyDisabled
+	// or by changing the JSON tag:
+	//
+	// - Mixed-version upgrades are supported. During rolling upgrades there can
+	//   be version skew between CP and DP.
+	// - If we flip the field name or the JSON tag to match the semantics, the
+	//   interpretation in version-skew combinations will invert:
+	//     * New DP -> Old CP:
+	//         Old CP deserializes "appProbeProxyDisabled: true" into its
+	//         AppProbeProxyEnabled = true and will treat the proxy as enabled,
+	//         which is the opposite of what the new DP intended.
+	//     * Old DP -> New CP:
+	//         Old DPs still send the "disabled" wire key. A new CP that expects
+	//         a renamed field would read the opposite meaning, again flipping
+	//         behavior.
+	// - Either case can break probes during upgrades. This violates our
+	//   backward-compatibility expectations for rolling upgrades.
+	//
+	// Possible alternatives like adding a second field, precedence rules, or
+	// versioning the bootstrap endpoint would add long-lived complexity and
+	// still risk behavior flips mid-upgrade.
+	//
+	// Therefore, DO NOT rename this field, DO NOT change the JSON tag, and DO
+	// NOT invert its meaning. Any attempt to "correct" it will break existing
+	// data planes during upgrades.
+	//
+	// Context: https://github.com/kumahq/kuma/issues/13885
 	AppProbeProxyEnabled bool                       `json:"appProbeProxyDisabled,omitempty"`
 	OperatingSystem      string                     `json:"operatingSystem"`
 	Features             []string                   `json:"features"`


### PR DESCRIPTION
## Motivation

The app probe proxy field uses a historical wire key that does not match the field name. During rolling upgrades CP and DP can run with different versions. Changing the field name or JSON tag would invert behavior between versions and can break probes. We need explicit documentation in code to make the constraint visible and to prevent accidental changes.

## Implementation information

Added comments in these places to document the contract and risks:
- DP remote bootstrap request construction
- CP bootstrap request type
- CP bootstrap parameters
- Bootstrap template metadata population

Alternatives like adding a new field or changing the tag were considered risky without a versioned endpoint and a deprecation window. The comments link to the issue that should guide any future versioned change.

## Supporting documentation

Closes https://github.com/kumahq/kuma/issues/13885