### PR TITLE
test(e2e): enable envoyconfig tests for MTP

### DIFF
--- a/test/e2e_env/universal/envoyconfig/sidecars.go
+++ b/test/e2e_env/universal/envoyconfig/sidecars.go
@@ -19,6 +19,7 @@ import (
 	meshretry "github.com/kumahq/kuma/v2/pkg/plugins/policies/meshretry/api/v1alpha1"
 	meshtimeout "github.com/kumahq/kuma/v2/pkg/plugins/policies/meshtimeout/api/v1alpha1"
 	meshtls "github.com/kumahq/kuma/v2/pkg/plugins/policies/meshtls/api/v1alpha1"
+	meshtrafficpermission "github.com/kumahq/kuma/v2/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1"
 	"github.com/kumahq/kuma/v2/pkg/test"
 	"github.com/kumahq/kuma/v2/pkg/test/matchers"
 	"github.com/kumahq/kuma/v2/pkg/test/resources/builders"
@@ -46,6 +47,7 @@ func Sidecars() {
 		meshcircuitbreaker.MeshCircuitBreakerResourceTypeDescriptor,
 		meshhttproute.MeshHTTPRouteResourceTypeDescriptor,
 		meshretry.MeshRetryResourceTypeDescriptor,
+		meshtrafficpermission.MeshTrafficPermissionResourceTypeDescriptor,
 	))
 
 	DescribeTable("should generate proper Envoy config",
@@ -57,6 +59,7 @@ func Sidecars() {
 		test.EntriesForFolder(filepath.Join("sidecars", "meshtls"), "envoyconfig"),
 		test.EntriesForFolder(filepath.Join("sidecars", "meshcircuitbreaker"), "envoyconfig"),
 		test.EntriesForFolder(filepath.Join("sidecars", "meshretry"), "envoyconfig"),
+		test.EntriesForFolder(filepath.Join("sidecars", "meshtrafficpermission"), "envoyconfig"),
 	)
 }
 

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/from-rules-long.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/from-rules-long.demo-client.golden.json
@@ -187,8 +187,9 @@
                 {
                   "endpoint": {
                     "address": {
-                      "pipe": {
-                        "path": "/tmp/kuma-readiness-reporter.sock"
+                      "socketAddress": {
+                        "address": "IP_REDACTED",
+                        "portValue": 9902
                       }
                     }
                   }
@@ -244,12 +245,6 @@
         "lbPolicy": "CLUSTER_PROVIDED",
         "name": "outbound:passthrough:ipv6",
         "type": "ORIGINAL_DST"
-      },
-      "self_transparentproxy_no_destination_inbound": {
-        "altStatName": "self_transparentproxy_no_destination_inbound",
-        "connectTimeout": "5s",
-        "name": "self_transparentproxy_no_destination_inbound",
-        "type": "STATIC"
       }
     },
     "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment": {
@@ -437,9 +432,6 @@
         "enableReusePort": false,
         "filterChains": [
           {
-            "filterChainMatch": {
-              "destinationPort": 3000
-            },
             "filters": [
               {
                 "name": "envoy.filters.network.tcp_proxy",
@@ -466,9 +458,6 @@
         "enableReusePort": false,
         "filterChains": [
           {
-            "filterChainMatch": {
-              "destinationPort": 3000
-            },
             "filters": [
               {
                 "name": "envoy.filters.network.tcp_proxy",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/from-rules-long.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/from-rules-long.test-server.golden.json
@@ -2605,8 +2605,9 @@
                 {
                   "endpoint": {
                     "address": {
-                      "pipe": {
-                        "path": "/tmp/kuma-readiness-reporter.sock"
+                      "socketAddress": {
+                        "address": "IP_REDACTED",
+                        "portValue": 9902
                       }
                     }
                   }
@@ -2675,12 +2676,6 @@
         "lbPolicy": "CLUSTER_PROVIDED",
         "name": "outbound:passthrough:ipv6",
         "type": "ORIGINAL_DST"
-      },
-      "self_transparentproxy_no_destination_inbound": {
-        "altStatName": "self_transparentproxy_no_destination_inbound",
-        "connectTimeout": "5s",
-        "name": "self_transparentproxy_no_destination_inbound",
-        "type": "STATIC"
       }
     },
     "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment": {
@@ -5195,9 +5190,6 @@
         "enableReusePort": false,
         "filterChains": [
           {
-            "filterChainMatch": {
-              "destinationPort": 80
-            },
             "filters": [
               {
                 "name": "envoy.filters.network.tcp_proxy",
@@ -5224,9 +5216,6 @@
         "enableReusePort": false,
         "filterChains": [
           {
-            "filterChainMatch": {
-              "destinationPort": 80
-            },
             "filters": [
               {
                 "name": "envoy.filters.network.tcp_proxy",

--- a/test/e2e_env/universal/envoyconfig/utils.go
+++ b/test/e2e_env/universal/envoyconfig/utils.go
@@ -134,5 +134,6 @@ func redactKumaDynamicConfig(jsonStr string) string {
 func cleanupAfterTest(mesh string, policies ...core_model.ResourceTypeDescriptor) func() {
 	return func() {
 		Expect(DeleteMeshResources(universal.Cluster, mesh, policies...)).To(Succeed())
+		Expect(universal.Cluster.Install(MeshTrafficPermissionAllowAllUniversal(mesh))).To(Succeed())
 	}
 }


### PR DESCRIPTION
## Motivation

[Backport](https://github.com/kumahq/kuma/pull/15455) passed the CI because tests were not enabled for MTP. 

## Implementation information

Enable the envoyconfig tests for MTP

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
