### PR TITLE
ci(deps): always use GOTOOLCHAIN=auto for go get

### DIFF
--- a/tools/ci/update-vulnerable-dependencies/update-vulnerable-dependencies.sh
+++ b/tools/ci/update-vulnerable-dependencies/update-vulnerable-dependencies.sh
@@ -40,13 +40,9 @@ for dep in $(osv-scanner "${OSV_FLAGS[@]}" | jq -c '.results[].packages[] | .pac
       go mod edit -go="$fixVersion"
       GO_VERSION_UPDATED=true
     else
-      # Use GOTOOLCHAIN=auto if Go version was updated to allow downloading
-      # newer Go toolchain when updating dependencies that require it
-      if [ "$GO_VERSION_UPDATED" = true ]; then
-        GOTOOLCHAIN=auto go get "$package"@v"$fixVersion"
-      else
-        go get "$package"@v"$fixVersion"
-      fi
+      # Always use GOTOOLCHAIN=auto to allow downloading newer Go toolchain
+      # when updating dependencies that require it (e.g., helm requiring Go 1.24+)
+      GOTOOLCHAIN=auto go get "$package"@v"$fixVersion"
     fi
   fi
 done


### PR DESCRIPTION
## Motivation

The vulnerable dependencies updater fails on release-2.7 when updating `helm.sh/helm/v3` to 3.18.5 because it requires Go 1.24+ but the branch uses Go 1.23.12 with `GOTOOLCHAIN=local` set by CI.

The previous fix (#14839) only used `GOTOOLCHAIN=auto` when `GO_VERSION_UPDATED=true` (stdlib updated first), but dependencies can require newer Go versions regardless of processing order.

## Implementation information

Changed the script to always use `GOTOOLCHAIN=auto` for all `go get` commands, removing the conditional check based on `GO_VERSION_UPDATED`. This allows Go to automatically download required toolchain versions whenever any dependency needs it.

Verified by:
1. Analyzing script logic - confirmed the fix removes conditional and always uses `GOTOOLCHAIN=auto`
2. Testing locally that `GOTOOLCHAIN=auto go get helm.sh/helm/v3@v3.18.5` succeeds
3. Confirming plain `go get` with `GOTOOLCHAIN=local` fails with the exact CI error

## Supporting documentation

Fixes: https://github.com/kumahq/kuma/actions/runs/19035025923

> Changelog: skip