### PR TITLE
fix(xds): skip workload label validation for gateway dataplanes

### DIFF
--- a/pkg/xds/server/callbacks/workload_label_validator.go
+++ b/pkg/xds/server/callbacks/workload_label_validator.go
@@ -43,12 +43,18 @@ func (v *WorkloadLabelValidator) OnProxyConnected(
 		return nil
 	}
 
-	if md.Resource == nil {
+	dp := md.GetDataplaneResource()
+	if dp == nil {
+		return nil
+	}
+
+	// Skip validation for gateway dataplanes
+	if dp.Spec.IsBuiltinGateway() {
 		return nil
 	}
 
 	mesh := proxyKey.Mesh
-	labels := md.Resource.GetMeta().GetLabels()
+	labels := dp.GetMeta().GetLabels()
 
 	log := workloadLabelLog.
 		WithValues("mesh", mesh).


### PR DESCRIPTION
## Motivation

Gateway dataplanes should not be validated for workload labels when connecting to the control plane, even if they are selected by a MeshIdentity that uses the workload label in its SPIFFE ID path template.

Issue: https://github.com/kumahq/kuma/issues/14903

## Implementation information

Modified `WorkloadLabelValidator.OnProxyConnected()` to skip validation for builtin gateway dataplanes by:
- Using `GetDataplaneResource()` to get typed dataplane resource
- Checking `IsBuiltinGateway()` before proceeding with label validation
- Added test case for gateway dataplanes to verify they're not validated

## Supporting documentation

Fixes https://github.com/kumahq/kuma/issues/15297