### PR TITLE
test(postgres): migrate e2e Postgres from Bitnami to CloudNativePG

### DIFF
--- a/test/e2e/helm/kuma_helm_deploy_global_and_zone_universal_mode.go
+++ b/test/e2e/helm/kuma_helm_deploy_global_and_zone_universal_mode.go
@@ -41,19 +41,9 @@ func GlobalAndZoneInUniversalModeWithHelmChart() {
 				postgres.WithDatabase("mesh"),
 				postgres.WithPrimaryName("postgres"),
 			)).
-			Install(YamlK8s(fmt.Sprintf(`
-apiVersion: v1
-kind: Secret
-metadata:
-  name: postgres
-  namespace: %s
-type: Opaque
-stringData:
-  password: "mesh"
-`, Config.KumaNamespace))).
 			Setup(zoneCluster)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(WaitPodsAvailableWithLabel(Config.KumaNamespace, "app.kubernetes.io/name", "postgresql")(zoneCluster)).To(Succeed())
+		Expect(WaitPodsAvailableWithLabel(Config.KumaNamespace, "cnpg.io/cluster", "postgres-cluster")(zoneCluster)).To(Succeed())
 
 		err = NewClusterSetup().
 			Install(Kuma(core.Global,
@@ -81,7 +71,7 @@ stringData:
 				WithHelmOpt("controlPlane.environment", "universal"),
 				WithHelmOpt("controlPlane.zone", "zone-1"),
 				WithHelmOpt("controlPlane.envVars.KUMA_MULTIZONE_GLOBAL_KDS_TLS_ENABLED", "false"),
-				WithHelmOpt("controlPlane.envVars.KUMA_STORE_POSTGRES_HOST", "postgres-release-postgresql"),
+				WithHelmOpt("controlPlane.envVars.KUMA_STORE_POSTGRES_HOST", "postgres-cluster-rw"),
 				WithHelmOpt("controlPlane.envVars.KUMA_STORE_POSTGRES_PORT", "5432"),
 				WithHelmOpt("controlPlane.envVars.KUMA_STORE_POSTGRES_USER", "mesh"),
 				WithHelmOpt("controlPlane.envVars.KUMA_STORE_POSTGRES_DB_NAME", "mesh"),

--- a/test/e2e/helm/kuma_helm_deploy_global_universal_mode_and_zone.go
+++ b/test/e2e/helm/kuma_helm_deploy_global_universal_mode_and_zone.go
@@ -44,19 +44,9 @@ func ZoneAndGlobalInUniversalModeWithHelmChart() {
 				postgres.WithDatabase("mesh"),
 				postgres.WithPrimaryName("postgres"),
 			)).
-			Install(YamlK8s(fmt.Sprintf(`
-apiVersion: v1
-kind: Secret
-metadata:
-  name: postgres
-  namespace: %s
-type: Opaque
-stringData:
-  password: "mesh"
-`, Config.KumaNamespace))).
 			Setup(globalCluster)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(WaitPodsAvailableWithLabel(Config.KumaNamespace, "app.kubernetes.io/name", "postgresql")(globalCluster)).To(Succeed())
+		Expect(WaitPodsAvailableWithLabel(Config.KumaNamespace, "cnpg.io/cluster", "postgres-cluster")(globalCluster)).To(Succeed())
 
 		err = NewClusterSetup().
 			Install(Kuma(core.Global,
@@ -69,7 +59,7 @@ stringData:
 				WithCPReplicas(2),
 				WithHelmOpt("controlPlane.environment", "universal"),
 				WithHelmOpt("controlPlane.envVars.KUMA_MULTIZONE_GLOBAL_KDS_TLS_ENABLED", "false"),
-				WithHelmOpt("controlPlane.envVars.KUMA_STORE_POSTGRES_HOST", "postgres-release-postgresql"),
+				WithHelmOpt("controlPlane.envVars.KUMA_STORE_POSTGRES_HOST", "postgres-cluster-rw"),
 				WithHelmOpt("controlPlane.envVars.KUMA_STORE_POSTGRES_PORT", "5432"),
 				WithHelmOpt("controlPlane.envVars.KUMA_STORE_POSTGRES_USER", "mesh"),
 				WithHelmOpt("controlPlane.envVars.KUMA_STORE_POSTGRES_DB_NAME", "mesh"),

--- a/test/framework/deployments/postgres/deployment.go
+++ b/test/framework/deployments/postgres/deployment.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"errors"
+	"fmt"
 
 	. "github.com/kumahq/kuma/test/framework"
 )
@@ -109,8 +110,11 @@ func WithPostgresPassword(postgresPassword string) DeployOptionsFunc {
 	}
 }
 
+// Wrap initScript in braces because CloudNativePG's `cluster.initdb.postInitSQL`
+// is defined as a list of SQL statements. Using braces forces a single-item list,
+// matching the API requirement
 func WithInitScript(initScript string) DeployOptionsFunc {
 	return func(o *deployOptions) {
-		o.initScript = initScript
+		o.initScript = fmt.Sprintf("{%s}", initScript)
 	}
 }


### PR DESCRIPTION
## Motivation

Bitnami registry changes broke our Postgres-based tests by causing chart and image pulls to fail, especially on older release branches. This blocked CI and made our Helm E2E suites flaky.

## Implementation information

We migrated the test Postgres setup from the Bitnami chart to CloudNativePG. The operator chart is installed first, followed by a minimal single-node `cluster` for tests. Charts are pinned by OCI digest for determinism.

Secrets are applied for the superuser and the database owner. The cluster is configured with PostgreSQL 16.10, a small PVC, and ready to accept post-init SQL scripts. E2E tests now wait on the CNPG labels and connect via the `postgres-cluster-rw` service. We use `helm upgrade --install --create-namespace --wait` for reliable installs and keep delete as a no-op since namespace teardown removes resources.

Alternatives considered: continuing with Bitnami and updating release branches to use floating version or mirroring the chart. These options were discarded due to ongoing maintenance burden and continued risk of external breakage.

## Additional information

As a follow-up, we need to configure Renovate to track and update these charts:

```go
const (
	cnpgChart    = "oci://ghcr.io/cloudnative-pg/charts/cloudnative-pg:0.26.0@sha256:b294ea82771c9049b2f1418a56cbab21716343fd44fe68721967c95ca7f5c523"
	clusterChart = "oci://ghcr.io/cloudnative-pg/charts/cluster:0.3.1@sha256:3f4f1a26dc0388f47bc456e0ec733255c1a8469b0742ce052df3885ba935c388"
)
```

> [!IMPORTANT]
> This update must also be backported
