### PR TITLE
test(e2e): enable envoyconfig tests for MTP

### DIFF
--- a/test/e2e_env/universal/envoyconfig/sidecars.go
+++ b/test/e2e_env/universal/envoyconfig/sidecars.go
@@ -14,6 +14,7 @@ import (
 	meshratelimit "github.com/kumahq/kuma/v2/pkg/plugins/policies/meshratelimit/api/v1alpha1"
 	meshtimeout "github.com/kumahq/kuma/v2/pkg/plugins/policies/meshtimeout/api/v1alpha1"
 	meshtls "github.com/kumahq/kuma/v2/pkg/plugins/policies/meshtls/api/v1alpha1"
+	meshtrafficpermission "github.com/kumahq/kuma/v2/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1"
 	"github.com/kumahq/kuma/v2/pkg/test"
 	"github.com/kumahq/kuma/v2/pkg/test/matchers"
 	"github.com/kumahq/kuma/v2/pkg/test/resources/builders"
@@ -79,7 +80,9 @@ func Sidecars() {
 			meshfaultinjection.MeshFaultInjectionResourceTypeDescriptor,
 			meshratelimit.MeshRateLimitResourceTypeDescriptor,
 			meshtls.MeshTLSResourceTypeDescriptor,
+			meshtrafficpermission.MeshTrafficPermissionResourceTypeDescriptor,
 		)).To(Succeed())
+		Expect(universal.Cluster.Install(MeshTrafficPermissionAllowAllUniversal(meshName))).To(Succeed())
 	})
 
 	DescribeTable("should generate proper Envoy config",
@@ -105,5 +108,6 @@ func Sidecars() {
 		test.EntriesForFolder(filepath.Join("sidecars", "meshratelimit"), "envoyconfig"),
 		test.EntriesForFolder(filepath.Join("sidecars", "meshtls"), "envoyconfig"),
 		test.EntriesForFolder(filepath.Join("sidecars", "meshcircuitbreaker"), "envoyconfig"),
+		test.EntriesForFolder(filepath.Join("sidecars", "meshtrafficpermission"), "envoyconfig"),
 	)
 }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/from-rules-long.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/from-rules-long.demo-client.golden.json
