### PR TITLE
chore(oapi): move `*Response` types under the `components.responses`

### DIFF
--- a/api/mesh/v1alpha1/dataplane/rest.yaml
+++ b/api/mesh/v1alpha1/dataplane/rest.yaml
@@ -56,17 +56,9 @@ paths:
               $ref: '#/components/schemas/DataplaneItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DataplaneCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/DataplaneCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DataplaneCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/DataplaneCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: deleteDataplane
@@ -87,11 +79,7 @@ paths:
           description: name of the Dataplane
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DataplaneDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/DataplaneDeleteSuccessResponse'
         '404':
           $ref: "/specs/base/specs/common/error_schema.yaml#/components/responses/NotFound"
 
@@ -144,20 +132,6 @@ components:
   schemas:
     DataplaneItem:
       $ref: 'schema.yaml'
-    DataplaneCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: |
-            warnings is a list of warning messages to return to the requesting Kuma API clients.
-            Warning messages describe a problem the client making the API request should correct or be aware of.
-          items:
-            type: string
-    DataplaneDeleteSuccessResponse:
-      type: object
-      properties: {}
 
   responses:
     DataplaneItem:
@@ -183,3 +157,24 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    DataplaneCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: |
+                  warnings is a list of warning messages to return to the requesting Kuma API clients.
+                  Warning messages describe a problem the client making the API request should correct or be aware of.
+                items:
+                  type: string
+    DataplaneDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object

--- a/api/mesh/v1alpha1/mesh/rest.yaml
+++ b/api/mesh/v1alpha1/mesh/rest.yaml
@@ -44,17 +44,9 @@ paths:
               $ref: '#/components/schemas/MeshItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: deleteMesh
@@ -69,11 +61,7 @@ paths:
           description: name of the Mesh
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshDeleteSuccessResponse'
         '404':
           $ref: "/specs/base/specs/common/error_schema.yaml#/components/responses/NotFound"
 
@@ -120,20 +108,6 @@ components:
   schemas:
     MeshItem:
       $ref: 'schema.yaml'
-    MeshCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: |
-            warnings is a list of warning messages to return to the requesting Kuma API clients.
-            Warning messages describe a problem the client making the API request should correct or be aware of.
-          items:
-            type: string
-    MeshDeleteSuccessResponse:
-      type: object
-      properties: {}
 
   responses:
     MeshItem:
@@ -159,3 +133,24 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: |
+                  warnings is a list of warning messages to return to the requesting Kuma API clients.
+                  Warning messages describe a problem the client making the API request should correct or be aware of.
+                items:
+                  type: string
+    MeshDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object

--- a/api/mesh/v1alpha1/meshgateway/rest.yaml
+++ b/api/mesh/v1alpha1/meshgateway/rest.yaml
@@ -56,17 +56,9 @@ paths:
               $ref: '#/components/schemas/MeshGatewayItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshGatewayCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshGatewayCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshGatewayCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshGatewayCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: deleteMeshGateway
@@ -87,11 +79,7 @@ paths:
           description: name of the MeshGateway
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshGatewayDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshGatewayDeleteSuccessResponse'
         '404':
           $ref: "/specs/base/specs/common/error_schema.yaml#/components/responses/NotFound"
 
@@ -144,20 +132,6 @@ components:
   schemas:
     MeshGatewayItem:
       $ref: 'schema.yaml'
-    MeshGatewayCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: |
-            warnings is a list of warning messages to return to the requesting Kuma API clients.
-            Warning messages describe a problem the client making the API request should correct or be aware of.
-          items:
-            type: string
-    MeshGatewayDeleteSuccessResponse:
-      type: object
-      properties: {}
 
   responses:
     MeshGatewayItem:
@@ -183,3 +157,24 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshGatewayCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: |
+                  warnings is a list of warning messages to return to the requesting Kuma API clients.
+                  Warning messages describe a problem the client making the API request should correct or be aware of.
+                items:
+                  type: string
+    MeshGatewayDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object

--- a/api/mesh/v1alpha1/zoneegress/rest.yaml
+++ b/api/mesh/v1alpha1/zoneegress/rest.yaml
@@ -44,17 +44,9 @@ paths:
               $ref: '#/components/schemas/ZoneEgressItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ZoneEgressCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/ZoneEgressCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ZoneEgressCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/ZoneEgressCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: deleteZoneEgress
@@ -69,11 +61,7 @@ paths:
           description: name of the ZoneEgress
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ZoneEgressDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/ZoneEgressDeleteSuccessResponse'
         '404':
           $ref: "/specs/base/specs/common/error_schema.yaml#/components/responses/NotFound"
 
@@ -120,20 +108,6 @@ components:
   schemas:
     ZoneEgressItem:
       $ref: 'schema.yaml'
-    ZoneEgressCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: |
-            warnings is a list of warning messages to return to the requesting Kuma API clients.
-            Warning messages describe a problem the client making the API request should correct or be aware of.
-          items:
-            type: string
-    ZoneEgressDeleteSuccessResponse:
-      type: object
-      properties: {}
 
   responses:
     ZoneEgressItem:
@@ -159,3 +133,24 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    ZoneEgressCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: |
+                  warnings is a list of warning messages to return to the requesting Kuma API clients.
+                  Warning messages describe a problem the client making the API request should correct or be aware of.
+                items:
+                  type: string
+    ZoneEgressDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object

--- a/api/mesh/v1alpha1/zoneingress/rest.yaml
+++ b/api/mesh/v1alpha1/zoneingress/rest.yaml
@@ -44,17 +44,9 @@ paths:
               $ref: '#/components/schemas/ZoneIngressItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ZoneIngressCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/ZoneIngressCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ZoneIngressCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/ZoneIngressCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: deleteZoneIngress
@@ -69,11 +61,7 @@ paths:
           description: name of the ZoneIngress
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ZoneIngressDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/ZoneIngressDeleteSuccessResponse'
         '404':
           $ref: "/specs/base/specs/common/error_schema.yaml#/components/responses/NotFound"
 
@@ -120,20 +108,6 @@ components:
   schemas:
     ZoneIngressItem:
       $ref: 'schema.yaml'
-    ZoneIngressCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: |
-            warnings is a list of warning messages to return to the requesting Kuma API clients.
-            Warning messages describe a problem the client making the API request should correct or be aware of.
-          items:
-            type: string
-    ZoneIngressDeleteSuccessResponse:
-      type: object
-      properties: {}
 
   responses:
     ZoneIngressItem:
@@ -159,3 +133,24 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    ZoneIngressCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: |
+                  warnings is a list of warning messages to return to the requesting Kuma API clients.
+                  Warning messages describe a problem the client making the API request should correct or be aware of.
+                items:
+                  type: string
+    ZoneIngressDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -478,19 +478,9 @@ paths:
               $ref: '#/components/schemas/MeshAccessLogItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: >-
-                  #/components/schemas/MeshAccessLogCreateOrUpdateSuccessResponse
+          $ref: '#/components/responses/MeshAccessLogCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: >-
-                  #/components/schemas/MeshAccessLogCreateOrUpdateSuccessResponse
+          $ref: '#/components/responses/MeshAccessLogCreateOrUpdateSuccessResponse'
     delete:
       operationId: deleteMeshAccessLog
       summary: Deletes MeshAccessLog entity
@@ -511,11 +501,7 @@ paths:
           description: name of the MeshAccessLog
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshAccessLogDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshAccessLogDeleteSuccessResponse'
         '404':
           $ref: '#/components/responses/NotFound'
   /meshes/{mesh}/meshaccesslogs:
@@ -614,19 +600,11 @@ paths:
               $ref: '#/components/schemas/MeshCircuitBreakerItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: >-
-                  #/components/schemas/MeshCircuitBreakerCreateOrUpdateSuccessResponse
+          $ref: >-
+            #/components/responses/MeshCircuitBreakerCreateOrUpdateSuccessResponse
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: >-
-                  #/components/schemas/MeshCircuitBreakerCreateOrUpdateSuccessResponse
+          $ref: >-
+            #/components/responses/MeshCircuitBreakerCreateOrUpdateSuccessResponse
     delete:
       operationId: deleteMeshCircuitBreaker
       summary: Deletes MeshCircuitBreaker entity
@@ -647,11 +625,7 @@ paths:
           description: name of the MeshCircuitBreaker
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshCircuitBreakerDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshCircuitBreakerDeleteSuccessResponse'
         '404':
           $ref: '#/components/responses/NotFound'
   /meshes/{mesh}/meshcircuitbreakers:
@@ -750,19 +724,11 @@ paths:
               $ref: '#/components/schemas/MeshFaultInjectionItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: >-
-                  #/components/schemas/MeshFaultInjectionCreateOrUpdateSuccessResponse
+          $ref: >-
+            #/components/responses/MeshFaultInjectionCreateOrUpdateSuccessResponse
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: >-
-                  #/components/schemas/MeshFaultInjectionCreateOrUpdateSuccessResponse
+          $ref: >-
+            #/components/responses/MeshFaultInjectionCreateOrUpdateSuccessResponse
     delete:
       operationId: deleteMeshFaultInjection
       summary: Deletes MeshFaultInjection entity
@@ -783,11 +749,7 @@ paths:
           description: name of the MeshFaultInjection
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshFaultInjectionDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshFaultInjectionDeleteSuccessResponse'
         '404':
           $ref: '#/components/responses/NotFound'
   /meshes/{mesh}/meshfaultinjections:
