### PR TITLE
fix(kumactl): initialize controller-runtime logger before package imports

### DIFF
--- a/app/kumactl/main.go
+++ b/app/kumactl/main.go
@@ -1,6 +1,18 @@
 package main
 
-import "github.com/kumahq/kuma/v2/app/kumactl/cmd"
+import (
+	kube_ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/kumahq/kuma/v2/app/kumactl/cmd"
+)
+
+func init() {
+	// Initialize controller-runtime logger before any packages are loaded
+	// to prevent panic in controller-runtime/pkg/cache/internal.init()
+	// This sets a default logger that will be overridden later if needed
+	kube_ctrl.SetLogger(zap.New(zap.UseDevMode(false)))
+}
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
## Motivation

Fix panic in kumactl when controller-runtime/pkg/cache tries to create a logger in its init() function before the root logger is set up.

## Implementation information

In controller-runtime v0.22.4, the cache/internal package's init() function attempts to create a logger using `.WithName()`. If the root logger hasn't been initialized via `ctrl.SetLogger()`, this causes a panic in `eventuallyFulfillRoot()`.

The issue occurs because:
1. kumactl's main.go imports cmd package
2. cmd package has init() that calls plugins.InitAll()
3. This happens before PersistentPreRunE sets up the logger
4. If any plugin or dependency uses controller-runtime/pkg/cache, its init() runs and panics

The fix initializes a default controller-runtime logger in kumactl's main.go init() function, ensuring it's available before any package initialization. This logger gets overridden later in PersistentPreRunE with the properly configured logger.

## Supporting documentation

Error stack trace:
```
sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
    sigs.k8s.io/controller-runtime@v0.22.4/pkg/log/log.go:60 +0xe8
sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).WithName(0x400037eb00, {0x2f64151, 0x5})
    sigs.k8s.io/controller-runtime@v0.22.4/pkg/log/deleg.go:147 +0x34
sigs.k8s.io/controller-runtime/pkg/cache/internal.init()
    sigs.k8s.io/controller-runtime@v0.22.4/pkg/cache/internal/informers.go:46 +0x4c
```