### PR TITLE
feat(kds): add zone_name to kds metric

### DIFF
--- a/pkg/kds/v2/server/components.go
+++ b/pkg/kds/v2/server/components.go
@@ -137,7 +137,7 @@ func newSyncTracker(
 					if changed {
 						result = ResultChanged
 					}
-					kdsMetrics.KdsGenerations.WithLabelValues(ReasonResync, result).
+					kdsMetrics.KdsGenerations.WithLabelValues(ReasonResync, result, node.Id).
 						Observe(float64(core.Now().Sub(start).Milliseconds()))
 				}
 				return err

--- a/pkg/kds/v2/server/event_based_watchdog.go
+++ b/pkg/kds/v2/server/event_based_watchdog.go
@@ -79,7 +79,7 @@ func (e *EventBasedWatchdog) Start(ctx context.Context) {
 				// we want to combine reason. One of the reasons we introduce this metric is to check if we need full resync
 				// If we just keep a single reason, we might get into races where full resync ticker runs,
 				// then listener, and we would lose information what triggered flush.
-				e.Metrics.KdsGenerations.WithLabelValues(reason, result).Observe(float64(core.Now().Sub(start).Milliseconds()))
+				e.Metrics.KdsGenerations.WithLabelValues(reason, result, e.Node.Id).Observe(float64(core.Now().Sub(start).Milliseconds()))
 				changedTypes = map[model.ResourceType]struct{}{}
 				reasons = map[string]struct{}{}
 			}

--- a/pkg/kds/v2/server/event_based_watchdog_test.go
+++ b/pkg/kds/v2/server/event_based_watchdog_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Event Based Watchdog", func() {
 		changedResTypes := <-reconciler.changedResTypes
 		Expect(changedResTypes).To(Equal(watchdog.ProvidedTypes))
 		Eventually(func(g Gomega) {
-			metric := test_metrics.FindMetric(metrics, "kds_delta_generation", "reason", ReasonResync)
+			metric := test_metrics.FindMetric(metrics, "kds_delta_generation", "reason", ReasonResync, "zone_name", "1")
 			g.Expect(metric).ToNot(BeNil())
 			g.Expect(*metric.Histogram.SampleCount).To(BeEquivalentTo(1))
 		}, "10s", "50ms").Should(Succeed())
@@ -130,7 +130,7 @@ var _ = Describe("Event Based Watchdog", func() {
 		Expect(changedResTypes).To(HaveKey(mesh.TrafficPermissionType))
 		Expect(changedResTypes).To(HaveKey(mesh.TrafficLogType))
 		Eventually(func(g Gomega) {
-			metric := test_metrics.FindMetric(metrics, "kds_delta_generation", "reason", ReasonEvent)
+			metric := test_metrics.FindMetric(metrics, "kds_delta_generation", "reason", ReasonEvent, "zone_name", "1")
 			g.Expect(metric).ToNot(BeNil())
 			g.Expect(*metric.Histogram.SampleCount).To(BeEquivalentTo(1))
 		}, "10s", "50ms").Should(Succeed())
@@ -145,7 +145,7 @@ var _ = Describe("Event Based Watchdog", func() {
 		changedResTypes := <-reconciler.changedResTypes
 		Expect(changedResTypes).To(Equal(watchdog.ProvidedTypes))
 		Eventually(func(g Gomega) {
-			metric := test_metrics.FindMetric(metrics, "kds_delta_generation", "reason", ReasonResync)
+			metric := test_metrics.FindMetric(metrics, "kds_delta_generation", "reason", ReasonResync, "zone_name", "1")
 			g.Expect(metric).ToNot(BeNil())
 			g.Expect(*metric.Histogram.SampleCount).To(BeEquivalentTo(2))
 		}, "10s", "50ms").Should(Succeed())

--- a/pkg/kds/v2/server/metrics.go
+++ b/pkg/kds/v2/server/metrics.go
@@ -22,7 +22,7 @@ func NewMetrics(metrics core_metrics.Metrics) (*Metrics, error) {
 	kdsGenerations := prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "kds_delta_generation",
 		Help: "Summary of KDS Snapshot generation",
-	}, []string{"reason", "result"})
+	}, []string{"reason", "result", "zone_name"})
 
 	kdsGenerationsErrors := prometheus.NewCounter(prometheus.CounterOpts{
 		Help: "Counter of errors during KDS generation",


### PR DESCRIPTION
## Motivation

Multi-Zone Grafana dashboard (MADR-096) requires per-zone breakdown of KDS metrics. Currently `kds_delta_generation` on Global CP has labels `["reason", "result"]` only — no way to query sync status per zone.

## Implementation information

Added `zone_name` label to `kds_delta_generation` HistogramVec, populated from `node.Id` in both watchdog paths (event-based and simple). Zone name is already available via `node.Id` in both call sites.

Note: `prometheus.WrapRegistererWith` already adds a constant `zone="Global"` label on Global CP. The new `zone_name` carries the remote zone name (different per stream), avoiding collision.

## Supporting documentation

> Changelog: feat(kuma-cp): improve control-plane observability with dashboards, histograms, and operational metrics
