### PR TITLE
chore(k8s): remove deprecated ServiceAccountName config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -174,9 +174,6 @@ linters:
         text: 'SA1019: .* is deprecated: use common.WithPolicyAttributes instead'
       - linters:
           - staticcheck
-        text: 'SA1019: .* is deprecated: Use AllowedUsers instead'
-      - linters:
-          - staticcheck
         text: 'ST1001: should not use dot imports'
     paths:
       - pkg/transparentproxy/iptables/builder

--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -214,8 +214,6 @@ runtime:
   kubernetes:
     # Service name of the Kuma Control Plane. It is used to point Kuma DP to proper URL.
     controlPlaneServiceName: kuma-control-plane # ENV: KUMA_RUNTIME_KUBERNETES_CONTROL_PLANE_SERVICE_NAME
-    # Name of Service Account that is used to run the Control Plane
-    serviceAccountName: "system:serviceaccount:kuma-system:kuma-control-plane" # ENV: KUMA_RUNTIME_KUBERNETES_SERVICE_ACCOUNT_NAME
     # Taint controller that prevents applications from scheduling until CNI is ready.
     nodeTaintController:
       # If true enables the taint controller.

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -214,8 +214,6 @@ runtime:
   kubernetes:
     # Service name of the Kuma Control Plane. It is used to point Kuma DP to proper URL.
     controlPlaneServiceName: kuma-control-plane # ENV: KUMA_RUNTIME_KUBERNETES_CONTROL_PLANE_SERVICE_NAME
-    # Name of Service Account that is used to run the Control Plane
-    serviceAccountName: "system:serviceaccount:kuma-system:kuma-control-plane" # ENV: KUMA_RUNTIME_KUBERNETES_SERVICE_ACCOUNT_NAME
     # Taint controller that prevents applications from scheduling until CNI is ready.
     nodeTaintController:
       # If true enables the taint controller.

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -166,7 +166,6 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.MonitoringAssignmentServer.TlsCipherSuites).To(Equal([]string{"TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_AES_256_GCM_SHA384"}))
 
 			Expect(cfg.Runtime.Kubernetes.ControlPlaneServiceName).To(Equal("custom-control-plane"))
-			Expect(cfg.Runtime.Kubernetes.ServiceAccountName).To(Equal("custom-sa"))
 			Expect(cfg.Runtime.Kubernetes.AllowedUsers).To(Equal([]string{"allowed-usr-1", "allowed-usr-2"}))
 			Expect(cfg.Runtime.Kubernetes.NodeTaintController.Enabled).To(BeTrue())
 			Expect(cfg.Runtime.Kubernetes.NodeTaintController.CniApp).To(Equal("kuma-cni"))
@@ -898,7 +897,6 @@ meshService:
 				"KUMA_MONITORING_ASSIGNMENT_SERVER_TLS_CIPHER_SUITES":                                      "TLS_RSA_WITH_AES_128_CBC_SHA,TLS_AES_256_GCM_SHA384",
 				"KUMA_REPORTS_ENABLED":                                                                     "false",
 				"KUMA_RUNTIME_KUBERNETES_CONTROL_PLANE_SERVICE_NAME":                                       "custom-control-plane",
-				"KUMA_RUNTIME_KUBERNETES_SERVICE_ACCOUNT_NAME":                                             "custom-sa",
 				"KUMA_RUNTIME_KUBERNETES_ALLOWED_USERS":                                                    "allowed-usr-1,allowed-usr-2",
 				"KUMA_RUNTIME_KUBERNETES_NODE_TAINT_CONTROLLER_ENABLED":                                    "true",
 				"KUMA_RUNTIME_KUBERNETES_NODE_TAINT_CONTROLLER_CNI_APP":                                    "kuma-cni",

--- a/pkg/config/plugins/runtime/k8s/config.go
+++ b/pkg/config/plugins/runtime/k8s/config.go
@@ -9,12 +9,7 @@ import (
 
 	"github.com/kumahq/kuma/v2/pkg/config"
 	config_types "github.com/kumahq/kuma/v2/pkg/config/types"
-	"github.com/kumahq/kuma/v2/pkg/core"
 )
