### PR TITLE
feat(xds): add workload label validator for MeshIdentity

### DIFF
--- a/pkg/xds/server/callbacks/workload_label_validator.go
+++ b/pkg/xds/server/callbacks/workload_label_validator.go
@@ -1,0 +1,106 @@
+package callbacks
+
+import (
+	"context"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/v2/pkg/core"
+	meshidentity_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshidentity/api/v1alpha1"
+	"github.com/kumahq/kuma/v2/pkg/core/resources/manager"
+	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
+	"github.com/kumahq/kuma/v2/pkg/core/resources/store"
+	core_xds "github.com/kumahq/kuma/v2/pkg/core/xds"
+	"github.com/kumahq/kuma/v2/pkg/plugins/runtime/k8s/metadata"
+	"github.com/kumahq/kuma/v2/pkg/util/pointer"
+)
+
+var workloadLabelLog = core.Log.WithName("xds").WithName("workload-label-validator")
+
+// WorkloadLabelValidator validates that dataplanes have the required kuma.io/workload label
+// when they are selected by a MeshIdentity that uses the workload label in its SPIFFE ID path template.
+type WorkloadLabelValidator struct {
+	rm manager.ReadOnlyResourceManager
+}
+
+var _ DataplaneCallbacks = &WorkloadLabelValidator{}
+
+func NewWorkloadLabelValidator(rm manager.ReadOnlyResourceManager) *WorkloadLabelValidator {
+	return &WorkloadLabelValidator{
+		rm: rm,
+	}
+}
+
+func (v *WorkloadLabelValidator) OnProxyConnected(
+	streamID core_xds.StreamID,
+	proxyKey core_model.ResourceKey,
+	ctx context.Context,
+	md core_xds.DataplaneMetadata,
+) error {
+	if md.GetProxyType() != mesh_proto.DataplaneProxyType {
+		return nil
+	}
+
+	if md.Resource == nil {
+		return nil
+	}
+
+	mesh := proxyKey.Mesh
+	labels := md.Resource.GetMeta().GetLabels()
+
+	log := workloadLabelLog.
+		WithValues("mesh", mesh).
+		WithValues("proxyKey", proxyKey).
+		WithValues("streamID", streamID)
+
+	meshIdentities := &meshidentity_api.MeshIdentityResourceList{}
+	if err := v.rm.List(ctx, meshIdentities, store.ListByMesh(mesh)); err != nil {
+		log.Error(err, "failed to list MeshIdentities")
+		return errors.Wrap(err, "failed to list MeshIdentities")
+	}
+
+	matched, found := meshidentity_api.BestMatched(labels, meshIdentities.Items)
+	if !found {
+		return nil
+	}
+
+	if matched.Spec.SpiffeID == nil {
+		return nil
+	}
+
+	pathTemplate := pointer.DerefOr(matched.Spec.SpiffeID.Path, "")
+	if !usesWorkloadLabel(pathTemplate) {
+		return nil
+	}
+
+	if _, ok := labels[metadata.KumaWorkload]; !ok {
+		miName := matched.Meta.GetName()
+		errMsg := errors.Errorf(
+			"missing required label '%s' - dataplane is selected by MeshIdentity '%s' with path template '%s'",
+			metadata.KumaWorkload,
+			miName,
+			pathTemplate,
+		)
+		log.Error(errMsg, "dataplane rejected - missing required workload label",
+			"meshIdentity", miName,
+			"pathTemplate", pathTemplate,
+			"dataplaneLabels", labels,
+		)
+		return errMsg
+	}
+
+	return nil
+}
+
+func (v *WorkloadLabelValidator) OnProxyDisconnected(ctx context.Context, streamID core_xds.StreamID, proxyKey core_model.ResourceKey) {
+	// No-op
+}
+
+// usesWorkloadLabel checks if the SPIFFE ID path template contains the kuma.io/workload label reference.
+func usesWorkloadLabel(pathTemplate string) bool {
+	return strings.Contains(pathTemplate, `label "kuma.io/workload"`) ||
+		strings.Contains(pathTemplate, `label 'kuma.io/workload'`) ||
+		strings.Contains(pathTemplate, "label `kuma.io/workload`")
+}

