### PR TITLE
fix(workload): skip workload resource creation for gateway dataplanes

### DIFF
--- a/pkg/core/resources/apis/workload/generate/generator.go
+++ b/pkg/core/resources/apis/workload/generate/generator.go
@@ -107,6 +107,10 @@ func (g *Generator) generate(ctx context.Context, mesh string, dataplanes []*cor
 func (g *Generator) collectWorkloadsByName(dataplanes []*core_mesh.DataplaneResource) map[string]bool {
 	workloadsByName := map[string]bool{}
 	for _, dataplane := range core_mesh.SortDataplanes(dataplanes) {
+		// Skip gateway dataplanes - they should not have workload resources
+		if dataplane.Spec.IsBuiltinGateway() || dataplane.Spec.IsDelegatedGateway() {
+			continue
+		}
 		if workloadName, ok := g.workloadForDataplane(dataplane); ok {
 			workloadsByName[workloadName] = true
 		}

--- a/pkg/plugins/runtime/k8s/controllers/testdata/workload/08.resources.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/workload/08.resources.yaml
@@ -1,0 +1,14 @@
+apiVersion: kuma.io/v1alpha1
+kind: Dataplane
+metadata:
+  name: gateway
+  namespace: demo
+  annotations:
+    kuma.io/workload: gateway-workload
+mesh: default
+spec:
+  networking:
+    gateway:
+      type: BUILTIN
+      tags:
+        kuma.io/service: gateway

--- a/pkg/plugins/runtime/k8s/controllers/testdata/workload/08.workload.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/workload/08.workload.yaml
@@ -1,0 +1,2 @@
+items: []
+metadata: {}

--- a/pkg/plugins/runtime/k8s/controllers/workload_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/workload_controller_test.go
@@ -126,5 +126,11 @@ var _ = Describe("WorkloadController", func() {
 			workloadName: "multi-mesh-workload",
 			namespace:    "demo",
 		}),
+		Entry("should not create Workload for gateway dataplane", testCase{
+			inputFile:    "08.resources.yaml",
+			outputFile:   "08.workload.yaml",
+			workloadName: "gateway-workload",
+			namespace:    "demo",
+		}),
 	)
 })


### PR DESCRIPTION
## Motivation

Gateway dataplanes (both builtin and delegated) should not have workload resources created for them, as workload resources are only intended for sidecar proxies.

## Implementation information

Added checks in both the K8s workload controller and Universal workload generator to skip gateway dataplanes:

- K8s controller: Check `IsBuiltinGateway()` and `IsDelegatedGateway()` before creating workload resources
- Universal generator: Same checks in `collectWorkloadsByName()` to skip gateway dataplanes
- Added test coverage for both implementations

## Supporting documentation

Fixes https://github.com/kumahq/kuma/issues/15296