### PR TITLE
chore(oapi): make parent project pick up this project openapi.yaml

### DIFF
--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -60,7 +60,7 @@ docs/generated/openapi.yaml: $(DOCS_OPENAPI_PREREQUISITES) | docs/generated docs
 	@echo "Bundling individual OpenAPI specs..."
 	@mkdir -p $(BUILD_DIR)/openapi-bundled
 	@cd $(BUILD_DIR)/oapitmp-rewritten && \
-		find . \( -name 'rest.yaml' -o -name 'api.yaml' -o -name 'kri.yaml' \) | while read f; do \
+		find . \( -name 'rest.yaml' -o -name 'api.yaml' -o -name 'kri.yaml' -o -name 'openapi.yaml' \) | while read f; do \
 			mkdir -p $(BUILD_DIR)/openapi-bundled/$$(dirname $$f); \
 			mise exec -- redocly bundle $$f -o $(BUILD_DIR)/openapi-bundled/$$f || echo "Skipping $$f"; \
 		done


### PR DESCRIPTION
## Motivation

After merging https://github.com/kumahq/kuma/pull/15157 we got empty oapi definitions from kuma in KM. This fixes that.

## Implementation information

Add `openapi.yaml` to list of searched files.

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
