### PR TITLE
chore(deps): bump `go` to `1.23.12`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kumahq/kuma
 
-go 1.23.10
+go 1.23.12
 
 require (
 	cirello.io/pglock v1.14.2


### PR DESCRIPTION
## Motivation

Address high severity vulnerabilities in Go stdlib by updating to the latest patch version.

## Implementation information

Updated Go version from `1.23.10` to `1.23.12` in `go.mod`.

### CVE Analysis

**Before (Go 1.23.10):**

| CVE | Title |
|-----|-------|
| [GO-2025-3849](https://osv.dev/GO-2025-3849) | Incorrect results returned from Rows.Scan in database/sql |
| [GO-2025-3956](https://osv.dev/GO-2025-3956) | Unexpected paths returned from LookPath in os/exec |
| [GO-2025-4006](https://osv.dev/GO-2025-4006) | Excessive CPU consumption in ParseAddress in net/mail |
| [GO-2025-4007](https://osv.dev/GO-2025-4007) | Quadratic complexity when checking name constraints in crypto/x509 |
| [GO-2025-4008](https://osv.dev/GO-2025-4008) | ALPN negotiation error contains attacker controlled information in crypto/tls |
| [GO-2025-4009](https://osv.dev/GO-2025-4009) | Quadratic complexity when parsing some invalid inputs in encoding/pem |
| [GO-2025-4010](https://osv.dev/GO-2025-4010) | Insufficient validation of bracketed IPv6 hostnames in net/url |
| [GO-2025-4011](https://osv.dev/GO-2025-4011) | Parsing DER payload can cause memory exhaustion in encoding/asn1 |
| [GO-2025-4012](https://osv.dev/GO-2025-4012) | Lack of limit when parsing cookies can cause memory exhaustion in net/http |
| [GO-2025-4013](https://osv.dev/GO-2025-4013) | Panic when validating certificates with DSA public keys in crypto/x509 |
| [GO-2025-4014](https://osv.dev/GO-2025-4014) | Unbounded allocation when parsing GNU sparse map in archive/tar |
| [GO-2025-4015](https://osv.dev/GO-2025-4015) | Excessive CPU consumption in Reader.ReadResponse in net/textproto |

**After (Go 1.23.12):**

| CVE | Title |
|-----|-------|
| [GO-2025-4006](https://osv.dev/GO-2025-4006) | Excessive CPU consumption in ParseAddress in net/mail |
| [GO-2025-4007](https://osv.dev/GO-2025-4007) | Quadratic complexity when checking name constraints in crypto/x509 |
| [GO-2025-4008](https://osv.dev/GO-2025-4008) | ALPN negotiation error contains attacker controlled information in crypto/tls |
| [GO-2025-4009](https://osv.dev/GO-2025-4009) | Quadratic complexity when parsing some invalid inputs in encoding/pem |
| [GO-2025-4010](https://osv.dev/GO-2025-4010) | Insufficient validation of bracketed IPv6 hostnames in net/url |
| [GO-2025-4011](https://osv.dev/GO-2025-4011) | Parsing DER payload can cause memory exhaustion in encoding/asn1 |
| [GO-2025-4012](https://osv.dev/GO-2025-4012) | Lack of limit when parsing cookies can cause memory exhaustion in net/http |
| [GO-2025-4013](https://osv.dev/GO-2025-4013) | Panic when validating certificates with DSA public keys in crypto/x509 |
| [GO-2025-4014](https://osv.dev/GO-2025-4014) | Unbounded allocation when parsing GNU sparse map in archive/tar |
| [GO-2025-4015](https://osv.dev/GO-2025-4015) | Excessive CPU consumption in Reader.ReadResponse in net/textproto |

**Fixed: 2 CVEs** (GO-2025-3849, GO-2025-3956)