@@ -886,19 +848,9 @@ paths:
               $ref: '#/components/schemas/MeshHealthCheckItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: >-
-                  #/components/schemas/MeshHealthCheckCreateOrUpdateSuccessResponse
+          $ref: '#/components/responses/MeshHealthCheckCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: >-
-                  #/components/schemas/MeshHealthCheckCreateOrUpdateSuccessResponse
+          $ref: '#/components/responses/MeshHealthCheckCreateOrUpdateSuccessResponse'
     delete:
       operationId: deleteMeshHealthCheck
       summary: Deletes MeshHealthCheck entity
@@ -919,11 +871,7 @@ paths:
           description: name of the MeshHealthCheck
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshHealthCheckDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshHealthCheckDeleteSuccessResponse'
         '404':
           $ref: '#/components/responses/NotFound'
   /meshes/{mesh}/meshhealthchecks:
@@ -1022,19 +970,9 @@ paths:
               $ref: '#/components/schemas/MeshHTTPRouteItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: >-
-                  #/components/schemas/MeshHTTPRouteCreateOrUpdateSuccessResponse
+          $ref: '#/components/responses/MeshHTTPRouteCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: >-
-                  #/components/schemas/MeshHTTPRouteCreateOrUpdateSuccessResponse
+          $ref: '#/components/responses/MeshHTTPRouteCreateOrUpdateSuccessResponse'
     delete:
       operationId: deleteMeshHTTPRoute
       summary: Deletes MeshHTTPRoute entity
@@ -1055,11 +993,7 @@ paths:
           description: name of the MeshHTTPRoute
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshHTTPRouteDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshHTTPRouteDeleteSuccessResponse'
         '404':
           $ref: '#/components/responses/NotFound'
   /meshes/{mesh}/meshhttproutes:
@@ -1158,19 +1092,11 @@ paths:
               $ref: '#/components/schemas/MeshLoadBalancingStrategyItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: >-
-                  #/components/schemas/MeshLoadBalancingStrategyCreateOrUpdateSuccessResponse
+          $ref: >-
+            #/components/responses/MeshLoadBalancingStrategyCreateOrUpdateSuccessResponse
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: >-
-                  #/components/schemas/MeshLoadBalancingStrategyCreateOrUpdateSuccessResponse
+          $ref: >-
+            #/components/responses/MeshLoadBalancingStrategyCreateOrUpdateSuccessResponse
     delete:
       operationId: deleteMeshLoadBalancingStrategy
       summary: Deletes MeshLoadBalancingStrategy entity
@@ -1191,12 +1117,8 @@ paths:
           description: name of the MeshLoadBalancingStrategy
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: >-
-                  #/components/schemas/MeshLoadBalancingStrategyDeleteSuccessResponse
-          description: Successful response
+          $ref: >-
+            #/components/responses/MeshLoadBalancingStrategyDeleteSuccessResponse
         '404':
           $ref: '#/components/responses/NotFound'
   /meshes/{mesh}/meshloadbalancingstrategies:
@@ -1295,17 +1217,9 @@ paths:
               $ref: '#/components/schemas/MeshMetricItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshMetricCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshMetricCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshMetricCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshMetricCreateOrUpdateSuccessResponse'
     delete:
       operationId: deleteMeshMetric
       summary: Deletes MeshMetric entity
@@ -1326,11 +1240,7 @@ paths:
           description: name of the MeshMetric
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshMetricDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshMetricDeleteSuccessResponse'
         '404':
           $ref: '#/components/responses/NotFound'
   /meshes/{mesh}/meshmetrics:
@@ -1429,19 +1339,9 @@ paths:
               $ref: '#/components/schemas/MeshPassthroughItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: >-
-                  #/components/schemas/MeshPassthroughCreateOrUpdateSuccessResponse
+          $ref: '#/components/responses/MeshPassthroughCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: >-
-                  #/components/schemas/MeshPassthroughCreateOrUpdateSuccessResponse
+          $ref: '#/components/responses/MeshPassthroughCreateOrUpdateSuccessResponse'
     delete:
       operationId: deleteMeshPassthrough
       summary: Deletes MeshPassthrough entity
@@ -1462,11 +1362,7 @@ paths:
           description: name of the MeshPassthrough
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshPassthroughDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshPassthroughDeleteSuccessResponse'
         '404':
           $ref: '#/components/responses/NotFound'
   /meshes/{mesh}/meshpassthroughs:
@@ -1565,19 +1461,9 @@ paths:
               $ref: '#/components/schemas/MeshProxyPatchItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: >-
-                  #/components/schemas/MeshProxyPatchCreateOrUpdateSuccessResponse
+          $ref: '#/components/responses/MeshProxyPatchCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: >-
-                  #/components/schemas/MeshProxyPatchCreateOrUpdateSuccessResponse
+          $ref: '#/components/responses/MeshProxyPatchCreateOrUpdateSuccessResponse'
     delete:
       operationId: deleteMeshProxyPatch
       summary: Deletes MeshProxyPatch entity
@@ -1598,11 +1484,7 @@ paths:
           description: name of the MeshProxyPatch
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshProxyPatchDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshProxyPatchDeleteSuccessResponse'
         '404':
           $ref: '#/components/responses/NotFound'
   /meshes/{mesh}/meshproxypatches:
@@ -1701,19 +1583,9 @@ paths:
               $ref: '#/components/schemas/MeshRateLimitItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: >-
-                  #/components/schemas/MeshRateLimitCreateOrUpdateSuccessResponse
+          $ref: '#/components/responses/MeshRateLimitCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: >-
-                  #/components/schemas/MeshRateLimitCreateOrUpdateSuccessResponse
+          $ref: '#/components/responses/MeshRateLimitCreateOrUpdateSuccessResponse'
     delete:
       operationId: deleteMeshRateLimit
       summary: Deletes MeshRateLimit entity
@@ -1734,11 +1606,7 @@ paths:
           description: name of the MeshRateLimit
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshRateLimitDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshRateLimitDeleteSuccessResponse'
         '404':
           $ref: '#/components/responses/NotFound'
   /meshes/{mesh}/meshratelimits:
@@ -1837,17 +1705,9 @@ paths:
               $ref: '#/components/schemas/MeshRetryItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshRetryCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshRetryCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshRetryCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshRetryCreateOrUpdateSuccessResponse'
     delete:
       operationId: deleteMeshRetry
       summary: Deletes MeshRetry entity
@@ -1868,11 +1728,7 @@ paths:
           description: name of the MeshRetry
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshRetryDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshRetryDeleteSuccessResponse'
         '404':
           $ref: '#/components/responses/NotFound'
   /meshes/{mesh}/meshretries:
@@ -1971,17 +1827,9 @@ paths:
               $ref: '#/components/schemas/MeshTCPRouteItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshTCPRouteCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshTCPRouteCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshTCPRouteCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshTCPRouteCreateOrUpdateSuccessResponse'
     delete:
       operationId: deleteMeshTCPRoute
       summary: Deletes MeshTCPRoute entity
@@ -2002,11 +1850,7 @@ paths:
           description: name of the MeshTCPRoute
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshTCPRouteDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshTCPRouteDeleteSuccessResponse'
         '404':
           $ref: '#/components/responses/NotFound'
   /meshes/{mesh}/meshtcproutes:
@@ -2105,17 +1949,9 @@ paths:
               $ref: '#/components/schemas/MeshTimeoutItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshTimeoutCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshTimeoutCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshTimeoutCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshTimeoutCreateOrUpdateSuccessResponse'
     delete:
       operationId: deleteMeshTimeout
       summary: Deletes MeshTimeout entity
@@ -2136,11 +1972,7 @@ paths:
           description: name of the MeshTimeout
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshTimeoutDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshTimeoutDeleteSuccessResponse'
         '404':
           $ref: '#/components/responses/NotFound'
   /meshes/{mesh}/meshtimeouts:
@@ -2239,17 +2071,9 @@ paths:
               $ref: '#/components/schemas/MeshTLSItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshTLSCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshTLSCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshTLSCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshTLSCreateOrUpdateSuccessResponse'
     delete:
       operationId: deleteMeshTLS
       summary: Deletes MeshTLS entity
@@ -2270,11 +2094,7 @@ paths:
           description: name of the MeshTLS
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshTLSDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshTLSDeleteSuccessResponse'
         '404':
           $ref: '#/components/responses/NotFound'
   /meshes/{mesh}/meshtlses:
@@ -2373,17 +2193,9 @@ paths:
               $ref: '#/components/schemas/MeshTraceItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshTraceCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshTraceCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshTraceCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshTraceCreateOrUpdateSuccessResponse'
     delete:
       operationId: deleteMeshTrace
       summary: Deletes MeshTrace entity
@@ -2404,11 +2216,7 @@ paths:
           description: name of the MeshTrace
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshTraceDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshTraceDeleteSuccessResponse'
         '404':
           $ref: '#/components/responses/NotFound'
   /meshes/{mesh}/meshtraces:
@@ -2507,19 +2315,11 @@ paths:
               $ref: '#/components/schemas/MeshTrafficPermissionItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: >-
