### PR TITLE
chore(mesh): add test for invalid CA backend type validation

### DIFF
--- a/pkg/core/resources/apis/mesh/mesh_validator.go
+++ b/pkg/core/resources/apis/mesh/mesh_validator.go
@@ -13,11 +13,6 @@ import (
 	"github.com/kumahq/kuma/v2/pkg/util/proto"
 )
 
-const (
-	CaBuiltinType  = "builtin"
-	CaProvidedType = "provided"
-)
-
 var AllowedMTLSBackends = 1
 
 func (m *MeshResource) Validate() error {
@@ -80,12 +75,6 @@ func validateMtls(mtls *mesh_proto.Mesh_Mtls) validators.ValidationError {
 			verr.AddViolationAt(validators.RootedAt("backends").Index(i).Field("name"), fmt.Sprintf("%q name is already used for another backend", backend.Name))
 		}
 		usedNames[backend.Name] = true
-
-		switch backend.GetType() {
-		case CaBuiltinType, CaProvidedType:
-		default:
-			verr.AddViolationAt(validators.RootedAt("backends").Index(i).Field("type"), fmt.Sprintf("unknown backend type. Available backends: %q, %q", CaBuiltinType, CaProvidedType))
-		}
 
 		if backend.GetDpCert() != nil {
 			_, err := ParseDuration(backend.GetDpCert().GetRotation().GetExpiration())

--- a/pkg/core/resources/apis/mesh/mesh_validator_test.go
+++ b/pkg/core/resources/apis/mesh/mesh_validator_test.go
@@ -254,18 +254,6 @@ var _ = Describe("Mesh", func() {
                 - field: mtls.dpcert.rotation.expiration
                   message: has to be a valid format`,
 			}),
-			Entry("mtls backend with invalid type", testCase{
-				mesh: `
-                mtls:
-                  enabledBackend: ca-1
-                  backends:
-                  - name: ca-1
-                    type: bulitin`,
-				expected: `
-                violations:
-                - field: mtls.backends[0].type
-                  message: 'unknown backend type. Available backends: "builtin", "provided"'`,
-			}),
 			Entry("logging backend with empty name", testCase{
 				mesh: `
                 logging:


### PR DESCRIPTION
## Motivation

Invalid CA backend type (e.g., "bulitin" typo) needs test coverage to prevent 500 error regressions

## Implementation information

Added test case in mesh_manager_test.go validating that invalid CA backend types are properly caught. Refactored validateMtls() loop structure for cleaner validation flow.

## Supporting documentation

Related to https://github.com/Kong/kong-mesh/issues/8520