### PR TITLE
refactor(config): rename skipInboundTagGeneration

### DIFF
--- a/pkg/api-server/testdata/resources/crud/put_dataplanes.input.yaml
+++ b/pkg/api-server/testdata/resources/crud/put_dataplanes.input.yaml
@@ -15,7 +15,7 @@
 #/meshes/default/dataplanes/dp-5 400 method=PUT
 # Name is a number
 #/meshes/default/dataplanes/dp-5 400 method=PUT
-# Empty tags (SkipInboundTagGeneration)
+# Empty tags (InboundTagsDisabled)
 #/meshes/default/dataplanes/dp-6 201 method=PUT
 type: Mesh
 name: default

--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -464,9 +464,8 @@ type ExperimentalConfig struct {
 	SidecarContainers bool `json:"sidecarContainers" envconfig:"KUMA_EXPERIMENTAL_SIDECAR_CONTAINERS"`
 	// If true uses Delta xDS to deliver changes to sidecars.
 	DeltaXds bool `json:"deltaXds" envconfig:"KUMA_EXPERIMENTAL_DELTA_XDS"`
-	// If true, inbound tags are not generated for K8s dataplanes.
-	// Used with label-based MeshService matching. Deprecated: will be removed in 3.0
-	SkipInboundTagGeneration bool `json:"skipInboundTagGeneration" envconfig:"KUMA_EXPERIMENTAL_SKIP_INBOUND_TAG_GENERATION"`
+	// If true, inbound tags are disabled. CP runs without relying on inbound tags.
+	InboundTagsDisabled bool `json:"inboundTagsDisabled" envconfig:"KUMA_EXPERIMENTAL_INBOUND_TAGS_DISABLED"`
 }
 
 type ExperimentalKDSEventBasedWatchdog struct {

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -1112,7 +1112,7 @@ meshService:
 				"KUMA_EXPERIMENTAL_AUTO_REACHABLE_SERVICES":                                                "true",
 				"KUMA_EXPERIMENTAL_SIDECAR_CONTAINERS":                                                     "true",
 				"KUMA_EXPERIMENTAL_DELTA_XDS":                                                              "true",
-				"KUMA_EXPERIMENTAL_SKIP_INBOUND_TAG_GENERATION":                                            "true",
+				"KUMA_EXPERIMENTAL_INBOUND_TAGS_DISABLED":                                                  "true",
 				"KUMA_PROXY_GATEWAY_GLOBAL_DOWNSTREAM_MAX_CONNECTIONS":                                     "1",
 				"KUMA_TRACING_OPENTELEMETRY_ENDPOINT":                                                      "otel-collector:4317",
 				"KUMA_TRACING_OPENTELEMETRY_ENABLED":                                                       "true",

--- a/pkg/core/resources/apis/mesh/dataplane_validator.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator.go
@@ -96,7 +96,7 @@ func validateNetworking(networking *mesh_proto.Dataplane_Networking) validators.
 		result := validateInbound(inbound, networking.Address)
 		err.AddErrorAt(field, result)
 		// Require service tag only if inbound has any tags (old setup).
-		// With SkipInboundTagGeneration inbounds have no tags (new setup).
+		// With InboundTagsDisabled inbounds have no tags (new setup).
 		if len(inbound.Tags) > 0 {
 			if _, exist := inbound.Tags[mesh_proto.ServiceTag]; !exist {
 				err.AddViolationAt(field.Field("tags").Key(mesh_proto.ServiceTag), `tag has to exist`)

--- a/pkg/core/resources/apis/mesh/dataplane_validator_test.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator_test.go
@@ -1355,7 +1355,7 @@ var _ = Describe("Dataplane", func() {
 	)
 
 	Describe("service tag requirement based on inbound tags presence", func() {
-		It("should allow dataplane with empty inbound tags (SkipInboundTagGeneration)", func() {
+		It("should allow dataplane with empty inbound tags (InboundTagsDisabled)", func() {
 			// setup
 			dataplane := core_mesh.NewDataplaneResource()
 

--- a/pkg/dns/vips_allocator_test.go
+++ b/pkg/dns/vips_allocator_test.go
@@ -832,7 +832,7 @@ var _ = DescribeTable("outboundView",
 		thenHostnameEntries: []vips.HostnameEntry{},
 		thenOutbounds:       map[vips.HostnameEntry][]vips.OutboundEntry{},
 	}),
-	Entry("skip inbounds without tags (SkipInboundTagGeneration)", outboundViewTestCase{
+	Entry("skip inbounds without tags (InboundTagsDisabled)", outboundViewTestCase{
 		givenResources: map[model.ResourceKey]model.Resource{
 			model.WithMesh("mesh", "dp-1"): &mesh.DataplaneResource{
 				Spec: dpWithTags(nil),

--- a/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
@@ -22,11 +22,11 @@ type InboundConverter struct {
 	NameExtractor            NameExtractor
 	NodeGetter               kube_client.Reader
 	NodeLabelsToCopy         []string
-	SkipInboundTagGeneration bool
+	InboundTagsDisabled bool
 }
 
 func (ic *InboundConverter) tagsOrEmpty(tagsFn func() map[string]string) map[string]string {
-	if ic.SkipInboundTagGeneration {
+	if ic.InboundTagsDisabled {
 		return map[string]string{}
 	}
 	return tagsFn()

--- a/pkg/plugins/runtime/k8s/controllers/meshservice_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/meshservice_controller.go
@@ -61,7 +61,7 @@ type MeshServiceReconciler struct {
 	Log                      logr.Logger
 	Scheme                   *kube_runtime.Scheme
 	ResourceConverter        k8s_common.Converter
-	SkipInboundTagGeneration bool
+	InboundTagsDisabled bool
 }
 
 func (r *MeshServiceReconciler) Reconcile(ctx context.Context, req kube_ctrl.Request) (kube_ctrl.Result, error) {
@@ -363,7 +363,7 @@ func (r *MeshServiceReconciler) setFromClusterIPSvc(_ context.Context, ms *meshs
 		}
 	}
 	ms.Labels[metadata.HeadlessService] = "false"
-	if r.SkipInboundTagGeneration {
+	if r.InboundTagsDisabled {
 		matchLabels := maps.Clone(svc.Spec.Selector)
 		if matchLabels == nil {
 			matchLabels = map[string]string{}

--- a/pkg/plugins/runtime/k8s/controllers/meshservice_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/meshservice_controller_test.go
@@ -34,7 +34,7 @@ var _ = Describe("MeshServiceController", func() {
 	type testCase struct {
 		inputFile                string
 		outputFile               string
-		skipInboundTagGeneration bool
+		inboundTagsDisabled bool
 	}
 
 	DescribeTable("should reconcile service",
@@ -74,7 +74,7 @@ var _ = Describe("MeshServiceController", func() {
 				Scheme:                   k8sClientScheme,
 				EventRecorder:            kube_events.NewFakeRecorder(10),
 				ResourceConverter:        k8s.NewSimpleConverter(),
-				SkipInboundTagGeneration: given.skipInboundTagGeneration,
+				InboundTagsDisabled: given.inboundTagsDisabled,
 			}
 
 			key := kube_types.NamespacedName{
@@ -128,10 +128,10 @@ var _ = Describe("MeshServiceController", func() {
 			inputFile:  "headless-gateway-disabled.resources.yaml",
 			outputFile: "headless-gateway-disabled.meshservice.yaml",
 		}),
-		Entry("with SkipInboundTagGeneration enabled", testCase{
-			inputFile:                "skip-inbound-tags.resources.yaml",
-			outputFile:               "skip-inbound-tags.meshservice.yaml",
-			skipInboundTagGeneration: true,
+		Entry("with InboundTagsDisabled enabled", testCase{
+			inputFile:           "skip-inbound-tags.resources.yaml",
+			outputFile:          "skip-inbound-tags.meshservice.yaml",
+			inboundTagsDisabled: true,
 		}),
 	)
 })

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
@@ -53,7 +53,7 @@ var _ = Describe("PodToDataplane(..)", func() {
 		existingDataplane        string
 		nodeLabelsToCopy         []string
 		workloadLabels           []string
-		skipInboundTagGeneration bool
+		inboundTagsDisabled bool
 	}
 	DescribeTable("should convert Pod into a Dataplane YAML version",
 		func(given testCase) {
@@ -135,7 +135,7 @@ var _ = Describe("PodToDataplane(..)", func() {
 					},
 					NodeGetter:               nodeGetter,
 					NodeLabelsToCopy:         given.nodeLabelsToCopy,
-					SkipInboundTagGeneration: given.skipInboundTagGeneration,
+					InboundTagsDisabled: given.inboundTagsDisabled,
 				},
 				Zone:              "zone-1",
 				ResourceConverter: k8s.NewSimpleConverter(),
@@ -356,12 +356,12 @@ var _ = Describe("PodToDataplane(..)", func() {
 			pod:                      "34.pod.yaml",
 			servicesForPod:           "34.services-for-pod.yaml",
 			dataplane:                "34.dataplane.yaml",
-			skipInboundTagGeneration: true,
+			inboundTagsDisabled: true,
 		}),
 		Entry("35. Pod without service with skip inbound tag generation enabled", testCase{
 			pod:                      "35.pod.yaml",
 			dataplane:                "35.dataplane.yaml",
-			skipInboundTagGeneration: true,
+			inboundTagsDisabled: true,
 		}),
 	)
 

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -160,7 +160,7 @@ func addMeshServiceReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime, co
 		Scheme:                   mgr.GetScheme(),
 		EventRecorder:            mgr.GetEventRecorder("k8s.kuma.io/mesh-service-generator"),
 		ResourceConverter:        converter,
-		SkipInboundTagGeneration: rt.Config().Experimental.SkipInboundTagGeneration,
+		InboundTagsDisabled: rt.Config().Experimental.InboundTagsDisabled,
 	}
 	return reconciler.SetupWithManager(mgr)
 }
@@ -203,7 +203,7 @@ func addPodReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter 
 				},
 				NodeGetter:               mgr.GetClient(),
 				NodeLabelsToCopy:         rt.Config().Runtime.Kubernetes.Injector.NodeLabelsToCopy,
-				SkipInboundTagGeneration: rt.Config().Experimental.SkipInboundTagGeneration,
+				InboundTagsDisabled: rt.Config().Experimental.InboundTagsDisabled,
 			},
 			Zone:                rt.Config().Multizone.Zone.Name,
 			SystemNamespace:     rt.Config().Store.Kubernetes.SystemNamespace,

--- a/test/e2e/skipinboundtags/e2e_suite_test.go
+++ b/test/e2e/skipinboundtags/e2e_suite_test.go
@@ -22,7 +22,7 @@ var _ = framework.E2EBeforeSuite(func() {
 
 	err := framework.NewClusterSetup().
 		Install(framework.Kuma(config_core.Zone,
-			framework.WithEnv("KUMA_EXPERIMENTAL_SKIP_INBOUND_TAG_GENERATION", "true"),
+			framework.WithEnv("KUMA_EXPERIMENTAL_INBOUND_TAGS_DISABLED", "true"),
 		)).
 		Setup(skipinboundtags.KubeCluster)
 


### PR DESCRIPTION
## Motivation

`skipInboundTagGeneration` implied a K8s-specific mechanism ("generation"). Universal also needs this mode, so the name should express the state: **the CP operates without inbound tags and doesn't rely on them**.

## Implementation information

Pure rename:
- Config field: `SkipInboundTagGeneration` → `InboundTagsDisabled`
- JSON tag: `skipInboundTagGeneration` → `inboundTagsDisabled`
- Env var: `KUMA_EXPERIMENTAL_SKIP_INBOUND_TAG_GENERATION` → `KUMA_EXPERIMENTAL_INBOUND_TAGS_DISABLED`
- Updated comment: removed K8s-specific language and `Deprecated` marker
- All usages in controllers, plugin wiring, validator, and tests updated

> Changelog: skip