### PR TITLE
chore(deps): group go version updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -273,6 +273,16 @@
     },
     {
       "description": [
+        " Group 'go' version updates from 'gomod' and 'mise' managers into a single PR",
+        " and explicitly enable them to override potential preset restrictions"
+      ],
+      "matchDepNames": ["go"],
+      "matchManagers": ["gomod", "mise"],
+      "groupName": "go version",
+      "enabled": true
+    },
+    {
+      "description": [
         " Catch-all rule that applies the standard commit message format for all dependencies",
         "",
         " This rule extends the shared baseline preset to ensure consistent commit message",


### PR DESCRIPTION
## Motivation

Currently, Renovate creates separate PRs for Go version updates from different managers (`gomod` and `mise`), which requires multiple PRs to be merged for a single Go version bump.

## Implementation information

- Added a new Renovate rule that groups `go` version updates from both `gomod` and `mise` managers into a single PR
- Explicitly enabled the rule to override potential preset restrictions

> Changelog: skip