### PR TITLE
fix(gha): use unique step id and fallback for branch matrix

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -29,7 +29,7 @@ jobs:
       pr_state: ${{ steps.get-pr-info.outputs.pr_state }}
       pr_base_ref: ${{ steps.get-pr-info.outputs.pr_base_ref }}
       pr_merge_commit_sha: ${{ steps.get-pr-info.outputs.pr_merge_commit_sha }}
-      branches: ${{ steps.generate-matrix.outputs.out }}
+      branches: ${{ steps.generate-matrix.outputs.out || steps.generate-matrix-active.outputs.out }}
     runs-on: ubuntu-24.04
     steps:
       - id: get-pr-info
@@ -100,7 +100,7 @@ jobs:
           ')" >> "$GITHUB_OUTPUT"
       - name: "generate-matrix (active branches)"
         if: inputs.branches == ''
-        id: generate-matrix
+        id: generate-matrix-active
         uses: ./.github/workflows/_get-active-branches.yaml
         with:
           beforeBranch: ${{ steps.get-pr-info.outputs.pr_base_ref }}


### PR DESCRIPTION
## Motivation

GitHub Actions failed because two steps used the same id `generate-matrix`. This violates the unique id requirement and breaks the workflow. In addition, the output for branches should work whether the user provides `inputs.branches` or relies on active branches.

## Implementation information

- Gave the active branches step a unique id `generate-matrix-active`
- Updated the `branches` job output to use a simple fallback expression so the matrix is built from either the input list or the active branches list

## Supporting documentation

Tested on fork