### PR TITLE
ci(k3d): cluster creation timeout is insufficient

### DIFF
--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -53,7 +53,7 @@ K3D_CLUSTER_CREATE_OPTS ?= -i rancher/k3s:$(CI_K3S_VERSION) \
 	--network kind \
 	--port "$(PORT_PREFIX)80-$(PORT_PREFIX)99:30080-30099@server:0" \
 	--registry-config "/tmp/.kuma-dev/k3d-registry.yaml" \
-	--timeout 120s
+	--timeout 300s
 
 ifeq ($(K3D_NETWORK_CNI),calico)
 	K3D_CLUSTER_CREATE_OPTS += --k3s-arg '--flannel-backend=none@server:*' --k3s-arg '--disable-network-policy@server:*'


### PR DESCRIPTION
## Motivation

Pulling k3s images from docker.io registry sometimes takes more than 2 minutes. Long-term fix will resolve the actual problem of long pulling, but for now we just want to have CI running on `master`.


## Implementation information

Increased timeout up to 300s


