### PR TITLE
ci(renovate): annotate Envoy version in dev.mk for auto updates

### DIFF
--- a/mk/dev.mk
+++ b/mk/dev.mk
@@ -7,6 +7,7 @@ GIT_TAG = $(word 2, $(BUILD_INFO))
 GIT_COMMIT = $(word 3, $(BUILD_INFO))
 BUILD_DATE = $(word 4, $(BUILD_INFO))
 CI_TOOLS_VERSION = $(word 5, $(BUILD_INFO))
+# renovate: datasource=github-tags depName=envoy packageName=kumahq/envoy-builds versioning=semver
 ENVOY_VERSION ?= 1.32.12
 KUMA_CHARTS_URL ?= https://kumahq.github.io/charts
 CHART_REPO_NAME ?= kuma


### PR DESCRIPTION
## Motivation

We want `renovate` to track and update the `envoy` build used by the project. Without an inline hint, `renovate` does not know how to discover and bump the value in the `Makefile`. This change tells `renovate` to use GitHub tags from `kumahq/envoy-builds` with `semver` rules, so we get automatic and predictable update PRs.

## Implementation information

Added a `renovate` directive comment above `ENVOY_VERSION` in `mk/dev.mk`. It points to the `github-tags` datasource for `kumahq/envoy-builds` and sets versioning to `semver`. There is no change to the current version value and no impact on runtime behavior. Alternatives considered included leaving this unmanaged and continuing with manual bumps, which we discarded to reduce toil and ensure timely updates.