### PR TITLE
ci(workflows): fix SBOM upload to GitHub releases

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -31,7 +31,7 @@ on:
       IMAGE_DIGESTS:
         value: ${{ jobs.digest-images.outputs.DIGESTS }}
 permissions:
-  contents: read
+  contents: write # needed to upload SBOM assets to GitHub releases
 env:
   CI_TOOLS_DIR: "/home/runner/work/kuma/kuma/.ci_tools"
   FULL_MATRIX: ${{ inputs.FULL_MATRIX }}
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       id-token: write # Required for image signing
-      contents: read
+      contents: write # needed to upload SBOM assets to GitHub releases
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -7,7 +7,7 @@ on:
     branches: ["master", "release-*"]
   workflow_dispatch: # Allows manual trigger from GitHub Actions UI or via REST call
 permissions:
-  contents: read
+  contents: write # needed to upload SBOM assets to GitHub releases
 env:
   KUMA_DIR: "."
   # To keep CI tools out of the SBOM, we use a `.ci_tools` directory in the parent
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   check:
     permissions:
-      contents: read
+      contents: write # needed to upload SBOM assets to GitHub releases
       checks: write # needed for golangci/golangci-lint-action to add code annotations in PRs
     timeout-minutes: 25
     runs-on: ubuntu-24.04
@@ -102,7 +102,7 @@ jobs:
     secrets: inherit
   build_publish:
     permissions:
-      contents: read
+      contents: write # needed to upload SBOM assets to GitHub releases
       id-token: write # Required for image signing
     needs: ["check", "test"]
     uses: ./.github/workflows/_build_publish.yaml


### PR DESCRIPTION
## Motivation

SBOM files are not being attached to GitHub releases due to insufficient permissions in CI workflows. When a published release exists before the build workflow completes, the `anchore/sbom-action` attempts to upload SBOM files but fails with "Resource not accessible by integration" error because the workflow jobs only have `contents: read` permission.

This issue was not visible in previous releases because:
- When releases were created after the build completed, the action skipped the upload (no release found)
- When releases were in draft state during the build, the action skipped the upload (only published releases trigger upload)

## Implementation information

Changed `contents: read` to `contents: write` in three workflow jobs that generate and upload SBOMs:
1. `check` job in `build-test-distribute.yaml` - generates project SBOM
2. `build_publish` job in `build-test-distribute.yaml` - calls `_build_publish.yaml`
3. `build-images` job in `_build_publish.yaml` - scans Docker images and generates image SBOMs

The `anchore/sbom-action` and `Kong/public-shared-actions/security-actions/scan-docker-image` actions require `contents: write` permission when `upload-sbom-release-assets: true` to attach files as release assets.

## Supporting documentation

Backport of https://github.com/kumahq/kuma/pull/14796