### PR TITLE
chore(cleanup): remove IsReferenceableInTo from descriptor

### DIFF
--- a/pkg/core/resources/apis/donothingresource/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/donothingresource/api/v1alpha1/zz_generated.resource.go
@@ -170,7 +170,6 @@ var DoNothingResourceResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasRulesTargetRef:            false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
-	IsReferenceableInTo:          false,
 	ShortName:                    "dnr",
 	IsFromAsRules:                false,
 }

--- a/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/zz_generated.resource.go
@@ -171,7 +171,6 @@ var HostnameGeneratorResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasRulesTargetRef:            false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: true,
-	IsReferenceableInTo:          false,
 	ShortName:                    "hg",
 	IsFromAsRules:                false,
 }

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/meshexternalservice.go
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/meshexternalservice.go
@@ -15,7 +15,6 @@ import (
 // +kuma:policy:is_policy=false
 // +kuma:policy:allowed_on_system_namespace_only=true
 // +kuma:policy:has_status=true
-// +kuma:policy:is_referenceable_in_to=true
 // +kuma:policy:short_name=extsvc
 // +kuma:policy:kds_flags=model.GlobalToZonesFlag | model.ZoneToGlobalFlag
 // +kuma:policy:is_destination=true

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/zz_generated.resource.go
@@ -185,7 +185,6 @@ var MeshExternalServiceResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasRulesTargetRef:            false,
 	HasStatus:                    true,
 	AllowedOnSystemNamespaceOnly: true,
-	IsReferenceableInTo:          true,
 	ShortName:                    "extsvc",
 	IsFromAsRules:                false,
 }

--- a/pkg/core/resources/apis/meshidentity/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/meshidentity/api/v1alpha1/zz_generated.resource.go
@@ -182,7 +182,6 @@ var MeshIdentityResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasRulesTargetRef:            false,
 	HasStatus:                    true,
 	AllowedOnSystemNamespaceOnly: true,
-	IsReferenceableInTo:          false,
 	ShortName:                    "mid",
 	IsFromAsRules:                false,
 }

--- a/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/meshmultizoneservice.go
+++ b/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/meshmultizoneservice.go
@@ -14,7 +14,6 @@ import (
 // It aggregates existing MeshServices by labels.
 // +kuma:policy:is_policy=false
 // +kuma:policy:has_status=true
-// +kuma:policy:is_referenceable_in_to=true
 // +kuma:policy:short_name=mzsvc
 // MeshMultizoneServices are only created on global
 // +kuma:policy:kds_flags=model.GlobalToZonesFlag

--- a/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/zz_generated.resource.go
@@ -185,7 +185,6 @@ var MeshMultiZoneServiceResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasRulesTargetRef:            false,
 	HasStatus:                    true,
 	AllowedOnSystemNamespaceOnly: false,
-	IsReferenceableInTo:          true,
 	ShortName:                    "mzsvc",
 	IsFromAsRules:                false,
 }

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/meshservice.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/meshservice.go
@@ -33,7 +33,6 @@ const maxNameLength = 63
 // +kuma:policy:is_policy=false
 // +kuma:policy:has_status=true
 // +kuma:policy:kds_flags=model.ZoneToGlobalFlag | model.SyncedAcrossZonesFlag
-// +kuma:policy:is_referenceable_in_to=true
 // +kuma:policy:short_name=msvc
 // +kuma:policy:is_destination=true
 // +kubebuilder:printcolumn:JSONPath=".status.addresses[0].hostname",name=Hostname,type=string

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/zz_generated.resource.go
@@ -185,7 +185,6 @@ var MeshServiceResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasRulesTargetRef:            false,
 	HasStatus:                    true,
 	AllowedOnSystemNamespaceOnly: false,
-	IsReferenceableInTo:          true,
 	ShortName:                    "msvc",
 	IsFromAsRules:                false,
 }

--- a/pkg/core/resources/apis/meshtrust/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/meshtrust/api/v1alpha1/zz_generated.resource.go
@@ -171,7 +171,6 @@ var MeshTrustResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasRulesTargetRef:            false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: true,
-	IsReferenceableInTo:          false,
 	ShortName:                    "mtrust",
 	IsFromAsRules:                false,
 }

--- a/pkg/core/resources/apis/workload/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/workload/api/v1alpha1/zz_generated.resource.go
@@ -182,7 +182,6 @@ var WorkloadResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasRulesTargetRef:            false,
 	HasStatus:                    true,
 	AllowedOnSystemNamespaceOnly: false,
-	IsReferenceableInTo:          false,
 	ShortName:                    "wl",
 	IsFromAsRules:                false,
 }

