### PR TITLE
chore(renovate): add range strategy to test if golang upgrade works

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -279,6 +279,7 @@
       "matchDepNames": ["go"],
       "matchManagers": ["gomod", "mise"],
       "groupName": "go version",
+      "rangeStrategy": "bump",
       "enabled": true
     },
     {


### PR DESCRIPTION
## Motivation

Renovate opens PR only with mise upgrade of golang

## Implementation information

Lets see if that helps

