### PR TITLE
ci(merge-to-master): make clear to run release to master merge from release branch

### DIFF
--- a/.github/workflows/merge-release-to-master.yaml
+++ b/.github/workflows/merge-release-to-master.yaml
@@ -6,7 +6,12 @@ concurrency:
 on:
   push:
     branches: ["release-*"]
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      _info:
+        description: "⚠️ This workflow MUST be run from a release branch (release-*), NOT from master"
+        required: false
+        default: ""
 permissions:
   contents: read
 jobs:
@@ -17,6 +22,14 @@ jobs:
         with:
           ref: "master"
           fetch-depth: 0
+      - name: Validate workflow is not run from master
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
+            echo "::error::This workflow must be run from a release branch (release-*), not from master"
+            echo "::error::Current branch: ${{ github.ref }}"
+            echo "::error::Please re-run this workflow from the latest release branch"
+            exit 1
+          fi
       - uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # v3.5.1
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Motivation

The "Merge release to master" workflow was silently skipping when run from master branch instead of failing, causing confusion and wasted CI resources (see https://github.com/kumahq/kuma/actions/runs/20292261087/job/58279057121).

##  Implementation information

- Added warning message in workflow_dispatch inputs visible in GitHub UI
- Added early validation step that fails immediately if workflow is run from master instead of a release branch
- Provides clear error messages directing users to run from the correct branch

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
