### PR TITLE
docs(MADR): mesh-scoped zone proxies representation

### DIFF
--- a/docs/madr/decisions/095-mesh-scoped-zone-ingress-egress.md
+++ b/docs/madr/decisions/095-mesh-scoped-zone-ingress-egress.md
@@ -358,6 +358,12 @@ Out of scope for this MADR. See https://github.com/Kong/kong-mesh/issues/9151.
 
 ## Implementation
 
+### Prerequisites
+
+New zone proxy listeners require unified resource naming and `meshServices.mode: Exclusive`.
+Legacy `kuma.io/service` labels and `ExternalService` resources are not supported.
+This constraint enables a cleaner implementation without legacy compatibility code.
+
 ### Avoiding excessive Envoy config for zone-proxy-only Dataplanes
 
 Dataplanes with only zone proxy listeners (no inbounds) should not have outbound listeners and clusters generated.


### PR DESCRIPTION
## Motivation

We want to replace global-scoped ZoneIngress/ZoneEgress with mesh-scoped Dataplane (with new fields for zone proxy specific info).

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix https://github.com/Kong/kong-mesh/issues/9028

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
