### PR TITLE
test(framework): add flexible DNS configuration

### DIFF
--- a/test/framework/universal_app.go
+++ b/test/framework/universal_app.go
@@ -288,9 +288,17 @@ cp %s/envoy /usr/bin/envoy
 
 	// Install transparent proxy
 	if transparent {
-		extraArgs := []string{}
+		extraArgs := []string{
+			"--kuma-dp-user", "kuma-dp",
+		}
 		if builtindns {
-			extraArgs = append(extraArgs, "--redirect-dns")
+			// Default: use --redirect-dns (original behavior)
+			// Override: set KUMA_TP_REDIRECT_ALL_DNS_TRAFFIC=true to use --redirect-all-dns-traffic
+			if envsMap["KUMA_TP_REDIRECT_ALL_DNS_TRAFFIC"] == "true" {
+				extraArgs = append(extraArgs, "--redirect-all-dns-traffic")
+			} else {
+				extraArgs = append(extraArgs, "--redirect-dns")
+			}
 		}
 		_, _ = fmt.Fprintf(cmd, "/usr/bin/kumactl install transparent-proxy --exclude-inbound-ports %s %s\n", sshPort, strings.Join(extraArgs, " "))
 	}

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -423,7 +423,10 @@ func (c *UniversalCluster) DeployApp(opt ...AppDeploymentOption) error {
 		if opts.dpEnvs == nil {
 			opts.dpEnvs = map[string]string{}
 		}
-		opts.dpEnvs["KUMA_DNS_PROXY_PORT"] = "15053"
+		// Only set default if not already configured (to allow version-specific DNS config)
+		if _, exists := opts.dpEnvs["KUMA_DNS_PROXY_PORT"]; !exists {
+			opts.dpEnvs["KUMA_DNS_PROXY_PORT"] = "15053"
+		}
 		if opts.bindOutbounds {
 			opts.dpEnvs["KUMA_DATAPLANE_RUNTIME_BIND_OUTBOUNDS"] = "true"
 		}


### PR DESCRIPTION
## Motivation

The test framework currently hardcodes DNS configuration options, making it difficult to test different DNS proxy behaviors and version-specific DNS configurations. This change adds flexibility to configure DNS redirect methods and ports via environment variables.

## Implementation information

- Add support for both `--redirect-dns` and `--redirect-all-dns-traffic` transparent proxy flags via `KUMA_TP_REDIRECT_ALL_DNS_TRAFFIC` environment variable (defaults to `--redirect-dns` for backward compatibility)
- Allow overriding `KUMA_DNS_PROXY_PORT` instead of always setting it to 15053
- Add `--kuma-dp-user` flag to transparent proxy setup for proper user configuration

> Changelog: skip