### PR TITLE
test(postgres): pin image, update to 18.0, fix legacy e2e secrets

### DIFF
--- a/test/e2e/helm/kuma_helm_deploy_global_and_zone_universal_mode.go
+++ b/test/e2e/helm/kuma_helm_deploy_global_and_zone_universal_mode.go
@@ -75,7 +75,7 @@ func GlobalAndZoneInUniversalModeWithHelmChart() {
 				WithHelmOpt("controlPlane.envVars.KUMA_STORE_POSTGRES_PORT", "5432"),
 				WithHelmOpt("controlPlane.envVars.KUMA_STORE_POSTGRES_USER", "mesh"),
 				WithHelmOpt("controlPlane.envVars.KUMA_STORE_POSTGRES_DB_NAME", "mesh"),
-				WithHelmOpt("controlPlane.secrets.postgresPassword.Secret", "postgres"),
+				WithHelmOpt("controlPlane.secrets.postgresPassword.Secret", "db-mesh-secret"),
 				WithHelmOpt("controlPlane.secrets.postgresPassword.Key", "password"),
 				WithHelmOpt("controlPlane.secrets.postgresPassword.Env", "KUMA_STORE_POSTGRES_PASSWORD"),
 			)).

--- a/test/e2e/helm/kuma_helm_deploy_global_universal_mode_and_zone.go
+++ b/test/e2e/helm/kuma_helm_deploy_global_universal_mode_and_zone.go
@@ -63,7 +63,7 @@ func ZoneAndGlobalInUniversalModeWithHelmChart() {
 				WithHelmOpt("controlPlane.envVars.KUMA_STORE_POSTGRES_PORT", "5432"),
 				WithHelmOpt("controlPlane.envVars.KUMA_STORE_POSTGRES_USER", "mesh"),
 				WithHelmOpt("controlPlane.envVars.KUMA_STORE_POSTGRES_DB_NAME", "mesh"),
-				WithHelmOpt("controlPlane.secrets.postgresPassword.Secret", "postgres"),
+				WithHelmOpt("controlPlane.secrets.postgresPassword.Secret", "db-mesh-secret"),
 				WithHelmOpt("controlPlane.secrets.postgresPassword.Key", "password"),
 				WithHelmOpt("controlPlane.secrets.postgresPassword.Env", "KUMA_STORE_POSTGRES_PASSWORD"),
 			)).

--- a/test/framework/deployments/postgres/kubernetes.go
+++ b/test/framework/deployments/postgres/kubernetes.go
@@ -14,14 +14,22 @@ import (
 // NOTE: We intentionally do not use the tag form like
 // "oci://ghcr.io/cloudnative-pg/charts/cloudnative-pg:<version>@<digest>"
 // for these charts because the tags appear to be mutable and sometimes
-// get overridden by the maintainers with new digests. This would cause
-// issues in our CI where all branches could suddenly resolve to a
-// different digest, leading to inconsistent and flaky runs. To keep CI
-// stable and reproducible, we pin the charts by immutable digest only
+// get overridden by the maintainers with new digests. When that happens,
+// our CI fails because it tries to fetch a tag with a matching digest,
+// but the tag now resolves to a different digest and the pull cannot
+// satisfy both. To avoid these CI failures, we pin the charts by
+// immutable digest only
 const (
 	cnpgChart    = "oci://ghcr.io/cloudnative-pg/charts/cloudnative-pg@sha256:b294ea82771c9049b2f1418a56cbab21716343fd44fe68721967c95ca7f5c523" // 0.26.0
 	clusterChart = "oci://ghcr.io/cloudnative-pg/charts/cluster@sha256:3f4f1a26dc0388f47bc456e0ec733255c1a8469b0742ce052df3885ba935c388"        // 0.3.1
 )
+
+// We must keep a tag with version here because CloudNativePG requires and checks
+// for a tag during installation. Additionally, we use tags that include a date
+// because those are the only stable tags provided by the project. To ensure
+// immutability and reproducibility, we still pin by digest, using the
+// <tag>@<digest> form
+const postgresImage = "ghcr.io/cloudnative-pg/postgresql:18.0-202509290807-minimal-trixie@sha256:dd7c678167cc6d06c2caf4e6ea7bc7a89e39754bc7e0111a81f5d75ac3068f70"
 
 type k8SDeployment struct {
 	envVars map[string]string
@@ -69,11 +77,10 @@ func (t *k8SDeployment) Deploy(cluster framework.Cluster) error {
 
 	opts := &helm.Options{
 		SetValues: map[string]string{
-			"version.postgresql":                       "16.10",
+			"cluster.imageName":                        postgresImage,
 			"cluster.instances":                        "1",
 			"cluster.storage.size":                     "100Mi",
 			"cluster.initdb.database":                  t.options.database,
-			"cluster.initdb.postInitSQL":               t.options.initScript,
 			"cluster.initdb.owner":                     t.options.username,
 			"cluster.initdb.secret.name":               fmt.Sprintf("db-%s-secret", t.options.username),
 			"cluster.superuserSecret":                  "db-postgres-secret",
@@ -81,6 +88,10 @@ func (t *k8SDeployment) Deploy(cluster framework.Cluster) error {
 		},
 		KubectlOptions: cluster.GetKubectlOptions(t.options.namespace),
 		ExtraArgs:      extraArgs,
+	}
+
+	for i, script := range t.options.initScripts {
+		opts.SetValues[fmt.Sprintf("cluster.initdb.postInitSQL[%d]", i)] = script
 	}
 
 	return helm.UpgradeE(cluster.GetTesting(), opts, clusterChart, t.options.primaryName)
@@ -91,7 +102,7 @@ func (t *k8SDeployment) Delete(framework.Cluster) error {
 	return nil
 }
 
-func NewK8SDeployment(opts *deployOptions) *k8SDeployment {
+func NewK8SDeployment(opts *deployOptions) PostgresDeployment {
 	return &k8SDeployment{
 		options: opts,
 	}


### PR DESCRIPTION
## Motivation

We need deterministic and stable Postgres deployments in tests. The CNPG controller requires an image tag to be present, but tags are mutable and can break CI when digests change behind them. E2E Helm values must reference the same secret that the Postgres deployment creates. We are also updating Postgres to version 18.0 to keep current and to verify compatibility. The e2e changes fix legacy tests, which is important for older release branches, and this will be backported.

## Implementation information

- Use `<tag>@<digest>` for `cluster.imageName` to satisfy CNPG checks while pinning immutably for CI reproducibility
- Update Postgres version to `18.0`
- Switch from a single `initScript` string to `initScripts []string` and set Helm values as an indexed list for `cluster.initdb.postInitSQL`
- Add sane defaults in `Install` so tests can omit repetitive options
- Change the e2e Helm value for `controlPlane.secrets.postgresPassword.Secret` to `db-mesh-secret`, which matches the secret generated by the Postgres deployment when the user is `mesh`
- The e2e secret alignment fixes legacy tests and will be backported to older release branches

## Supporting documentation

- CNPG charts require a tag and allow `<tag>@<digest>` notation