### PR TITLE
ci(version.sh): correct v-prefix removal in tag parsing

### DIFF
--- a/tools/releases/version.sh
+++ b/tools/releases/version.sh
@@ -78,7 +78,7 @@ function version_info() {
     exactTag=$(git describe --exact-match --tags 2> /dev/null || echo "not-tagged")
     # We only support tags of the format: "v?X.Y.Z(-<alphaNumericName>)?" all other tags will just be ignored and use the regular versioning scheme
     if [[ ${exactTag} =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ ]]; then
-      version="${exactTag/^v//}"
+      version="${exactTag#v}"
     elif [[ ${currentBranch} == release-* ]]; then
         releasePrefix=${currentBranch//release-/}
         lastGitTag=$(git tag -l | grep -E "^v?${releasePrefix}\.[0-9]+$" | sed 's/^v//'| sort -V | tail -1)


### PR DESCRIPTION
## Motivation

This fixes a 2.5-year-old bash parameter expansion bug from PR #4463 (June 2022) that attempted to add v-prefix support for release tags but had incorrect syntax that was never caught because Kuma never used v-prefixed tags.

## Implementation information

**The Bug:**

Line 81 in `tools/releases/version.sh` used incorrect bash parameter expansion syntax:
```bash
version="${exactTag/^v//}"
```

This attempts to replace the literal string `"^v"` (caret followed by v), not a `"v"` at the beginning of the string. The code path was never exercised because Kuma never used v-prefixed tags, so the bug remained undetected.

**The Fix:**

Changed to correct bash parameter expansion syntax:
```bash
version="${exactTag#v}"
```

The `#` operator removes the shortest match from the beginning of the string, properly stripping the `"v"` prefix if present.

**Why This is Safe:**

1. **Backward compatible**: Works with existing non-prefixed tags (e.g., `2.12.0` → `2.12.0`)
2. **Enables v-prefix support**: Now correctly handles v-prefixed tags (e.g., `v2.12.0` → `2.12.0`)
3. **Regex unchanged**: Tag validation regex already supported v-prefix (`^v?[0-9]+...`), only the removal logic was broken
4. **Extensively tested**: Verified with various tag formats:
   - Non-prefixed: `2.99.99` → `2.99.99` ✅
   - V-prefixed: `v2.99.98` → `2.99.98` ✅  
   - Pre-release: `2.99.97-rc1` → `2.99.97-rc1` ✅
   - V-prefix + pre-release: `v2.99.96-rc1` → `2.99.96-rc1` ✅

**Alternative Considered:**

Could use `${exactTag/v/}` but this would remove ALL occurrences of `"v"`, not just the prefix. The `#` operator is the correct and idiomatic bash solution for prefix removal.

## Supporting documentation

Related to #2073

Related to PR #4463 (original v-prefix attempt from 2022)