-                  #/components/schemas/MeshTrafficPermissionCreateOrUpdateSuccessResponse
+          $ref: >-
+            #/components/responses/MeshTrafficPermissionCreateOrUpdateSuccessResponse
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: >-
-                  #/components/schemas/MeshTrafficPermissionCreateOrUpdateSuccessResponse
+          $ref: >-
+            #/components/responses/MeshTrafficPermissionCreateOrUpdateSuccessResponse
     delete:
       operationId: deleteMeshTrafficPermission
       summary: Deletes MeshTrafficPermission entity
@@ -2540,12 +2340,7 @@ paths:
           description: name of the MeshTrafficPermission
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: >-
-                  #/components/schemas/MeshTrafficPermissionDeleteSuccessResponse
-          description: Successful response
+          $ref: '#/components/responses/MeshTrafficPermissionDeleteSuccessResponse'
         '404':
           $ref: '#/components/responses/NotFound'
   /meshes/{mesh}/meshtrafficpermissions:
@@ -2644,17 +2439,9 @@ paths:
               $ref: '#/components/schemas/DataplaneItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DataplaneCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/DataplaneCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DataplaneCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/DataplaneCreateOrUpdateSuccessResponse'
     delete:
       operationId: deleteDataplane
       summary: Deletes Dataplane entity
@@ -2675,11 +2462,7 @@ paths:
           description: name of the Dataplane
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DataplaneDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/DataplaneDeleteSuccessResponse'
         '404':
           $ref: '#/components/responses/NotFound'
   /meshes/{mesh}/dataplanes:
@@ -2806,17 +2589,9 @@ paths:
               $ref: '#/components/schemas/MeshItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshCreateOrUpdateSuccessResponse'
     delete:
       operationId: deleteMesh
       summary: Deletes Mesh entity
@@ -2831,11 +2606,7 @@ paths:
           description: name of the Mesh
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshDeleteSuccessResponse'
         '404':
           $ref: '#/components/responses/NotFound'
   /meshes:
@@ -2928,17 +2699,9 @@ paths:
               $ref: '#/components/schemas/MeshGatewayItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshGatewayCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshGatewayCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshGatewayCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshGatewayCreateOrUpdateSuccessResponse'
     delete:
       operationId: deleteMeshGateway
       summary: Deletes MeshGateway entity
@@ -2959,11 +2722,7 @@ paths:
           description: name of the MeshGateway
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshGatewayDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshGatewayDeleteSuccessResponse'
         '404':
           $ref: '#/components/responses/NotFound'
   /meshes/{mesh}/meshgateways:
@@ -3050,17 +2809,9 @@ paths:
               $ref: '#/components/schemas/ZoneEgressItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ZoneEgressCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/ZoneEgressCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ZoneEgressCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/ZoneEgressCreateOrUpdateSuccessResponse'
     delete:
       operationId: deleteZoneEgress
       summary: Deletes ZoneEgress entity
@@ -3075,11 +2826,7 @@ paths:
           description: name of the ZoneEgress
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ZoneEgressDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/ZoneEgressDeleteSuccessResponse'
         '404':
           $ref: '#/components/responses/NotFound'
   /zoneegresses:
@@ -3160,17 +2907,9 @@ paths:
               $ref: '#/components/schemas/ZoneIngressItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ZoneIngressCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/ZoneIngressCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ZoneIngressCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/ZoneIngressCreateOrUpdateSuccessResponse'
     delete:
       operationId: deleteZoneIngress
       summary: Deletes ZoneIngress entity
@@ -3185,11 +2924,7 @@ paths:
           description: name of the ZoneIngress
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ZoneIngressDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/ZoneIngressDeleteSuccessResponse'
         '404':
           $ref: '#/components/responses/NotFound'
   /zoneingresses:
@@ -3270,19 +3005,11 @@ paths:
               $ref: '#/components/schemas/HostnameGeneratorItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: >-
-                  #/components/schemas/HostnameGeneratorCreateOrUpdateSuccessResponse
+          $ref: >-
+            #/components/responses/HostnameGeneratorCreateOrUpdateSuccessResponse
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: >-
-                  #/components/schemas/HostnameGeneratorCreateOrUpdateSuccessResponse
+          $ref: >-
+            #/components/responses/HostnameGeneratorCreateOrUpdateSuccessResponse
     delete:
       operationId: deleteHostnameGenerator
       summary: Deletes HostnameGenerator entity
@@ -3297,11 +3024,7 @@ paths:
           description: name of the HostnameGenerator
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HostnameGeneratorDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/HostnameGeneratorDeleteSuccessResponse'
         '404':
           $ref: '#/components/responses/NotFound'
   /hostnamegenerators:
@@ -3394,19 +3117,11 @@ paths:
               $ref: '#/components/schemas/MeshExternalServiceItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: >-
-                  #/components/schemas/MeshExternalServiceCreateOrUpdateSuccessResponse
+          $ref: >-
+            #/components/responses/MeshExternalServiceCreateOrUpdateSuccessResponse
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: >-
-                  #/components/schemas/MeshExternalServiceCreateOrUpdateSuccessResponse
+          $ref: >-
+            #/components/responses/MeshExternalServiceCreateOrUpdateSuccessResponse
     delete:
       operationId: deleteMeshExternalService
       summary: Deletes MeshExternalService entity
@@ -3427,11 +3142,7 @@ paths:
           description: name of the MeshExternalService
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshExternalServiceDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshExternalServiceDeleteSuccessResponse'
         '404':
           $ref: '#/components/responses/NotFound'
   /meshes/{mesh}/meshexternalservices:
@@ -3530,17 +3241,9 @@ paths:
               $ref: '#/components/schemas/MeshIdentityItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshIdentityCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshIdentityCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshIdentityCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshIdentityCreateOrUpdateSuccessResponse'
     delete:
       operationId: deleteMeshIdentity
       summary: Deletes MeshIdentity entity
@@ -3561,11 +3264,7 @@ paths:
           description: name of the MeshIdentity
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshIdentityDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshIdentityDeleteSuccessResponse'
         '404':
           $ref: '#/components/responses/NotFound'
   /meshes/{mesh}/meshidentities:
@@ -3664,19 +3363,11 @@ paths:
               $ref: '#/components/schemas/MeshMultiZoneServiceItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: >-
-                  #/components/schemas/MeshMultiZoneServiceCreateOrUpdateSuccessResponse
+          $ref: >-
+            #/components/responses/MeshMultiZoneServiceCreateOrUpdateSuccessResponse
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: >-
-                  #/components/schemas/MeshMultiZoneServiceCreateOrUpdateSuccessResponse
+          $ref: >-
+            #/components/responses/MeshMultiZoneServiceCreateOrUpdateSuccessResponse
     delete:
       operationId: deleteMeshMultiZoneService
       summary: Deletes MeshMultiZoneService entity
@@ -3697,11 +3388,7 @@ paths:
           description: name of the MeshMultiZoneService
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshMultiZoneServiceDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshMultiZoneServiceDeleteSuccessResponse'
         '404':
           $ref: '#/components/responses/NotFound'
   /meshes/{mesh}/meshmultizoneservices:
@@ -3800,17 +3487,9 @@ paths:
               $ref: '#/components/schemas/MeshServiceItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshServiceCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshServiceCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshServiceCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshServiceCreateOrUpdateSuccessResponse'
     delete:
       operationId: deleteMeshService
       summary: Deletes MeshService entity
@@ -3831,11 +3510,7 @@ paths:
           description: name of the MeshService
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshServiceDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshServiceDeleteSuccessResponse'
         '404':
           $ref: '#/components/responses/NotFound'
   /meshes/{mesh}/meshservices:
@@ -3934,17 +3609,9 @@ paths:
               $ref: '#/components/schemas/MeshTrustItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshTrustCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshTrustCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshTrustCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshTrustCreateOrUpdateSuccessResponse'
     delete:
       operationId: deleteMeshTrust
       summary: Deletes MeshTrust entity
@@ -3965,11 +3632,7 @@ paths:
           description: name of the MeshTrust
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshTrustDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshTrustDeleteSuccessResponse'
         '404':
           $ref: '#/components/responses/NotFound'
   /meshes/{mesh}/meshtrusts:
@@ -5893,23 +5556,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/MeshAccessLogItem'
-    MeshAccessLogCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
-    MeshAccessLogDeleteSuccessResponse:
-      type: object
-      properties: {}
     MeshCircuitBreakerItem:
       type: object
       required:
@@ -7630,23 +7276,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/MeshCircuitBreakerItem'
-    MeshCircuitBreakerCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
-    MeshCircuitBreakerDeleteSuccessResponse:
-      type: object
-      properties: {}
     MeshFaultInjectionItem:
       type: object
       required:
@@ -8295,23 +7924,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/MeshFaultInjectionItem'
-    MeshFaultInjectionCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
-    MeshFaultInjectionDeleteSuccessResponse:
-      type: object
-      properties: {}
     MeshHealthCheckItem:
       type: object
       required:
@@ -8807,23 +8419,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/MeshHealthCheckItem'
-    MeshHealthCheckCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
-    MeshHealthCheckDeleteSuccessResponse:
-      type: object
-      properties: {}
     MeshHTTPRouteItem:
       type: object
       required:
@@ -9633,23 +9228,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/MeshHTTPRouteItem'
-    MeshHTTPRouteCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
-    MeshHTTPRouteDeleteSuccessResponse:
-      type: object
-      properties: {}
     MeshLoadBalancingStrategyItem:
       type: object
       required:
