### PR TITLE
docs(README): update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Users that require enterprise-level support for Kuma can explore the [enterprise
 
 ## Get Started 
 
-- [Installation](https://kuma.io/docs/2.13.x/quickstart/kubernetes-demo/)
+- [Installation](https://kuma.io/docs/latest/quickstart/kubernetes-demo/)
 - [Documentation](https://kuma.io/docs)
 
 ## Get Involved


### PR DESCRIPTION
## Motivation

README.md contained deprecated TrafficRoute policy example and old policy names (Traffic Permissions, Traffic Routing, etc.), misleading first-time visitors with outdated v1.x API patterns.

## Implementation information

**Replaced TrafficRoute example (lines 69-97):**
- Old: `TrafficRoute` with sources/destinations matching
- New: `MeshHTTPRoute` with targetRef-based selectors
- Demonstrates: PCI compliance tags, zone-based routing, backendRefs with weights

**Updated features list (lines 117-123):**
- Traffic Permissions → MeshTrafficPermission
- Traffic Routing → MeshHTTPRoute & MeshTCPRoute
- Fault Injection → MeshFaultInjection
- Traffic Logs → MeshAccessLog
- Traffic Tracing → MeshTrace
- Traffic Metrics → MeshMetric
- Retries → MeshRetry

GUI screenshot unchanged (already v3).

## Supporting documentation

Fixes #13248