### PR TITLE
fix(e2e): increase MeshHealthCheck gw timeout

### DIFF
--- a/test/e2e_env/kubernetes/gateway/delegated/meshhealthcheck.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshhealthcheck.go
@@ -84,7 +84,7 @@ spec:
 				)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(response.ResponseCode).To(Equal(503))
-			}, "30s", "1s").Should(Succeed())
+			}, "60s", "1s").Should(Succeed())
 		})
 	}
 }


### PR DESCRIPTION
## Motivation

Flaky `meshhealthcheck.go:87` in the delegated gateway e2e tests. The 30s `Eventually` timeout is too tight - after applying the MeshHealthCheck policy, the chain is CP reconciliation + xDS push (5-25s in CI) + 3 health check failures at 3s intervals (~9s). On loaded runners this exceeds 30s. Both failed CI runs polled for the full window without ever seeing 503.

## Implementation information

Bumped the `Eventually` timeout from 30s to 60s, consistent with other gateway e2e timeouts in the codebase.

## Supporting documentation

Failed CI runs:
- https://github.com/kumahq/kuma/runs/64389332310
- https://github.com/kumahq/kuma/runs/64356266923

> Changelog: skip