### PR TITLE
chore(deps): upgrade coredns version from v1.13.1 to 1.14.1

### DIFF
--- a/mk/build.mk
+++ b/mk/build.mk
@@ -20,7 +20,7 @@ export PATH := $(BUILD_KUMACTL_DIR):$(PATH)
 
 # An optional extension to the coredns packages
 COREDNS_EXT ?=
-COREDNS_VERSION = v1.13.1
+COREDNS_VERSION = v1.14.1
 
 # List of binaries that we have build/release build rules for.
 BUILD_RELEASE_BINARIES := kuma-cp kuma-dp kumactl coredns kuma-cni install-cni envoy


### PR DESCRIPTION
## Motivation

> This release primarily addresses security vulnerabilities affecting Go versions prior to
Go 1.25.6 and Go 1.24.12 (https://github.com/advisories/GHSA-g9q4-qjx4-2v7q, https://github.com/advisories/GHSA-gm9r-q53w-2gh4, CVE-2025-68121, https://github.com/advisories/GHSA-xvqr-69v8-f3gv,
https://github.com/advisories/GHSA-cm6p-qc7v-m3jw). It also includes performance improvements to the proxy plugin via
multiplexed connections, along with various documentation updates.
