### PR TITLE
ci(pr-comments): add /tproxy_golden_files trigger

### DIFF
--- a/.github/workflows/pr-comments.yaml
+++ b/.github/workflows/pr-comments.yaml
@@ -9,8 +9,8 @@ permissions:
   contents: read
 jobs:
   pr_comments:
-    timeout-minutes: 90
-    if: github.event.issue.pull_request != '' && (contains(github.event.comment.body, '/format') || contains(github.event.comment.body, '/golden_files'))
+    timeout-minutes: 45
+    if: github.event.issue.pull_request != '' && (contains(github.event.comment.body, '/format') || contains(github.event.comment.body, '/golden_files') || contains(github.event.comment.body, '/tproxy_golden_files'))
     runs-on: ubuntu-24.04
     steps:
       - name: Generate GitHub app token


### PR DESCRIPTION
## Motivation

The `/tproxy_golden_files` command is defined in the workflow but not included in the job-level condition, causing the workflow to skip when triggered.

**Skipped run:** https://github.com/kumahq/kuma/actions/runs/21946800489

## Implementation information

**Issue:**

The workflow has a step that checks for `/tproxy_golden_files` comment, but the job condition only checks for `/format` or `/golden_files`, causing all steps to skip.

**Fix:**

Added `/tproxy_golden_files` to the job-level if condition.

## Supporting documentation

- Skipped workflow run: https://github.com/kumahq/kuma/actions/runs/21946800489