@@ -10521,23 +10099,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/MeshLoadBalancingStrategyItem'
-    MeshLoadBalancingStrategyCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
-    MeshLoadBalancingStrategyDeleteSuccessResponse:
-      type: object
-      properties: {}
     MeshMetricItem:
       type: object
       required:
@@ -10862,23 +10423,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/MeshMetricItem'
-    MeshMetricCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
-    MeshMetricDeleteSuccessResponse:
-      type: object
-      properties: {}
     MeshPassthroughItem:
       type: object
       required:
@@ -11066,23 +10610,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/MeshPassthroughItem'
-    MeshPassthroughCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
-    MeshPassthroughDeleteSuccessResponse:
-      type: object
-      properties: {}
     MeshProxyPatchItem:
       type: object
       required:
@@ -11794,23 +11321,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/MeshProxyPatchItem'
-    MeshProxyPatchCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
-    MeshProxyPatchDeleteSuccessResponse:
-      type: object
-      properties: {}
     MeshRateLimitItem:
       type: object
       required:
@@ -12543,23 +12053,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/MeshRateLimitItem'
-    MeshRateLimitCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
-    MeshRateLimitDeleteSuccessResponse:
-      type: object
-      properties: {}
     MeshRetryItem:
       type: object
       required:
@@ -13212,23 +12705,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/MeshRetryItem'
-    MeshRetryCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
-    MeshRetryDeleteSuccessResponse:
-      type: object
-      properties: {}
     MeshTCPRouteItem:
       type: object
       required:
@@ -13567,23 +13043,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/MeshTCPRouteItem'
-    MeshTCPRouteCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
-    MeshTCPRouteDeleteSuccessResponse:
-      type: object
-      properties: {}
     MeshTimeoutItem:
       type: object
       required:
@@ -14154,23 +13613,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/MeshTimeoutItem'
-    MeshTimeoutCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
-    MeshTimeoutDeleteSuccessResponse:
-      type: object
-      properties: {}
     MeshTLSItem:
       type: object
       required:
@@ -14513,23 +13955,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/MeshTLSItem'
-    MeshTLSCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
-    MeshTLSDeleteSuccessResponse:
-      type: object
-      properties: {}
     MeshTraceItem:
       type: object
       required:
@@ -14879,23 +14304,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/MeshTraceItem'
-    MeshTraceCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
-    MeshTraceDeleteSuccessResponse:
-      type: object
-      properties: {}
     MeshTrafficPermissionItem:
       type: object
       required:
@@ -15241,23 +14649,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/MeshTrafficPermissionItem'
-    MeshTrafficPermissionCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
-    MeshTrafficPermissionDeleteSuccessResponse:
-      type: object
-      properties: {}
     BuiltinCertificateAuthorityConfig:
       properties:
         caCert:
@@ -15857,23 +15248,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/DataplaneItem'
-    DataplaneCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
-    DataplaneDeleteSuccessResponse:
-      type: object
-      properties: {}
     PrometheusMetricsBackendConfig:
       description: >-
         PrometheusMetricsBackendConfig defines configuration of Prometheus
@@ -17135,23 +16509,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/MeshItem'
-    MeshCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
-    MeshDeleteSuccessResponse:
-      type: object
-      properties: {}
     TcpLoggingBackendConfig:
       description: TcpLoggingBackendConfig defines configuration for TCP based access logs
       properties:
@@ -17388,23 +16745,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/MeshGatewayItem'
-    MeshGatewayCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
-    MeshGatewayDeleteSuccessResponse:
-      type: object
-      properties: {}
     Zone:
       description: >-
         Zone defines the Zone configuration used at the Global Control Plane
@@ -17461,23 +16801,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/ZoneEgressItem'
-    ZoneEgressCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
-    ZoneEgressDeleteSuccessResponse:
-      type: object
-      properties: {}
     ZoneIngressItem:
       properties:
         availableServices:
@@ -17561,23 +16884,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/ZoneIngressItem'
-    ZoneIngressCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
-    ZoneIngressDeleteSuccessResponse:
-      type: object
-      properties: {}
     HostnameGeneratorItem:
       type: object
       required:
@@ -17654,23 +16960,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-    HostnameGeneratorCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
-    HostnameGeneratorDeleteSuccessResponse:
-      type: object
-      properties: {}
     MeshExternalServiceItem:
       type: object
       required:
@@ -18019,23 +17308,6 @@ components:
               type: object
           type: object
           readOnly: true
-    MeshExternalServiceCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
-    MeshExternalServiceDeleteSuccessResponse:
-      type: object
-      properties: {}
     MeshIdentityItem:
       type: object
       required:
@@ -18322,23 +17594,6 @@ components:
               x-kubernetes-list-type: map
           type: object
           readOnly: true
-    MeshIdentityCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
-    MeshIdentityDeleteSuccessResponse:
-      type: object
-      properties: {}
     MeshMultiZoneServiceItem:
       type: object
       required:
@@ -18540,23 +17795,6 @@ components:
               type: array
           type: object
           readOnly: true
-    MeshMultiZoneServiceCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
-    MeshMultiZoneServiceDeleteSuccessResponse:
-      type: object
-      properties: {}
     MeshServiceItem:
       type: object
       required:
@@ -18788,23 +18026,6 @@ components:
               type: array
           type: object
           readOnly: true
-    MeshServiceCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
-    MeshServiceDeleteSuccessResponse:
-      type: object
-      properties: {}
     MeshTrustItem:
       type: object
       required:
@@ -18892,23 +18113,6 @@ components:
           description: Time at which the resource was updated
           format: date-time
           example: '0001-01-01T00:00:00Z'
-    MeshTrustCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: >
-            warnings is a list of warning messages to return to the requesting
-            Kuma API clients.
-
-            Warning messages describe a problem the client making the API
-            request should correct or be aware of.
-          items:
-            type: string
-    MeshTrustDeleteSuccessResponse:
-      type: object
-      properties: {}
   responses:
     IndexResponse:
       description: A response for the index endpoint
@@ -19038,6 +18242,30 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshAccessLogCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: >
+                  warnings is a list of warning messages to return to the
+                  requesting Kuma API clients.
+
+                  Warning messages describe a problem the client making the API
+                  request should correct or be aware of.
+                items:
+                  type: string
+    MeshAccessLogDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
     MeshCircuitBreakerItem:
       description: Successful response
       content:
@@ -19061,6 +18289,30 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshCircuitBreakerCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: >
+                  warnings is a list of warning messages to return to the
+                  requesting Kuma API clients.
+
+                  Warning messages describe a problem the client making the API
+                  request should correct or be aware of.
+                items:
+                  type: string
+    MeshCircuitBreakerDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
     MeshFaultInjectionItem:
       description: Successful response
       content:
@@ -19084,6 +18336,30 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshFaultInjectionCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: >
+                  warnings is a list of warning messages to return to the
+                  requesting Kuma API clients.
+
+                  Warning messages describe a problem the client making the API
+                  request should correct or be aware of.
+                items:
+                  type: string
+    MeshFaultInjectionDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
     MeshHealthCheckItem:
       description: Successful response
       content:
@@ -19107,6 +18383,30 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshHealthCheckCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: >
+                  warnings is a list of warning messages to return to the
+                  requesting Kuma API clients.
+
+                  Warning messages describe a problem the client making the API
+                  request should correct or be aware of.
+                items:
+                  type: string
+    MeshHealthCheckDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
     MeshHTTPRouteItem:
       description: Successful response
       content:
@@ -19130,6 +18430,30 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshHTTPRouteCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: >
+                  warnings is a list of warning messages to return to the
+                  requesting Kuma API clients.
+
+                  Warning messages describe a problem the client making the API
+                  request should correct or be aware of.
+                items:
+                  type: string
+    MeshHTTPRouteDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
     MeshLoadBalancingStrategyItem:
       description: Successful response
       content:
@@ -19153,6 +18477,30 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshLoadBalancingStrategyCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: >
+                  warnings is a list of warning messages to return to the
+                  requesting Kuma API clients.
+
+                  Warning messages describe a problem the client making the API
+                  request should correct or be aware of.
+                items:
+                  type: string
+    MeshLoadBalancingStrategyDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
     MeshMetricItem:
       description: Successful response
       content:
@@ -19176,6 +18524,30 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshMetricCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: >
+                  warnings is a list of warning messages to return to the
+                  requesting Kuma API clients.
+
+                  Warning messages describe a problem the client making the API
+                  request should correct or be aware of.
+                items:
+                  type: string
+    MeshMetricDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
     MeshPassthroughItem:
       description: Successful response
       content:
@@ -19199,6 +18571,30 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshPassthroughCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: >
+                  warnings is a list of warning messages to return to the
+                  requesting Kuma API clients.
+
+                  Warning messages describe a problem the client making the API
+                  request should correct or be aware of.
+                items:
+                  type: string
+    MeshPassthroughDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
     MeshProxyPatchItem:
       description: Successful response
       content:
@@ -19222,6 +18618,30 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshProxyPatchCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: >
+                  warnings is a list of warning messages to return to the
+                  requesting Kuma API clients.
+
+                  Warning messages describe a problem the client making the API
+                  request should correct or be aware of.
+                items:
+                  type: string
+    MeshProxyPatchDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
     MeshRateLimitItem:
       description: Successful response
       content:
