### PR TITLE
chore(lint): suppress ServiceAccountName deprecation warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -174,6 +174,9 @@ linters:
         text: 'SA1019: .* is deprecated: use common.WithPolicyAttributes instead'
       - linters:
           - staticcheck
+        text: 'SA1019: .* is deprecated: Use AllowedUsers instead'
+      - linters:
+          - staticcheck
         text: 'ST1001: should not use dot imports'
     paths:
       - pkg/transparentproxy/iptables/builder


### PR DESCRIPTION
## Motivation

Fix `make check` failures on master caused by staticcheck SA1019 deprecation warnings for `ServiceAccountName` field usage.

## Implementation information

- Added exclusion rule in `.golangci.yml` to suppress SA1019 warnings for deprecated `ServiceAccountName` field
- The field is deprecated in favor of `AllowedUsers` but still used for backwards compatibility
- Exclusion rule follows the same pattern as other deprecation suppressions in the file

## Supporting documentation

Related CI failure: https://github.com/kumahq/kuma/actions/runs/19412732388/job/55536444047

> Changelog: skip