### PR TITLE
feat(helm): expose inboundTagsDisabled flag

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -930,6 +930,8 @@ experimental:
   # -- If true, enable native Kubernetes sidecars. This requires at least
   # Kubernetes v1.29
   sidecarContainers: false
+  # -- If true, inbound tags are not generated for dataplanes. Used with label-based MeshService matching.
+  inboundTagsDisabled: false
 
 # Postgres' settings for universal control plane on k8s
 postgres:

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -287,6 +287,7 @@ A Helm chart for the Kuma Control Plane
 | experimental.ebpf.tcAttachIface | string | `""` | Name of the network interface which TC programs should be attached to, we'll try to automatically determine it if empty |
 | experimental.ebpf.programsSourcePath | string | `"/tmp/kuma-ebpf"` | Path where compiled eBPF programs which will be installed can be found |
 | experimental.sidecarContainers | bool | `false` | If true, enable native Kubernetes sidecars. This requires at least Kubernetes v1.29 |
+| experimental.inboundTagsDisabled | bool | `false` | If true, inbound tags are not generated for dataplanes. Used with label-based MeshService matching. |
 | postgres.port | string | `"5432"` | Postgres port, password should be provided as a secret reference in "controlPlane.secrets" with the Env value "KUMA_STORE_POSTGRES_PASSWORD". Example: controlPlane:   secrets:     - Secret: postgres-postgresql       Key: postgresql-password       Env: KUMA_STORE_POSTGRES_PASSWORD |
 | postgres.tls.mode | string | `"disable"` | Mode of TLS connection. Available values are: "disable", "verifyNone", "verifyCa", "verifyFull" |
 | postgres.tls.disableSSLSNI | bool | `false` | Whether to disable SNI the postgres `sslsni` option. |

--- a/deployments/charts/kuma/templates/_helpers.tpl
+++ b/deployments/charts/kuma/templates/_helpers.tpl
@@ -307,6 +307,10 @@ env:
 - name: KUMA_EXPERIMENTAL_SIDECAR_CONTAINERS
   value: "true"
 {{- end }}
+{{- if .Values.experimental.inboundTagsDisabled }}
+- name: KUMA_EXPERIMENTAL_INBOUND_TAGS_DISABLED
+  value: "true"
+{{- end }}
 {{- if and .Values.cni.enabled .Values.cni.taintController.enabled }}
 - name: KUMA_RUNTIME_KUBERNETES_NODE_TAINT_CONTROLLER_ENABLED
   value: "true"

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -930,6 +930,8 @@ experimental:
   # -- If true, enable native Kubernetes sidecars. This requires at least
   # Kubernetes v1.29
   sidecarContainers: false
+  # -- If true, inbound tags are not generated for dataplanes. Used with label-based MeshService matching.
+  inboundTagsDisabled: false
 
 # Postgres' settings for universal control plane on k8s
 postgres:

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -930,6 +930,8 @@ experimental:
   # -- If true, enable native Kubernetes sidecars. This requires at least
   # Kubernetes v1.29
   sidecarContainers: false
+  # -- If true, inbound tags are not generated for dataplanes. Used with label-based MeshService matching.
+  inboundTagsDisabled: false
 
 # Postgres' settings for universal control plane on k8s
 postgres:

--- a/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
@@ -19,9 +19,9 @@ import (
 )
 
 type InboundConverter struct {
-	NameExtractor            NameExtractor
-	NodeGetter               kube_client.Reader
-	NodeLabelsToCopy         []string
+	NameExtractor       NameExtractor
+	NodeGetter          kube_client.Reader
+	NodeLabelsToCopy    []string
 	InboundTagsDisabled bool
 }
 

