### PR TITLE
ci(renovate): use flexible internalChecksFilter

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,7 +31,7 @@
     "mise"
   ],
   "automergeStrategy": "squash",
-  "internalChecksFilter": "strict",
+  "internalChecksFilter": "flexible",
   "keepUpdatedLabel": "renovate/keep-updated",
   "rebaseWhen": "conflicted",
   "prTitleStrict": true,


### PR DESCRIPTION
## Motivation

Currently, Renovate uses `internalChecksFilter: "strict"` which prevents PRs from being created until `minimumReleaseAge` (default 12 days) is satisfied. This blocks visibility into available updates and prevents maintainers from merging urgent updates (e.g., security fixes) early.

## Implementation information

- Change `internalChecksFilter` from `strict` to `flexible`
- With `flexible`, Renovate creates PRs immediately with a pending `renovate/stability-days` status check
- The check turns green once the configured release age passes
- Maintainers can choose to merge early or wait for the check to pass

This matches the approach used in the mink-charts project.

> Changelog: skip