### PR TITLE
ci(renovate): update kubectl in helm-values.yaml

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -93,6 +93,21 @@
       "datasourceTemplate": "docker",
       "packageNameTemplate": "registry.k8s.io/kubectl",
       "depNameTemplate": "kubectl"
+    },
+    {
+      "customType": "regex",
+      "description": [
+        " Update kubectl image tag in generated helm-values.yaml documentation.",
+        " Keeps generated docs in sync with values.yaml when Renovate updates kubectl.",
+        " Uses RE2-compatible pattern matching YAML tag field with optional digest"
+      ],
+      "managerFilePatterns": ["/docs/generated/raw/helm-values\\.yaml$/"],
+      "matchStrings": [
+        "tag: (?<currentValue>[^@\\s]+)(?:@(?<currentDigest>sha256:[0-9a-f]{64}))?"
+      ],
+      "datasourceTemplate": "docker",
+      "packageNameTemplate": "registry.k8s.io/kubectl",
+      "depNameTemplate": "kubectl"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
## Summary

Add custom regex manager to automatically update kubectl versions in `docs/generated/raw/helm-values.yaml` when Renovate updates the main `values.yaml` file.

## Motivation

The file `docs/generated/raw/helm-values.yaml` is generated from `values.yaml` and contains the same kubectl version tag. When Renovate updates kubectl in `values.yaml`, it doesn't automatically update this generated file, causing CI failures like:

https://github.com/kumahq/kuma/actions/runs/19293299311/job/55168928349?pr=14952

## Implementation

- Added custom regex manager targeting `/docs/generated/raw/helm-values\.yaml$/`
- Pattern matches YAML `tag:` field with optional digest (RE2 compatible)
- Uses explicit `packageNameTemplate: "registry.k8s.io/kubectl"` to ensure proper grouping
- Will be grouped with existing kubectl updates (README.md and values.yaml) via the kubectl grouping rule

## Testing

- Verified pattern matches actual file content
- Tested with regex101.com for RE2 compatibility
- Confirmed grouping with other kubectl updates

> Changelog: skip