### PR TITLE
test(e2e): skip cluster start in DEBUG mode if already running

### DIFF
--- a/docs/guides/e2e-test-tips.md
+++ b/docs/guides/e2e-test-tips.md
@@ -69,6 +69,14 @@ When you use `make test/e2e/debug` and the test fails, execution will immediatel
 
 `test/e2e/debug` works with the same envs as `test/e2e` like `E2E_PKG_LIST`
 
+Similarly, `test/e2e-kubernetes` with `DEBUG=1` will:
+- Skip starting clusters if already running
+- Not stop clusters after tests finish
+
+```bash
+make test/e2e-kubernetes DEBUG=1
+```
+
 ## Decide which Kubernetes clusters will be created
 
 If you know you are running only universal tests you can skip creating Kubernetes clusters by setting


### PR DESCRIPTION
## Motivation

`make test/e2e-kubernetes K8SCLUSTERS=kuma-1 DEBUG=1` was attempting to recreate clusters even when they already existed, causing "cluster already exists" failures.

## Implementation information

Added cluster existence check before starting in DEBUG mode:
- Checks if kubectl can connect to each cluster  
- Only calls test/e2e/k8s/start if any cluster check fails
- Uses KIND_KUBECONFIG_DIR/kind-<cluster>-config path matching k3d/kind operations

## Supporting documentation

Updated e2e-test-tips.md to document DEBUG=1 behavior for test/e2e-kubernetes