### PR TITLE
fix(tools): fix AddGoComments for cross-project symlink calls

### DIFF
--- a/tools/resource-gen/pkg/generator/main.go
+++ b/tools/resource-gen/pkg/generator/main.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"strings"
@@ -482,9 +483,43 @@ func openApiGenerator(pkg string, resources []ResourceInfo) error {
 			return snakeToCamel(key)
 		},
 	}
-	// Module path for v2
+
+	// Module path for /v2 migration. This is required for AddGoComments to load
+	// Go source code comments for OpenAPI schema field descriptions.
 	modulePath := "github.com/kumahq/kuma/v2"
-	err := reflector.AddGoComments(modulePath, path.Join(readDir, "api/"))
+
+	// AddGoComments from invopop/jsonschema uses Go's package loading which
+	// requires the current working directory to be at the module root.
+	// When downstream projects (e.g., Kong Mesh) call this generator via
+	// symlinks, the working directory needs to be adjusted.
+	originalDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get working directory: %w", err)
+	}
+
+	// Resolve any symlinks in readDir to get the actual Kuma module path.
+	// This is necessary for cross-project calls where readDir might be a symlink.
+	resolvedReadDir, err := filepath.EvalSymlinks(readDir)
+	if err != nil {
+		// If symlink resolution fails, fall back to original path
+		resolvedReadDir = readDir
+	}
+
+	// Convert to absolute path to ensure correct directory reference
+	absReadDir, err := filepath.Abs(resolvedReadDir)
+	if err != nil {
+		return fmt.Errorf("failed to get absolute path: %w", err)
+	}
+
+	// Temporarily change to module root directory so AddGoComments can find
+	// Go source files and extract doc comments for schema descriptions
+	if err := os.Chdir(absReadDir); err != nil {
+		return fmt.Errorf("failed to change directory to %s: %w", absReadDir, err)
+	}
+	err = reflector.AddGoComments(modulePath, "api/")
+	// Restore working directory immediately (not deferred) to ensure
+	// subsequent ReflectFromType calls work correctly
+	_ = os.Chdir(originalDir)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Motivation

When downstream projects (e.g., Kong Mesh) call Kuma's `resource-gen` tool via symlinks, `AddGoComments` fails to load Go source comments, resulting in OpenAPI schemas missing field descriptions. This is needed for the `/v2` module path migration to work correctly in downstream projects.

## Implementation information

- Resolve symlinks in `readDir` to get actual module path
- Change to module root directory before calling `AddGoComments`
- Restore working directory immediately after (not deferred)
- `AddGoComments` uses Go's package loading which requires correct working directory
- Symlink resolution ensures we find the actual module, not symlink
- Immediate directory restoration (vs defer) prevents issues with subsequent `ReflectFromType` calls

## Supporting documentation

Related to #2073 (/v2 module path migration)

> Changelog: skip