### PR TITLE
docs(MADR): workload identifier

### DIFF
--- a/docs/madr/decisions/092-workload-identifier.md
+++ b/docs/madr/decisions/092-workload-identifier.md
@@ -1,0 +1,7 @@
+# Workload Identifier
+
+* Status: accepted
+
+Technical Story: https://github.com/kumahq/kuma/issues/12095
+
+Contents: https://docs.google.com/document/d/1NOiIikp-zZ_qtBYC3zoW_X4JQRVVUwuiH-uSUxczk5Q/edit?tab=t.zcwbvlfhyhme#heading=h.fhfd63veywke


### PR DESCRIPTION
## Motivation

Persist Google Doc link in the repo

## Implementation information

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #14636 
