### PR TITLE
ci(gha): remove secrets inheritance from `_get-active-branches`

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -102,7 +102,6 @@ jobs:
         if: inputs.branches == ''
         id: generate-matrix
         uses: ./.github/workflows/_get-active-branches.yaml
-        secrets: inherit
         with:
           beforeBranch: ${{ steps.get-pr-info.outputs.pr_base_ref }}
   open-prs:

--- a/.github/workflows/ci-stability-release-branches.yaml
+++ b/.github/workflows/ci-stability-release-branches.yaml
@@ -25,7 +25,6 @@ jobs:
       - name: "Get active branches"
         id: active-branches
         uses: ./.github/workflows/_get-active-branches.yaml
-        secrets: inherit
         with:
           excludeDefault: true
           summary: true

--- a/.github/workflows/pr-modification.yaml
+++ b/.github/workflows/pr-modification.yaml
@@ -24,7 +24,6 @@ jobs:
       - id: active-branches
         name: Get active branches
         uses: ./.github/workflows/_get-active-branches.yaml
-        secrets: inherit
       - id: get-recent-prs
         name: Get recent PRs
         run: |

--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -33,7 +33,6 @@ jobs:
       - name: "Get active branches"
         id: active-branches
         uses: ./.github/workflows/_get-active-branches.yaml
-        secrets: inherit
       - name: "sync docs" # loop over all the branches and generate the docs
         shell: bash
         env:

--- a/.github/workflows/update-insecure-dependencies.yaml
+++ b/.github/workflows/update-insecure-dependencies.yaml
@@ -14,7 +14,6 @@ jobs:
       - name: "Get active branches"
         id: generate-matrix
         uses: ./.github/workflows/_get-active-branches.yaml
-        secrets: inherit
   update-insecure-dependencies:
     env:
       OSV_SCANNER_ADDITIONAL_OPTS: ""


### PR DESCRIPTION
## Motivation

The reusable workflow `_get-active-branches.yaml` does not use any secrets. Several workflows were inheriting secrets when invoking it, which unnecessarily broadened access and created confusion about secret usage. Removing the inheritance follows the least privilege principle and clarifies that the called workflow operates without secrets.

## Implementation information

Removed `secrets: inherit` from all job steps that call `./.github/workflows/_get-active-branches.yaml` in the following workflows: `ci-stability-release-branches.yaml`, `pr-modification.yaml`, `update-docs.yaml`, `backport.yaml`, and `update-insecure-dependencies.yaml`. No behavior change is expected because the called workflow does not require secrets. Alternatives considered: leaving the configuration as is, which was rejected due to unnecessary secret exposure and reduced clarity.

This fixes: https://github.com/kumahq/kuma/actions/runs/18278812499/workflow