### PR TITLE
fix(meshservice): skip empty-tag inbounds silently

### DIFF
--- a/pkg/core/resources/apis/meshservice/generate/component.go
+++ b/pkg/core/resources/apis/meshservice/generate/component.go
@@ -30,6 +30,7 @@ func Setup(rt runtime.Runtime) error {
 		rt.ResourceManager(),
 		rt.MeshCache(),
 		rt.Config().Multizone.Zone.Name,
+		rt.Config().Experimental.InboundTagsDisabled,
 	)
 	if err != nil {
 		return err

--- a/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
@@ -19,9 +19,9 @@ import (
 )
 
 type InboundConverter struct {
-	NameExtractor            NameExtractor
-	NodeGetter               kube_client.Reader
-	NodeLabelsToCopy         []string
+	NameExtractor       NameExtractor
+	NodeGetter          kube_client.Reader
+	NodeLabelsToCopy    []string
 	InboundTagsDisabled bool
 }
 

--- a/pkg/plugins/runtime/k8s/controllers/meshservice_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/meshservice_controller.go
@@ -58,9 +58,9 @@ const (
 type MeshServiceReconciler struct {
 	kube_client.Client
 	kube_event.EventRecorder
-	Log                      logr.Logger
-	Scheme                   *kube_runtime.Scheme
-	ResourceConverter        k8s_common.Converter
+	Log                 logr.Logger
+	Scheme              *kube_runtime.Scheme
+	ResourceConverter   k8s_common.Converter
 	InboundTagsDisabled bool
 }
 

--- a/pkg/plugins/runtime/k8s/controllers/meshservice_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/meshservice_controller_test.go
@@ -32,8 +32,8 @@ var _ = Describe("MeshServiceController", func() {
 	var reconciler kube_reconcile.Reconciler
 
 	type testCase struct {
-		inputFile                string
-		outputFile               string
+		inputFile           string
+		outputFile          string
 		inboundTagsDisabled bool
 	}
 
@@ -69,11 +69,11 @@ var _ = Describe("MeshServiceController", func() {
 				Build()
 
 			reconciler = &MeshServiceReconciler{
-				Client:                   kubeClient,
-				Log:                      logr.Discard(),
-				Scheme:                   k8sClientScheme,
-				EventRecorder:            kube_events.NewFakeRecorder(10),
-				ResourceConverter:        k8s.NewSimpleConverter(),
+				Client:              kubeClient,
+				Log:                 logr.Discard(),
+				Scheme:              k8sClientScheme,
+				EventRecorder:       kube_events.NewFakeRecorder(10),
+				ResourceConverter:   k8s.NewSimpleConverter(),
 				InboundTagsDisabled: given.inboundTagsDisabled,
 			}
 

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
@@ -42,17 +42,17 @@ func Parse[T any](values []string) ([]T, error) {
 
 var _ = Describe("PodToDataplane(..)", func() {
 	type testCase struct {
-		pod                      string
-		servicesForPod           string
-		otherDataplanes          string
-		otherServices            string
-		otherReplicaSets         string
-		otherJobs                string
-		node                     string
-		dataplane                string
-		existingDataplane        string
-		nodeLabelsToCopy         []string
-		workloadLabels           []string
+		pod                 string
+		servicesForPod      string
+		otherDataplanes     string
+		otherServices       string
+		otherReplicaSets    string
+		otherJobs           string
+		node                string
+		dataplane           string
+		existingDataplane   string
+		nodeLabelsToCopy    []string
+		workloadLabels      []string
 		inboundTagsDisabled bool
 	}
 	DescribeTable("should convert Pod into a Dataplane YAML version",
@@ -133,8 +133,8 @@ var _ = Describe("PodToDataplane(..)", func() {
 						ReplicaSetGetter: replicaSetGetter,
 						JobGetter:        jobGetter,
 					},
-					NodeGetter:               nodeGetter,
-					NodeLabelsToCopy:         given.nodeLabelsToCopy,
+					NodeGetter:          nodeGetter,
+					NodeLabelsToCopy:    given.nodeLabelsToCopy,
 					InboundTagsDisabled: given.inboundTagsDisabled,
 				},
 				Zone:              "zone-1",
@@ -353,14 +353,14 @@ var _ = Describe("PodToDataplane(..)", func() {
 			dataplane:      "33.dataplane.yaml",
 		}),
 		Entry("34. Pod with skip inbound tag generation enabled", testCase{
-			pod:                      "34.pod.yaml",
-			servicesForPod:           "34.services-for-pod.yaml",
-			dataplane:                "34.dataplane.yaml",
+			pod:                 "34.pod.yaml",
+			servicesForPod:      "34.services-for-pod.yaml",
+			dataplane:           "34.dataplane.yaml",
 			inboundTagsDisabled: true,
 		}),
 		Entry("35. Pod without service with skip inbound tag generation enabled", testCase{
-			pod:                      "35.pod.yaml",
-			dataplane:                "35.dataplane.yaml",
+			pod:                 "35.pod.yaml",
+			dataplane:           "35.dataplane.yaml",
 			inboundTagsDisabled: true,
 		}),
 	)

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -155,11 +155,11 @@ func addMeshServiceReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime, co
 		return nil
 	}
 	reconciler := &k8s_controllers.MeshServiceReconciler{
-		Client:                   mgr.GetClient(),
-		Log:                      core.Log.WithName("controllers").WithName("MeshService"),
-		Scheme:                   mgr.GetScheme(),
-		EventRecorder:            mgr.GetEventRecorder("k8s.kuma.io/mesh-service-generator"),
-		ResourceConverter:        converter,
+		Client:              mgr.GetClient(),
+		Log:                 core.Log.WithName("controllers").WithName("MeshService"),
+		Scheme:              mgr.GetScheme(),
+		EventRecorder:       mgr.GetEventRecorder("k8s.kuma.io/mesh-service-generator"),
+		ResourceConverter:   converter,
 		InboundTagsDisabled: rt.Config().Experimental.InboundTagsDisabled,
 	}
 	return reconciler.SetupWithManager(mgr)
@@ -201,8 +201,8 @@ func addPodReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter 
 					ReplicaSetGetter: mgr.GetClient(),
 					JobGetter:        mgr.GetClient(),
 				},
-				NodeGetter:               mgr.GetClient(),
-				NodeLabelsToCopy:         rt.Config().Runtime.Kubernetes.Injector.NodeLabelsToCopy,
+				NodeGetter:          mgr.GetClient(),
+				NodeLabelsToCopy:    rt.Config().Runtime.Kubernetes.Injector.NodeLabelsToCopy,
 				InboundTagsDisabled: rt.Config().Experimental.InboundTagsDisabled,
 			},
 			Zone:                rt.Config().Multizone.Zone.Name,


### PR DESCRIPTION
## Motivation

On universal with transparent proxy and `KUMA_EXPERIMENTAL_INBOUND_TAGS_DISABLED=true`,
dataplanes have inbounds with no tags. `meshServicesForDataplane` logs an info
message for every such inbound on each generation cycle (DNS1035 validation
fails on empty string), causing noisy log spam.

## Implementation information

Added `inboundTagsDisabled bool` field to `Generator`. When set, inbounds with
no tags are skipped silently before reaching the DNS1035 validation log.

The flag is wired through `New()` and `component.go` reads it from
`rt.Config().Experimental.InboundTagsDisabled`.

Also includes struct field alignment fixes in k8s controllers — these files
were misformatted after the `InboundTagsDisabled` rename commit landed on
`master` without running `make format`.

> Changelog: feat(kuma-cp): support running without inbound tags