--- a/pkg/plugins/runtime/k8s/controllers/meshservice_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/meshservice_controller.go
@@ -58,9 +58,9 @@ const (
 type MeshServiceReconciler struct {
 	kube_client.Client
 	kube_event.EventRecorder
-	Log                      logr.Logger
-	Scheme                   *kube_runtime.Scheme
-	ResourceConverter        k8s_common.Converter
+	Log                 logr.Logger
+	Scheme              *kube_runtime.Scheme
+	ResourceConverter   k8s_common.Converter
 	InboundTagsDisabled bool
 }
 

--- a/pkg/plugins/runtime/k8s/controllers/meshservice_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/meshservice_controller_test.go
@@ -32,8 +32,8 @@ var _ = Describe("MeshServiceController", func() {
 	var reconciler kube_reconcile.Reconciler
 
 	type testCase struct {
-		inputFile                string
-		outputFile               string
+		inputFile           string
+		outputFile          string
 		inboundTagsDisabled bool
 	}
 
@@ -69,11 +69,11 @@ var _ = Describe("MeshServiceController", func() {
 				Build()
 
 			reconciler = &MeshServiceReconciler{
-				Client:                   kubeClient,
-				Log:                      logr.Discard(),
-				Scheme:                   k8sClientScheme,
-				EventRecorder:            kube_events.NewFakeRecorder(10),
-				ResourceConverter:        k8s.NewSimpleConverter(),
+				Client:              kubeClient,
+				Log:                 logr.Discard(),
+				Scheme:              k8sClientScheme,
+				EventRecorder:       kube_events.NewFakeRecorder(10),
+				ResourceConverter:   k8s.NewSimpleConverter(),
 				InboundTagsDisabled: given.inboundTagsDisabled,
 			}
 

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
@@ -42,17 +42,17 @@ func Parse[T any](values []string) ([]T, error) {
 
 var _ = Describe("PodToDataplane(..)", func() {
 	type testCase struct {
-		pod                      string
-		servicesForPod           string
-		otherDataplanes          string
-		otherServices            string
-		otherReplicaSets         string
-		otherJobs                string
-		node                     string
-		dataplane                string
-		existingDataplane        string
-		nodeLabelsToCopy         []string
-		workloadLabels           []string
+		pod                 string
+		servicesForPod      string
+		otherDataplanes     string
+		otherServices       string
+		otherReplicaSets    string
+		otherJobs           string
+		node                string
+		dataplane           string
+		existingDataplane   string
+		nodeLabelsToCopy    []string
+		workloadLabels      []string
 		inboundTagsDisabled bool
 	}
 	DescribeTable("should convert Pod into a Dataplane YAML version",
@@ -133,8 +133,8 @@ var _ = Describe("PodToDataplane(..)", func() {
 						ReplicaSetGetter: replicaSetGetter,
 						JobGetter:        jobGetter,
 					},
-					NodeGetter:               nodeGetter,
-					NodeLabelsToCopy:         given.nodeLabelsToCopy,
+					NodeGetter:          nodeGetter,
+					NodeLabelsToCopy:    given.nodeLabelsToCopy,
 					InboundTagsDisabled: given.inboundTagsDisabled,
 				},
 				Zone:              "zone-1",
@@ -353,14 +353,14 @@ var _ = Describe("PodToDataplane(..)", func() {
 			dataplane:      "33.dataplane.yaml",
 		}),
 		Entry("34. Pod with skip inbound tag generation enabled", testCase{
-			pod:                      "34.pod.yaml",
-			servicesForPod:           "34.services-for-pod.yaml",
-			dataplane:                "34.dataplane.yaml",
+			pod:                 "34.pod.yaml",
+			servicesForPod:      "34.services-for-pod.yaml",
+			dataplane:           "34.dataplane.yaml",
 			inboundTagsDisabled: true,
 		}),
 		Entry("35. Pod without service with skip inbound tag generation enabled", testCase{
-			pod:                      "35.pod.yaml",
-			dataplane:                "35.dataplane.yaml",
+			pod:                 "35.pod.yaml",
+			dataplane:           "35.dataplane.yaml",
 			inboundTagsDisabled: true,
 		}),
 	)

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -155,11 +155,11 @@ func addMeshServiceReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime, co
 		return nil
 	}
 	reconciler := &k8s_controllers.MeshServiceReconciler{
-		Client:                   mgr.GetClient(),
-		Log:                      core.Log.WithName("controllers").WithName("MeshService"),
-		Scheme:                   mgr.GetScheme(),
-		EventRecorder:            mgr.GetEventRecorder("k8s.kuma.io/mesh-service-generator"),
-		ResourceConverter:        converter,
+		Client:              mgr.GetClient(),
+		Log:                 core.Log.WithName("controllers").WithName("MeshService"),
+		Scheme:              mgr.GetScheme(),
+		EventRecorder:       mgr.GetEventRecorder("k8s.kuma.io/mesh-service-generator"),
+		ResourceConverter:   converter,
 		InboundTagsDisabled: rt.Config().Experimental.InboundTagsDisabled,
 	}
 	return reconciler.SetupWithManager(mgr)
@@ -201,8 +201,8 @@ func addPodReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter 
 					ReplicaSetGetter: mgr.GetClient(),
 					JobGetter:        mgr.GetClient(),
 				},
-				NodeGetter:               mgr.GetClient(),
-				NodeLabelsToCopy:         rt.Config().Runtime.Kubernetes.Injector.NodeLabelsToCopy,
+				NodeGetter:          mgr.GetClient(),
+				NodeLabelsToCopy:    rt.Config().Runtime.Kubernetes.Injector.NodeLabelsToCopy,
 				InboundTagsDisabled: rt.Config().Experimental.InboundTagsDisabled,
 			},
 			Zone:                rt.Config().Multizone.Zone.Name,


### PR DESCRIPTION
## Motivation

`KUMA_EXPERIMENTAL_INBOUND_TAGS_DISABLED` existed in `ExperimentalConfig` but had no Helm counterpart, making it unusable in K8s deployments without manual env var injection.

## Implementation information

Added `experimental.inboundTagsDisabled` (default: `false`) to `values.yaml` and wired the corresponding env var in `_helpers.tpl`, following the same pattern as `experimental.sidecarContainers`.

> Changelog: feat(kuma-cp): support running without inbound tags
