### PR TITLE
test(e2e/helm): fix upgrade test registry logic after `bitnami` changes

### DIFF
--- a/test/e2e/helm/kuma_helm_upgrade_standalone.go
+++ b/test/e2e/helm/kuma_helm_upgrade_standalone.go
@@ -67,6 +67,7 @@ func UpgradingWithHelmChartStandalone() {
 			err = k8sCluster.UpgradeKuma(core.Zone,
 				WithHelmReleaseName(releaseName),
 				WithHelmChartPath(Config.HelmChartPath),
+				WithoutHelmOpt("kubectl.image.tag"),
 				ClearNoHelmOpts(),
 			)
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/helm/kuma_helm_upgrade_standalone.go
+++ b/test/e2e/helm/kuma_helm_upgrade_standalone.go
@@ -67,8 +67,8 @@ func UpgradingWithHelmChartStandalone() {
 			err = k8sCluster.UpgradeKuma(core.Zone,
 				WithHelmReleaseName(releaseName),
 				WithHelmChartPath(Config.HelmChartPath),
-				WithoutHelmOpt("kubectl.image.tag"),
 				ClearNoHelmOpts(),
+				WithoutHelmOpt("kubectl.image.tag"),
 			)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/test/framework/config.go
+++ b/test/framework/config.go
@@ -214,7 +214,7 @@ var defaultConf = E2eConfig{
 	KumaZoneK8sCtlFlags:  map[string]string{},
 	SuiteConfig: SuiteConfig{
 		Compatibility: CompatibilitySuiteConfig{
-			HelmVersion: "2.6.10",
+			HelmVersion: "2.7.17",
 		},
 	},
 	K8sType:                      KindK8sType,

--- a/test/framework/ginkgo.go
+++ b/test/framework/ginkgo.go
@@ -100,6 +100,8 @@ func E2EDeferCleanup(args ...interface{}) {
 }
 
 func SupportedVersionEntries() []ginkgo.TableEntry {
+	ginkgo.GinkgoHelper()
+
 	var res []ginkgo.TableEntry
 	for _, v := range versions.UpgradableVersionsFromBuild(Config.SupportedVersions()) {
 		res = append(res, ginkgo.Entry(nil, v))

--- a/versions.yml
+++ b/versions.yml
@@ -29,20 +29,20 @@
   endOfLifeDate: "2025-02-01"
   branch: release-2.6
 - edition: kuma
-  version: 2.7.12
+  version: 2.7.17
   release: 2.7.x
   releaseDate: "2024-04-19"
   endOfLifeDate: "2026-04-19"
   branch: release-2.7
   lts: true
 - edition: kuma
-  version: 2.8.7
+  version: 2.8.8
   release: 2.8.x
   releaseDate: "2024-06-24"
   endOfLifeDate: "2025-06-24"
   branch: release-2.8
 - edition: kuma
-  version: 2.9.4
+  version: 2.9.9
   release: 2.9.x
   latest: true
   releaseDate: "2024-10-22"


### PR DESCRIPTION
## Motivation

CI on `release-2.10` was failing due to outdated version defaults and the deprecation of the `Bitnami` registry, which broke Helm upgrade tests for `2.8.x`. We needed to align patch lines with supported releases and ensure a reliable upgrade flow independent of old image sources.

## Implementation information

- Bumped the default `Helm` version used by tests to match the compatibility level of the supported Kuma line (`2.7.x`), as `2.6.x` is no longer supported
- Updated `versions.yml` to the latest patch releases we track: `2.7.17`, `2.8.8`, and `2.9.9`, which now use images from the official `registry.k8s.io` instead of the deprecated `Bitnami` registry. This keeps CI and documentation aligned with maintained image sources
- Adjusted the standalone Helm upgrade e2e, so for `2.8.x` only, set `kubectl.image.tag` to `latest` to handle the registry migration and ensure valid image pulls during upgrade tests.
