### PR TITLE
ci(pr-coments): handle partial successes in pr-comments workflow

### DIFF
--- a/.github/workflows/pr-comments.yaml
+++ b/.github/workflows/pr-comments.yaml
@@ -54,19 +54,19 @@ jobs:
         continue-on-error: true
         run: make clean/generated check
 
-      - name: "Commit and push format changes"
+      - name: "Commit format changes"
         if: contains(github.event.comment.body, '/format') && steps.format.outcome == 'success'
+        id: commit-format
         continue-on-error: true
-        env:
-          GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
         run: |
           if git diff --exit-code --stat; then
             echo "No format changes detected"
+            echo "committed=false" >> "$GITHUB_OUTPUT"
           else
             git config user.name "${GH_USER}"
             git config user.email "${GH_EMAIL}"
             git commit -s -m "fix(ci): format files" .
-            git push
+            echo "committed=true" >> "$GITHUB_OUTPUT"
           fi
 
       # Update all golden files except transparent proxy tests if /golden_files is in the comment
@@ -76,19 +76,19 @@ jobs:
         continue-on-error: true
         run: make test UPDATE_GOLDEN_FILES=true
 
-      - name: "Commit and push golden files changes"
+      - name: "Commit golden files changes"
         if: contains(github.event.comment.body, '/golden_files') && steps.golden-files.outcome == 'success'
+        id: commit-golden-files
         continue-on-error: true
-        env:
-          GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
         run: |
           if git diff --exit-code --stat; then
             echo "No golden files changes detected"
+            echo "committed=false" >> "$GITHUB_OUTPUT"
           else
             git config user.name "${GH_USER}"
             git config user.email "${GH_EMAIL}"
             git commit -s -m "fix(ci): update golden files" .
-            git push
+            echo "committed=true" >> "$GITHUB_OUTPUT"
           fi
 
       # Update only transparent proxy golden files if /golden_files_tproxy is in the comment
@@ -98,20 +98,30 @@ jobs:
         continue-on-error: true
         run: make test/transparentproxy UPDATE_GOLDEN_FILES=true
 
-      - name: "Commit and push transparent proxy golden files changes"
+      - name: "Commit transparent proxy golden files changes"
         if: contains(github.event.comment.body, '/golden_files_tproxy') && steps.golden-files-tproxy.outcome == 'success'
+        id: commit-golden-files-tproxy
         continue-on-error: true
-        env:
-          GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
         run: |
           if git diff --exit-code --stat; then
             echo "No transparent proxy golden files changes detected"
+            echo "committed=false" >> "$GITHUB_OUTPUT"
           else
             git config user.name "${GH_USER}"
             git config user.email "${GH_EMAIL}"
             git commit -s -m "fix(ci): update transparent proxy golden files" .
-            git push
+            echo "committed=true" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: "Push all commits"
+        if: |
+          always() &&
+          (steps.commit-format.outputs.committed == 'true' ||
+           steps.commit-golden-files.outputs.committed == 'true' ||
+           steps.commit-golden-files-tproxy.outputs.committed == 'true')
+        env:
+          GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
+        run: git push
 
       - name: "Post summary comment"
         if: always()
@@ -122,7 +132,11 @@ jobs:
 
           if [ "${{ steps.format.outcome }}" != "" ]; then
             if [ "${{ steps.format.outcome }}" == "success" ]; then
-              SUMMARY="${SUMMARY}✅ **Format**: Succeeded and pushed\n"
+              if [ "${{ steps.commit-format.outputs.committed }}" == "true" ]; then
+                SUMMARY="${SUMMARY}✅ **Format**: Succeeded and committed\n"
+              else
+                SUMMARY="${SUMMARY}✅ **Format**: Succeeded (no changes)\n"
+              fi
             elif [ "${{ steps.format.outcome }}" == "failure" ]; then
               SUMMARY="${SUMMARY}❌ **Format**: Failed\n"
             fi
@@ -130,7 +144,11 @@ jobs:
 
           if [ "${{ steps.golden-files.outcome }}" != "" ]; then
             if [ "${{ steps.golden-files.outcome }}" == "success" ]; then
-              SUMMARY="${SUMMARY}✅ **Golden files**: Succeeded and pushed\n"
+              if [ "${{ steps.commit-golden-files.outputs.committed }}" == "true" ]; then
+                SUMMARY="${SUMMARY}✅ **Golden files**: Succeeded and committed\n"
+              else
+                SUMMARY="${SUMMARY}✅ **Golden files**: Succeeded (no changes)\n"
+              fi
             elif [ "${{ steps.golden-files.outcome }}" == "failure" ]; then
               SUMMARY="${SUMMARY}❌ **Golden files**: Failed\n"
             fi
