### PR TITLE
feat(kumactl): switch from Bitnami to registry.k8s.io and pin

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-observability.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.defaults.golden.yaml
@@ -12104,7 +12104,7 @@ spec:
       serviceAccountName: prometheus-kube-state-metrics
       containers:
         - name: prometheus-kube-state-metrics
-          image: "bitnami/kube-state-metrics:2.9.2"
+          image: "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.9.2@sha256:5ac2e67a862cd3baa0eb4fd7683d54928fd76ea3a61cde50508922c956901d8c"
           imagePullPolicy: "IfNotPresent"
           ports:
             - name: metrics

--- a/app/kumactl/cmd/install/testdata/install-observability.no-grafana.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-grafana.golden.yaml
@@ -652,7 +652,7 @@ spec:
       serviceAccountName: prometheus-kube-state-metrics
       containers:
         - name: prometheus-kube-state-metrics
-          image: "bitnami/kube-state-metrics:2.9.2"
+          image: "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.9.2@sha256:5ac2e67a862cd3baa0eb4fd7683d54928fd76ea3a61cde50508922c956901d8c"
           imagePullPolicy: "IfNotPresent"
           ports:
             - name: metrics

--- a/app/kumactl/cmd/install/testdata/install-observability.no-jaeger.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-jaeger.golden.yaml
@@ -12104,7 +12104,7 @@ spec:
       serviceAccountName: prometheus-kube-state-metrics
       containers:
         - name: prometheus-kube-state-metrics
-          image: "bitnami/kube-state-metrics:2.9.2"
+          image: "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.9.2@sha256:5ac2e67a862cd3baa0eb4fd7683d54928fd76ea3a61cde50508922c956901d8c"
           imagePullPolicy: "IfNotPresent"
           ports:
             - name: metrics

--- a/app/kumactl/cmd/install/testdata/install-observability.no-loki.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-loki.golden.yaml
@@ -12104,7 +12104,7 @@ spec:
       serviceAccountName: prometheus-kube-state-metrics
       containers:
         - name: prometheus-kube-state-metrics
-          image: "bitnami/kube-state-metrics:2.9.2"
+          image: "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.9.2@sha256:5ac2e67a862cd3baa0eb4fd7683d54928fd76ea3a61cde50508922c956901d8c"
           imagePullPolicy: "IfNotPresent"
           ports:
             - name: metrics

--- a/app/kumactl/cmd/install/testdata/install-observability.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.overrides.golden.yaml
@@ -12104,7 +12104,7 @@ spec:
       serviceAccountName: prometheus-kube-state-metrics
       containers:
         - name: prometheus-kube-state-metrics
-          image: "bitnami/kube-state-metrics:2.9.2"
+          image: "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.9.2@sha256:5ac2e67a862cd3baa0eb4fd7683d54928fd76ea3a61cde50508922c956901d8c"
           imagePullPolicy: "IfNotPresent"
           ports:
             - name: metrics

--- a/app/kumactl/data/install/k8s/metrics/prometheus/kube-stats-metrics.yaml
+++ b/app/kumactl/data/install/k8s/metrics/prometheus/kube-stats-metrics.yaml
@@ -174,7 +174,7 @@ spec:
       serviceAccountName: prometheus-kube-state-metrics
       containers:
         - name: prometheus-kube-state-metrics
-          image: "bitnami/kube-state-metrics:2.9.2"
+          image: "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.9.2@sha256:5ac2e67a862cd3baa0eb4fd7683d54928fd76ea3a61cde50508922c956901d8c"
           imagePullPolicy: "IfNotPresent"
           ports:
             - name: metrics


### PR DESCRIPTION
## Motivation

Bitnami registry changes caused friction and reliability issues when pulling kube-state-metrics. To reduce risk and align with upstream hosting, we switched to the upstream image on registry.k8s.io and pinned it by digest for deterministic deployments.

## Implementation information

- Replaced the Bitnami kube-state-metrics image with the upstream image hosted on registry.k8s.io and pinned it by sha256 digest
- Updated all affected golden files so tests reflect the new image reference