### PR TITLE
chore(oas): add validation of a full OAS

### DIFF
--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -60,3 +60,4 @@ ifdef BASE_API
 else
 	docker run --rm -v $(OAPI_TMP_DIR):/specs ghcr.io/kumahq/openapi-tool:$(OAPI_TOOLS_VERSION) generate '/specs/**/*.yaml' > $@
 endif
+	$(MAKE) --no-print-directory validate/openapi-generated-docs

--- a/mk/generate.mk
+++ b/mk/generate.mk
@@ -116,6 +116,21 @@ generate/oas: $(GENERATE_OAS_PREREQUISITES) $(RESOURCE_GEN) $(OAPI_GEN)
 	$(RESOURCE_GEN) -package mesh -generator openapi -readDir $(KUMA_DIR) -writeDir .
 	$(OAPI_GEN) kri
 
+.PHONY: validate/openapi-generated-docs
+validate/openapi-generated-docs:
+	@schema=docs/generated/openapi.yaml; \
+	if [ ! -f $$schema ]; then \
+		echo "Error: $$schema not found. Run 'make docs/generated/openapi.yaml' first."; \
+		exit 1; \
+	fi; \
+	mkdir -p $(BUILD_DIR); \
+	tmp_file=$$(mktemp $(BUILD_DIR)/openapi-validate.XXXXXX.go); \
+	if ! $(OAPI_CODEGEN) -config api/openapi/openapi.cfg.yaml -o $$tmp_file $$schema; then \
+		rm -f $$tmp_file; \
+		exit 1; \
+	fi; \
+	rm -f $$tmp_file
+
 .PHONY: generate/oas-for-ts
 generate/oas-for-ts: generate/oas docs/generated/openapi.yaml ## Regenerate OpenAPI spec from `/api/openapi/specs` ready for typescript type generation
 


### PR DESCRIPTION
## Motivation

When we moved some schemas under the `components.responses` we have caught the issue only in Kong Mesh. We could've catch it earlier with OAS validation.

Now when I try changes from https://github.com/kumahq/kuma/pull/12558 I immediately see the error:
```
error loading swagger spec in docs/generated/openapi.yaml
: failed to load OpenAPI specification: bad data in "#/components/responses/HostnameGeneratorDeleteSuccessResponse" (expecting ref to schema object)
make[1]: *** [validate/openapi-generated-docs] Error 1
make: *** [docs/generated/openapi.yaml] Error 2
```

Which happens because `component.schemas` and `component.responses` have different schemas. 
```yaml
components:
  schemas:
    type: object
    description: "..."
    properties: {}
  responses:
    description: "..."
    content:
      application/json:
        schema: {}
```

So we can't just move the type from `schemas` to `responses`, we need to add `content`.

## Implementation information

New `validate/openapi-generated-docs` target that runs at the end of `docs/generated/openapi.yaml`

