### PR TITLE
ci(renovate): add regex manager for Makefile images and pin digests

### DIFF
--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -3,8 +3,8 @@ DOCS_CP_CONFIG ?= pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
 DOCS_EXTRA_TARGETS ?=
 DOCS_OPENAPI_PREREQUISITES ?=
 
-# renovate: datasource=docker depName=kumahq/openapi-tool versioning=semver-coerced registryUrl=https://ghcr.io
-OAPI_TOOLS_VERSION ?= v1.2.0
+# renovate[custom/docker]: depName=kumahq/openapi-tool registryUrl=https://ghcr.io
+OAPI_TOOLS_VERSION ?= v1.2.0@sha256:2df7305447ec0c2fc41637f9ddc54c0ae6982c91549afdfcf0393a708919ffb4
 
 .PHONY: clean/docs
 clean/docs:

--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -5,7 +5,7 @@ METALLB_VERSION ?= v0.15.2
 METALLB_MANIFESTS ?= https://raw.githubusercontent.com/metallb/metallb/$(METALLB_VERSION)/config/manifests/metallb-native.yaml
 METALLB_NAMESPACE ?= metallb-system
 
-# renovate: datasource=helm depName=calico packageName=projectcalico/tigera-operator registryUrl=https://docs.tigera.io/calico/charts
+# renovate: datasource=github-releases depName=projectcalico/tigera-operator packageName=projectcalico/calico versioning=semver
 CALICO_VERSION ?= v3.30.3
 CALICO_NAMESPACE ?= tigera-operator
 CALICO_HELM_REPO_ADDR ?= https://docs.tigera.io/calico/charts

--- a/renovate.json
+++ b/renovate.json
@@ -44,6 +44,31 @@
     ],
     "managerFilePatterns": ["/app/kumactl/(?:cmd|data)/install/(?:k8s|testdata)/.+\\.ya?ml$/"]
   },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": [
+        " Parse docker image tags pinned in Makefiles and .mk files via inline renovate hints.",
+        " Looks for a directive on the preceding line of a version variable, e.g.:",
+        "  '# renovate[custom/docker]: depName=kumahq/openapi-tool registryUrl=https://ghcr.io'",
+        " followed by a variable assignment like 'OAPI_TOOLS_VERSION ?= v1.1.7@sha256:…'.",
+        " The regex extracts:",
+        "  - depName (required), with optional packageName, extractVersion, registryUrl",
+        "  - currentValue (the tag), and optional currentDigest (sha256) appended after '@'",
+        " and treats them with the docker datasource and versioning templates so Renovate can",
+        " propose tag and digest updates. See mk/docs.mk for a working example"
+      ],
+      "managerFilePatterns": [
+        "/(^|/)[Mm]akefile$/",
+        "/\\.mk$/"
+      ],
+      "matchStrings": [
+        "# renovate\\[custom/docker.*?\\]: depName=(?<depName>\\S+?)(?: packageName=(?<packageName>\\S+?))?(?: extractVersion=(?<extractVersion>\\S+?))?(?: registryUrl=(?<registryUrl>\\S+?))?\\s+(?:export )?[A-Za-z0-9_]+?_VERSION\\s*:*\\??=\\s*[\"']?(?<currentValue>[^@\\s\"']+)(?:@(?<currentDigest>sha256:[0-9a-f]{64}))?[\"']?"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
+    }
+  ],
   "packageRules": [
     {
       "description": [
@@ -70,7 +95,7 @@
         " manually"
       ],
       "matchManagers": ["kubernetes"],
-      "matchPackageNames": ["/^gcr.io/octo/", "/^docker.io/kumahq/", "/^kuma-ci/"],
+      "matchPackageNames": ["gcr.io/octo/**", "docker.io/{kumahq,[Kk]ong}/**", "kuma-ci/**"],
       "matchFileNames": ["/app/kumactl/cmd/install/testdata/.+\\.ya?ml$/"],
       "enabled": false
     },
@@ -135,17 +160,6 @@
       ],
       "matchPackageNames": ["{github.com/,}kumahq/*"],
       "minimumReleaseAge": "24h"
-    },
-    {
-      "description": [
-        " Disable pinning for 'kumahq/openapi-tool'. Pinning this tool to a specific commit or",
-        " version is not supported in our current setup and consistently fails, so we skip 'pin'",
-        " and 'pinDigest' updates for it. Managed by the Makefile regex manager"
-      ],
-      "matchManagers": ["custom.regex"],
-      "matchDepNames": ["kumahq/openapi-tool"],
-      "matchUpdateTypes": ["pin", "pinDigest"],
-      "enabled": false
     },
     {
       "description": [


### PR DESCRIPTION
## Motivation

We want Renovate to manage versions in our Makefiles and .mk files, including image digests, so builds are reproducible and updates are automated. The current inline hints and rules did not let Renovate understand a tag plus digest pattern. We also want Calico updates to follow upstream GitHub releases, and our kubernetes match patterns to be easier to maintain.

## Implementation information

- Add a custom regex manager in `renovate.json` that looks for lines marked `# renovate[custom/docker]` followed by a `*_VERSION` assignment, extracts the tag and an optional `@sha256:...` digest, and treats them with the docker datasource and versioning. This lets Renovate propose both tag and digest updates.
- Update `mk/docs.mk` to use the new hint and pin `OAPI_TOOLS_VERSION` with a sha256 digest for deterministic builds.
- Drop the old rule that disabled `pin` and `pinDigest` for `kumahq/openapi-tool` since the new manager supports digest pinning.
- Switch the Calico hint in `mk/k3d.mk` from the Helm datasource to GitHub releases so version bumps reflect upstream releases more reliably in this context.
- Convert regex-like `matchPackageNames` in a kubernetes rule to Renovate glob syntax and expand the scope to include `docker.io/Kong` images.

Alternatives considered and discarded:
- Relying on Dockerfile or Helm managers does not cover Makefile variables with tag plus digest.
- Keeping Helm as the source for Calico updates was brittle for this use and did not align with how we track versions.

## Supporting documentation

- Renovate custom managers: https://docs.renovatebot.com/modules/manager/regex/
- Docker datasource and digest pinning: https://docs.renovatebot.com/modules/datasource/docker/