### PR TITLE
fix(workload): handle AlreadyExists error gracefully

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/testdata/workload/08.resources.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/workload/08.resources.yaml
@@ -1,0 +1,18 @@
+apiVersion: kuma.io/v1alpha1
+kind: Dataplane
+metadata:
+  name: example
+  namespace: demo
+  annotations:
+    kuma.io/workload: test-workload
+mesh: default
+---
+apiVersion: workloads.kuma.io/v1alpha1
+kind: Workload
+metadata:
+  name: test-workload
+  namespace: demo
+  labels:
+    kuma.io/mesh: default
+    kuma.io/managed-by: k8s-controller
+spec: {}

--- a/pkg/plugins/runtime/k8s/controllers/testdata/workload/08.workload.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/workload/08.workload.yaml
@@ -1,0 +1,10 @@
+items:
+- metadata:
+    labels:
+      kuma.io/managed-by: k8s-controller
+      kuma.io/mesh: default
+    name: test-workload
+    namespace: demo
+    resourceVersion: "999"
+  spec: {}
+metadata: {}

--- a/pkg/plugins/runtime/k8s/controllers/workload_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/workload_controller.go
@@ -133,6 +133,10 @@ func (r *WorkloadReconciler) createOrUpdateWorkload(ctx context.Context, workloa
 		return nil
 	})
 	if err != nil {
+		if kube_apierrs.IsAlreadyExists(err) {
+			log.Info("workload already exists")
+			return nil
+		}
 		return errors.Wrapf(err, "failed to create/update Workload %s in namespace %s", workloadName, namespace)
 	}
 

--- a/pkg/plugins/runtime/k8s/controllers/workload_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/workload_controller_test.go
@@ -126,5 +126,11 @@ var _ = Describe("WorkloadController", func() {
 			workloadName: "multi-mesh-workload",
 			namespace:    "demo",
 		}),
+		Entry("should handle existing Workload gracefully", testCase{
+			inputFile:    "08.resources.yaml",
+			outputFile:   "08.workload.yaml",
+			workloadName: "test-workload",
+			namespace:    "demo",
+		}),
 	)
 })


### PR DESCRIPTION
## Motivation

Workload controller was failing with reconciliation errors when workloads already exist, causing error logs during race conditions.

## Implementation information

- Catches `IsAlreadyExists` error in `createOrUpdateWorkload`
- Logs as info instead of returning error
- Added test case for existing workload scenario
- Follows existing error handling pattern from configmap controller

## Supporting documentation

Fixes reconciliation error:
```
failed to create/update Workload default in namespace kuma-demo: workloads.kuma.io "default" already exists
```