--- a/pkg/core/resources/model/resource.go
+++ b/pkg/core/resources/model/resource.go
@@ -216,8 +216,6 @@ type ResourceTypeDescriptor struct {
 	DumpForGlobal bool
 	// AllowedOnSystemNamespaceOnly whether this resource type can be created only in the system namespace
 	AllowedOnSystemNamespaceOnly bool
-	// IsReferenceableInTo whether this resource type can be used in spec.to[].targetRef
-	IsReferenceableInTo bool
 	// ShortName a name that is used in kubectl or in the envoy configuration
 	ShortName string
 	// IsFromAsRules if true, the entries in the spec.from field should be interpreted as rules.

--- a/pkg/plugins/policies/donothingpolicy/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/donothingpolicy/api/v1alpha1/zz_generated.resource.go
@@ -170,7 +170,6 @@ var DoNothingPolicyResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasRulesTargetRef:            false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
-	IsReferenceableInTo:          false,
 	ShortName:                    "dnp",
 	IsFromAsRules:                false,
 }

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/zz_generated.resource.go
@@ -171,7 +171,6 @@ var MeshAccessLogResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasRulesTargetRef:            true,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
-	IsReferenceableInTo:          false,
 	ShortName:                    "mal",
 	IsFromAsRules:                true,
 }

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/zz_generated.resource.go
@@ -171,7 +171,6 @@ var MeshCircuitBreakerResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasRulesTargetRef:            true,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
-	IsReferenceableInTo:          false,
 	ShortName:                    "mcb",
 	IsFromAsRules:                true,
 }

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/zz_generated.resource.go
@@ -171,7 +171,6 @@ var MeshFaultInjectionResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasRulesTargetRef:            true,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
-	IsReferenceableInTo:          false,
 	ShortName:                    "mfi",
 	IsFromAsRules:                false,
 }

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/zz_generated.resource.go
@@ -171,7 +171,6 @@ var MeshHealthCheckResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasRulesTargetRef:            false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
-	IsReferenceableInTo:          false,
 	ShortName:                    "mhc",
 	IsFromAsRules:                false,
 }

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/zz_generated.resource.go
@@ -171,7 +171,6 @@ var MeshHTTPRouteResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasRulesTargetRef:            false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
-	IsReferenceableInTo:          false,
 	ShortName:                    "mhttpr",
 	IsFromAsRules:                false,
 }

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/zz_generated.resource.go
@@ -171,7 +171,6 @@ var MeshLoadBalancingStrategyResourceTypeDescriptor = model.ResourceTypeDescript
 	HasRulesTargetRef:            false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
-	IsReferenceableInTo:          false,
 	ShortName:                    "mlbs",
 	IsFromAsRules:                false,
 }

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/zz_generated.resource.go
@@ -171,7 +171,6 @@ var MeshMetricResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasRulesTargetRef:            false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
-	IsReferenceableInTo:          false,
 	ShortName:                    "mm",
 	IsFromAsRules:                false,
 }

--- a/pkg/plugins/policies/meshpassthrough/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshpassthrough/api/v1alpha1/zz_generated.resource.go
@@ -171,7 +171,6 @@ var MeshPassthroughResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasRulesTargetRef:            false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
-	IsReferenceableInTo:          false,
 	ShortName:                    "mp",
 	IsFromAsRules:                false,
 }

--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/zz_generated.resource.go
@@ -171,7 +171,6 @@ var MeshProxyPatchResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasRulesTargetRef:            false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
-	IsReferenceableInTo:          false,
 	ShortName:                    "mpp",
 	IsFromAsRules:                false,
 }

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/zz_generated.resource.go
@@ -171,7 +171,6 @@ var MeshRateLimitResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasRulesTargetRef:            true,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
-	IsReferenceableInTo:          false,
 	ShortName:                    "mrl",
 	IsFromAsRules:                true,
 }

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/zz_generated.resource.go
@@ -171,7 +171,6 @@ var MeshRetryResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasRulesTargetRef:            false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
-	IsReferenceableInTo:          false,
 	ShortName:                    "mr",
 	IsFromAsRules:                false,
 }

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/zz_generated.resource.go
@@ -171,7 +171,6 @@ var MeshTCPRouteResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasRulesTargetRef:            false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
-	IsReferenceableInTo:          false,
 	ShortName:                    "mtcpr",
 	IsFromAsRules:                false,
 }

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/zz_generated.resource.go
@@ -171,7 +171,6 @@ var MeshTimeoutResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasRulesTargetRef:            true,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
-	IsReferenceableInTo:          false,
 	ShortName:                    "mt",
 	IsFromAsRules:                true,
 }

