### PR TITLE
chore(deps): bump `go` to `1.25.3`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kumahq/kuma
 
-go 1.25.2
+go 1.25.3
 
 require (
 	cirello.io/pglock v1.16.1


### PR DESCRIPTION
## Motivation

Address high severity vulnerabilities in Go stdlib by updating to the latest patch version.

## Implementation information

Updated Go version from `1.25.2` to `1.25.3` in `go.mod`.

### CVE Analysis

**Before (Go 1.25.2):**

| CVE | Title |
|-----|-------|
| [GO-2025-4007](https://osv.dev/GO-2025-4007) | Quadratic complexity when checking name constraints in crypto/x509 |

**After (Go 1.25.3):**

No stdlib vulnerabilities detected.

**Fixed: 1 CVE**