### PR TITLE
fix(api-server): deduplicate zones in _hostnames endpoint

### DIFF
--- a/pkg/api-server/testdata/resources/inspect/services/_resources/hostnames/meshservice_hostnames_multiple_generators.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/services/_resources/hostnames/meshservice_hostnames_multiple_generators.golden.json
@@ -1,0 +1,13 @@
+{
+ "items": [
+  {
+   "hostname": "test-server.svc.west.mesh.local",
+   "zones": [
+    {
+     "name": "west"
+    }
+   ]
+  }
+ ],
+ "total": 1
+}

--- a/pkg/api-server/testdata/resources/inspect/services/_resources/hostnames/meshservice_hostnames_multiple_generators.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/services/_resources/hostnames/meshservice_hostnames_multiple_generators.input.yaml
@@ -1,0 +1,43 @@
+#/meshes/default/meshservices/test-server/_hostnames 200
+type: Mesh
+name: default
+---
+type: MeshService
+name: test-server
+mesh: default
+labels:
+  kuma.io/origin: zone
+  kuma.io/env: universal
+  kuma.io/display-name: test-server
+  kuma.io/zone: west
+spec:
+  selector:
+    dataplaneTags:
+      kuma.io/service: test-server
+  ports:
+    - port: 80
+      targetPort: 80
+      appProtocol: http
+      name: main-port
+---
+type: HostnameGenerator
+name: generator-1
+labels:
+  kuma.io/origin: global
+spec:
+  template: '{{ .DisplayName }}.svc.{{ .Zone }}.mesh.local'
+  selector:
+    meshService:
+      matchLabels:
+        kuma.io/env: universal
+---
+type: HostnameGenerator
+name: generator-2
+labels:
+  kuma.io/origin: global
+spec:
+  template: '{{ .DisplayName }}.svc.{{ .Zone }}.mesh.local'
+  selector:
+    meshService:
+      matchLabels:
+        kuma.io/origin: zone


### PR DESCRIPTION
## Motivation

The `_hostnames` endpoint was returning duplicate zones when multiple HostnameGenerators matched the same service and generated the same hostname. This caused the same zone to appear multiple times in the zones array for a single hostname.

## Implementation information

Changed the internal data structure from `map[string][]types.InspectHostnameZone` to `map[string]map[string]struct{}` to deduplicate zones using the set pattern (already used elsewhere in the codebase). Zones are then converted to a sorted array when building the response.

Added a test case with multiple HostnameGenerators that generate the same hostname for the same service to verify deduplication works correctly.

## Supporting documentation

Fixes #14772