### PR TITLE
docs(MADR): record decision to add KRI to REST API resources

### DIFF
--- a/docs/madr/decisions/084-add-kri-to-rest-api-resources.md
+++ b/docs/madr/decisions/084-add-kri-to-rest-api-resources.md
@@ -1,0 +1,138 @@
+# Add KRI to All REST API Resources
+
+* Status: Accepted
+
+Technical Story: https://github.com/kumahq/kuma/issues/14462
+GUI Issue: https://github.com/kumahq/kuma-gui/issues/4220
+
+## Context and Problem Statement
+
+The GUI needs a stable, machine-generated identifier to link any resource or policy from the REST API with the origin that produced its Envoy configuration. We already use KRI (Kuma Resource Identifier) in new components and in the Inspect API, where per-rule origins are exposed. But most REST list/get endpoints do not return the KRI field. Clients must reconstruct it manually, which is fragile and error-prone.
+
+We need a lightweight way to expose KRI across REST API responses without major refactors or storage changes.
+
+## Decision Drivers
+
+* Changes should be minimal, additive, and safe for existing clients
+* Avoid unnecessary work on legacy protobuf-based resources that are being deprecated
+* Make KRI reliably available to GUI and tooling
+* Minimize schema churn and developer confusion
+
+## Options Considered
+
+### Option A: Add a `kri` field to all resource/policy structs
+
+**Pros**
+
+* Explicit in types
+* OpenAPI can immediately document it
+
+**Cons**
+
+* KRI is derived, not stored - we must recompute it everywhere
+* Requires touching many code paths
+* High risk of inconsistencies or bugs
+
+### Option B: Compute and inject `kri` during JSON marshalling of `ResourceMeta` (chosen)
+
+**Idea**
+
+* In `pkg/core/resources/model/rest/v1alpha1/ResourceMeta`, override JSON marshalling to insert a computed `kri` based on `type`, `mesh`, `labels` and `name`.
+
+**Pros**
+
+* Minimal code changes
+* Automatically appears wherever `ResourceMeta` is used
+* Clients see it without needing to modify storage
+* No problem with OpenAPI schema generation since our templates can be adjusted to include it
+
+**Cons**
+
+* The field is computed and not settable in code
+
+### Option C: Add a `KRI` field to `ResourceMeta`, but only set it at marshalling time
+
+**Pros**
+
+* Easier to annotate as `readOnly` in schemas
+
+**Cons**
+
+* Confusing to developers (should not be set manually)
+* Still needs extra scaffolding for clarity and safety
+
+## Decision
+
+We choose Option B: compute and inject `kri` during JSON marshalling of `ResourceMeta`. This meets our goal of minimal, safe change, while making KRI available in REST API responses without touching storage or reconciliation. Our OpenAPI templates will be updated to include the field and mark it as `readOnly`. This also aligns with how KRI is used in the Inspect API for per-rule origin.
+
+## Design
+
+```go
+type ResourceMeta struct {
+    Type             string            `json:"type"`
+    Mesh             string            `json:"mesh,omitempty"`
+    Name             string            `json:"name"`
+    CreationTime     time.Time         `json:"creationTime"`
+    ModificationTime time.Time         `json:"modificationTime"`
+    Labels           map[string]string `json:"labels,omitempty"`
+}
+
+func (r ResourceMeta) MarshalJSON() ([]byte, error) {
+    type Alias ResourceMeta
+    return json.Marshal(&struct {
+        Alias
+        KRI string `json:"kri,omitempty"`
+    }{
+        Alias: Alias(r),
+        KRI:   kri.FromResourceMeta(r, core_model.ResourceType(r.Type)).String(),
+    })
+}
+```
+
+* `KRI` is derived and never stored
+* Anywhere `ResourceMeta` is rendered in a REST response, `meta.kri` will be included
+* No changes to storage, reconciliation, or resource logic
+
+## Scope and Legacy Resources
+
+* We will not retrofit full KRI support into legacy protobuf-based resources beyond what [Inspect API](./075-inspect-api-redesign.md) already covers
+* Adding KRI to legacy resources would require defining short names and extra logic, which we intend to remove in version 3.0.0
+* Only the new Inspect API endpoints can return an origin resource by its KRI used in the GUI. Legacy resources will not appear as origins
+
+## Compatibility
+
+* The change is additive in JSON. Clients ignoring unknown fields continue to work
+* No change to storage, hashing, reconciliation, or system behavior
+
+## API Schema and OpenAPI
+
+* OpenAPI templates will be updated so `meta.kri` is documented as `string` and `readOnly: true`
+* Clients will see it in generated SDKs
+
+## Security
+
+* No new secrets or internal state are exposed
+* KRI is derived from `type`, `mesh`, `labels`, and `name`, which are already public in the API
+
+## Performance and Reliability
+
+* The overhead is minimal (computing a small string during JSON marshalling)
+* No extra database calls or caching changes
+* No impact on performance or stability
+
+## Migration
+
+* No migrations required for users
+* GUI should begin reading `meta.kri` when present
+* Fallback logic: if `meta.kri` is absent, GUI may still reconstruct it temporarily during rollout
+
+## Acceptance Criteria
+
+* REST API responses now include `meta.kri`
+* The value matches Inspect API KRI for the same resource
+* GUI no longer needs to reconstruct KRI
+* No breakage observed in existing API clients
+
+## Implication for Kong Mesh
+
+There are no product-specific implications for Kong Mesh. The change is purely additive to the REST API and affects only the representation of resources. Kong Mesh behavior, configuration, and features remain the same. Existing clients continue to work without modification, while new clients can optionally take advantage of the `meta.kri` field.

