### PR TITLE
feat(MeshService): add dataplane.matchLabels selector

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -6463,6 +6463,13 @@ spec:
                 x-kubernetes-list-type: map
               selector:
                 properties:
+                  dataplaneLabels:
+                    properties:
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
                   dataplaneRef:
                     properties:
                       name:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -6463,6 +6463,13 @@ spec:
                 x-kubernetes-list-type: map
               selector:
                 properties:
+                  dataplaneLabels:
+                    properties:
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
                   dataplaneRef:
                     properties:
                       name:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -6483,6 +6483,13 @@ spec:
                 x-kubernetes-list-type: map
               selector:
                 properties:
+                  dataplaneLabels:
+                    properties:
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
                   dataplaneRef:
                     properties:
                       name:

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -8526,6 +8526,13 @@ spec:
                 x-kubernetes-list-type: map
               selector:
                 properties:
+                  dataplaneLabels:
+                    properties:
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
                   dataplaneRef:
                     properties:
                       name:

--- a/deployments/charts/kuma/crds/kuma.io_meshservices.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshservices.yaml
@@ -93,6 +93,13 @@ spec:
                 x-kubernetes-list-type: map
               selector:
                 properties:
+                  dataplaneLabels:
+                    properties:
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
                   dataplaneRef:
                     properties:
                       name:

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -18489,6 +18489,13 @@ components:
               x-kubernetes-list-type: map
             selector:
               properties:
+                dataplaneLabels:
+                  properties:
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
                 dataplaneRef:
                   properties:
                     name:

--- a/docs/generated/raw/crds/kuma.io_meshservices.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshservices.yaml
@@ -93,6 +93,13 @@ spec:
                 x-kubernetes-list-type: map
               selector:
                 properties:
