### PR TITLE
fix(xds): prevent panic on send to closed channel during stream closure

### DIFF
--- a/pkg/xds/sync/dataplane_watchdog_factory.go
+++ b/pkg/xds/sync/dataplane_watchdog_factory.go
@@ -24,7 +24,7 @@ func NewDataplaneWatchdogFactory(
 	xdsSyncMetrics *xds_metrics.Metrics,
 	refreshInterval time.Duration,
 	deps DataplaneWatchdogDependencies,
-) (DataplaneWatchdogFactory, error) {
+) (DataplaneWatchdogFactoryWithStreamCtx, error) {
 	return &dataplaneWatchdogFactory{
 		deps:            deps,
 		refreshInterval: refreshInterval,
@@ -33,6 +33,10 @@ func NewDataplaneWatchdogFactory(
 }
 
 func (d *dataplaneWatchdogFactory) New(dpKey model.ResourceKey, meta *core_xds.DataplaneMetadata) util_xds_v3.Watchdog {
+	return d.NewWithStreamCtx(dpKey, meta, nil)
+}
+
+func (d *dataplaneWatchdogFactory) NewWithStreamCtx(dpKey model.ResourceKey, meta *core_xds.DataplaneMetadata, streamCtx context.Context) util_xds_v3.Watchdog {
 	log := xdsServerLog.WithName("dataplane-sync-watchdog").WithValues("dataplaneKey", dpKey)
 	dataplaneWatchdog := NewDataplaneWatchdog(d.deps, meta, dpKey)
 	return &util_watchdog.SimpleWatchdog{
@@ -60,5 +64,6 @@ func (d *dataplaneWatchdogFactory) New(dpKey model.ResourceKey, meta *core_xds.D
 				log.Error(err, "OnTick() failed")
 			}
 		},
+		StreamCtx: streamCtx,
 	}
 }

--- a/pkg/xds/sync/interfaces.go
+++ b/pkg/xds/sync/interfaces.go
@@ -24,6 +24,14 @@ type DataplaneWatchdogFactory interface {
 	New(dpKey core_model.ResourceKey, meta *core_xds.DataplaneMetadata) util_xds_v3.Watchdog
 }
 
+// DataplaneWatchdogFactoryWithStreamCtx extends DataplaneWatchdogFactory with stream context support.
+// When the stream context is closed, the watchdog will skip ticks to prevent
+// race conditions between gRPC stream closure and xDS snapshot updates.
+type DataplaneWatchdogFactoryWithStreamCtx interface {
+	DataplaneWatchdogFactory
+	NewWithStreamCtx(dpKey core_model.ResourceKey, meta *core_xds.DataplaneMetadata, streamCtx context.Context) util_xds_v3.Watchdog
+}
+
 type DataplaneWatchdogFactoryFunc func(dpKey core_model.ResourceKey, meta *core_xds.DataplaneMetadata) util_xds_v3.Watchdog
 
 func (f DataplaneWatchdogFactoryFunc) New(dpKey core_model.ResourceKey, meta *core_xds.DataplaneMetadata) util_xds_v3.Watchdog {


### PR DESCRIPTION
## Motivation

Race condition between gRPC stream closure and xDS snapshot updates causes panic in go-control-plane (#13626).

**Timeline:**
1. Proxy disconnects → gRPC stream closes → go-control-plane closes watch channel
2. `OnStreamClosed` callback invoked
3. `OnProxyDisconnected` called
4. Watchdog context canceled

**Race window**: Between step 1 and 3, watchdog ticker can fire → `SetSnapshot` sends to closed channel → panic

## Implementation information

Add optional `StreamCtx` field to `SimpleWatchdog` that's checked before each tick. When the stream context is closed, skip the tick and wait for the main context cancellation.

**Key design decisions:**
- Field injection instead of interface change - backwards compatible, existing code continues to work
- Added `DataplaneWatchdogFactoryWithStreamCtx` interface extending `DataplaneWatchdogFactory`
- Type assertion in `dataplane_sync_tracker.go` to use stream context when factory supports it
- No changes to `watchdog_callbacks.go` which is used by other systems (HDS, KDS)

**Files changed:**
- `pkg/util/watchdog/watchdog.go` - Added `StreamCtx` field, check before each tick
- `pkg/xds/sync/interfaces.go` - Added `DataplaneWatchdogFactoryWithStreamCtx` interface
- `pkg/xds/sync/dataplane_watchdog_factory.go` - Implemented `NewWithStreamCtx` method
- `pkg/xds/server/callbacks/dataplane_sync_tracker.go` - Pass stream context to watchdog

## Supporting documentation

Fixes #13626