--- a/pkg/plugins/policies/meshtls/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshtls/api/v1alpha1/zz_generated.resource.go
@@ -171,7 +171,6 @@ var MeshTLSResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasRulesTargetRef:            true,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
-	IsReferenceableInTo:          false,
 	ShortName:                    "mtls",
 	IsFromAsRules:                true,
 }

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/zz_generated.resource.go
@@ -171,7 +171,6 @@ var MeshTraceResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasRulesTargetRef:            false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
-	IsReferenceableInTo:          false,
 	ShortName:                    "mtr",
 	IsFromAsRules:                false,
 }

--- a/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/zz_generated.resource.go
@@ -171,7 +171,6 @@ var MeshTrafficPermissionResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	HasRulesTargetRef:            true,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
-	IsReferenceableInTo:          false,
 	ShortName:                    "mtp",
 	IsFromAsRules:                false,
 }

--- a/pkg/xds/context/mesh_context_builder.go
+++ b/pkg/xds/context/mesh_context_builder.go
@@ -297,7 +297,7 @@ func (m *meshContextBuilder) BuildBaseMeshContextIfChanged(ctx context.Context, 
 		case desc.IsDestination:
 			rmap[t], err = m.fetchResourceList(ctx, t, mesh, nil)
 			destinations = append(destinations, rmap[t].GetItems())
-		case desc.IsPolicy || desc.IsReferenceableInTo || desc.Name == core_mesh.MeshGatewayType || desc.Name == core_mesh.ExternalServiceType:
+		case desc.IsPolicy || desc.Name == core_mesh.MeshGatewayType || desc.Name == core_mesh.ExternalServiceType:
 			rmap[t], err = m.fetchResourceList(ctx, t, mesh, nil)
 		case desc.Name == system.ConfigType:
 			rmap[t], err = m.fetchResourceList(ctx, t, mesh, func(rs core_model.Resource) bool {

--- a/tools/policy-gen/generator/cmd/core_resource.go
+++ b/tools/policy-gen/generator/cmd/core_resource.go
@@ -253,7 +253,6 @@ var {{.Name}}ResourceTypeDescriptor = model.ResourceTypeDescriptor{
         HasRulesTargetRef: {{.HasRules}},
 		HasStatus: {{.HasStatus}},
 		AllowedOnSystemNamespaceOnly: {{.AllowedOnSystemNamespaceOnly}},
-		IsReferenceableInTo: {{.IsReferenceableInTo}},
 		ShortName: "{{.ShortName}}",
 		IsFromAsRules: {{.IsFromAsRules}},
 	}

--- a/tools/policy-gen/generator/pkg/parse/policyconfig.go
+++ b/tools/policy-gen/generator/pkg/parse/policyconfig.go
@@ -44,7 +44,6 @@ type PolicyConfig struct {
 	KDSFlags                     string
 	Scope                        ResourceScope
 	AllowedOnSystemNamespaceOnly bool
-	IsReferenceableInTo          bool
 	KubebuilderMarkers           []string
 	IsFromAsRules                bool
 	RegisterGenerator            bool
@@ -170,9 +169,6 @@ func newPolicyConfig(pkg, name string, markers map[string]string, fields map[str
 	}
 	if v, ok := parseBool(markers, "kuma:policy:allowed_on_system_namespace_only"); ok {
 		res.AllowedOnSystemNamespaceOnly = v
-	}
-	if v, ok := parseBool(markers, "kuma:policy:is_referenceable_in_to"); ok {
-		res.IsReferenceableInTo = v
 	}
 	if v, ok := parseBool(markers, "kuma:policy:is_from_as_rules"); ok {
 		res.IsFromAsRules = v


### PR DESCRIPTION
## Motivation

  Issue #13837 requests collapsing `IsReferenceableInTo` and `IsDestination` flags in `ResourceTypeDescriptor`. Both flags currently mark the exact same
  3 resources (MeshService, MeshExternalService, MeshMultiZoneService), making one redundant.

  ## Implementation information

  Removed `IsReferenceableInTo` field and kept `IsDestination` because:
  - `IsDestination` has clearer semantics - these resources ARE destinations
  - Directly ties to `core.Destination` interface requirement
  - Better aligns with DestinationIndex naming/functionality

  Changes made:
  - Removed `IsReferenceableInTo` field from `ResourceTypeDescriptor` (pkg/core/resources/model/resource.go)
  - Removed `+kuma:policy:is_referenceable_in_to=true` markers from 3 API files
  - Updated mesh_context_builder.go to use only `IsDestination` in condition
  - Removed `IsReferenceableInTo` from policy generator (policyconfig.go, core_resource.go template)
  - Regenerated all zz_generated.resource.go files via `make generate`

  No functional changes - both flags were identical in purpose and usage.

  ## Supporting documentation

  Fixes #13837

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