-
-const defaultServiceAccountName = "system:serviceaccount:kuma-system:kuma-control-plane"
-
-var logger = core.Log.WithName("kubernetes-config")
 
 func DefaultKubernetesRuntimeConfig() *KubernetesRuntimeConfig {
 	return &KubernetesRuntimeConfig{
@@ -22,7 +17,6 @@ func DefaultKubernetesRuntimeConfig() *KubernetesRuntimeConfig {
 			Port: 5443,
 		},
 		ControlPlaneServiceName: "kuma-control-plane",
-		ServiceAccountName:      defaultServiceAccountName,
 		Injector: Injector{
 			CNIEnabled:                false,
 			VirtualProbesEnabled:      true,
@@ -142,10 +136,6 @@ type KubernetesRuntimeConfig struct {
 	// marshaled objects will be stored in the cache. If equal to 0s then
 	// cache is turned off
 	MarshalingCacheExpirationTime config_types.Duration `json:"marshalingCacheExpirationTime" envconfig:"kuma_runtime_kubernetes_marshaling_cache_expiration_time"`
-	// Name of Service Account that is used to run the Control Plane
-	//
-	// Deprecated: Use AllowedUsers instead.
-	ServiceAccountName string `json:"serviceAccountName,omitempty" envconfig:"kuma_runtime_kubernetes_service_account_name"`
 	// List of names of Service Accounts that admission requests are allowed.
 	// This list is appended with Control Plane's Service Account and generic-garbage-collector
 	AllowedUsers []string `json:"allowedUsers,omitempty" envconfig:"kuma_runtime_kubernetes_allowed_users"`
@@ -465,9 +455,6 @@ func (c *KubernetesRuntimeConfig) Validate() error {
 	}
 	if c.MarshalingCacheExpirationTime.Duration < 0 {
 		errs = multierr.Append(errs, errors.Errorf(".MarshalingCacheExpirationTime must be positive or equal to 0"))
-	}
-	if c.ServiceAccountName != defaultServiceAccountName {
-		logger.Info("[WARNING]: using deprecated configuration option - .ServiceAccountName, please use AllowedUsers.")
 	}
 	return errs
 }

--- a/pkg/config/plugins/runtime/k8s/testdata/default-config.golden.yaml
+++ b/pkg/config/plugins/runtime/k8s/testdata/default-config.golden.yaml
@@ -88,7 +88,6 @@ nodeTaintController:
   cniApp: ""
   cniNamespace: kube-system
   enabled: false
-serviceAccountName: system:serviceaccount:kuma-system:kuma-control-plane
 skipMeshOwnerReference: false
 supportGatewaySecretsInAllNamespaces: false
 workloadLabels: []

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -289,7 +289,6 @@ func addValidators(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter k8s
 	resourceAdmissionChecker := k8s_webhooks.ResourceAdmissionChecker{
 		AllowedUsers: append(
 			rt.Config().Runtime.Kubernetes.AllowedUsers,
-			rt.Config().Runtime.Kubernetes.ServiceAccountName,
 			"system:serviceaccount:kube-system:generic-garbage-collector",
 		),
 		Mode:                         rt.Config().Mode,
@@ -409,7 +408,6 @@ func addMutators(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter k8s_c
 	resourceAdmissionChecker := k8s_webhooks.ResourceAdmissionChecker{
 		AllowedUsers: append(
 			rt.Config().Runtime.Kubernetes.AllowedUsers,
-			rt.Config().Runtime.Kubernetes.ServiceAccountName,
 			"system:serviceaccount:kube-system:generic-garbage-collector",
 		),
 		Mode:                         rt.Config().Mode,

--- a/pkg/plugins/runtime/k8s/webhooks/resourceadmissionchecker.go
+++ b/pkg/plugins/runtime/k8s/webhooks/resourceadmissionchecker.go
@@ -72,7 +72,7 @@ func (c *ResourceAdmissionChecker) isResourceAllowed(r core_model.Resource, ns s
 
 func (c *ResourceAdmissionChecker) isPrivilegedUser(allowedUsers []string, userInfo authenticationv1.UserInfo) bool {
 	// Assume this means one of the following:
-	// - sync from another zone (rt.Config().Runtime.Kubernetes.ServiceAccountName)
+	// - sync from another zone
 	// - GC cleanup resources due to OwnerRef. ("system:serviceaccount:kube-system:generic-garbage-collector")
 	// - storageversionmigratior
 	// Not security; protecting user from self.


### PR DESCRIPTION
## Motivation

  Remove deprecated `ServiceAccountName` config option from kubernetes-config module. Option deprecated in 2.6 (PR #6505), default changed in 2.8 (PR
  #10593). Cleanup warning present since 2.6.

  ## Implementation information

  Removed all references to `ServiceAccountName`:
  - Config struct field, constant, default value, deprecation warning
  - Usage in `addValidators()` and `addMutators()` where it was appended to AllowedUsers
  - Linter suppression rule
  - Test assertions and env vars
  - Config defaults file
  - Golden test files
  - Comment references

  AllowedUsers remains as replacement. Control plane service account now set via helm template (KUMA_RUNTIME_KUBERNETES_ALLOWED_USERS) per PR #10593.

  ## Supporting documentation

  Fixes #12212

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
