### PR TITLE
ci(k3d): add CNI selector, switch Calico to Helm, bump MetalLB

### DIFF
--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -188,7 +188,7 @@ k3d/configure/cni: k3d/configure/cni/$(K3D_NETWORK_CNI_EFFECTIVE)
 k3d/configure/cni/flannel:
 	@true
 
-# Calico (runs when K3D_CNI=calico)
+# Calico (runs when K3D_NETWORK_CNI=calico)
 .PHONY: k3d/configure/cni/calico
 k3d/configure/cni/calico:
 	@helm repo add $(CALICO_HELM_REPO_NAME) $(CALICO_HELM_REPO_ADDR) >/dev/null


### PR DESCRIPTION
## Motivation

Bringing up k3d clusters needed more flexibility and reliability. The previous flow hard coded Calico and applied a single YAML, which made switching CNIs harder and versions opaque. Some tests that depend on Calico were flaky because components were not fully ready when tests started.

## Implementation information

- Introduced a dispatcher target `k3d/configure/cni` that selects the CNI with `K3D_NETWORK_CNI`. Default is flannel which needs no extra steps. A guard target fails fast on unsupported values.
- Switched Calico setup to Helm with explicit repo, chart, release, namespace, and version variables. Enabled `--install --create-namespace --wait` so the cluster only proceeds when Calico is actually ready, which should remove timing-related flakes in tests that rely on Calico.
- Upgraded MetalLB to `v0.15.2` and parameterized the manifests URL and namespace so we can pin and update more safely.
- Kept the existing k3s flags to disable flannel and network policy when Calico is used. Split long argument additions for readability.