@@ -138,7 +156,11 @@ jobs:
 
           if [ "${{ steps.golden-files-tproxy.outcome }}" != "" ]; then
             if [ "${{ steps.golden-files-tproxy.outcome }}" == "success" ]; then
-              SUMMARY="${SUMMARY}✅ **Transparent proxy golden files**: Succeeded and pushed\n"
+              if [ "${{ steps.commit-golden-files-tproxy.outputs.committed }}" == "true" ]; then
+                SUMMARY="${SUMMARY}✅ **Transparent proxy golden files**: Succeeded and committed\n"
+              else
+                SUMMARY="${SUMMARY}✅ **Transparent proxy golden files**: Succeeded (no changes)\n"
+              fi
             elif [ "${{ steps.golden-files-tproxy.outcome }}" == "failure" ]; then
               SUMMARY="${SUMMARY}❌ **Transparent proxy golden files**: Failed\n"
             fi

--- a/.github/workflows/pr-comments.yaml
+++ b/.github/workflows/pr-comments.yaml
@@ -50,31 +50,84 @@ jobs:
       # Automatically update code formatting if /format is in the comment
       - name: "Auto-format code"
         if: contains(github.event.comment.body, '/format')
-        run: make clean/generated check
+        id: format
         continue-on-error: true
+        run: make clean/generated check
 
-      # Update all golden files except transparent proxy tests if /golden_files is in the comment
-      - name: "Update golden files (excluding transparent proxy)"
-        if: contains(github.event.comment.body, '/golden_files')
-        run: make test UPDATE_GOLDEN_FILES=true
-
-      # Update only transparent proxy golden files if /golden_files_tproxy is in the comment
-      - name: "Update transparent proxy golden files"
-        if: contains(github.event.comment.body, '/golden_files_tproxy')
-        run: make test/transparentproxy UPDATE_GOLDEN_FILES=true
-
-      - name: commit and push fixes
+      - name: "Commit and push format changes"
+        if: contains(github.event.comment.body, '/format') && steps.format.outcome != 'skipped'
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
         run: |
           if git diff --exit-code --stat; then
-            echo "No change detected, skipping git push"
+            echo "No format changes detected"
           else
             git config user.name "${GH_USER}"
             git config user.email "${GH_EMAIL}"
             git commit -s -m "fix(ci): format files" .
             git push
+            echo "FORMAT_PUSHED=true" >> "$GITHUB_ENV"
           fi
-      - run: gh api --method POST -f content='hooray' ${{ github.event.comment.url }}/reactions
+
+      # Update all golden files except transparent proxy tests if /golden_files is in the comment
+      - name: "Update golden files (excluding transparent proxy)"
+        if: contains(github.event.comment.body, '/golden_files')
+        id: golden-files
+        continue-on-error: true
+        run: make test UPDATE_GOLDEN_FILES=true
+
+      - name: "Commit and push golden files changes"
+        if: contains(github.event.comment.body, '/golden_files') && steps.golden-files.outcome != 'skipped'
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
+        run: |
+          if git diff --exit-code --stat; then
+            echo "No golden files changes detected"
+          else
+            git config user.name "${GH_USER}"
+            git config user.email "${GH_EMAIL}"
+            git commit -s -m "fix(ci): update golden files" .
+            git push
+            echo "GOLDEN_FILES_PUSHED=true" >> "$GITHUB_ENV"
+          fi
+
+      # Update only transparent proxy golden files if /golden_files_tproxy is in the comment
+      - name: "Update transparent proxy golden files"
+        if: contains(github.event.comment.body, '/golden_files_tproxy')
+        id: golden-files-tproxy
+        continue-on-error: true
+        run: make test/transparentproxy UPDATE_GOLDEN_FILES=true
+
+      - name: "Commit and push transparent proxy golden files changes"
+        if: contains(github.event.comment.body, '/golden_files_tproxy') && steps.golden-files-tproxy.outcome != 'skipped'
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
+        run: |
+          if git diff --exit-code --stat; then
+            echo "No transparent proxy golden files changes detected"
+          else
+            git config user.name "${GH_USER}"
+            git config user.email "${GH_EMAIL}"
+            git commit -s -m "fix(ci): update transparent proxy golden files" .
+            git push
+            echo "TPROXY_GOLDEN_FILES_PUSHED=true" >> "$GITHUB_ENV"
+          fi
+
+      - name: "Add success reaction"
+        if: |
+          always() &&
+          steps.format.outcome != 'failure' &&
+          steps.golden-files.outcome != 'failure' &&
+          steps.golden-files-tproxy.outcome != 'failure'
+        run: gh api --method POST -f content='hooray' ${{ github.event.comment.url }}/reactions
+        env:
+          GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
+
+      - name: "Add failure reaction"
+        if: always() && (steps.format.outcome == 'failure' || steps.golden-files.outcome == 'failure' || steps.golden-files-tproxy.outcome == 'failure')
+        run: gh api --method POST -f content='-1' ${{ github.event.comment.url }}/reactions
         env:
           GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}

