### PR TITLE
test(framework): fix CNPG cluster naming in wait

### DIFF
--- a/test/framework/deployments/postgres/kubernetes.go
+++ b/test/framework/deployments/postgres/kubernetes.go
@@ -105,7 +105,7 @@ func (t *k8SDeployment) Deploy(cluster framework.Cluster) error {
 		cluster.GetKubectlOptions(t.options.namespace),
 		"wait",
 		"--for=condition=Ready",
-		fmt.Sprintf("cluster/%s", t.options.primaryName),
+		fmt.Sprintf("clusters.postgresql.cnpg.io/%s-cluster", t.options.primaryName),
 		"--timeout=180s",
 	)
 }


### PR DESCRIPTION
## Motivation

The `postgres.Install()` test helper has a naming mismatch bug. The CloudNativePG (CNPG) Helm chart creates clusters with name `{primaryName}-cluster`, but the kubectl wait command was looking for `{primaryName}` without the `-cluster` suffix. This caused wait operations to fail even though the cluster was created successfully.

## Implementation information

- Updated the kubectl wait command in `test/framework/deployments/postgres/kubernetes.go` to append `-cluster` suffix to the primary name
- Changed from short form `cluster/` to full resource name `clusters.postgresql.cnpg.io/` for better clarity and compatibility
- This fix ensures the wait command targets the correct resource name created by the CNPG Helm chart

## Supporting documentation

Related to PR #15033 which added the wait logic but didn't account for CNPG Helm chart naming conventions.

> Changelog: skip