### PR TITLE
feat(observability): change Summaries to Histograms

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,18 @@ does not have any particular instructions.
 
 ## Upgrade to `2.14.x`
 
+### Observability: Prometheus metrics migration from Summary to Histogram
+
+Internal Kuma Prometheus metrics changed from `Summary` to `Histogram` types to fix stale values that accumulated over long windows.
+
+**What changed:**
+- All metrics previously exported as `prometheus.Summary` or `prometheus.SummaryVec` are now `prometheus.Histogram` or `prometheus.HistogramVec`.
+- Metrics that previously exposed quantiles (`0.5`, `0.9`, `0.99`) now use histogram buckets (`_bucket` with `le` labels).
+- `DefaultObjectives` is replaced by `DefaultBuckets`.
+
+**Action required:**
+- Update any dashboards, alerts, or queries that use the old quantile representations to use histogram buckets and the `histogram_quantile` function.
+
 ### RBAC: Added `events.k8s.io` API group
 
 The control plane ClusterRole and the namespaced Role used by the control plane for `events` now include the `events.k8s.io` API group alongside the core (`""`) API group for `events` resources. This aligns with the Kubernetes `events.k8s.io/v1` API which replaced the deprecated core `v1` Events API.

--- a/app/kuma-dp/pkg/dataplane/configfetcher/metrics.go
+++ b/app/kuma-dp/pkg/dataplane/configfetcher/metrics.go
@@ -5,7 +5,7 @@ import (
 )
 
 type handlerMetrics struct {
-	HandlerTickDuration prometheus.Summary
+	HandlerTickDuration prometheus.Histogram
 	HandlerErrorCount   prometheus.Counter
 	HandlerTickCount    prometheus.Counter
 }
@@ -18,7 +18,7 @@ func newHandlerMetrics(path string) *handlerMetrics {
 		ConstLabels: labels,
 	})
 	prometheus.MustRegister(handlerTickCount)
