### PR TITLE
fix(inspect): show MeshHTTPRoutes using MMZS when using _rules endpoint

### DIFF
--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -1305,6 +1305,15 @@ func (r *resourceEndpoints) rulesForResource() restful.RouteFunction {
 						matchesByHash[meshhttproute_api.HashMatches(r.Matches)] = r.Matches
 					}
 				}
+				for _, resourceRule := range res.ToRules.ResourceRules {
+					for _, conf := range resourceRule.Conf {
+						if pd, ok := conf.(meshhttproute_api.PolicyDefault); ok {
+							for _, r := range pd.Rules {
+								matchesByHash[meshhttproute_api.HashMatches(r.Matches)] = r.Matches
+							}
+						}
+					}
+				}
 			}
 			if err != nil {
 				rest_errors.HandleError(request.Request.Context(), response, err, fmt.Sprintf("could not apply policy plugin %s", policyPlugin.Name))
@@ -1314,7 +1323,7 @@ func (r *resourceEndpoints) rulesForResource() restful.RouteFunction {
 			}
 
 			//nolint:staticcheck // SA1019 REST API backward compatibility: return old Rules format for existing clients
-			if len(res.ToRules.Rules) == 0 && len(res.FromRules.Rules) == 0 && len(res.SingleItemRules.Rules) == 0 {
+			if len(res.ToRules.Rules) == 0 && len(res.ToRules.ResourceRules) == 0 && len(res.FromRules.Rules) == 0 && len(res.SingleItemRules.Rules) == 0 {
 				continue
 			}
 			toRules := []api_common.Rule{}

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/meshhttproute_mzms_exclusive.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/meshhttproute_mzms_exclusive.golden.json
@@ -1,0 +1,89 @@
+{
+ "httpMatches": [
+  {
+   "hash": "JNNc6//C3P17nUsOJm5f4kqG+U3v8pXhS0od9C3+oss=",
+   "match": [
+    {
+     "path": {
+      "value": "/",
+      "type": "Exact"
+     }
+    }
+   ]
+  }
+ ],
+ "resource": {
+  "labels": {
+   "app": "backend",
+   "kuma.io/origin": "zone",
+   "kuma.io/zone": "zone1"
+  },
+  "mesh": "default",
+  "name": "dp-1",
+  "type": "Dataplane"
+ },
+ "rules": [
+  {
+   "fromRules": [],
+   "inboundRules": [],
+   "toResourceRules": [
+    {
+     "conf": [
+      {
+       "rules": [
+        {
+         "matches": [
+          {
+           "path": {
+            "value": "/",
+            "type": "Exact"
+           }
+          }
+         ],
+         "default": {
+          "backendRefs": [
+           {
+            "kind": "MeshMultiZoneService",
+            "labels": {
+             "kuma.io/display-name": "kv"
+            },
+            "weight": 1,
+            "port": 5050
+           }
+          ]
+         }
+        }
+       ]
+      }
+     ],
+     "origin": [
+      {
+       "resourceMeta": {
+        "labels": {
+         "kuma.io/origin": "global"
+        },
+        "mesh": "default",
+        "name": "http-route-mmzs",
+        "type": "MeshHTTPRoute"
+       },
+       "ruleIndex": 0
+      }
+     ],
+     "resourceMeta": {
+      "labels": {
+       "kuma.io/display-name": "kv",
+       "kuma.io/origin": "global"
+      },
+      "mesh": "default",
+      "name": "kv",
+      "type": "MeshMultiZoneService"
+     },
+     "resourceSectionName": "5050"
+    }
+   ],
+   "toRules": [],
+   "type": "MeshHTTPRoute",
+   "warnings": []
+  }
+ ]
+}

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/meshhttproute_mzms_exclusive.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/meshhttproute_mzms_exclusive.input.yaml
@@ -1,0 +1,99 @@
+#/meshes/default/dataplanes/dp-1/_rules 200
+type: Mesh
+name: default
+meshServices:
+  mode: Exclusive
+---
+type: MeshService
+name: backend-1
+mesh: default
+labels:
+  kuma.io/display-name: backend
+  kuma.io/origin: zone
+  kuma.io/zone: zone1
+spec:
+  selector:
+    dataplaneTags:
+      app: backend
+  ports:
+    - port: 5050
+      targetPort: 5050
+      appProtocol: http
+      name: http
+---
+type: MeshService
+name: kv
+mesh: default
+labels:
+  kuma.io/display-name: kv
+  kuma.io/origin: zone
+  kuma.io/zone: zone1
+spec:
+  selector:
+    dataplaneTags:
+      app: kv
+  ports:
+    - port: 5050
+      targetPort: 5050
+      appProtocol: http
+      name: http
+---
+type: MeshHTTPRoute
+name: http-route-mmzs
+mesh: default
+labels:
+  kuma.io/origin: global
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
+      app: backend
+  to:
+    - targetRef:
+        kind: MeshMultiZoneService
+        labels:
+          kuma.io/display-name: kv
+        sectionName: '5050'
+      rules:
+        - matches:
+            - path:
+                type: Exact
+                value: /
+          default:
+            backendRefs:
+              - kind: MeshMultiZoneService
+                labels:
+                  kuma.io/display-name: kv
+                weight: 1
+                port: 5050
+---
+type: MeshMultiZoneService
+name: kv
+mesh: default
+labels:
+  kuma.io/display-name: kv
+  kuma.io/origin: global
+spec:
+  selector:
+    meshService:
+      matchLabels:
+        kuma.io/display-name: kv
+  ports:
+    - port: 5050
+      appProtocol: http
+---
+type: Dataplane
+name: dp-1
+mesh: default
+labels:
+  kuma.io/origin: zone
+  kuma.io/zone: zone1
+  app: backend
+networking:
+  address: 127.0.0.1
+  inbound:
+    - port: 5050
+      protocol: http
+      tags:
+        app: backend
+        kuma.io/service: foo


### PR DESCRIPTION
## Motivation

The _rules inspect endpoint for dataplanes didn't return MeshHTTPRoute policies that target MeshMultiZoneService (MMZS). When using Exclusive mesh services mode, HTTP routes referencing MMZS were silently omitted from the `_rules` response.

## Implementation information

- Modified `pkg/api-server/resource_endpoints.go` to also iterate over ResourceRules (not just legacy Rules) when collecting HTTP route matches by hash, so MMZS-targeted routes are included in the httpMatches response
- Extended the skip condition to also check `len(res.ToRules.ResourceRules)`: previously only legacy Rules were checked, causing MMZS-based policies to be filtered out entirely
- Added a test case