### PR TITLE
ci(e2e): use free-disk-space action for cleanup

### DIFF
--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -35,15 +35,12 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           MISE_DISABLE_TOOLS: "clang-format,golangci-lint,skaffold,protoc-gen-go-grpc"
       - name: "Free up disk space for the Runner"
-        run: |
-          echo "Disk usage before cleanup"
-          sudo df -h
-          echo "Removing big directories"
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
-          echo "Pruning images"
-          docker system prune --all -f
-          echo "Disk usage after cleanup"
-          sudo df -h
+        uses: endersonmenezes/free-disk-space@6c4664f43348c8c7011b53488d5ca65e9fc5cd1a # v3.0.0
+        with:
+          remove_android: true
+          remove_dotnet: true
+          remove_haskell: true
+          remove_docker_images: true
       - run: |
           make build
       - run: |


### PR DESCRIPTION
## Motivation

We are experiencing disk space issues in our CI runs. The manual disk space cleanup script can be replaced with a maintained community action that provides more reliable and efficient cleanup.

## Implementation information

- Replaced manual `rm -rf` commands with `endersonmenezes/free-disk-space@v3.0.0` action
- Action is pinned to commit digest `6c4664f43348c8c7011b53488d5ca65e9fc5cd1a`
- Configured to remove Android SDK (~12-14 GB), .NET SDK (~1.7-2.7 GB), and Haskell
- Expected to free up 12-16 GB of disk space total
- Provides better maintainability and reliability compared to manual cleanup

## Supporting documentation

- Action repository: https://github.com/endersonmenezes/free-disk-space
- Runner images research: https://github.com/actions/runner-images

> Changelog: skip