--- a/docs/madr/decisions/084-add-kri-to-rest-api-resources.md
+++ b/docs/madr/decisions/084-add-kri-to-rest-api-resources.md
@@ -9,7 +9,9 @@ GUI Issue: https://github.com/kumahq/kuma-gui/issues/4220
 
 The GUI needs a stable, machine-generated identifier to link any resource or policy from the REST API with the origin that produced its Envoy configuration. We already use KRI (Kuma Resource Identifier) in new components and in the Inspect API, where per-rule origins are exposed. But most REST list/get endpoints do not return the KRI field. Clients must reconstruct it manually, which is fragile and error-prone.
 
-We need a lightweight way to expose KRI across REST API responses without major refactors or storage changes.
+This task focuses only on **changing the REST API responses** to include KRI. It does not cover modifying resource stores or managers such as Kubernetes, In-Memory, or Postgres. Storing KRI in backends would require widespread changes across the codebase and is not in scope here.
+
+The problem is that without KRI directly available in REST responses, client applications like the GUI need to build it themselves, leading to inconsistency and potential errors. At the same time, this MADR does not rule out the possibility of storing KRI in backends in the future if that becomes valuable.
 
 ## Decision Drivers
 

--- a/docs/madr/decisions/084-add-kri-to-rest-api-resources.md
+++ b/docs/madr/decisions/084-add-kri-to-rest-api-resources.md
@@ -97,9 +97,10 @@ func (r ResourceMeta) MarshalJSON() ([]byte, error) {
 
 ## Scope and Legacy Resources
 
-* We will not retrofit full KRI support into legacy protobuf-based resources beyond what [Inspect API](./075-inspect-api-redesign.md) already covers
-* Adding KRI to legacy resources would require defining short names and extra logic, which we intend to remove in version 3.0.0
-* Only the new Inspect API endpoints can return an origin resource by its KRI used in the GUI. Legacy resources will not appear as origins
+* Resources defined in protobuf that are part of the core data model, such as `Dataplane`, `Mesh`, `ZoneIngress`, and `ZoneEgress`, are **not** considered deprecated or legacy. When returned by the REST API, they will also include the `kri` field
+* We will not retrofit full KRI support into truly legacy protobuf-based policies that are being phased out. Those remain covered only by what the [Inspect API](./075-inspect-api-redesign.md) already provides
+* Adding KRI to deprecated policies would require defining short names and introducing additional logic, which we plan to remove in version 3.0.0
+* Only the new Inspect API endpoints can return an origin resource by its KRI for use in the GUI. Deprecated policy types will not appear as origins
 
 ## Compatibility
 

--- a/docs/madr/decisions/084-add-kri-to-rest-api-resources.md
+++ b/docs/madr/decisions/084-add-kri-to-rest-api-resources.md
@@ -1,4 +1,4 @@
-# Add KRI to All REST API Resources
+# Add KRI to REST API Resources
 
 * Status: Accepted
 

--- a/docs/madr/decisions/084-add-kri-to-rest-api-resources.md
+++ b/docs/madr/decisions/084-add-kri-to-rest-api-resources.md
@@ -9,9 +9,11 @@ GUI Issue: https://github.com/kumahq/kuma-gui/issues/4220
 
 The GUI needs a stable, machine-generated identifier to link any resource or policy from the REST API with the origin that produced its Envoy configuration. We already use KRI (Kuma Resource Identifier) in new components and in the Inspect API, where per-rule origins are exposed. But most REST list/get endpoints do not return the KRI field. Clients must reconstruct it manually, which is fragile and error-prone.
 
-This task focuses only on **changing the REST API responses** to include KRI. It does not cover modifying resource stores or managers such as Kubernetes, In-Memory, or Postgres. Storing KRI in backends would require widespread changes across the codebase and is not in scope here.
+This task focuses only on **changing the REST API responses** to include KRI. It does not cover modifying resource stores or managers such as Kubernetes, In-Memory, or Postgres.
 
-The problem is that without KRI directly available in REST responses, client applications like the GUI need to build it themselves, leading to inconsistency and potential errors. At the same time, this MADR does not rule out the possibility of storing KRI in backends in the future if that becomes valuable.
+Having KRI available directly in CRD resources returned by the Kubernetes API, or more generally in resources returned by any store/manager, would also be useful. However, that would likely require storing KRI as part of the resource itself. Storing KRI comes with drawbacks: it depends on values that are already part of the resource (`name`, `mesh`, `labels`) as well as the resource type. This means that every time those values change, the stored KRI would have to be recalculated and updated. Ensuring this consistency would require many code changes and additional design effort.
+
+Because of that complexity, storing KRI in backends is not included in the scope of this MADR. The current decision only addresses returning KRI in REST API responses by computing it at marshalling time. At the same time, this MADR does not prevent us from exploring persistent KRI storage in the future if it becomes valuable. That broader discussion will be handled in a separate MADR.
 
 ## Decision Drivers
 


### PR DESCRIPTION
## Motivation

The GUI and other clients need a stable machine generated identifier to reliably correlate REST API resources with the origins that produced their Envoy configuration. Reconstructing KRI on the client is fragile and inconsistent across endpoints.

## Implementation information

This PR adds a MADR documenting the decision to compute and inject `meta.kri` during JSON marshalling of `ResourceMeta`. The decision explains why this is preferred over adding fields across many structs and code paths. It also notes that OpenAPI templates will be updated to document `meta.kri` as a readOnly string and clarifies that legacy protobuf resources are out of scope beyond existing Inspect API coverage.

## Supporting documentation

- Technical Story: https://github.com/kumahq/kuma/issues/14462
- GUI Issue: https://github.com/kumahq/kuma-gui/issues/4220