@@ -19245,6 +18665,30 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshRateLimitCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: >
+                  warnings is a list of warning messages to return to the
+                  requesting Kuma API clients.
+
+                  Warning messages describe a problem the client making the API
+                  request should correct or be aware of.
+                items:
+                  type: string
+    MeshRateLimitDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
     MeshRetryItem:
       description: Successful response
       content:
@@ -19268,6 +18712,30 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshRetryCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: >
+                  warnings is a list of warning messages to return to the
+                  requesting Kuma API clients.
+
+                  Warning messages describe a problem the client making the API
+                  request should correct or be aware of.
+                items:
+                  type: string
+    MeshRetryDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
     MeshTCPRouteItem:
       description: Successful response
       content:
@@ -19291,6 +18759,30 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshTCPRouteCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: >
+                  warnings is a list of warning messages to return to the
+                  requesting Kuma API clients.
+
+                  Warning messages describe a problem the client making the API
+                  request should correct or be aware of.
+                items:
+                  type: string
+    MeshTCPRouteDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
     MeshTimeoutItem:
       description: Successful response
       content:
@@ -19314,6 +18806,30 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshTimeoutCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: >
+                  warnings is a list of warning messages to return to the
+                  requesting Kuma API clients.
+
+                  Warning messages describe a problem the client making the API
+                  request should correct or be aware of.
+                items:
+                  type: string
+    MeshTimeoutDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
     MeshTLSItem:
       description: Successful response
       content:
@@ -19337,6 +18853,30 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshTLSCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: >
+                  warnings is a list of warning messages to return to the
+                  requesting Kuma API clients.
+
+                  Warning messages describe a problem the client making the API
+                  request should correct or be aware of.
+                items:
+                  type: string
+    MeshTLSDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
     MeshTraceItem:
       description: Successful response
       content:
@@ -19360,6 +18900,30 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshTraceCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: >
+                  warnings is a list of warning messages to return to the
+                  requesting Kuma API clients.
+
+                  Warning messages describe a problem the client making the API
+                  request should correct or be aware of.
+                items:
+                  type: string
+    MeshTraceDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
     MeshTrafficPermissionItem:
       description: Successful response
       content:
@@ -19383,6 +18947,30 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshTrafficPermissionCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: >
+                  warnings is a list of warning messages to return to the
+                  requesting Kuma API clients.
+
+                  Warning messages describe a problem the client making the API
+                  request should correct or be aware of.
+                items:
+                  type: string
+    MeshTrafficPermissionDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
     DataplaneItem:
       description: Successful response
       content:
@@ -19406,6 +18994,30 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    DataplaneCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: >
+                  warnings is a list of warning messages to return to the
+                  requesting Kuma API clients.
+
+                  Warning messages describe a problem the client making the API
+                  request should correct or be aware of.
+                items:
+                  type: string
+    DataplaneDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
     GetDataplaneOverviewResponse:
       description: A response containing the overview of a dataplane.
       content:
@@ -19451,6 +19063,30 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: >
+                  warnings is a list of warning messages to return to the
+                  requesting Kuma API clients.
+
+                  Warning messages describe a problem the client making the API
+                  request should correct or be aware of.
+                items:
+                  type: string
+    MeshDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
     MeshGatewayItem:
       description: Successful response
       content:
@@ -19474,6 +19110,30 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshGatewayCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: >
+                  warnings is a list of warning messages to return to the
+                  requesting Kuma API clients.
+
+                  Warning messages describe a problem the client making the API
+                  request should correct or be aware of.
+                items:
+                  type: string
+    MeshGatewayDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
     ZoneEgressItem:
       description: Successful response
       content:
@@ -19497,6 +19157,30 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    ZoneEgressCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: >
+                  warnings is a list of warning messages to return to the
+                  requesting Kuma API clients.
+
+                  Warning messages describe a problem the client making the API
+                  request should correct or be aware of.
+                items:
+                  type: string
+    ZoneEgressDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
     ZoneIngressItem:
       description: Successful response
       content:
@@ -19520,6 +19204,30 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    ZoneIngressCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: >
+                  warnings is a list of warning messages to return to the
+                  requesting Kuma API clients.
+
+                  Warning messages describe a problem the client making the API
+                  request should correct or be aware of.
+                items:
+                  type: string
+    ZoneIngressDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
     HostnameGeneratorItem:
       description: Successful response
       content:
@@ -19543,6 +19251,30 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    HostnameGeneratorCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: >
+                  warnings is a list of warning messages to return to the
+                  requesting Kuma API clients.
+
+                  Warning messages describe a problem the client making the API
+                  request should correct or be aware of.
+                items:
+                  type: string
+    HostnameGeneratorDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
     MeshExternalServiceItem:
       description: Successful response
       content:
@@ -19566,6 +19298,30 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshExternalServiceCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: >
+                  warnings is a list of warning messages to return to the
+                  requesting Kuma API clients.
+
+                  Warning messages describe a problem the client making the API
+                  request should correct or be aware of.
+                items:
+                  type: string
+    MeshExternalServiceDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
     MeshIdentityItem:
       description: Successful response
       content:
@@ -19589,6 +19345,30 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshIdentityCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: >
+                  warnings is a list of warning messages to return to the
+                  requesting Kuma API clients.
+
+                  Warning messages describe a problem the client making the API
+                  request should correct or be aware of.
+                items:
+                  type: string
+    MeshIdentityDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
     MeshMultiZoneServiceItem:
       description: Successful response
       content:
@@ -19612,6 +19392,30 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshMultiZoneServiceCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: >
+                  warnings is a list of warning messages to return to the
+                  requesting Kuma API clients.
+
+                  Warning messages describe a problem the client making the API
+                  request should correct or be aware of.
+                items:
+                  type: string
+    MeshMultiZoneServiceDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
     MeshServiceItem:
       description: Successful response
       content:
@@ -19635,6 +19439,30 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshServiceCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: >
+                  warnings is a list of warning messages to return to the
+                  requesting Kuma API clients.
+
+                  Warning messages describe a problem the client making the API
+                  request should correct or be aware of.
+                items:
+                  type: string
+    MeshServiceDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
     MeshTrustItem:
       description: Successful response
       content:
@@ -19658,6 +19486,30 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshTrustCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: >
+                  warnings is a list of warning messages to return to the
+                  requesting Kuma API clients.
+
+                  Warning messages describe a problem the client making the API
+                  request should correct or be aware of.
+                items:
+                  type: string
+    MeshTrustDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
   examples:
     GlobalInsightExample:
       value:

--- a/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/rest.yaml
@@ -44,17 +44,9 @@ paths:
               $ref: '#/components/schemas/HostnameGeneratorItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HostnameGeneratorCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/HostnameGeneratorCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HostnameGeneratorCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/HostnameGeneratorCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: deleteHostnameGenerator
@@ -69,11 +61,7 @@ paths:
           description: name of the HostnameGenerator
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HostnameGeneratorDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/HostnameGeneratorDeleteSuccessResponse'
         '404':
           $ref: "/specs/base/specs/common/error_schema.yaml#/components/responses/NotFound"
 
@@ -120,20 +108,6 @@ components:
   schemas:
     HostnameGeneratorItem:
       $ref: 'schema.yaml'
-    HostnameGeneratorCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: |
-            warnings is a list of warning messages to return to the requesting Kuma API clients.
-            Warning messages describe a problem the client making the API request should correct or be aware of.
-          items:
-            type: string
-    HostnameGeneratorDeleteSuccessResponse:
-      type: object
-      properties: {}
 
   responses:
     HostnameGeneratorItem:
@@ -159,3 +133,24 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    HostnameGeneratorCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: |
+                  warnings is a list of warning messages to return to the requesting Kuma API clients.
+                  Warning messages describe a problem the client making the API request should correct or be aware of.
+                items:
+                  type: string
+    HostnameGeneratorDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/rest.yaml
@@ -56,17 +56,9 @@ paths:
               $ref: '#/components/schemas/MeshExternalServiceItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshExternalServiceCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshExternalServiceCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshExternalServiceCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshExternalServiceCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: deleteMeshExternalService
@@ -87,11 +79,7 @@ paths:
           description: name of the MeshExternalService
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshExternalServiceDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshExternalServiceDeleteSuccessResponse'
         '404':
           $ref: "/specs/base/specs/common/error_schema.yaml#/components/responses/NotFound"
 
@@ -144,20 +132,6 @@ components:
   schemas:
     MeshExternalServiceItem:
       $ref: 'schema.yaml'
-    MeshExternalServiceCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: |
-            warnings is a list of warning messages to return to the requesting Kuma API clients.
-            Warning messages describe a problem the client making the API request should correct or be aware of.
-          items:
-            type: string
-    MeshExternalServiceDeleteSuccessResponse:
-      type: object
-      properties: {}
 
   responses:
     MeshExternalServiceItem:
@@ -183,3 +157,24 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshExternalServiceCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: |
+                  warnings is a list of warning messages to return to the requesting Kuma API clients.
+                  Warning messages describe a problem the client making the API request should correct or be aware of.
+                items:
+                  type: string
+    MeshExternalServiceDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object

--- a/pkg/core/resources/apis/meshidentity/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshidentity/api/v1alpha1/rest.yaml
@@ -56,17 +56,9 @@ paths:
               $ref: '#/components/schemas/MeshIdentityItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshIdentityCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshIdentityCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshIdentityCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshIdentityCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: deleteMeshIdentity
