### PR TITLE
test(postgres): fix PostgresContainer with -trimpath

### DIFF
--- a/pkg/test/store/postgres/test_container.go
+++ b/pkg/test/store/postgres/test_container.go
@@ -29,6 +29,16 @@ type PostgresContainer struct {
 }
 
 func findProjectRoot(cwd, callerFile string) string {
+	// When -trimpath is used, runtime.Caller returns relative paths like:
+	// "github.com/kumahq/kuma/v2@v2.0.0-20251106183812-a52a8779dbb5/pkg/test/store/postgres/test_container.go"
+	// We need to prepend GOPATH/pkg/mod/ to construct the full path
+	if !strings.HasPrefix(callerFile, "/") {
+		file := path.Join(util_files.GetGopath(), "pkg", "mod", callerFile)
+		if util_files.FileExists(file) {
+			return util_files.GetProjectRoot(file)
+		}
+	}
+
 	projectRootParent := util_files.GetProjectRootParent(cwd)
 	fileRelativeToProjectRootParent := util_files.RelativeToProjectRootParent(callerFile)
 	projectRoot := util_files.GetProjectRoot(cwd)


### PR DESCRIPTION
## Motivation

When downstream projects build with `-trimpath -race` flags, `PostgresContainer` tests fail because `runtime.Caller()` returns relative paths instead of absolute paths, preventing the code from locating the postgres client key file.

## Implementation information

- Added early check in `findProjectRoot()` to detect trimmed paths (paths not starting with `/`)
- When detected, prepends `GOPATH/pkg/mod/` to construct the full path to the module in the module cache
- Preserves existing fallback logic for non-trimmed paths

## Supporting documentation

Tested locally with `-trimpath -race` flags multiple times. All postgres-related tests pass in downstream projects with no regressions in normal builds without `-trimpath`.