### PR TITLE
docs(governance): add bartsmykla to SC

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -14,6 +14,10 @@ Renews 2025/07/01:
 - Michael Beaumont @michaelbeaumont (mjboamail@gmail.com)
 - Charly Molter @lahabana (charly@molter.io)
 
+Renews 2028/02/25:
+
+- Bart Smykla @bartsmykla (bartek@smykla.com)
+
 # Maintainers
 
 kumahq org group: https://github.com/orgs/kumahq/teams/kuma-maintainers 


### PR DESCRIPTION
## Motivation

Nominating myself (Bart Smykla @bartsmykla) for the steering committee. I've been a maintainer of Kuma for several years and want to take on broader project stewardship responsibilities.

## Implementation information

Added to `OWNERS.md` with a 2-year term renewing 2028/02/25.

Voting per GOVERNANCE.md: 6-week voting period, ≥2/3 supermajority of current steering committee required.

/vote