### PR TITLE
chore(MeshFaultInjection): rename legacy configurer

### DIFF
--- a/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin.go
@@ -187,7 +187,7 @@ func configure(
 			conf := rule.Conf.(api.Conf)
 			from := rule.Subset
 
-			configurer := plugin_xds.Configurer{
+			configurer := plugin_xds.LegacyConfigurer{
 				FaultInjections: pointer.Deref(conf.Http),
 				From:            from,
 			}


### PR DESCRIPTION
## Motivation

Small refactoring to make future changes to MeshFaultInjection rules API easier to review 


> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
