### PR TITLE
test(e2e): escape shell special characters in token generation

### DIFF
--- a/test/framework/universal_controlplane.go
+++ b/test/framework/universal_controlplane.go
@@ -183,19 +183,27 @@ func (c *UniversalControlPlane) GenerateDpToken(mesh, service, workload string) 
 		return "", err
 	}
 
-	data := fmt.Sprintf("'%s'", string(dataBytes))
+	// Escape single quotes for shell safety: replace ' with '\''
+	escapedData := strings.ReplaceAll(string(dataBytes), "'", `'\''`)
+	data := fmt.Sprintf("'%s'", escapedData)
 
 	return c.generateToken("/dataplane", data)
 }
 
 func (c *UniversalControlPlane) GenerateZoneIngressToken(zone string) (string, error) {
-	data := fmt.Sprintf(`'{"zone": %q, "scope": ["ingress"]}'`, zone)
+	rawData := fmt.Sprintf(`{"zone": %q, "scope": ["ingress"]}`, zone)
+	// Escape single quotes for shell safety: replace ' with '\''
+	escapedData := strings.ReplaceAll(rawData, "'", `'\''`)
+	data := fmt.Sprintf("'%s'", escapedData)
 
 	return c.generateToken("/zone", data)
 }
 
 func (c *UniversalControlPlane) GenerateZoneEgressToken(zone string) (string, error) {
-	data := fmt.Sprintf(`'{"zone": %q, "scope": ["egress"]}'`, zone)
+	rawData := fmt.Sprintf(`{"zone": %q, "scope": ["egress"]}`, zone)
+	// Escape single quotes for shell safety: replace ' with '\''
+	escapedData := strings.ReplaceAll(rawData, "'", `'\''`)
+	data := fmt.Sprintf("'%s'", escapedData)
 
 	return c.generateToken("/zone", data)
 }
@@ -209,7 +217,10 @@ func (c *UniversalControlPlane) GenerateZoneToken(
 		return "", err
 	}
 
-	data := fmt.Sprintf(`'{"zone": %q, "scope": %s}'`, zone, scopeJson)
+	rawData := fmt.Sprintf(`{"zone": %q, "scope": %s}`, zone, scopeJson)
+	// Escape single quotes for shell safety: replace ' with '\''
+	escapedData := strings.ReplaceAll(rawData, "'", `'\''`)
+	data := fmt.Sprintf("'%s'", escapedData)
 
 	return c.generateToken("/zone", data)
 }


### PR DESCRIPTION
## Motivation
This PR fixes a command injection vulnerability in the test framework's token generation methods. User-provided data (mesh names, service names, workload names, zone names, and scope values) was being embedded in shell command strings without proper escaping of single quotes.

## Implementation information
   Fixed four methods in `test/framework/universal_controlplane.go`:
   - `GenerateDpToken`: Escapes single quotes in mesh, service, and workload names
   - `GenerateZoneIngressToken`: Escapes single quotes in zone names
   - `GenerateZoneEgressToken`: Escapes single quotes in zone names
   - `GenerateZoneToken`: Escapes single quotes in zone names and scope arrays
