### PR TITLE
ci(golangci-lint): fix slowdown by disabling auto-fix

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -53,7 +53,7 @@ jobs:
           GOGC: "80"
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
-          args: --timeout=25m --verbose
+          args: --fix=false --timeout=10m --verbose
           only-new-issues: ${{ github.event_name == 'pull_request' }}
           github-token: ${{ github.token }}
   check:


### PR DESCRIPTION
## Motivation

The golangci-lint job in CI has been running 18-46 minutes instead of the expected ~7-10 minutes since commit 8829403fde (Nov 7). This is causing significant CI slowdown and blocking PRs.

## Implementation information

The root cause was the accidental removal of the `--fix=false` flag during workflow refactoring. Without this flag, golangci-lint defaults to the `.golangci.yml` config setting `fix: true` (line 177), which attempts to auto-fix issues across 2,600+ Go files with 27 enabled linters. This adds 8-27 minutes to the runtime.

Changes made:
- Added `--fix=false` flag back to the `args` parameter to prevent auto-fixing in CI
- Reduced timeout from `25m` back to `10m` (the 25m timeout was a workaround symptom, not needed with the real fix)

Expected impact: golangci-lint runtime will drop from 18-46 minutes to ~7-10 minutes.

## Supporting documentation

Investigation details and performance analysis available in the commit message.