### PR TITLE
fix(envoy-naming): rename inbound Envoy resource names and stats to use `sectionName` instead of port value when using unified naming

### DIFF
--- a/api/mesh/v1alpha1/dataplane_helpers.go
+++ b/api/mesh/v1alpha1/dataplane_helpers.go
@@ -178,6 +178,7 @@ type InboundInterface struct {
 	DataplanePort         uint32
 	WorkloadIP            string
 	WorkloadPort          uint32
+	InboundName           string
 }
 
 // We need to implement TextMarshaler because InboundInterface is used
@@ -331,6 +332,7 @@ func (n *Dataplane_Networking) ToInboundInterface(inbound *Dataplane_Networking_
 	} else {
 		iface.WorkloadPort = inbound.Port
 	}
+	iface.InboundName = inbound.GetSectionName()
 	return iface
 }
 

--- a/api/mesh/v1alpha1/dataplane_helpers_test.go
+++ b/api/mesh/v1alpha1/dataplane_helpers_test.go
@@ -120,6 +120,7 @@ var _ = Describe("Dataplane_Networking", func() {
 						Inbound: []*Dataplane_Networking_Inbound{
 							{
 								Port: 80,
+								Name: "test-port",
 							},
 							{
 								Address:        "192.168.0.2",
@@ -130,8 +131,8 @@ var _ = Describe("Dataplane_Networking", func() {
 						},
 					},
 					expected: []InboundInterface{
-						{DataplaneAdvertisedIP: "192.168.0.1", DataplaneIP: "192.168.0.1", DataplanePort: 80, WorkloadIP: "192.168.0.1", WorkloadPort: 80},
-						{DataplaneAdvertisedIP: "192.168.0.2", DataplaneIP: "192.168.0.2", DataplanePort: 443, WorkloadIP: "192.168.0.3", WorkloadPort: 8443},
+						{DataplaneAdvertisedIP: "192.168.0.1", DataplaneIP: "192.168.0.1", DataplanePort: 80, WorkloadIP: "192.168.0.1", WorkloadPort: 80, InboundName: "test-port"},
+						{DataplaneAdvertisedIP: "192.168.0.2", DataplaneIP: "192.168.0.2", DataplanePort: 443, WorkloadIP: "192.168.0.3", WorkloadPort: 8443, InboundName: "443"},
 					},
 				}),
 			)

--- a/pkg/core/faultinjections/matcher_test.go
+++ b/pkg/core/faultinjections/matcher_test.go
@@ -131,6 +131,7 @@ var _ = Describe("Match", func() {
 				mesh_proto.InboundInterface{
 					WorkloadIP:   "1.2.3.4",
 					WorkloadPort: 8080,
+					InboundName:  "0",
 				}: {
 					policyWithDestinationsFunc("fi2", time.Unix(1, 0), []*mesh_proto.Selector{
 						{
@@ -180,6 +181,7 @@ var _ = Describe("Match", func() {
 				mesh_proto.InboundInterface{
 					WorkloadIP:   "1.2.3.4",
 					WorkloadPort: 8081,
+					InboundName:  "0",
 				}: {
 					policyWithDestinationsFunc("fi1", time.Unix(1, 0), []*mesh_proto.Selector{
 						{
@@ -244,6 +246,7 @@ var _ = Describe("Match", func() {
 				mesh_proto.InboundInterface{
 					WorkloadIP:   "1.2.3.4",
 					WorkloadPort: 8080,
+					InboundName:  "0",
 				}: {
 					policyWithDestinationsFunc("fi1", time.Unix(1, 0), []*mesh_proto.Selector{
 						{

--- a/pkg/core/faultinjections/matcher_test.go
+++ b/pkg/core/faultinjections/matcher_test.go
@@ -100,6 +100,7 @@ var _ = Describe("Match", func() {
 			dataplane: dataplaneWithInboundsFunc([]*mesh_proto.Dataplane_Networking_Inbound{
 				{
 					ServiceAddress: "1.2.3.4",
+					Port:           80,
 					ServicePort:    8080,
 					Tags: map[string]string{
 						"service":          "web",
@@ -129,9 +130,10 @@ var _ = Describe("Match", func() {
 			},
 			expected: core_xds.FaultInjectionMap{
 				mesh_proto.InboundInterface{
-					WorkloadIP:   "1.2.3.4",
-					WorkloadPort: 8080,
-					InboundName:  "0",
+					DataplanePort: 80,
+					WorkloadIP:    "1.2.3.4",
+					WorkloadPort:  8080,
+					InboundName:   "80",
 				}: {
 					policyWithDestinationsFunc("fi2", time.Unix(1, 0), []*mesh_proto.Selector{
 						{
@@ -148,6 +150,7 @@ var _ = Describe("Match", func() {
 			dataplane: dataplaneWithInboundsFunc([]*mesh_proto.Dataplane_Networking_Inbound{
 				{
 					ServiceAddress: "1.2.3.4",
+					Port:           80,
 					ServicePort:    8080,
 					Tags: map[string]string{
 						"service":          "web",
@@ -158,6 +161,7 @@ var _ = Describe("Match", func() {
 				},
 				{
 					ServiceAddress: "1.2.3.4",
+					Port:           81,
 					ServicePort:    8081,
 					Tags: map[string]string{
 						"service":          "web-api",
@@ -179,9 +183,10 @@ var _ = Describe("Match", func() {
 			},
 			expected: core_xds.FaultInjectionMap{
 				mesh_proto.InboundInterface{
-					WorkloadIP:   "1.2.3.4",
-					WorkloadPort: 8081,
-					InboundName:  "0",
+					DataplanePort: 81,
+					WorkloadIP:    "1.2.3.4",
+					WorkloadPort:  8081,
+					InboundName:   "81",
 				}: {
 					policyWithDestinationsFunc("fi1", time.Unix(1, 0), []*mesh_proto.Selector{
 						{
@@ -198,6 +203,7 @@ var _ = Describe("Match", func() {
 			dataplane: dataplaneWithInboundsFunc([]*mesh_proto.Dataplane_Networking_Inbound{
 				{
 					ServiceAddress: "1.2.3.4",
+					Port:           80,
 					ServicePort:    8080,
 					Tags: map[string]string{
 						"service":          "web",
@@ -244,9 +250,10 @@ var _ = Describe("Match", func() {
 			},
 			expected: core_xds.FaultInjectionMap{
 				mesh_proto.InboundInterface{
-					WorkloadIP:   "1.2.3.4",
-					WorkloadPort: 8080,
-					InboundName:  "0",
+					DataplanePort: 80,
+					WorkloadIP:    "1.2.3.4",
+					WorkloadPort:  8080,
+					InboundName:   "80",
 				}: {
 					policyWithDestinationsFunc("fi1", time.Unix(1, 0), []*mesh_proto.Selector{
 						{

--- a/pkg/core/permissions/matcher_test.go
+++ b/pkg/core/permissions/matcher_test.go
@@ -172,8 +172,8 @@ var _ = Describe("Match", func() {
 				},
 			},
 			expected: map[mesh_proto.InboundInterface]string{
-				{DataplaneAdvertisedIP: "192.168.0.1", DataplaneIP: "192.168.0.1", WorkloadIP: "192.168.0.1", WorkloadPort: 8081, DataplanePort: 8080}: "more-specific-kong-to-web",
-				{DataplaneAdvertisedIP: "192.168.0.1", DataplaneIP: "192.168.0.1", WorkloadIP: "192.168.0.1", WorkloadPort: 1234, DataplanePort: 1234}: "metrics",
+				{DataplaneAdvertisedIP: "192.168.0.1", DataplaneIP: "192.168.0.1", WorkloadIP: "192.168.0.1", WorkloadPort: 8081, DataplanePort: 8080, InboundName: "8080"}: "more-specific-kong-to-web",
+				{DataplaneAdvertisedIP: "192.168.0.1", DataplaneIP: "192.168.0.1", WorkloadIP: "192.168.0.1", WorkloadPort: 1234, DataplanePort: 1234, InboundName: "1234"}: "metrics",
 			},
 		}),
 	)

--- a/pkg/core/ratelimits/matcher_test.go
+++ b/pkg/core/ratelimits/matcher_test.go
@@ -106,6 +106,7 @@ var _ = Describe("Match", func() {
 			dataplane: dataplaneWithInboundsFunc([]*mesh_proto.Dataplane_Networking_Inbound{
 				{
 					ServiceAddress: "1.2.3.4",
+					Port:           80,
 					ServicePort:    8080,
 					Tags: map[string]string{
 						"kuma.io/service":  "web",
@@ -154,9 +155,10 @@ var _ = Describe("Match", func() {
 			expected: core_xds.RateLimitsMap{
 				Inbound: core_xds.InboundRateLimitsMap{
 					mesh_proto.InboundInterface{
-						WorkloadIP:   "1.2.3.4",
-						WorkloadPort: 8080,
-						InboundName:  "0",
+						DataplanePort: 80,
+						WorkloadIP:    "1.2.3.4",
+						WorkloadPort:  8080,
+						InboundName:   "80",
 					}: []*core_mesh.RateLimitResource{
 						policyWithDestinationsFunc("rl2", time.Unix(1, 0),
 							[]*mesh_proto.Selector{
@@ -257,6 +259,7 @@ var _ = Describe("Match", func() {
 			dataplane: dataplaneWithInboundsFunc([]*mesh_proto.Dataplane_Networking_Inbound{
 				{
 					ServiceAddress: "1.2.3.4",
+					Port:           80,
 					ServicePort:    8080,
 					Tags: map[string]string{
 						"kuma.io/service":  "web",
@@ -267,6 +270,7 @@ var _ = Describe("Match", func() {
 				},
 				{
 					ServiceAddress: "1.2.3.4",
+					Port:           81,
 					ServicePort:    8081,
 					Tags: map[string]string{
 						"kuma.io/service":  "web-api",
@@ -298,9 +302,10 @@ var _ = Describe("Match", func() {
 			expected: core_xds.RateLimitsMap{
 				Inbound: core_xds.InboundRateLimitsMap{
 					mesh_proto.InboundInterface{
-						WorkloadIP:   "1.2.3.4",
-						WorkloadPort: 8081,
-						InboundName:  "0",
+						DataplanePort: 81,
+						WorkloadIP:    "1.2.3.4",
+						WorkloadPort:  8081,
+						InboundName:   "81",
 					}: []*core_mesh.RateLimitResource{
 						policyWithDestinationsFunc("rl1", time.Unix(1, 0),
 							[]*mesh_proto.Selector{
@@ -393,6 +398,7 @@ var _ = Describe("Match", func() {
 			dataplane: dataplaneWithInboundsFunc([]*mesh_proto.Dataplane_Networking_Inbound{
 				{
 					ServiceAddress: "1.2.3.4",
+					Port:           80,
 					ServicePort:    8080,
 					Tags: map[string]string{
 						"kuma.io/service":  "backend",
@@ -439,9 +445,10 @@ var _ = Describe("Match", func() {
 			expected: core_xds.RateLimitsMap{
 				Inbound: core_xds.InboundRateLimitsMap{
 					mesh_proto.InboundInterface{
-						WorkloadIP:   "1.2.3.4",
-						WorkloadPort: 8080,
-						InboundName:  "0",
+						DataplanePort: 80,
+						WorkloadIP:    "1.2.3.4",
+						WorkloadPort:  8080,
+						InboundName:   "80",
 					}: []*core_mesh.RateLimitResource{
 						policyWithDestinationsFunc("rl2", time.Unix(1, 0),
 							[]*mesh_proto.Selector{
@@ -555,6 +562,7 @@ var _ = Describe("Match", func() {
 			dataplane: dataplaneWithInboundsFunc([]*mesh_proto.Dataplane_Networking_Inbound{
 				{
 					ServiceAddress: "1.2.3.4",
+					Port:           80,
 					ServicePort:    8080,
 					Tags: map[string]string{
 						"kuma.io/service":  "backend",
@@ -623,9 +631,10 @@ var _ = Describe("Match", func() {
 			expected: core_xds.RateLimitsMap{
 				Inbound: core_xds.InboundRateLimitsMap{
 					mesh_proto.InboundInterface{
-						WorkloadIP:   "1.2.3.4",
-						WorkloadPort: 8080,
-						InboundName:  "0",
+						DataplanePort: 80,
+						WorkloadIP:    "1.2.3.4",
+						WorkloadPort:  8080,
+						InboundName:   "80",
 					}: []*core_mesh.RateLimitResource{
 						policyWithDestinationsFunc("rl3", time.Unix(1, 0),
 							[]*mesh_proto.Selector{

--- a/pkg/core/ratelimits/matcher_test.go
+++ b/pkg/core/ratelimits/matcher_test.go
@@ -156,6 +156,7 @@ var _ = Describe("Match", func() {
 					mesh_proto.InboundInterface{
 						WorkloadIP:   "1.2.3.4",
 						WorkloadPort: 8080,
+						InboundName:  "0",
 					}: []*core_mesh.RateLimitResource{
 						policyWithDestinationsFunc("rl2", time.Unix(1, 0),
 							[]*mesh_proto.Selector{
@@ -299,6 +300,7 @@ var _ = Describe("Match", func() {
 					mesh_proto.InboundInterface{
 						WorkloadIP:   "1.2.3.4",
 						WorkloadPort: 8081,
+						InboundName:  "0",
 					}: []*core_mesh.RateLimitResource{
 						policyWithDestinationsFunc("rl1", time.Unix(1, 0),
 							[]*mesh_proto.Selector{
@@ -439,6 +441,7 @@ var _ = Describe("Match", func() {
 					mesh_proto.InboundInterface{
 						WorkloadIP:   "1.2.3.4",
 						WorkloadPort: 8080,
+						InboundName:  "0",
 					}: []*core_mesh.RateLimitResource{
 						policyWithDestinationsFunc("rl2", time.Unix(1, 0),
 							[]*mesh_proto.Selector{
@@ -622,6 +625,7 @@ var _ = Describe("Match", func() {
 					mesh_proto.InboundInterface{
 						WorkloadIP:   "1.2.3.4",
 						WorkloadPort: 8080,
+						InboundName:  "0",
 					}: []*core_mesh.RateLimitResource{
 						policyWithDestinationsFunc("rl3", time.Unix(1, 0),
 							[]*mesh_proto.Selector{

--- a/pkg/core/xds/inspect/attachments_test.go
+++ b/pkg/core/xds/inspect/attachments_test.go
@@ -2,6 +2,7 @@ package inspect_test
 
 import (
 	"fmt"
+	"strconv"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -21,6 +22,7 @@ func inbound(ip string, dpPort, workloadPort uint32) mesh_proto.InboundInterface
 		DataplanePort:         dpPort,
 		WorkloadIP:            ip,
 		WorkloadPort:          workloadPort,
+		InboundName:           strconv.Itoa(int(dpPort)),
 	}
 }
 

--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin_test.go
@@ -354,6 +354,7 @@ var _ = Describe("MeshRateLimit", func() {
 					DataplanePort:         17777,
 					WorkloadIP:            "127.0.0.1",
 					WorkloadPort:          17777,
+					InboundName:           "17777",
 				}: []*core_mesh.RateLimitResource{
 					{
 						Spec: &mesh_proto.RateLimit{

--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/testdata/old_policy.golden.yaml
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/testdata/old_policy.golden.yaml
@@ -5,22 +5,10 @@ address:
 enableReusePort: false
 filterChains:
 - filters:
-  - name: envoy.extensions.filters.network.local_ratelimit.v3.LocalRateLimit
-    typedConfig:
-      '@type': type.googleapis.com/envoy.extensions.filters.network.local_ratelimit.v3.LocalRateLimit
-      statPrefix: tcp_rate_limit
-      tokenBucket:
-        fillInterval: 99s
-        maxTokens: 100
-        tokensPerFill: 100
   - name: envoy.filters.network.http_connection_manager
     typedConfig:
       '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
       httpFilters:
-      - name: envoy.filters.http.local_ratelimit
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
-          statPrefix: rate_limit
       - name: envoy.filters.http.router
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/testdata/old_policy.golden.yaml
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/testdata/old_policy.golden.yaml
@@ -5,10 +5,22 @@ address:
 enableReusePort: false
 filterChains:
 - filters:
+  - name: envoy.extensions.filters.network.local_ratelimit.v3.LocalRateLimit
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.network.local_ratelimit.v3.LocalRateLimit
+      statPrefix: tcp_rate_limit
+      tokenBucket:
+        fillInterval: 99s
+        maxTokens: 100
+        tokensPerFill: 100
   - name: envoy.filters.network.http_connection_manager
     typedConfig:
       '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
       httpFilters:
+      - name: envoy.filters.http.local_ratelimit
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+          statPrefix: rate_limit
       - name: envoy.filters.http.router
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin.go
@@ -284,7 +284,7 @@ func configureListener(
 	getName := naming.GetNameOrFallbackFunc(unifiedNaming)
 
 	inboundID := kri.WithSectionName(kri.From(proxy.Dataplane), iface.WorkloadPort).String()
-	inboundContextualID := naming.MustContextualInboundName(proxy.Dataplane, iface.WorkloadPort)
+	inboundContextualID := naming.MustContextualInboundName(proxy.Dataplane, inbound.GetSectionName())
 
 	legacyClusterName := envoy_names.GetLocalClusterName(iface.WorkloadPort)
 	legacyListenerName := envoy_names.GetInboundListenerName(iface.DataplaneIP, iface.DataplanePort)

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin.go
@@ -284,7 +284,7 @@ func configureListener(
 	getName := naming.GetNameOrFallbackFunc(unifiedNaming)
 
 	inboundID := kri.WithSectionName(kri.From(proxy.Dataplane), iface.WorkloadPort).String()
-	inboundContextualID := naming.MustContextualInboundName(proxy.Dataplane, inbound.GetSectionName())
+	inboundContextualID := naming.MustContextualInboundName(proxy.Dataplane, iface.InboundName)
 
 	legacyClusterName := envoy_names.GetLocalClusterName(iface.WorkloadPort)
 	legacyListenerName := envoy_names.GetInboundListenerName(iface.DataplaneIP, iface.DataplanePort)

--- a/pkg/xds/generator/inbound_proxy_generator.go
+++ b/pkg/xds/generator/inbound_proxy_generator.go
@@ -38,7 +38,7 @@ func (g InboundProxyGenerator) Generate(_ context.Context, _ *core_xds.ResourceS
 
 		iface := proxy.Dataplane.Spec.Networking.Inbound[i]
 		protocol := core_meta.ParseProtocol(iface.GetProtocol())
-		unifiedName := naming.MustContextualInboundName(proxy.Dataplane, endpoint.WorkloadPort)
+		unifiedName := naming.MustContextualInboundName(proxy.Dataplane, endpoint.InboundName)
 
 		// generate CDS resource
 		localClusterName := envoy_names.GetLocalClusterName(endpoint.WorkloadPort)
@@ -152,7 +152,7 @@ func FilterChainBuilder(
 ) *envoy_listeners.FilterChainBuilder {
 	unifiedNaming := unified_naming.Enabled(proxy.Metadata, xdsCtx.Mesh.Resource)
 	getName := naming.GetNameOrFallbackFunc(unifiedNaming)
-	contextualName := naming.MustContextualInboundName(proxy.Dataplane, endpoint.WorkloadPort)
+	contextualName := naming.MustContextualInboundName(proxy.Dataplane, endpoint.InboundName)
 	routeConfigName := getName(contextualName, envoy_names.GetInboundRouteName(service))
 	virtualHostName := getName(contextualName, service)
 

--- a/pkg/xds/generator/inbound_proxy_generator_test.go
+++ b/pkg/xds/generator/inbound_proxy_generator_test.go
@@ -87,6 +87,7 @@ var _ = Describe("InboundProxyGenerator", func() {
 							DataplanePort:         80,
 							WorkloadIP:            "192.168.0.1",
 							WorkloadPort:          8080,
+							InboundName:           "80",
 						}: &core_mesh.TrafficPermissionResource{
 							Meta: &test_model.ResourceMeta{
 								Name: "tp-1",
@@ -119,6 +120,7 @@ var _ = Describe("InboundProxyGenerator", func() {
 							DataplanePort:         80,
 							WorkloadIP:            "192.168.0.1",
 							WorkloadPort:          8080,
+							InboundName:           "80",
 						}: []*core_mesh.FaultInjectionResource{{Spec: &mesh_proto.FaultInjection{
 							Sources: []*mesh_proto.Selector{
 								{
@@ -149,6 +151,7 @@ var _ = Describe("InboundProxyGenerator", func() {
 							DataplanePort:         80,
 							WorkloadIP:            "192.168.0.1",
 							WorkloadPort:          8080,
+							InboundName:           "80",
 						}: []*core_mesh.RateLimitResource{
 							{
 								Spec: &mesh_proto.RateLimit{

--- a/pkg/xds/generator/testdata/inbound-proxy/8-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/8-envoy-config.golden.yaml
@@ -1,10 +1,25 @@
 resources:
-- name: self_inbound_dp_8080
+- name: self_inbound_dp_443
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     connectTimeout: 10s
     loadAssignment:
-      clusterName: self_inbound_dp_8080
+      clusterName: self_inbound_dp_443
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.0.2
+                portValue: 8443
+    name: self_inbound_dp_443
+    type: STATIC
+- name: self_inbound_dp_80
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 10s
+    loadAssignment:
+      clusterName: self_inbound_dp_80
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -12,7 +27,7 @@ resources:
               socketAddress:
                 address: 192.168.0.2
                 portValue: 8080
-    name: self_inbound_dp_8080
+    name: self_inbound_dp_80
     type: STATIC
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
@@ -21,22 +36,57 @@ resources:
           idleTimeout: 7200s
         explicitHttpConfig:
           httpProtocolOptions: {}
-- name: self_inbound_dp_8443
+- name: self_inbound_dp_443
   resource:
-    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 10s
-    loadAssignment:
-      clusterName: self_inbound_dp_8443
-      endpoints:
-      - lbEndpoints:
-        - endpoint:
-            address:
-              socketAddress:
-                address: 192.168.0.2
-                portValue: 8443
-    name: self_inbound_dp_8443
-    type: STATIC
-- name: self_inbound_dp_8080
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.2
+        portValue: 443
+    enableReusePort: false
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.rbac
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
+          rules: {}
+          statPrefix: self_inbound_dp_443.
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: self_inbound_dp_443
+          idleTimeout: 7200s
+          statPrefix: self_inbound_dp_443
+      transportSocket:
+        name: envoy.transport_sockets.tls
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          commonTlsContext:
+            combinedValidationContext:
+              defaultValidationContext:
+                matchTypedSubjectAltNames:
+                - matcher:
+                    prefix: spiffe://default/
+                  sanType: URI
+              validationContextSdsSecretConfig:
+                name: system_mtls_ca_default
+                sdsConfig:
+                  ads: {}
+                  resourceApiVersion: V3
+            tlsCertificateSdsSecretConfigs:
+            - name: system_mtls_identity_default
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+          requireClientCertificate: true
+    metadata:
+      filterMetadata:
+        io.kuma.tags:
+          kuma.io/service: backend4
+    name: self_inbound_dp_443
+    statPrefix: self_inbound_dp_443
+    trafficDirection: INBOUND
+- name: self_inbound_dp_80
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener
     address:
@@ -50,7 +100,7 @@ resources:
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
           rules: {}
-          statPrefix: self_inbound_dp_8080.
+          statPrefix: self_inbound_dp_80.
       - name: envoy.filters.network.http_connection_manager
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
@@ -70,23 +120,23 @@ resources:
             - addressPrefix: ::1/128
               prefixLen: 128
           routeConfig:
-            name: self_inbound_dp_8080
+            name: self_inbound_dp_80
             requestHeadersToRemove:
             - x-kuma-tags
             validateClusters: false
             virtualHosts:
             - domains:
               - '*'
-              name: self_inbound_dp_8080
+              name: self_inbound_dp_80
               routes:
               - match:
                   prefix: /
                 route:
-                  cluster: self_inbound_dp_8080
+                  cluster: self_inbound_dp_80
                   timeout: 0s
           setCurrentClientCertDetails:
             uri: true
-          statPrefix: self_inbound_dp_8080
+          statPrefix: self_inbound_dp_80
           streamIdleTimeout: 3600s
       transportSocket:
         name: envoy.transport_sockets.tls
@@ -115,56 +165,6 @@ resources:
         io.kuma.tags:
           kuma.io/protocol: http
           kuma.io/service: backend3
-    name: self_inbound_dp_8080
-    statPrefix: self_inbound_dp_8080
-    trafficDirection: INBOUND
-- name: self_inbound_dp_8443
-  resource:
-    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
-    address:
-      socketAddress:
-        address: 192.168.0.2
-        portValue: 443
-    enableReusePort: false
-    filterChains:
-    - filters:
-      - name: envoy.filters.network.rbac
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
-          rules: {}
-          statPrefix: self_inbound_dp_8443.
-      - name: envoy.filters.network.tcp_proxy
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: self_inbound_dp_8443
-          idleTimeout: 7200s
-          statPrefix: self_inbound_dp_8443
-      transportSocket:
-        name: envoy.transport_sockets.tls
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
-          commonTlsContext:
-            combinedValidationContext:
-              defaultValidationContext:
-                matchTypedSubjectAltNames:
-                - matcher:
-                    prefix: spiffe://default/
-                  sanType: URI
-              validationContextSdsSecretConfig:
-                name: system_mtls_ca_default
-                sdsConfig:
-                  ads: {}
-                  resourceApiVersion: V3
-            tlsCertificateSdsSecretConfigs:
-            - name: system_mtls_identity_default
-              sdsConfig:
-                ads: {}
-                resourceApiVersion: V3
-          requireClientCertificate: true
-    metadata:
-      filterMetadata:
-        io.kuma.tags:
-          kuma.io/service: backend4
-    name: self_inbound_dp_8443
-    statPrefix: self_inbound_dp_8443
+    name: self_inbound_dp_80
+    statPrefix: self_inbound_dp_80
     trafficDirection: INBOUND

--- a/pkg/xds/generator/testdata/profile-source/5-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/5-envoy-config.golden.yaml
@@ -83,12 +83,12 @@ resources:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         explicitHttpConfig:
           http2ProtocolOptions: {}
-- name: self_inbound_dp_8080
+- name: self_inbound_dp_80
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     connectTimeout: 10s
     loadAssignment:
-      clusterName: self_inbound_dp_8080
+      clusterName: self_inbound_dp_80
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -96,7 +96,7 @@ resources:
               socketAddress:
                 address: 192.168.0.1
                 portValue: 8080
-    name: self_inbound_dp_8080
+    name: self_inbound_dp_80
     type: STATIC
 - name: system_envoy_admin
   resource:
@@ -199,7 +199,7 @@ resources:
           kuma.io/service: elastic
     name: outbound:127.0.0.1:59200
     trafficDirection: OUTBOUND
-- name: self_inbound_dp_8080
+- name: self_inbound_dp_80
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener
     address:
@@ -213,13 +213,13 @@ resources:
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
           rules: {}
-          statPrefix: self_inbound_dp_8080.
+          statPrefix: self_inbound_dp_80.
       - name: envoy.filters.network.tcp_proxy
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: self_inbound_dp_8080
+          cluster: self_inbound_dp_80
           idleTimeout: 7200s
-          statPrefix: self_inbound_dp_8080
+          statPrefix: self_inbound_dp_80
       transportSocket:
         name: envoy.transport_sockets.tls
         typedConfig:
@@ -246,8 +246,8 @@ resources:
       filterMetadata:
         io.kuma.tags:
           kuma.io/service: backend
-    name: self_inbound_dp_8080
-    statPrefix: self_inbound_dp_8080
+    name: self_inbound_dp_80
+    statPrefix: self_inbound_dp_80
     trafficDirection: INBOUND
 - name: system_envoy_admin
   resource:


### PR DESCRIPTION
## Motivation
Right now we are having issue with `inbounds[].proxyResourceName` in `_layout` endpoint being different then actual inbound name in Envoy config and stats. Which makes it impossible for GUI to simply match them. They need to have the same name. 

According to the [MADR](https://github.com/kumahq/kuma/blob/master/docs/madr/decisions/077-migrating-to-consistent-and-well-defined-naming-for-non-system-envoy-resources-and-stats.md#option-1-use-the-contextual-format-defined-for-proxy-local-resources) This should be `sectionName` not port value, so we need to align Envoy config and stats with API. This change should be only applied to unified resource naming

## Implementation information

Updating how we build inbound name for Envoy config and stats by extending `InboundInterface` with `sectionName`

Fix https://github.com/kumahq/kuma/issues/14469

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
