### PR TITLE
ci(tools): use correct module path in resource-gen

### DIFF
--- a/tools/resource-gen/pkg/generator/main.go
+++ b/tools/resource-gen/pkg/generator/main.go
@@ -396,15 +396,6 @@ func init() {
 {{end}}
 `))
 
-// moduleVersion is the module path suffix for Kuma's Go module.
-// Used by AddGoComments() to construct the full import path:
-//
-//	github.com/kumahq/kuma/v2
-//
-// IMPORTANT: When releasing Kuma v3, update this to "/v3" and search for
-// "github.com/kumahq/kuma/v2" across the codebase to find all occurrences.
-const moduleVersion = "/v2"
-
 var (
 	readDir  = "."
 	writeDir = "."
@@ -645,15 +636,11 @@ func (r *reflector) reflectFromType(t reflect.Type, withBackendCheck bool) (*jso
 			return s
 		},
 	}
-	base := "kuma"
-	if readDir == "kuma" {
-		base = ""
-	}
 
 	// Workaround: AddGoComments requires the correct module path to load Go source
 	// comments for OpenAPI schema descriptions. Without this, field descriptions
 	// are lost during schema generation.
-	modulePath := "github.com/kumahq/" + base + moduleVersion
+	modulePath := "github.com/kumahq/kuma/v2"
 
 	// AddGoComments uses Go's package loading which requires the path to be relative
 	// to the current working directory. For downstream projects using symlinks,


### PR DESCRIPTION
## Motivation

Fixes missing field descriptions in generated OpenAPI schemas when running in CI environments where Kuma is checked out to a `kuma/` subdirectory (affects downstream projects like Kong Mesh).

The existing logic cleared the `base` variable when `readDir == "kuma"`, resulting in an invalid module path `github.com/kumahq/v2` instead of `github.com/kumahq/kuma/v2`. This caused `AddGoComments` to fail silently because the module path didn't match the declaration in `go.mod`.

## Implementation information

**Root cause:** When Kuma is cloned to a `kuma/` subdirectory in CI, the code set `base = ""` which resulted in `modulePath = "github.com/kumahq/" + "" + "/v2" = "github.com/kumahq/v2"`. The Go package loader requires the module path to exactly match `go.mod` (`github.com/kumahq/kuma/v2`), so `AddGoComments` failed silently and field descriptions were lost.

**Solution:** Hardcode `modulePath = "github.com/kumahq/kuma/v2"` directly, removing the conditional `base` variable logic entirely. Also removed the `moduleVersion` constant since it's no longer needed with the hardcoded path.

**Why the bug only appeared in CI:** Locally, downstream projects use `readDir="../kuma"` (symlink), which kept `base="kuma"` and worked correctly. In CI, Kuma is cloned to `kuma/` subdirectory, so `readDir="kuma"` exactly matched the buggy condition.

## Supporting documentation

- Related fix: #14931 (restored cwd before reflect)
- Original workaround: #14578 (introduced the bug)

> Changelog: skip