### PR TITLE
test(e2e): disable mes priority on ipv6

### DIFF
--- a/test/e2e_env/universal/meshexternalservice/meshexternalservice.go
+++ b/test/e2e_env/universal/meshexternalservice/meshexternalservice.go
@@ -592,6 +592,7 @@ spec:
 		})
 	})
 
+	// https://github.com/kumahq/kuma/issues/15805
 	Context("MeshExternalService with endpoint priority", Ordered, Label("ipv6-not-supported"), func() {
 		mesPrimaryName := "mes-priority-primary"
 		mesPrimaryPort := 83


### PR DESCRIPTION
## Motivation

We can see it failing in IPv6 

## Implementation information

disable ipv6 while investigating to keep build green

Issue: https://github.com/kumahq/kuma/issues/15805