### PR TITLE
fix(xds): don't create empty filter chain for a gateway

### DIFF
--- a/pkg/xds/generator/testdata/transparent-proxy/09.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/transparent-proxy/09.envoy.golden.yaml
@@ -1,0 +1,114 @@
+resources:
+- name: self_transparentproxy_no_destination_inbound
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    altStatName: self_transparentproxy_no_destination_inbound
+    connectTimeout: 5s
+    name: self_transparentproxy_no_destination_inbound
+    type: STATIC
+- name: self_transparentproxy_passthrough_inbound_ipv4
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 5s
+    lbPolicy: CLUSTER_PROVIDED
+    name: self_transparentproxy_passthrough_inbound_ipv4
+    type: ORIGINAL_DST
+    upstreamBindConfig:
+      sourceAddress:
+        address: 127.0.0.6
+        portValue: 0
+- name: self_transparentproxy_passthrough_inbound_ipv6
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 5s
+    lbPolicy: CLUSTER_PROVIDED
+    name: self_transparentproxy_passthrough_inbound_ipv6
+    type: ORIGINAL_DST
+    upstreamBindConfig:
+      sourceAddress:
+        address: ::6
+        portValue: 0
+- name: self_transparentproxy_passthrough_outbound_ipv4
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 5s
+    lbPolicy: CLUSTER_PROVIDED
+    name: self_transparentproxy_passthrough_outbound_ipv4
+    type: ORIGINAL_DST
+- name: self_transparentproxy_passthrough_outbound_ipv6
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 5s
+    lbPolicy: CLUSTER_PROVIDED
+    name: self_transparentproxy_passthrough_outbound_ipv6
+    type: ORIGINAL_DST
+- name: self_transparentproxy_passthrough_inbound_ipv4
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 0.0.0.0
+        portValue: 15006
+    enableReusePort: false
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: self_transparentproxy_passthrough_inbound_ipv4
+          statPrefix: self_transparentproxy_passthrough_inbound_ipv4
+    name: self_transparentproxy_passthrough_inbound_ipv4
+    trafficDirection: INBOUND
+    useOriginalDst: true
+- name: self_transparentproxy_passthrough_inbound_ipv6
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: '::'
+        portValue: 15006
+    enableReusePort: false
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: self_transparentproxy_passthrough_inbound_ipv6
+          statPrefix: self_transparentproxy_passthrough_inbound_ipv6
+    name: self_transparentproxy_passthrough_inbound_ipv6
+    trafficDirection: INBOUND
+    useOriginalDst: true
+- name: self_transparentproxy_passthrough_outbound_ipv4
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 0.0.0.0
+        portValue: 15001
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: self_transparentproxy_passthrough_outbound_ipv4
+          statPrefix: self_transparentproxy_passthrough_outbound_ipv4
+    name: self_transparentproxy_passthrough_outbound_ipv4
+    trafficDirection: OUTBOUND
+    useOriginalDst: true
+- name: self_transparentproxy_passthrough_outbound_ipv6
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: '::'
+        portValue: 15001
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: self_transparentproxy_passthrough_outbound_ipv6
+          statPrefix: self_transparentproxy_passthrough_outbound_ipv6
+    name: self_transparentproxy_passthrough_outbound_ipv6
+    trafficDirection: OUTBOUND
+    useOriginalDst: true

--- a/pkg/xds/generator/transparent_proxy_generator.go
+++ b/pkg/xds/generator/transparent_proxy_generator.go
@@ -134,7 +134,7 @@ func CreateInboundPassthroughListener(
 		WithOverwriteName(listenerName).
 		Configure(envoy_listeners.OriginalDstForwarder())
 
-	if useStrictInboundPorts {
+	if useStrictInboundPorts && len(proxy.Dataplane.Spec.Networking.Inbound) > 0 {
 		for _, inbound := range proxy.Dataplane.Spec.Networking.Inbound {
 			// if service doesn't have any port we don't need to expose listener
 			if inbound.Port == mesh_proto.TCPPortReserved {


### PR DESCRIPTION
## Motivation

Delegated gateways with transparent proxy enabled were failing with:
```
  xds.nack-backoff    config was previously rejected by Envoy. Applying backoff before resending it {"reason": "Error adding/updating listener(s) inbound:passthrough:ipv4: error adding listener '0.0.0.0:15006': no filter chains specified\n..."}
```

  The issue occurs when all these conditions are met:
  - Delegated gateway (no inbounds defined)
  - Transparent proxy enabled
  - mTLS with STRICT CA backend mode
  - FeatureStrictInboundPorts feature flag enabled (default in newer versions)

In `CreateInboundPassthroughListener`, the condition if `useStrictInboundPorts` would enter a loop over `proxy.Dataplane.Spec.Networking.Inbound` to create per-port filter chains. For delegated gateways with no inbounds, this loop produces zero filter chains, causing Envoy to reject the listener.

## Implementation information

 - Modified the condition in `CreateInboundPassthroughListener` from if `useStrictInboundPorts` to if `useStrictInboundPorts && len(proxy.Dataplane.Spec.Networking.Inbound) > 0`
 - When no inbounds exist, the code now falls through to the else branch which creates a default passthrough filter chain
 - Updated the test case to properly cover the delegated gateway scenario with strict mTLS and FeatureStrictInboundPorts enabled

