### PR TITLE
chore(deps): security update for release-2.7

### DIFF
--- a/tools/releases/dockerfiles/base-root.Dockerfile
+++ b/tools/releases/dockerfiles/base-root.Dockerfile
@@ -1,5 +1,5 @@
 # use only when root is really needed
-FROM gcr.io/distroless/base-nossl-debian11:debug@sha256:4cba3ac67aa5b17e3833bf0b53bf40f8345155a0df76eec5a624d1cfe61f0789
+FROM gcr.io/distroless/base-nossl-debian12:debug@sha256:12dbb4f46c5f712fe3da1c7a441602ee91eb87a5d46b0e725b4440b852000538
 
 COPY /tools/releases/templates/LICENSE \
     /tools/releases/templates/README \

--- a/tools/releases/dockerfiles/base.Dockerfile
+++ b/tools/releases/dockerfiles/base.Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/base-nossl-debian11:debug-nonroot@sha256:ae2d0ffab317ec2f30c9309c7116b4bbf7ac3a2aad3eb64d24e4c1cb3f406378
+FROM gcr.io/distroless/base-nossl-debian12:debug-nonroot@sha256:d86c78b580ebcd04f3606c8201fd1ea76e457c21059cc1d2a17695b6f9ebf121
 
 COPY /tools/releases/templates/LICENSE \
     /tools/releases/templates/README \


### PR DESCRIPTION
## Motivation

Update distroless Docker base images from debian11 to debian12 for security updates.

## Implementation information

Updated the base Docker images used in Kuma container builds:
- `tools/releases/dockerfiles/base.Dockerfile`: `gcr.io/distroless/base-nossl-debian11:debug-nonroot` → `gcr.io/distroless/base-nossl-debian12:debug-nonroot`
- `tools/releases/dockerfiles/base-root.Dockerfile`: `gcr.io/distroless/base-nossl-debian11:debug` → `gcr.io/distroless/base-nossl-debian12:debug`

Both images use pinned SHA256 digests to ensure reproducible builds:
- `base.Dockerfile`: `@sha256:d86c78b580ebcd04f3606c8201fd1ea76e457c21059cc1d2a17695b6f9ebf121`
- `base-root.Dockerfile`: `@sha256:12dbb4f46c5f712fe3da1c7a441602ee91eb87a5d46b0e725b4440b852000538`

## Supporting documentation

Backport to release-2.7 for security maintenance.