### PR TITLE
ci(deps): always use GOTOOLCHAIN=auto for go mod tidy

### DIFF
--- a/tools/ci/update-vulnerable-dependencies/update-vulnerable-dependencies.sh
+++ b/tools/ci/update-vulnerable-dependencies/update-vulnerable-dependencies.sh
@@ -21,8 +21,6 @@ for i in "${OSV_SCANNER_ADDITIONAL_OPTS[@]}"; do
    OSV_FLAGS+=("${i}")
 done
 
-GO_VERSION_UPDATED=false
-
 for dep in $(osv-scanner "${OSV_FLAGS[@]}" | jq -c '.results[].packages[] | .package.name as $vulnerablePackage | {
   name: $vulnerablePackage,
   current: .package.version,
@@ -38,7 +36,6 @@ for dep in $(osv-scanner "${OSV_FLAGS[@]}" | jq -c '.results[].packages[] | .pac
 
     if [[ "$package" == "stdlib" ]]; then
       go mod edit -go="$fixVersion"
-      GO_VERSION_UPDATED=true
     else
       # Always use GOTOOLCHAIN=auto to allow downloading newer Go toolchain
       # when updating dependencies that require it (e.g., helm requiring Go 1.24+)
@@ -47,10 +44,7 @@ for dep in $(osv-scanner "${OSV_FLAGS[@]}" | jq -c '.results[].packages[] | .pac
   fi
 done
 
-# Use GOTOOLCHAIN=auto when running `go mod tidy` to allow downloading
+# Always use GOTOOLCHAIN=auto when running `go mod tidy` to allow downloading
 # newer Go versions if `go.mod` was updated to require a newer version
-if [ "$GO_VERSION_UPDATED" = true ]; then
-  GOTOOLCHAIN=auto go mod tidy
-else
-  go mod tidy
-fi
+# (either explicitly via go mod edit or implicitly via go get)
+GOTOOLCHAIN=auto go mod tidy


### PR DESCRIPTION
## Motivation

The previous fix (#14846) only used `GOTOOLCHAIN=auto` for `go get` commands but not for `go mod tidy`. This causes CI failures on release-2.7 when `go get` implicitly updates `go.mod` to require a newer Go version.

When updating `helm.sh/helm/v3` to 3.18.5 (which requires Go 1.24+) on release-2.7 (Go 1.23.12), `go get` with `GOTOOLCHAIN=auto` succeeds and implicitly updates `go.mod` to require Go 1.24. However, `go mod tidy` then fails with `GOTOOLCHAIN=local` (set by CI):
```
go: go.mod requires go >= 1.24.0 (running go 1.23.12; GOTOOLCHAIN=local)
```

## Implementation information

Updated the script to:
1. Always use `GOTOOLCHAIN=auto` for `go mod tidy` (not just when stdlib is explicitly updated)
2. Removed `GO_VERSION_UPDATED` variable as it's no longer needed

The fix ensures both `go get` and `go mod tidy` can download and use newer Go toolchains when needed, regardless of dependency processing order or whether `go.mod` was explicitly or implicitly updated.

## Testing

Verified the fix through:
1. Script analysis confirming all `go get` and `go mod tidy` commands use `GOTOOLCHAIN=auto`
2. Shellcheck passes
3. Logic analysis confirming it handles implicit `go.mod` updates from `go get`
4. Verified it works with CI's `GOTOOLCHAIN=local` environment

The script now correctly handles the following scenario:
- `GOTOOLCHAIN=auto go get helm.sh/helm/v3@v3.18.5` → downloads Go 1.24+, updates `go.mod` to Go 1.24
- `GOTOOLCHAIN=auto go mod tidy` → uses downloaded Go 1.24+ toolchain, succeeds

High confidence this will resolve the CI failures.

## Supporting documentation

Fixes: https://github.com/kumahq/kuma/actions/runs/19036887682

> Changelog: skip