### PR TITLE
feat(dataplane): store protocol in Inbound field instead of tags

### DIFF
--- a/api/mesh/v1alpha1/dataplane.pb.go
+++ b/api/mesh/v1alpha1/dataplane.pb.go
@@ -494,7 +494,9 @@ type Dataplane_Networking_Inbound struct {
 	// State describes the current state of the listener.
 	State Dataplane_Networking_Inbound_State `protobuf:"varint,9,opt,name=state,proto3,enum=kuma.mesh.v1alpha1.Dataplane_Networking_Inbound_State" json:"state,omitempty"`
 	// Name adds another way of referencing this port, usable with MeshService
-	Name          string `protobuf:"bytes,10,opt,name=name,proto3" json:"name,omitempty"`
+	Name string `protobuf:"bytes,10,opt,name=name,proto3" json:"name,omitempty"`
+	// Protocol of the service (tcp, http, grpc, etc).
+	Protocol      string `protobuf:"bytes,11,opt,name=protocol,proto3" json:"protocol,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -588,6 +590,13 @@ func (x *Dataplane_Networking_Inbound) GetState() Dataplane_Networking_Inbound_S
 func (x *Dataplane_Networking_Inbound) GetName() string {
 	if x != nil {
 		return x.Name
+	}
+	return ""
+}
+
+func (x *Dataplane_Networking_Inbound) GetProtocol() string {
+	if x != nil {
+		return x.Protocol
 	}
 	return ""
 }
@@ -1290,13 +1299,13 @@ var File_api_mesh_v1alpha1_dataplane_proto protoreflect.FileDescriptor
 
 const file_api_mesh_v1alpha1_dataplane_proto_rawDesc = "" +
 	"\n" +
-	"!api/mesh/v1alpha1/dataplane.proto\x12\x12kuma.mesh.v1alpha1\x1a\x16api/mesh/options.proto\x1a#api/mesh/v1alpha1/envoy_admin.proto\x1a\x1fapi/mesh/v1alpha1/metrics.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a\x17validate/validate.proto\"\xfd\"\n" +
+	"!api/mesh/v1alpha1/dataplane.proto\x12\x12kuma.mesh.v1alpha1\x1a\x16api/mesh/options.proto\x1a#api/mesh/v1alpha1/envoy_admin.proto\x1a\x1fapi/mesh/v1alpha1/metrics.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a\x17validate/validate.proto\"\x99#\n" +
 	"\tDataplane\x12H\n" +
 	"\n" +
 	"networking\x18\x01 \x01(\v2(.kuma.mesh.v1alpha1.Dataplane.NetworkingR\n" +
 	"networking\x12<\n" +
 	"\ametrics\x18\x02 \x01(\v2\".kuma.mesh.v1alpha1.MetricsBackendR\ametrics\x12<\n" +
-	"\x06probes\x18\x03 \x01(\v2$.kuma.mesh.v1alpha1.Dataplane.ProbesR\x06probes\x1a\x8b\x1a\n" +
+	"\x06probes\x18\x03 \x01(\v2$.kuma.mesh.v1alpha1.Dataplane.ProbesR\x06probes\x1a\xa7\x1a\n" +
 	"\n" +
 	"Networking\x12\x18\n" +
 	"\aaddress\x18\x05 \x01(\tR\aaddress\x12,\n" +
@@ -1305,7 +1314,7 @@ const file_api_mesh_v1alpha1_dataplane_proto_rawDesc = "" +
 	"\ainbound\x18\x01 \x03(\v20.kuma.mesh.v1alpha1.Dataplane.Networking.InboundR\ainbound\x12M\n" +
 	"\boutbound\x18\x02 \x03(\v21.kuma.mesh.v1alpha1.Dataplane.Networking.OutboundR\boutbound\x12o\n" +
 	"\x14transparent_proxying\x18\x04 \x01(\v2<.kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxyingR\x13transparentProxying\x124\n" +
-	"\x05admin\x18\b \x01(\v2\x1e.kuma.mesh.v1alpha1.EnvoyAdminR\x05admin\x1a\xec\a\n" +
+	"\x05admin\x18\b \x01(\v2\x1e.kuma.mesh.v1alpha1.EnvoyAdminR\x05admin\x1a\x88\b\n" +
 	"\aInbound\x12\x12\n" +
 	"\x04port\x18\x03 \x01(\rR\x04port\x12 \n" +
 	"\vservicePort\x18\x04 \x01(\rR\vservicePort\x12&\n" +
@@ -1316,7 +1325,8 @@ const file_api_mesh_v1alpha1_dataplane_proto_rawDesc = "" +
 	"\fserviceProbe\x18\b \x01(\v2=.kuma.mesh.v1alpha1.Dataplane.Networking.Inbound.ServiceProbeR\fserviceProbe\x12L\n" +
 	"\x05state\x18\t \x01(\x0e26.kuma.mesh.v1alpha1.Dataplane.Networking.Inbound.StateR\x05state\x12\x12\n" +
 	"\x04name\x18\n" +
-	" \x01(\tR\x04name\x1a7\n" +
+	" \x01(\tR\x04name\x12\x1a\n" +
+	"\bprotocol\x18\v \x01(\tR\bprotocol\x1a7\n" +
 	"\tTagsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a\x1e\n" +

--- a/api/mesh/v1alpha1/dataplane.proto
+++ b/api/mesh/v1alpha1/dataplane.proto
@@ -155,6 +155,9 @@ message Dataplane {
 
       // Name adds another way of referencing this port, usable with MeshService
       string name = 10;
+
+      // Protocol of the service (tcp, http, grpc, etc).
+      string protocol = 11;
     }
 
     // Outbound describes a service consumed by the data plane proxy.

--- a/api/mesh/v1alpha1/dataplane/rest.yaml
+++ b/api/mesh/v1alpha1/dataplane/rest.yaml
@@ -188,6 +188,9 @@ components:
                       listening to. When transparent proxying is not used, Envoy will bind to
                       this port.
                     type: integer
+                  protocol:
+                    description: Protocol of the service (tcp, http, grpc, etc).
+                    type: string
                   serviceAddress:
                     description: |-
                       Address of the service that requests will be forwarded to.

--- a/api/mesh/v1alpha1/dataplane_helpers.go
+++ b/api/mesh/v1alpha1/dataplane_helpers.go
@@ -386,13 +386,15 @@ func (d *Dataplane_Networking_Inbound) GetService() string {
 	return d.Tags[ServiceTag]
 }
 
-// GetProtocol returns a protocol supported by this inbound interface.
-//
-// The purpose of this method is to encapsulate implementation detail
-// that protocol is modeled as a tag rather than a separate field.
-func (d *Dataplane_Networking_Inbound) GetProtocol() string {
+// GetProtocolFallback returns a protocol supported by this inbound interface.
+// It first checks the Protocol field, then falls back to the protocol tag
+// for backward compatibility.
+func (d *Dataplane_Networking_Inbound) GetProtocolFallback() string {
 	if d == nil {
 		return ""
+	}
+	if d.Protocol != "" {
+		return d.Protocol
 	}
 	return d.Tags[ProtocolTag]
 }

--- a/api/mesh/v1alpha1/dataplaneoverview/schema.yaml
+++ b/api/mesh/v1alpha1/dataplaneoverview/schema.yaml
@@ -138,6 +138,9 @@ components:
                           listening to. When transparent proxying is not used, Envoy will bind to
                           this port.
                         type: integer
+                      protocol:
+                        description: Protocol of the service (tcp, http, grpc, etc).
+                        type: string
                       serviceAddress:
                         description: |-
                           Address of the service that requests will be forwarded to.

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -5408,6 +5408,9 @@ components:
 
                       this port.
                     type: integer
+                  protocol:
+                    description: Protocol of the service (tcp, http, grpc, etc).
+                    type: string
                   serviceAddress:
                     description: >-
                       Address of the service that requests will be forwarded to.
@@ -16815,6 +16818,9 @@ components:
 
                           this port.
                         type: integer
+                      protocol:
+                        description: Protocol of the service (tcp, http, grpc, etc).
+                        type: string
                       serviceAddress:
                         description: >-
                           Address of the service that requests will be forwarded

--- a/docs/generated/raw/protos/Dataplane.json
+++ b/docs/generated/raw/protos/Dataplane.json
@@ -159,6 +159,10 @@
                 "name": {
                     "type": "string",
                     "description": "Name adds another way of referencing this port, usable with MeshService"
+                },
+                "protocol": {
+                    "type": "string",
+                    "description": "Protocol of the service (tcp, http, grpc, etc)."
                 }
             },
             "additionalProperties": true,

--- a/docs/generated/raw/protos/DataplaneOverview.json
+++ b/docs/generated/raw/protos/DataplaneOverview.json
@@ -175,6 +175,10 @@
                 "name": {
                     "type": "string",
                     "description": "Name adds another way of referencing this port, usable with MeshService"
+                },
+                "protocol": {
+                    "type": "string",
+                    "description": "Protocol of the service (tcp, http, grpc, etc)."
                 }
             },
             "additionalProperties": true,

--- a/pkg/api-server/dataplane_layout_endpoint.go
+++ b/pkg/api-server/dataplane_layout_endpoint.go
@@ -81,7 +81,7 @@ func (dle *dataplaneLayoutEndpoint) getLayout(request *restful.Request, response
 		return api_common.DataplaneInbound{
 			Kri:               kri.WithSectionName(kri.From(dataplane), inbound.GetSectionName()).String(),
 			Port:              int32(inbound.GetPort()),
-			Protocol:          inbound.GetProtocol(),
+			Protocol:          inbound.GetProtocolFallback(),
 			ProxyResourceName: naming.MustContextualInboundName(dataplane, inbound.GetSectionName()),
 		}
 	})

--- a/pkg/core/resources/apis/mesh/dataplane_validator.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator.go
@@ -194,6 +194,13 @@ func validateInbound(inbound *mesh_proto.Dataplane_Networking_Inbound, dpAddress
 		ExtraTagsValidators: []TagsValidatorFunc{validateProtocol},
 	}))
 
+	if inbound.Protocol != "" && core_meta.ParseProtocol(inbound.Protocol) == core_meta.ProtocolUnknown {
+		result.AddViolationAt(
+			validators.RootedAt("protocol"),
+			fmt.Sprintf("has an invalid value %q. %s", inbound.Protocol, AllowedValuesHint(core_meta.SupportedProtocols.Strings()...)),
+		)
+	}
+
 	result.Add(validateServiceProbe(inbound.ServiceProbe))
 
 	return result

--- a/pkg/core/resources/apis/meshservice/generate/generator.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator.go
@@ -96,7 +96,12 @@ func (g *Generator) meshServicesForDataplane(dataplane *core_mesh.DataplaneResou
 			port.Name = pointer.To(fmt.Sprintf("%d", port.Port))
 		}
 
-		if proto, ok := inbound.GetTags()[mesh_proto.ProtocolTag]; ok {
+		// Check protocol field first, fall back to tag for backward compatibility
+		if inbound.Protocol != "" {
+			if p := core_meta.ParseProtocol(inbound.Protocol); p != core_meta.ProtocolUnknown {
+				port.AppProtocol = p
+			}
+		} else if proto, ok := inbound.GetTags()[mesh_proto.ProtocolTag]; ok {
 			if p := core_meta.ParseProtocol(proto); p != core_meta.ProtocolUnknown {
 				port.AppProtocol = p
 			}

--- a/pkg/core/resources/apis/meshservice/generate/generator.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator.go
@@ -96,12 +96,7 @@ func (g *Generator) meshServicesForDataplane(dataplane *core_mesh.DataplaneResou
 			port.Name = pointer.To(fmt.Sprintf("%d", port.Port))
 		}
 
-		// Check protocol field first, fall back to tag for backward compatibility
-		if inbound.Protocol != "" {
-			if p := core_meta.ParseProtocol(inbound.Protocol); p != core_meta.ProtocolUnknown {
-				port.AppProtocol = p
-			}
-		} else if proto, ok := inbound.GetTags()[mesh_proto.ProtocolTag]; ok {
+		if proto := inbound.GetProtocolFallback(); proto != "" {
 			if p := core_meta.ParseProtocol(proto); p != core_meta.ProtocolUnknown {
 				port.AppProtocol = p
 			}

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin.go
@@ -123,7 +123,7 @@ func applyToInbounds(
 		if !ok {
 			continue
 		}
-		protocol := core_meta.ParseProtocol(inbound.GetProtocol())
+		protocol := core_meta.ParseProtocol(inbound.GetProtocolFallback())
 		conf := rules_inbound.MatchesAllIncomingTraffic[api.Conf](rules.InboundRules[listenerKey])
 		kumaValues := listeners_v3.KumaValues{
 			SourceService:      mesh_proto.ServiceUnknown,

--- a/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin.go
@@ -71,7 +71,7 @@ func applyToInbounds(
 ) error {
 	for _, inbound := range proxy.Dataplane.Spec.GetNetworking().GetInbound() {
 		iface := proxy.Dataplane.Spec.Networking.ToInboundInterface(inbound)
-		protocol := core_meta.ParseProtocol(inbound.GetProtocol())
+		protocol := core_meta.ParseProtocol(inbound.GetProtocolFallback())
 		if _, exists := proxy.Policies.FaultInjections[iface]; exists {
 			continue
 		}

--- a/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
@@ -99,7 +99,7 @@ func applyToInbounds(fromRules core_rules.FromRules, inboundListeners map[core_r
 			continue
 		}
 
-		protocol := core_meta.ParseProtocol(inbound.GetProtocol())
+		protocol := core_meta.ParseProtocol(inbound.GetProtocolFallback())
 
 		conf := rules_inbound.MatchesAllIncomingTraffic[api.Conf](fromRules.InboundRules[listenerKey])
 		configurer := plugin_xds.ListenerConfigurer{

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin.go
@@ -374,7 +374,7 @@ func configureListener(
 		return nil, err
 	}
 
-	protocol := core_meta.ParseProtocol(inbound.GetProtocol())
+	protocol := core_meta.ParseProtocol(inbound.GetProtocolFallback())
 	service := inbound.GetService()
 	cluster := policies_xds.NewClusterBuilder().WithName(clusterName).Build()
 	routes := generator.GenerateRoutes(proxy, iface, cluster)

--- a/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
@@ -86,11 +86,12 @@ func (ic *InboundConverter) inboundForService(zone string, pod *kube_core.Pod, s
 		}
 
 		ifaces = append(ifaces, &mesh_proto.Dataplane_Networking_Inbound{
-			Port:   uint32(containerPort),
-			Name:   portName,
-			Tags:   tags,
-			State:  state,
-			Health: &health, // write health for backwards compatibility with Kuma 2.5 and older
+			Port:     uint32(containerPort),
+			Name:     portName,
+			Tags:     tags,
+			State:    state,
+			Health:   &health, // write health for backwards compatibility with Kuma 2.5 and older
+			Protocol: ProtocolTagFor(service, &svcPort),
 		})
 	}
 
@@ -136,10 +137,11 @@ func (ic *InboundConverter) inboundForServiceless(zone string, pod *kube_core.Po
 	}
 
 	return &mesh_proto.Dataplane_Networking_Inbound{
-		Port:   mesh_proto.TCPPortReserved,
-		Tags:   tags,
-		State:  state,
-		Health: &health, // write health for backwards compatibility with Kuma 2.5 and older
+		Port:     mesh_proto.TCPPortReserved,
+		Tags:     tags,
+		State:    state,
+		Health:   &health, // write health for backwards compatibility with Kuma 2.5 and older
+		Protocol: string(core_meta.ProtocolTCP),
 	}
 }
 

--- a/pkg/plugins/runtime/k8s/controllers/testdata/01.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/01.dataplane.yaml
@@ -14,6 +14,7 @@ spec:
     - health:
         ready: true
       port: 8080
+      protocol: http
       tags:
         app: example
         k8s.kuma.io/namespace: demo
@@ -26,6 +27,7 @@ spec:
     - health:
         ready: true
       port: 8443
+      protocol: tcp
       tags:
         app: example
         k8s.kuma.io/namespace: demo
@@ -38,6 +40,7 @@ spec:
     - health:
         ready: true
       port: 7070
+      protocol: tcp
       tags:
         app: example
         k8s.kuma.io/namespace: demo
@@ -51,6 +54,7 @@ spec:
         ready: true
       name: metrics
       port: 6060
+      protocol: tcp
       tags:
         app: example
         k8s.kuma.io/namespace: demo

--- a/pkg/plugins/runtime/k8s/controllers/testdata/02.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/02.dataplane.yaml
@@ -13,6 +13,7 @@ spec:
     - health:
         ready: true
       port: 8080
+      protocol: tcp
       tags:
         app: example
         k8s.kuma.io/namespace: demo

--- a/pkg/plugins/runtime/k8s/controllers/testdata/04.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/04.dataplane.yaml
@@ -13,6 +13,7 @@ spec:
     - health:
         ready: true
       port: 8080
+      protocol: tcp
       tags:
         app: example
         k8s.kuma.io/namespace: demo

--- a/pkg/plugins/runtime/k8s/controllers/testdata/05.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/05.dataplane.yaml
@@ -13,6 +13,7 @@ spec:
     - health:
         ready: true
       port: 8080
+      protocol: tcp
       tags:
         app: example
         k8s.kuma.io/namespace: demo

--- a/pkg/plugins/runtime/k8s/controllers/testdata/06.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/06.dataplane.yaml
@@ -13,6 +13,7 @@ spec:
     - health:
         ready: true
       port: 8080
+      protocol: tcp
       tags:
         app: example
         k8s.kuma.io/namespace: demo
@@ -26,6 +27,7 @@ spec:
     - health:
         ready: true
       port: 8443
+      protocol: tcp
       tags:
         app: example
         k8s.kuma.io/namespace: demo

--- a/pkg/plugins/runtime/k8s/controllers/testdata/07.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/07.dataplane.yaml
@@ -18,6 +18,7 @@ spec:
     - health:
         ready: true
       port: 7070
+      protocol: tcp
       tags:
         app: example
         k8s.kuma.io/namespace: demo

--- a/pkg/plugins/runtime/k8s/controllers/testdata/08.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/08.dataplane.yaml
@@ -13,6 +13,7 @@ spec:
     - health:
         ready: true
       port: 8080
+      protocol: tcp
       tags:
         app: example
         k8s.kuma.io/namespace: demo

--- a/pkg/plugins/runtime/k8s/controllers/testdata/09.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/09.dataplane.yaml
@@ -13,6 +13,7 @@ spec:
     - health:
         ready: true
       port: 10001
+      protocol: tcp
       tags:
         app: kuma-ingress
         k8s.kuma.io/namespace: kuma-system

--- a/pkg/plugins/runtime/k8s/controllers/testdata/10.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/10.dataplane.yaml
@@ -13,6 +13,7 @@ spec:
     - health:
         ready: true
       port: 8080
+      protocol: http
       tags:
         app: example
         k8s.kuma.io/namespace: demo
@@ -25,6 +26,7 @@ spec:
     - health:
         ready: true
       port: 8443
+      protocol: tcp
       tags:
         app: example
         k8s.kuma.io/namespace: demo
@@ -37,6 +39,7 @@ spec:
     - health:
         ready: true
       port: 7070
+      protocol: tcp
       tags:
         app: example
         k8s.kuma.io/namespace: demo

--- a/pkg/plugins/runtime/k8s/controllers/testdata/11.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/11.dataplane.yaml
@@ -13,6 +13,7 @@ spec:
     - health:
         ready: true
       port: 8080
+      protocol: http
       tags:
         app: example
         k8s.kuma.io/namespace: demo
@@ -25,6 +26,7 @@ spec:
     - health:
         ready: true
       port: 8443
+      protocol: tcp
       tags:
         app: example
         k8s.kuma.io/namespace: demo
@@ -36,6 +38,7 @@ spec:
         version: "0.1"
     - health: {}
       port: 7070
+      protocol: tcp
       state: NotReady
       tags:
         app: example

--- a/pkg/plugins/runtime/k8s/controllers/testdata/12.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/12.dataplane.yaml
@@ -12,6 +12,7 @@ spec:
     inbound:
     - health: {}
       port: 8080
+      protocol: http
       state: NotReady
       tags:
         app: example
@@ -24,6 +25,7 @@ spec:
         version: "0.1"
     - health: {}
       port: 8443
+      protocol: tcp
       state: NotReady
       tags:
         app: example
@@ -36,6 +38,7 @@ spec:
         version: "0.1"
     - health: {}
       port: 7070
+      protocol: mongo
       state: NotReady
       tags:
         app: example

--- a/pkg/plugins/runtime/k8s/controllers/testdata/13.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/13.dataplane.yaml
@@ -13,6 +13,7 @@ spec:
     - health:
         ready: true
       port: 49151
+      protocol: tcp
       tags:
         app: example
         k8s.kuma.io/namespace: demo

--- a/pkg/plugins/runtime/k8s/controllers/testdata/15.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/15.dataplane.yaml
@@ -13,6 +13,7 @@ spec:
     - health:
         ready: true
       port: 8080
+      protocol: tcp
       tags:
         app: example
         k8s.kuma.io/namespace: demo

--- a/pkg/plugins/runtime/k8s/controllers/testdata/16.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/16.dataplane.yaml
@@ -13,6 +13,7 @@ spec:
     - health:
         ready: true
       port: 10002
+      protocol: tcp
       tags:
         app: kuma-egress
         k8s.kuma.io/namespace: kuma-system

--- a/pkg/plugins/runtime/k8s/controllers/testdata/17.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/17.dataplane.yaml
@@ -13,6 +13,7 @@ spec:
     - health:
         ready: true
       port: 8080
+      protocol: tcp
       tags:
         app: example
         k8s.kuma.io/namespace: demo

--- a/pkg/plugins/runtime/k8s/controllers/testdata/19.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/19.dataplane.yaml
@@ -12,6 +12,7 @@ spec:
     inbound:
     - health: {}
       port: 8080
+      protocol: http
       state: NotReady
       tags:
         app: example
@@ -24,6 +25,7 @@ spec:
         version: "0.1"
     - health: {}
       port: 8443
+      protocol: tcp
       state: NotReady
       tags:
         app: example

--- a/pkg/plugins/runtime/k8s/controllers/testdata/23.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/23.dataplane.yaml
@@ -14,6 +14,7 @@ spec:
     - health:
         ready: true
       port: 7070
+      protocol: http
       tags:
         app: example
         k8s.kuma.io/namespace: demo

--- a/pkg/plugins/runtime/k8s/controllers/testdata/24.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/24.dataplane.yaml
@@ -13,6 +13,7 @@ spec:
     - health:
         ready: true
       port: 8080
+      protocol: tcp
       tags:
         app: example
         k8s.kuma.io/namespace: demo

--- a/pkg/plugins/runtime/k8s/controllers/testdata/25.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/25.dataplane.yaml
@@ -13,6 +13,7 @@ spec:
     - health:
         ready: true
       port: 8080
+      protocol: tcp
       tags:
         app: example
         k8s.kuma.io/namespace: demo

--- a/pkg/plugins/runtime/k8s/controllers/testdata/26.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/26.dataplane.yaml
@@ -13,6 +13,7 @@ spec:
     - health:
         ready: true
       port: 49151
+      protocol: tcp
       tags:
         app: example
         k8s.kuma.io/namespace: demo

--- a/pkg/plugins/runtime/k8s/controllers/testdata/27.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/27.dataplane.yaml
@@ -13,6 +13,7 @@ spec:
     - health:
         ready: true
       port: 49151
+      protocol: tcp
       tags:
         app: example
         k8s.kuma.io/namespace: demo

--- a/pkg/plugins/runtime/k8s/controllers/testdata/28.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/28.dataplane.yaml
@@ -13,6 +13,7 @@ spec:
     - health:
         ready: true
       port: 8080
+      protocol: tcp
       tags:
         app: example
         k8s.kuma.io/namespace: demo

--- a/pkg/plugins/runtime/k8s/controllers/testdata/29.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/29.dataplane.yaml
@@ -13,6 +13,7 @@ spec:
     - health:
         ready: true
       port: 8080
+      protocol: tcp
       tags:
         app: example
         k8s.kuma.io/namespace: demo

--- a/pkg/plugins/runtime/k8s/controllers/testdata/30.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/30.dataplane.yaml
@@ -15,6 +15,7 @@ spec:
     - health:
         ready: true
       port: 8080
+      protocol: http
       tags:
         app: example
         k8s.kuma.io/namespace: demo
@@ -27,6 +28,7 @@ spec:
     - health:
         ready: true
       port: 8443
+      protocol: tcp
       tags:
         app: example
         k8s.kuma.io/namespace: demo
@@ -39,6 +41,7 @@ spec:
     - health:
         ready: true
       port: 7070
+      protocol: tcp
       tags:
         app: example
         k8s.kuma.io/namespace: demo

--- a/pkg/plugins/runtime/k8s/controllers/testdata/31.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/31.dataplane.yaml
@@ -16,6 +16,7 @@ spec:
     - health:
         ready: true
       port: 6379
+      protocol: tcp
       tags:
         app: redis
         k8s.kuma.io/namespace: demo

--- a/pkg/plugins/runtime/k8s/controllers/testdata/32.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/32.dataplane.yaml
@@ -16,6 +16,7 @@ spec:
     - health:
         ready: true
       port: 3306
+      protocol: tcp
       tags:
         component: database
         k8s.kuma.io/namespace: demo

--- a/pkg/plugins/runtime/k8s/controllers/testdata/33.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/33.dataplane.yaml
@@ -16,6 +16,7 @@ spec:
     - health:
         ready: true
       port: 5432
+      protocol: tcp
       tags:
         app: postgres
         k8s.kuma.io/namespace: demo

--- a/pkg/plugins/runtime/k8s/controllers/testdata/34.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/34.dataplane.yaml
@@ -14,3 +14,4 @@ spec:
     - health:
         ready: true
       port: 8080
+      protocol: http

--- a/pkg/plugins/runtime/k8s/controllers/testdata/35.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/35.dataplane.yaml
@@ -13,3 +13,4 @@ spec:
     - health:
         ready: true
       port: 49151
+      protocol: tcp

--- a/pkg/plugins/runtime/k8s/controllers/testdata/duplicated-inbounds.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/duplicated-inbounds.dataplane.yaml
@@ -15,6 +15,7 @@ spec:
         ready: true
       name: main-port
       port: 7070
+      protocol: tcp
       tags:
         app: example
         k8s.kuma.io/namespace: demo
@@ -28,6 +29,7 @@ spec:
         ready: true
       name: metrics
       port: 6060
+      protocol: tcp
       tags:
         app: example
         k8s.kuma.io/namespace: demo

--- a/pkg/plugins/runtime/k8s/controllers/testdata/mismatch-ports.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/mismatch-ports.dataplane.yaml
@@ -13,6 +13,7 @@ spec:
     - health:
         ready: true
       port: 49151
+      protocol: tcp
       tags:
         app: example
         k8s.kuma.io/namespace: demo

--- a/pkg/plugins/runtime/k8s/controllers/testdata/pod_controller/dataplane-for-pod-ms.golden.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/pod_controller/dataplane-for-pod-ms.golden.yaml
@@ -24,6 +24,7 @@ spec:
     inbound:
     - health: {}
       port: 8080
+      protocol: http
       state: NotReady
       tags:
         app: sample-ms
@@ -36,6 +37,7 @@ spec:
     - health: {}
       name: metrics
       port: 6060
+      protocol: tcp
       state: NotReady
       tags:
         app: sample-ms

--- a/pkg/plugins/runtime/k8s/controllers/testdata/pod_controller/dataplane-for-pod.golden.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/pod_controller/dataplane-for-pod.golden.yaml
@@ -24,6 +24,7 @@ spec:
     inbound:
     - health: {}
       port: 8080
+      protocol: http
       state: NotReady
       tags:
         app: sample
@@ -36,6 +37,7 @@ spec:
     - health: {}
       name: metrics
       port: 6060
+      protocol: tcp
       state: NotReady
       tags:
         app: sample
@@ -47,6 +49,7 @@ spec:
         kuma.io/zone: zone-1
     - health: {}
       port: 9090
+      protocol: http
       state: NotReady
       tags:
         app: sample

--- a/pkg/plugins/runtime/k8s/controllers/testdata/pod_controller/dataplane-not-changed.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/pod_controller/dataplane-not-changed.yaml
@@ -27,6 +27,7 @@ spec:
     inbound:
     - health: {}
       port: 8080
+      protocol: http
       state: NotReady
       tags:
         app: sample

--- a/pkg/plugins/runtime/k8s/controllers/testdata/pod_controller/dataplane-update-after-service-register.golden.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/pod_controller/dataplane-update-after-service-register.golden.yaml
@@ -24,6 +24,7 @@ spec:
     inbound:
     - health: {}
       port: 8080
+      protocol: http
       state: NotReady
       tags:
         app: sample
@@ -36,6 +37,7 @@ spec:
     - health: {}
       name: metrics
       port: 6060
+      protocol: tcp
       state: NotReady
       tags:
         app: sample
@@ -47,6 +49,7 @@ spec:
         kuma.io/zone: zone-1
     - health: {}
       port: 9090
+      protocol: http
       state: NotReady
       tags:
         app: sample

--- a/pkg/plugins/runtime/k8s/controllers/testdata/pod_controller/dataplane-updated-on-label-add.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/pod_controller/dataplane-updated-on-label-add.yaml
@@ -26,6 +26,7 @@ spec:
     inbound:
     - health: {}
       port: 8080
+      protocol: http
       state: NotReady
       tags:
         app: sample

--- a/pkg/plugins/runtime/k8s/controllers/testdata/update-dataplane.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/update-dataplane.dataplane.yaml
@@ -18,6 +18,7 @@ spec:
     - health:
         ready: true
       port: 8080
+      protocol: tcp
       tags:
         app: example
         k8s.kuma.io/namespace: demo

--- a/pkg/xds/generator/inbound_proxy_generator.go
+++ b/pkg/xds/generator/inbound_proxy_generator.go
@@ -37,7 +37,7 @@ func (g InboundProxyGenerator) Generate(_ context.Context, _ *core_xds.ResourceS
 		}
 
 		iface := proxy.Dataplane.Spec.Networking.Inbound[i]
-		protocol := core_meta.ParseProtocol(iface.GetProtocol())
+		protocol := core_meta.ParseProtocol(iface.GetProtocolFallback())
 		unifiedName := naming.MustContextualInboundName(proxy.Dataplane, endpoint.InboundName)
 
 		// generate CDS resource

--- a/pkg/xds/topology/outbound.go
+++ b/pkg/xds/topology/outbound.go
@@ -281,6 +281,10 @@ func fillDataplaneOutbounds(
 
 		for _, inbound := range dpNetworking.GetHealthyInbounds() {
 			inboundTags := maps.Clone(inbound.GetTags())
+			// Propagate protocol from field to tags for endpoint consumers
+			if inbound.Protocol != "" && inboundTags[mesh_proto.ProtocolTag] == "" {
+				inboundTags[mesh_proto.ProtocolTag] = inbound.Protocol
+			}
 			serviceName := inboundTags[mesh_proto.ServiceTag]
 			inboundInterface := dpNetworking.ToInboundInterface(inbound)
 			inboundAddress := inboundInterface.DataplaneAdvertisedIP
@@ -325,6 +329,10 @@ func fillLocalMeshServices(
 					}
 
 					inboundTags := maps.Clone(inbound.GetTags())
+					// Propagate protocol from field to tags for endpoint consumers
+					if inbound.Protocol != "" && inboundTags[mesh_proto.ProtocolTag] == "" {
+						inboundTags[mesh_proto.ProtocolTag] = inbound.Protocol
+					}
 					serviceName := destinationname.MustResolve(false, meshSvc, port)
 					inboundInterface := dpNetworking.ToInboundInterface(inbound)
 

--- a/pkg/xds/topology/outbound.go
+++ b/pkg/xds/topology/outbound.go
@@ -281,10 +281,6 @@ func fillDataplaneOutbounds(
 
 		for _, inbound := range dpNetworking.GetHealthyInbounds() {
 			inboundTags := maps.Clone(inbound.GetTags())
-			// Propagate protocol from field to tags for endpoint consumers
-			if inbound.Protocol != "" && inboundTags[mesh_proto.ProtocolTag] == "" {
-				inboundTags[mesh_proto.ProtocolTag] = inbound.Protocol
-			}
 			serviceName := inboundTags[mesh_proto.ServiceTag]
 			inboundInterface := dpNetworking.ToInboundInterface(inbound)
 			inboundAddress := inboundInterface.DataplaneAdvertisedIP
@@ -329,10 +325,6 @@ func fillLocalMeshServices(
 					}
 
 					inboundTags := maps.Clone(inbound.GetTags())
-					// Propagate protocol from field to tags for endpoint consumers
-					if inbound.Protocol != "" && inboundTags[mesh_proto.ProtocolTag] == "" {
-						inboundTags[mesh_proto.ProtocolTag] = inbound.Protocol
-					}
 					serviceName := destinationname.MustResolve(false, meshSvc, port)
 					inboundInterface := dpNetworking.ToInboundInterface(inbound)
 


### PR DESCRIPTION
## Motivation

Protocol was previously stored only in `kuma.io/protocol` tag within Inbound tags map. This change adds a dedicated `protocol` field to the Inbound message for cleaner separation and enables future optimizations where tags may be skipped entirely (e.g., with `SkipInboundTagGeneration`).

## Implementation information

- Added `string protocol = 11` field to `Dataplane_Networking_Inbound` proto message
- K8s controller always populates the protocol field for both service-backed and serviceless inbounds
- Created `GetProtocolFallback()` helper that checks field first, then falls back to tag for backward compatibility
- Updated endpoint propagation in `pkg/xds/topology/outbound.go` to ensure protocol is available in tags for existing consumers
- Updated MeshService generator to prefer protocol field over tag
- All policy plugins updated to use `GetProtocolFallback()` for backward compat

## Supporting documentation

Fixes #15431

> Changelog: feat(kuma-cp): support running without inbound tags
