### PR TITLE
feat(kumactl): deprecate install observability

### DIFF
--- a/app/kumactl/cmd/install/install_observability.go
+++ b/app/kumactl/cmd/install/install_observability.go
@@ -1,6 +1,7 @@
 package install
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -22,6 +23,9 @@ func newInstallObservability(pctx *kumactl_cmd.RootContext) *cobra.Command {
 		Short: "Install Observability (Metrics, Logging, Tracing) backend in Kubernetes cluster (Prometheus + Grafana + Loki + Jaeger + Zipkin)",
 		Long:  `Install Observability (Metrics, Logging, Tracing) backend in Kubernetes cluster (Prometheus + Grafana + Loki + Jaeger + Zipkin) in its own namespace.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "Warning: 'kumactl install observability' is deprecated and will be removed in Kuma 3.0.\n"); err != nil {
+				return err
+			}
 			componentsMap := map[string]bool{}
 			for _, component := range args.Components {
 				componentsMap[component] = true

--- a/app/kumactl/cmd/install/install_observability_test.go
+++ b/app/kumactl/cmd/install/install_observability_test.go
@@ -26,7 +26,7 @@ var _ = Context("kumactl install observability", func() {
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
-			Expect(stderr.String()).To(BeEmpty())
+			Expect(stderr.String()).To(ContainSubstring("Warning: 'kumactl install observability' is deprecated and will be removed in Kuma 3.0."))
 
 			// and output matches golden files
 			actual := stdout.Bytes()


### PR DESCRIPTION
## Motivation

Users running `kumactl install observability` receive no indication this
command will be removed. Adding a warning makes the deprecation visible.

## Implementation information

Print deprecation warning to stderr at the start of `RunE` before any
processing. Stdout (YAML output) is unaffected.

## Supporting documentation

> Changelog: feat(kumactl): add deprecation warning to install observability