### PR TITLE
ci(tools): restore cwd before reflect in resource-gen

### DIFF
--- a/tools/resource-gen/pkg/generator/main.go
+++ b/tools/resource-gen/pkg/generator/main.go
@@ -675,15 +675,13 @@ func (r *reflector) reflectFromType(t reflect.Type, withBackendCheck bool) (*jso
 		return nil, fmt.Errorf("failed to get absolute path: %w", err)
 	}
 
-	// Change to module root directory
+	// Change to module root directory only for AddGoComments
+	// Must restore before ReflectFromType to avoid path issues in recursive calls
 	if err := os.Chdir(absReadDir); err != nil {
 		return nil, fmt.Errorf("failed to change directory to %s: %w", absReadDir, err)
 	}
-	defer func() {
-		_ = os.Chdir(originalDir)
-	}()
-
 	err = rflctr.AddGoComments(modulePath, "api/")
+	_ = os.Chdir(originalDir)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Motivation

The `resource-gen` tool was failing with path resolution errors during cross-project calls, with duplicated path segments like `/work/kong-mesh/kong-mesh/kuma/kuma`. The root cause was incorrect working directory management: the directory was changed before `ReflectFromType`, causing recursive calls in `Mapper.reflectFromType()` to resolve paths relative to the already-changed directory.

## Implementation information

- Move directory restoration from `defer` to immediately after `AddGoComments` completes
- `AddGoComments` requires the module root directory to load Go source comments
- `ReflectFromType` must execute with the original working directory to handle recursive calls correctly

## Supporting documentation

Fixes the issue introduced in commit `8c7d52b585` when fixing `AddGoComments` for cross-project calls.

> Changelog: skip