### PR TITLE
fix(oapi): add required fields on schemas that are used in one of

### DIFF
--- a/api/mesh/v1alpha1/datadogtracingbackendconfig/schema.yaml
+++ b/api/mesh/v1alpha1/datadogtracingbackendconfig/schema.yaml
@@ -16,6 +16,9 @@ components:
             get service names like `backend_INBOUND`, `backend_OUTBOUND_db1`, and
             `backend_OUTBOUND_db2` in Datadog. Default: false
           type: boolean
+      required:
+      - address
+      - port
       type: object
 info:
   x-ref-schema-name: DatadogTracingBackendConfig

--- a/api/mesh/v1alpha1/fileloggingbackendconfig/schema.yaml
+++ b/api/mesh/v1alpha1/fileloggingbackendconfig/schema.yaml
@@ -7,6 +7,8 @@ components:
         path:
           description: Path to a file that logs will be written to
           type: string
+      required:
+      - path
       type: object
 info:
   x-ref-schema-name: FileLoggingBackendConfig

--- a/api/mesh/v1alpha1/providedcertificateauthorityconfig/schema.yaml
+++ b/api/mesh/v1alpha1/providedcertificateauthorityconfig/schema.yaml
@@ -14,6 +14,9 @@ components:
           - $ref: /specs/protoresources/datasource_inline/schema.yaml#/components/schemas/DataSource_Inline
           - $ref: /specs/protoresources/datasource_inlinestring/schema.yaml#/components/schemas/DataSource_InlineString
           - $ref: /specs/protoresources/datasource_secret/schema.yaml#/components/schemas/DataSource_Secret
+      required:
+      - cert
+      - key
       type: object
 info:
   x-ref-schema-name: ProvidedCertificateAuthorityConfig

--- a/api/mesh/v1alpha1/tcploggingbackendconfig/schema.yaml
+++ b/api/mesh/v1alpha1/tcploggingbackendconfig/schema.yaml
@@ -7,6 +7,8 @@ components:
         address:
           description: Address to TCP service that will receive logs
           type: string
+      required:
+      - address
       type: object
 info:
   x-ref-schema-name: TcpLoggingBackendConfig

--- a/api/mesh/v1alpha1/zipkintracingbackendconfig/schema.yaml
+++ b/api/mesh/v1alpha1/zipkintracingbackendconfig/schema.yaml
@@ -20,6 +20,8 @@ components:
         url:
           description: Address of Zipkin collector.
           type: string
+      required:
+      - url
       type: object
 info:
   x-ref-schema-name: ZipkinTracingBackendConfig

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -14817,6 +14817,9 @@ components:
 
             `backend_OUTBOUND_db2` in Datadog. Default: false
           type: boolean
+      required:
+        - address
+        - port
       type: object
     DataplaneItem:
       properties:
@@ -16309,6 +16312,8 @@ components:
         path:
           description: Path to a file that logs will be written to
           type: string
+      required:
+        - path
       type: object
     MeshItem:
       properties:
@@ -16649,6 +16654,8 @@ components:
         address:
           description: Address to TCP service that will receive logs
           type: string
+      required:
+        - address
       type: object
     ProvidedCertificateAuthorityConfig:
       properties:
@@ -16664,6 +16671,9 @@ components:
             - $ref: '#/components/schemas/DataSource_Inline'
             - $ref: '#/components/schemas/DataSource_InlineString'
             - $ref: '#/components/schemas/DataSource_Secret'
+      required:
+        - cert
+        - key
       type: object
     ZipkinTracingBackendConfig:
       properties:
@@ -16690,6 +16700,8 @@ components:
         url:
           description: Address of Zipkin collector.
           type: string
+      required:
+        - url
       type: object
     MeshGatewayItem:
       properties:


### PR DESCRIPTION
## Motivation

Unfortunately none of our oneOf subschemas objects have required fields, so the golang deserializer in speakeasy generator, which has a default strategy of trying to fit one-by-one, can effectively "fit" any of the subschemas in.
There was a correctness change, if the count of required fields was the same, to prefer to OAS ordering when deserializing. This causes the regression in https://github.com/Kong/terraform-provider-konnect-beta/issues/104.
In general, deserialization strategy in speakeasy for oneOf is pretty primitive; it effectively tries all of them and if all of them fit, the order in the OAS is preferred. Ideally we'd look at non-required fields too with some kinda scoring mechanism. The fix is ideally an OAS update to set at least one required field on these blobs so that each oneOf subschema is distinct. 

Unfortunately speakeasy can't revert the behaviour because it's a correctness change and appears sound. They usually hide these behind some kind of feature flag to avoid accidentally regressing live code, but that got missed here.

## Implementation information

Change the `AdditionalProtoTypes` array to be a map of type to required fields.

## Supporting documentation

xrel https://github.com/Kong/terraform-provider-konnect-beta/issues/104

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
