### PR TITLE
fix(meshidentity): add a trailing slash to prefix matcher

### DIFF
--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin.go
@@ -442,7 +442,7 @@ func downstreamTLSContext(xdsCtx xds_context.Context, proxy *core_xds.Proxy, con
 			if err != nil {
 				return nil, err
 			}
-			conf := bldrs_tls.NewSubjectAltNameMatcher().Configure(bldrs_tls.URI(bldrs_matcher.NewStringMatcher().Configure(bldrs_matcher.PrefixMatcher(id.IDString()))))
+			conf := bldrs_tls.NewSubjectAltNameMatcher().Configure(bldrs_tls.URI(bldrs_matcher.NewStringMatcher().Configure(bldrs_matcher.PrefixMatcher(id.IDString() + "/"))))
 			sanMatchers = append(sanMatchers, conf)
 		}
 	}

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin_test.go
@@ -226,6 +226,26 @@ var _ = Describe("MeshTLS", func() {
 				},
 			},
 		}),
+		Entry("strict with MeshTrust and kuma managed identity", testCase{
+			caseName:    "strict-with-mesh-trust-kuma-managed",
+			meshBuilder: samples.MeshMTLSBuilder(),
+			meshService: true,
+			workloadIdentity: &core_xds.WorkloadIdentity{
+				KRI:            kri.Identifier{ResourceType: meshidentity_api.MeshIdentityType, Mesh: "default", Zone: "default", Name: "my-identity"},
+				ManagementMode: core_xds.KumaManagementMode,
+				IdentitySourceConfigurer: func() bldrs_common.Configurer[envoy_tls.SdsSecretConfig] {
+					return bldrs_tls.SdsSecretConfigSource(
+						"my-secret-name",
+						bldrs_core.NewConfigSource().Configure(bldrs_core.Sds()),
+					)
+				},
+			},
+			casByTrustDomain: map[string][]xds_context.PEMBytes{
+				"domain-1": {
+					xds_context.PEMBytes("123"),
+				},
+			},
+		}),
 		Entry("strict mode + strict mesh = no passthrough listeners", testCase{
 			caseName:    "strict-with-strict-mtls",
 			meshBuilder: samples.MeshMTLSBuilder(),

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-mesh-trust-kuma-managed.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-mesh-trust-kuma-managed.clusters.golden.yaml
@@ -1,0 +1,28 @@
+resources:
+- name: outbound
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    name: outgoing
+    transportSocket:
+      name: envoy.transport_sockets.tls
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        commonTlsContext:
+          alpnProtocols:
+          - kuma
+          combinedValidationContext:
+            defaultValidationContext:
+              matchTypedSubjectAltNames:
+              - matcher:
+                  exact: spiffe://default/outgoing
+                sanType: URI
+            validationContextSdsSecretConfig:
+              name: mesh_ca:secret:default
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+          tlsCertificateSdsSecretConfigs:
+          - name: identity_cert:secret:default
+            sdsConfig:
+              ads: {}
+              resourceApiVersion: V3

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-mesh-trust-kuma-managed.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-mesh-trust-kuma-managed.listeners.golden.yaml
@@ -1,0 +1,157 @@
+resources:
+- name: inbound:127.0.0.1:17777
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 127.0.0.1
+        portValue: 17777
+    bindToPort: false
+    enableReusePort: false
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.rbac
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
+          rules: {}
+          statPrefix: inbound_127_0_0_1_17777.
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: localhost:17777
+          idleTimeout: 7200s
+          statPrefix: localhost_17777
+      transportSocket:
+        name: envoy.transport_sockets.tls
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          commonTlsContext:
+            combinedValidationContext:
+              defaultValidationContext:
+                matchTypedSubjectAltNames:
+                - matcher:
+                    prefix: spiffe://domain-1/
+                  sanType: URI
+              validationContextSdsSecretConfig:
+                name: system_trust_bundle
+                sdsConfig:
+                  ads: {}
+                  resourceApiVersion: V3
+            tlsCertificateSdsSecretConfigs:
+            - name: my-secret-name
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+          requireClientCertificate: true
+    metadata:
+      filterMetadata:
+        io.kuma.tags:
+          kuma.io/service: backend
+    name: inbound:127.0.0.1:17777
+    trafficDirection: INBOUND
+- name: inbound:127.0.0.1:17778
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 127.0.0.1
+        portValue: 17778
+    bindToPort: false
+    enableReusePort: false
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.rbac
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
+          rules: {}
+          statPrefix: inbound_127_0_0_1_17778.
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: localhost:17778
+          idleTimeout: 7200s
+          statPrefix: localhost_17778
+      transportSocket:
+        name: envoy.transport_sockets.tls
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          commonTlsContext:
+            combinedValidationContext:
+              defaultValidationContext:
+                matchTypedSubjectAltNames:
+                - matcher:
+                    prefix: spiffe://domain-1/
+                  sanType: URI
+              validationContextSdsSecretConfig:
+                name: system_trust_bundle
+                sdsConfig:
+                  ads: {}
+                  resourceApiVersion: V3
+            tlsCertificateSdsSecretConfigs:
+            - name: my-secret-name
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+          requireClientCertificate: true
+    metadata:
+      filterMetadata:
+        io.kuma.tags:
+          kuma.io/service: frontend
+    name: inbound:127.0.0.1:17778
+    trafficDirection: INBOUND
+- name: inbound:passthrough:ipv4
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 0.0.0.0
+        portValue: 15001
+    enableReusePort: false
+    filterChains:
+    - filterChainMatch:
+        destinationPort: 17777
+      filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: inbound:passthrough:ipv4
+          statPrefix: inbound_passthrough_ipv4
+    - filterChainMatch:
+        destinationPort: 17778
+      filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: inbound:passthrough:ipv4
+          statPrefix: inbound_passthrough_ipv4
+    name: inbound:passthrough:ipv4
+    trafficDirection: INBOUND
+    useOriginalDst: true
+- name: inbound:passthrough:ipv6
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: '::'
+        portValue: 15001
+    enableReusePort: false
+    filterChains:
+    - filterChainMatch:
+        destinationPort: 17777
+      filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: inbound:passthrough:ipv6
+          statPrefix: inbound_passthrough_ipv6
+    - filterChainMatch:
+        destinationPort: 17778
+      filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: inbound:passthrough:ipv6
+          statPrefix: inbound_passthrough_ipv6
+    name: inbound:passthrough:ipv6
+    trafficDirection: INBOUND
+    useOriginalDst: true

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-mesh-trust-kuma-managed.policy.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-mesh-trust-kuma-managed.policy.yaml
@@ -1,0 +1,7 @@
+targetRef:
+  kind: Mesh
+from:
+  - targetRef:
+      kind: Mesh
+    default:
+      mode: Strict


### PR DESCRIPTION
## Motivation

While validating prefix `spiffe://example.org` we might validate `spiffe://example.orgi` as a correct trust domain.

## Implementation information

* Fixed prefix construction to use `id.IDString() + "/"` producing correct SPIFFE URI prefix `spiffe://domain-1/`
* Added test case "strict with MeshTrust and kuma managed identity" that exercises the `CAsByTrustDomain` code path with `ManagementMode: KumaManagementMode`

