### PR TITLE
fix(MeshMetric): ensure all internal entities in Basic filter

### DIFF
--- a/app/kuma-dp/pkg/dataplane/metrics/merge.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/merge.go
@@ -15,7 +15,15 @@ import (
 const (
 	EnvoyClusterLabelName               = "envoy_cluster_name"
 	EnvoyHttpConnManagerPrefixLabelName = "envoy_http_conn_manager_prefix"
+	EnvoyListenerAddressLabelName       = "envoy_listener_address"
 )
+
+// EntityLabels a set of labels which may contain entity names
+var EntityLabels = map[string]struct{}{
+	EnvoyClusterLabelName:               {},
+	EnvoyHttpConnManagerPrefixLabelName: {},
+	EnvoyListenerAddressLabelName:       {},
+}
 
 const MeshTrafficLabelName = "kuma_io_mesh_traffic"
 

--- a/app/kuma-dp/pkg/dataplane/metrics/profiles.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/profiles.go
@@ -281,7 +281,7 @@ func ProfileMutatorGenerator(sidecar *v1alpha1.Sidecar) PrometheusMutator {
 				for _, m := range metricFamily.Metric {
 					includeMetric := true
 					for _, l := range m.Label {
-						if metricFromInternalCluster(l, effectiveLabelsSelectors) {
+						if metricFromInternalEntity(l, effectiveLabelsSelectors) {
 							includeMetric = false
 							break
 						}
@@ -308,9 +308,12 @@ func ProfileMutatorGenerator(sidecar *v1alpha1.Sidecar) PrometheusMutator {
 	}
 }
 
-func metricFromInternalCluster(l *io_prometheus_client.LabelPair, effectiveLabelsSelectors []selectorFunction) bool {
+func metricFromInternalEntity(l *io_prometheus_client.LabelPair, effectiveLabelsSelectors []selectorFunction) bool {
+	if _, ok := EntityLabels[l.GetName()]; !ok {
+		return false
+	}
 	for _, selector := range effectiveLabelsSelectors {
-		if l.GetName() == EnvoyClusterLabelName && selector(l.GetValue()) {
+		if selector(l.GetValue()) {
 			return true
 		}
 	}

--- a/app/kuma-dp/pkg/dataplane/metrics/testdata/profiles/basic.in
+++ b/app/kuma-dp/pkg/dataplane/metrics/testdata/profiles/basic.in
@@ -109,3 +109,9 @@ envoy_server_memory_heap_size{envoy_cluster_name="example"} 1
 
 # TYPE envoy_server_uptime counter
 envoy_server_uptime{envoy_cluster_name="example"} 1
+
+# TYPE envoy_http_downstream_cx_active counter
+envoy_http_downstream_cx_active{envoy_http_conn_manager_prefix="system_envoy_admin"} 23
+
+# TYPE envoy_listener_sock_downstream_pre_cx_active counter
+envoy_listener_sock_downstream_pre_cx_active{envoy_listener_address="system_meshmetric_foo_bar_baz"} 233


### PR DESCRIPTION
Only metrics with labels: `EnvoyClusterLabelName` where extracted
We now also do it for: `EnvoyHttpConnManagerPrefixLabelName` and `EnvoyListenerAddressLabelName`