-	handlerTickDuration := prometheus.NewSummary(prometheus.SummaryOpts{
+	handlerTickDuration := prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name:        "kuma_dp_envoyconfigfetcher_handler_call_duration_seconds",
 		Help:        "The duration for the envoy configuration to be fetched and processed by the handler. This is not computed when no change happened",
 		ConstLabels: labels,

--- a/app/kuma-dp/pkg/dataplane/dnsproxy/metrics.go
+++ b/app/kuma-dp/pkg/dataplane/dnsproxy/metrics.go
@@ -5,8 +5,8 @@ import (
 )
 
 type metrics struct {
-	RequestDuration             prometheus.Summary
-	UpstreamRequestDuration     prometheus.Summary
+	RequestDuration             prometheus.Histogram
+	UpstreamRequestDuration     prometheus.Histogram
 	UpstreamRequestFailureCount prometheus.Counter
 }
 
@@ -16,12 +16,12 @@ func newMetrics() *metrics {
 	if m != nil {
 		return m
 	}
-	upstreamRequestDuration := prometheus.NewSummary(prometheus.SummaryOpts{
+	upstreamRequestDuration := prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name: "kuma_dp_dns_upstream_request_duration_seconds",
 		Help: "The duration of the proxied requests.",
 	})
 	prometheus.MustRegister(upstreamRequestDuration)
-	requestDuration := prometheus.NewSummary(prometheus.SummaryOpts{
+	requestDuration := prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name: "kuma_dp_dns_request_duration_seconds",
 		Help: "The duration of the request (inclusive of request that use internal DNS map).",
 	})

--- a/pkg/core/resources/apis/core/vip/allocator.go
+++ b/pkg/core/resources/apis/core/vip/allocator.go
@@ -41,7 +41,7 @@ type Allocator struct {
 	interval          time.Duration
 	cidrToDescriptors map[string]model.ResourceTypeDescriptor
 	resManager        manager.ResourceManager
-	metric            prometheus.Summary
+	metric            prometheus.Histogram
 }
 
 var _ component.Component = &Allocator{}
@@ -53,10 +53,9 @@ func NewAllocator(
 	metrics core_metrics.Metrics,
 	resManager manager.ResourceManager,
 ) (*Allocator, error) {
-	metric := prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:       "component_vip_allocator",
-		Help:       "Summary of VIP allocation duration",
-		Objectives: core_metrics.DefaultObjectives,
+	metric := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: "component_vip_allocator",
+		Help: "Summary of VIP allocation duration",
 	})
 	if err := metrics.Register(metric); err != nil {
 		return nil, err

--- a/pkg/core/resources/apis/hostnamegenerator/hostname/generator.go
+++ b/pkg/core/resources/apis/hostnamegenerator/hostname/generator.go
@@ -36,7 +36,7 @@ type HostnameGenerator interface {
 type Generator struct {
 	logger     logr.Logger
 	interval   time.Duration
-	metric     prometheus.Summary
+	metric     prometheus.Histogram
 	resManager manager.ResourceManager
 	zone       string
 	generators []HostnameGenerator
@@ -52,10 +52,9 @@ func NewGenerator(
 	interval time.Duration,
 	generators []HostnameGenerator,
 ) (*Generator, error) {
-	metric := prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:       "component_hostname_generator",
-		Help:       "Summary of hostname generator interval",
-		Objectives: core_metrics.DefaultObjectives,
+	metric := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: "component_hostname_generator",
+		Help: "Summary of hostname generator interval",
 	})
 	if err := metrics.Register(metric); err != nil {
 		return nil, err

--- a/pkg/core/resources/apis/meshmultizoneservice/status_updater.go
+++ b/pkg/core/resources/apis/meshmultizoneservice/status_updater.go
@@ -29,7 +29,7 @@ type StatusUpdater struct {
 	roResManager manager.ReadOnlyResourceManager
 	resManager   manager.ResourceManager
 	logger       logr.Logger
-	metric       prometheus.Summary
+	metric       prometheus.Histogram
 	interval     time.Duration
 }
 
@@ -42,10 +42,9 @@ func NewStatusUpdater(
 	interval time.Duration,
 	metrics core_metrics.Metrics,
 ) (component.Component, error) {
-	metric := prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:       "component_mzms_status_updater",
-		Help:       "Summary of MeshMultizoneService Updater component",
-		Objectives: core_metrics.DefaultObjectives,
+	metric := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: "component_mzms_status_updater",
+		Help: "Summary of MeshMultizoneService Updater component",
 	})
 	if err := metrics.Register(metric); err != nil {
 		return nil, err

--- a/pkg/core/resources/apis/meshservice/generate/generator.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator.go
@@ -38,7 +38,7 @@ type Generator struct {
 	logger              logr.Logger
 	generateInterval    time.Duration
 	deletionGracePeriod time.Duration
-	metric              prometheus.Summary
+	metric              prometheus.Histogram
 	resManager          manager.ResourceManager
 	meshCache           *mesh_cache.Cache
 	zone                string
@@ -57,10 +57,9 @@ func New(
 	zone string,
 	inboundTagsDisabled bool,
 ) (*Generator, error) {
-	metric := prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:       "component_meshservice_generator",
-		Help:       "Summary of MeshService generation duration",
-		Objectives: core_metrics.DefaultObjectives,
+	metric := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: "component_meshservice_generator",
+		Help: "Summary of MeshService generation duration",
 	})
 	if err := metrics.Register(metric); err != nil {
 		return nil, err

--- a/pkg/core/resources/apis/meshservice/status/updater.go
+++ b/pkg/core/resources/apis/meshservice/status/updater.go
@@ -31,7 +31,7 @@ type StatusUpdater struct {
 	roResManager manager.ReadOnlyResourceManager
 	resManager   manager.ResourceManager
 	logger       logr.Logger
-	metric       prometheus.Summary
+	metric       prometheus.Histogram
 	interval     time.Duration
 	localZone    string
 	environment  config_core.EnvironmentType
@@ -48,10 +48,9 @@ func NewStatusUpdater(
 	localZone string,
 	environment config_core.EnvironmentType,
 ) (component.Component, error) {
-	metric := prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:       "component_ms_status_updater",
-		Help:       "Summary of Inter CP Heartbeat component interval",
-		Objectives: core_metrics.DefaultObjectives,
+	metric := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: "component_ms_status_updater",
+		Help: "Summary of Inter CP Heartbeat component interval",
 	})
 	if err := metrics.Register(metric); err != nil {
 		return nil, err

--- a/pkg/core/resources/apis/workload/generate/generator.go
+++ b/pkg/core/resources/apis/workload/generate/generator.go
@@ -31,7 +31,7 @@ const (
 type Generator struct {
 	logger           logr.Logger
 	generateInterval time.Duration
-	metric           prometheus.Summary
+	metric           prometheus.Histogram
 	resManager       manager.ResourceManager
 	meshCache        *mesh_cache.Cache
 	zone             string
@@ -47,10 +47,9 @@ func New(
 	meshCache *mesh_cache.Cache,
 	zone string,
 ) (*Generator, error) {
-	metric := prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:       "component_workload_generator",
-		Help:       "Summary of Workload generation duration",
-		Objectives: core_metrics.DefaultObjectives,
+	metric := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: "component_workload_generator",
+		Help: "Summary of Workload generation duration",
 	})
 	if err := metrics.Register(metric); err != nil {
 		return nil, err

--- a/pkg/core/resources/apis/workload/status/updater.go
+++ b/pkg/core/resources/apis/workload/status/updater.go
@@ -27,7 +27,7 @@ type StatusUpdater struct {
 	roResManager manager.ReadOnlyResourceManager
 	resManager   manager.ResourceManager
 	logger       logr.Logger
-	metric       prometheus.Summary
+	metric       prometheus.Histogram
 	interval     time.Duration
 }
 
@@ -40,10 +40,9 @@ func NewStatusUpdater(
 	interval time.Duration,
 	metrics core_metrics.Metrics,
 ) (component.Component, error) {
-	metric := prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:       "component_workload_status_updater",
-		Help:       "Summary of Workload status updater component interval",
-		Objectives: core_metrics.DefaultObjectives,
+	metric := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: "component_workload_status_updater",
+		Help: "Summary of Workload status updater component interval",
 	})
 	if err := metrics.Register(metric); err != nil {
 		return nil, err

--- a/pkg/dns/metrics/metrics.go
+++ b/pkg/dns/metrics/metrics.go
@@ -7,15 +7,14 @@ import (
 )
 
 type Metrics struct {
-	VipGenerations       prometheus.Summary
+	VipGenerations       prometheus.Histogram
 	VipGenerationsErrors prometheus.Counter
 }
 
 func NewMetrics(metrics core_metrics.Metrics) (*Metrics, error) {
-	vipGenerations := prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:       "vip_generation",
-		Help:       "Summary of VIP generation",
-		Objectives: core_metrics.DefaultObjectives,
+	vipGenerations := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: "vip_generation",
+		Help: "Summary of VIP generation",
 	})
 	vipGenerationsErrors := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "vip_generation_errors",

--- a/pkg/dns/vips_allocator_test.go
+++ b/pkg/dns/vips_allocator_test.go
@@ -127,7 +127,7 @@ var _ = Describe("VIP Allocator", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// then
-		Expect(test_metrics.FindMetric(metrics, "vip_generation").GetSummary().GetSampleCount()).To(Equal(uint64(1)))
+		Expect(test_metrics.FindMetric(metrics, "vip_generation").GetHistogram().GetSampleCount()).To(Equal(uint64(1)))
 	})
 
 	It("should respect already allocated VIPs in case of IPAM restarts", func() {

--- a/pkg/gc/collector.go
+++ b/pkg/gc/collector.go
@@ -30,7 +30,7 @@ type collector struct {
 	rm                 manager.ResourceManager
 	cleanupAge         time.Duration
 	newTicker          func() *time.Ticker
-	metric             prometheus.Summary
+	metric             prometheus.Histogram
 	resourcesToCleanup map[InsightType]ResourceType
 	log                logr.Logger
 }
@@ -43,10 +43,9 @@ func NewCollector(
 	metricsName string,
 	resourcesToCleanup map[InsightType]ResourceType,
 ) (component.Component, error) {
-	metric := prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:       fmt.Sprintf("component_%s_gc", metricsName),
-		Help:       "Summary of Dataplane GC component interval",
-		Objectives: core_metrics.DefaultObjectives,
+	metric := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: fmt.Sprintf("component_%s_gc", metricsName),
+		Help: "Summary of Dataplane GC component interval",
 	})
 	if err := metrics.Register(metric); err != nil {
 		return nil, err

--- a/pkg/gc/finalizer.go
+++ b/pkg/gc/finalizer.go
@@ -52,7 +52,7 @@ type subscriptionFinalizer struct {
 	types          []core_model.ResourceType
 	onlineInsights tenantInsights
 	tenants        multitenant.Tenants
-	metric         prometheus.Summary
+	metric         prometheus.Histogram
 	extensions     context.Context
 	upsert         store.UpsertConfig
 }
@@ -64,10 +64,9 @@ func NewSubscriptionFinalizer(rm manager.ResourceManager, tenants multitenant.Te
 		}
 	}
 
-	metric := prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:       "component_sub_finalizer",
-		Help:       "Summary of Subscription finalizer component interval",
-		Objectives: core_metrics.DefaultObjectives,
+	metric := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: "component_sub_finalizer",
+		Help: "Summary of Subscription finalizer component interval",
 	})
 	if err := metrics.Register(metric); err != nil {
 		return nil, err

--- a/pkg/hds/metrics/metrics.go
+++ b/pkg/hds/metrics/metrics.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Metrics struct {
-	HdsGenerations          prometheus.Summary
+	HdsGenerations          prometheus.Histogram
 	HdsGenerationsErrors    prometheus.Counter
 	ResponsesReceivedMetric prometheus.Counter
 	RequestsReceivedMetric  prometheus.Counter
@@ -21,10 +21,9 @@ type Metrics struct {
 func NewMetrics(metrics core_metrics.Metrics) (*Metrics, error) {
 	m := &Metrics{}
 
-	m.HdsGenerations = prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:       "hds_generation",
-		Help:       "Summary of HDS Snapshot generation",
-		Objectives: core_metrics.DefaultObjectives,
+	m.HdsGenerations = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: "hds_generation",
+		Help: "Summary of HDS Snapshot generation",
 	})
 	if err := metrics.Register(m.HdsGenerations); err != nil {
 		return nil, err

--- a/pkg/insights/resyncer.go
+++ b/pkg/insights/resyncer.go
@@ -80,9 +80,9 @@ type resyncer struct {
 	metrics             core_metrics.Metrics
 	now                 func() time.Time
 
-	idleTime           prometheus.Summary
-	timeToProcessItem  prometheus.Summary
-	itemProcessingTime *prometheus.SummaryVec
+	idleTime           prometheus.Histogram
+	timeToProcessItem  prometheus.Histogram
+	itemProcessingTime *prometheus.HistogramVec
 
 	allResourceTypes []model.ResourceType
 	extensions       context.Context
@@ -97,20 +97,17 @@ type resyncer struct {
 // by RateLimiter. FullResyncInterval is provided by goroutine with Ticker, it runs
 // resync every t = FullResyncInterval - MinResyncInterval.
 func NewResyncer(config *Config) component.Component {
-	idleTime := prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:       "insights_resyncer_processor_idle_time",
-		Help:       "Summary of the time that the processor loop sits idle, the closer this gets to 0 the more the processing loop is at capacity",
-		Objectives: core_metrics.DefaultObjectives,
+	idleTime := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: "insights_resyncer_processor_idle_time",
+		Help: "Summary of the time that the processor loop sits idle, the closer this gets to 0 the more the processing loop is at capacity",
 	})
-	timeToProcessItem := prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:       "insights_resyncer_event_time_to_process",
-		Help:       "Summary of the time between an event being added to a batch and it being processed, in a well behaving system this should be less of equal to the MinResyncInterval",
-		Objectives: core_metrics.DefaultObjectives,
+	timeToProcessItem := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: "insights_resyncer_event_time_to_process",
+		Help: "Summary of the time between an event being added to a batch and it being processed, in a well behaving system this should be less of equal to the MinResyncInterval",
 	})
-	itemProcessingTime := prometheus.NewSummaryVec(prometheus.SummaryOpts{
-		Name:       "insights_resyncer_event_time_processing",
-		Help:       "Summary of the time spent to process an event",
-		Objectives: core_metrics.DefaultObjectives,
+	itemProcessingTime := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "insights_resyncer_event_time_processing",
+		Help: "Summary of the time spent to process an event",
 	}, []string{"reason", "result"})
 	config.Metrics.MustRegister(idleTime, timeToProcessItem, itemProcessingTime)
 

--- a/pkg/insights/resyncer_test.go
+++ b/pkg/insights/resyncer_test.go
@@ -1163,7 +1163,7 @@ var _ = Describe("Insight Persistence", func() {
 			err := rm.Get(context.Background(), insight, store.GetByKey("mesh-1", model.NoMesh))
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(insight.Meta.GetVersion()).To(Equal("1"))
-			g.Expect(test_metrics.FindMetric(metric, "insights_resyncer_event_time_processing", "result", "changed").GetSummary().GetSampleCount()).To(Equal(uint64(1)))
+			g.Expect(test_metrics.FindMetric(metric, "insights_resyncer_event_time_processing", "result", "changed").GetHistogram().GetSampleCount()).To(Equal(uint64(1)))
 		}).Should(Succeed())
 
 		eventCh <- events.ResourceChangedEvent{
@@ -1180,7 +1180,7 @@ var _ = Describe("Insight Persistence", func() {
 			err := rm.Get(context.Background(), insight, store.GetByKey("mesh-1", model.NoMesh))
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(insight.Meta.GetVersion()).To(Equal("1"))
-			g.Expect(test_metrics.FindMetric(metric, "insights_resyncer_event_time_processing", "result", "no_changes").GetSummary().GetSampleCount()).To(Equal(uint64(1)))
+			g.Expect(test_metrics.FindMetric(metric, "insights_resyncer_event_time_processing", "result", "no_changes").GetHistogram().GetSampleCount()).To(Equal(uint64(1)))
 		}).Should(Succeed())
 	})
 })

--- a/pkg/intercp/catalog/heartbeat_component.go
+++ b/pkg/intercp/catalog/heartbeat_component.go
@@ -24,7 +24,7 @@ type heartbeatComponent struct {
 	interval    time.Duration
 
 	leader *Instance
-	metric prometheus.Summary
+	metric prometheus.Histogram
 }
 
 var _ component.Component = &heartbeatComponent{}
@@ -38,10 +38,9 @@ func NewHeartbeatComponent(
 	newClientFn GetClientFn,
 	metrics core_metrics.Metrics,
 ) (component.Component, error) {
-	metric := prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:       "component_heartbeat",
-		Help:       "Summary of Inter CP Heartbeat component interval",
-		Objectives: core_metrics.DefaultObjectives,
+	metric := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: "component_heartbeat",
+		Help: "Summary of Inter CP Heartbeat component interval",
 	})
 	if err := metrics.Register(metric); err != nil {
 		return nil, err

--- a/pkg/intercp/catalog/writer.go
+++ b/pkg/intercp/catalog/writer.go
@@ -20,7 +20,7 @@ type catalogWriter struct {
 	heartbeats *Heartbeats
 	instance   Instance
 	interval   time.Duration
-	metric     prometheus.Summary
+	metric     prometheus.Histogram
 }
 
 var _ component.Component = &catalogWriter{}
@@ -32,10 +32,9 @@ func NewWriter(
 	interval time.Duration,
 	metrics core_metrics.Metrics,
 ) (component.Component, error) {
-	metric := prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:       "component_catalog_writer",
-		Help:       "Summary of Inter CP Catalog Writer component interval",
-		Objectives: core_metrics.DefaultObjectives,
+	metric := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: "component_catalog_writer",
+		Help: "Summary of Inter CP Catalog Writer component interval",
 	})
 	if err := metrics.Register(metric); err != nil {
 		return nil, err

--- a/pkg/kds/mux/zone_watch.go
+++ b/pkg/kds/mux/zone_watch.go
@@ -17,7 +17,6 @@ import (
 	"github.com/kumahq/kuma/v2/pkg/events"
 	"github.com/kumahq/kuma/v2/pkg/kds/service"
 	kuma_log "github.com/kumahq/kuma/v2/pkg/log"
-	core_metrics "github.com/kumahq/kuma/v2/pkg/metrics"
 	"github.com/kumahq/kuma/v2/pkg/multitenant"
 	"github.com/kumahq/kuma/v2/pkg/util/proto"
 )
@@ -34,7 +33,7 @@ type ZoneWatch struct {
 	bus            events.EventBus
 	extensions     context.Context
 	rm             manager.ReadOnlyResourceManager
-	summary        prometheus.Summary
+	summary        prometheus.Histogram
 	zones          map[zoneTenant]time.Time
 	zoneStreams    map[zoneTenant]map[service.StreamType]time.Time
 	closeStaleConn bool
@@ -48,10 +47,9 @@ func NewZoneWatch(
 	rm manager.ReadOnlyResourceManager,
 	extensions context.Context,
 ) (*ZoneWatch, error) {
-	summary := prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:       "component_zone_watch",
-		Help:       "Summary of ZoneWatch component interval",
-		Objectives: core_metrics.DefaultObjectives,
+	summary := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: "component_zone_watch",
+		Help: "Summary of ZoneWatch component interval",
 	})
 	if err := metrics.Register(summary); err != nil {
 		return nil, err

--- a/pkg/kds/v2/server/event_based_watchdog_test.go
+++ b/pkg/kds/v2/server/event_based_watchdog_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Event Based Watchdog", func() {
 		Eventually(func(g Gomega) {
 			metric := test_metrics.FindMetric(metrics, "kds_delta_generation", "reason", ReasonResync)
 			g.Expect(metric).ToNot(BeNil())
-			g.Expect(*metric.Summary.SampleCount).To(BeEquivalentTo(1))
+			g.Expect(*metric.Histogram.SampleCount).To(BeEquivalentTo(1))
 		}, "10s", "50ms").Should(Succeed())
 	})
 
@@ -132,7 +132,7 @@ var _ = Describe("Event Based Watchdog", func() {
 		Eventually(func(g Gomega) {
 			metric := test_metrics.FindMetric(metrics, "kds_delta_generation", "reason", ReasonEvent)
 			g.Expect(metric).ToNot(BeNil())
-			g.Expect(*metric.Summary.SampleCount).To(BeEquivalentTo(1))
+			g.Expect(*metric.Histogram.SampleCount).To(BeEquivalentTo(1))
 		}, "10s", "50ms").Should(Succeed())
 	})
 
@@ -147,7 +147,7 @@ var _ = Describe("Event Based Watchdog", func() {
 		Eventually(func(g Gomega) {
 			metric := test_metrics.FindMetric(metrics, "kds_delta_generation", "reason", ReasonResync)
 			g.Expect(metric).ToNot(BeNil())
-			g.Expect(*metric.Summary.SampleCount).To(BeEquivalentTo(2))
+			g.Expect(*metric.Histogram.SampleCount).To(BeEquivalentTo(2))
 		}, "10s", "50ms").Should(Succeed())
 	})
 }, Ordered)

--- a/pkg/kds/v2/server/metrics.go
+++ b/pkg/kds/v2/server/metrics.go
@@ -14,15 +14,14 @@ const (
 )
 
 type Metrics struct {
-	KdsGenerations      *prometheus.SummaryVec
+	KdsGenerations      *prometheus.HistogramVec
 	KdsGenerationErrors prometheus.Counter
 }
 
 func NewMetrics(metrics core_metrics.Metrics) (*Metrics, error) {
-	kdsGenerations := prometheus.NewSummaryVec(prometheus.SummaryOpts{
-		Name:       "kds_delta_generation",
-		Help:       "Summary of KDS Snapshot generation",
-		Objectives: core_metrics.DefaultObjectives,
+	kdsGenerations := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "kds_delta_generation",
+		Help: "Summary of KDS Snapshot generation",
 	}, []string{"reason", "result"})
 
 	kdsGenerationsErrors := prometheus.NewCounter(prometheus.CounterOpts{

--- a/pkg/metrics/defaults.go
+++ b/pkg/metrics/defaults.go
@@ -1,8 +1,1 @@
 package metrics
-
-// DefaultObjectives defines default percentiles for Summary (50th, 90th, 99th percentile)
-var DefaultObjectives = map[float64]float64{
-	0.5:  0.05,
-	0.9:  0.01,
-	0.99: 0.001,
-}

--- a/pkg/metrics/store/counter.go
+++ b/pkg/metrics/store/counter.go
@@ -23,7 +23,7 @@ type storeCounter struct {
 	resManager manager.ReadOnlyResourceManager
 	counts     *prometheus.GaugeVec
 	tenants    multitenant.Tenants
-	metric     prometheus.Summary
+	metric     prometheus.Histogram
 }
 
 var _ component.Component = &storeCounter{}
@@ -33,10 +33,9 @@ func NewStoreCounter(resManager manager.ReadOnlyResourceManager, metrics core_me
 		Name: "resources_count",
 	}, []string{"resource_type", "tenant"})
 
-	metric := prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:       "component_store_counter",
-		Help:       "Summary of Store Counter component interval",
-		Objectives: core_metrics.DefaultObjectives,
+	metric := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: "component_store_counter",
+		Help: "Summary of Store Counter component interval",
 	})
 	if err := metrics.BulkRegister(counts, metric); err != nil {
 		return nil, err

--- a/pkg/util/xds/stats_callbacks.go
+++ b/pkg/util/xds/stats_callbacks.go
@@ -10,7 +10,6 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/kumahq/kuma/v2/pkg/core"
-	core_metrics "github.com/kumahq/kuma/v2/pkg/metrics"
 )
 
 var statsLogger = core.Log.WithName("stats-callbacks")
@@ -46,7 +45,7 @@ type statsCallbacks struct {
 	responsesSentMetric    *prometheus.CounterVec
 	requestsReceivedMetric *prometheus.CounterVec
 	versionsMetric         *prometheus.GaugeVec
-	deliveryMetric         prometheus.Summary
+	deliveryMetric         prometheus.Histogram
 	deliveryMetricName     string
 	streamsActive          int
 	configsQueue           map[string]time.Time
@@ -114,10 +113,9 @@ func NewStatsCallbacks(metrics prometheus.Registerer, dsType string, versionExtr
 	}
 
 	stats.deliveryMetricName = dsType + "_delivery"
-	stats.deliveryMetric = prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:       stats.deliveryMetricName,
-		Help:       "Summary of config delivery including a response (ACK/NACK) from the client",
-		Objectives: core_metrics.DefaultObjectives,
+	stats.deliveryMetric = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: stats.deliveryMetricName,
+		Help: "Summary of config delivery including a response (ACK/NACK) from the client",
 	})
 	if err := metrics.Register(stats.deliveryMetric); err != nil {
 		return nil, err

--- a/pkg/util/xds/stats_callbacks_test.go
+++ b/pkg/util/xds/stats_callbacks_test.go
@@ -167,8 +167,8 @@ var _ = Describe("Stats callbacks", func() {
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
-			Expect(test_metrics.FindMetric(metrics, "xds_delivery").GetSummary().GetSampleCount()).To(Equal(uint64(1)))
-			Expect(test_metrics.FindMetric(metrics, "xds_delivery").GetSummary().GetSampleSum()).To(Equal(float64(time.Second.Milliseconds())))
+			Expect(test_metrics.FindMetric(metrics, "xds_delivery").GetHistogram().GetSampleCount()).To(Equal(uint64(1)))
+			Expect(test_metrics.FindMetric(metrics, "xds_delivery").GetHistogram().GetSampleSum()).To(Equal(float64(time.Second.Milliseconds())))
 		})
 
 		It("should not track delivery of configs that were not ready to being delivered", func() {
@@ -181,7 +181,7 @@ var _ = Describe("Stats callbacks", func() {
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
-			Expect(test_metrics.FindMetric(metrics, "xds_delivery").GetSummary().GetSampleCount()).To(Equal(uint64(0)))
+			Expect(test_metrics.FindMetric(metrics, "xds_delivery").GetHistogram().GetSampleCount()).To(Equal(uint64(0)))
 		})
 
 		It("should not track discarded configs", func() {
@@ -198,7 +198,7 @@ var _ = Describe("Stats callbacks", func() {
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
-			Expect(test_metrics.FindMetric(metrics, "xds_delivery").GetSummary().GetSampleCount()).To(Equal(uint64(0)))
+			Expect(test_metrics.FindMetric(metrics, "xds_delivery").GetHistogram().GetSampleCount()).To(Equal(uint64(0)))
 		})
 	})
 
@@ -343,8 +343,8 @@ var _ = Describe("Stats callbacks", func() {
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
-			Expect(test_metrics.FindMetric(metrics, "delta_xds_delivery").GetSummary().GetSampleCount()).To(Equal(uint64(1)))
-			Expect(test_metrics.FindMetric(metrics, "delta_xds_delivery").GetSummary().GetSampleSum()).To(Equal(float64(time.Second.Milliseconds())))
+			Expect(test_metrics.FindMetric(metrics, "delta_xds_delivery").GetHistogram().GetSampleCount()).To(Equal(uint64(1)))
+			Expect(test_metrics.FindMetric(metrics, "delta_xds_delivery").GetHistogram().GetSampleSum()).To(Equal(float64(time.Second.Milliseconds())))
 		})
 	})
 })