+                  dataplaneLabels:
+                    properties:
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
                   dataplaneRef:
                     properties:
                       name:

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/meshservice.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/meshservice.go
@@ -4,13 +4,15 @@ package v1alpha1
 import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	common_api "github.com/kumahq/kuma/v2/api/common/v1alpha1"
 	core_meta "github.com/kumahq/kuma/v2/pkg/core/metadata"
 	hostnamegenerator_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1"
 )
 
 type Selector struct {
-	DataplaneTags *map[string]string `json:"dataplaneTags,omitempty"`
-	DataplaneRef  *DataplaneRef      `json:"dataplaneRef,omitempty"`
+	DataplaneTags   *map[string]string        `json:"dataplaneTags,omitempty"`
+	DataplaneRef    *DataplaneRef             `json:"dataplaneRef,omitempty"`
+	DataplaneLabels *common_api.LabelSelector `json:"dataplaneLabels,omitempty"`
 }
 
 type DataplaneRef struct {

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/rest.yaml
@@ -196,6 +196,13 @@ components:
               x-kubernetes-list-type: map
             selector:
               properties:
+                dataplaneLabels:
+                  properties:
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
                 dataplaneRef:
                   properties:
                     name:

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/validator.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/validator.go
@@ -12,18 +12,18 @@ func (r *MeshServiceResource) validate() error {
 	verr.Add(validators.ValidateLength(validators.RootedAt("name"), maxNameLength, name))
 
 	// Validate selector mutual exclusivity
-	count := 0
+	var setSelectors []bool
 	if r.Spec.Selector.DataplaneTags != nil {
-		count++
+		setSelectors = append(setSelectors, true)
 	}
 	if r.Spec.Selector.DataplaneRef != nil {
-		count++
+		setSelectors = append(setSelectors, true)
 	}
 	if r.Spec.Selector.DataplaneLabels != nil {
-		count++
+		setSelectors = append(setSelectors, true)
 	}
 
-	if count > 1 {
+	if len(setSelectors) > 1 {
 		verr.AddViolationAt(validators.RootedAt("spec").Field("selector"), "must specify only one of: dataplaneTags, dataplaneRef, or dataplaneLabels")
 	}
 

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/validator.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/validator.go
@@ -11,5 +11,21 @@ func (r *MeshServiceResource) validate() error {
 	name := model.GetDisplayName(r.GetMeta())
 	verr.Add(validators.ValidateLength(validators.RootedAt("name"), maxNameLength, name))
 
+	// Validate selector mutual exclusivity
+	count := 0
+	if r.Spec.Selector.DataplaneTags != nil {
+		count++
+	}
+	if r.Spec.Selector.DataplaneRef != nil {
+		count++
+	}
+	if r.Spec.Selector.DataplaneLabels != nil {
+		count++
+	}
+
+	if count > 1 {
+		verr.AddViolationAt(validators.RootedAt("spec").Field("selector"), "must specify only one of: dataplaneTags, dataplaneRef, or dataplaneLabels")
+	}
+
 	return verr.OrNil()
 }

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/validator_test.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/validator_test.go
@@ -22,6 +22,24 @@ var _ = Describe("MeshService", func() {
 				Resource: "",
 			},
 		),
+		Entry(
+			"multiple selectors specified",
+			ResourceValidationCase{
+				Violations: []validators.Violation{{
+					Field:   `spec.selector`,
+					Message: `must specify only one of: dataplaneTags, dataplaneRef, or dataplaneLabels`,
+				}},
+				Name: "meshservice",
+				Resource: `
+selector:
+  dataplaneTags:
+    app: redis
+  dataplaneLabels:
+    matchLabels:
+      app: redis
+`,
+			},
+		),
 	)
 	DescribeValidCases(
 		api.NewMeshServiceResource,
@@ -30,6 +48,40 @@ var _ = Describe("MeshService", func() {
 			ResourceValidationCase{
 				Name:     "meshservice",
 				Resource: "",
+			},
+		),
+		Entry(
+			"accepts dataplaneTags selector",
+			ResourceValidationCase{
+				Name: "meshservice",
+				Resource: `
+selector:
+  dataplaneTags:
+    app: redis
+`,
+			},
+		),
+		Entry(
+			"accepts dataplaneRef selector",
+			ResourceValidationCase{
+				Name: "meshservice",
+				Resource: `
+selector:
+  dataplaneRef:
+    name: redis-01
+`,
+			},
+		),
+		Entry(
+			"accepts dataplaneLabels selector",
+			ResourceValidationCase{
+				Name: "meshservice",
+				Resource: `
+selector:
+  dataplaneLabels:
+    matchLabels:
+      app: redis
+`,
 			},
 		),
 	)

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/zz_generated.deepcopy.go
@@ -5,6 +5,7 @@
 package v1alpha1
 
 import (
+	commonv1alpha1 "github.com/kumahq/kuma/v2/api/common/v1alpha1"
 	apiv1alpha1 "github.com/kumahq/kuma/v2/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -163,6 +164,11 @@ func (in *Selector) DeepCopyInto(out *Selector) {
 		in, out := &in.DataplaneRef, &out.DataplaneRef
 		*out = new(DataplaneRef)
 		**out = **in
+	}
+	if in.DataplaneLabels != nil {
+		in, out := &in.DataplaneLabels, &out.DataplaneLabels
+		*out = new(commonv1alpha1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 }
 

--- a/pkg/core/resources/apis/meshservice/k8s/crd/kuma.io_meshservices.yaml
+++ b/pkg/core/resources/apis/meshservice/k8s/crd/kuma.io_meshservices.yaml
@@ -93,6 +93,13 @@ spec:
                 x-kubernetes-list-type: map
               selector:
                 properties:
+                  dataplaneLabels:
+                    properties:
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
                   dataplaneRef:
                     properties:
                       name:

--- a/pkg/test/resources/builders/meshservice_builder.go
+++ b/pkg/test/resources/builders/meshservice_builder.go
@@ -5,6 +5,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	common_api "github.com/kumahq/kuma/v2/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
 	core_meta "github.com/kumahq/kuma/v2/pkg/core/metadata"
 	"github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshservice/api/v1alpha1"
@@ -75,6 +76,15 @@ func (m *MeshServiceBuilder) WithDataplaneTagsSelector(selector map[string]strin
 
 func (m *MeshServiceBuilder) WithDataplaneTagsSelectorKV(selectorKV ...string) *MeshServiceBuilder {
 	return m.WithDataplaneTagsSelector(TagsKVToMap(selectorKV))
+}
+
+func (m *MeshServiceBuilder) WithDataplaneLabelsSelector(selector map[string]string) *MeshServiceBuilder {
+	m.res.Spec.Selector = v1alpha1.Selector{
+		DataplaneLabels: &common_api.LabelSelector{
+			MatchLabels: &selector,
+		},
+	}
+	return m
 }
 
 func (m *MeshServiceBuilder) AddIntPort(port, target int32, protocol core_meta.Protocol) *MeshServiceBuilder {


### PR DESCRIPTION
## Motivation

Support fine-grained MeshService selection using pod labels instead of inbound tags. This enables:
- Version-specific service definitions (e.g., redis-v1 vs redis-v2 by `version` label)
- Better integration with K8s primitives (pod labels vs synthetic tags)
- Cleaner service definitions in Exclusive mode + MeshIdentity

Closes #15430

## Implementation information

**API Changes:**
- Add `DataplaneLabels *common_api.LabelSelector` to MeshService Selector
- Reuse existing `common_api.LabelSelector` type with `Matches()` method

**Matching Logic:**
- New `matchByLabels()` function matches Dataplane.Meta.Labels
- More efficient than tag matching: O(n) vs O(n*m)
- Mesh isolation via `indexDpsByMesh()` - prevents cross-mesh matches

**Validation:**
- Enforce mutual exclusivity: only one of dataplaneTags, dataplaneRef, dataplaneLabels
- Empty matchLabels valid - matches all dataplanes in mesh (K8s convention)

**Backward Compatibility:**
- Additive change only
- Existing selectors (dataplaneTags, dataplaneRef) unchanged
- No breaking changes

**Testing:**
- Unit tests: label matching, mesh isolation, empty selector, unhealthy inbounds
- Validation tests: mutual exclusivity enforcement

## Supporting documentation

- Issue: #15430
- MADR: TODO (will add after initial review)

> Changelog: feat(kuma-cp): support running without inbound tags
