### PR TITLE
ci(cleanup): add disk cleanup before checkout

### DIFF
--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -28,6 +28,12 @@ jobs:
       matrix:
         parallelRunnerId: ${{ fromJSON((fromJSON(inputs.matrix).parallelism == '4' && '[0, 1, 2, 3]') || '[0]') }}
     steps:
+      - name: "Free up disk space for the Runner"
+        uses: endersonmenezes/free-disk-space@6c4664f43348c8c7011b53488d5ca65e9fc5cd1a # v3.0.0
+        with:
+          remove_android: true
+          remove_dotnet: true
+          remove_haskell: true
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
@@ -35,13 +41,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           MISE_DISABLE_TOOLS: "clang-format,golangci-lint,skaffold,protoc-gen-go-grpc"
-      - name: "Free up disk space for the Runner"
-        uses: endersonmenezes/free-disk-space@6c4664f43348c8c7011b53488d5ca65e9fc5cd1a # v3.0.0
-        with:
-          remove_android: true
-          remove_dotnet: true
-          remove_haskell: true
-          remove_docker_images: true
       - run: |
           make build
       - run: |

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -44,6 +44,12 @@ jobs:
         run: |
           echo "::error title=Label 'ci/force-publish' cannot be used on PRs from forks::To prevent accidental exposure of secrets, CI won't use repository secrets on pull requests from forks"
           exit 1
+      - name: "Free up disk space for the Runner"
+        uses: endersonmenezes/free-disk-space@6c4664f43348c8c7011b53488d5ca65e9fc5cd1a # v3.0.0
+        with:
+          remove_android: true
+          remove_dotnet: true
+          remove_haskell: true
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0


### PR DESCRIPTION
## Motivation

The check and e2e jobs were experiencing disk space issues during the build process. This adds disk cleanup to free up space before build operations begin.

## Implementation information

- Added `endersonmenezes/free-disk-space@v3.0.0` action before checkout in both check and e2e jobs
- Removes Android SDK, .NET, and Haskell packages
- Action runs before checkout to prevent creating untracked files that cause `make check` to fail
- Expected to free up 12-16 GB of disk space

## Supporting documentation

Backport of disk cleanup improvements from master