--- a/.github/workflows/pr-comments.yaml
+++ b/.github/workflows/pr-comments.yaml
@@ -55,7 +55,7 @@ jobs:
         run: make clean/generated check
 
       - name: "Commit and push format changes"
-        if: contains(github.event.comment.body, '/format') && steps.format.outcome != 'skipped'
+        if: contains(github.event.comment.body, '/format') && steps.format.outcome == 'success'
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
@@ -67,7 +67,6 @@ jobs:
             git config user.email "${GH_EMAIL}"
             git commit -s -m "fix(ci): format files" .
             git push
-            echo "FORMAT_PUSHED=true" >> "$GITHUB_ENV"
           fi
 
       # Update all golden files except transparent proxy tests if /golden_files is in the comment
@@ -78,7 +77,7 @@ jobs:
         run: make test UPDATE_GOLDEN_FILES=true
 
       - name: "Commit and push golden files changes"
-        if: contains(github.event.comment.body, '/golden_files') && steps.golden-files.outcome != 'skipped'
+        if: contains(github.event.comment.body, '/golden_files') && steps.golden-files.outcome == 'success'
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
@@ -90,7 +89,6 @@ jobs:
             git config user.email "${GH_EMAIL}"
             git commit -s -m "fix(ci): update golden files" .
             git push
-            echo "GOLDEN_FILES_PUSHED=true" >> "$GITHUB_ENV"
           fi
 
       # Update only transparent proxy golden files if /golden_files_tproxy is in the comment
@@ -101,7 +99,7 @@ jobs:
         run: make test/transparentproxy UPDATE_GOLDEN_FILES=true
 
       - name: "Commit and push transparent proxy golden files changes"
-        if: contains(github.event.comment.body, '/golden_files_tproxy') && steps.golden-files-tproxy.outcome != 'skipped'
+        if: contains(github.event.comment.body, '/golden_files_tproxy') && steps.golden-files-tproxy.outcome == 'success'
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
@@ -113,8 +111,40 @@ jobs:
             git config user.email "${GH_EMAIL}"
             git commit -s -m "fix(ci): update transparent proxy golden files" .
             git push
-            echo "TPROXY_GOLDEN_FILES_PUSHED=true" >> "$GITHUB_ENV"
           fi
+
+      - name: "Post summary comment"
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
+        run: |
+          SUMMARY="## Workflow Results\n\n"
+
+          if [ "${{ steps.format.outcome }}" != "" ]; then
+            if [ "${{ steps.format.outcome }}" == "success" ]; then
+              SUMMARY="${SUMMARY}✅ **Format**: Succeeded and pushed\n"
+            elif [ "${{ steps.format.outcome }}" == "failure" ]; then
+              SUMMARY="${SUMMARY}❌ **Format**: Failed\n"
+            fi
+          fi
+
+          if [ "${{ steps.golden-files.outcome }}" != "" ]; then
+            if [ "${{ steps.golden-files.outcome }}" == "success" ]; then
+              SUMMARY="${SUMMARY}✅ **Golden files**: Succeeded and pushed\n"
+            elif [ "${{ steps.golden-files.outcome }}" == "failure" ]; then
+              SUMMARY="${SUMMARY}❌ **Golden files**: Failed\n"
+            fi
+          fi
+
+          if [ "${{ steps.golden-files-tproxy.outcome }}" != "" ]; then
+            if [ "${{ steps.golden-files-tproxy.outcome }}" == "success" ]; then
+              SUMMARY="${SUMMARY}✅ **Transparent proxy golden files**: Succeeded and pushed\n"
+            elif [ "${{ steps.golden-files-tproxy.outcome }}" == "failure" ]; then
+              SUMMARY="${SUMMARY}❌ **Transparent proxy golden files**: Failed\n"
+            fi
+          fi
+
+          gh pr comment ${{ github.event.issue.number }} --repo ${{ github.repository }} --body "$SUMMARY"
 
       - name: "Add success reaction"
         if: |


### PR DESCRIPTION
## Motivation

If there is a partial failure like this https://github.com/kumahq/kuma/actions/runs/20259928702 it still might be valid to push format changes.

## Implementation information

Made it possible to submit partial success, added 👎 when failure.
