### PR TITLE
refactor(api-server): use auxiliary struct for JSON marshaling

### DIFF
--- a/pkg/api-server/testdata/resources/crud/list_workloads.golden.json
+++ b/pkg/api-server/testdata/resources/crud/list_workloads.golden.json
@@ -2,11 +2,12 @@
  "total": 2,
  "items": [
   {
-   "creationTime": "0001-01-01T00:00:00Z",
-   "kri": "kri_wl_default___workload-1_",
+   "type": "Workload",
    "mesh": "default",
-   "modificationTime": "0001-01-01T00:00:00Z",
    "name": "workload-1",
+   "creationTime": "0001-01-01T00:00:00Z",
+   "modificationTime": "0001-01-01T00:00:00Z",
+   "kri": "kri_wl_default___workload-1_",
    "spec": {},
    "status": {
     "dataplaneProxies": {
@@ -14,15 +15,15 @@
      "healthy": 2,
      "total": 3
     }
-   },
-   "type": "Workload"
+   }
   },
   {
-   "creationTime": "0001-01-01T00:00:00Z",
-   "kri": "kri_wl_default___workload-2_",
+   "type": "Workload",
    "mesh": "default",
-   "modificationTime": "0001-01-01T00:00:00Z",
    "name": "workload-2",
+   "creationTime": "0001-01-01T00:00:00Z",
+   "modificationTime": "0001-01-01T00:00:00Z",
+   "kri": "kri_wl_default___workload-2_",
    "spec": {},
    "status": {
     "dataplaneProxies": {
@@ -30,8 +31,7 @@
      "healthy": 3,
      "total": 5
     }
-   },
-   "type": "Workload"
+   }
   }
  ],
  "next": null

--- a/pkg/api-server/testdata/resources/crud/put_workload_with_status_01.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_workload_with_status_01.golden.json
@@ -1,15 +1,16 @@
 {
+ "type": "Workload",
+ "mesh": "default",
+ "name": "with-status",
  "creationTime": "0001-01-01T00:00:00Z",
- "kri": "kri_wl_default_default__with-status_",
+ "modificationTime": "0001-01-01T00:00:00Z",
  "labels": {
   "kuma.io/env": "universal",
   "kuma.io/mesh": "default",
   "kuma.io/origin": "zone",
   "kuma.io/zone": "default"
  },
- "mesh": "default",
- "modificationTime": "0001-01-01T00:00:00Z",
- "name": "with-status",
+ "kri": "kri_wl_default_default__with-status_",
  "spec": {},
  "status": {
   "dataplaneProxies": {
@@ -17,6 +18,5 @@
    "healthy": 0,
    "total": 0
   }
- },
- "type": "Workload"
+ }
 }

--- a/pkg/api-server/testdata/resources/crud/put_workload_with_status_03.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_workload_with_status_03.golden.json
@@ -1,15 +1,16 @@
 {
+ "type": "Workload",
+ "mesh": "default",
+ "name": "with-status",
  "creationTime": "0001-01-01T00:00:00Z",
- "kri": "kri_wl_default_default__with-status_",
+ "modificationTime": "0001-01-01T00:00:00Z",
  "labels": {
   "kuma.io/env": "universal",
   "kuma.io/mesh": "default",
   "kuma.io/origin": "zone",
   "kuma.io/zone": "default"
  },
- "mesh": "default",
- "modificationTime": "0001-01-01T00:00:00Z",
- "name": "with-status",
+ "kri": "kri_wl_default_default__with-status_",
  "spec": {},
  "status": {
   "dataplaneProxies": {
@@ -17,6 +18,5 @@
    "healthy": 0,
    "total": 0
   }
- },
- "type": "Workload"
+ }
 }

--- a/pkg/core/resources/model/rest/v1alpha1/resource.go
+++ b/pkg/core/resources/model/rest/v1alpha1/resource.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/kumahq/kuma/v2/pkg/core/kri"
 	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
@@ -40,17 +41,27 @@ func (r *Resource) MarshalJSON() ([]byte, error) {
 	}
 
 	// Explicit struct with all fields in desired order
-	// Uses standard json.Marshal to avoid manual byte manipulation
+	// Cannot embed ResourceMeta as it has MarshalJSON which would override this struct's marshaling
 	aux := &struct {
-		ResourceMeta
-		KRI    string          `json:"kri,omitempty"`
-		Spec   json.RawMessage `json:"spec,omitempty"`
-		Status json.RawMessage `json:"status,omitempty"`
+		Type             string            `json:"type"`
+		Mesh             string            `json:"mesh,omitempty"`
+		Name             string            `json:"name"`
+		CreationTime     time.Time         `json:"creationTime"`
+		ModificationTime time.Time         `json:"modificationTime"`
+		Labels           map[string]string `json:"labels,omitempty"`
+		KRI              string            `json:"kri,omitempty"`
+		Spec             json.RawMessage   `json:"spec,omitempty"`
+		Status           json.RawMessage   `json:"status,omitempty"`
 	}{
-		ResourceMeta: r.ResourceMeta,
-		KRI:          kriStr,
-		Spec:         specJSON,
-		Status:       statusJSON,
+		Type:             r.Type,
+		Mesh:             r.Mesh,
+		Name:             r.Name,
+		CreationTime:     r.CreationTime,
+		ModificationTime: r.ModificationTime,
+		Labels:           r.Labels,
+		KRI:              kriStr,
+		Spec:             specJSON,
+		Status:           statusJSON,
 	}
 
 	return json.Marshal(aux)

--- a/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/06.meshservice.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/06.meshservice.yaml
@@ -1,4 +1,2 @@
-# Empty because no MeshService should be created for delegated gateways
-# when the kuma.io/gateway annotation is on the Pod (not the Service)
 items: []
 metadata: {}


### PR DESCRIPTION
## Motivation

PR #15168 fixed field ordering in HTTP responses by replacing map-based marshaling with manual byte concatenation. While functional, byte manipulation is error-prone and harder to maintain.

## Implementation information

Replaced manual byte concatenation in `Resource.MarshalJSON` with explicit auxiliary struct approach:

**Before:** Manual byte slicing and appending
```go
result := metaBytes[:len(metaBytes)-1] // Remove closing }
if len(specBytes) > 0 {
    result = append(result, []byte(`,"spec":`)...)
    result = append(result, specBytes...)
}
```

**After:** Standard json.Marshal with ordered struct
```go
aux := &struct {
    Type string `json:"type"`
    // ... explicit field order ...
    Spec   json.RawMessage `json:"spec,omitempty"`
    Status json.RawMessage `json:"status,omitempty"`
}{...}
return json.Marshal(aux)
```

Benefits:
- Uses standard Go JSON encoding (no manual byte manipulation)
- Type-safe with compiler-checked field assignments
- Preserves field order through struct definition
- More maintainable and less error-prone
- Easier to extend with new fields

Trade-off: Inlines KRI logic from ResourceMeta.MarshalJSON, but explicit field ordering is worth the duplication.

## Supporting documentation

Related: #15168, #15127