### PR TITLE
feat(kumactl): switch kube-state-metrics to upstream image

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-observability.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.defaults.golden.yaml
@@ -12111,7 +12111,7 @@ spec:
       serviceAccountName: prometheus-kube-state-metrics
       containers:
         - name: prometheus-kube-state-metrics
-          image: "bitnami/kube-state-metrics:2.15.0@sha256:929ee8c6bb15788412becb9de354098121517771f3ecf5dc94a3148854243c3c"
+          image: "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.15.0@sha256:db384bf43222b066c378e77027a675d4cd9911107adba46c2922b3a55e10d6fb"
           imagePullPolicy: "IfNotPresent"
           ports:
             - name: metrics

--- a/app/kumactl/cmd/install/testdata/install-observability.no-grafana.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-grafana.golden.yaml
@@ -660,7 +660,7 @@ spec:
       serviceAccountName: prometheus-kube-state-metrics
       containers:
         - name: prometheus-kube-state-metrics
-          image: "bitnami/kube-state-metrics:2.15.0@sha256:929ee8c6bb15788412becb9de354098121517771f3ecf5dc94a3148854243c3c"
+          image: "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.15.0@sha256:db384bf43222b066c378e77027a675d4cd9911107adba46c2922b3a55e10d6fb"
           imagePullPolicy: "IfNotPresent"
           ports:
             - name: metrics

--- a/app/kumactl/cmd/install/testdata/install-observability.no-jaeger.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-jaeger.golden.yaml
@@ -12111,7 +12111,7 @@ spec:
       serviceAccountName: prometheus-kube-state-metrics
       containers:
         - name: prometheus-kube-state-metrics
-          image: "bitnami/kube-state-metrics:2.15.0@sha256:929ee8c6bb15788412becb9de354098121517771f3ecf5dc94a3148854243c3c"
+          image: "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.15.0@sha256:db384bf43222b066c378e77027a675d4cd9911107adba46c2922b3a55e10d6fb"
           imagePullPolicy: "IfNotPresent"
           ports:
             - name: metrics

--- a/app/kumactl/cmd/install/testdata/install-observability.no-loki.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-loki.golden.yaml
@@ -12111,7 +12111,7 @@ spec:
       serviceAccountName: prometheus-kube-state-metrics
       containers:
         - name: prometheus-kube-state-metrics
-          image: "bitnami/kube-state-metrics:2.15.0@sha256:929ee8c6bb15788412becb9de354098121517771f3ecf5dc94a3148854243c3c"
+          image: "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.15.0@sha256:db384bf43222b066c378e77027a675d4cd9911107adba46c2922b3a55e10d6fb"
           imagePullPolicy: "IfNotPresent"
           ports:
             - name: metrics

--- a/app/kumactl/cmd/install/testdata/install-observability.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.overrides.golden.yaml
@@ -12111,7 +12111,7 @@ spec:
       serviceAccountName: prometheus-kube-state-metrics
       containers:
         - name: prometheus-kube-state-metrics
-          image: "bitnami/kube-state-metrics:2.15.0@sha256:929ee8c6bb15788412becb9de354098121517771f3ecf5dc94a3148854243c3c"
+          image: "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.15.0@sha256:db384bf43222b066c378e77027a675d4cd9911107adba46c2922b3a55e10d6fb"
           imagePullPolicy: "IfNotPresent"
           ports:
             - name: metrics

--- a/app/kumactl/data/install/k8s/metrics/prometheus/kube-stats-metrics.yaml
+++ b/app/kumactl/data/install/k8s/metrics/prometheus/kube-stats-metrics.yaml
@@ -182,7 +182,7 @@ spec:
       serviceAccountName: prometheus-kube-state-metrics
       containers:
         - name: prometheus-kube-state-metrics
-          image: "bitnami/kube-state-metrics:2.15.0@sha256:929ee8c6bb15788412becb9de354098121517771f3ecf5dc94a3148854243c3c"
+          image: "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.15.0@sha256:db384bf43222b066c378e77027a675d4cd9911107adba46c2922b3a55e10d6fb"
           imagePullPolicy: "IfNotPresent"
           ports:
             - name: metrics


### PR DESCRIPTION
## Motivation

Recent changes on the Bitnami registry introduced uncertainty around where the image is hosted and how it is packaged. To avoid surprises and stay close to the project defaults, we switch to the upstream kube-state-metrics image. We keep the same version and add a digest to make deployments repeatable.

## Implementation information

- Replace the Bitnami kube-state-metrics image with `registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.15.0` and pin by sha256 digest
- Update kumactl install observability golden files to reflect the new image reference