### PR TITLE
fix(xds): set listener stat_prefix

### DIFF
--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin.go
@@ -128,6 +128,7 @@ func configurePrometheus(rs *core_xds.ResourceSet, proxy *core_xds.Proxy, promet
 				systemName,
 				fmt.Sprintf("_%s", envoy_names.GetMetricsHijackerClusterName()),
 			),
+			StatPrefix:  getNameOrDefault(systemName, ""),
 			StatsPath:   PrometheusDataplaneStatsPath,
 			IPv6Enabled: proxy.Metadata.GetIPv6Enabled(),
 		}
@@ -179,6 +180,7 @@ func configureOpenTelemetryBackend(rs *core_xds.ResourceSet, proxy *core_xds.Pro
 		Endpoint:     endpoint,
 		ListenerName: getNameOrDefault(systemName, envoy_names.GetOpenTelemetryListenerName(backendName)),
 		ClusterName:  getNameOrDefault(systemName, envoy_names.GetOpenTelemetryListenerName(backendName)),
+		StatPrefix:   getNameOrDefault(systemName, ""),
 		SocketName:   core_xds.OpenTelemetrySocketName(proxy.Metadata.WorkDir, backendName),
 		ApiVersion:   proxy.APIVersion,
 		IPv6Enabled:  proxy.Metadata.GetIPv6Enabled(),

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/otel_and_prometheus_unified_naming.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/otel_and_prometheus_unified_naming.listeners.golden.yaml
@@ -47,6 +47,7 @@ resources:
                     value: 89bcddd53f040cae9ccc6dcb3878ee69524f674bc086e828f8a4ab0fc13ee3c1
           statPrefix: system_dynamicconfig
     name: system_dynamicconfig
+    statPrefix: system_dynamicconfig
 - name: system_meshmetric_otel_otel-collector-observability-svc-4317
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener
@@ -83,6 +84,7 @@ resources:
                   cluster: system_meshmetric_otel_otel-collector-observability-svc-4317
           statPrefix: system_meshmetric_otel_otel-collector-observability-svc-4317
     name: system_meshmetric_otel_otel-collector-observability-svc-4317
+    statPrefix: system_meshmetric_otel_otel-collector-observability-svc-4317
 - name: system_meshmetric_prometheus_default-backend
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener
@@ -118,4 +120,5 @@ resources:
                   prefixRewrite: /meshmetric
           statPrefix: system_meshmetric_prometheus_default-backend
     name: system_meshmetric_prometheus_default-backend
+    statPrefix: system_meshmetric_prometheus_default-backend
     trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshmetric/plugin/xds/open_telemetry_configurer.go
+++ b/pkg/plugins/policies/meshmetric/plugin/xds/open_telemetry_configurer.go
@@ -12,6 +12,7 @@ type OpenTelemetryConfigurer struct {
 	ListenerName string
 	ClusterName  string
 	SocketName   string
+	StatPrefix   string
 	ApiVersion   core_xds.APIVersion
 	IPv6Enabled  bool
 }
@@ -28,6 +29,7 @@ func (oc *OpenTelemetryConfigurer) ConfigureCluster(isIPv6 bool) (envoy_common.N
 func (oc *OpenTelemetryConfigurer) ConfigureListener() (envoy_common.NamedResource, error) {
 	return envoy_listeners.NewListenerBuilder(oc.ApiVersion, oc.ListenerName).
 		Configure(envoy_listeners.PipeListener(oc.SocketName)).
+		Configure(envoy_listeners.StatPrefix(oc.StatPrefix)).
 		Configure(envoy_listeners.FilterChain(
 			envoy_listeners.NewFilterChainBuilder(oc.ApiVersion, envoy_common.AnonymousResource).
 				Configure(envoy_listeners.StaticEndpoints(oc.IPv6Enabled, oc.ListenerName, []*envoy_common.StaticEndpointPath{

--- a/pkg/plugins/policies/meshmetric/plugin/xds/prometheus_configurer.go
+++ b/pkg/plugins/policies/meshmetric/plugin/xds/prometheus_configurer.go
@@ -15,6 +15,7 @@ type PrometheusConfigurer struct {
 	Backend         *api.PrometheusBackend
 	ClusterName     string
 	ListenerName    string
+	StatPrefix      string
 	EndpointAddress string
 	StatsPath       string
 	IPv6Enabled     bool
@@ -80,6 +81,7 @@ func (pc *PrometheusConfigurer) providedTlsListener(proxy *core_xds.Proxy) (envo
 func (pc *PrometheusConfigurer) unsecuredListener(proxy *core_xds.Proxy) (envoy_common.NamedResource, error) {
 	return envoy_listeners.NewInboundListenerBuilder(proxy.APIVersion, pc.EndpointAddress, pc.Backend.Port, core_xds.SocketAddressProtocolTCP).
 		WithOverwriteName(pc.ListenerName).
+		Configure(envoy_listeners.StatPrefix(pc.StatPrefix)).
 		Configure(envoy_listeners.FilterChain(envoy_listeners.NewFilterChainBuilder(proxy.APIVersion, envoy_common.AnonymousResource).
 			Configure(envoy_listeners.StaticEndpoints(pc.IPv6Enabled, pc.ListenerName, pc.staticEndpoint())),
 		)).
@@ -89,6 +91,7 @@ func (pc *PrometheusConfigurer) unsecuredListener(proxy *core_xds.Proxy) (envoy_
 func (pc *PrometheusConfigurer) baseSecuredListenerBuilder(proxy *core_xds.Proxy, match envoy_listeners.FilterChainBuilderOpt) *envoy_listeners.ListenerBuilder {
 	return envoy_listeners.NewInboundListenerBuilder(proxy.APIVersion, pc.EndpointAddress, pc.Backend.Port, core_xds.SocketAddressProtocolTCP).
 		WithOverwriteName(pc.ListenerName).
+		Configure(envoy_listeners.StatPrefix(pc.StatPrefix)).
 		// generate filter chain that does not require mTLS when DP scrapes itself (for example DP next to Prometheus Server)
 		Configure(envoy_listeners.FilterChain(
 			envoy_listeners.NewFilterChainBuilder(proxy.APIVersion, envoy_common.AnonymousResource).Configure(

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin.go
@@ -323,6 +323,7 @@ func configureInboundPassthroughListener(
 		inboundName = nameOrDefault(naming.ContextualTransparentProxyName("inbound", 6), metadata.TransparentInboundNameIPv6)
 		address = metadata.TransparentAllIPv6
 	}
+	statPrefix := nameOrDefault(inboundName, "")
 	switch tlsMode {
 	case api.ModeStrict:
 		return generator.CreateInboundPassthroughListener(
@@ -331,6 +332,7 @@ func configureInboundPassthroughListener(
 			address,
 			tpCfg.Redirect.Inbound.Port.Uint32(),
 			true,
+			statPrefix,
 		)
 	case api.ModePermissive:
 		return generator.CreateInboundPassthroughListener(
@@ -339,6 +341,7 @@ func configureInboundPassthroughListener(
 			address,
 			tpCfg.Redirect.Inbound.Port.Uint32(),
 			false,
+			statPrefix,
 		)
 	}
 	return nil, nil

--- a/pkg/xds/dynconf/listener.go
+++ b/pkg/xds/dynconf/listener.go
@@ -38,6 +38,7 @@ func AddConfigRoute(proxy *core_xds.Proxy, rs *core_xds.ResourceSet, unifiedNami
 	if listener == nil {
 		nr, err := envoy_listeners.NewListenerBuilder(proxy.APIVersion, listenerName).
 			Configure(envoy_listeners.PipeListener(core_xds.MeshMetricsDynamicConfigurationSocketName(proxy.Metadata.WorkDir))).
+			Configure(envoy_listeners.StatPrefix(getNameOrDefault(system_names.SystemResourceNameDynamicConfigListener, ""))).
 			Configure(envoy_listeners.FilterChain(
 				envoy_listeners.NewFilterChainBuilder(proxy.APIVersion, envoy_common.AnonymousResource).
 					Configure(

--- a/pkg/xds/generator/testdata/dns/5-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/dns/5-envoy-config.golden.yaml
@@ -47,3 +47,4 @@ resources:
                     value: 639772d25f9c22e338f3c54ebe8be0faeae7e30c57f1acbf2d8ba5eb191007fb
           statPrefix: system_dynamicconfig
     name: system_dynamicconfig
+    statPrefix: system_dynamicconfig

--- a/pkg/xds/generator/testdata/transparent-proxy/05.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/transparent-proxy/05.envoy.golden.yaml
@@ -58,6 +58,7 @@ resources:
           cluster: self_transparentproxy_passthrough_inbound_ipv4
           statPrefix: self_transparentproxy_passthrough_inbound_ipv4
     name: self_transparentproxy_passthrough_inbound_ipv4
+    statPrefix: self_transparentproxy_passthrough_inbound_ipv4
     trafficDirection: INBOUND
     useOriginalDst: true
 - name: self_transparentproxy_passthrough_inbound_ipv6
@@ -76,6 +77,7 @@ resources:
           cluster: self_transparentproxy_passthrough_inbound_ipv6
           statPrefix: self_transparentproxy_passthrough_inbound_ipv6
     name: self_transparentproxy_passthrough_inbound_ipv6
+    statPrefix: self_transparentproxy_passthrough_inbound_ipv6
     trafficDirection: INBOUND
     useOriginalDst: true
 - name: self_transparentproxy_passthrough_outbound_ipv4
@@ -93,6 +95,7 @@ resources:
           cluster: self_transparentproxy_passthrough_outbound_ipv4
           statPrefix: self_transparentproxy_passthrough_outbound_ipv4
     name: self_transparentproxy_passthrough_outbound_ipv4
+    statPrefix: self_transparentproxy_passthrough_outbound_ipv4
     trafficDirection: OUTBOUND
     useOriginalDst: true
 - name: self_transparentproxy_passthrough_outbound_ipv6
@@ -110,5 +113,6 @@ resources:
           cluster: self_transparentproxy_passthrough_outbound_ipv6
           statPrefix: self_transparentproxy_passthrough_outbound_ipv6
     name: self_transparentproxy_passthrough_outbound_ipv6
+    statPrefix: self_transparentproxy_passthrough_outbound_ipv6
     trafficDirection: OUTBOUND
     useOriginalDst: true

--- a/pkg/xds/generator/testdata/transparent-proxy/06.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/transparent-proxy/06.envoy.golden.yaml
@@ -60,6 +60,7 @@ resources:
           cluster: self_transparentproxy_passthrough_inbound_ipv4
           statPrefix: self_transparentproxy_passthrough_inbound_ipv4
     name: self_transparentproxy_passthrough_inbound_ipv4
+    statPrefix: self_transparentproxy_passthrough_inbound_ipv4
     trafficDirection: INBOUND
     useOriginalDst: true
 - name: self_transparentproxy_passthrough_inbound_ipv6
@@ -80,6 +81,7 @@ resources:
           cluster: self_transparentproxy_passthrough_inbound_ipv6
           statPrefix: self_transparentproxy_passthrough_inbound_ipv6
     name: self_transparentproxy_passthrough_inbound_ipv6
+    statPrefix: self_transparentproxy_passthrough_inbound_ipv6
     trafficDirection: INBOUND
     useOriginalDst: true
 - name: self_transparentproxy_passthrough_outbound_ipv4
@@ -97,6 +99,7 @@ resources:
           cluster: self_transparentproxy_passthrough_outbound_ipv4
           statPrefix: self_transparentproxy_passthrough_outbound_ipv4
     name: self_transparentproxy_passthrough_outbound_ipv4
+    statPrefix: self_transparentproxy_passthrough_outbound_ipv4
     trafficDirection: OUTBOUND
     useOriginalDst: true
 - name: self_transparentproxy_passthrough_outbound_ipv6
@@ -114,5 +117,6 @@ resources:
           cluster: self_transparentproxy_passthrough_outbound_ipv6
           statPrefix: self_transparentproxy_passthrough_outbound_ipv6
     name: self_transparentproxy_passthrough_outbound_ipv6
+    statPrefix: self_transparentproxy_passthrough_outbound_ipv6
     trafficDirection: OUTBOUND
     useOriginalDst: true

--- a/pkg/xds/generator/testdata/transparent-proxy/07.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/transparent-proxy/07.envoy.golden.yaml
@@ -58,6 +58,7 @@ resources:
           cluster: self_transparentproxy_passthrough_inbound_ipv4
           statPrefix: self_transparentproxy_passthrough_inbound_ipv4
     name: self_transparentproxy_passthrough_inbound_ipv4
+    statPrefix: self_transparentproxy_passthrough_inbound_ipv4
     trafficDirection: INBOUND
     useOriginalDst: true
 - name: self_transparentproxy_passthrough_inbound_ipv6
@@ -76,6 +77,7 @@ resources:
           cluster: self_transparentproxy_passthrough_inbound_ipv6
           statPrefix: self_transparentproxy_passthrough_inbound_ipv6
     name: self_transparentproxy_passthrough_inbound_ipv6
+    statPrefix: self_transparentproxy_passthrough_inbound_ipv6
     trafficDirection: INBOUND
     useOriginalDst: true
 - name: self_transparentproxy_passthrough_outbound_ipv4
@@ -93,6 +95,7 @@ resources:
           cluster: self_transparentproxy_passthrough_outbound_ipv4
           statPrefix: self_transparentproxy_passthrough_outbound_ipv4
     name: self_transparentproxy_passthrough_outbound_ipv4
+    statPrefix: self_transparentproxy_passthrough_outbound_ipv4
     trafficDirection: OUTBOUND
     useOriginalDst: true
 - name: self_transparentproxy_passthrough_outbound_ipv6
@@ -110,5 +113,6 @@ resources:
           cluster: self_transparentproxy_passthrough_outbound_ipv6
           statPrefix: self_transparentproxy_passthrough_outbound_ipv6
     name: self_transparentproxy_passthrough_outbound_ipv6
+    statPrefix: self_transparentproxy_passthrough_outbound_ipv6
     trafficDirection: OUTBOUND
     useOriginalDst: true

--- a/pkg/xds/generator/testdata/transparent-proxy/08.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/transparent-proxy/08.envoy.golden.yaml
@@ -58,6 +58,7 @@ resources:
           cluster: self_transparentproxy_passthrough_inbound_ipv4
           statPrefix: self_transparentproxy_passthrough_inbound_ipv4
     name: self_transparentproxy_passthrough_inbound_ipv4
+    statPrefix: self_transparentproxy_passthrough_inbound_ipv4
     trafficDirection: INBOUND
     useOriginalDst: true
 - name: self_transparentproxy_passthrough_inbound_ipv6
@@ -76,6 +77,7 @@ resources:
           cluster: self_transparentproxy_passthrough_inbound_ipv6
           statPrefix: self_transparentproxy_passthrough_inbound_ipv6
     name: self_transparentproxy_passthrough_inbound_ipv6
+    statPrefix: self_transparentproxy_passthrough_inbound_ipv6
     trafficDirection: INBOUND
     useOriginalDst: true
 - name: self_transparentproxy_passthrough_outbound_ipv4
@@ -93,6 +95,7 @@ resources:
           cluster: self_transparentproxy_passthrough_outbound_ipv4
           statPrefix: self_transparentproxy_passthrough_outbound_ipv4
     name: self_transparentproxy_passthrough_outbound_ipv4
+    statPrefix: self_transparentproxy_passthrough_outbound_ipv4
     trafficDirection: OUTBOUND
     useOriginalDst: true
 - name: self_transparentproxy_passthrough_outbound_ipv6
@@ -110,5 +113,6 @@ resources:
           cluster: self_transparentproxy_passthrough_outbound_ipv6
           statPrefix: self_transparentproxy_passthrough_outbound_ipv6
     name: self_transparentproxy_passthrough_outbound_ipv6
+    statPrefix: self_transparentproxy_passthrough_outbound_ipv6
     trafficDirection: OUTBOUND
     useOriginalDst: true


### PR DESCRIPTION
## Motivation

With unified naming enabled, listener-level metrics like `envoy_listener_downstream_cx_active` use the raw listener address (IP:port or socket path) instead of the listener name. This happens because Envoy uses the listener address for `envoy_listener_*` metrics when `stat_prefix` is not set on the Listener proto itself.

The `stat_prefix` inside filters (HttpConnectionManager, TcpProxy) only affects filter-level metrics, not listener-level ones.

## Implementation information

Set `stat_prefix` on the Listener proto for all listeners that were missing it when unified naming is enabled:

- transparent proxy passthrough listeners (inbound/outbound, ipv4/ipv6)
- dynconf listener (pipe listener for mesh metric config)
- meshmetric prometheus listener
- meshmetric opentelemetry listener (pipe listener)
- meshtls passthrough listener (updated call sites)

Follows the existing pattern from `inbound_proxy_generator.go` - only sets `stat_prefix` when unified naming is active, so no change for users without it.

Manually tested on k3d - all `envoy_listener_*` metrics now use the listener name instead of address.

## Supporting documentation

Fixes #15416