### PR TITLE
test(e2e/helm): fix upgrade test registry logic after `bitnami` changes

### DIFF
--- a/test/e2e/helm/kuma_helm_upgrade_standalone.go
+++ b/test/e2e/helm/kuma_helm_upgrade_standalone.go
@@ -35,7 +35,7 @@ func UpgradingWithHelmChartStandalone() {
 
 			opts := []KumaDeploymentOption{
 				WithInstallationMode(HelmInstallationMode),
-				WithHelmChartPath(Config.HelmChartPath),
+				WithHelmChartPath(Config.HelmChartName),
 				WithHelmReleaseName(releaseName),
 				WithHelmChartVersion(version),
 				WithoutHelmOpt("global.image.tag"),

--- a/test/e2e/helm/kuma_helm_upgrade_standalone.go
+++ b/test/e2e/helm/kuma_helm_upgrade_standalone.go
@@ -67,6 +67,7 @@ func UpgradingWithHelmChartStandalone() {
 			err = k8sCluster.UpgradeKuma(core.Zone,
 				WithHelmReleaseName(releaseName),
 				WithHelmChartPath(Config.HelmChartPath),
+				WithoutHelmOpt("kubectl.image.tag"),
 				ClearNoHelmOpts(),
 			)
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/helm/kuma_helm_upgrade_standalone.go
+++ b/test/e2e/helm/kuma_helm_upgrade_standalone.go
@@ -33,15 +33,32 @@ func UpgradingWithHelmChartStandalone() {
 				strings.ToLower(random.UniqueId()),
 			)
 
+			opts := []KumaDeploymentOption{
+				WithInstallationMode(HelmInstallationMode),
+				WithHelmChartPath(Config.HelmChartPath),
+				WithHelmReleaseName(releaseName),
+				WithHelmChartVersion(version),
+				WithoutHelmOpt("global.image.tag"),
+			}
+
+			// Bitnami registry changes:
+			// We switched the kubectl image source from Bitnami to the official registry.k8s.io
+			// on supported release branches. These changes were not backported to 2.8.x, which is
+			// out of support and still uses the Bitnami image. After Bitnami's registry changes,
+			// installation of 2.8 fails in our upgrade tests because the Bitnami kubectl repository
+			// does not provide versioned tags.
+			// Our upgrade tests purposely install older versions (like 2.8.4) and then upgrade them,
+			// so fixing this properly would require releasing a new, long out-of-support 2.8 just to
+			// change the registry. Instead, for 2.8.x only, we set kubectl.image.tag to "latest"
+			// (a tag that still exists), which should keep these tests passing until upgrades only
+			// involve supported versions that already use the new registry.
+			if strings.HasPrefix(version, "2.8.") {
+				opts = append(opts, WithHelmOpt("kubectl.image.tag", "latest"))
+			}
+
 			// nolint:staticcheck
 			err := NewClusterSetup().
-				Install(Kuma(core.Standalone,
-					WithInstallationMode(HelmInstallationMode),
-					WithHelmChartPath(Config.HelmChartName),
-					WithHelmReleaseName(releaseName),
-					WithHelmChartVersion(version),
-					WithoutHelmOpt("global.image.tag"),
-				)).
+				Install(Kuma(core.Standalone, opts...)).
 				Setup(cluster)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/helm/kuma_helm_upgrade_standalone.go
+++ b/test/e2e/helm/kuma_helm_upgrade_standalone.go
@@ -67,8 +67,8 @@ func UpgradingWithHelmChartStandalone() {
 			err = k8sCluster.UpgradeKuma(core.Zone,
 				WithHelmReleaseName(releaseName),
 				WithHelmChartPath(Config.HelmChartPath),
-				WithoutHelmOpt("kubectl.image.tag"),
 				ClearNoHelmOpts(),
+				WithoutHelmOpt("kubectl.image.tag"),
 			)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/test/framework/config.go
+++ b/test/framework/config.go
@@ -210,7 +210,7 @@ var defaultConf = E2eConfig{
 	KumaZoneK8sCtlFlags:  map[string]string{},
 	SuiteConfig: SuiteConfig{
 		Compatibility: CompatibilitySuiteConfig{
-			HelmVersion: "2.6.10",
+			HelmVersion: "2.7.17",
 		},
 	},
 	K8sType:                      KindK8sType,

--- a/test/framework/ginkgo.go
+++ b/test/framework/ginkgo.go
@@ -100,6 +100,8 @@ func E2EDeferCleanup(args ...interface{}) {
 }
 
 func SupportedVersionEntries() []ginkgo.TableEntry {
+	ginkgo.GinkgoHelper()
+
 	var res []ginkgo.TableEntry
 	for _, v := range versions.UpgradableVersionsFromBuild(Config.SupportedVersions()) {
 		res = append(res, ginkgo.Entry(nil, v))

--- a/versions.yml
+++ b/versions.yml
@@ -83,7 +83,7 @@
   endOfLifeDate: "2025-02-01"
   branch: release-2.6
 - edition: kuma
-  version: 2.7.8
+  version: 2.7.17
   release: 2.7.x
   releaseDate: "2024-04-19"
   endOfLifeDate: "2026-04-19"


### PR DESCRIPTION
## Motivation

CI on `release-2.9` was failing due to two issues: outdated test defaults and a `Bitnami` registry change that broke Helm upgrade tests for `2.8.x`. We needed to align our patch lines with current supported releases and ensure a stable upgrade flow unaffected by deprecated image sources.

## Implementation information

- Bumped the default `Helm` version used in tests to match the compatibility level of the supported Kuma release line (`2.7.x`), as `2.6.x` is out of support and no longer relevant for CI.
- Updated `versions.yml` to use the latest patch releases that reference images from the official `registry.k8s.io` instead of the deprecated `Bitnami` registry. This ensures consistent `kubectl` image availability and resolves upgrade test failures.
- Adjusted the Helm upgrade e2e for standalone installs to set `kuma.kubectl.image.tag` to `latest` during upgrade tests for `2.8.x`, ensuring a valid image tag is always pulled and keeping the test focused on the control plane upgrade rather than external registry differences.