### PR TITLE
test(files): fix RelativeToPkgMod for v2 module paths

### DIFF
--- a/pkg/util/files/files_test.go
+++ b/pkg/util/files/files_test.go
@@ -22,3 +22,32 @@ var _ = DescribeTable("",
 	Entry(nil, "C?on_between_old_an/d_new_DPP_\"from_version:_2-7-12", "C-on_between_old_an-d_new_DPP_-from_version-_2-7-12"),
 	Entry(nil, "Compatibility_connection_between_old_and_new_DPP_from_version:_2-7-12", "Compatibility_connection_between_old_and_new_DPP_from_version-_2-7-12"),
 )
+
+var _ = DescribeTable("RelativeToPkgMod",
+	func(in string, out string) string {
+		return fmt.Sprintf(`RelativeToPkgMod(%q)=%q`, in, out)
+	},
+	func(in string, out string) {
+		Expect(files.RelativeToPkgMod(in)).To(Equal(out))
+	},
+	Entry("v1 module path",
+		"/home/ubuntu/go/pkg/mod/github.com/kumahq/kuma@v1.8.0-20231106140736-df9c4e43a672/pkg/test/store/postgres/test_container.go",
+		"/github.com/kumahq/kuma@v1.8.0-20231106140736-df9c4e43a672/pkg/test/store/postgres/test_container.go",
+	),
+	Entry("v2 module path",
+		"/home/ubuntu/go/pkg/mod/github.com/kumahq/kuma/v2@v2.0.0-20251106140736-df9c4e43a672/pkg/test/store/postgres/test_container.go",
+		"/github.com/kumahq/kuma/v2@v2.0.0-20251106140736-df9c4e43a672/pkg/test/store/postgres/test_container.go",
+	),
+	Entry("v2 module path with app directory",
+		"/home/ubuntu/go/pkg/mod/github.com/kumahq/kuma/v2@v2.0.0-20251106140736-df9c4e43a672/app/kumactl/cmd/root.go",
+		"/github.com/kumahq/kuma/v2@v2.0.0-20251106140736-df9c4e43a672/app/kumactl/cmd/root.go",
+	),
+	Entry("different org v2 module path",
+		"/home/ubuntu/go/pkg/mod/github.com/example/project/v2@v2.1.0/pkg/main.go",
+		"/github.com/example/project/v2@v2.1.0/pkg/main.go",
+	),
+	Entry("v3 module path",
+		"/home/ubuntu/go/pkg/mod/github.com/kumahq/kuma/v3@v3.0.0-20251106140736-df9c4e43a672/pkg/test/store/postgres/test_container.go",
+		"/github.com/kumahq/kuma/v3@v3.0.0-20251106140736-df9c4e43a672/pkg/test/store/postgres/test_container.go",
+	),
+)

--- a/pkg/util/files/project.go
+++ b/pkg/util/files/project.go
@@ -20,6 +20,11 @@ func GetProjectRootParent(file string) string {
 }
 
 func RelativeToPkgMod(file string) string {
+	pkgModPath := "/pkg/mod/"
+	if idx := strings.Index(file, pkgModPath); idx != -1 {
+		return "/" + file[idx+len(pkgModPath):]
+	}
+
 	root := path.Dir(path.Dir(path.Dir(GetProjectRoot(file))))
 	return strings.TrimPrefix(file, root)
 }


### PR DESCRIPTION
## Summary

Fixed a bug in `pkg/util/files/project.go` where `RelativeToPkgMod()` incorrectly handled v2 module paths in `pkg/mod`, causing downstream projects like Kong Mesh to fail when running tests with `PostgresContainer`.

## Issues resolved

Fixes downstream test failures when Kuma v2 is used as a dependency.

## Description

The `RelativeToPkgMod()` function hardcoded three `path.Dir()` calls which worked for v1 modules (`github.com/kumahq/kuma@version`) but incorrectly stripped `github.com/` from v2 module paths (`github.com/kumahq/kuma/v2@version`) due to the extra `/v2` directory level. This caused paths like `/home/ubuntu/go/pkg/mod/github.com/kumahq/kuma/v2@version/test/dockerfiles` to be incorrectly transformed to `/kumahq/kuma/v2@version/test/dockerfiles`, missing the `github.com/` prefix.

The fix detects `/pkg/mod/` in paths and returns everything after it, correctly preserving the full module path for all module versions (v1, v2, v3+). The fallback behavior for non-pkg/mod paths remains unchanged.

## Implementation

- Modified `RelativeToPkgMod()` in `pkg/util/files/project.go` to detect `/pkg/mod/` and return the correct relative path
- Added comprehensive test coverage in `pkg/util/files/files_test.go` for v1, v2, and v3 module paths
- Tests verify both `pkg` and `app` directory paths work correctly

## Test plan

- Added unit tests covering v1, v2, v3 module paths in various configurations
- All existing tests in `pkg/util/files` pass successfully
- Verified fix resolves Kong Mesh test failures with `PostgresContainer`