### PR TITLE
chore(deps): fix CVE-2025-4802 in kuma-init

### DIFF
--- a/tools/releases/dockerfiles/kuma-init.Dockerfile
+++ b/tools/releases/dockerfiles/kuma-init.Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/k8s-staging-build-image/distroless-iptables:v0.7.3@sha256:25cc119a89bf860f964e5c47d0422eabcd260424692a2b6d4e7a74d5c3bb2231
+FROM gcr.io/k8s-staging-build-image/distroless-iptables:v0.8.4@sha256:a59cba69fdb78c15903a561b6824b4ca5644adcc33d745530d168efa8b87160b
 ARG ARCH
 
 COPY /build/artifacts-linux-$ARCH/kumactl/kumactl /usr/bin


### PR DESCRIPTION
## Motivation

Security vulnerability `CVE-2025-4802` (HIGH severity) was identified in the `kuma-init` image. The `distroless-iptables` base image `v0.7.3` contains a vulnerable version of glibc that allows static setuid binaries to incorrectly search `LD_LIBRARY_PATH` during `dlopen` operations.

## Implementation information

Updated `tools/releases/dockerfiles/kuma-init.Dockerfile` to use `distroless-iptables:v0.8.4` (from `v0.7.3`). The `v0.8.4` image includes:
- glibc `2.36-9+deb12u13` (debian `12.12`) - fixes `CVE-2025-4802`
- Previous `v0.7.3` had glibc `2.36-9+deb12u9` (vulnerable)
- Fixed version requires glibc `2.36-9+deb12u11` or later

Verified with `trivy` scan: `0` HIGH/CRITICAL vulnerabilities in the updated image.

## Supporting documentation

- `CVE-2025-4802`: glibc static setuid binary `dlopen` may incorrectly search `LD_LIBRARY_PATH`
- `trivy` security scan confirms the `v0.8.4` image is clean
- This completes the security updates started in previous commits that fixed `kuma-dp`, `kuma-cp`, and `kumactl` images

> Changelog: fix(kuma-init): update base image to fix CVE-2025-4802 (HIGH severity)