### PR TITLE
build(make): fix GO variable evaluation to prevent mod errors

### DIFF
--- a/mk/dev.mk
+++ b/mk/dev.mk
@@ -32,8 +32,8 @@ K8S_MAX_VERSION=v1.34.1-k3s1
 # This should have the same minor version as K8S_MAX_VERSION
 KUBEBUILDER_ASSETS_VERSION=1.33
 
-GO=$(shell $(MISE) which go)
-export GO_VERSION=$(shell $(GO) mod edit -json | jq -r .Go)
+GO := $(shell $(MISE) which go)
+export GO_VERSION := $(shell $(GO) mod edit -json | jq -r .Go)
 GOOS := $(shell $(GO) env GOOS)
 GOARCH := $(shell $(GO) env GOARCH)
 


### PR DESCRIPTION
## Motivation

When running `make` targets, developers see repeated `bash: line 1: mod: command not found` errors. This occurs because the `GO` variable uses deferred evaluation (`=`) but is referenced in contexts requiring immediate evaluation (`:=`), causing the variable to expand in environments without proper mise PATH setup, resulting in an empty `GO` variable and `go mod` commands becoming just `mod`.

## Implementation information

Changed `GO` and `GO_VERSION` variable assignments in `mk/dev.mk` from deferred evaluation (`=`) to immediate evaluation (`:=`). This ensures the variables are evaluated once when the Makefile is parsed, capturing the correct `go` binary path from mise before being used in other immediate evaluation contexts.

## Supporting documentation

N/A