### PR TITLE
chore(deps): security update

### DIFF
--- a/tools/releases/dockerfiles/base-root.Dockerfile
+++ b/tools/releases/dockerfiles/base-root.Dockerfile
@@ -1,5 +1,5 @@
 # use only when root is really needed
-FROM gcr.io/distroless/base-nossl-debian12:debug@sha256:84c4a85988fed534e53dc708615c83dbe44b1e78c06ab8ddf29cb8d9a8b4026b
+FROM gcr.io/distroless/base-nossl-debian12:debug@sha256:12dbb4f46c5f712fe3da1c7a441602ee91eb87a5d46b0e725b4440b852000538
 
 COPY /tools/releases/templates/LICENSE \
     /tools/releases/templates/README \

--- a/tools/releases/dockerfiles/base.Dockerfile
+++ b/tools/releases/dockerfiles/base.Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/base-nossl-debian12:debug-nonroot@sha256:081a62d414528059b08f5054fefd56e3df3c2d48bdb4090281baa76b6240ca59
+FROM gcr.io/distroless/base-nossl-debian12:debug-nonroot@sha256:d86c78b580ebcd04f3606c8201fd1ea76e457c21059cc1d2a17695b6f9ebf121
 
 COPY /tools/releases/templates/LICENSE \
     /tools/releases/templates/README \


### PR DESCRIPTION
## Motivation

Security vulnerabilities were identified in Docker base images used in the Kuma project. This PR updates these dependencies to address HIGH severity CVEs and maintain security compliance for the release-2.11 branch.

## Implementation information

This PR addresses security vulnerabilities through the following updates:

**Go Dependencies:**
- No vulnerabilities found using `osv-scanner v1.9.1` - all Go dependencies are up to date

**Docker Base Images:**
- Updated `gcr.io/distroless/base-nossl-debian12:debug` from debian 12.11 to 12.12 (digest: `84c4a85...` → `12dbb4f...`)
- Updated `gcr.io/distroless/base-nossl-debian12:debug-nonroot` from debian 12.11 to 12.12 (digest: `081a62d...` → `d86c78b...`)
- Both updates fix `CVE-2025-4802` (HIGH): glibc static setuid binary dlopen may incorrectly search LD_LIBRARY_PATH

**Note:** The `gcr.io/k8s-staging-build-image/distroless-iptables:v0.8.1` image still contains `CVE-2025-4802` but is maintained by the Kubernetes team and requires an upstream update before we can address it.

## Supporting documentation

Security scanning performed using:
- `osv-scanner v1.9.1` for Go dependencies
- Docker image updates aligned with release-2.12 security updates

All HIGH and CRITICAL vulnerabilities that can be fixed have been addressed. One vulnerability remains in the `distroless-iptables` image pending upstream release from the Kubernetes team.