### PR TITLE
fix(tools): backport AddGoComments symlink fix to release-2.11

### DIFF
--- a/tools/resource-gen/pkg/generator/main.go
+++ b/tools/resource-gen/pkg/generator/main.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"strings"
@@ -482,9 +483,43 @@ func openApiGenerator(pkg string, resources []ResourceInfo) error {
 			return snakeToCamel(key)
 		},
 	}
-	// Module path for v2
+
+	// Module path for /v2 migration. This is required for AddGoComments to load
+	// Go source code comments for OpenAPI schema field descriptions.
 	modulePath := "github.com/kumahq/kuma/v2"
-	err := reflector.AddGoComments(modulePath, path.Join(readDir, "api/"))
+
+	// AddGoComments from invopop/jsonschema uses Go's package loading which
+	// requires the current working directory to be at the module root.
+	// When downstream projects (e.g., Kong Mesh) call this generator via
+	// symlinks, the working directory needs to be adjusted.
+	originalDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get working directory: %w", err)
+	}
+
+	// Resolve any symlinks in readDir to get the actual Kuma module path.
+	// This is necessary for cross-project calls where readDir might be a symlink.
+	resolvedReadDir, err := filepath.EvalSymlinks(readDir)
+	if err != nil {
+		// If symlink resolution fails, fall back to original path
+		resolvedReadDir = readDir
+	}
+
+	// Convert to absolute path to ensure correct directory reference
+	absReadDir, err := filepath.Abs(resolvedReadDir)
+	if err != nil {
+		return fmt.Errorf("failed to get absolute path: %w", err)
+	}
+
+	// Temporarily change to module root directory so AddGoComments can find
+	// Go source files and extract doc comments for schema descriptions
+	if err := os.Chdir(absReadDir); err != nil {
+		return fmt.Errorf("failed to change directory to %s: %w", absReadDir, err)
+	}
+	err = reflector.AddGoComments(modulePath, "api/")
+	// Restore working directory immediately (not deferred) to ensure
+	// subsequent ReflectFromType calls work correctly
+	_ = os.Chdir(originalDir)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Motivation

During /v2 module path migration for Kong Mesh release-2.11, OpenAPI schema generation removes field descriptions from generated files. This breaks `make check` because the regenerated `docs/generated/openapi.yaml` has descriptions stripped out.

The issue occurs because `AddGoComments` from `invopop/jsonschema` cannot load Go source code comments when Kuma's `resource-gen` tool is called from downstream projects (Kong Mesh) via symlinks. The function requires the working directory to be at the module root to find Go source files.

## Implementation information

This PR backports the fix from release-2.12 (commit 81fdbf8456, Kuma PR #14978).

The fix modifies `tools/resource-gen/pkg/generator/main.go` to:
- Resolve symlinks in the `readDir` path using `filepath.EvalSymlinks`
- Convert to absolute path for correct directory reference
- Temporarily change to the module root directory before calling `AddGoComments`
- Restore the original working directory immediately after

This ensures OpenAPI schema field descriptions are preserved when generating schemas from downstream projects.

## Supporting documentation

- Original fix: Kuma PR #14978 (release-2.12)
- Original commit: 81fdbf8456
- Related: Kong Mesh PR #8712 (release-2.11 /v2 migration)

> Changelog: skip