### PR TITLE
test(e2e): make MeshIdentity tests more reliable

### DIFF
--- a/test/e2e_env/multizone/meshidentity/meshidentity.go
+++ b/test/e2e_env/multizone/meshidentity/meshidentity.go
@@ -9,7 +9,9 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	meshidentity_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshidentity/api/v1alpha1"
 	meshtrust_api "github.com/kumahq/kuma/pkg/core/resources/apis/meshtrust/api/v1alpha1"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/model/rest"
 	"github.com/kumahq/kuma/pkg/kds/hash"
 	"github.com/kumahq/kuma/pkg/test/resources/builders"
@@ -77,12 +79,16 @@ func Identity() {
 	// identity-c2v4v6874cx8x6c8-cww8457w48b482c7
 	// identity-c2v4v6874cx8x6c8-w54dw4d47449z9z8
 
-	getMeshTrust := func(zone string) *meshtrust_api.MeshTrust {
+	getMeshTrust := func(zone string) (*meshtrust_api.MeshTrust, error) {
 		trust, err := multizone.Global.GetKumactlOptions().RunKumactlAndGetOutput("get", "meshtrust", "-m", meshName, hash.HashedName(meshName, hash.HashedName(meshName, "identity"), zone, Config.KumaNamespace), "-ojson")
-		Expect(err).ToNot(HaveOccurred())
+		if err != nil {
+			return nil, err
+		}
 		r, err := rest.JSON.Unmarshal([]byte(trust), meshtrust_api.MeshTrustResourceTypeDescriptor)
-		Expect(err).ToNot(HaveOccurred())
-		return r.GetSpec().(*meshtrust_api.MeshTrust)
+		if err != nil {
+			return nil, err
+		}
+		return r.GetSpec().(*meshtrust_api.MeshTrust), nil
 	}
 
 	indent := func(pem string, spaces int) string {
@@ -137,6 +143,8 @@ spec:
 		Expect(NewClusterSetup().
 			Install(YamlUniversal(yaml)).
 			Setup(multizone.Global)).To(Succeed())
+		hashedName := hash.HashedName(meshName, "identity")
+		Expect(WaitForResource(meshidentity_api.MeshIdentityResourceTypeDescriptor, model.ResourceKey{Mesh: meshName, Name: fmt.Sprintf("%s.%s", hashedName, Config.KumaNamespace)}, multizone.KubeZone1, multizone.KubeZone2)).To(Succeed())
 
 		// then
 		// mTLS traffic in local zone works
@@ -179,12 +187,24 @@ spec:
 %s
   trustDomain: %s
 `
-		trustZone1 := getMeshTrust(multizone.KubeZone1.Name())
+		var trustZone1 *meshtrust_api.MeshTrust
+		Eventually(func(g Gomega) {
+			var err error
+			trustZone1, err = getMeshTrust(multizone.KubeZone1.Name())
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(trustZone1).ToNot(BeNil())
+		}, "30s", "1s").Should(Succeed())
 		Expect(NewClusterSetup().
 			Install(YamlK8s(fmt.Sprintf(trustTmpl, multizone.KubeZone1.Name(), meshName, multizone.KubeZone2.Name(), indent(trustZone1.CABundles[0].PEM.Value, 10), trustZone1.TrustDomain))).
 			Setup(multizone.KubeZone2)).To(Succeed())
 
-		trustZone2 := getMeshTrust(multizone.KubeZone2.Name())
+		var trustZone2 *meshtrust_api.MeshTrust
+		Eventually(func(g Gomega) {
+			var err error
+			trustZone2, err = getMeshTrust(multizone.KubeZone2.Name())
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(trustZone2).ToNot(BeNil())
+		}, "30s", "1s").Should(Succeed())
 		Expect(NewClusterSetup().
 			Install(YamlK8s(fmt.Sprintf(trustTmpl, multizone.KubeZone2.Name(), meshName, multizone.KubeZone1.Name(), indent(trustZone2.CABundles[0].PEM.Value, 10), trustZone2.TrustDomain))).
 			Setup(multizone.KubeZone1)).To(Succeed())

--- a/test/e2e_env/multizone/meshidentity/migration.go
+++ b/test/e2e_env/multizone/meshidentity/migration.go
@@ -82,7 +82,7 @@ func Migration() {
 	// identity-c2v4v6874cx8x6c8-w54dw4d47449z9z8
 
 	getMeshTrust := func(zone string) (*meshtrust_api.MeshTrust, error) {
-		trust, err := multizone.Global.GetKumactlOptions().RunKumactlAndGetOutput("get", "meshtrust", "-m", meshName, hash.HashedName(meshName, hash.HashedName(meshName, "identity"), zone, Config.KumaNamespace), "-ojson")
+		trust, err := multizone.Global.GetKumactlOptions().RunKumactlAndGetOutput("get", "meshtrust", "-m", meshName, hash.HashedName(meshName, hash.HashedName(meshName, "identity-migration"), zone, Config.KumaNamespace), "-ojson")
 		if err != nil {
 			return nil, err
 		}
@@ -115,7 +115,7 @@ func Migration() {
 		// create identity without selecting any Dataplane to create builtin certificates
 		yaml := fmt.Sprintf(`
 type: MeshIdentity
-name: identity
+name: identity-migration
 mesh: %s
 spec:
   selector: {}
@@ -136,7 +136,7 @@ spec:
 			Install(YamlUniversal(yaml)).
 			Setup(multizone.Global)).To(Succeed())
 
-		hashedName := hash.HashedName(meshName, "identity")
+		hashedName := hash.HashedName(meshName, "identity-migration")
 		Expect(WaitForResource(meshidentity_api.MeshIdentityResourceTypeDescriptor, model.ResourceKey{Mesh: meshName, Name: fmt.Sprintf("%s.%s", hashedName, Config.KumaNamespace)}, multizone.KubeZone1, multizone.KubeZone2)).To(Succeed())
 
 		// when
@@ -145,7 +145,7 @@ spec:
 apiVersion: kuma.io/v1alpha1
 kind: MeshTrust
 metadata:
-  name: identity-trust-%s
+  name: identity-migration-trust-%s
   namespace: kuma-system
   labels:
     kuma.io/mesh: %s
@@ -184,7 +184,7 @@ spec:
 		// select all dataplanes
 		yaml = fmt.Sprintf(`
 type: MeshIdentity
-name: identity
+name: identity-migration
 mesh: %s
 spec:
   selector:
@@ -206,7 +206,7 @@ spec:
 		Expect(NewClusterSetup().
 			Install(YamlUniversal(yaml)).
 			Setup(multizone.Global)).To(Succeed())
-		hashedName = hash.HashedName(meshName, "identity")
+		hashedName = hash.HashedName(meshName, "identity-migration")
 		Expect(WaitForResource(meshidentity_api.MeshIdentityResourceTypeDescriptor, model.ResourceKey{Mesh: meshName, Name: fmt.Sprintf("%s.%s", hashedName, Config.KumaNamespace)}, multizone.KubeZone1, multizone.KubeZone2)).To(Succeed())
 
 		// and disable tls on Mesh


### PR DESCRIPTION
## Motivation

MeshIdentity test flaked

## Implementation information

MeshTrust resources were created on the Zone with the same name in two different meshes, which caused flaky behavior.
Renamed the resources to avoid naming conflicts and added Eventually checks since the controller may create the resource asynchronously at a later time.
