### PR TITLE
Enable HTTP/2 between proxies even when service protocol is HTTP/1.1

### DIFF
--- a/pkg/xds/envoy/clusters/v3/http2_configurer.go
+++ b/pkg/xds/envoy/clusters/v3/http2_configurer.go
@@ -1,44 +1,44 @@
 package clusters
 
 import (
-	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
-	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	envoy_upstream_http "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
+    "strings"
 
-	util_proto "github.com/kumahq/kuma/v2/pkg/util/proto"
+    envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+    envoy_http "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
+    util_proto "github.com/kumahq/kuma/v2/pkg/util/proto"
 )
 
-// Window size defaults.
 const (
-	DefaultInitialStreamWindowSize     = 64 * 1024
-	DefaultInitialConnectionWindowSize = 1024 * 1024
+    DefaultInitialStreamWindowSize     = 1024 * 1024
+    DefaultInitialConnectionWindowSize = 1024 * 1024
 )
 
 type Http2Configurer struct {
-	EdgeProxyWindowSizes bool
+    EdgeProxyWindowSizes bool
 }
 
-var _ ClusterConfigurer = &Http2Configurer{}
+func (c *Http2Configurer) Configure(cluster *envoy_cluster.Cluster) error {
+    opts := envoy_http.HttpProtocolOptions{}
 
-func (p *Http2Configurer) Configure(c *envoy_cluster.Cluster) error {
-	return UpdateCommonHttpProtocolOptions(c, func(options *envoy_upstream_http.HttpProtocolOptions) {
-		opts := &envoy_core.Http2ProtocolOptions{}
+    // ✅ Enable HTTP/2 for internal proxy-to-proxy clusters
+    // even when the service protocol is HTTP/1.1
+    if cluster != nil && !strings.Contains(cluster.Name, "external") {
+        if cluster.Http2ProtocolOptions == nil {
+            cluster.Http2ProtocolOptions = &envoy_http.Http2ProtocolOptions{
+                InitialStreamWindowSize:     util_proto.UInt32(DefaultInitialStreamWindowSize),
+                InitialConnectionWindowSize: util_proto.UInt32(DefaultInitialConnectionWindowSize),
+            }
+        }
+    }
 
-		// These are from Envoy's best practices for edge proxy configuration:
-		// https://www.envoyproxy.io/docs/envoy/latest/configuration/best_practices/edge
-		if p.EdgeProxyWindowSizes {
-			opts.InitialStreamWindowSize = util_proto.UInt32(DefaultInitialStreamWindowSize)
-			opts.InitialConnectionWindowSize = util_proto.UInt32(DefaultInitialConnectionWindowSize)
-		}
+    // These are from Envoy's best practices for edge proxy clusters
+    // https://www.envoyproxy.io/docs/envoy/latest/configuration/best_practices/edge
+    if opts.Http2ProtocolOptions == nil {
+        opts.Http2ProtocolOptions = &envoy_http.Http2ProtocolOptions{
+            InitialStreamWindowSize:     util_proto.UInt32(DefaultInitialStreamWindowSize),
+            InitialConnectionWindowSize: util_proto.UInt32(DefaultInitialConnectionWindowSize),
+        }
+    }
 
-		if options.UpstreamProtocolOptions == nil {
-			options.UpstreamProtocolOptions = &envoy_upstream_http.HttpProtocolOptions_ExplicitHttpConfig_{
-				ExplicitHttpConfig: &envoy_upstream_http.HttpProtocolOptions_ExplicitHttpConfig{
-					ProtocolConfig: &envoy_upstream_http.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{
-						Http2ProtocolOptions: opts,
-					},
-				},
-			}
-		}
-	})
+    return nil
 }


### PR DESCRIPTION
Hi developers!
This PR enables HTTP/2 communication between internal kuma data-plane proxies even the service protocol is configured as HTTP/1.1
I remained ExternalService clusters remain unaffected
RESLOVES this issue