### PR TITLE
ci(golangci-lint): optimize performance and caching

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -23,7 +23,7 @@ jobs:
   golangci-lint:
     permissions:
       contents: read
-      pull-requests: read # needed to fetch PR metadata for only-new-issues
+      pull-requests: read # needed by golangci-lint-action
       checks: write # needed to create check runs with annotations
     timeout-minutes: 20
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary

Optimize golangci-lint job performance and cache management to restore historical 7-10 minute runtime after recent job split introduced slowdowns.

## Motivation

After PR #14915 split golangci-lint into a separate job, runtime increased from ~7-10 minutes to ~18 minutes due to:
1. Missing Go build cache (fixed in first commit)
2. `only-new-issues` git diff overhead (fixed in second commit)
3. Suboptimal cache management for PRs (fixed in second commit)

## Implementation

**Commit 1: Add Go build cache and reduce timeout**
- Added Go build cache (`~/.cache/go-build`, `~/go/pkg/mod`) to restore caching removed when job was split
- Reduced job timeout from 30m to 20m (completes revert started in PR #14920)

**Commit 2: Optimize performance and caching**
- Removed `only-new-issues` parameter that adds 20-50% overhead from git diff computation (28+ seconds on large repos)
- Added `skip-save-cache` for PRs to prevent cache storage bloat while maintaining cache restoration benefits
- Added `problem-matchers: true` for improved error annotations in GitHub UI
- Explicitly passed `GOMEMLIMIT` to ensure memory tuning applies to containerized golangci-lint execution

## Test plan

- Verify golangci-lint completes successfully on this PR
- Compare runtime to baseline (expecting ~7-10 minutes vs previous ~18 minutes)
- Verify cache hit/miss rates in action logs
- Verify error annotations appear correctly in Files Changed tab

> Changelog: skip