### PR TITLE
ci(workflows): checkout repo before using local workflow actions

### DIFF
--- a/.github/workflows/ci-stability-release-branches.yaml
+++ b/.github/workflows/ci-stability-release-branches.yaml
@@ -22,6 +22,7 @@ jobs:
     outputs:
       branches: ${{ steps.active-branches.outputs.out }}
     steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: "Get active branches"
         id: active-branches
         uses: ./.github/workflows/_get-active-branches.yaml

--- a/.github/workflows/pr-modification.yaml
+++ b/.github/workflows/pr-modification.yaml
@@ -21,8 +21,9 @@ jobs:
       recent_prs: ${{ steps.get-recent-prs.outputs.out }}
       active_branches: ${{ steps.active-branches.outputs.out }}
     steps:
-      - id: active-branches
-        name: Get active branches
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Get active branches
+        id: active-branches
         uses: ./.github/workflows/_get-active-branches.yaml
       - id: get-recent-prs
         name: Get recent PRs

--- a/.github/workflows/update-insecure-dependencies.yaml
+++ b/.github/workflows/update-insecure-dependencies.yaml
@@ -11,6 +11,7 @@ jobs:
     outputs:
       branches: ${{ steps.generate-matrix.outputs.out }}
     steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: "Get active branches"
         id: generate-matrix
         uses: ./.github/workflows/_get-active-branches.yaml


### PR DESCRIPTION
## Motivation

These workflows call a local workflow via a relative path. On a fresh runner there is no repository content until we run checkout. This caused intermittent failures where the local workflow file could not be found. We also want a pinned version of `actions/checkout` for stability and security.

## Implementation information

We added a `actions/checkout@v5` step (pinned by commit SHA) at the start of the relevant jobs in three workflows. This ensures the local workflow files exist in the workspace before they are referenced. No logic of the local workflow changed. We only inserted the checkout step and kept step metadata clear.

Alternatives considered:
- Rely on implicit checkout: rejected, since GitHub runners start without repository files by default
- Convert the local workflow to a published action: rejected for now to keep the current repo-local reuse pattern simple

## Supporting documentation

- GitHub Actions docs: local actions require repository content to be present in the workspace before use