### PR TITLE
fix(hds): preserve Dataplane labels on update

### DIFF
--- a/pkg/hds/tracker/callbacks.go
+++ b/pkg/hds/tracker/callbacks.go
@@ -235,7 +235,7 @@ func (t *tracker) updateDataplane(streamID xds.StreamID, healthMap map[uint32]bo
 
 	if changed {
 		t.log.V(1).Info("status updated", "dataplaneKey", dataplaneKey)
-		return t.resourceManager.Update(ctx, dp)
+		return t.resourceManager.Update(ctx, dp, store.UpdateWithLabels(dp.Meta.GetLabels()))
 	}
 
 	return nil


### PR DESCRIPTION
## Motivation

Once I started debugging Workload Identity with MeshIdentity on Universal, I noticed that after a few seconds my Dataplane was missing the custom `kuma.io/workload` label. After further investigation, I discovered that HDS updates the Dataplane but does not preserve existing labels, which caused the Dataplane to fail to resolve its identity after a few seconds.

## Implementation information

Ensure that existing labels are passed through during the update call.

