### PR TITLE
fix(meshpassthrough): sort IP address to provide predictable order

### DIFF
--- a/pkg/plugins/policies/meshpassthrough/plugin/xds/order.go
+++ b/pkg/plugins/policies/meshpassthrough/plugin/xds/order.go
@@ -242,9 +242,16 @@ func orderMatchers(matchers []FilterChainMatch) {
 			return sortDomains(matchers[i].Value, matchers[j].Value)
 		}
 		if matchers[i].MatchType == CIDR || matchers[i].MatchType == CIDRV6 {
-			_, prefixI := getIpAndMask(matchers[i].Value)
-			_, prefixJ := getIpAndMask(matchers[j].Value)
+			ipI, prefixI := getIpAndMask(matchers[i].Value)
+			ipJ, prefixJ := getIpAndMask(matchers[j].Value)
+			if prefixI == prefixJ {
+				return ipI > ipJ
+			}
 			return prefixI > prefixJ
+		}
+
+		if matchers[i].MatchType == IP || matchers[i].MatchType == IPV6 {
+			return matchers[i].Value > matchers[j].Value
 		}
 
 		return len(matchers[i].Routes) > len(matchers[j].Routes)

--- a/pkg/plugins/policies/meshpassthrough/plugin/xds/order_test.go
+++ b/pkg/plugins/policies/meshpassthrough/plugin/xds/order_test.go
@@ -123,6 +123,16 @@ var _ = Describe("Match order", func() {
 					},
 					{
 						Type:     api.MatchType("CIDR"),
+						Value:    "192.168.1.1/30",
+						Protocol: api.ProtocolType("tcp"),
+					},
+					{
+						Type:     api.MatchType("CIDR"),
+						Value:    "192.168.2.1/30",
+						Protocol: api.ProtocolType("tcp"),
+					},
+					{
+						Type:     api.MatchType("CIDR"),
 						Value:    "192.168.0.1/30",
 						Protocol: api.ProtocolType("tcp"),
 					},

--- a/pkg/plugins/policies/meshpassthrough/plugin/xds/testdata/ordered.golden.yaml
+++ b/pkg/plugins/policies/meshpassthrough/plugin/xds/testdata/ordered.golden.yaml
@@ -197,6 +197,16 @@
   Port: 9091
   Protocol: tcp
   Routes: []
+  Value: 192.168.2.1/30
+- MatchType: 3
+  Port: 9091
+  Protocol: tcp
+  Routes: []
+  Value: 192.168.1.1/30
+- MatchType: 3
+  Port: 9091
+  Protocol: tcp
+  Routes: []
   Value: 192.168.0.1/30
 - MatchType: 3
   Port: 9091
@@ -207,6 +217,16 @@
   Port: 9001
   Protocol: tcp
   Routes: []
+  Value: 192.168.2.1/30
+- MatchType: 3
+  Port: 9001
+  Protocol: tcp
+  Routes: []
+  Value: 192.168.1.1/30
+- MatchType: 3
+  Port: 9001
+  Protocol: tcp
+  Routes: []
   Value: 192.168.0.1/30
 - MatchType: 3
   Port: 9001
@@ -217,6 +237,16 @@
   Port: 9000
   Protocol: tcp
   Routes: []
+  Value: 192.168.2.1/30
+- MatchType: 3
+  Port: 9000
+  Protocol: tcp
+  Routes: []
+  Value: 192.168.1.1/30
+- MatchType: 3
+  Port: 9000
+  Protocol: tcp
+  Routes: []
   Value: 192.168.0.1/30
 - MatchType: 3
   Port: 9000
@@ -227,6 +257,16 @@
   Port: 8080
   Protocol: tcp
   Routes: []
+  Value: 192.168.2.1/30
+- MatchType: 3
+  Port: 8080
+  Protocol: tcp
+  Routes: []
+  Value: 192.168.1.1/30
+- MatchType: 3
+  Port: 8080
+  Protocol: tcp
+  Routes: []
   Value: 192.168.0.1/30
 - MatchType: 3
   Port: 8080
@@ -237,12 +277,32 @@
   Port: 443
   Protocol: tcp
   Routes: []
+  Value: 192.168.2.1/30
+- MatchType: 3
+  Port: 443
+  Protocol: tcp
+  Routes: []
+  Value: 192.168.1.1/30
+- MatchType: 3
+  Port: 443
+  Protocol: tcp
+  Routes: []
   Value: 192.168.0.1/30
 - MatchType: 3
   Port: 443
   Protocol: tcp
   Routes: []
   Value: 192.168.0.1/24
+- MatchType: 3
+  Port: 0
+  Protocol: tcp
+  Routes: []
+  Value: 192.168.2.1/30
+- MatchType: 3
+  Port: 0
+  Protocol: tcp
+  Routes: []
+  Value: 192.168.1.1/30
 - MatchType: 3
   Port: 0
   Protocol: tcp


### PR DESCRIPTION
## Motivation

While running a mesh with `MeshPassthrough`, I noticed that the configuration was reconciled even when there were no changes. After investigating, I found that the IP addresses and parts of the CIDR blocks were not sorted, which caused the configuration to be reconciled unnecessarily.

## Implementation information

* Added sorting rule for IP addresses in both CIDR and single IP modes
* Added test cases to verify the functionality