### PR TITLE
ci(github): avoid shell template injection

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -103,9 +103,13 @@ jobs:
           sudo apt-get update; sudo apt-get install -y qemu-user-static binfmt-support
       - uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
       - id: image_meta
+        env:
+          REGISTRY: ${{ inputs.REGISTRY }}
+          IMAGE_NAME: ${{ matrix.image }}
+          VERSION_NAME: ${{ inputs.VERSION_NAME }}
         run: |
-          echo "Extracting image meta for ${{ matrix.image }}"
-          echo "image=${{ inputs.REGISTRY }}/${{ matrix.image }}:${{ inputs.VERSION_NAME }}" >> "$GITHUB_OUTPUT"
+          echo "Extracting image meta for $IMAGE_NAME"
+          printf 'image=%s/%s:%s\n' "$REGISTRY" "$IMAGE_NAME" "$VERSION_NAME" >> "$GITHUB_OUTPUT"
       - run: |
           make images/${{ matrix.image }}
       - run: |

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -75,13 +75,15 @@ jobs:
             .test_e2e = false
             | .test_e2e_env.include = []
             | .test_e2e_env.exclude += [{"arch": "arm64"}, {"k8sVersion": "kindIpv6"}, {"k8sVersion": "${{ env.K8S_MIN_VERSION}}"}]
+          FULL_MATRIX: ${{ inputs.FULL_MATRIX }}
+          SKIP_E2E_TESTS: ${{ contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e-test') || contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
         run: |-
-          BASE_MATRIX_ALL='${{ env.BASE_MATRIX }}'
-          if [[ "${{ inputs.FULL_MATRIX }}" != "true" ]]; then
-            BASE_MATRIX_ALL=$(echo "$BASE_MATRIX_ALL" | jq -r '${{ env.OVERRIDE_JQ_CMD }}')
+          BASE_MATRIX_ALL="$BASE_MATRIX"
+          if [[ "$FULL_MATRIX" != "true" ]]; then
+            BASE_MATRIX_ALL=$(echo "$BASE_MATRIX_ALL" | jq -r "$OVERRIDE_JQ_CMD")
           fi
           # Skip e2e tests if the PR has the label "ci/skip-e2e-test" or "ci/skip-test"
-          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e-test') || contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}" == "true" ]]; then
+          if [[ "$SKIP_E2E_TESTS" == "true" ]]; then
             BASE_MATRIX_ALL='{}'
           fi
 

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -35,8 +35,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_DEBUG: ${{ runner.debug == '1' }}
+          INPUT_PR: ${{ inputs.PR }}
         run: |
           [[ "${GH_DEBUG}" == "true" ]] && set -x
+
+          if [[ ! "$INPUT_PR" =~ ^[0-9]+$ ]]; then
+            echo "PR input must be a numeric pull request number"
+            exit 1
+          fi
 
           function get_change_log() {
             awk '
@@ -60,8 +66,8 @@ jobs:
             ' <<< "$1"
           }
           
-          PR_INFO_JSON=$(gh pr view ${{ inputs.PR }} --json 'number,title,mergedAt,state,mergeCommit,baseRefName' || echo '{}')
-          PR_INFO_BODY=$(gh pr view ${{ inputs.PR }} --json 'body' -q '.body' || echo '')
+          PR_INFO_JSON=$(gh pr view "$INPUT_PR" --json 'number,title,mergedAt,state,mergeCommit,baseRefName' || echo '{}')
+          PR_INFO_BODY=$(gh pr view "$INPUT_PR" --json 'body' -q '.body' || echo '')
           
           TITLE=$(echo -n "$PR_INFO_JSON" | jq -r '.title //empty')
           CHANGE_LOG=$(get_change_log "$PR_INFO_BODY")
@@ -79,9 +85,12 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
       - name: ensure-pr-merged
+        env:
+          PR_NUMBER: ${{ inputs.PR }}
+          PR_STATE: ${{ steps.get-pr-info.outputs.pr_state }}
         run: |
-          if [[ "${{ steps.get-pr-info.outputs.pr_state }}" != "MERGED" ]]; then
-            echo "PR #${{ inputs.PR }} is not merged, current state: '$PR_STATE'"
+          if [[ "$PR_STATE" != "MERGED" ]]; then
+            echo "PR #$PR_NUMBER is not merged, current state: '$PR_STATE'"
             exit 1
           fi
   active-branches:


### PR DESCRIPTION
## Motivation

GitHub Actions expands workflow expressions before the shell runs. That left `_build_publish.yaml` and `backport.yaml` open to template injection, and it also kept `_test.yaml` noisy for the scanner.

## Implementation information

- move registry, image, version, and manual PR input values into step `env`
- validate the backport `PR` input before calling `gh pr view`
- reuse shell variables in the affected `run:` blocks instead of inline `${{ ... }}`
- route the `_test.yaml` booleans through `env` without changing behavior

## Supporting documentation

Verified against the upstream Kuma findings already confirmed from the Kong Mesh sync report.

> Changelog: skip