--- a/pkg/xds/server/callbacks/workload_label_validator_test.go
+++ b/pkg/xds/server/callbacks/workload_label_validator_test.go
@@ -1,0 +1,431 @@
+package callbacks_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	common_api "github.com/kumahq/kuma/v2/api/common/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
+	core_mesh "github.com/kumahq/kuma/v2/pkg/core/resources/apis/mesh"
+	meshidentity_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshidentity/api/v1alpha1"
+	core_manager "github.com/kumahq/kuma/v2/pkg/core/resources/manager"
+	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
+	core_store "github.com/kumahq/kuma/v2/pkg/core/resources/store"
+	core_xds "github.com/kumahq/kuma/v2/pkg/core/xds"
+	"github.com/kumahq/kuma/v2/pkg/plugins/resources/memory"
+	"github.com/kumahq/kuma/v2/pkg/plugins/runtime/k8s/metadata"
+	test_model "github.com/kumahq/kuma/v2/pkg/test/resources/model"
+	"github.com/kumahq/kuma/v2/pkg/util/pointer"
+	. "github.com/kumahq/kuma/v2/pkg/xds/server/callbacks"
+)
+
+var _ = Describe("Workload Label Validator", func() {
+	var resManager core_manager.ResourceManager
+	var validator *WorkloadLabelValidator
+
+	BeforeEach(func() {
+		memStore := memory.NewStore()
+		resManager = core_manager.NewResourceManager(memStore)
+		validator = NewWorkloadLabelValidator(resManager)
+
+		// Create default mesh
+		err := resManager.Create(context.Background(), core_mesh.NewMeshResource(), core_store.CreateByKey(core_model.DefaultMesh, core_model.NoMesh))
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Context("when MeshIdentity uses workload label in path template", func() {
+		BeforeEach(func() {
+			// Create MeshIdentity with workload label in path template
+			mi := &meshidentity_api.MeshIdentityResource{
+				Meta: &test_model.ResourceMeta{
+					Name: "mi-with-workload-label",
+					Mesh: "default",
+				},
+				Spec: &meshidentity_api.MeshIdentity{
+					Selector: &meshidentity_api.Selector{
+						Dataplane: &common_api.LabelSelector{
+							MatchLabels: &map[string]string{
+								"kuma.io/service": "web",
+							},
+						},
+					},
+					SpiffeID: &meshidentity_api.SpiffeID{
+						TrustDomain: pointer.To("{{ label \"kuma.io/mesh\" }}.mesh.local"),
+						Path:        pointer.To("/workload/{{ label \"kuma.io/workload\" }}"),
+					},
+				},
+			}
+			err := resManager.Create(context.Background(), mi, core_store.CreateByKey("mi-with-workload-label", "default"))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should allow connection when dataplane has workload label", func() {
+			// given
+			dpRes := &core_mesh.DataplaneResource{
+				Meta: &test_model.ResourceMeta{
+					Name: "web-01",
+					Mesh: "default",
+					Labels: map[string]string{
+						"kuma.io/service":     "web",
+						metadata.KumaWorkload: "my-workload",
+					},
+				},
+				Spec: &mesh_proto.Dataplane{
+					Networking: &mesh_proto.Dataplane_Networking{
+						Address: "127.0.0.1",
+						Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+							{
+								Port:        8080,
+								ServicePort: 8081,
+								Tags: map[string]string{
+									"kuma.io/service": "web",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			md := core_xds.DataplaneMetadata{
+				Resource:  dpRes,
+				ProxyType: mesh_proto.DataplaneProxyType,
+			}
+
+			// when
+			err := validator.OnProxyConnected(
+				core_xds.StreamID(1),
+				core_model.ResourceKey{Mesh: "default", Name: "web-01"},
+				context.Background(),
+				md,
+			)
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should deny connection when dataplane is missing workload label", func() {
+			// given
+			dpRes := &core_mesh.DataplaneResource{
+				Meta: &test_model.ResourceMeta{
+					Name: "web-02",
+					Mesh: "default",
+					Labels: map[string]string{
+						"kuma.io/service": "web",
+						// Missing kuma.io/workload label
+					},
+				},
+				Spec: &mesh_proto.Dataplane{
+					Networking: &mesh_proto.Dataplane_Networking{
+						Address: "127.0.0.1",
+						Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+							{
+								Port:        8080,
+								ServicePort: 8081,
+								Tags: map[string]string{
+									"kuma.io/service": "web",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			md := core_xds.DataplaneMetadata{
+				Resource:  dpRes,
+				ProxyType: mesh_proto.DataplaneProxyType,
+			}
+
+			// when
+			err := validator.OnProxyConnected(
+				core_xds.StreamID(2),
+				core_model.ResourceKey{Mesh: "default", Name: "web-02"},
+				context.Background(),
+				md,
+			)
+
+			// then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("missing required label 'kuma.io/workload'"))
+			Expect(err.Error()).To(ContainSubstring("mi-with-workload-label"))
+			Expect(err.Error()).To(ContainSubstring("/workload/{{ label \"kuma.io/workload\" }}"))
+		})
+	})
+
+	Context("when MeshIdentity does not use workload label", func() {
+		BeforeEach(func() {
+			// Create MeshIdentity without workload label in path template
+			mi := &meshidentity_api.MeshIdentityResource{
+				Meta: &test_model.ResourceMeta{
+					Name: "mi-without-workload-label",
+					Mesh: "default",
+				},
+				Spec: &meshidentity_api.MeshIdentity{
+					Selector: &meshidentity_api.Selector{
+						Dataplane: &common_api.LabelSelector{
+							MatchLabels: &map[string]string{
+								"kuma.io/service": "backend",
+							},
+						},
+					},
+					SpiffeID: &meshidentity_api.SpiffeID{
+						Path: pointer.To("/ns/{{ .Namespace }}/sa/{{ .ServiceAccount }}"),
+					},
+				},
+			}
+			err := resManager.Create(context.Background(), mi, core_store.CreateByKey("mi-without-workload-label", "default"))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should allow connection even without workload label", func() {
+			// given
+			dpRes := &core_mesh.DataplaneResource{
+				Meta: &test_model.ResourceMeta{
+					Name: "backend-01",
+					Mesh: "default",
+					Labels: map[string]string{
+						"kuma.io/service": "backend",
+						// No workload label
+					},
+				},
+				Spec: &mesh_proto.Dataplane{
+					Networking: &mesh_proto.Dataplane_Networking{
+						Address: "127.0.0.1",
+						Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+							{
+								Port:        8080,
+								ServicePort: 8081,
+								Tags: map[string]string{
+									"kuma.io/service": "backend",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			md := core_xds.DataplaneMetadata{
+				Resource:  dpRes,
+				ProxyType: mesh_proto.DataplaneProxyType,
+			}
+
+			// when
+			err := validator.OnProxyConnected(
+				core_xds.StreamID(3),
+				core_model.ResourceKey{Mesh: "default", Name: "backend-01"},
+				context.Background(),
+				md,
+			)
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("when no MeshIdentity applies to dataplane", func() {
+		It("should allow connection", func() {
+			// given - no MeshIdentity created
+			dpRes := &core_mesh.DataplaneResource{
+				Meta: &test_model.ResourceMeta{
+					Name: "other-01",
+					Mesh: "default",
+					Labels: map[string]string{
+						"kuma.io/service": "other",
+					},
+				},
+				Spec: &mesh_proto.Dataplane{
+					Networking: &mesh_proto.Dataplane_Networking{
+						Address: "127.0.0.1",
+						Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+							{
+								Port:        8080,
+								ServicePort: 8081,
+								Tags: map[string]string{
+									"kuma.io/service": "other",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			md := core_xds.DataplaneMetadata{
+				Resource:  dpRes,
+				ProxyType: mesh_proto.DataplaneProxyType,
+			}
+
+			// when
+			err := validator.OnProxyConnected(
+				core_xds.StreamID(4),
+				core_model.ResourceKey{Mesh: "default", Name: "other-01"},
+				context.Background(),
+				md,
+			)
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("when proxy is not a dataplane", func() {
+		It("should allow ingress proxy", func() {
+			// given
+			ingressRes := &core_mesh.ZoneIngressResource{
+				Meta: &test_model.ResourceMeta{
+					Name: "ingress-01",
+					Mesh: core_model.NoMesh,
+				},
+				Spec: &mesh_proto.ZoneIngress{
+					Networking: &mesh_proto.ZoneIngress_Networking{
+						Address: "1.1.1.1",
+						Port:    10001,
+					},
+				},
+			}
+
+			md := core_xds.DataplaneMetadata{
+				Resource:  ingressRes,
+				ProxyType: mesh_proto.IngressProxyType,
+			}
+
+			// when
+			err := validator.OnProxyConnected(
+				core_xds.StreamID(5),
+				core_model.ResourceKey{Mesh: core_model.NoMesh, Name: "ingress-01"},
+				context.Background(),
+				md,
+			)
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should allow egress proxy", func() {
+			// given
+			egressRes := &core_mesh.ZoneEgressResource{
+				Meta: &test_model.ResourceMeta{
+					Name: "egress-01",
+					Mesh: core_model.NoMesh,
+				},
+				Spec: &mesh_proto.ZoneEgress{
+					Networking: &mesh_proto.ZoneEgress_Networking{
+						Address: "1.1.1.1",
+						Port:    10002,
+					},
+				},
+			}
+
+			md := core_xds.DataplaneMetadata{
+				Resource:  egressRes,
+				ProxyType: mesh_proto.EgressProxyType,
+			}
+
+			// when
+			err := validator.OnProxyConnected(
+				core_xds.StreamID(6),
+				core_model.ResourceKey{Mesh: core_model.NoMesh, Name: "egress-01"},
+				context.Background(),
+				md,
+			)
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("with multiple MeshIdentities", func() {
+		BeforeEach(func() {
+			// Create less specific MeshIdentity
+			mi1 := &meshidentity_api.MeshIdentityResource{
+				Meta: &test_model.ResourceMeta{
+					Name: "mi-less-specific",
+					Mesh: "default",
+				},
+				Spec: &meshidentity_api.MeshIdentity{
+					Selector: &meshidentity_api.Selector{
+						Dataplane: &common_api.LabelSelector{
+							MatchLabels: &map[string]string{
+								"kuma.io/service": "api",
+							},
+						},
+					},
+					SpiffeID: &meshidentity_api.SpiffeID{
+						Path: pointer.To("/service/{{ label \"kuma.io/service\" }}"),
+					},
+				},
+			}
+			err := resManager.Create(context.Background(), mi1, core_store.CreateByKey("mi-less-specific", "default"))
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create more specific MeshIdentity with workload label
+			mi2 := &meshidentity_api.MeshIdentityResource{
+				Meta: &test_model.ResourceMeta{
+					Name: "mi-more-specific",
+					Mesh: "default",
+				},
+				Spec: &meshidentity_api.MeshIdentity{
+					Selector: &meshidentity_api.Selector{
+						Dataplane: &common_api.LabelSelector{
+							MatchLabels: &map[string]string{
+								"kuma.io/service": "api",
+								"version":         "v2",
+							},
+						},
+					},
+					SpiffeID: &meshidentity_api.SpiffeID{
+						Path: pointer.To("/workload/{{ label \"kuma.io/workload\" }}"),
+					},
+				},
+			}
+			err = resManager.Create(context.Background(), mi2, core_store.CreateByKey("mi-more-specific", "default"))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should use best match and require workload label", func() {
+			// given - dataplane matching more specific MeshIdentity
+			dpRes := &core_mesh.DataplaneResource{
+				Meta: &test_model.ResourceMeta{
+					Name: "api-v2-01",
+					Mesh: "default",
+					Labels: map[string]string{
+						"kuma.io/service": "api",
+						"version":         "v2",
+						// Missing workload label
+					},
+				},
+				Spec: &mesh_proto.Dataplane{
+					Networking: &mesh_proto.Dataplane_Networking{
+						Address: "127.0.0.1",
+						Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+							{
+								Port:        8080,
+								ServicePort: 8081,
+								Tags: map[string]string{
+									"kuma.io/service": "api",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			md := core_xds.DataplaneMetadata{
+				Resource:  dpRes,
+				ProxyType: mesh_proto.DataplaneProxyType,
+			}
+
+			// when
+			err := validator.OnProxyConnected(
+				core_xds.StreamID(7),
+				core_model.ResourceKey{Mesh: "default", Name: "api-v2-01"},
+				context.Background(),
+				md,
+			)
+
+			// then - should fail because best match requires workload label
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("mi-more-specific"))
+		})
+	})
+})

--- a/pkg/xds/server/v3/components.go
+++ b/pkg/xds/server/v3/components.go
@@ -41,12 +41,13 @@ func RegisterXDS(
 
 	authenticator := rt.XDS().PerProxyTypeAuthenticator()
 	authCallbacks := auth.NewCallbacks(rt.ReadOnlyResourceManager(), authenticator, auth.DPNotFoundRetry{}) // no need to retry on DP Not Found because we are creating DP in DataplaneLifecycle callback
+	workloadLabelValidator := xds_callbacks.DataplaneCallbacksToXdsCallbacks(xds_callbacks.NewWorkloadLabelValidator(rt.ReadOnlyResourceManager()))
 
 	dpLifecycle := xds_callbacks.DataplaneCallbacksToXdsCallbacks(
 		xds_callbacks.NewDataplaneLifecycle(rt.AppContext(), rt.ResourceManager(), authenticator, rt.Config().XdsServer.DataplaneDeregistrationDelay.Duration, rt.GetInstanceId(), rt.Config().Store.Cache.ExpirationTime.Duration))
 	reconciler := DefaultReconciler(rt, xdsContext, statsCallbacks)
-	ingressReconciler := DefaultIngressReconciler(rt, xdsContext, statsCallbacks)
-	egressReconciler := DefaultEgressReconciler(rt, xdsContext, statsCallbacks)
+	ingressReconciler := DefaultIngressReconciler(xdsContext, statsCallbacks)
+	egressReconciler := DefaultEgressReconciler(xdsContext, statsCallbacks)
 	watchdogFactory, err := xds_sync.DefaultDataplaneWatchdogFactory(rt, reconciler, ingressReconciler, egressReconciler, xdsMetrics, envoyCpCtx, envoy_common.APIV3)
 	if err != nil {
 		return err
@@ -59,6 +60,7 @@ func RegisterXDS(
 		util_xds_v3.NewControlPlaneIdCallbacks(rt.GetInstanceId()),
 		util_xds_v3.AdaptCallbacks(statsCallbacks),
 		util_xds_v3.AdaptCallbacks(authCallbacks),
+		util_xds_v3.AdaptCallbacks(workloadLabelValidator),
 		util_xds_v3.AdaptCallbacks(dpLifecycle),
 		util_xds_v3.AdaptCallbacks(syncTracker),
 		util_xds_v3.AdaptCallbacks(dpStatusTracker),
@@ -73,6 +75,7 @@ func RegisterXDS(
 		util_xds_v3.NewControlPlaneIdCallbacks(rt.GetInstanceId()),
 		util_xds_v3.AdaptDeltaCallbacks(statsCallbacks),
 		util_xds_v3.AdaptDeltaCallbacks(authCallbacks),
+		util_xds_v3.AdaptDeltaCallbacks(workloadLabelValidator),
 		util_xds_v3.AdaptDeltaCallbacks(dpLifecycle),
 		util_xds_v3.AdaptDeltaCallbacks(syncTracker),
 		util_xds_v3.AdaptDeltaCallbacks(dpStatusTracker),
@@ -117,7 +120,6 @@ func DefaultReconciler(
 }
 
 func DefaultIngressReconciler(
-	rt core_runtime.Runtime,
 	xdsContext XdsContext,
 	statsCallbacks util_xds.StatsCallbacks,
 ) xds_sync.SnapshotReconciler {
@@ -141,7 +143,6 @@ func DefaultIngressReconciler(
 }
 
 func DefaultEgressReconciler(
-	rt core_runtime.Runtime,
 	xdsContext XdsContext,
 	statsCallbacks util_xds.StatsCallbacks,
 ) xds_sync.SnapshotReconciler {

--- a/test/e2e_env/universal/universal_suite_test.go
+++ b/test/e2e_env/universal/universal_suite_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/kumahq/kuma/v2/test/e2e_env/universal/trafficroute"
 	"github.com/kumahq/kuma/v2/test/e2e_env/universal/transparentproxy"
 	"github.com/kumahq/kuma/v2/test/e2e_env/universal/virtualoutbound"
+	"github.com/kumahq/kuma/v2/test/e2e_env/universal/workload"
 	"github.com/kumahq/kuma/v2/test/e2e_env/universal/zoneegress"
 	. "github.com/kumahq/kuma/v2/test/framework"
 	"github.com/kumahq/kuma/v2/test/framework/envs/universal"
@@ -69,6 +70,7 @@ var (
 	_ = Describe("HealthCheck", healthcheck.Policy)
 	_ = Describe("MeshHealthCheck panic threshold", meshhealthcheck.MeshHealthCheckPanicThreshold, Ordered)
 	_ = Describe("MeshHealthCheck", meshhealthcheck.MeshHealthCheck)
+	_ = Describe("Workload", workload.Workload, Ordered)
 	_ = Describe("Service Probes", healthcheck.ServiceProbes, Ordered)
 	_ = Describe("External Services", externalservices.Policy, Ordered)
 	_ = Describe("External Services through Zone Egress", externalservices.ThroughZoneEgress, Ordered)

--- a/test/e2e_env/universal/workload/workload.go
+++ b/test/e2e_env/universal/workload/workload.go
@@ -1,0 +1,167 @@
+package workload
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/kumahq/kuma/v2/test/framework"
+	"github.com/kumahq/kuma/v2/test/framework/envs/universal"
+)
+
+func Workload() {
+	const mesh = "workload"
+
+	BeforeAll(func() {
+		err := NewClusterSetup().
+			Install(MeshUniversal(mesh)).
+			Setup(universal.Cluster)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEachFailure(func() {
+		DebugUniversal(universal.Cluster, mesh)
+	})
+
+	E2EAfterAll(func() {
+		Expect(universal.Cluster.DeleteMeshApps(mesh)).To(Succeed())
+		Expect(universal.Cluster.DeleteMesh(mesh)).To(Succeed())
+	})
+
+	It("should deny DPP connection when workload label is missing for MeshIdentity using workload label", func() {
+		// given MeshIdentity that uses workload label in path template
+		meshIdentityYaml := fmt.Sprintf(`
+type: MeshIdentity
+name: mi-with-workload-label
+mesh: %s
+spec:
+  selector:
+    dataplane:
+      matchLabels:
+        app: test-server
+  spiffeID:
+    trustDomain: "{{ label \"kuma.io/mesh\" }}.mesh.local"
+    path: "/workload/{{ label \"kuma.io/workload\" }}"
+  provider:
+    type: Bundled
+    bundled:
+      autogenerate:
+        enabled: true
+`, mesh)
+		Expect(YamlUniversal(meshIdentityYaml)(universal.Cluster)).To(Succeed())
+
+		// when trying to start proxy without workload label
+		err := TestServerUniversal("test-server-without-label", mesh,
+			WithArgs([]string{"echo", "--instance", "test-v1"}),
+			WithServiceName("test-server"),
+			WithAppLabel("test-server"),
+		)(universal.Cluster)
+		Expect(err).ToNot(HaveOccurred())
+
+		// then the validator should reject the connection and log the error
+		Eventually(func(g Gomega) {
+			logs := universal.Cluster.GetKumaCPLogs()
+			stderr := logs["stderr"]
+
+			g.Expect(stderr).To(ContainSubstring("dataplane rejected - missing required workload label"))
+			g.Expect(stderr).To(ContainSubstring("missing required label 'kuma.io/workload'"))
+			g.Expect(stderr).To(ContainSubstring("mi-with-workload-label"))
+		}, "30s", "1s").Should(Succeed())
+	})
+
+	It("should allow DPP connection when workload label is present for MeshIdentity using workload label", func() {
+		// given MeshIdentity that uses workload label in path template
+		meshIdentityYaml := fmt.Sprintf(`
+type: MeshIdentity
+name: mi-with-workload-label-2
+mesh: %s
+spec:
+  selector:
+    dataplane:
+      matchLabels:
+        app: backend
+  spiffeID:
+    trustDomain: "{{ label \"kuma.io/mesh\" }}.mesh.local"
+    path: "/workload/{{ label \"kuma.io/workload\" }}"
+  provider:
+    type: Bundled
+    bundled:
+      autogenerate:
+        enabled: true
+`, mesh)
+		Expect(YamlUniversal(meshIdentityYaml)(universal.Cluster)).To(Succeed())
+
+		// when trying to start test server with workload label
+		err := TestServerUniversal("backend-with-label", mesh,
+			WithArgs([]string{"echo", "--instance", "backend-v1"}),
+			WithServiceName("backend"),
+			WithAppLabel("backend"),
+			WithAppendDataplaneYaml(`
+labels:
+  kuma.io/workload: my-workload`),
+		)(universal.Cluster)
+		Expect(err).ToNot(HaveOccurred())
+
+		// then the dataplane proxy should connect successfully
+		Eventually(func(g Gomega) {
+			out, err := universal.Cluster.GetKumactlOptions().RunKumactlAndGetOutput("get", "dataplanes", "-m", mesh, "-ojson")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(out).To(ContainSubstring("backend-with-label"))
+		}, "30s", "1s").Should(Succeed())
+	})
+
+	It("should allow DPP connection when MeshIdentity does not use workload label", func() {
+		// given MeshIdentity that does NOT use workload label in path template
+		meshIdentityYaml := fmt.Sprintf(`
+type: MeshIdentity
+name: mi-without-workload-label
+mesh: %s
+spec:
+  selector:
+    dataplane:
+      matchLabels:
+        app: api
+  spiffeID:
+    trustDomain: "mesh.local"
+    path: "/ns/default/sa/{{ label \"kuma.io/service\" }}"
+  provider:
+    type: Bundled
+    bundled:
+      autogenerate:
+        enabled: true
+`, mesh)
+		Expect(YamlUniversal(meshIdentityYaml)(universal.Cluster)).To(Succeed())
+
+		// when trying to start test server without workload label
+		err := TestServerUniversal("api-without-label", mesh,
+			WithArgs([]string{"echo", "--instance", "api-v1"}),
+			WithServiceName("api"),
+			WithAppLabel("api"),
+		)(universal.Cluster)
+		Expect(err).ToNot(HaveOccurred())
+
+		// then the dataplane proxy should connect successfully
+		Eventually(func(g Gomega) {
+			out, err := universal.Cluster.GetKumactlOptions().RunKumactlAndGetOutput("get", "dataplanes", "-m", mesh, "-ojson")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(out).To(ContainSubstring("api-without-label"))
+		}, "30s", "1s").Should(Succeed())
+	})
+
+	It("should allow DPP connection when no MeshIdentity applies", func() {
+		// when trying to start test server with no matching MeshIdentity
+		err := TestServerUniversal("other-service", mesh,
+			WithArgs([]string{"echo", "--instance", "other-v1"}),
+			WithServiceName("other"),
+		)(universal.Cluster)
+		Expect(err).ToNot(HaveOccurred())
+
+		// then the dataplane proxy should connect successfully
+		Eventually(func(g Gomega) {
+			out, err := universal.Cluster.GetKumactlOptions().RunKumactlAndGetOutput("get", "dataplanes", "-m", mesh, "-ojson")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(out).To(ContainSubstring("other-service"))
+		}, "30s", "1s").Should(Succeed())
+	})
+}


### PR DESCRIPTION
## Motivation

  When MeshIdentity uses workload labels in SPIFFE ID path (e.g., /workload/{{ label "kuma.io/workload" }}), DPPs must have the required label to prevent identity
  mismatches.

##  Implementation information

  Added WorkloadLabelValidator callback that validates DPP connections:
  - Checks during DiscoveryRequest if MeshIdentity configured for DPP
  - If MeshIdentity uses workload label template, verifies kuma.io/workload label exists
  - Denies connection if label missing
  - Accesses MeshIdentity from read-only cached ResourceStore
  - Registered after auth callbacks, before lifecycle in xDS callback chain

  Validation logic:
  1. Skip non-dataplane proxies (ingress/egress)
  2. List MeshIdentities for mesh
  3. Use BestMatched() to find applicable MeshIdentity based on selector
  4. Check if path template contains {{ label "kuma.io/workload" }}
  5. Validate label exists, return detailed error if missing (includes MeshIdentity name + path template)

  Applies to all connections (new + reconnects), both K8s and Universal modes.

##  Supporting documentation

  Fixes https://github.com/kumahq/kuma/issues/14903