### PR TITLE
ci(lint): increase golangci-lint timeout to 25 minutes

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -25,7 +25,7 @@ jobs:
       contents: read
       pull-requests: read # needed to fetch PR metadata for only-new-issues
       checks: write # needed to create check runs with annotations
-    timeout-minutes: 20
+    timeout-minutes: 30
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -53,7 +53,7 @@ jobs:
           GOGC: "80"
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
-          args: --timeout=10m --verbose
+          args: --timeout=25m --verbose
           only-new-issues: ${{ github.event_name == 'pull_request' }}
           github-token: ${{ github.token }}
   check:


### PR DESCRIPTION
## Motivation

The `golangci-lint` job is timing out in downstream projects with the current 10-minute timeout configuration.

## Implementation information

- Increased `golangci-lint` timeout from `10m` to `25m` in `.github/workflows/build-test-distribute.yaml:56`
- Increased job timeout from `20` to `30` minutes in `.github/workflows/build-test-distribute.yaml:28`

## Supporting documentation

Addresses CI timeout issues observed in downstream projects.

> Changelog: skip