--- a/pkg/xds/metrics/metrics.go
+++ b/pkg/xds/metrics/metrics.go
@@ -8,16 +8,15 @@ import (
 )
 
 type Metrics struct {
-	XdsGenerations       *prometheus.SummaryVec
+	XdsGenerations       *prometheus.HistogramVec
 	XdsGenerationsErrors prometheus.Counter
 	KubeAuthCache        *prometheus.CounterVec
 }
 
 func NewMetrics(metrics core_metrics.Metrics) (*Metrics, error) {
-	xdsGenerations := prometheus.NewSummaryVec(prometheus.SummaryOpts{
-		Name:       "xds_generation",
-		Help:       "Summary of XDS Snapshot generation",
-		Objectives: core_metrics.DefaultObjectives,
+	xdsGenerations := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "xds_generation",
+		Help: "Summary of XDS Snapshot generation",
 	}, []string{"proxy_type", "result"})
 	xdsGenerationsErrors := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "xds_generation_errors",

--- a/pkg/xds/secrets/ca_provider.go
+++ b/pkg/xds/secrets/ca_provider.go
@@ -19,10 +19,9 @@ type CaProvider interface {
 }
 
 func NewCaProvider(caManagers core_ca.Managers, metrics core_metrics.Metrics) (CaProvider, error) {
-	latencyMetrics := prometheus.NewSummaryVec(prometheus.SummaryOpts{
-		Name:       "ca_manager_get_root_cert_chain",
-		Help:       "Summary of CA manager get CA root certificate chain latencies",
-		Objectives: core_metrics.DefaultObjectives,
+	latencyMetrics := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "ca_manager_get_root_cert_chain",
+		Help: "Summary of CA manager get CA root certificate chain latencies",
 	}, []string{"backend_name"})
 	if err := metrics.Register(latencyMetrics); err != nil {
 		return nil, err
@@ -35,7 +34,7 @@ func NewCaProvider(caManagers core_ca.Managers, metrics core_metrics.Metrics) (C
 
 type meshCaProvider struct {
 	caManagers     core_ca.Managers
-	latencyMetrics *prometheus.SummaryVec
+	latencyMetrics *prometheus.HistogramVec
 }
 
 // Get retrieves the root CA for a given backend with a default timeout of 10

--- a/pkg/xds/secrets/identity_provider.go
+++ b/pkg/xds/secrets/identity_provider.go
@@ -26,10 +26,9 @@ type IdentityProvider interface {
 }
 
 func NewIdentityProvider(caManagers core_ca.Managers, metrics core_metrics.Metrics) (IdentityProvider, error) {
-	latencyMetrics := prometheus.NewSummaryVec(prometheus.SummaryOpts{
-		Name:       "ca_manager_get_cert",
-		Help:       "Summary of CA manager get certificate latencies",
-		Objectives: core_metrics.DefaultObjectives,
+	latencyMetrics := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "ca_manager_get_cert",
+		Help: "Summary of CA manager get certificate latencies",
 	}, []string{"backend_name"})
 	if err := metrics.Register(latencyMetrics); err != nil {
 		return nil, err
@@ -42,7 +41,7 @@ func NewIdentityProvider(caManagers core_ca.Managers, metrics core_metrics.Metri
 
 type identityCertProvider struct {
 	caManagers     core_ca.Managers
-	latencyMetrics *prometheus.SummaryVec
+	latencyMetrics *prometheus.HistogramVec
 }
 
 func (s *identityCertProvider) Get(ctx context.Context, requestor Identity, mesh *core_mesh.MeshResource) (*core_xds.IdentitySecret, string, error) {

--- a/pkg/xds/secrets/secrets_test.go
+++ b/pkg/xds/secrets/secrets_test.go
@@ -179,7 +179,7 @@ var _ = Describe("Secrets", Ordered, func() {
 
 			// and metric is published
 			Expect(test_metrics.FindMetric(metrics, "cert_generation").GetCounter().GetValue()).To(Equal(1.0))
-			Expect(test_metrics.FindMetric(metrics, "ca_manager_get_cert", "backend_name", "ca-1").GetSummary().GetSampleCount()).To(Equal(uint64(1)))
+			Expect(test_metrics.FindMetric(metrics, "ca_manager_get_cert", "backend_name", "ca-1").GetHistogram().GetSampleCount()).To(Equal(uint64(1)))
 		})
 
 		It("should not regenerate certs if nothing has changed", func() {
@@ -197,7 +197,7 @@ var _ = Describe("Secrets", Ordered, func() {
 			Expect(newCa).To(HaveLen(1))
 			Expect(cas["default"]).To(Equal(newCa["default"]))
 			Expect(test_metrics.FindMetric(metrics, "cert_generation").GetCounter().GetValue()).To(Equal(1.0))
-			Expect(test_metrics.FindMetric(metrics, "ca_manager_get_cert", "backend_name", "ca-1").GetSummary().GetSampleCount()).To(Equal(uint64(1)))
+			Expect(test_metrics.FindMetric(metrics, "ca_manager_get_cert", "backend_name", "ca-1").GetHistogram().GetSampleCount()).To(Equal(uint64(1)))
 		})
 
 		Context("should regenerate certificate", func() {
@@ -241,7 +241,7 @@ var _ = Describe("Secrets", Ordered, func() {
 				// then
 				Expect(err).ToNot(HaveOccurred())
 				Expect(test_metrics.FindMetric(metrics, "cert_generation").GetCounter().GetValue()).To(Equal(2.0))
-				Expect(test_metrics.FindMetric(metrics, "ca_manager_get_cert", "backend_name", "ca-2").GetSummary().GetSampleCount()).To(Equal(uint64(1)))
+				Expect(test_metrics.FindMetric(metrics, "ca_manager_get_cert", "backend_name", "ca-2").GetHistogram().GetSampleCount()).To(Equal(uint64(1)))
 			})
 
 			It("when dp tags has changed", func() {
@@ -255,7 +255,7 @@ var _ = Describe("Secrets", Ordered, func() {
 				// then
 				Expect(err).ToNot(HaveOccurred())
 				Expect(test_metrics.FindMetric(metrics, "cert_generation").GetCounter().GetValue()).To(Equal(2.0))
-				Expect(test_metrics.FindMetric(metrics, "ca_manager_get_cert", "backend_name", "ca-1").GetSummary().GetSampleCount()).To(Equal(uint64(2)))
+				Expect(test_metrics.FindMetric(metrics, "ca_manager_get_cert", "backend_name", "ca-1").GetHistogram().GetSampleCount()).To(Equal(uint64(2)))
 			})
 
 			It("when cert is expiring", func() {
@@ -268,7 +268,7 @@ var _ = Describe("Secrets", Ordered, func() {
 				// then
 				Expect(err).ToNot(HaveOccurred())
 				Expect(test_metrics.FindMetric(metrics, "cert_generation").GetCounter().GetValue()).To(Equal(2.0))
-				Expect(test_metrics.FindMetric(metrics, "ca_manager_get_cert", "backend_name", "ca-1").GetSummary().GetSampleCount()).To(Equal(uint64(2)))
+				Expect(test_metrics.FindMetric(metrics, "ca_manager_get_cert", "backend_name", "ca-1").GetHistogram().GetSampleCount()).To(Equal(uint64(2)))
 			})
 
 			It("when cert was cleaned up", func() {
@@ -281,7 +281,7 @@ var _ = Describe("Secrets", Ordered, func() {
 				// then
 				Expect(err).ToNot(HaveOccurred())
 				Expect(test_metrics.FindMetric(metrics, "cert_generation").GetCounter().GetValue()).To(Equal(2.0))
-				Expect(test_metrics.FindMetric(metrics, "ca_manager_get_cert", "backend_name", "ca-1").GetSummary().GetSampleCount()).To(Equal(uint64(2)))
+				Expect(test_metrics.FindMetric(metrics, "ca_manager_get_cert", "backend_name", "ca-1").GetHistogram().GetSampleCount()).To(Equal(uint64(2)))
 			})
 		})
 
@@ -322,7 +322,7 @@ var _ = Describe("Secrets", Ordered, func() {
 
 			// and metric is published
 			Expect(test_metrics.FindMetric(metrics, "cert_generation").GetCounter().GetValue()).To(Equal(1.0))
-			Expect(test_metrics.FindMetric(metrics, "ca_manager_get_cert", "backend_name", "ca-1").GetSummary().GetSampleCount()).To(Equal(uint64(1)))
+			Expect(test_metrics.FindMetric(metrics, "ca_manager_get_cert", "backend_name", "ca-1").GetHistogram().GetSampleCount()).To(Equal(uint64(1)))
 		})
 
 		It("should not regenerate certs if nothing has changed", func() {
@@ -338,7 +338,7 @@ var _ = Describe("Secrets", Ordered, func() {
 			Expect(identity).To(Equal(newIdentity))
 			Expect(ca).To(Equal(newCa))
 			Expect(test_metrics.FindMetric(metrics, "cert_generation").GetCounter().GetValue()).To(Equal(1.0))
-			Expect(test_metrics.FindMetric(metrics, "ca_manager_get_cert", "backend_name", "ca-1").GetSummary().GetSampleCount()).To(Equal(uint64(1)))
+			Expect(test_metrics.FindMetric(metrics, "ca_manager_get_cert", "backend_name", "ca-1").GetHistogram().GetSampleCount()).To(Equal(uint64(1)))
 		})
 
 		Context("should regenerate certificate", func() {
@@ -358,7 +358,7 @@ var _ = Describe("Secrets", Ordered, func() {
 				// then
 				Expect(err).ToNot(HaveOccurred())
 				Expect(test_metrics.FindMetric(metrics, "cert_generation").GetCounter().GetValue()).To(Equal(2.0))
-				Expect(test_metrics.FindMetric(metrics, "ca_manager_get_cert", "backend_name", "ca-2").GetSummary().GetSampleCount()).To(Equal(uint64(1)))
+				Expect(test_metrics.FindMetric(metrics, "ca_manager_get_cert", "backend_name", "ca-2").GetHistogram().GetSampleCount()).To(Equal(uint64(1)))
 			})
 
 			It("when cert is expiring", func() {
@@ -371,7 +371,7 @@ var _ = Describe("Secrets", Ordered, func() {
 				// then
 				Expect(err).ToNot(HaveOccurred())
 				Expect(test_metrics.FindMetric(metrics, "cert_generation").GetCounter().GetValue()).To(Equal(2.0))
-				Expect(test_metrics.FindMetric(metrics, "ca_manager_get_cert", "backend_name", "ca-1").GetSummary().GetSampleCount()).To(Equal(uint64(2)))
+				Expect(test_metrics.FindMetric(metrics, "ca_manager_get_cert", "backend_name", "ca-1").GetHistogram().GetSampleCount()).To(Equal(uint64(2)))
 			})
 
 			It("when cert was cleaned up", func() {
@@ -384,7 +384,7 @@ var _ = Describe("Secrets", Ordered, func() {
 				// then
 				Expect(err).ToNot(HaveOccurred())
 				Expect(test_metrics.FindMetric(metrics, "cert_generation").GetCounter().GetValue()).To(Equal(2.0))
-				Expect(test_metrics.FindMetric(metrics, "ca_manager_get_cert", "backend_name", "ca-1").GetSummary().GetSampleCount()).To(Equal(uint64(2)))
+				Expect(test_metrics.FindMetric(metrics, "ca_manager_get_cert", "backend_name", "ca-1").GetHistogram().GetSampleCount()).To(Equal(uint64(2)))
 			})
 		})
 

--- a/pkg/zone/available_services.go
+++ b/pkg/zone/available_services.go
@@ -21,7 +21,7 @@ import (
 
 type ZoneAvailableServicesTracker struct {
 	logger            logr.Logger
-	metric            prometheus.Summary
+	metric            prometheus.Histogram
 	resManager        manager.ResourceManager
 	meshCache         *mesh.Cache
 	interval          time.Duration
@@ -38,10 +38,9 @@ func NewZoneAvailableServicesTracker(
 	ingressTagFilters []string,
 	zone string,
 ) (*ZoneAvailableServicesTracker, error) {
-	metric := prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:       "component_zone_available_services",
-		Help:       "Summary of available services tracker component interval",
-		Objectives: core_metrics.DefaultObjectives,
+	metric := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: "component_zone_available_services",
+		Help: "Summary of available services tracker component interval",
 	})
 	if err := metrics.Register(metric); err != nil {
 		return nil, err


### PR DESCRIPTION
## Motivation

Prometheus `Summary` metrics retain values over long windows, making observability data go stale. Switching to `Histogram` types fixes this and produces more responsive metric updates.

## Changes

- Migrated all `prometheus.Summary` and `prometheus.SummaryVec` metrics in `pkg/` and `app/` to `prometheus.Histogram` and `prometheus.HistogramVec`.
- Updated unit tests that called `GetSummary()` to use `GetHistogram()`.
- Removed summary-specific `DefaultObjectives`; histograms use `prometheus.DefBuckets` by default.
- Documented the breaking change in metric structure (quantiles vs buckets) in `UPGRADE.md` for `2.14.x`.

## Supporting documentation

Fixes https://github.com/kumahq/kuma/issues/7816

> Changelog: feat(kuma-cp): improve control-plane observability with dashboards, histograms, and operational metrics