@@ -87,11 +79,7 @@ paths:
           description: name of the MeshIdentity
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshIdentityDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshIdentityDeleteSuccessResponse'
         '404':
           $ref: "/specs/base/specs/common/error_schema.yaml#/components/responses/NotFound"
 
@@ -144,20 +132,6 @@ components:
   schemas:
     MeshIdentityItem:
       $ref: 'schema.yaml'
-    MeshIdentityCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: |
-            warnings is a list of warning messages to return to the requesting Kuma API clients.
-            Warning messages describe a problem the client making the API request should correct or be aware of.
-          items:
-            type: string
-    MeshIdentityDeleteSuccessResponse:
-      type: object
-      properties: {}
 
   responses:
     MeshIdentityItem:
@@ -183,3 +157,24 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshIdentityCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: |
+                  warnings is a list of warning messages to return to the requesting Kuma API clients.
+                  Warning messages describe a problem the client making the API request should correct or be aware of.
+                items:
+                  type: string
+    MeshIdentityDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object

--- a/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/rest.yaml
@@ -56,17 +56,9 @@ paths:
               $ref: '#/components/schemas/MeshMultiZoneServiceItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshMultiZoneServiceCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshMultiZoneServiceCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshMultiZoneServiceCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshMultiZoneServiceCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: deleteMeshMultiZoneService
@@ -87,11 +79,7 @@ paths:
           description: name of the MeshMultiZoneService
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshMultiZoneServiceDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshMultiZoneServiceDeleteSuccessResponse'
         '404':
           $ref: "/specs/base/specs/common/error_schema.yaml#/components/responses/NotFound"
 
@@ -144,20 +132,6 @@ components:
   schemas:
     MeshMultiZoneServiceItem:
       $ref: 'schema.yaml'
-    MeshMultiZoneServiceCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: |
-            warnings is a list of warning messages to return to the requesting Kuma API clients.
-            Warning messages describe a problem the client making the API request should correct or be aware of.
-          items:
-            type: string
-    MeshMultiZoneServiceDeleteSuccessResponse:
-      type: object
-      properties: {}
 
   responses:
     MeshMultiZoneServiceItem:
@@ -183,3 +157,24 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshMultiZoneServiceCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: |
+                  warnings is a list of warning messages to return to the requesting Kuma API clients.
+                  Warning messages describe a problem the client making the API request should correct or be aware of.
+                items:
+                  type: string
+    MeshMultiZoneServiceDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/rest.yaml
@@ -56,17 +56,9 @@ paths:
               $ref: '#/components/schemas/MeshServiceItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshServiceCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshServiceCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshServiceCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshServiceCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: deleteMeshService
@@ -87,11 +79,7 @@ paths:
           description: name of the MeshService
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshServiceDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshServiceDeleteSuccessResponse'
         '404':
           $ref: "/specs/base/specs/common/error_schema.yaml#/components/responses/NotFound"
 
@@ -144,20 +132,6 @@ components:
   schemas:
     MeshServiceItem:
       $ref: 'schema.yaml'
-    MeshServiceCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: |
-            warnings is a list of warning messages to return to the requesting Kuma API clients.
-            Warning messages describe a problem the client making the API request should correct or be aware of.
-          items:
-            type: string
-    MeshServiceDeleteSuccessResponse:
-      type: object
-      properties: {}
 
   responses:
     MeshServiceItem:
@@ -183,3 +157,24 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshServiceCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: |
+                  warnings is a list of warning messages to return to the requesting Kuma API clients.
+                  Warning messages describe a problem the client making the API request should correct or be aware of.
+                items:
+                  type: string
+    MeshServiceDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object

--- a/pkg/core/resources/apis/meshtrust/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshtrust/api/v1alpha1/rest.yaml
@@ -56,17 +56,9 @@ paths:
               $ref: '#/components/schemas/MeshTrustItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshTrustCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshTrustCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshTrustCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshTrustCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: deleteMeshTrust
@@ -87,11 +79,7 @@ paths:
           description: name of the MeshTrust
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshTrustDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshTrustDeleteSuccessResponse'
         '404':
           $ref: "/specs/base/specs/common/error_schema.yaml#/components/responses/NotFound"
 
@@ -144,20 +132,6 @@ components:
   schemas:
     MeshTrustItem:
       $ref: 'schema.yaml'
-    MeshTrustCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: |
-            warnings is a list of warning messages to return to the requesting Kuma API clients.
-            Warning messages describe a problem the client making the API request should correct or be aware of.
-          items:
-            type: string
-    MeshTrustDeleteSuccessResponse:
-      type: object
-      properties: {}
 
   responses:
     MeshTrustItem:
@@ -183,3 +157,24 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshTrustCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: |
+                  warnings is a list of warning messages to return to the requesting Kuma API clients.
+                  Warning messages describe a problem the client making the API request should correct or be aware of.
+                items:
+                  type: string
+    MeshTrustDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/rest.yaml
@@ -56,17 +56,9 @@ paths:
               $ref: '#/components/schemas/MeshAccessLogItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshAccessLogCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshAccessLogCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshAccessLogCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshAccessLogCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: deleteMeshAccessLog
@@ -87,11 +79,7 @@ paths:
           description: name of the MeshAccessLog
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshAccessLogDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshAccessLogDeleteSuccessResponse'
         '404':
           $ref: "/specs/base/specs/common/error_schema.yaml#/components/responses/NotFound"
 
@@ -144,20 +132,6 @@ components:
   schemas:
     MeshAccessLogItem:
       $ref: 'schema.yaml'
-    MeshAccessLogCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: |
-            warnings is a list of warning messages to return to the requesting Kuma API clients.
-            Warning messages describe a problem the client making the API request should correct or be aware of.
-          items:
-            type: string
-    MeshAccessLogDeleteSuccessResponse:
-      type: object
-      properties: {}
 
   responses:
     MeshAccessLogItem:
@@ -183,3 +157,24 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshAccessLogCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: |
+                  warnings is a list of warning messages to return to the requesting Kuma API clients.
+                  Warning messages describe a problem the client making the API request should correct or be aware of.
+                items:
+                  type: string
+    MeshAccessLogDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/rest.yaml
@@ -56,17 +56,9 @@ paths:
               $ref: '#/components/schemas/MeshCircuitBreakerItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshCircuitBreakerCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshCircuitBreakerCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshCircuitBreakerCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshCircuitBreakerCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: deleteMeshCircuitBreaker
@@ -87,11 +79,7 @@ paths:
           description: name of the MeshCircuitBreaker
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshCircuitBreakerDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshCircuitBreakerDeleteSuccessResponse'
         '404':
           $ref: "/specs/base/specs/common/error_schema.yaml#/components/responses/NotFound"
 
@@ -144,20 +132,6 @@ components:
   schemas:
     MeshCircuitBreakerItem:
       $ref: 'schema.yaml'
-    MeshCircuitBreakerCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: |
-            warnings is a list of warning messages to return to the requesting Kuma API clients.
-            Warning messages describe a problem the client making the API request should correct or be aware of.
-          items:
-            type: string
-    MeshCircuitBreakerDeleteSuccessResponse:
-      type: object
-      properties: {}
 
   responses:
     MeshCircuitBreakerItem:
@@ -183,3 +157,24 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshCircuitBreakerCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: |
+                  warnings is a list of warning messages to return to the requesting Kuma API clients.
+                  Warning messages describe a problem the client making the API request should correct or be aware of.
+                items:
+                  type: string
+    MeshCircuitBreakerDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/rest.yaml
@@ -56,17 +56,9 @@ paths:
               $ref: '#/components/schemas/MeshFaultInjectionItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshFaultInjectionCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshFaultInjectionCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshFaultInjectionCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshFaultInjectionCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: deleteMeshFaultInjection
@@ -87,11 +79,7 @@ paths:
           description: name of the MeshFaultInjection
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshFaultInjectionDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshFaultInjectionDeleteSuccessResponse'
         '404':
           $ref: "/specs/base/specs/common/error_schema.yaml#/components/responses/NotFound"
 
@@ -144,20 +132,6 @@ components:
   schemas:
     MeshFaultInjectionItem:
       $ref: 'schema.yaml'
-    MeshFaultInjectionCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: |
-            warnings is a list of warning messages to return to the requesting Kuma API clients.
-            Warning messages describe a problem the client making the API request should correct or be aware of.
-          items:
-            type: string
-    MeshFaultInjectionDeleteSuccessResponse:
-      type: object
-      properties: {}
 
   responses:
     MeshFaultInjectionItem:
@@ -183,3 +157,24 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshFaultInjectionCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: |
+                  warnings is a list of warning messages to return to the requesting Kuma API clients.
+                  Warning messages describe a problem the client making the API request should correct or be aware of.
+                items:
+                  type: string
+    MeshFaultInjectionDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/rest.yaml
@@ -56,17 +56,9 @@ paths:
               $ref: '#/components/schemas/MeshHealthCheckItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshHealthCheckCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshHealthCheckCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshHealthCheckCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshHealthCheckCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: deleteMeshHealthCheck
@@ -87,11 +79,7 @@ paths:
           description: name of the MeshHealthCheck
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshHealthCheckDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshHealthCheckDeleteSuccessResponse'
         '404':
           $ref: "/specs/base/specs/common/error_schema.yaml#/components/responses/NotFound"
 
