### PR TITLE
chore(generator): work around comments not correctly mapped

### DIFF
--- a/tools/resource-gen/pkg/generator/main.go
+++ b/tools/resource-gen/pkg/generator/main.go
@@ -487,7 +487,7 @@ func openApiGenerator(pkg string, resources []ResourceInfo) error {
 	if readDir == "kuma" {
 		base = ""
 	}
-	err := reflector.AddGoComments("github.com/kumahq/" + base, path.Join(readDir, "api/"))
+	err := reflector.AddGoComments("github.com/kumahq/"+base, path.Join(readDir, "api/"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Motivation

In parent project for some reason only on CI the description is removed when generating the OpenAPI schema.
Details in: https://github.com/Kong/kong-mesh/issues/7376#issuecomment-3209289907

## Implementation information

Add if case for when "kuma" is parent project is in "./kuma" and not in "../kuma".

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

closes https://github.com/Kong/kong-mesh/issues/7376#issuecomment-3209289907

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
