### PR TITLE
ci(workflows): fix workflow_dispatch validation issues

### DIFF
--- a/.github/workflows/validate-workflows-and-scripts.yaml
+++ b/.github/workflows/validate-workflows-and-scripts.yaml
@@ -7,7 +7,7 @@ run-name: >-
     format('Validate: {0}{1}{2}',
       inputs.run_actionlint && 'actionlint' || '',
       inputs.run_actionlint && inputs.run_shellcheck && ' + ' || '',
-      inputs.run_shellcheck && 'shellcheck' || 'none'
+      inputs.run_shellcheck && 'shellcheck' || ''
     ) ||
     github.event_name
   }}
@@ -68,9 +68,9 @@ jobs:
           steps.changes.outputs.workflows == 'true'
         with:
           github_token: ${{ github.token }}
-          reporter: github-pr-review
+          reporter: ${{ github.event_name == 'workflow_dispatch' && 'local' || 'github-pr-review' }}
           fail_level: error
-          filter_mode: diff_context
+          filter_mode: ${{ github.event_name == 'workflow_dispatch' && 'nofilter' || 'diff_context' }}
 
   shellcheck:
     name: "Validate Shell Scripts"
@@ -99,9 +99,9 @@ jobs:
           steps.changes.outputs.scripts == 'true'
         with:
           github_token: ${{ github.token }}
-          reporter: github-pr-review
+          reporter: ${{ github.event_name == 'workflow_dispatch' && 'local' || 'github-pr-review' }}
           fail_level: error
-          filter_mode: diff_context
+          filter_mode: ${{ github.event_name == 'workflow_dispatch' && 'nofilter' || 'diff_context' }}
           shellcheck_flags: "-P SCRIPTDIR -x"
           pattern: "*.sh"
 


### PR DESCRIPTION
## Motivation

The validation workflow fails when triggered via `workflow_dispatch` (manual runs) due to using `github-pr-review` reporter which requires PR context. Additionally, the run name shows an unnecessary "none" suffix when only one linter is selected. Finally, shellcheck issues are not displayed because `diff_context` filter mode requires PR diff context.

## Implementation information

- Changed run name to use empty string instead of `'none'` when shellcheck is not selected
- Modified `actionlint` step to dynamically select reporter: `local` for `workflow_dispatch` events (outputs to logs), `github-pr-review` for PR events (posts review comments)
- Modified `shellcheck` step to dynamically select reporter: `local` for `workflow_dispatch` events (outputs to logs), `github-pr-review` for PR events (posts review comments)
- Modified both steps to use `nofilter` filter mode for `workflow_dispatch` events (shows all issues) and `diff_context` for PR events (shows only changed lines)

The `local` reporter outputs issues directly to the workflow run logs without requiring any special permissions or PR context. The `nofilter` mode ensures all issues are visible in manual runs without requiring a PR diff.

## Supporting documentation

Fixes the issues described in https://github.com/kumahq/kuma/actions/runs/19130604195

> Changelog: skip