@@ -144,20 +132,6 @@ components:
   schemas:
     MeshHealthCheckItem:
       $ref: 'schema.yaml'
-    MeshHealthCheckCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: |
-            warnings is a list of warning messages to return to the requesting Kuma API clients.
-            Warning messages describe a problem the client making the API request should correct or be aware of.
-          items:
-            type: string
-    MeshHealthCheckDeleteSuccessResponse:
-      type: object
-      properties: {}
 
   responses:
     MeshHealthCheckItem:
@@ -183,3 +157,24 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshHealthCheckCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: |
+                  warnings is a list of warning messages to return to the requesting Kuma API clients.
+                  Warning messages describe a problem the client making the API request should correct or be aware of.
+                items:
+                  type: string
+    MeshHealthCheckDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/rest.yaml
@@ -56,17 +56,9 @@ paths:
               $ref: '#/components/schemas/MeshHTTPRouteItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshHTTPRouteCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshHTTPRouteCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshHTTPRouteCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshHTTPRouteCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: deleteMeshHTTPRoute
@@ -87,11 +79,7 @@ paths:
           description: name of the MeshHTTPRoute
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshHTTPRouteDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshHTTPRouteDeleteSuccessResponse'
         '404':
           $ref: "/specs/base/specs/common/error_schema.yaml#/components/responses/NotFound"
 
@@ -144,20 +132,6 @@ components:
   schemas:
     MeshHTTPRouteItem:
       $ref: 'schema.yaml'
-    MeshHTTPRouteCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: |
-            warnings is a list of warning messages to return to the requesting Kuma API clients.
-            Warning messages describe a problem the client making the API request should correct or be aware of.
-          items:
-            type: string
-    MeshHTTPRouteDeleteSuccessResponse:
-      type: object
-      properties: {}
 
   responses:
     MeshHTTPRouteItem:
@@ -183,3 +157,24 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshHTTPRouteCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: |
+                  warnings is a list of warning messages to return to the requesting Kuma API clients.
+                  Warning messages describe a problem the client making the API request should correct or be aware of.
+                items:
+                  type: string
+    MeshHTTPRouteDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/rest.yaml
@@ -56,17 +56,9 @@ paths:
               $ref: '#/components/schemas/MeshLoadBalancingStrategyItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshLoadBalancingStrategyCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshLoadBalancingStrategyCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshLoadBalancingStrategyCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshLoadBalancingStrategyCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: deleteMeshLoadBalancingStrategy
@@ -87,11 +79,7 @@ paths:
           description: name of the MeshLoadBalancingStrategy
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshLoadBalancingStrategyDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshLoadBalancingStrategyDeleteSuccessResponse'
         '404':
           $ref: "/specs/base/specs/common/error_schema.yaml#/components/responses/NotFound"
 
@@ -144,20 +132,6 @@ components:
   schemas:
     MeshLoadBalancingStrategyItem:
       $ref: 'schema.yaml'
-    MeshLoadBalancingStrategyCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: |
-            warnings is a list of warning messages to return to the requesting Kuma API clients.
-            Warning messages describe a problem the client making the API request should correct or be aware of.
-          items:
-            type: string
-    MeshLoadBalancingStrategyDeleteSuccessResponse:
-      type: object
-      properties: {}
 
   responses:
     MeshLoadBalancingStrategyItem:
@@ -183,3 +157,24 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshLoadBalancingStrategyCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: |
+                  warnings is a list of warning messages to return to the requesting Kuma API clients.
+                  Warning messages describe a problem the client making the API request should correct or be aware of.
+                items:
+                  type: string
+    MeshLoadBalancingStrategyDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/rest.yaml
@@ -56,17 +56,9 @@ paths:
               $ref: '#/components/schemas/MeshMetricItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshMetricCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshMetricCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshMetricCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshMetricCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: deleteMeshMetric
@@ -87,11 +79,7 @@ paths:
           description: name of the MeshMetric
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshMetricDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshMetricDeleteSuccessResponse'
         '404':
           $ref: "/specs/base/specs/common/error_schema.yaml#/components/responses/NotFound"
 
@@ -144,20 +132,6 @@ components:
   schemas:
     MeshMetricItem:
       $ref: 'schema.yaml'
-    MeshMetricCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: |
-            warnings is a list of warning messages to return to the requesting Kuma API clients.
-            Warning messages describe a problem the client making the API request should correct or be aware of.
-          items:
-            type: string
-    MeshMetricDeleteSuccessResponse:
-      type: object
-      properties: {}
 
   responses:
     MeshMetricItem:
@@ -183,3 +157,24 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshMetricCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: |
+                  warnings is a list of warning messages to return to the requesting Kuma API clients.
+                  Warning messages describe a problem the client making the API request should correct or be aware of.
+                items:
+                  type: string
+    MeshMetricDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object

--- a/pkg/plugins/policies/meshpassthrough/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshpassthrough/api/v1alpha1/rest.yaml
@@ -56,17 +56,9 @@ paths:
               $ref: '#/components/schemas/MeshPassthroughItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshPassthroughCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshPassthroughCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshPassthroughCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshPassthroughCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: deleteMeshPassthrough
@@ -87,11 +79,7 @@ paths:
           description: name of the MeshPassthrough
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshPassthroughDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshPassthroughDeleteSuccessResponse'
         '404':
           $ref: "/specs/base/specs/common/error_schema.yaml#/components/responses/NotFound"
 
@@ -144,20 +132,6 @@ components:
   schemas:
     MeshPassthroughItem:
       $ref: 'schema.yaml'
-    MeshPassthroughCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: |
-            warnings is a list of warning messages to return to the requesting Kuma API clients.
-            Warning messages describe a problem the client making the API request should correct or be aware of.
-          items:
-            type: string
-    MeshPassthroughDeleteSuccessResponse:
-      type: object
-      properties: {}
 
   responses:
     MeshPassthroughItem:
@@ -183,3 +157,24 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshPassthroughCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: |
+                  warnings is a list of warning messages to return to the requesting Kuma API clients.
+                  Warning messages describe a problem the client making the API request should correct or be aware of.
+                items:
+                  type: string
+    MeshPassthroughDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object

--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/rest.yaml
@@ -56,17 +56,9 @@ paths:
               $ref: '#/components/schemas/MeshProxyPatchItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshProxyPatchCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshProxyPatchCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshProxyPatchCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshProxyPatchCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: deleteMeshProxyPatch
@@ -87,11 +79,7 @@ paths:
           description: name of the MeshProxyPatch
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshProxyPatchDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshProxyPatchDeleteSuccessResponse'
         '404':
           $ref: "/specs/base/specs/common/error_schema.yaml#/components/responses/NotFound"
 
@@ -144,20 +132,6 @@ components:
   schemas:
     MeshProxyPatchItem:
       $ref: 'schema.yaml'
-    MeshProxyPatchCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: |
-            warnings is a list of warning messages to return to the requesting Kuma API clients.
-            Warning messages describe a problem the client making the API request should correct or be aware of.
-          items:
-            type: string
-    MeshProxyPatchDeleteSuccessResponse:
-      type: object
-      properties: {}
 
   responses:
     MeshProxyPatchItem:
@@ -183,3 +157,24 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshProxyPatchCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: |
+                  warnings is a list of warning messages to return to the requesting Kuma API clients.
+                  Warning messages describe a problem the client making the API request should correct or be aware of.
+                items:
+                  type: string
+    MeshProxyPatchDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/rest.yaml
@@ -56,17 +56,9 @@ paths:
               $ref: '#/components/schemas/MeshRateLimitItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshRateLimitCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshRateLimitCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshRateLimitCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshRateLimitCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: deleteMeshRateLimit
@@ -87,11 +79,7 @@ paths:
           description: name of the MeshRateLimit
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshRateLimitDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshRateLimitDeleteSuccessResponse'
         '404':
           $ref: "/specs/base/specs/common/error_schema.yaml#/components/responses/NotFound"
 
@@ -144,20 +132,6 @@ components:
   schemas:
     MeshRateLimitItem:
       $ref: 'schema.yaml'
-    MeshRateLimitCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: |
-            warnings is a list of warning messages to return to the requesting Kuma API clients.
-            Warning messages describe a problem the client making the API request should correct or be aware of.
-          items:
-            type: string
-    MeshRateLimitDeleteSuccessResponse:
-      type: object
-      properties: {}
 
   responses:
     MeshRateLimitItem:
@@ -183,3 +157,24 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshRateLimitCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: |
+                  warnings is a list of warning messages to return to the requesting Kuma API clients.
+                  Warning messages describe a problem the client making the API request should correct or be aware of.
+                items:
+                  type: string
+    MeshRateLimitDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/rest.yaml
@@ -56,17 +56,9 @@ paths:
               $ref: '#/components/schemas/MeshRetryItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshRetryCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshRetryCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshRetryCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshRetryCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: deleteMeshRetry
@@ -87,11 +79,7 @@ paths:
           description: name of the MeshRetry
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshRetryDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshRetryDeleteSuccessResponse'
         '404':
           $ref: "/specs/base/specs/common/error_schema.yaml#/components/responses/NotFound"
 
@@ -144,20 +132,6 @@ components:
   schemas:
     MeshRetryItem:
       $ref: 'schema.yaml'
