### PR TITLE
chore(e2e): disable protoc for e2e tests

### DIFF
--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -34,7 +34,7 @@ jobs:
       - uses: jdx/mise-action@e3d7b8d67a7958d1207f6ed871e83b1ea780e7b0 # v3.3.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          MISE_DISABLE_TOOLS: "golangci-lint,skaffold"
+          MISE_DISABLE_TOOLS: "clang-format,golangci-lint,skaffold,protoc-gen-go-grpc"
       - name: "Free up disk space for the Runner"
         run: |
           echo "Disk usage before cleanup"


### PR DESCRIPTION
## Motivation

There is no `protoc-gen-go-grpc` for arm64.

## Implementation information

Disable installation of `protoc-gen-go-grpc` during e2e tests

## Supporting documentation

https://github.com/kumahq/kuma/commit/4919979884aeeac82f8c4a9876bd038471d64b70