### PR TITLE
build(openapi): add OAS_SPECS_EXTRA_FILTER var

### DIFF
--- a/mk/generate.mk
+++ b/mk/generate.mk
@@ -110,8 +110,10 @@ generate/policy-helm:
 # Discover OpenAPI specification files
 # - Searches api/openapi/specs/ and immediate subdirectories for *.yaml files
 # - Excludes kri/ subdirectory (handled separately by oapi-gen tool)
+# - Allows additional exclusions via OAS_SPECS_EXTRA_FILTER (for downstream projects)
 # - Sorts results for deterministic ordering
-OAS_SPECS := $(sort $(filter-out api/openapi/specs/kri/%, \
+OAS_SPECS_EXTRA_FILTER ?=
+OAS_SPECS := $(sort $(filter-out api/openapi/specs/kri/% $(OAS_SPECS_EXTRA_FILTER), \
 	$(wildcard api/openapi/specs/*.yaml) \
 	$(wildcard api/openapi/specs/*/*.yaml)))
 


### PR DESCRIPTION
## Motivation

Add `OAS_SPECS_EXTRA_FILTER` variable to allow downstream projects to exclude additional OpenAPI specs from code generation without needing to override targets or modify Kuma's Makefile.

## Implementation information

- Added `OAS_SPECS_EXTRA_FILTER` variable to `mk/generate.mk`
- Extended the filter pattern to include both existing and extra filters
- Enables downstream projects to copy specs for `$ref` resolution while excluding them from their own generation

## Supporting documentation

This change supports downstream projects (like enterprise forks) that need to:
- Copy specs for `$ref` resolution
- Import generated types from Kuma
- Exclude specific specs from their own generation

Example usage in downstream project:
```make
OAS_SPECS_EXTRA_FILTER := %/error_schema.yaml
```