### PR TITLE
feat(observability): grafana dashboards scaffold

### DIFF
--- a/dashboards/grafana/README.md
+++ b/dashboards/grafana/README.md
@@ -1,0 +1,9 @@
+# Grafana Dashboards
+
+Grafana dashboard definitions (JSON) for Kuma.
+
+Dashboards placed here are automatically included in release tarballs
+under `kuma-VERSION/dashboards/grafana/`.
+
+See [MADR-096](../../docs/madr/decisions/096-grafana-dashboards.md) for
+the decision record.

--- a/mk/distribution.mk
+++ b/mk/distribution.mk
@@ -31,6 +31,8 @@ build/distributions/$(1)-$(2)/$(DISTRIBUTION_TARGET_NAME): build/artifacts-$(1)-
 	command cp build/artifacts-$(1)-$(2)/kuma-dp/kuma-dp $$@/bin
 	command cp $(DISTRIBUTION_LICENSE_PATH)/* $$@
 	command cp $(DISTRIBUTION_CONFIG_PATH) $$@/conf
+	mkdir -p $$@/dashboards/grafana
+	$(if $(wildcard dashboards/grafana/*.json),command cp dashboards/grafana/*.json $$@/dashboards/grafana/)
 # CoreDNS is not included when the value is `skip` otherwise it's used as the COREDNS_EXT (which is most commonly just coredns)
 ifneq ($(3),skip)
 	$(MAKE) build/artifacts-$(1)-$(2)/coredns COREDNS_EXT=$(subst coredns,,$(3))

--- a/mk/distribution.mk
+++ b/mk/distribution.mk
@@ -31,8 +31,7 @@ build/distributions/$(1)-$(2)/$(DISTRIBUTION_TARGET_NAME): build/artifacts-$(1)-
 	command cp build/artifacts-$(1)-$(2)/kuma-dp/kuma-dp $$@/bin
 	command cp $(DISTRIBUTION_LICENSE_PATH)/* $$@
 	command cp $(DISTRIBUTION_CONFIG_PATH) $$@/conf
-	mkdir -p $$@/dashboards
-	command cp -r dashboards/grafana $$@/dashboards/
+	command cp -r dashboards $$@/
 # CoreDNS is not included when the value is `skip` otherwise it's used as the COREDNS_EXT (which is most commonly just coredns)
 ifneq ($(3),skip)
 	$(MAKE) build/artifacts-$(1)-$(2)/coredns COREDNS_EXT=$(subst coredns,,$(3))

--- a/mk/distribution.mk
+++ b/mk/distribution.mk
@@ -31,8 +31,8 @@ build/distributions/$(1)-$(2)/$(DISTRIBUTION_TARGET_NAME): build/artifacts-$(1)-
 	command cp build/artifacts-$(1)-$(2)/kuma-dp/kuma-dp $$@/bin
 	command cp $(DISTRIBUTION_LICENSE_PATH)/* $$@
 	command cp $(DISTRIBUTION_CONFIG_PATH) $$@/conf
-	mkdir -p $$@/dashboards/grafana
-	$(if $(wildcard dashboards/grafana/*.json),command cp dashboards/grafana/*.json $$@/dashboards/grafana/)
+	mkdir -p $$@/dashboards
+	command cp -r dashboards/grafana $$@/dashboards/
 # CoreDNS is not included when the value is `skip` otherwise it's used as the COREDNS_EXT (which is most commonly just coredns)
 ifneq ($(3),skip)
 	$(MAKE) build/artifacts-$(1)-$(2)/coredns COREDNS_EXT=$(subst coredns,,$(3))


### PR DESCRIPTION
## Motivation

Create the `dashboards/grafana/` directory scaffold required by MADR-096, which mandates Grafana dashboards live at `dashboards/grafana/` in the repo root and ship in release tarballs.

## Implementation information

- Added `dashboards/grafana/README.md` to establish the directory in git
- Updated `mk/distribution.mk` to copy the `dashboards/` tree into release tarballs via `cp -r dashboards $$@/`

## Supporting documentation

Closes #15712

> Changelog: feat(kuma-cp): improve control-plane observability with dashboards, histograms, and operational metrics
