### PR TITLE
test(kds): verify copilot instructions pickup for KDS package

### DIFF
--- a/pkg/kds/types.go
+++ b/pkg/kds/types.go
@@ -1,5 +1,6 @@
 package kds
 
+// Test change to verify KDS-specific copilot instructions pickup
 const (
 	googleApis = "type.googleapis.com/"
 


### PR DESCRIPTION
## Motivation

Testing to verify that KDS-specific copilot instructions in `.github/instructions/kds.instructions.md` are being picked up by the code review workflow.

This PR modifies a file in `pkg/kds/` which should trigger the KDS-specific instructions that use:
```yaml
---
applyTo:
  - "pkg/kds/**"
---
```

## Implementation information

Minimal test change (comment) in `pkg/kds/types.go` to verify:
1. The custom instructions JSON includes all 10 instruction files
2. The KDS-specific instructions are applied when reviewing KDS code

Expected: `custom-instructions.json` should contain 10 entries, and copilot should apply KDS-specific guidance when reviewing this change.

## Supporting documentation

Follow-up to PR #15218 - investigating why modular `.instructions.md` files aren't being picked up by the workflow.