### PR TITLE
chore(api-server): update KRI GET goldens to match current response

### DIFF
--- a/pkg/api-server/testdata/resources/crud/get_dp_by_kri.golden.json
+++ b/pkg/api-server/testdata/resources/crud/get_dp_by_kri.golden.json
@@ -4,6 +4,7 @@
  "name": "dp-1",
  "creationTime": "0001-01-01T00:00:00Z",
  "modificationTime": "0001-01-01T00:00:00Z",
+ "kri": "kri_dp_default___dp-1_",
  "networking": {
   "address": "10.1.2.1",
   "inbound": [

--- a/pkg/api-server/testdata/resources/crud/get_resource_by_kri.golden.json
+++ b/pkg/api-server/testdata/resources/crud/get_resource_by_kri.golden.json
@@ -1,9 +1,9 @@
 {
- "type": "MeshTrafficPermission",
- "mesh": "default",
- "name": "mtp-1",
  "creationTime": "0001-01-01T00:00:00Z",
+ "kri": "kri_mtp_default___mtp-1_",
+ "mesh": "default",
  "modificationTime": "0001-01-01T00:00:00Z",
+ "name": "mtp-1",
  "spec": {
   "targetRef": {
    "kind": "Mesh"
@@ -18,5 +18,6 @@
     }
    }
   ]
- }
+ },
+ "type": "MeshTrafficPermission"
 }

--- a/pkg/api-server/testdata/resources/crud/get_resource_by_kri_bad-request.golden.json
+++ b/pkg/api-server/testdata/resources/crud/get_resource_by_kri_bad-request.golden.json
@@ -1,7 +1,7 @@
 {
-  "type": "/std-errors",
-  "status": 400,
-  "title": "Bad Request",
-  "detail": "bad request: unknown short name of resource type: \"\"",
-  "details": "bad request: unknown short name of resource type: \"\""
+ "type": "/std-errors",
+ "status": 400,
+ "title": "Bad Request",
+ "detail": "bad request: unknown short name of resource type: \"\"",
+ "details": "bad request: unknown short name of resource type: \"\""
 }

--- a/pkg/api-server/testdata/resources/crud/get_zone-ingress_by_kri.golden.json
+++ b/pkg/api-server/testdata/resources/crud/get_zone-ingress_by_kri.golden.json
@@ -3,6 +3,7 @@
  "name": "zone-ingress-1",
  "creationTime": "0001-01-01T00:00:00Z",
  "modificationTime": "0001-01-01T00:00:00Z",
+ "kri": "kri_zi____zone-ingress-1_",
  "networking": {
   "address": "10.2.3.4",
   "advertisedAddress": "10.3.4.5",


### PR DESCRIPTION
## Motivation

The branch broke after #14674 was merged with green CI and other changes landed in the meantime. The API server now emits a `kri` field and uses a slightly different field order in JSON, so the CRUD-by-KRI golden files no longer matched the actual output.

## Implementation information

Only golden snapshots in `pkg/api-server/testdata/resources/crud` were updated:
- Added `kri` to `get_dp_by_kri.golden.json` and `get_zone-ingress_by_kri.golden.json`
- Added `kri` and adjusted top-level key order in `get_resource_by_kri.golden.json` (moved `type` to the end to match the serializer)
- Normalized whitespace in `get_resource_by_kri_bad-request.golden.json`

No runtime code changes. This simply re-syncs expected outputs with the current server behavior to unblock CI on master.

## Supporting documentation

- Related PR: https://github.com/kumahq/kuma/pull/14674