### PR TITLE
ci(github-actions): reuse active-branches workflow and fix jobs

### DIFF
--- a/.github/workflows/_get-active-branches.yaml
+++ b/.github/workflows/_get-active-branches.yaml
@@ -16,6 +16,11 @@ on:
         type: string
         required: false
         default: ""
+      branches:
+        description: "If set, return only this comma-separated list of branches"
+        type: string
+        required: false
+        default: ""
     outputs:
       out:
         description: "JSON array of active branch patterns (filtered if requested)"
@@ -30,7 +35,8 @@ jobs:
     outputs:
       out: ${{ steps.main.outputs.out }}
     steps:
-      - id: main
+      - name: Get active branches
+        id: main
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -40,9 +46,10 @@ jobs:
           EXCLUDE_DEFAULT: ${{ inputs.excludeDefault }}
           SHOW_SUMMARY: ${{ inputs.summary }}
           BEFORE_BRANCH: ${{ inputs.beforeBranch }}
+          BRANCHES: ${{ inputs.branches }}
         run: |
           # shellcheck shell=bash
-          [[ "${GH_DEBUG}" == "1" ]] && set -x
+          [[ "${GH_DEBUG}" == "true" ]] && set -x
           set -euo pipefail
           
           readonly REPOSITORY="${REPOSITORY:?REPOSITORY is required}"
@@ -52,6 +59,17 @@ jobs:
           readonly DEFAULT_BRANCH="${DEFAULT_BRANCH:-master}"
           readonly SHOW_SUMMARY="${SHOW_SUMMARY:-${GH_DEBUG:-0}}"
           readonly BEFORE_BRANCH="${BEFORE_BRANCH:-}"
