### PR TITLE
feat(MeshService): use DataplaneLabels selector with SkipInboundTagGeneration

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/meshservice_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/meshservice_controller_test.go
@@ -32,8 +32,9 @@ var _ = Describe("MeshServiceController", func() {
 	var reconciler kube_reconcile.Reconciler
 
 	type testCase struct {
-		inputFile  string
-		outputFile string
+		inputFile                string
+		outputFile               string
+		skipInboundTagGeneration bool
 	}
 
 	DescribeTable("should reconcile service",
@@ -68,11 +69,12 @@ var _ = Describe("MeshServiceController", func() {
 				Build()
 
 			reconciler = &MeshServiceReconciler{
-				Client:            kubeClient,
-				Log:               logr.Discard(),
-				Scheme:            k8sClientScheme,
-				EventRecorder:     kube_record.NewFakeRecorder(10),
-				ResourceConverter: k8s.NewSimpleConverter(),
+				Client:                   kubeClient,
+				Log:                      logr.Discard(),
+				Scheme:                   k8sClientScheme,
+				EventRecorder:            kube_record.NewFakeRecorder(10),
+				ResourceConverter:        k8s.NewSimpleConverter(),
+				SkipInboundTagGeneration: given.skipInboundTagGeneration,
 			}
 
 			key := kube_types.NamespacedName{
@@ -125,6 +127,11 @@ var _ = Describe("MeshServiceController", func() {
 		Entry("headless gateway service with mode Disabled", testCase{
 			inputFile:  "headless-gateway-disabled.resources.yaml",
 			outputFile: "headless-gateway-disabled.meshservice.yaml",
+		}),
+		Entry("with SkipInboundTagGeneration enabled", testCase{
+			inputFile:                "skip-inbound-tags.resources.yaml",
+			outputFile:               "skip-inbound-tags.meshservice.yaml",
+			skipInboundTagGeneration: true,
 		}),
 	)
 })

--- a/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/skip-inbound-tags.meshservice.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/skip-inbound-tags.meshservice.yaml
@@ -1,0 +1,33 @@
+items:
+- metadata:
+    labels:
+      k8s.kuma.io/is-headless-service: "false"
+      k8s.kuma.io/service-name: example
+      kuma.io/env: kubernetes
+      kuma.io/managed-by: k8s-controller
+      kuma.io/mesh: default
+    name: example
+    namespace: demo
+    ownerReferences:
+    - apiVersion: v1
+      kind: Service
+      name: example
+      uid: ""
+    resourceVersion: "1"
+  spec:
+    ports:
+    - appProtocol: http
+      name: "80"
+      port: 80
+      targetPort: 8080
+    selector:
+      dataplaneLabels:
+        matchLabels:
+          app: backend
+          k8s.kuma.io/namespace: demo
+  status:
+    dataplaneProxies: {}
+    tls: {}
+    vips:
+    - ip: 192.168.0.1
+metadata: {}

--- a/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/skip-inbound-tags.resources.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/skip-inbound-tags.resources.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: demo
+  name: example
+  labels:
+    kuma.io/mesh: default
+spec:
+  clusterIP: 192.168.0.1
+  selector:
+    app: backend
+  ports:
+    - appProtocol: http
+      port: 80
+      targetPort: 8080
+      protocol: TCP
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: demo
+---
+apiVersion: kuma.io/v1alpha1
+kind: Mesh
+metadata:
+  name: default
+spec:
+  meshServices:
+    mode: Everywhere

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -155,11 +155,12 @@ func addMeshServiceReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime, co
 		return nil
 	}
 	reconciler := &k8s_controllers.MeshServiceReconciler{
-		Client:            mgr.GetClient(),
-		Log:               core.Log.WithName("controllers").WithName("MeshService"),
-		Scheme:            mgr.GetScheme(),
-		EventRecorder:     mgr.GetEventRecorderFor("k8s.kuma.io/mesh-service-generator"),
-		ResourceConverter: converter,
+		Client:                   mgr.GetClient(),
+		Log:                      core.Log.WithName("controllers").WithName("MeshService"),
+		Scheme:                   mgr.GetScheme(),
+		EventRecorder:            mgr.GetEventRecorderFor("k8s.kuma.io/mesh-service-generator"),
+		ResourceConverter:        converter,
+		SkipInboundTagGeneration: rt.Config().Experimental.SkipInboundTagGeneration,
 	}
 	return reconciler.SetupWithManager(mgr)
 }


### PR DESCRIPTION
## Motivation

When `SkipInboundTagGeneration` is enabled, dataplanes have no inbound tags (empty tags map). Auto-generated MeshService uses `dataplaneTags` selector which can't match dataplanes without tags, breaking service discovery.

## Implementation information

When `SkipInboundTagGeneration` enabled, auto-generated MeshService now uses `DataplaneLabels` selector instead of `DataplaneTags`. This allows matching dataplanes by pod labels instead of inbound tags.

Changes:
- Added `SkipInboundTagGeneration` field to `MeshServiceReconciler`
- Modified `setFromClusterIPSvc()` to conditionally use `DataplaneLabels` selector
- Wired config from `rt.Config().Experimental.SkipInboundTagGeneration`
- Added unit tests

## Supporting documentation

Fixes #15442

> Changelog: feat(kuma-cp): support running without inbound tags
