### PR TITLE
fix(meshservice): allow zero-inbound dataplanes

### DIFF
--- a/pkg/core/resources/apis/mesh/dataplane_validator.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator.go
@@ -70,9 +70,6 @@ func (d *DataplaneResource) Validate() error {
 		err.Add(validateNetworking(d.Spec.GetNetworking()))
 
 	default:
-		if len(d.Spec.GetNetworking().GetInbound()) == 0 {
-			err.AddViolationAt(net, "has to contain at least one inbound interface or gateway")
-		}
 		err.Add(validateNetworking(d.Spec.GetNetworking()))
 		err.Add(validateProbes(d.Spec.GetProbes()))
 		if d.Spec.GetMetrics() != nil {

--- a/pkg/core/resources/apis/mesh/dataplane_validator_test.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator_test.go
@@ -357,6 +357,27 @@ var _ = Describe("Dataplane", func() {
                       kuma.io/display-name: redis
                     port: 8080`,
 		),
+		Entry("no inbound with transparent proxy", `
+            type: Dataplane
+            name: dp-1
+            mesh: default
+            networking:
+              address: 192.168.0.1
+              transparentProxying:
+                redirectPortInbound: 15006
+                redirectPortOutbound: 15001`,
+		),
+		Entry("no inbound outbound-only", `
+            type: Dataplane
+            name: dp-1
+            mesh: default
+            networking:
+              address: 192.168.0.1
+              outbound:
+                - port: 3333
+                  tags:
+                    kuma.io/service: redis`,
+		),
 	)
 
 	type testCase struct {
@@ -415,22 +436,6 @@ var _ = Describe("Dataplane", func() {
                 - field: networking.address
                   message: 'must not be 0.0.0.0 or ::'`,
 		}),
-		Entry("networking: not enough inbound interfaces and no gateway", testCase{
-			dataplane: `
-                type: Dataplane
-                name: dp-1
-                mesh: default
-                networking:
-                  address: 192.168.0.1
-                  outbound:
-                    - port: 3333
-                      tags:
-                        kuma.io/service: redis`,
-			expected: `
-                violations:
-                - field: networking
-                  message: has to contain at least one inbound interface or gateway`,
-		}),
 		Entry("missing networking", testCase{
 			dataplane: `
                 type: Dataplane
@@ -449,8 +454,6 @@ var _ = Describe("Dataplane", func() {
                 networking: {}`,
 			expected: `
                 violations:
-                - field: networking
-                  message: has to contain at least one inbound interface or gateway
                 - field: networking.address
                   message: address can't be empty`,
 		}),

--- a/pkg/core/resources/apis/meshservice/generate/component.go
+++ b/pkg/core/resources/apis/meshservice/generate/component.go
@@ -30,6 +30,7 @@ func Setup(rt runtime.Runtime) error {
 		rt.ResourceManager(),
 		rt.MeshCache(),
 		rt.Config().Multizone.Zone.Name,
+		rt.Config().Experimental.InboundTagsDisabled,
 	)
 	if err != nil {
 		return err

--- a/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
@@ -19,9 +19,9 @@ import (
 )
 
 type InboundConverter struct {
-	NameExtractor            NameExtractor
-	NodeGetter               kube_client.Reader
-	NodeLabelsToCopy         []string
+	NameExtractor       NameExtractor
+	NodeGetter          kube_client.Reader
+	NodeLabelsToCopy    []string
 	InboundTagsDisabled bool
 }
 

--- a/pkg/plugins/runtime/k8s/controllers/meshservice_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/meshservice_controller.go
@@ -58,9 +58,9 @@ const (
 type MeshServiceReconciler struct {
 	kube_client.Client
 	kube_event.EventRecorder
-	Log                      logr.Logger
-	Scheme                   *kube_runtime.Scheme
-	ResourceConverter        k8s_common.Converter
+	Log                 logr.Logger
+	Scheme              *kube_runtime.Scheme
+	ResourceConverter   k8s_common.Converter
 	InboundTagsDisabled bool
 }
 

--- a/pkg/plugins/runtime/k8s/controllers/meshservice_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/meshservice_controller_test.go
@@ -32,8 +32,8 @@ var _ = Describe("MeshServiceController", func() {
 	var reconciler kube_reconcile.Reconciler
 
 	type testCase struct {
-		inputFile                string
-		outputFile               string
+		inputFile           string
+		outputFile          string
 		inboundTagsDisabled bool
 	}
 
@@ -69,11 +69,11 @@ var _ = Describe("MeshServiceController", func() {
 				Build()
 
 			reconciler = &MeshServiceReconciler{
-				Client:                   kubeClient,
-				Log:                      logr.Discard(),
-				Scheme:                   k8sClientScheme,
-				EventRecorder:            kube_events.NewFakeRecorder(10),
-				ResourceConverter:        k8s.NewSimpleConverter(),
+				Client:              kubeClient,
+				Log:                 logr.Discard(),
+				Scheme:              k8sClientScheme,
+				EventRecorder:       kube_events.NewFakeRecorder(10),
+				ResourceConverter:   k8s.NewSimpleConverter(),
 				InboundTagsDisabled: given.inboundTagsDisabled,
 			}
 

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
@@ -42,17 +42,17 @@ func Parse[T any](values []string) ([]T, error) {
 
 var _ = Describe("PodToDataplane(..)", func() {
 	type testCase struct {
-		pod                      string
-		servicesForPod           string
-		otherDataplanes          string
-		otherServices            string
-		otherReplicaSets         string
-		otherJobs                string
-		node                     string
-		dataplane                string
-		existingDataplane        string
-		nodeLabelsToCopy         []string
-		workloadLabels           []string
+		pod                 string
+		servicesForPod      string
+		otherDataplanes     string
+		otherServices       string
+		otherReplicaSets    string
+		otherJobs           string
+		node                string
+		dataplane           string
+		existingDataplane   string
+		nodeLabelsToCopy    []string
+		workloadLabels      []string
 		inboundTagsDisabled bool
 	}
 	DescribeTable("should convert Pod into a Dataplane YAML version",
@@ -133,8 +133,8 @@ var _ = Describe("PodToDataplane(..)", func() {
 						ReplicaSetGetter: replicaSetGetter,
 						JobGetter:        jobGetter,
 					},
-					NodeGetter:               nodeGetter,
-					NodeLabelsToCopy:         given.nodeLabelsToCopy,
+					NodeGetter:          nodeGetter,
+					NodeLabelsToCopy:    given.nodeLabelsToCopy,
 					InboundTagsDisabled: given.inboundTagsDisabled,
 				},
 				Zone:              "zone-1",
@@ -353,14 +353,14 @@ var _ = Describe("PodToDataplane(..)", func() {
 			dataplane:      "33.dataplane.yaml",
 		}),
 		Entry("34. Pod with skip inbound tag generation enabled", testCase{
-			pod:                      "34.pod.yaml",
-			servicesForPod:           "34.services-for-pod.yaml",
-			dataplane:                "34.dataplane.yaml",
+			pod:                 "34.pod.yaml",
+			servicesForPod:      "34.services-for-pod.yaml",
+			dataplane:           "34.dataplane.yaml",
 			inboundTagsDisabled: true,
 		}),
 		Entry("35. Pod without service with skip inbound tag generation enabled", testCase{
-			pod:                      "35.pod.yaml",
-			dataplane:                "35.dataplane.yaml",
+			pod:                 "35.pod.yaml",
+			dataplane:           "35.dataplane.yaml",
 			inboundTagsDisabled: true,
 		}),
 	)

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -155,11 +155,11 @@ func addMeshServiceReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime, co
 		return nil
 	}
 	reconciler := &k8s_controllers.MeshServiceReconciler{
-		Client:                   mgr.GetClient(),
-		Log:                      core.Log.WithName("controllers").WithName("MeshService"),
-		Scheme:                   mgr.GetScheme(),
-		EventRecorder:            mgr.GetEventRecorder("k8s.kuma.io/mesh-service-generator"),
-		ResourceConverter:        converter,
+		Client:              mgr.GetClient(),
+		Log:                 core.Log.WithName("controllers").WithName("MeshService"),
+		Scheme:              mgr.GetScheme(),
+		EventRecorder:       mgr.GetEventRecorder("k8s.kuma.io/mesh-service-generator"),
+		ResourceConverter:   converter,
 		InboundTagsDisabled: rt.Config().Experimental.InboundTagsDisabled,
 	}
 	return reconciler.SetupWithManager(mgr)
@@ -201,8 +201,8 @@ func addPodReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter 
 					ReplicaSetGetter: mgr.GetClient(),
 					JobGetter:        mgr.GetClient(),
 				},
-				NodeGetter:               mgr.GetClient(),
-				NodeLabelsToCopy:         rt.Config().Runtime.Kubernetes.Injector.NodeLabelsToCopy,
+				NodeGetter:          mgr.GetClient(),
+				NodeLabelsToCopy:    rt.Config().Runtime.Kubernetes.Injector.NodeLabelsToCopy,
 				InboundTagsDisabled: rt.Config().Experimental.InboundTagsDisabled,
 			},
 			Zone:                rt.Config().Multizone.Zone.Name,


### PR DESCRIPTION
## Motivation

With `KUMA_EXPERIMENTAL_INBOUND_TAGS_DISABLED=true` on Universal + transparent proxy, users provide a Dataplane YAML with no inbound interfaces. `DataplaneResource.Validate()` rejected these with "has to contain at least one inbound interface or gateway".

Fixes #15660

## Implementation information

Removed the `len(inbound) == 0` guard from the `default` case in `dataplane_validator.go`. The check was a 2019 sanity guard that the system no longer needs:

- `InboundProxyGenerator` iterates over inbounds — empty loop returns empty `ResourceSet`, no crash
- `TransparentProxyGenerator` is fully independent of inbound count
- `GetIdentifyingService()` returns `"unknown"` safely; `TagSet()` returns empty map
- With `InboundTagsDisabled`, service identity comes from MeshService, not inbound tags

A DP with no inbounds + transparent proxy is a valid outbound-only proxy.

Updated tests: removed the now-invalid failing entry, fixed "networking empty" expected violations, added passing entries for no-inbound+tproxy and no-inbound outbound-only.

> Changelog: feat(kuma-cp): support running without inbound tags