-    MeshRetryCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: |
-            warnings is a list of warning messages to return to the requesting Kuma API clients.
-            Warning messages describe a problem the client making the API request should correct or be aware of.
-          items:
-            type: string
-    MeshRetryDeleteSuccessResponse:
-      type: object
-      properties: {}
 
   responses:
     MeshRetryItem:
@@ -183,3 +157,24 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshRetryCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: |
+                  warnings is a list of warning messages to return to the requesting Kuma API clients.
+                  Warning messages describe a problem the client making the API request should correct or be aware of.
+                items:
+                  type: string
+    MeshRetryDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/rest.yaml
@@ -56,17 +56,9 @@ paths:
               $ref: '#/components/schemas/MeshTCPRouteItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshTCPRouteCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshTCPRouteCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshTCPRouteCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshTCPRouteCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: deleteMeshTCPRoute
@@ -87,11 +79,7 @@ paths:
           description: name of the MeshTCPRoute
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshTCPRouteDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshTCPRouteDeleteSuccessResponse'
         '404':
           $ref: "/specs/base/specs/common/error_schema.yaml#/components/responses/NotFound"
 
@@ -144,20 +132,6 @@ components:
   schemas:
     MeshTCPRouteItem:
       $ref: 'schema.yaml'
-    MeshTCPRouteCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: |
-            warnings is a list of warning messages to return to the requesting Kuma API clients.
-            Warning messages describe a problem the client making the API request should correct or be aware of.
-          items:
-            type: string
-    MeshTCPRouteDeleteSuccessResponse:
-      type: object
-      properties: {}
 
   responses:
     MeshTCPRouteItem:
@@ -183,3 +157,24 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshTCPRouteCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: |
+                  warnings is a list of warning messages to return to the requesting Kuma API clients.
+                  Warning messages describe a problem the client making the API request should correct or be aware of.
+                items:
+                  type: string
+    MeshTCPRouteDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/rest.yaml
@@ -56,17 +56,9 @@ paths:
               $ref: '#/components/schemas/MeshTimeoutItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshTimeoutCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshTimeoutCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshTimeoutCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshTimeoutCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: deleteMeshTimeout
@@ -87,11 +79,7 @@ paths:
           description: name of the MeshTimeout
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshTimeoutDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshTimeoutDeleteSuccessResponse'
         '404':
           $ref: "/specs/base/specs/common/error_schema.yaml#/components/responses/NotFound"
 
@@ -144,20 +132,6 @@ components:
   schemas:
     MeshTimeoutItem:
       $ref: 'schema.yaml'
-    MeshTimeoutCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: |
-            warnings is a list of warning messages to return to the requesting Kuma API clients.
-            Warning messages describe a problem the client making the API request should correct or be aware of.
-          items:
-            type: string
-    MeshTimeoutDeleteSuccessResponse:
-      type: object
-      properties: {}
 
   responses:
     MeshTimeoutItem:
@@ -183,3 +157,24 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshTimeoutCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: |
+                  warnings is a list of warning messages to return to the requesting Kuma API clients.
+                  Warning messages describe a problem the client making the API request should correct or be aware of.
+                items:
+                  type: string
+    MeshTimeoutDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object

--- a/pkg/plugins/policies/meshtls/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtls/api/v1alpha1/rest.yaml
@@ -56,17 +56,9 @@ paths:
               $ref: '#/components/schemas/MeshTLSItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshTLSCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshTLSCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshTLSCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshTLSCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: deleteMeshTLS
@@ -87,11 +79,7 @@ paths:
           description: name of the MeshTLS
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshTLSDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshTLSDeleteSuccessResponse'
         '404':
           $ref: "/specs/base/specs/common/error_schema.yaml#/components/responses/NotFound"
 
@@ -144,20 +132,6 @@ components:
   schemas:
     MeshTLSItem:
       $ref: 'schema.yaml'
-    MeshTLSCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: |
-            warnings is a list of warning messages to return to the requesting Kuma API clients.
-            Warning messages describe a problem the client making the API request should correct or be aware of.
-          items:
-            type: string
-    MeshTLSDeleteSuccessResponse:
-      type: object
-      properties: {}
 
   responses:
     MeshTLSItem:
@@ -183,3 +157,24 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshTLSCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: |
+                  warnings is a list of warning messages to return to the requesting Kuma API clients.
+                  Warning messages describe a problem the client making the API request should correct or be aware of.
+                items:
+                  type: string
+    MeshTLSDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/rest.yaml
@@ -56,17 +56,9 @@ paths:
               $ref: '#/components/schemas/MeshTraceItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshTraceCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshTraceCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshTraceCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshTraceCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: deleteMeshTrace
@@ -87,11 +79,7 @@ paths:
           description: name of the MeshTrace
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshTraceDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshTraceDeleteSuccessResponse'
         '404':
           $ref: "/specs/base/specs/common/error_schema.yaml#/components/responses/NotFound"
 
@@ -144,20 +132,6 @@ components:
   schemas:
     MeshTraceItem:
       $ref: 'schema.yaml'
-    MeshTraceCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: |
-            warnings is a list of warning messages to return to the requesting Kuma API clients.
-            Warning messages describe a problem the client making the API request should correct or be aware of.
-          items:
-            type: string
-    MeshTraceDeleteSuccessResponse:
-      type: object
-      properties: {}
 
   responses:
     MeshTraceItem:
@@ -183,3 +157,24 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshTraceCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: |
+                  warnings is a list of warning messages to return to the requesting Kuma API clients.
+                  Warning messages describe a problem the client making the API request should correct or be aware of.
+                items:
+                  type: string
+    MeshTraceDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object

--- a/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/rest.yaml
@@ -56,17 +56,9 @@ paths:
               $ref: '#/components/schemas/MeshTrafficPermissionItem'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshTrafficPermissionCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshTrafficPermissionCreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshTrafficPermissionCreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/MeshTrafficPermissionCreateOrUpdateSuccessResponse'
 
     delete:
       operationId: deleteMeshTrafficPermission
@@ -87,11 +79,7 @@ paths:
           description: name of the MeshTrafficPermission
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MeshTrafficPermissionDeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/MeshTrafficPermissionDeleteSuccessResponse'
         '404':
           $ref: "/specs/base/specs/common/error_schema.yaml#/components/responses/NotFound"
 
@@ -144,20 +132,6 @@ components:
   schemas:
     MeshTrafficPermissionItem:
       $ref: 'schema.yaml'
-    MeshTrafficPermissionCreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: |
-            warnings is a list of warning messages to return to the requesting Kuma API clients.
-            Warning messages describe a problem the client making the API request should correct or be aware of.
-          items:
-            type: string
-    MeshTrafficPermissionDeleteSuccessResponse:
-      type: object
-      properties: {}
 
   responses:
     MeshTrafficPermissionItem:
@@ -183,3 +157,24 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    MeshTrafficPermissionCreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: |
+                  warnings is a list of warning messages to return to the requesting Kuma API clients.
+                  Warning messages describe a problem the client making the API request should correct or be aware of.
+                items:
+                  type: string
+    MeshTrafficPermissionDeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object

--- a/tools/openapi/templates/endpoints.yaml
+++ b/tools/openapi/templates/endpoints.yaml
@@ -60,17 +60,9 @@ paths:
               $ref: '#/components/schemas/{{.Name}}Item'
       responses:
         '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/{{.Name}}CreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/{{.Name}}CreateOrUpdateSuccessResponse'
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/{{.Name}}CreateOrUpdateSuccessResponse'
+          $ref: '#/components/responses/{{.Name}}CreateOrUpdateSuccessResponse'
 
     delete:
       operationId: delete{{ .Name }}
@@ -93,11 +85,7 @@ paths:
           description: name of the {{ .Name }}
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/{{.Name}}DeleteSuccessResponse'
-          description: Successful response
+          $ref: '#/components/responses/{{.Name}}DeleteSuccessResponse'
         '404':
           $ref: "/specs/base/specs/common/error_schema.yaml#/components/responses/NotFound"
 
@@ -152,20 +140,6 @@ components:
   schemas:
     {{.Name}}Item:
       $ref: 'schema.yaml'
-    {{.Name}}CreateOrUpdateSuccessResponse:
-      type: object
-      properties:
-        warnings:
-          type: array
-          readOnly: true
-          description: |
-            warnings is a list of warning messages to return to the requesting Kuma API clients.
-            Warning messages describe a problem the client making the API request should correct or be aware of.
-          items:
-            type: string
-    {{.Name}}DeleteSuccessResponse:
-      type: object
-      properties: {}
 
   responses:
     {{.Name}}Item:
@@ -191,3 +165,24 @@ components:
               next:
                 type: string
                 description: URL to the next page
+    {{.Name}}CreateOrUpdateSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              warnings:
+                type: array
+                readOnly: true
+                description: |
+                  warnings is a list of warning messages to return to the requesting Kuma API clients.
+                  Warning messages describe a problem the client making the API request should correct or be aware of.
+                items:
+                  type: string
+    {{.Name}}DeleteSuccessResponse:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: object


### PR DESCRIPTION
## Motivation

Responses have to be under `components.responses`

## Implementation information

* moved types from `components.schemas` to `components.responses`
* updated types to have `content.application/json`

## Supporting documentation

Fix https://github.com/kumahq/kuma/issues/12322

