### PR TITLE
ci(workflows): fix osv-scanner output in security update PRs

### DIFF
--- a/.github/workflows/update-insecure-dependencies.yaml
+++ b/.github/workflows/update-insecure-dependencies.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: "Prepare commit body - before"
         id: prepare_commit_body_before
         run: |
-          SCAN_OUTPUT_BEFORE=$(osv-scanner "$OSV_SCANNER_ADDITIONAL_OPTS" --lockfile=go.mod | tr "+" "|" | awk 'NR>3 {print last} {last=$0}' || true)
+          SCAN_OUTPUT_BEFORE=$(osv-scanner ${OSV_SCANNER_ADDITIONAL_OPTS} --lockfile=go.mod | tr "+" "|" | awk 'NR>3 {print last} {last=$0}' || true)
           {
             echo "SCAN_OUTPUT_BEFORE<<EOF"
             echo "$SCAN_OUTPUT_BEFORE"
@@ -48,7 +48,7 @@ jobs:
       - name: "Prepare commit body - after"
         id: prepare_commit_body_after
         run: |
-          SCAN_OUTPUT_AFTER=$(osv-scanner "$OSV_SCANNER_ADDITIONAL_OPTS" --lockfile=go.mod | tr "+" "|" | awk 'NR>3 {print last} {last=$0}' || true)
+          SCAN_OUTPUT_AFTER=$(osv-scanner ${OSV_SCANNER_ADDITIONAL_OPTS} --lockfile=go.mod | tr "+" "|" | awk 'NR>3 {print last} {last=$0}' || true)
           {
             echo "SCAN_OUTPUT_AFTER<<EOF"
             echo "$SCAN_OUTPUT_AFTER"


### PR DESCRIPTION
## Motivation

Since commit f1601ceb4c (November 6, 2025), all security update PRs created by the `update-insecure-dependencies.yaml` workflow have empty scan outputs in their descriptions. For example, #15059, #15060, and #15061 show no vulnerability information, making it impossible to understand what vulnerabilities were addressed.

Previously (e.g., #14260 from August, #13363 from April), these PRs included detailed vulnerability tables showing affected packages, CVSS scores, and versions before and after the update.

## Implementation information

The issue was introduced in f1601ceb4c when `OSV_SCANNER_ADDITIONAL_OPTS` was quoted to fix shellcheck warning SC2086:

```bash
# Before (working)
osv-scanner $OSV_SCANNER_ADDITIONAL_OPTS --lockfile=go.mod

# After (broken)
osv-scanner "$OSV_SCANNER_ADDITIONAL_OPTS" --lockfile=go.mod
```

When `OSV_SCANNER_ADDITIONAL_OPTS=""` (empty string) and quoted, it passes a literal empty string as an argument to `osv-scanner`, causing the command to fail silently with no table output.

The fix removes quotes from `$OSV_SCANNER_ADDITIONAL_OPTS` to restore proper word splitting behavior:
- When empty: expands to nothing (correct)
- When populated with additional options: expands to those options (correct)

The shellcheck warning SC2086 is expected and safe in this case since we control the variable content and intentionally need word splitting behavior.

Verified locally that the unquoted version produces the expected vulnerability scan table output.

## Supporting documentation

Fixes empty outputs in PRs: #15059, #15060, #15061

> Changelog: skip