### PR TITLE
chore(dev): use mise which for proto codegen tools

### DIFF
--- a/mk/dev.mk
+++ b/mk/dev.mk
@@ -69,18 +69,17 @@ PROTOC_BIN=$(shell $(MISE) which protoc)
 SHELLCHECK=$(shell $(MISE) which shellcheck)
 ACTIONLINT=$(shell $(MISE) which actionlint)
 CONTAINER_STRUCTURE_TEST=$(shell $(MISE) which container-structure-test)
-# Go-installed tools: mise which doesn't work (looks in mise paths, not GOBIN)
-# Use defensive fallback: check CI_TOOLS_BIN_DIR first, then PATH
-PROTOC_GEN_GO=$(shell test -f $(CI_TOOLS_BIN_DIR)/protoc-gen-go && echo $(CI_TOOLS_BIN_DIR)/protoc-gen-go || command -v protoc-gen-go)
-PROTOC_GEN_GO_GRPC=$(shell test -f $(CI_TOOLS_BIN_DIR)/protoc-gen-go-grpc && echo $(CI_TOOLS_BIN_DIR)/protoc-gen-go-grpc || command -v protoc-gen-go-grpc)
+PROTOC_GEN_GO=$(shell $(MISE) which protoc-gen-go)
+PROTOC_GEN_GO_GRPC=$(shell $(MISE) which protoc-gen-go-grpc)
 PROTOC_GEN_VALIDATE=$(MISE) exec -- protoc-gen-validate
 PROTOC_GEN_KUMADOC=$(MISE) exec -- protoc-gen-kumadoc
-PROTOC_GEN_JSONSCHEMA=$(shell test -f $(CI_TOOLS_BIN_DIR)/protoc-gen-jsonschema && echo $(CI_TOOLS_BIN_DIR)/protoc-gen-jsonschema || command -v protoc-gen-jsonschema)
+PROTOC_GEN_JSONSCHEMA=$(shell $(MISE) which protoc-gen-jsonschema)
 GINKGO=$(shell $(MISE) which ginkgo)
 GOLANGCI_LINT=$(shell $(MISE) which golangci-lint)
 HELM_DOCS=$(shell $(MISE) which helm-docs)
 KUBE_LINTER=$(shell $(MISE) which kube-linter)
 HADOLINT=$(shell $(MISE) which hadolint)
+# oapi-codegen: mise go: backend installs to CI_TOOLS_BIN_DIR, mise which doesn't find it
 OAPI_CODEGEN=$(shell test -f $(CI_TOOLS_BIN_DIR)/oapi-codegen && echo $(CI_TOOLS_BIN_DIR)/oapi-codegen || command -v oapi-codegen)
 
 TOOLS_DEPS_DIRS=$(KUMA_DIR)/mk/dependencies


### PR DESCRIPTION
## Motivation

Proto codegen tools (`protoc-gen-go`, `protoc-gen-go-grpc`, `protoc-gen-jsonschema`) were resolved with a defensive fallback: check `CI_TOOLS_BIN_DIR` first, then fall back to `PATH`. This could silently pick up stale binaries from `GOBIN` when the expected file wasn't in `CI_TOOLS_BIN_DIR`.

## Implementation information

Switch all three tools to `mise which`, consistent with how other tools are resolved. `oapi-codegen` stays on the old fallback - the `mise go` backend installs it to `CI_TOOLS_BIN_DIR`, which `mise which` doesn't search.

## Supporting documentation

> Changelog: skip