+          readonly BRANCHES="${BRANCHES:-}"
+          
+          # If branches input is provided, short-circuit and return it as JSON array
+          if [[ -n "${BRANCHES}" ]]; then
+            echo "out=$(printf '%s' "${BRANCHES}" | jq --raw-input --compact-output '
+              split(",")
+              | map(gsub("^[[:space:]]+|[[:space:]]+$";""))
+              | map(select(. != ""))
+            ')" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           
           # Write summary to $GITHUB_STEP_SUMMARY when enabled
           write_summary() {

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -20,27 +20,23 @@ env:
   GH_USER: kumahq[bot]
   GH_EMAIL: <110050114+kumahq[bot]@users.noreply.github.com>
   GH_REPO: ${{ github.repository }}
-  BRANCH_FILE_PATH: active-branches.json
 jobs:
-  collect-info:
+  pr-info:
+    runs-on: ubuntu-24.04
     outputs:
       pr_title: ${{ steps.get-pr-info.outputs.pr_title }}
       pr_change_log: ${{ steps.get-pr-info.outputs.pr_change_log }}
       pr_state: ${{ steps.get-pr-info.outputs.pr_state }}
       pr_base_ref: ${{ steps.get-pr-info.outputs.pr_base_ref }}
       pr_merge_commit_sha: ${{ steps.get-pr-info.outputs.pr_merge_commit_sha }}
-      branches: ${{ steps.generate-matrix.outputs.out || steps.generate-matrix-active.outputs.out }}
-    runs-on: ubuntu-24.04
     steps:
-      - id: get-pr-info
-        name: get-pr-info
+      - name: get-pr-info
+        id: get-pr-info
         env:
           GH_TOKEN: ${{ github.token }}
           GH_DEBUG: ${{ runner.debug == '1' }}
         run: |
-          if [[ "${{ runner.debug }}" == "1" ]]; then
-            set -x
-          fi
+          [[ "${GH_DEBUG}" == "true" ]] && set -x
 
           function get_change_log() {
             awk '
@@ -86,36 +82,23 @@ jobs:
             echo "PR #${{ inputs.PR }} is not merged, current state: '$PR_STATE'"
             exit 1
           fi
-      # If explicit branches are provided via workflow_dispatch input, use them; otherwise compute
-      # from active branches before the PR base
-      - name: "generate-matrix (from input)"
-        if: inputs.branches != ''
-        id: generate-matrix
-        shell: bash
-        run: |
-          echo "out=$(printf '${{ inputs.branches }}' | jq -Rc '
-            split(",")
-            | map(gsub("^[[:space:]]+|[[:space:]]+$";""))
-            | map(select(. != ""))
-          ')" >> "$GITHUB_OUTPUT"
-      - name: "generate-matrix (active branches)"
-        if: inputs.branches == ''
-        id: generate-matrix-active
-        uses: ./.github/workflows/_get-active-branches.yaml
-        with:
-          beforeBranch: ${{ steps.get-pr-info.outputs.pr_base_ref }}
+  active-branches:
+    needs: pr-info
+    uses: ./.github/workflows/_get-active-branches.yaml
+    with:
+      beforeBranch: ${{ needs.pr-info.outputs.pr_base_ref }}
+      branches: ${{ inputs.branches }}
   open-prs:
-    needs:
-      - collect-info
+    needs: [pr-info, active-branches]
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
-        branch: ${{ fromJSON(needs.collect-info.outputs.branches) }}
-    runs-on: ubuntu-24.04
+        branch: ${{ fromJSON(needs.active-branches.outputs.out) }}
     env:
       PR_NUMBER: ${{ inputs.PR }}
-      PR_TITLE: ${{ needs.collect-info.outputs.pr_title }}
-      SHA: ${{ needs.collect-info.outputs.pr_merge_commit_sha }}
+      PR_TITLE: ${{ needs.pr-info.outputs.pr_title }}
+      SHA: ${{ needs.pr-info.outputs.pr_merge_commit_sha }}
       TARGET_BRANCH: ${{ matrix.branch }}
       USE_APP_TOKEN: ${{ secrets.APP_ID != '' }}
     steps:
@@ -123,16 +106,13 @@ jobs:
         with:
           append: true
           message: backporting to ${{ matrix.branch }} with [action](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
-      - id: github-app-token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+      - name: Generate GitHub app token
+        id: github-app-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
         if: ${{ env.USE_APP_TOKEN == 'true' }}
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
-      - id: github-context-token
-        if: ${{ env.USE_APP_TOKEN != 'true' }}
-        run: |
-          echo "token=${{ github.token }}" >> $GITHUB_OUTPUT
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           ref: ${{ env.TARGET_BRANCH }}
@@ -175,7 +155,7 @@ jobs:
             
             ${{ env.DIFF }}
             
-            ${{ needs.collect-info.outputs.pr_change_log }}
+            ${{ needs.pr-info.outputs.pr_change_log }}
           commit-message: |
             Automatic cherry-pick of PR ${{ env.PR_NUMBER }} for branch ${{ env.TARGET_BRANCH }}
             
@@ -183,6 +163,6 @@ jobs:
           delete-branch: true
           draft: ${{ contains(env.LABELS, 'conflict') }}
           labels: ${{ env.LABELS }}
-          token: ${{env.USE_APP_TOKEN == 'true' && steps.github-app-token.outputs.token || steps.github-context-token.outputs.token }}
+          token: ${{ env.USE_APP_TOKEN == 'true' && steps.github-app-token.outputs.token || github.token }}
           committer: ${{ env.GH_USER }} ${{ env.GH_EMAIL }}
           author: ${{ env.GH_USER }} ${{ env.GH_EMAIL }}

--- a/.github/workflows/ci-stability-release-branches.yaml
+++ b/.github/workflows/ci-stability-release-branches.yaml
@@ -15,23 +15,16 @@ env:
   WORKFLOW_ID_TO_TRIGGER: build-test-distribute.yaml
 
 jobs:
-  get-active-release-branches:
-    runs-on: ubuntu-24.04
+  active-branches:
+    uses: ./.github/workflows/_get-active-branches.yaml
     permissions:
       contents: read
-    outputs:
-      branches: ${{ steps.active-branches.outputs.out }}
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - name: "Get active branches"
-        id: active-branches
-        uses: ./.github/workflows/_get-active-branches.yaml
-        with:
-          excludeDefault: true
-          summary: true
+    with:
+      excludeDefault: true
+      summary: true
 
   trigger-build-test-distribute:
-    needs: get-active-release-branches
+    needs: active-branches
     runs-on: ubuntu-24.04
     permissions:
       actions: write # required to trigger workflows
@@ -39,7 +32,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        branch: ${{ fromJSON(needs.get-active-release-branches.outputs.branches) }}
+        branch: ${{ fromJSON(needs.active-branches.outputs.out) }}
       fail-fast: false
       max-parallel: 1
     env:

--- a/.github/workflows/pr-modification.yaml
+++ b/.github/workflows/pr-modification.yaml
@@ -9,22 +9,23 @@ on:
         default: '10 minutes'
 permissions: {}
 jobs:
+  active-branches:
+    uses: ./.github/workflows/_get-active-branches.yaml
+    permissions:
+      contents: read
   find-prs:
+    runs-on: ubuntu-24.04
+    needs: active-branches
     permissions:
       contents: read
       pull-requests: read
     env:
       LOOK_BACK: ${{ github.event.inputs.lookback || '10 minutes' }}
       GH_TOKEN: ${{ github.token }}
-    runs-on: ubuntu-24.04
     outputs:
       recent_prs: ${{ steps.get-recent-prs.outputs.out }}
-      active_branches: ${{ steps.active-branches.outputs.out }}
+      active_branches: ${{ needs.active-branches.outputs.out }}
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - name: Get active branches
-        id: active-branches
-        uses: ./.github/workflows/_get-active-branches.yaml
       - id: get-recent-prs
         name: Get recent PRs
         run: |
@@ -37,7 +38,7 @@ jobs:
       - name: Show outputs
         env:
           RECENT_PRS: ${{ steps.get-recent-prs.outputs.out }}
-          ACTIVE_BRANCHES: ${{ steps.active-branches.outputs.out }}
+          ACTIVE_BRANCHES: ${{ needs.active-branches.outputs.out }}
         run: |
           echo "::group::recent-prs"
           echo "${RECENT_PRS}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,8 @@ env:
   CHECK: ${{ inputs.check || 'false' }}
   EDITION: kuma
   MIN_VERSION: "2.2.0"
+  # renovate: datasource=go depName=ci-tools/release-tool packageName=github.com/kumahq/ci-tools versioning=semver
+  RELEASE_TOOL_VERSION: "v1.1.5"
 permissions:
   contents: read
 jobs:
@@ -44,7 +46,7 @@ jobs:
       - name: install-kuma-ci-tools
         run: |
           echo $(go env GOPATH)/bin >> $GITHUB_PATH
-          go install github.com/kumahq/ci-tools/cmd/release-tool@v1.1.5
+          go install github.com/kumahq/ci-tools/cmd/release-tool@${{ env.RELEASE_TOOL_VERSION }}
       - name: Generate GitHub app token
         id: github-app-token
         uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4

--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -18,7 +18,10 @@ env:
 permissions:
   contents: read
 jobs:
+  active-branches:
+    uses: ./.github/workflows/_get-active-branches.yaml
   generate-docs:
+    needs: active-branches
     timeout-minutes: 10
     runs-on: ubuntu-24.04
     steps:
@@ -30,15 +33,12 @@ jobs:
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version-file: repo/go.mod
-      - name: "Get active branches"
-        id: active-branches
-        uses: ./.github/workflows/_get-active-branches.yaml
       - name: "sync docs" # loop over all the branches and generate the docs
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           GH_DEBUG: ${{ runner.debug == '1' }}
-          BRANCHES: ${{ steps.active-branches.outputs.out }}
+          BRANCHES: ${{ needs.active-branches.outputs.out }}
         run: |
           [[ "${GH_DEBUG}" == "1" ]] && set -x
           set -euo pipefail

--- a/.github/workflows/update-insecure-dependencies.yaml
+++ b/.github/workflows/update-insecure-dependencies.yaml
@@ -5,26 +5,17 @@ on:
     - cron: 0 3 * * *
 permissions: read-all
 jobs:
-  build-matrix:
-    timeout-minutes: 10
-    runs-on: ubuntu-24.04
-    outputs:
-      branches: ${{ steps.generate-matrix.outputs.out }}
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - name: "Get active branches"
-        id: generate-matrix
-        uses: ./.github/workflows/_get-active-branches.yaml
+  active-branches:
+    uses: ./.github/workflows/_get-active-branches.yaml
   update-insecure-dependencies:
     env:
       OSV_SCANNER_ADDITIONAL_OPTS: ""
     timeout-minutes: 20
-    needs:
-      - build-matrix
+    needs: active-branches
     strategy:
       fail-fast: false
       matrix:
-        branch: ${{ fromJSON(needs.build-matrix.outputs.branches) }}
+        branch: ${{ fromJSON(needs.active-branches.outputs.out) }}
     runs-on: ubuntu-24.04
     steps:
       - name: Set Swap Space

--- a/renovate.json
+++ b/renovate.json
@@ -175,6 +175,17 @@
     },
     {
       "description": [
+        " Apply the 'immediately' helper for all dependencies from the 'kumahq' org (matching both",
+        " 'kumahq/*' and 'github.com/kumahq/*') so Renovate proposes updates as soon as they're",
+        " available, without waiting for the default release-age delay. This lets us consume our own",
+        " releases quickly while other third-party dependencies continue to observe their configured",
+        " delays"
+      ],
+      "matchPackageNames": ["{,github.com/}kumahq/**"],
+      "extends": ["Kong/public-shared-renovate//helpers/immediately"]
+    },
+    {
+      "description": [
         " Disable all dependency updates by default on 'release-*' branches to keep",
         " those branches stable and predictable"
       ],


### PR DESCRIPTION
## Motivation

We had repeated logic across workflows to compute active branches and some places invoked the reusable `_get-active-branches.yaml` as a step. Reusable workflows must run as separate jobs. Calling them as steps is invalid and caused fragile behavior. In `backport.yaml` it did not fail but it was still wrong.

## Implementation information

- Extended the reusable workflow with a `branches` input and a short-circuit that returns a validated JSON array
- Switched all callers to use `_get-active-branches.yaml` as a separate job and to consume outputs through `needs`
- Fixed jobs that previously used the reusable workflow as a step and adjusted matrices to read from the job outputs
- Refactored `backport.yaml` into `pr-info` and `active-branches`, updated token generation to `actions/create-github-app-token`, and simplified token selection with a fallback to `github.token`
- Parameterized the release tool version via `RELEASE_TOOL_VERSION`
- Taught Renovate to apply the `immediately` helper to all `kumahq/**` packages to propose internal updates as soon as they are available

## Additional information

I have tested all of the changed workflows on my fork