### PR TITLE
feat(metrics): deprecate metrics pod annotations

### DIFF
--- a/pkg/plugins/runtime/k8s/metadata/annotations.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations.go
@@ -158,6 +158,14 @@ var PodAnnotationDeprecations = []Deprecation{
 		Key:     KumaSidecarInjectionAnnotation,
 		Message: "WARNING: you are using kuma.io/sidecar-injection as annotation. This is not supported you should use it as a label instead",
 	},
+	{
+		Key:     KumaMetricsPrometheusPort,
+		Message: "WARNING: 'prometheus.metrics.kuma.io/port' is deprecated, use MeshMetric policy instead",
+	},
+	{
+		Key:     KumaMetricsPrometheusPath,
+		Message: "WARNING: 'prometheus.metrics.kuma.io/path' is deprecated, use MeshMetric policy instead",
+	},
 }
 
 type Deprecation struct {


### PR DESCRIPTION
## Motivation

Deprecate `prometheus.metrics.kuma.io/port`, `prometheus.metrics.kuma.io/path`, and all `prometheus.metrics.kuma.io/aggregate-*` pod annotations in favor of the `MeshMetric` policy. Annotations remain functional - deprecation warnings are logged when present.

Closes #9198.

## Implementation information

- Added `KumaMetricsPrometheusPort` and `KumaMetricsPrometheusPath` to `PodAnnotationDeprecations` in `metadata/annotations.go`
- Added `logMetricsAggregateDeprecations` in `precheck.go` using a regex to detect `prometheus.metrics.kuma.io/aggregate-*` annotations and log warnings
- Called from `preCheck` after existing `logYesNoDeprecations`
- Tests added for both fixed-key and aggregate pattern deprecations

> Changelog: feat(metrics): deprecate metrics pod annotations