### PR TITLE
docs(governance): update SC and emeritus

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -20,7 +20,6 @@ kumahq org group: https://github.com/orgs/kumahq/teams/kuma-maintainers
 
 - Ilya Lobkov @lobkovilya (ilya.lobkov@konghq.com)
 - Krzysztof Slonka @slonka (krzysztof.slonka@konghq.com)
-- Marcin Skalski @Automaat (marcin.skalski@konghq.com)
 - Lukasz Dziedziak @lukidzi (lukidzi@gmail.com)
 
 # Reviewers


### PR DESCRIPTION
## Motivation

Restructure governance:
- Move Jakub Dyszkiewicz, Michael Beaumont, Icarus Wu, Jay Jijie Chen to Emeritus Maintainers
- Move Bart Smykla to Steering Committee
- Consolidate SC into single renewal group (2028/02/25), removing expired 2025/07/01 group

## Implementation information

Updated `OWNERS.md` with consolidated SC and updated emeritus list.

> Changelog: skip