### PR TITLE
ci(renovate): label release-tool workflow bumps to skip tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kumahq/kuma
 
-go 1.25.0
+go 1.25.1
 
 require (
 	cirello.io/pglock v1.16.1

--- a/renovate.json
+++ b/renovate.json
@@ -119,6 +119,15 @@
     },
     {
       "description": [
+        " For GitHub Actions workflow updates to 'ci-tools/release-tool' under '.github/workflows/**':",
+        " add the 'ci/skip-test' label so these workflow-only bumps don't run the full test matrix"
+      ],
+      "matchFileNames": [".github/workflows/**"],
+      "matchDepNames": ["ci-tools/release-tool"],
+      "addLabels": ["ci/skip-test"]
+    },
+    {
+      "description": [
         "Apply a 24h minimumReleaseAge to dependencies from the 'kumahq' GitHub org",
         "(matching both 'kumahq/*' and 'github.com/kumahq/*'). Unlike the default 12-day delay,",
         "this shorter window gives us enough time to catch mistakes or regressions in freshly",


### PR DESCRIPTION
## Motivation

Reduce CI waste on workflow-only updates and align the project with the latest stable Go patch release for incremental fixes and stability.

## Implementation information

- Renovate: introduced a rule that detects updates to `ci-tools/release-tool` within `.github/workflows/**` and adds the `ci/skip-test` label, ensuring these PRs avoid the full test matrix while remaining visible to reviewers
- Go: bumped the toolchain in `go.mod` from `1.25.0` to `1.25.1` to pick up upstream bug fixes and improvements with no expected breaking changes