### PR TITLE
chore(deps): bump `go` to `1.24.9`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kumahq/kuma
 
-go 1.24.6
+go 1.24.9
 
 require (
 	cirello.io/pglock v1.16.0


### PR DESCRIPTION
## Motivation

Address high severity vulnerabilities in Go stdlib by updating to the latest patch version.

## Implementation information

Updated Go version from `1.24.6` to `1.24.9` in `go.mod`.

### CVE Analysis

**Before (Go 1.24.6):**

| CVE | Title |
|-----|-------|
| [GO-2025-4006](https://osv.dev/GO-2025-4006) | Excessive CPU consumption in ParseAddress in net/mail |
| [GO-2025-4007](https://osv.dev/GO-2025-4007) | Quadratic complexity when checking name constraints in crypto/x509 |
| [GO-2025-4008](https://osv.dev/GO-2025-4008) | ALPN negotiation error contains attacker controlled information in crypto/tls |
| [GO-2025-4009](https://osv.dev/GO-2025-4009) | Quadratic complexity when parsing some invalid inputs in encoding/pem |
| [GO-2025-4010](https://osv.dev/GO-2025-4010) | Insufficient validation of bracketed IPv6 hostnames in net/url |
| [GO-2025-4011](https://osv.dev/GO-2025-4011) | Parsing DER payload can cause memory exhaustion in encoding/asn1 |
| [GO-2025-4012](https://osv.dev/GO-2025-4012) | Lack of limit when parsing cookies can cause memory exhaustion in net/http |
| [GO-2025-4013](https://osv.dev/GO-2025-4013) | Panic when validating certificates with DSA public keys in crypto/x509 |
| [GO-2025-4014](https://osv.dev/GO-2025-4014) | Unbounded allocation when parsing GNU sparse map in archive/tar |
| [GO-2025-4015](https://osv.dev/GO-2025-4015) | Excessive CPU consumption in Reader.ReadResponse in net/textproto |

**After (Go 1.24.9):**

No stdlib vulnerabilities detected.

**Fixed: 10 CVEs**