### PR TITLE
ci(oapi): filter out non-YAML files from OpenAPI generation

### DIFF
--- a/mk/generate.mk
+++ b/mk/generate.mk
@@ -102,7 +102,7 @@ generate/policy-defaults:
 generate/policy-helm:
 	PATH=$(CI_TOOLS_BIN_DIR):$$PATH $(TOOLS_DIR)/policy-gen/generate-policy-helm.sh $(HELM_VALUES_FILE) $(HELM_CRD_DIR) $(HELM_VALUES_FILE_POLICY_PATH) $(POLICIES_DIR) $(policies)
 
-endpoints = $(foreach dir,$(shell find api/openapi/specs -type f | sort),$(basename $(dir)))
+endpoints?=$(foreach dir,$(shell find api/openapi/specs -type f -name "*.yaml" | sort),$(basename $(dir)))
 
 generate/oas: $(GENERATE_OAS_PREREQUISITES) $(RESOURCE_GEN)
 	for endpoint in $(endpoints); do \


### PR DESCRIPTION
## Motivation

Fix OpenAPI code generation failures caused by non-YAML files (like `.gitignore`) being processed as OpenAPI specs.

## Implementation information

- Added `-name "*.yaml"` to `endpoints` variable to filter only YAML files
- Changed `=` to `?=` to allow downstream projects to override

## Error fixed

```
error loading swagger spec in api/openapi/specs/common/.yaml
: failed to load OpenAPI specification: open api/openapi/specs/common/.yaml: no such file or directory
```

## Supporting documentation

Backport of a53866c54b from release-2.11.