### PR TITLE
fix(k8s): replace depracted mgr.GetEventRecorderFor()

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/configmap_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/configmap_controller.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	kube_runtime "k8s.io/apimachinery/pkg/runtime"
 	kube_types "k8s.io/apimachinery/pkg/types"
-	kube_record "k8s.io/client-go/tools/record"
+	kube_events "k8s.io/client-go/tools/events"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 	kube_handler "sigs.k8s.io/controller-runtime/pkg/handler"
@@ -30,7 +30,7 @@ import (
 // ConfigMapReconciler reconciles a ConfigMap object
 type ConfigMapReconciler struct {
 	kube_client.Client
-	kube_record.EventRecorder
+	kube_events.EventRecorder
 	Scheme              *kube_runtime.Scheme
 	Log                 logr.Logger
 	ResourceManager     manager.ResourceManager

--- a/pkg/plugins/runtime/k8s/controllers/gateway_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/gateway_converter.go
@@ -33,7 +33,7 @@ func (r *PodReconciler) createOrUpdateBuiltinGatewayDataplane(ctx context.Contex
 
 	if !ok {
 		r.Eventf(
-			pod, kube_core.EventTypeWarning, FailedToGenerateKumaDataplaneReason, "Missing %s annotation on Pod serving a builtin Gateway", metadata.KumaTagsAnnotation,
+			pod, nil, kube_core.EventTypeWarning, FailedToGenerateKumaDataplaneReason, "FailedToGenerate", "Missing %s annotation on Pod serving a builtin Gateway", metadata.KumaTagsAnnotation,
 		)
 		return nil
 	}
@@ -41,7 +41,7 @@ func (r *PodReconciler) createOrUpdateBuiltinGatewayDataplane(ctx context.Contex
 	var tags map[string]string
 	if err := json.Unmarshal([]byte(tagsAnnotation), &tags); err != nil || tags == nil {
 		r.Eventf(
-			pod, kube_core.EventTypeWarning, FailedToGenerateKumaDataplaneReason, "Invalid %s annotation on Pod serving a builtin Gateway", metadata.KumaTagsAnnotation,
+			pod, nil, kube_core.EventTypeWarning, FailedToGenerateKumaDataplaneReason, "FailedToGenerate", "Invalid %s annotation on Pod serving a builtin Gateway", metadata.KumaTagsAnnotation,
 		)
 		return nil
 	}
@@ -91,17 +91,17 @@ func (r *PodReconciler) createOrUpdateBuiltinGatewayDataplane(ctx context.Contex
 	})
 	if err != nil {
 		log.Error(err, "unable to create/update Dataplane", "operationResult", operationResult)
-		r.Eventf(pod, kube_core.EventTypeWarning, FailedToGenerateKumaDataplaneReason, "Failed to generate Kuma Dataplane: %s", err.Error())
+		r.Eventf(pod, nil, kube_core.EventTypeWarning, FailedToGenerateKumaDataplaneReason, "FailedToGenerate", "Failed to generate Kuma Dataplane: %s", err.Error())
 		return err
 	}
 
 	switch operationResult {
 	case kube_controllerutil.OperationResultCreated:
 		log.Info("Dataplane created")
-		r.Eventf(pod, kube_core.EventTypeNormal, CreatedKumaDataplaneReason, "Created Kuma Dataplane: %s", dataplane.Name)
+		r.Eventf(pod, nil, kube_core.EventTypeNormal, CreatedKumaDataplaneReason, "Create", "Created Kuma Dataplane: %s", dataplane.Name)
 	case kube_controllerutil.OperationResultUpdated:
 		log.Info("Dataplane updated")
-		r.Eventf(pod, kube_core.EventTypeNormal, UpdatedKumaDataplaneReason, "Updated Kuma Dataplane: %s", dataplane.Name)
+		r.Eventf(pod, nil, kube_core.EventTypeNormal, UpdatedKumaDataplaneReason, "Update", "Updated Kuma Dataplane: %s", dataplane.Name)
 	}
 	return nil
 }

--- a/pkg/plugins/runtime/k8s/controllers/meshservice_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/meshservice_controller_test.go
@@ -12,7 +12,7 @@ import (
 	kube_core "k8s.io/api/core/v1"
 	kube_discovery "k8s.io/api/discovery/v1"
 	kube_types "k8s.io/apimachinery/pkg/types"
-	kube_record "k8s.io/client-go/tools/record"
+	kube_events "k8s.io/client-go/tools/events"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 	kube_client_fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -72,7 +72,7 @@ var _ = Describe("MeshServiceController", func() {
 				Client:                   kubeClient,
 				Log:                      logr.Discard(),
 				Scheme:                   k8sClientScheme,
-				EventRecorder:            kube_record.NewFakeRecorder(10),
+				EventRecorder:            kube_events.NewFakeRecorder(10),
 				ResourceConverter:        k8s.NewSimpleConverter(),
 				SkipInboundTagGeneration: given.skipInboundTagGeneration,
 			}

--- a/pkg/plugins/runtime/k8s/controllers/pod_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller.go
@@ -11,7 +11,7 @@ import (
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_runtime "k8s.io/apimachinery/pkg/runtime"
 	kube_types "k8s.io/apimachinery/pkg/types"
-	kube_record "k8s.io/client-go/tools/record"
+	kube_events "k8s.io/client-go/tools/events"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,7 +48,7 @@ const (
 // PodReconciler reconciles a Pod object
 type PodReconciler struct {
 	kube_client.Client
-	kube_record.EventRecorder
+	kube_events.EventRecorder
 	Scheme                       *kube_runtime.Scheme
 	Log                          logr.Logger
 	PodConverter                 PodConverter
@@ -350,7 +350,7 @@ func (r *PodReconciler) createOrUpdateDataplane(
 	if err != nil {
 		if !errors.Is(err, context.Canceled) {
 			log.Error(err, "unable to create/update Dataplane", "operationResult", operationResult)
-			r.Eventf(pod, kube_core.EventTypeWarning, FailedToGenerateKumaDataplaneReason, "Failed to generate Kuma Dataplane: %s", err.Error())
+			r.Eventf(pod, nil, kube_core.EventTypeWarning, FailedToGenerateKumaDataplaneReason, "FailedToGenerate", "Failed to generate Kuma Dataplane: %s", err.Error())
 		}
 
 		return err
@@ -358,10 +358,10 @@ func (r *PodReconciler) createOrUpdateDataplane(
 	switch operationResult {
 	case kube_controllerutil.OperationResultCreated:
 		log.Info("Dataplane created")
-		r.Eventf(pod, kube_core.EventTypeNormal, CreatedKumaDataplaneReason, "Created Kuma Dataplane: %s", pod.Name)
+		r.Eventf(pod, nil, kube_core.EventTypeNormal, CreatedKumaDataplaneReason, "Create", "Created Kuma Dataplane: %s", pod.Name)
 	case kube_controllerutil.OperationResultUpdated:
 		log.Info("Dataplane updated")
-		r.Eventf(pod, kube_core.EventTypeNormal, UpdatedKumaDataplaneReason, "Updated Kuma Dataplane: %s", pod.Name)
+		r.Eventf(pod, nil, kube_core.EventTypeNormal, UpdatedKumaDataplaneReason, "Update", "Updated Kuma Dataplane: %s", pod.Name)
 	}
 	return nil
 }
@@ -386,16 +386,16 @@ func (r *PodReconciler) createOrUpdateIngress(ctx context.Context, pod *kube_cor
 	log := r.Log.WithValues("pod", kube_types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name})
 	if err != nil {
 		log.Error(err, "unable to create/update Ingress", "operationResult", operationResult)
-		r.Eventf(pod, kube_core.EventTypeWarning, FailedToGenerateKumaDataplaneReason, "Failed to generate Kuma Ingress: %s", err.Error())
+		r.Eventf(pod, nil, kube_core.EventTypeWarning, FailedToGenerateKumaDataplaneReason, "FailedToGenerate", "Failed to generate Kuma Ingress: %s", err.Error())
 		return err
 	}
 	switch operationResult {
 	case kube_controllerutil.OperationResultCreated:
 		log.Info("ZoneIngress created")
-		r.Eventf(pod, kube_core.EventTypeNormal, CreatedKumaDataplaneReason, "Created Kuma Ingress: %s", pod.Name)
+		r.Eventf(pod, nil, kube_core.EventTypeNormal, CreatedKumaDataplaneReason, "Create", "Created Kuma Ingress: %s", pod.Name)
 	case kube_controllerutil.OperationResultUpdated:
 		log.Info("ZoneIngress updated")
-		r.Eventf(pod, kube_core.EventTypeNormal, UpdatedKumaDataplaneReason, "Updated Kuma Ingress: %s", pod.Name)
+		r.Eventf(pod, nil, kube_core.EventTypeNormal, UpdatedKumaDataplaneReason, "Update", "Updated Kuma Ingress: %s", pod.Name)
 	}
 	return nil
 }
@@ -420,16 +420,16 @@ func (r *PodReconciler) createOrUpdateEgress(ctx context.Context, pod *kube_core
 	log := r.Log.WithValues("pod", kube_types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name})
 	if err != nil {
 		log.Error(err, "unable to create/update Egress", "operationResult", operationResult)
-		r.Eventf(pod, kube_core.EventTypeWarning, FailedToGenerateKumaDataplaneReason, "Failed to generate Kuma Egress: %s", err.Error())
+		r.Eventf(pod, nil, kube_core.EventTypeWarning, FailedToGenerateKumaDataplaneReason, "FailedToGenerate", "Failed to generate Kuma Egress: %s", err.Error())
 		return err
 	}
 	switch operationResult {
 	case kube_controllerutil.OperationResultCreated:
 		log.Info("ZoneEgress created")
-		r.Eventf(pod, kube_core.EventTypeNormal, CreatedKumaDataplaneReason, "Created Kuma Egress: %s", pod.Name)
+		r.Eventf(pod, nil, kube_core.EventTypeNormal, CreatedKumaDataplaneReason, "Create", "Created Kuma Egress: %s", pod.Name)
 	case kube_controllerutil.OperationResultUpdated:
 		log.Info("ZoneEgress updated")
-		r.Eventf(pod, kube_core.EventTypeNormal, UpdatedKumaDataplaneReason, "Updated Kuma Egress: %s", pod.Name)
+		r.Eventf(pod, nil, kube_core.EventTypeNormal, UpdatedKumaDataplaneReason, "Update", "Updated Kuma Egress: %s", pod.Name)
 	}
 	return nil
 }

--- a/pkg/plugins/runtime/k8s/controllers/pod_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller_test.go
@@ -11,7 +11,7 @@ import (
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_types "k8s.io/apimachinery/pkg/types"
 	kube_intstr "k8s.io/apimachinery/pkg/util/intstr"
-	kube_record "k8s.io/client-go/tools/record"
+	kube_events "k8s.io/client-go/tools/events"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 	kube_client_fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -555,7 +555,7 @@ var _ = Describe("PodReconciler", func() {
 
 		reconciler = &PodReconciler{
 			Client:        kubeClient,
-			EventRecorder: kube_record.NewFakeRecorder(10),
+			EventRecorder: kube_events.NewFakeRecorder(10),
 			Scheme:        k8sClientScheme,
 			Log:           core.Log.WithName("test"),
 			PodConverter: PodConverter{

--- a/pkg/plugins/runtime/k8s/controllers/pod_status_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_status_controller.go
@@ -8,7 +8,7 @@ import (
 	kube_core "k8s.io/api/core/v1"
 	kube_apierrs "k8s.io/apimachinery/pkg/api/errors"
 	kube_runtime "k8s.io/apimachinery/pkg/runtime"
-	kube_record "k8s.io/client-go/tools/record"
+	kube_events "k8s.io/client-go/tools/events"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -27,7 +27,7 @@ import (
 // but only when Kuma isn't using the SidecarContainer feature
 type PodStatusReconciler struct {
 	kube_client.Client
-	kube_record.EventRecorder
+	kube_events.EventRecorder
 	Scheme            *kube_runtime.Scheme
 	ResourceManager   manager.ResourceManager
 	Log               logr.Logger

--- a/pkg/plugins/runtime/k8s/controllers/pod_status_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_status_controller_test.go
@@ -8,7 +8,7 @@ import (
 	kube_core "k8s.io/api/core/v1"
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_types "k8s.io/apimachinery/pkg/types"
-	kube_record "k8s.io/client-go/tools/record"
+	kube_events "k8s.io/client-go/tools/events"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 	kube_client_fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -173,7 +173,7 @@ var _ = Describe("PodStatusReconciler", func() {
 		postQuitCalled = 0
 		reconciler = &PodStatusReconciler{
 			Client:            kubeClient,
-			EventRecorder:     kube_record.NewFakeRecorder(10),
+			EventRecorder:     kube_events.NewFakeRecorder(10),
 			Scheme:            k8sClientScheme,
 			Log:               core.Log.WithName("test"),
 			ResourceConverter: k8s.NewSimpleConverter(),

--- a/pkg/plugins/runtime/k8s/controllers/workload_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/workload_controller.go
@@ -9,7 +9,7 @@ import (
 	kube_apierrs "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_types "k8s.io/apimachinery/pkg/types"
-	kube_record "k8s.io/client-go/tools/record"
+	kube_events "k8s.io/client-go/tools/events"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 	kube_controllerutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -32,7 +32,7 @@ const (
 // WorkloadReconciler reconciles Workload resources based on Dataplane labels
 type WorkloadReconciler struct {
 	kube_client.Client
-	kube_record.EventRecorder
+	kube_events.EventRecorder
 	Log logr.Logger
 }
 
@@ -103,7 +103,7 @@ func (r *WorkloadReconciler) handleMultipleMeshesDetected(ctx context.Context, n
 	if err := r.Get(ctx, kube_types.NamespacedName{Name: namespace}, ns); err != nil {
 		log.V(1).Info("unable to fetch namespace for event emission", "error", err)
 	} else {
-		r.Eventf(ns, kube_core.EventTypeWarning, MultipleMeshesDetectedReason,
+		r.Eventf(ns, nil, kube_core.EventTypeWarning, MultipleMeshesDetectedReason, "MultipleMeshesDetected",
 			"Skipping Workload generation: namespace %s has pods in multiple meshes (%d meshes) for workload %s. This configuration is not supported.",
 			namespace, meshCount, workloadName)
 	}

--- a/pkg/plugins/runtime/k8s/controllers/workload_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/workload_controller_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 	kube_core "k8s.io/api/core/v1"
 	kube_types "k8s.io/apimachinery/pkg/types"
-	kube_record "k8s.io/client-go/tools/record"
+	kube_events "k8s.io/client-go/tools/events"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 	kube_client_fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -65,7 +65,7 @@ var _ = Describe("WorkloadController", func() {
 
 			reconciler = &WorkloadReconciler{
 				Client:        kubeClient,
-				EventRecorder: kube_record.NewFakeRecorder(10),
+				EventRecorder: kube_events.NewFakeRecorder(10),
 				Log:           logr.Discard(),
 			}
 

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -158,7 +158,7 @@ func addMeshServiceReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime, co
 		Client:                   mgr.GetClient(),
 		Log:                      core.Log.WithName("controllers").WithName("MeshService"),
 		Scheme:                   mgr.GetScheme(),
-		EventRecorder:            mgr.GetEventRecorderFor("k8s.kuma.io/mesh-service-generator"),
+		EventRecorder:            mgr.GetEventRecorder("k8s.kuma.io/mesh-service-generator"),
 		ResourceConverter:        converter,
 		SkipInboundTagGeneration: rt.Config().Experimental.SkipInboundTagGeneration,
 	}
@@ -190,7 +190,7 @@ func addPodReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter 
 	}
 	reconciler := &k8s_controllers.PodReconciler{
 		Client:        mgr.GetClient(),
-		EventRecorder: mgr.GetEventRecorderFor("k8s.kuma.io/dataplane-generator"),
+		EventRecorder: mgr.GetEventRecorder("k8s.kuma.io/dataplane-generator"),
 		Scheme:        mgr.GetScheme(),
 		Log:           core.Log.WithName("controllers").WithName("Pod"),
 		PodConverter: k8s_controllers.PodConverter{
@@ -225,7 +225,7 @@ func addPodStatusReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime, conv
 	}
 	reconciler := &k8s_controllers.PodStatusReconciler{
 		Client:            mgr.GetClient(),
-		EventRecorder:     mgr.GetEventRecorderFor("k8s.kuma.io/dataplane-jobs-syncer"),
+		EventRecorder:     mgr.GetEventRecorder("k8s.kuma.io/dataplane-jobs-syncer"),
 		Scheme:            mgr.GetScheme(),
 		Log:               core.Log.WithName("controllers").WithName("Pod"),
 		ResourceConverter: converter,
@@ -240,7 +240,7 @@ func addWorkloadReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime) error
 	}
 	reconciler := &k8s_controllers.WorkloadReconciler{
 		Client:        mgr.GetClient(),
-		EventRecorder: mgr.GetEventRecorderFor("kuma-workload-controller"),
+		EventRecorder: mgr.GetEventRecorder("kuma-workload-controller"),
 		Log:           core.Log.WithName("controllers").WithName("Workload"),
 	}
 	return reconciler.SetupWithManager(mgr)
@@ -267,7 +267,7 @@ func addDNS(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter k8s_common
 	}
 	reconciler := &k8s_controllers.ConfigMapReconciler{
 		Client:              mgr.GetClient(),
-		EventRecorder:       mgr.GetEventRecorderFor("k8s.kuma.io/vips-generator"),
+		EventRecorder:       mgr.GetEventRecorder("k8s.kuma.io/vips-generator"),
 		Scheme:              mgr.GetScheme(),
 		Log:                 core.Log.WithName("controllers").WithName("ConfigMap"),
 		ResourceManager:     rt.ResourceManager(),


### PR DESCRIPTION
## Motivation

  The controller-runtime library deprecated `mgr.GetEventRecorderFor()` in favor of `mgr.GetEventRecorder()`. This triggers `staticcheck SA1019 warnings`:

  `pkg/plugins/runtime/k8s/plugin.go:161:29: SA1019: mgr.GetEventRecorderFor is deprecated:`
  this uses the old events API and will be removed in a future release.
  Please use `GetEventRecorder` instead.

  The new API returns `events.EventRecorder` (from `k8s.io/client-go/tools/events`) instead of `record.EventRecorder` (from `k8s.io/client-go/tools/record`), which has a different method signature:

  - Old: `Eventf(object, eventtype, reason, messageFmt, args...)`
  - New: `Eventf(regarding, related, eventtype, reason, action, note, args...)`

## Implementation information

  - Replaced `mgr.GetEventRecorderFor()` with `mgr.GetEventRecorder()` in `plugin.go`
  - Updated all controller structs to embed `events.EventRecorder` instead of `record.EventRecorder`
  - Migrated all `Eventf()` calls to the new signature, adding:
    - nil for the related object parameter
    - Appropriate action string (e.g., "Create", "Update", "FailedToGenerate")
  - Updated test files to use `events.NewFakeRecorder()` instead of `record.NewFakeRecorder()`
