### PR TITLE
chore(cleanup): remove service validator rollback handler

### DIFF
--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/Masterminds/semver/v3"
@@ -332,10 +331,6 @@ func addValidators(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter k8s
 	})
 
 	mgr.GetWebhookServer().Register("/validate-kuma-io-v1alpha1", composite.IntoWebhook(mgr.GetScheme()))
-	// TODO remove in 2.12 or higher https://github.com/kumahq/kuma/issues/12759
-	mgr.GetWebhookServer().Register("/validate-v1-service", &kube_webhook.Admission{Handler: kube_admission.HandlerFunc(func(ctx context.Context, request kube_admission.Request) kube_admission.Response {
-		return kube_admission.Allowed("")
-	})})
 
 	admissionDecoder := kube_admission.NewDecoder(mgr.GetScheme())
 


### PR DESCRIPTION
## Motivation

  In 2.10, Service validator webhook removed but rollback handler kept for backward compat. Now in 2.13.x (master), safe to remove per TODO comment
  referencing 2.12+.

  ## Implementation information

  Removed no-op `/validate-v1-service` webhook handler registration from `pkg/plugins/runtime/k8s/plugin.go`. Handler always returned success, provided
  no functionality.

  Webhook config already removed in PR #12762. No tests affected (validator tests deleted in same PR).

  ## Supporting documentation

  Fixes #12759

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