@@ -1,5 +1,41 @@
 {
-  "diff": [],
+  "diff": [
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/commonLbConfig",
+      "value": {
+        "healthyPanicThreshold": {
+          "value": 20
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/outlierDetection",
+      "value": {
+        "baseEjectionTime": "30s",
+        "consecutive5xx": 10,
+        "consecutiveGatewayFailure": 10,
+        "consecutiveLocalOriginFailure": 10,
+        "enforcingConsecutive5xx": 100,
+        "enforcingConsecutiveGatewayFailure": 100,
+        "enforcingConsecutiveLocalOriginFailure": 100,
+        "enforcingFailurePercentage": 100,
+        "enforcingFailurePercentageLocalOrigin": 100,
+        "enforcingLocalOriginSuccessRate": 100,
+        "enforcingSuccessRate": 100,
+        "failurePercentageMinimumHosts": 5,
+        "failurePercentageRequestVolume": 10,
+        "failurePercentageThreshold": 85,
+        "interval": "5s",
+        "maxEjectionPercent": 20,
+        "splitExternalLocalOriginErrors": true,
+        "successRateMinimumHosts": 5,
+        "successRateRequestVolume": 10,
+        "successRateStdevFactor": 1900000
+      }
+    }
+  ],
   "xds": {
     "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
       "envoyconfig_demo-client__kuma-3_msvc_3000": {
@@ -62,6 +98,11 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "commonLbConfig": {
+          "healthyPanicThreshold": {
+            "value": 20
+          }
+        },
         "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
@@ -70,6 +111,28 @@
           }
         },
         "name": "envoyconfig_test-server__kuma-3_msvc_80",
+        "outlierDetection": {
+          "baseEjectionTime": "30s",
+          "consecutive5xx": 10,
+          "consecutiveGatewayFailure": 10,
+          "consecutiveLocalOriginFailure": 10,
+          "enforcingConsecutive5xx": 100,
+          "enforcingConsecutiveGatewayFailure": 100,
+          "enforcingConsecutiveLocalOriginFailure": 100,
+          "enforcingFailurePercentage": 100,
+          "enforcingFailurePercentageLocalOrigin": 100,
+          "enforcingLocalOriginSuccessRate": 100,
+          "enforcingSuccessRate": 100,
+          "failurePercentageMinimumHosts": 5,
+          "failurePercentageRequestVolume": 10,
+          "failurePercentageThreshold": 85,
+          "interval": "5s",
+          "maxEjectionPercent": 20,
+          "splitExternalLocalOriginErrors": true,
+          "successRateMinimumHosts": 5,
+          "successRateRequestVolume": 10,
+          "successRateStdevFactor": 1900000
+        },
         "transportSocket": {
           "name": "envoy.transport_sockets.tls",
           "typedConfig": {
@@ -151,55 +214,6 @@
           }
         }
       },
-      "kuma:envoy:admin": {
-        "altStatName": "kuma_envoy_admin",
-        "connectTimeout": "5s",
-        "loadAssignment": {
-          "clusterName": "kuma:envoy:admin",
-          "endpoints": [
-            {
-              "lbEndpoints": [
-                {
-                  "endpoint": {
-                    "address": {
-                      "socketAddress": {
-                        "address": "IP_REDACTED",
-                        "portValue": 9901
-                      }
-                    }
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "name": "kuma:envoy:admin",
-        "type": "STATIC"
-      },
-      "kuma:readiness": {
-        "altStatName": "kuma_readiness",
-        "connectTimeout": "5s",
-        "loadAssignment": {
-          "clusterName": "kuma:readiness",
-          "endpoints": [
-            {
-              "lbEndpoints": [
-                {
-                  "endpoint": {
-                    "address": {
-                      "pipe": {
-                        "path": "/tmp/kuma-readiness-reporter.sock"
-                      }
-                    }
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "name": "kuma:readiness",
-        "type": "STATIC"
-      },
       "localhost:3000": {
         "altStatName": "localhost_3000",
         "connectTimeout": "5s",
@@ -244,12 +258,6 @@
         "lbPolicy": "CLUSTER_PROVIDED",
         "name": "outbound:passthrough:ipv6",
         "type": "ORIGINAL_DST"
-      },
-      "self_transparentproxy_no_destination_inbound": {
-        "altStatName": "self_transparentproxy_no_destination_inbound",
-        "connectTimeout": "5s",
-        "name": "self_transparentproxy_no_destination_inbound",
-        "type": "STATIC"
       }
     },
     "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment": {
@@ -437,9 +445,6 @@
         "enableReusePort": false,
         "filterChains": [
           {
-            "filterChainMatch": {
-              "destinationPort": 3000
-            },
             "filters": [
               {
                 "name": "envoy.filters.network.tcp_proxy",
@@ -466,9 +471,6 @@
         "enableReusePort": false,
         "filterChains": [
           {
-            "filterChainMatch": {
-              "destinationPort": 3000
-            },
             "filters": [
               {
                 "name": "envoy.filters.network.tcp_proxy",
@@ -484,169 +486,6 @@
         "name": "inbound:passthrough:ipv6",
         "trafficDirection": "INBOUND",
         "useOriginalDst": true
-      },
-      "kuma:envoy:admin": {
-        "address": {
-          "socketAddress": {
-            "address": "IP_REDACTED",
-            "portValue": 9901
-          }
-        },
-        "enableReusePort": false,
-        "filterChains": [
-          {
-            "filters": [
-              {
-                "name": "envoy.filters.network.http_connection_manager",
-                "typedConfig": {
-                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                  "httpFilters": [
-                    {
-                      "name": "envoy.filters.http.router",
-                      "typedConfig": {
-                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
-                      }
-                    }
-                  ],
-                  "internalAddressConfig": {
-                    "cidrRanges": [
-                      {
-                        "addressPrefix": "IP_REDACTED",
-                        "prefixLen": 32
-                      }
-                    ]
-                  },
-                  "routeConfig": {
-                    "validateClusters": false,
-                    "virtualHosts": [
-                      {
-                        "domains": [
-                          "*"
-                        ],
-                        "name": "kuma:envoy:admin",
-                        "routes": [
-                          {
-                            "match": {
-                              "prefix": "/ready"
-                            },
-                            "route": {
-                              "cluster": "kuma:readiness",
-                              "prefixRewrite": "/ready"
-                            }
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  "statPrefix": "STAT_PREFIX_REDACTED"
-                }
-              }
-            ]
-          },
-          {
-            "filterChainMatch": {
-              "transportProtocol": "tls"
-            },
-            "filters": [
-              {
-                "name": "envoy.filters.network.http_connection_manager",
-                "typedConfig": {
-                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                  "httpFilters": [
-                    {
-                      "name": "envoy.filters.http.router",
-                      "typedConfig": {
-                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
-                      }
-                    }
-                  ],
-                  "internalAddressConfig": {
-                    "cidrRanges": [
-                      {
-                        "addressPrefix": "IP_REDACTED",
-                        "prefixLen": 32
-                      }
-                    ]
-                  },
-                  "routeConfig": {
-                    "validateClusters": false,
-                    "virtualHosts": [
-                      {
-                        "domains": [
-                          "*"
-                        ],
-                        "name": "kuma:envoy:admin",
-                        "routes": [
-                          {
-                            "match": {
-                              "prefix": "/ready"
-                            },
-                            "route": {
-                              "cluster": "kuma:readiness",
-                              "prefixRewrite": "/ready"
-                            }
-                          },
-                          {
-                            "match": {
-                              "prefix": "/"
-                            },
-                            "route": {
-                              "cluster": "kuma:envoy:admin",
-                              "prefixRewrite": "/"
-                            }
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  "statPrefix": "STAT_PREFIX_REDACTED"
-                }
-              }
-            ],
-            "transportSocket": {
-              "name": "envoy.transport_sockets.tls",
-              "typedConfig": {
-                "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
-                "commonTlsContext": {
-                  "tlsCertificates": [
-                    {
-                      "certificateChain": {
-                        "inlineBytes": ""
-                      },
-                      "privateKey": {
-                        "inlineBytes": ""
-                      }
-                    }
-                  ],
-                  "validationContext": {
-                    "matchTypedSubjectAltNames": [
-                      {
-                        "matcher": {
-                          "exact": "kuma-cp"
-                        },
-                        "sanType": "DNS"
-                      }
-                    ],
-                    "trustedCa": {
-                      "inlineBytes": ""
-                    }
-                  }
-                },
-                "requireClientCertificate": true
-              }
-            }
-          }
-        ],
-        "listenerFilters": [
-          {
-            "name": "envoy.filters.listener.tls_inspector",
-            "typedConfig": {
-              "@type": "type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector"
-            }
-          }
-        ],
-        "name": "kuma:envoy:admin",
-        "trafficDirection": "INBOUND"
       },
       "outbound:IP_REDACTED:3000": {
         "address": {
@@ -728,7 +567,7 @@
                   "normalizePath": true,
                   "requestHeadersTimeout": "0s",
                   "routeConfig": {
-                    "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",
+                    "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
                     "virtualHosts": [
                       {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/from-rules-long.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/from-rules-long.test-server.golden.json
@@ -2,6 +2,41 @@
   "diff": [
     {
       "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/commonLbConfig",
+      "value": {
+        "healthyPanicThreshold": {
+          "value": 20
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/envoyconfig_test-server__kuma-3_msvc_80/outlierDetection",
+      "value": {
+        "baseEjectionTime": "30s",
+        "consecutive5xx": 10,
+        "consecutiveGatewayFailure": 10,
+        "consecutiveLocalOriginFailure": 10,
+        "enforcingConsecutive5xx": 100,
+        "enforcingConsecutiveGatewayFailure": 100,
+        "enforcingConsecutiveLocalOriginFailure": 100,
+        "enforcingFailurePercentage": 100,
+        "enforcingFailurePercentageLocalOrigin": 100,
+        "enforcingLocalOriginSuccessRate": 100,
+        "enforcingSuccessRate": 100,
+        "failurePercentageMinimumHosts": 5,
+        "failurePercentageRequestVolume": 10,
+        "failurePercentageThreshold": 85,
+        "interval": "5s",
+        "maxEjectionPercent": 20,
+        "splitExternalLocalOriginErrors": true,
+        "successRateMinimumHosts": 5,
+        "successRateRequestVolume": 10,
+        "successRateStdevFactor": 1900000
+      }
+    },
+    {
+      "op": "add",
       "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/inbound:IP_REDACTED:80/filterChains/0/filters/0/typedConfig/httpFilters/0/typedConfig/rules/policies/MeshTrafficPermission/principals/0/andIds",
       "value": {
         "ids": [
@@ -2480,6 +2515,11 @@
         }
       },
       "envoyconfig_test-server__kuma-3_msvc_80": {
+        "commonLbConfig": {
+          "healthyPanicThreshold": {
+            "value": 20
+          }
+        },
         "connectTimeout": "5s",
         "edsClusterConfig": {
           "edsConfig": {
@@ -2488,6 +2528,28 @@
           }
         },
         "name": "envoyconfig_test-server__kuma-3_msvc_80",
+        "outlierDetection": {
+          "baseEjectionTime": "30s",
+          "consecutive5xx": 10,
+          "consecutiveGatewayFailure": 10,
+          "consecutiveLocalOriginFailure": 10,
+          "enforcingConsecutive5xx": 100,
+          "enforcingConsecutiveGatewayFailure": 100,
+          "enforcingConsecutiveLocalOriginFailure": 100,
+          "enforcingFailurePercentage": 100,
+          "enforcingFailurePercentageLocalOrigin": 100,
+          "enforcingLocalOriginSuccessRate": 100,
+          "enforcingSuccessRate": 100,
+          "failurePercentageMinimumHosts": 5,
+          "failurePercentageRequestVolume": 10,
+          "failurePercentageThreshold": 85,
+          "interval": "5s",
+          "maxEjectionPercent": 20,
+          "splitExternalLocalOriginErrors": true,
+          "successRateMinimumHosts": 5,
+          "successRateRequestVolume": 10,
+          "successRateStdevFactor": 1900000
+        },
         "transportSocket": {
           "name": "envoy.transport_sockets.tls",
           "typedConfig": {
@@ -2569,55 +2631,6 @@
           }
         }
       },
-      "kuma:envoy:admin": {
-        "altStatName": "kuma_envoy_admin",
-        "connectTimeout": "5s",
-        "loadAssignment": {
-          "clusterName": "kuma:envoy:admin",
-          "endpoints": [
-            {
-              "lbEndpoints": [
-                {
-                  "endpoint": {
-                    "address": {
-                      "socketAddress": {
-                        "address": "IP_REDACTED",
-                        "portValue": 9901
-                      }
-                    }
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "name": "kuma:envoy:admin",
-        "type": "STATIC"
-      },
-      "kuma:readiness": {
-        "altStatName": "kuma_readiness",
-        "connectTimeout": "5s",
-        "loadAssignment": {
-          "clusterName": "kuma:readiness",
-          "endpoints": [
-            {
-              "lbEndpoints": [
-                {
-                  "endpoint": {
-                    "address": {
-                      "pipe": {
-                        "path": "/tmp/kuma-readiness-reporter.sock"
-                      }
-                    }
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "name": "kuma:readiness",
-        "type": "STATIC"
-      },
       "localhost:8080": {
         "altStatName": "localhost_8080",
         "connectTimeout": "5s",
@@ -2675,12 +2688,6 @@
         "lbPolicy": "CLUSTER_PROVIDED",
         "name": "outbound:passthrough:ipv6",
         "type": "ORIGINAL_DST"
-      },
-      "self_transparentproxy_no_destination_inbound": {
-        "altStatName": "self_transparentproxy_no_destination_inbound",
-        "connectTimeout": "5s",
-        "name": "self_transparentproxy_no_destination_inbound",
-        "type": "STATIC"
       }
     },
     "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment": {
@@ -5195,9 +5202,6 @@
         "enableReusePort": false,
         "filterChains": [
           {
-            "filterChainMatch": {
-              "destinationPort": 80
-            },
             "filters": [
               {
                 "name": "envoy.filters.network.tcp_proxy",
@@ -5224,9 +5228,6 @@
         "enableReusePort": false,
         "filterChains": [
           {
-            "filterChainMatch": {
-              "destinationPort": 80
-            },
             "filters": [
               {
                 "name": "envoy.filters.network.tcp_proxy",
@@ -5242,169 +5243,6 @@
         "name": "inbound:passthrough:ipv6",
         "trafficDirection": "INBOUND",
         "useOriginalDst": true
-      },
-      "kuma:envoy:admin": {
-        "address": {
-          "socketAddress": {
-            "address": "IP_REDACTED",
-            "portValue": 9901
-          }
-        },
-        "enableReusePort": false,
-        "filterChains": [
-          {
-            "filters": [
-              {
-                "name": "envoy.filters.network.http_connection_manager",
-                "typedConfig": {
-                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                  "httpFilters": [
-                    {
-                      "name": "envoy.filters.http.router",
-                      "typedConfig": {
-                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
-                      }
-                    }
-                  ],
-                  "internalAddressConfig": {
-                    "cidrRanges": [
-                      {
-                        "addressPrefix": "IP_REDACTED",
-                        "prefixLen": 32
-                      }
-                    ]
-                  },
-                  "routeConfig": {
-                    "validateClusters": false,
-                    "virtualHosts": [
-                      {
-                        "domains": [
-                          "*"
-                        ],
-                        "name": "kuma:envoy:admin",
-                        "routes": [
-                          {
-                            "match": {
-                              "prefix": "/ready"
-                            },
-                            "route": {
-                              "cluster": "kuma:readiness",
-                              "prefixRewrite": "/ready"
-                            }
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  "statPrefix": "STAT_PREFIX_REDACTED"
-                }
-              }
-            ]
-          },
-          {
-            "filterChainMatch": {
-              "transportProtocol": "tls"
-            },
-            "filters": [
-              {
-                "name": "envoy.filters.network.http_connection_manager",
-                "typedConfig": {
-                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                  "httpFilters": [
-                    {
-                      "name": "envoy.filters.http.router",
-                      "typedConfig": {
-                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
-                      }
-                    }
-                  ],
-                  "internalAddressConfig": {
-                    "cidrRanges": [
-                      {
-                        "addressPrefix": "IP_REDACTED",
-                        "prefixLen": 32
-                      }
-                    ]
-                  },
-                  "routeConfig": {
-                    "validateClusters": false,
-                    "virtualHosts": [
-                      {
-                        "domains": [
-                          "*"
-                        ],
-                        "name": "kuma:envoy:admin",
-                        "routes": [
-                          {
-                            "match": {
-                              "prefix": "/ready"
-                            },
-                            "route": {
-                              "cluster": "kuma:readiness",
-                              "prefixRewrite": "/ready"
-                            }
-                          },
-                          {
-                            "match": {
-                              "prefix": "/"
-                            },
-                            "route": {
-                              "cluster": "kuma:envoy:admin",
-                              "prefixRewrite": "/"
-                            }
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  "statPrefix": "STAT_PREFIX_REDACTED"
-                }
-              }
-            ],
-            "transportSocket": {
-              "name": "envoy.transport_sockets.tls",
-              "typedConfig": {
-                "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
-                "commonTlsContext": {
-                  "tlsCertificates": [
-                    {
-                      "certificateChain": {
-                        "inlineBytes": ""
-                      },
-                      "privateKey": {
-                        "inlineBytes": ""
-                      }
-                    }
-                  ],
-                  "validationContext": {
-                    "matchTypedSubjectAltNames": [
-                      {
-                        "matcher": {
-                          "exact": "kuma-cp"
-                        },
-                        "sanType": "DNS"
-                      }
-                    ],
-                    "trustedCa": {
-                      "inlineBytes": ""
-                    }
-                  }
-                },
-                "requireClientCertificate": true
-              }
-            }
-          }
-        ],
-        "listenerFilters": [
-          {
-            "name": "envoy.filters.listener.tls_inspector",
-            "typedConfig": {
-              "@type": "type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector"
-            }
-          }
-        ],
-        "name": "kuma:envoy:admin",
-        "trafficDirection": "INBOUND"
       },
       "outbound:IP_REDACTED:3000": {
         "address": {
@@ -5486,7 +5324,7 @@
                   "normalizePath": true,
                   "requestHeadersTimeout": "0s",
                   "routeConfig": {
-                    "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",
+                    "name": "outbound:envoyconfig_test-server__kuma-3_msvc_80",
                     "validateClusters": false,
                     "virtualHosts": [
                       {


### PR DESCRIPTION
## Motivation

[Backport](https://github.com/kumahq/kuma/pull/15454) passed the CI because tests were not enabled for MTP. 

## Implementation information

Enable the envoyconfig tests for MTP

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
