### PR TITLE
chore(deps): bump kumahq/ci-tools from v1.4.4 to v1.4.5

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ env:
   EDITION: kuma
   MIN_VERSION: "2.2.0"
   # renovate: datasource=go depName=ci-tools/release-tool packageName=github.com/kumahq/ci-tools versioning=semver
-  RELEASE_TOOL_VERSION: "v1.4.4"
+  RELEASE_TOOL_VERSION: "v1.4.5"
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
## Motivation

We should have a default LTS 24months and use a comment to extend specific release

## Implementation information

Bump version with default to 24 months