### PR TITLE
docs(MADR): address MADR-091 review feedback

### DIFF
--- a/docs/madr/decisions/091-migrate-to-v2-module-path.md
+++ b/docs/madr/decisions/091-migrate-to-v2-module-path.md
@@ -70,7 +70,7 @@ For affected users, migration is a simple find-replace operation:
 
 ```bash
 # Update imports
-find . -name "*.go" -type f -exec sed -i '' \
+find . -name "*.go" -type f -exec sed -i.bak \
   's|"github.com/kumahq/kuma/|"github.com/kumahq/kuma/v2/|g' {} +
 go mod tidy
 ```
@@ -148,7 +148,7 @@ github.com/kumahq/kuma/v2 v2.0.0-20251103153646-fc66bbfced92
 **External user migration**:
 
 ```bash
-find . -name "*.go" -type f -exec sed -i '' \
+find . -name "*.go" -type f -exec sed -i.bak \
   's|"github.com/kumahq/kuma/|"github.com/kumahq/kuma/v2/|g' {} +
 go mod tidy
 ```


### PR DESCRIPTION
## Motivation

Address review feedback from issue #14904 on MADR 091 (v2 module path migration).

## Implementation information

- Added "Who Is Affected" section early in the document to clearly define the scope of breaking changes
  - Only users importing Kuma/Kong Mesh as Go libraries are affected
  - Users deploying via Helm, kumactl, Docker, or REST API are not affected
  - Include migration command for affected users
- Updated Phase 3 migration strategy to use master-first approach (per @lahabana's suggestion)
  - Start with `master` branch first, monitor for 24-48 hours
  - Then propagate to release branches
  - Allows validation in less critical environment before affecting release branches

## Supporting documentation

Fix #14904

> Changelog: skip