### PR TITLE
chore(kuma-dp): remove advertised address from dataplane object

### DIFF
--- a/api/mesh/v1alpha1/dataplane.pb.go
+++ b/api/mesh/v1alpha1/dataplane.pb.go
@@ -274,14 +274,6 @@ type Dataplane_Networking struct {
 	// other data plane proxies in the same network. This can also be a
 	// hostname, in which case the control plane will periodically resolve it.
 	Address string `protobuf:"bytes,5,opt,name=address,proto3" json:"address,omitempty"`
-	// In some situations, a data plane proxy resides in a private network (e.g.
-	// Docker) and is not reachable via `address` to other data plane proxies.
-	// `advertisedAddress` is configured with a routable address for such data
-	// plane proxy so that other proxies in the mesh can connect to it over
-	// `advertisedAddress` and not via address.
-	//
-	// Envoy still binds to the `address`, not `advertisedAddress`.
-	AdvertisedAddress string `protobuf:"bytes,7,opt,name=advertisedAddress,proto3" json:"advertisedAddress,omitempty"`
 	// Gateway describes a configuration of the gateway of the data plane proxy.
 	Gateway *Dataplane_Networking_Gateway `protobuf:"bytes,3,opt,name=gateway,proto3" json:"gateway,omitempty"`
 	// Inbound describes a list of inbound interfaces of the data plane proxy.
@@ -342,13 +334,6 @@ func (*Dataplane_Networking) Descriptor() ([]byte, []int) {
 func (x *Dataplane_Networking) GetAddress() string {
 	if x != nil {
 		return x.Address
-	}
-	return ""
-}
-
-func (x *Dataplane_Networking) GetAdvertisedAddress() string {
-	if x != nil {
-		return x.AdvertisedAddress
 	}
 	return ""
 }
@@ -1299,17 +1284,16 @@ var File_api_mesh_v1alpha1_dataplane_proto protoreflect.FileDescriptor
 
 const file_api_mesh_v1alpha1_dataplane_proto_rawDesc = "" +
 	"\n" +
-	"!api/mesh/v1alpha1/dataplane.proto\x12\x12kuma.mesh.v1alpha1\x1a\x16api/mesh/options.proto\x1a#api/mesh/v1alpha1/envoy_admin.proto\x1a\x1fapi/mesh/v1alpha1/metrics.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a\x17validate/validate.proto\"\x99#\n" +
+	"!api/mesh/v1alpha1/dataplane.proto\x12\x12kuma.mesh.v1alpha1\x1a\x16api/mesh/options.proto\x1a#api/mesh/v1alpha1/envoy_admin.proto\x1a\x1fapi/mesh/v1alpha1/metrics.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a\x17validate/validate.proto\"\xf1\"\n" +
 	"\tDataplane\x12H\n" +
 	"\n" +
 	"networking\x18\x01 \x01(\v2(.kuma.mesh.v1alpha1.Dataplane.NetworkingR\n" +
 	"networking\x12<\n" +
 	"\ametrics\x18\x02 \x01(\v2\".kuma.mesh.v1alpha1.MetricsBackendR\ametrics\x12<\n" +
-	"\x06probes\x18\x03 \x01(\v2$.kuma.mesh.v1alpha1.Dataplane.ProbesR\x06probes\x1a\xa7\x1a\n" +
+	"\x06probes\x18\x03 \x01(\v2$.kuma.mesh.v1alpha1.Dataplane.ProbesR\x06probes\x1a\xff\x19\n" +
 	"\n" +
 	"Networking\x12\x18\n" +
-	"\aaddress\x18\x05 \x01(\tR\aaddress\x12,\n" +
-	"\x11advertisedAddress\x18\a \x01(\tR\x11advertisedAddress\x12J\n" +
+	"\aaddress\x18\x05 \x01(\tR\aaddress\x12J\n" +
 	"\agateway\x18\x03 \x01(\v20.kuma.mesh.v1alpha1.Dataplane.Networking.GatewayR\agateway\x12J\n" +
 	"\ainbound\x18\x01 \x03(\v20.kuma.mesh.v1alpha1.Dataplane.Networking.InboundR\ainbound\x12M\n" +
 	"\boutbound\x18\x02 \x03(\v21.kuma.mesh.v1alpha1.Dataplane.Networking.OutboundR\boutbound\x12o\n" +
@@ -1393,7 +1377,7 @@ const file_api_mesh_v1alpha1_dataplane_proto_rawDesc = "" +
 	"\vUnSpecified\x10\x00\x12\r\n" +
 	"\tDualStack\x10\x01\x12\b\n" +
 	"\x04IPv4\x10\x02\x12\b\n" +
-	"\x04IPv6\x10\x03J\x04\b\x04\x10\x05R\x18redirect_port_inbound_v6J\x04\b\x06\x10\a\x1a\xcf\x01\n" +
+	"\x04IPv6\x10\x03J\x04\b\x04\x10\x05R\x18redirect_port_inbound_v6J\x04\b\x06\x10\aJ\x04\b\a\x10\b\x1a\xcf\x01\n" +
 	"\x06Probes\x12\x12\n" +
 	"\x04port\x18\x01 \x01(\rR\x04port\x12K\n" +
 	"\tendpoints\x18\x02 \x03(\v2-.kuma.mesh.v1alpha1.Dataplane.Probes.EndpointR\tendpoints\x1ad\n" +

--- a/api/mesh/v1alpha1/dataplane.proto
+++ b/api/mesh/v1alpha1/dataplane.proto
@@ -48,14 +48,7 @@ message Dataplane {
 
     reserved 6; // Formerly ingress mode message, see #3435
 
-    // In some situations, a data plane proxy resides in a private network (e.g.
-    // Docker) and is not reachable via `address` to other data plane proxies.
-    // `advertisedAddress` is configured with a routable address for such data
-    // plane proxy so that other proxies in the mesh can connect to it over
-    // `advertisedAddress` and not via address.
-    //
-    // Envoy still binds to the `address`, not `advertisedAddress`.
-    string advertisedAddress = 7;
+    reserved 7; // Formerly advertisedAddress, see #15629
 
     // Inbound describes a service implemented by the data plane proxy.
     // All incoming traffic to a data plane proxy are going through inbound

--- a/api/mesh/v1alpha1/dataplane/rest.yaml
+++ b/api/mesh/v1alpha1/dataplane/rest.yaml
@@ -99,16 +99,6 @@ components:
                   description: Port on which Envoy Admin API server will be listening
                   type: integer
               type: object
-            advertisedAddress:
-              description: |-
-                In some situations, a data plane proxy resides in a private network (e.g.
-                Docker) and is not reachable via `address` to other data plane proxies.
-                `advertisedAddress` is configured with a routable address for such data
-                plane proxy so that other proxies in the mesh can connect to it over
-                `advertisedAddress` and not via address.
-
-                Envoy still binds to the `address`, not `advertisedAddress`.
-              type: string
             gateway:
               description: Gateway describes a configuration of the gateway of the
                 data plane proxy.

--- a/api/mesh/v1alpha1/dataplane_helpers.go
+++ b/api/mesh/v1alpha1/dataplane_helpers.go
@@ -173,12 +173,11 @@ func (t ProxyType) IsValid() error {
 }
 
 type InboundInterface struct {
-	DataplaneAdvertisedIP string
-	DataplaneIP           string
-	DataplanePort         uint32
-	WorkloadIP            string
-	WorkloadPort          uint32
-	InboundName           string
+	DataplaneIP   string
+	DataplanePort uint32
+	WorkloadIP    string
+	WorkloadPort  uint32
+	InboundName   string
 }
 
 // We need to implement TextMarshaler because InboundInterface is used
@@ -316,11 +315,6 @@ func (n *Dataplane_Networking) ToInboundInterface(inbound *Dataplane_Networking_
 		iface.DataplaneIP = inbound.Address
 	} else {
 		iface.DataplaneIP = n.Address
-	}
-	if n.AdvertisedAddress != "" {
-		iface.DataplaneAdvertisedIP = n.AdvertisedAddress
-	} else {
-		iface.DataplaneAdvertisedIP = iface.DataplaneIP
 	}
 	if inbound.ServiceAddress != "" {
 		iface.WorkloadIP = inbound.ServiceAddress

--- a/api/mesh/v1alpha1/dataplane_helpers_test.go
+++ b/api/mesh/v1alpha1/dataplane_helpers_test.go
@@ -131,8 +131,8 @@ var _ = Describe("Dataplane_Networking", func() {
 						},
 					},
 					expected: []InboundInterface{
-						{DataplaneAdvertisedIP: "192.168.0.1", DataplaneIP: "192.168.0.1", DataplanePort: 80, WorkloadIP: "192.168.0.1", WorkloadPort: 80, InboundName: "test-port"},
-						{DataplaneAdvertisedIP: "192.168.0.2", DataplaneIP: "192.168.0.2", DataplanePort: 443, WorkloadIP: "192.168.0.3", WorkloadPort: 8443, InboundName: "443"},
+						{DataplaneIP: "192.168.0.1", DataplanePort: 80, WorkloadIP: "192.168.0.1", WorkloadPort: 80, InboundName: "test-port"},
+						{DataplaneIP: "192.168.0.2", DataplanePort: 443, WorkloadIP: "192.168.0.3", WorkloadPort: 8443, InboundName: "443"},
 					},
 				}),
 			)

--- a/api/mesh/v1alpha1/dataplaneoverview/schema.yaml
+++ b/api/mesh/v1alpha1/dataplaneoverview/schema.yaml
@@ -49,16 +49,6 @@ components:
                       description: Port on which Envoy Admin API server will be listening
                       type: integer
                   type: object
-                advertisedAddress:
-                  description: |-
-                    In some situations, a data plane proxy resides in a private network (e.g.
-                    Docker) and is not reachable via `address` to other data plane proxies.
-                    `advertisedAddress` is configured with a routable address for such data
-                    plane proxy so that other proxies in the mesh can connect to it over
-                    `advertisedAddress` and not via address.
-
-                    Envoy still binds to the `address`, not `advertisedAddress`.
-                  type: string
                 gateway:
                   description: Gateway describes a configuration of the gateway of
                     the data plane proxy.

--- a/app/kumactl/cmd/get/table_printer.go
+++ b/app/kumactl/cmd/get/table_printer.go
@@ -16,10 +16,7 @@ var CustomTablePrinters = map[model.ResourceType]RowPrinter{
 		Headers: []string{"MESH", "NAME", "TAGS", "ADDRESS", "AGE"},
 		RowFn: func(rootTime time.Time, item model.Resource) []string {
 			dataplane := item.(*mesh.DataplaneResource)
-			address := dataplane.Spec.GetNetworking().GetAdvertisedAddress()
-			if address == "" {
-				address = dataplane.Spec.GetNetworking().GetAddress()
-			}
+			address := dataplane.Spec.GetNetworking().GetAddress()
 			return []string{
 				dataplane.Meta.GetMesh(),         // MESH
 				dataplane.Meta.GetName(),         // NAME,

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -5265,25 +5265,6 @@ components:
                   description: Port on which Envoy Admin API server will be listening
                   type: integer
               type: object
-            advertisedAddress:
-              description: >-
-                In some situations, a data plane proxy resides in a private
-                network (e.g.
-
-                Docker) and is not reachable via `address` to other data plane
-                proxies.
-
-                `advertisedAddress` is configured with a routable address for
-                such data
-
-                plane proxy so that other proxies in the mesh can connect to it
-                over
-
-                `advertisedAddress` and not via address.
-
-
-                Envoy still binds to the `address`, not `advertisedAddress`.
-              type: string
             gateway:
               description: >-
                 Gateway describes a configuration of the gateway of the data
@@ -16672,25 +16653,6 @@ components:
                       description: Port on which Envoy Admin API server will be listening
                       type: integer
                   type: object
-                advertisedAddress:
-                  description: >-
-                    In some situations, a data plane proxy resides in a private
-                    network (e.g.
-
-                    Docker) and is not reachable via `address` to other data
-                    plane proxies.
-
-                    `advertisedAddress` is configured with a routable address
-                    for such data
-
-                    plane proxy so that other proxies in the mesh can connect to
-                    it over
-
-                    `advertisedAddress` and not via address.
-
-
-                    Envoy still binds to the `address`, not `advertisedAddress`.
-                  type: string
                 gateway:
                   description: >-
                     Gateway describes a configuration of the gateway of the data

--- a/docs/generated/raw/protos/Dataplane.json
+++ b/docs/generated/raw/protos/Dataplane.json
@@ -31,10 +31,6 @@
                     "type": "string",
                     "description": "IP on which the data plane proxy is accessible to the control plane and other data plane proxies in the same network. This can also be a hostname, in which case the control plane will periodically resolve it."
                 },
-                "advertisedAddress": {
-                    "type": "string",
-                    "description": "In some situations, a data plane proxy resides in a private network (e.g. Docker) and is not reachable via `address` to other data plane proxies. `advertisedAddress` is configured with a routable address for such data plane proxy so that other proxies in the mesh can connect to it over `advertisedAddress` and not via address. Envoy still binds to the `address`, not `advertisedAddress`."
-                },
                 "gateway": {
                     "$ref": "#/definitions/kuma.mesh.v1alpha1.Dataplane.Networking.Gateway",
                     "additionalProperties": true,

--- a/docs/generated/raw/protos/DataplaneOverview.json
+++ b/docs/generated/raw/protos/DataplaneOverview.json
@@ -47,10 +47,6 @@
                     "type": "string",
                     "description": "IP on which the data plane proxy is accessible to the control plane and other data plane proxies in the same network. This can also be a hostname, in which case the control plane will periodically resolve it."
                 },
-                "advertisedAddress": {
-                    "type": "string",
-                    "description": "In some situations, a data plane proxy resides in a private network (e.g. Docker) and is not reachable via `address` to other data plane proxies. `advertisedAddress` is configured with a routable address for such data plane proxy so that other proxies in the mesh can connect to it over `advertisedAddress` and not via address. Envoy still binds to the `address`, not `advertisedAddress`."
-                },
                 "gateway": {
                     "$ref": "#/definitions/kuma.mesh.v1alpha1.Dataplane.Networking.Gateway",
                     "additionalProperties": true,

--- a/pkg/core/permissions/matcher_test.go
+++ b/pkg/core/permissions/matcher_test.go
@@ -172,8 +172,8 @@ var _ = Describe("Match", func() {
 				},
 			},
 			expected: map[mesh_proto.InboundInterface]string{
-				{DataplaneAdvertisedIP: "192.168.0.1", DataplaneIP: "192.168.0.1", WorkloadIP: "192.168.0.1", WorkloadPort: 8081, DataplanePort: 8080, InboundName: "8080"}: "more-specific-kong-to-web",
-				{DataplaneAdvertisedIP: "192.168.0.1", DataplaneIP: "192.168.0.1", WorkloadIP: "192.168.0.1", WorkloadPort: 1234, DataplanePort: 1234, InboundName: "1234"}: "metrics",
+				{DataplaneIP: "192.168.0.1", WorkloadIP: "192.168.0.1", WorkloadPort: 8081, DataplanePort: 8080, InboundName: "8080"}: "more-specific-kong-to-web",
+				{DataplaneIP: "192.168.0.1", WorkloadIP: "192.168.0.1", WorkloadPort: 1234, DataplanePort: 1234, InboundName: "1234"}: "metrics",
 			},
 		}),
 	)

--- a/pkg/core/resources/apis/mesh/dataplane_helpers.go
+++ b/pkg/core/resources/apis/mesh/dataplane_helpers.go
@@ -112,11 +112,7 @@ func (d *DataplaneResource) GetIP() string {
 	if d == nil {
 		return ""
 	}
-	if d.Spec.Networking.AdvertisedAddress != "" {
-		return d.Spec.Networking.AdvertisedAddress
-	} else {
-		return d.Spec.Networking.Address
-	}
+	return d.Spec.Networking.Address
 }
 
 func (d *DataplaneResource) IsIPv6() bool {
@@ -172,7 +168,6 @@ func (d *DataplaneResource) Hash() []byte {
 	hasher := fnv.New128a()
 	_, _ = hasher.Write(core_model.HashMeta(d))
 	_, _ = hasher.Write([]byte(d.Spec.GetNetworking().GetAddress()))
-	_, _ = hasher.Write([]byte(d.Spec.GetNetworking().GetAdvertisedAddress()))
 	return hasher.Sum(nil)
 }
 

--- a/pkg/core/xds/inspect/attachments_test.go
+++ b/pkg/core/xds/inspect/attachments_test.go
@@ -17,12 +17,11 @@ import (
 
 func inbound(ip string, dpPort, workloadPort uint32) mesh_proto.InboundInterface {
 	return mesh_proto.InboundInterface{
-		DataplaneAdvertisedIP: ip,
-		DataplaneIP:           ip,
-		DataplanePort:         dpPort,
-		WorkloadIP:            ip,
-		WorkloadPort:          workloadPort,
-		InboundName:           strconv.Itoa(int(dpPort)),
+		DataplaneIP:   ip,
+		DataplanePort: dpPort,
+		WorkloadIP:    ip,
+		WorkloadPort:  workloadPort,
+		InboundName:   strconv.Itoa(int(dpPort)),
 	}
 }
 

--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin_test.go
@@ -349,12 +349,11 @@ var _ = Describe("MeshRateLimit", func() {
 			},
 			inboundRateLimitsMap: core_xds.InboundRateLimitsMap{
 				mesh_proto.InboundInterface{
-					DataplaneAdvertisedIP: "127.0.0.1",
-					DataplaneIP:           "127.0.0.1",
-					DataplanePort:         17777,
-					WorkloadIP:            "127.0.0.1",
-					WorkloadPort:          17777,
-					InboundName:           "17777",
+					DataplaneIP:   "127.0.0.1",
+					DataplanePort: 17777,
+					WorkloadIP:    "127.0.0.1",
+					WorkloadPort:  17777,
+					InboundName:   "17777",
 				}: []*core_mesh.RateLimitResource{
 					{
 						Spec: &mesh_proto.RateLimit{

--- a/pkg/xds/generator/inbound_proxy_generator_test.go
+++ b/pkg/xds/generator/inbound_proxy_generator_test.go
@@ -84,12 +84,11 @@ var _ = Describe("InboundProxyGenerator", func() {
 				Policies: model.MatchedPolicies{
 					TrafficPermissions: model.TrafficPermissionMap{
 						mesh_proto.InboundInterface{
-							DataplaneAdvertisedIP: "192.168.0.1",
-							DataplaneIP:           "192.168.0.1",
-							DataplanePort:         80,
-							WorkloadIP:            "192.168.0.1",
-							WorkloadPort:          8080,
-							InboundName:           "80",
+							DataplaneIP:   "192.168.0.1",
+							DataplanePort: 80,
+							WorkloadIP:    "192.168.0.1",
+							WorkloadPort:  8080,
+							InboundName:   "80",
 						}: &core_mesh.TrafficPermissionResource{
 							Meta: &test_model.ResourceMeta{
 								Name: "tp-1",
@@ -117,12 +116,11 @@ var _ = Describe("InboundProxyGenerator", func() {
 					},
 					FaultInjections: model.FaultInjectionMap{
 						mesh_proto.InboundInterface{
-							DataplaneAdvertisedIP: "192.168.0.1",
-							DataplaneIP:           "192.168.0.1",
-							DataplanePort:         80,
-							WorkloadIP:            "192.168.0.1",
-							WorkloadPort:          8080,
-							InboundName:           "80",
+							DataplaneIP:   "192.168.0.1",
+							DataplanePort: 80,
+							WorkloadIP:    "192.168.0.1",
+							WorkloadPort:  8080,
+							InboundName:   "80",
 						}: []*core_mesh.FaultInjectionResource{{Spec: &mesh_proto.FaultInjection{
 							Sources: []*mesh_proto.Selector{
 								{
@@ -148,12 +146,11 @@ var _ = Describe("InboundProxyGenerator", func() {
 					},
 					RateLimitsInbound: model.InboundRateLimitsMap{
 						mesh_proto.InboundInterface{
-							DataplaneAdvertisedIP: "192.168.0.1",
-							DataplaneIP:           "192.168.0.1",
-							DataplanePort:         80,
-							WorkloadIP:            "192.168.0.1",
-							WorkloadPort:          8080,
-							InboundName:           "80",
+							DataplaneIP:   "192.168.0.1",
+							DataplanePort: 80,
+							WorkloadIP:    "192.168.0.1",
+							WorkloadPort:  8080,
+							InboundName:   "80",
 						}: []*core_mesh.RateLimitResource{
 							{
 								Spec: &mesh_proto.RateLimit{

--- a/pkg/xds/sync/dataplane_watchdog.go
+++ b/pkg/xds/sync/dataplane_watchdog.go
@@ -185,7 +185,7 @@ func (d *DataplaneWatchdog) syncDataplane(ctx context.Context) (SyncResult, erro
 		proxy.WorkloadIdentity = d.workloadIdentity
 	}
 	networking := proxy.Dataplane.Spec.Networking
-	envoyAdminMTLS, err := d.getEnvoyAdminMTLS(ctx, networking.Address, networking.AdvertisedAddress)
+	envoyAdminMTLS, err := d.getEnvoyAdminMTLS(ctx, networking.Address)
 	if err != nil {
 		return SyncResult{}, errors.Wrap(err, "could not get Envoy Admin mTLS certs")
 	}
@@ -259,7 +259,7 @@ func (d *DataplaneWatchdog) syncIngress(ctx context.Context) (SyncResult, error)
 		return SyncResult{}, errors.Wrap(err, "could not build ingress proxy")
 	}
 	networking := proxy.ZoneIngressProxy.ZoneIngressResource.Spec.GetNetworking()
-	envoyAdminMTLS, err := d.getEnvoyAdminMTLS(ctx, networking.GetAddress(), networking.GetAdvertisedAddress())
+	envoyAdminMTLS, err := d.getEnvoyAdminMTLS(ctx, networking.GetAddress())
 	if err != nil {
 		return SyncResult{}, errors.Wrap(err, "could not get Envoy Admin mTLS certs")
 	}
@@ -319,7 +319,7 @@ func (d *DataplaneWatchdog) syncEgress(ctx context.Context) (SyncResult, error) 
 		return SyncResult{}, errors.Wrap(err, "could not build egress proxy")
 	}
 	networking := proxy.ZoneEgressProxy.ZoneEgressResource.Spec.Networking
-	envoyAdminMTLS, err := d.getEnvoyAdminMTLS(ctx, networking.Address, "")
+	envoyAdminMTLS, err := d.getEnvoyAdminMTLS(ctx, networking.Address)
 	if err != nil {
 		return SyncResult{}, errors.Wrap(err, "could not get Envoy Admin mTLS certs")
 	}
@@ -336,7 +336,7 @@ func (d *DataplaneWatchdog) syncEgress(ctx context.Context) (SyncResult, error) 
 	return result, nil
 }
 
-func (d *DataplaneWatchdog) getEnvoyAdminMTLS(ctx context.Context, address string, advertisedAddress string) (core_xds.ServerSideMTLSCerts, error) {
+func (d *DataplaneWatchdog) getEnvoyAdminMTLS(ctx context.Context, address string) (core_xds.ServerSideMTLSCerts, error) {
 	if d.envoyAdminMTLS == nil || d.dpAddress != address {
 		ca, err := envoy_admin_tls.LoadCA(ctx, d.ResManager)
 		if err != nil {
@@ -347,9 +347,6 @@ func (d *DataplaneWatchdog) getEnvoyAdminMTLS(ctx context.Context, address strin
 			return core_xds.ServerSideMTLSCerts{}, err
 		}
 		ips := []string{address}
-		if advertisedAddress != "" && advertisedAddress != address {
-			ips = append(ips, advertisedAddress)
-		}
 		serverPair, err := envoy_admin_tls.GenerateServerCert(ca, ips...)
 		if err != nil {
 			return core_xds.ServerSideMTLSCerts{}, errors.Wrap(err, "could not generate server certificate")

--- a/pkg/xds/topology/dataplanes.go
+++ b/pkg/xds/topology/dataplanes.go
@@ -23,17 +23,10 @@ func ResolveDataplaneAddress(lookupIPFunc lookup.LookupIPFunc, dataplane *core_m
 	if err != nil {
 		return nil, err
 	}
-	aip, err := lookupFirstIp(lookupIPFunc, dataplane.Spec.Networking.AdvertisedAddress)
-	if err != nil {
-		return nil, err
-	}
-	if ip != "" || aip != "" { // only if we resolve any address, in most cases this is IP not a hostname
+	if ip != "" { // only if we resolve an address, in most cases this is IP not a hostname
 		dpSpec := proto.Clone(dataplane.Spec).(*mesh_proto.Dataplane)
 		if ip != "" {
 			dpSpec.Networking.Address = ip
-		}
-		if aip != "" {
-			dpSpec.Networking.AdvertisedAddress = aip
 		}
 		return &core_mesh.DataplaneResource{
 			Meta: dataplane.Meta,

--- a/pkg/xds/topology/dataplanes_test.go
+++ b/pkg/xds/topology/dataplanes_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Resolve Dataplane address", func() {
 			// given
 			dp := &mesh.DataplaneResource{
 				Spec: &mesh_proto.Dataplane{
-					Networking: &mesh_proto.Dataplane_Networking{Address: "example.com", AdvertisedAddress: "advertise.example.com"},
+					Networking: &mesh_proto.Dataplane_Networking{Address: "example.com"},
 				},
 			}
 
@@ -50,10 +50,9 @@ var _ = Describe("Resolve Dataplane address", func() {
 			// then
 			Expect(err).ToNot(HaveOccurred())
 			Expect(resolvedDp.Spec.Networking.Address).To(Equal("192.168.0.1"))
-			Expect(resolvedDp.Spec.Networking.AdvertisedAddress).To(Equal("192.0.2.1"))
+
 			// and original DP is not modified
 			Expect(dp.Spec.Networking.Address).To(Equal("example.com"))
-			Expect(dp.Spec.Networking.AdvertisedAddress).To(Equal("advertise.example.com"))
 		})
 	})
 })

--- a/pkg/xds/topology/ingress_outbound_test.go
+++ b/pkg/xds/topology/ingress_outbound_test.go
@@ -229,8 +229,7 @@ var _ = Describe("IngressTrafficRoute", func() {
 						Meta: &test_model.ResourceMeta{Mesh: "default"},
 						Spec: &mesh_proto.Dataplane{
 							Networking: &mesh_proto.Dataplane_Networking{
-								AdvertisedAddress: "192.168.0.2",
-								Address:           "192.168.0.1",
+								Address: "192.168.0.1",
 								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
 									{
 										Tags:        map[string]string{mesh_proto.ServiceTag: "redis"},
@@ -245,7 +244,7 @@ var _ = Describe("IngressTrafficRoute", func() {
 				expected: core_xds.EndpointMap{
 					"redis": []core_xds.Endpoint{
 						{
-							Target: "192.168.0.2",
+							Target: "192.168.0.1",
 							Port:   6379,
 							Tags:   map[string]string{mesh_proto.ServiceTag: "redis"},
 							Weight: 1,

--- a/pkg/xds/topology/outbound.go
+++ b/pkg/xds/topology/outbound.go
@@ -283,7 +283,7 @@ func fillDataplaneOutbounds(
 			inboundTags := maps.Clone(inbound.GetTags())
 			serviceName := inboundTags[mesh_proto.ServiceTag]
 			inboundInterface := dpNetworking.ToInboundInterface(inbound)
-			inboundAddress := inboundInterface.DataplaneAdvertisedIP
+			inboundAddress := inboundInterface.DataplaneIP
 			inboundPort := inboundInterface.DataplanePort
 
 			if _, ok := meshServiceDestinations[serviceName]; ok {
@@ -329,7 +329,7 @@ func fillLocalMeshServices(
 					inboundInterface := dpNetworking.ToInboundInterface(inbound)
 
 					outbound[serviceName] = append(outbound[serviceName], core_xds.Endpoint{
-						Target:   inboundInterface.DataplaneAdvertisedIP,
+						Target:   inboundInterface.DataplaneIP,
 						Port:     inboundInterface.DataplanePort,
 						Tags:     inboundTags,
 						Weight:   1,


### PR DESCRIPTION
## Motivation

As mentioned in the issue, this field does not affect the ingress, and hence, remove the advertised address from the dataplane object

## Implementation information

1. Remove the `networking.advertisedAddress` from the dataplane object
2. fix tests


## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #15629

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
