### PR TITLE
fix(api-server): include insights when filtering dataplanes by labels

### DIFF
--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -336,8 +336,15 @@ func (r *resourceEndpoints) listResources(withInsight bool) func(request *restfu
 		}
 		if withInsight {
 			// we cannot paginate insights since there is no guarantee that the insights elements will be the same as regular entities
+			// Extract ResourceKeys from filtered dataplanes
+			resourceKeys := make([]core_model.ResourceKey, 0, len(list.GetItems()))
+			for _, item := range list.GetItems() {
+				resourceKeys = append(resourceKeys, core_model.MetaToResourceKey(item.GetMeta()))
+			}
+
+			// Fetch insights only for filtered dataplanes
 			insights := r.descriptor.NewInsightList()
-			if err := r.resManager.List(request.Request.Context(), insights, store.ListByMesh(meshName), store.ListByNameContains(nameContains), store.ListByFilterFunc(filter)); err != nil {
+			if err := r.resManager.List(request.Request.Context(), insights, store.ListByMesh(meshName), store.ListByResourceKeys(resourceKeys)); err != nil {
 				rest_errors.HandleError(request.Request.Context(), response, err, "Could not retrieve resources")
 				return
 			}


### PR DESCRIPTION
## Motivation

When filtering `/meshes/{mesh}/dataplanes/_overview` by labels (e.g., `?filter[labels.kuma.io/workload]=value`), the `dataplaneInsight` field was missing from response items.

The root cause was that label filters were applied to both dataplanes and insights. Since DataplaneInsights don't have labels like `kuma.io/workload`, they were incorrectly filtered out, causing `MergeInOverview` to produce incomplete overview objects.

## Implementation information

Changed `pkg/api-server/resource_endpoints.go` to:
1. Apply all filters (labels, tags, gateway) to dataplanes as before
2. Extract ResourceKeys from the filtered dataplanes
3. Fetch insights only for those specific dataplanes using `ListByResourceKeys()`

This ensures insights are fetched based on dataplane names rather than being filtered by label criteria they don't possess.

Added test coverage in `dataplane_overview_endpoints_test.go` verifying that dataplaneInsight is present when filtering by workload labels.

## Supporting documentation

Fixes #15403