### PR TITLE
chore(deps): bump ci-tools/release-tool from v0.10.2 to v1.2.1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: install-kuma-ci-tools
         run: |
           echo $(go env GOPATH)/bin >> $GITHUB_PATH
-          go install github.com/kumahq/ci-tools/cmd/release-tool@v0.10.2
+          go install github.com/kumahq/ci-tools/cmd/release-tool@v1.2.1
       - name: Generate GitHub app token
         id: github-app-token
         uses: actions/create-github-app-token@7bfa3a4717ef143a604ee0a99d859b8886a96d00 # v1.9.3


### PR DESCRIPTION
This PR updates the `release-tool` version in the release workflow from v0.10.2 to v1.2.1 to fix a critical issue with the `active-branches.json` format.

## Problem

When releases are published from this branch, GitHub Actions uses the workflow file from the release tag (not from master). The current version (v0.10.2) generates `active-branches.json` as a plain array:

```json
["release-2.7", "release-2.10", "release-2.11", "release-2.12", "master"]
```

However, the correct format (required for Renovate preset compatibility) is:

```json
{"baseBranchPatterns": ["release-2.7", "release-2.10", "release-2.11", "release-2.12", "master"]}
```

This caused PR #14790 to be created with the wrong format when the 2.12.2 release was published, as the workflow ran from the release-2.12 branch which had v1.1.5 (also lacking the `baseBranchPatterns` feature).

## Solution

Update to v1.2.1 (released Oct 16, 2025) which includes the feature added in v1.2.0 to emit `baseBranchPatterns` for active branches. This ensures future releases from this branch will generate the correct format.

## Impact

- Future releases from the release-2.7 branch will generate `active-branches.json` with the correct `baseBranchPatterns` format
- Prevents the issue that occurred in PR #14790 from happening again
- Aligns with the format already used in master branch