### PR TITLE
docs(MADR): observability dashboards redesign

### DIFF
--- a/docs/madr/decisions/096-observability-dashboards.md
+++ b/docs/madr/decisions/096-observability-dashboards.md
@@ -55,6 +55,8 @@ Five dashboards replace the previous set. The Service Map dashboard is dropped; 
 
 Raw JSON is the right choice for the initial set of five dashboards. Revisit if the count grows past ten or bulk cross-dashboard changes become routine.
 
+Datasource and namespace selection are handled via Grafana's native variable system (`$datasource`, `$namespace`) defined inside the JSON. No build-time preprocessing is needed.
+
 ### Shipping
 
 Three approaches for distributing dashboards to users.


### PR DESCRIPTION
## Motivation

`kumactl install observability` is being removed in Kuma 3.0. This MADR documents the decision on how to deliver Grafana dashboards going forward and what the new dashboard set should include.

Closes https://github.com/Kong/kong-mesh/issues/9162

## Implementation information

MADR 096 covering:
- New dashboard set (5 dashboards, Service Map dropped)
- Format decision: raw JSON over Jsonnet
- Delivery: release tarball (decided), with Helm ConfigMaps and grafana.com registry as alternatives
- Label migration from `kuma_io_service` to `kuma.workload` KRI labels
- Known gap: `zone_name` label missing from KDS metrics

## Supporting documentation

> Changelog: skip