### PR TITLE
chore(deps): security update

### DIFF
--- a/tools/releases/dockerfiles/base-root.Dockerfile
+++ b/tools/releases/dockerfiles/base-root.Dockerfile
@@ -1,5 +1,5 @@
 # use only when root is really needed
-FROM gcr.io/distroless/base-nossl-debian11:debug@sha256:d66c60eff6c55972af9e661a57c1afe96ef4ddfa4fff37b625a448df41a15820
+FROM gcr.io/distroless/base-nossl-debian12:debug@sha256:12dbb4f46c5f712fe3da1c7a441602ee91eb87a5d46b0e725b4440b852000538
 
 COPY /tools/releases/templates/LICENSE \
     /tools/releases/templates/README \

--- a/tools/releases/dockerfiles/base.Dockerfile
+++ b/tools/releases/dockerfiles/base.Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/base-nossl-debian11:debug-nonroot@sha256:934b713496a9ed100550aaa58636270c4d69c27040e44f2aed1fa39594c45eba
+FROM gcr.io/distroless/base-nossl-debian12:debug-nonroot@sha256:d86c78b580ebcd04f3606c8201fd1ea76e457c21059cc1d2a17695b6f9ebf121
 
 COPY /tools/releases/templates/LICENSE \
     /tools/releases/templates/README \


### PR DESCRIPTION
## Motivation

Security vulnerabilities were identified in Docker base images used in the Kuma project. This PR updates these dependencies to address HIGH severity CVEs and maintain security compliance for the release-2.10 branch.

## Implementation information

This PR addresses security vulnerabilities through the following updates:

**Go Dependencies:**
- No vulnerabilities found using `osv-scanner v1.9.1` - all Go dependencies are up to date

**Docker Base Images:**
- Updated `gcr.io/distroless/base-nossl-debian11:debug` to `gcr.io/distroless/base-nossl-debian12:debug` (debian 11.10 to 12.12, digest: `d66c60e...` → `12dbb4f...`)
- Updated `gcr.io/distroless/base-nossl-debian11:debug-nonroot` to `gcr.io/distroless/base-nossl-debian12:debug-nonroot` (debian 11.10 to 12.12, digest: `934b713...` → `d86c78b...`)
- Both updates fix `CVE-2025-4802` (HIGH): glibc static setuid binary dlopen may incorrectly search LD_LIBRARY_PATH

**Note:** The `gcr.io/k8s-staging-build-image/distroless-iptables:v0.8.1` image still contains `CVE-2025-4802` but is maintained by the Kubernetes team and requires an upstream update before we can address it.

## Supporting documentation

Security scanning performed using:
- `osv-scanner v1.9.1` for Go dependencies
- `trivy` for Docker image vulnerability scanning

All HIGH and CRITICAL vulnerabilities that can be fixed have been addressed. One vulnerability remains in the `distroless-iptables` image pending upstream release from the Kubernetes team.