### PR TITLE
feat(grafana): add Grafana dashboards

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,9 +4,9 @@ run:
 linters:
   enable:
     - bodyclose
-    - contextcheck
     - depguard
     - errcheck
+    - forbidigo
     - ginkgolinter
     - gocritic
     - gomodguard
@@ -21,26 +21,63 @@ linters:
     - nolintlint
     - nonamedreturns
     - nosprintfhostport
+    - revive
     - staticcheck
     - unconvert
     - unparam
     - unused
+    - usestdlibvars
     - whitespace
   settings:
     depguard:
       rules:
-        pkg-import:
-          list-mode: lax # only disallow some imports
+        DenyGolangProtobuf:
           files:
-            - "!**/app/**/*.go"
-            - "!**/pkg/api-server/gui_handler.go"
+            - $all
           deny:
-            - pkg: "github.com/kumahq/kuma/app"
-              desc: "pkg can't import app"
+            - pkg: github.com/golang/protobuf
+              desc: github.com/golang/protobuf is deprecated; use google.golang.org/protobuf instead
+        DenyGoogleProtoJson:
+          files:
+            - $all
+          deny:
+            - pkg: google.golang.org/protobuf/encoding/protojson
+              desc: don't use the protojson package, it's incompatible and might cause issues(https://github.com/golang/protobuf/issues/1374); use github.com/golang/protobuf/jsonpb instead
+        DenyControllerRuntimePkgLog:
+          files:
+            - $all
+          deny:
+            - pkg: sigs.k8s.io/controller-runtime/pkg/log$
+              desc: Disallowed due to internal data races caused by cyclic dependencies and global state in controller-runtime. This can lead to long delays (up to 2 minutes) in init containers. Use sigs.k8s.io/controller-runtime instead. See https://github.com/kumahq/kuma/v2/issues/13299
+        pkg-import:
+          list-mode: lax
+          files:
+            - '!**/app/**/*.go'
+            - '!**/pkg/api-server/gui_handler.go'
+          deny:
+            - pkg: github.com/kumahq/kuma/v2/app
+              desc: pkg can't import app
+    forbidigo:
+      forbid:
+        - pattern: '[a-zA-Z_]\w*\.End\('
+          msg: "Use tracing.SafeSpanEnd(span) instead of span.End() to prevent panics during OTel init/shutdown"
+      exclude-godoc-examples: false
+      analyze-types: true
     gocritic:
       disabled-checks:
-        - deprecatedComment
-        - singleCaseSwitch
+        - appendAssign
+        - commentedOutCode
+        - deferInLoop
+        - docStub
+        - exposedSyncMutex
+        - filepathJoin
+        - hugeParam
+        - importShadow
+        - paramTypeCombine
+        - rangeValCopy
+        - unnamedResult
+        - whyNoLint
+      enable-all: true
     gomodguard:
       blocked:
         modules:
@@ -50,9 +87,15 @@ linters:
           - github.com/ghodss/yaml:
               recommendations:
                 - sigs.k8s.io/yaml
-          - github.com/hashicorp/go-multierror:
+          - github.com/hashicorp/multierror:
               recommendations:
                 - errors
+          - golang.org/x/exp/maps:
+              recommendations:
+                - maps
+          - golang.org/x/exp/slices:
+              recommendations:
+                - slices
           - gopkg.in/yaml.v2:
               recommendations:
                 - sigs.k8s.io/yaml
@@ -65,36 +108,32 @@ linters:
                 - os
     gosec:
       excludes:
-        - G101 # Potential hardcoded credentials
+        - G104 # Errors unhandled
         - G115
-        - G118 # context cancellation not called
-        - G202 # SQL string concatenation
-        - G602 # slice index out of range
-        - G703 # path traversal via taint analysis
-        - G704 # SSRF via taint analysis
+        - G301 # Expect directory permissions to be 0750 or less
     importas:
       alias:
-        - pkg: github.com/kumahq/kuma/pkg/core/resources/apis/mesh
+        - pkg: github.com/kumahq/kuma/v2/pkg/core/resources/apis/mesh
           alias: core_mesh
-        - pkg: github.com/kumahq/kuma/api/mesh/v1alpha1
+        - pkg: github.com/kumahq/kuma/v2/api/mesh/v1alpha1
           alias: mesh_proto
-        - pkg: github.com/kumahq/kuma/api/system/v1alpha1
+        - pkg: github.com/kumahq/kuma/v2/api/system/v1alpha1
           alias: system_proto
-        - pkg: github.com/kumahq/kuma/pkg/util/proto
+        - pkg: github.com/kumahq/kuma/v2/pkg/util/proto
           alias: util_proto
-        - pkg: github.com/kumahq/kuma/pkg/util/rsa
+        - pkg: github.com/kumahq/kuma/v2/pkg/util/rsa
           alias: util_rsa
-        - pkg: github.com/kumahq/kuma/pkg/cmd
+        - pkg: github.com/kumahq/kuma/v2/pkg/cmd
           alias: kuma_cmd
-        - pkg: github.com/kumahq/kuma/pkg/plugins/bootstrap/k8s
+        - pkg: github.com/kumahq/kuma/v2/pkg/plugins/bootstrap/k8s
           alias: bootstrap_k8s
-        - pkg: github.com/kumahq/kuma/pkg/config/core
+        - pkg: github.com/kumahq/kuma/v2/pkg/config/core
           alias: config_core
-        - pkg: github.com/kumahq/kuma/pkg/core/resources/model
+        - pkg: github.com/kumahq/kuma/v2/pkg/core/resources/model
           alias: core_model
-        - pkg: github.com/kumahq/kuma/api/common/v1alpha1
+        - pkg: github.com/kumahq/kuma/v2/api/common/v1alpha1
           alias: common_api
-        - pkg: github.com/kumahq/kuma/api/openapi/types
+        - pkg: github.com/kumahq/kuma/v2/api/openapi/types
           alias: api_types
     misspell:
       locale: US
@@ -111,72 +150,43 @@ linters:
       require-specific: true
     nonamedreturns:
       report-error-in-defer: false
+    revive:
+      max-open-files: 2048
+      rules:
+        - name: var-declaration
     staticcheck:
       checks:
         - all
-        - -QF1001 # Defer quick-fix refactors on release branches
-        - -QF1002 # Defer quick-fix refactors on release branches
-        - -QF1003 # Defer quick-fix refactors on release branches
-        - -QF1008 # Defer quick-fix refactors on release branches
-        - -QF1012 # Defer quick-fix refactors on release branches
         - -ST1003 # Poorly chosen identifier
-        - -ST1005 # Error strings should not be capitalized
-        - -ST1006 # Receiver name should not be an underscore
-        - -ST1012 # Error var should have name of the form ErrFoo
         - -ST1016 # Use consistent method receiver names
-        - -ST1017 # Defer style-only Yoda condition fixes on release branches
-        - -ST1019 # Package is being imported more than once
-        - -SA4011 # Break statement with no effect
+        - -SA4011 # Break statement with no effect. Did you mean to break out of an outer loop?
+    usestdlibvars:
+      http-status-code: false
   exclusions:
     generated: lax
     presets:
       - comments
       - common-false-positives
-      - legacy
       - std-error-handling
     rules:
       - linters:
           - staticcheck
-        text: 'SA1019: "github.com/golang/protobuf' # TODO ignore deprecation of proto library. We don't want to migrate yet because go-control-plane is not ready
+        text: 'SA1019: "github.com/golang/protobuf/jsonpb"'
       - linters:
           - staticcheck
-        text: "SA1019: proto.MessageName is deprecated" # TODO ignore deprecation of proto library. We don't want to migrate yet because go-control-plane is not ready
+        text: 'SA1019: cfg.Runtime.Kubernetes.Injector.SidecarContainer.AdminPort is deprecated: Use KUMA_BOOTSTRAP_SERVER_PARAMS_ADMIN_PORT instead.'
       - linters:
           - staticcheck
-        text: "SA1019: proto.MessageType is deprecated" # TODO ignore deprecation of proto library. We don't want to migrate yet because go-control-plane is not ready
+        text: 'SA1019: .* for new policies use pkg/plugins/policies/xds/cluster.go'
       - linters:
           - staticcheck
-        text: "SA1019: l.UseOriginalDst is deprecated: Do not use." # TODO What is the up-to-date alternative ?
+        text: 'SA1019: .* is deprecated: use MinResyncInterval instead'
       - linters:
           - staticcheck
-        text: "IsIngress is deprecated: use ZoneIngress" # It's deprecated but Kuma still needs to support it for backwards compatibility.
-      - linters:
-          - gocritic
-        text: "appendAssign: append result not assigned to the same slice" # None of the instances of this in Kuma were bugs.
+        text: 'SA1019: .* is deprecated: use FullResyncInterval instead'
       - linters:
           - staticcheck
-        text: "SA1019: package sigs.k8s.io/controller-runtime/pkg/client/fake is deprecated" # https://github.com/kumahq/kuma/issues/2460
-      - linters:
-          - staticcheck
-        text: "SA1019: l.ReusePort is deprecated"
-      - linters:
-          - staticcheck
-        text: "SA1019: cfg.Runtime.Kubernetes.Injector.SidecarContainer.AdminPort is deprecated: Use KUMA_BOOTSTRAP_SERVER_PARAMS_ADMIN_PORT instead."
-      - linters:
-          - staticcheck
-        text: "SA1019: kumaCPConfig.Runtime.Kubernetes.Injector.SidecarContainer.AdminPort is deprecated: Use KUMA_BOOTSTRAP_SERVER_PARAMS_ADMIN_PORT instead."
-      - linters:
-          - staticcheck
-        text: "SA1019: c.Runtime.Kubernetes.Injector.SidecarContainer.AdminPort is deprecated: Use KUMA_BOOTSTRAP_SERVER_PARAMS_ADMIN_PORT instead."
-      - linters:
-          - staticcheck
-        text: "SA1019: .* for new policies use pkg/plugins/policies/xds/cluster.go"
-      - linters:
-          - staticcheck
-        text: "SA1019: .* is deprecated: use MinResyncInterval instead"
-      - linters:
-          - staticcheck
-        text: "SA1019: .* is deprecated: use FullResyncInterval instead"
+        text: 'SA1019: .* is deprecated: use common.WithPolicyAttributes instead'
       - linters:
           - staticcheck
         text: 'SA1019: .*.Endpoint is deprecated: use BackendRef instead'
@@ -185,19 +195,30 @@ linters:
         text: 'ST1001: should not use dot imports'
       - linters:
           - staticcheck
-        path: 'api/common/v1alpha1/'
+        path: 'api/common/v1alpha1/targetref\.go'
         text: 'SA5008'
       - linters:
           - gosec
         path: '(_test\.go$|^test/)'
+      - linters:
+          - forbidigo
+        path: pkg/core/tracing/span\.go
+        text: 'Use tracing.SafeSpanEnd'
+      - linters:
+          - forbidigo
+        path: pkg/core/tracing/.*_test\.go
+        text: 'Use tracing.SafeSpanEnd'
     paths:
-      - app/kumactl/pkg/k8s/kubectl_proxy.go # excluded to keep as close to original file from K8S repository
-      - pkg/xds/server/server.go # excluded to keep as close to original file from Envoy repository
-      - pkg/xds/server/server_test.go # excluded to keep as close to original file from Envoy repository
-      - (^|/)vendored($|/)
+      - pkg/transparentproxy/iptables/builder
+    warn-unused: true
 issues:
+  # Fix found issues (if it's supported by the linter).
   fix: true
+  # Maximum issues count per one linter.
+  # Set to 0 to disable.
   max-issues-per-linter: 0
+  # Maximum count of issues with the same text.
+  # Set to 0 to disable.
   max-same-issues: 0
 formatters:
   enable:
@@ -208,12 +229,5 @@ formatters:
       sections:
         - standard
         - default
-        - prefix(github.com/kumahq/kuma)
+        - prefix(github.com/kumahq/kuma/v2)
       custom-order: true
-  exclusions:
-    generated: lax
-    paths:
-      - app/kumactl/pkg/k8s/kubectl_proxy.go # excluded to keep as close to original file from K8S repository
-      - pkg/xds/server/server.go # excluded to keep as close to original file from Envoy repository
-      - pkg/xds/server/server_test.go # excluded to keep as close to original file from Envoy repository
-      - (^|/)vendored($|/)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,9 +4,9 @@ run:
 linters:
   enable:
     - bodyclose
+    - contextcheck
     - depguard
     - errcheck
-    - forbidigo
     - ginkgolinter
     - gocritic
     - gomodguard
@@ -21,63 +21,26 @@ linters:
     - nolintlint
     - nonamedreturns
     - nosprintfhostport
-    - revive
     - staticcheck
     - unconvert
     - unparam
     - unused
-    - usestdlibvars
     - whitespace
   settings:
     depguard:
       rules:
-        DenyGolangProtobuf:
-          files:
-            - $all
-          deny:
-            - pkg: github.com/golang/protobuf
-              desc: github.com/golang/protobuf is deprecated; use google.golang.org/protobuf instead
-        DenyGoogleProtoJson:
-          files:
-            - $all
-          deny:
-            - pkg: google.golang.org/protobuf/encoding/protojson
-              desc: don't use the protojson package, it's incompatible and might cause issues(https://github.com/golang/protobuf/issues/1374); use github.com/golang/protobuf/jsonpb instead
-        DenyControllerRuntimePkgLog:
-          files:
-            - $all
-          deny:
-            - pkg: sigs.k8s.io/controller-runtime/pkg/log$
-              desc: Disallowed due to internal data races caused by cyclic dependencies and global state in controller-runtime. This can lead to long delays (up to 2 minutes) in init containers. Use sigs.k8s.io/controller-runtime instead. See https://github.com/kumahq/kuma/v2/issues/13299
         pkg-import:
-          list-mode: lax
+          list-mode: lax # only disallow some imports
           files:
-            - '!**/app/**/*.go'
-            - '!**/pkg/api-server/gui_handler.go'
+            - "!**/app/**/*.go"
+            - "!**/pkg/api-server/gui_handler.go"
           deny:
-            - pkg: github.com/kumahq/kuma/v2/app
-              desc: pkg can't import app
-    forbidigo:
-      forbid:
-        - pattern: '[a-zA-Z_]\w*\.End\('
-          msg: "Use tracing.SafeSpanEnd(span) instead of span.End() to prevent panics during OTel init/shutdown"
-      exclude-godoc-examples: false
-      analyze-types: true
+            - pkg: "github.com/kumahq/kuma/app"
+              desc: "pkg can't import app"
     gocritic:
       disabled-checks:
-        - appendAssign
-        - commentedOutCode
-        - deferInLoop
-        - docStub
-        - exposedSyncMutex
-        - filepathJoin
-        - hugeParam
-        - importShadow
-        - paramTypeCombine
-        - rangeValCopy
-        - unnamedResult
-        - whyNoLint
-      enable-all: true
+        - deprecatedComment
+        - singleCaseSwitch
     gomodguard:
       blocked:
         modules:
@@ -87,15 +50,9 @@ linters:
           - github.com/ghodss/yaml:
               recommendations:
                 - sigs.k8s.io/yaml
-          - github.com/hashicorp/multierror:
+          - github.com/hashicorp/go-multierror:
               recommendations:
                 - errors
-          - golang.org/x/exp/maps:
-              recommendations:
-                - maps
-          - golang.org/x/exp/slices:
-              recommendations:
-                - slices
           - gopkg.in/yaml.v2:
               recommendations:
                 - sigs.k8s.io/yaml
@@ -108,32 +65,36 @@ linters:
                 - os
     gosec:
       excludes:
-        - G104 # Errors unhandled
+        - G101 # Potential hardcoded credentials
         - G115
-        - G301 # Expect directory permissions to be 0750 or less
+        - G118 # context cancellation not called
+        - G202 # SQL string concatenation
+        - G602 # slice index out of range
+        - G703 # path traversal via taint analysis
+        - G704 # SSRF via taint analysis
     importas:
       alias:
-        - pkg: github.com/kumahq/kuma/v2/pkg/core/resources/apis/mesh
+        - pkg: github.com/kumahq/kuma/pkg/core/resources/apis/mesh
           alias: core_mesh
-        - pkg: github.com/kumahq/kuma/v2/api/mesh/v1alpha1
+        - pkg: github.com/kumahq/kuma/api/mesh/v1alpha1
           alias: mesh_proto
-        - pkg: github.com/kumahq/kuma/v2/api/system/v1alpha1
+        - pkg: github.com/kumahq/kuma/api/system/v1alpha1
           alias: system_proto
-        - pkg: github.com/kumahq/kuma/v2/pkg/util/proto
+        - pkg: github.com/kumahq/kuma/pkg/util/proto
           alias: util_proto
-        - pkg: github.com/kumahq/kuma/v2/pkg/util/rsa
+        - pkg: github.com/kumahq/kuma/pkg/util/rsa
           alias: util_rsa
-        - pkg: github.com/kumahq/kuma/v2/pkg/cmd
+        - pkg: github.com/kumahq/kuma/pkg/cmd
           alias: kuma_cmd
-        - pkg: github.com/kumahq/kuma/v2/pkg/plugins/bootstrap/k8s
+        - pkg: github.com/kumahq/kuma/pkg/plugins/bootstrap/k8s
           alias: bootstrap_k8s
-        - pkg: github.com/kumahq/kuma/v2/pkg/config/core
+        - pkg: github.com/kumahq/kuma/pkg/config/core
           alias: config_core
-        - pkg: github.com/kumahq/kuma/v2/pkg/core/resources/model
+        - pkg: github.com/kumahq/kuma/pkg/core/resources/model
           alias: core_model
-        - pkg: github.com/kumahq/kuma/v2/api/common/v1alpha1
+        - pkg: github.com/kumahq/kuma/api/common/v1alpha1
           alias: common_api
-        - pkg: github.com/kumahq/kuma/v2/api/openapi/types
+        - pkg: github.com/kumahq/kuma/api/openapi/types
           alias: api_types
     misspell:
       locale: US
@@ -150,43 +111,72 @@ linters:
       require-specific: true
     nonamedreturns:
       report-error-in-defer: false
-    revive:
-      max-open-files: 2048
-      rules:
-        - name: var-declaration
     staticcheck:
       checks:
         - all
+        - -QF1001 # Defer quick-fix refactors on release branches
+        - -QF1002 # Defer quick-fix refactors on release branches
+        - -QF1003 # Defer quick-fix refactors on release branches
+        - -QF1008 # Defer quick-fix refactors on release branches
+        - -QF1012 # Defer quick-fix refactors on release branches
         - -ST1003 # Poorly chosen identifier
+        - -ST1005 # Error strings should not be capitalized
+        - -ST1006 # Receiver name should not be an underscore
+        - -ST1012 # Error var should have name of the form ErrFoo
         - -ST1016 # Use consistent method receiver names
-        - -SA4011 # Break statement with no effect. Did you mean to break out of an outer loop?
-    usestdlibvars:
-      http-status-code: false
+        - -ST1017 # Defer style-only Yoda condition fixes on release branches
+        - -ST1019 # Package is being imported more than once
+        - -SA4011 # Break statement with no effect
   exclusions:
     generated: lax
     presets:
       - comments
       - common-false-positives
+      - legacy
       - std-error-handling
     rules:
       - linters:
           - staticcheck
-        text: 'SA1019: "github.com/golang/protobuf/jsonpb"'
+        text: 'SA1019: "github.com/golang/protobuf' # TODO ignore deprecation of proto library. We don't want to migrate yet because go-control-plane is not ready
       - linters:
           - staticcheck
-        text: 'SA1019: cfg.Runtime.Kubernetes.Injector.SidecarContainer.AdminPort is deprecated: Use KUMA_BOOTSTRAP_SERVER_PARAMS_ADMIN_PORT instead.'
+        text: "SA1019: proto.MessageName is deprecated" # TODO ignore deprecation of proto library. We don't want to migrate yet because go-control-plane is not ready
       - linters:
           - staticcheck
-        text: 'SA1019: .* for new policies use pkg/plugins/policies/xds/cluster.go'
+        text: "SA1019: proto.MessageType is deprecated" # TODO ignore deprecation of proto library. We don't want to migrate yet because go-control-plane is not ready
       - linters:
           - staticcheck
-        text: 'SA1019: .* is deprecated: use MinResyncInterval instead'
+        text: "SA1019: l.UseOriginalDst is deprecated: Do not use." # TODO What is the up-to-date alternative ?
       - linters:
           - staticcheck
-        text: 'SA1019: .* is deprecated: use FullResyncInterval instead'
+        text: "IsIngress is deprecated: use ZoneIngress" # It's deprecated but Kuma still needs to support it for backwards compatibility.
+      - linters:
+          - gocritic
+        text: "appendAssign: append result not assigned to the same slice" # None of the instances of this in Kuma were bugs.
       - linters:
           - staticcheck
-        text: 'SA1019: .* is deprecated: use common.WithPolicyAttributes instead'
+        text: "SA1019: package sigs.k8s.io/controller-runtime/pkg/client/fake is deprecated" # https://github.com/kumahq/kuma/issues/2460
+      - linters:
+          - staticcheck
+        text: "SA1019: l.ReusePort is deprecated"
+      - linters:
+          - staticcheck
+        text: "SA1019: cfg.Runtime.Kubernetes.Injector.SidecarContainer.AdminPort is deprecated: Use KUMA_BOOTSTRAP_SERVER_PARAMS_ADMIN_PORT instead."
+      - linters:
+          - staticcheck
+        text: "SA1019: kumaCPConfig.Runtime.Kubernetes.Injector.SidecarContainer.AdminPort is deprecated: Use KUMA_BOOTSTRAP_SERVER_PARAMS_ADMIN_PORT instead."
+      - linters:
+          - staticcheck
+        text: "SA1019: c.Runtime.Kubernetes.Injector.SidecarContainer.AdminPort is deprecated: Use KUMA_BOOTSTRAP_SERVER_PARAMS_ADMIN_PORT instead."
+      - linters:
+          - staticcheck
+        text: "SA1019: .* for new policies use pkg/plugins/policies/xds/cluster.go"
+      - linters:
+          - staticcheck
+        text: "SA1019: .* is deprecated: use MinResyncInterval instead"
+      - linters:
+          - staticcheck
+        text: "SA1019: .* is deprecated: use FullResyncInterval instead"
       - linters:
           - staticcheck
         text: 'SA1019: .*.Endpoint is deprecated: use BackendRef instead'
@@ -195,30 +185,19 @@ linters:
         text: 'ST1001: should not use dot imports'
       - linters:
           - staticcheck
-        path: 'api/common/v1alpha1/targetref\.go'
+        path: 'api/common/v1alpha1/'
         text: 'SA5008'
       - linters:
           - gosec
         path: '(_test\.go$|^test/)'
-      - linters:
-          - forbidigo
-        path: pkg/core/tracing/span\.go
-        text: 'Use tracing.SafeSpanEnd'
-      - linters:
-          - forbidigo
-        path: pkg/core/tracing/.*_test\.go
-        text: 'Use tracing.SafeSpanEnd'
     paths:
-      - pkg/transparentproxy/iptables/builder
-    warn-unused: true
+      - app/kumactl/pkg/k8s/kubectl_proxy.go # excluded to keep as close to original file from K8S repository
+      - pkg/xds/server/server.go # excluded to keep as close to original file from Envoy repository
+      - pkg/xds/server/server_test.go # excluded to keep as close to original file from Envoy repository
+      - (^|/)vendored($|/)
 issues:
-  # Fix found issues (if it's supported by the linter).
   fix: true
-  # Maximum issues count per one linter.
-  # Set to 0 to disable.
   max-issues-per-linter: 0
-  # Maximum count of issues with the same text.
-  # Set to 0 to disable.
   max-same-issues: 0
 formatters:
   enable:
@@ -229,5 +208,12 @@ formatters:
       sections:
         - standard
         - default
-        - prefix(github.com/kumahq/kuma/v2)
+        - prefix(github.com/kumahq/kuma)
       custom-order: true
+  exclusions:
+    generated: lax
+    paths:
+      - app/kumactl/pkg/k8s/kubectl_proxy.go # excluded to keep as close to original file from K8S repository
+      - pkg/xds/server/server.go # excluded to keep as close to original file from Envoy repository
+      - pkg/xds/server/server_test.go # excluded to keep as close to original file from Envoy repository
+      - (^|/)vendored($|/)

--- a/dashboards/grafana/.lint
+++ b/dashboards/grafana/.lint
@@ -1,0 +1,28 @@
+exclusions:
+  template-job-rule:
+    reason: "Kuma dashboards filter by mesh/namespace/workload, not by job"
+    entries: []
+  template-instance-rule:
+    reason: "Kuma dashboards filter by mesh/namespace/workload, not by instance"
+    entries: []
+  target-job-rule:
+    reason: "Kuma metrics use mesh/namespace/workload labels, not job"
+    entries: []
+  target-instance-rule:
+    reason: "Kuma metrics use mesh/namespace/workload labels, not instance"
+    entries: []
+  target-rate-interval-rule:
+    reason: "Using [5m] because $__rate_interval requires min_step configuration"
+    entries: []
+  panel-title-description-rule:
+    reason: "Panel titles are self-descriptive, descriptions not required"
+    entries: []
+  panel-datasource-rule:
+    reason: "CP dashboard uses hardcoded datasource UID, to be migrated"
+    entries: []
+  panel-units-rule:
+    reason: "Stat panels showing raw counts do not need units"
+    entries: []
+  uneditable-dashboard:
+    reason: "Dashboards are managed via GrafanaDashboard CRs, editable flag is irrelevant"
+    entries: []

--- a/dashboards/grafana/kuma-control-plane.json
+++ b/dashboards/grafana/kuma-control-plane.json
@@ -1,0 +1,3560 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Kuma Control Plane \u2014 xDS generation, store operations, leader election, gRPC server",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "title": "Mesh Drilldown",
+      "url": "/d/kuma-mesh/kuma-mesh-drilldown?orgId=1",
+      "type": "link",
+      "icon": "dashboard",
+      "tooltip": "Fleet-wide mesh overview"
+    },
+    {
+      "title": "Workload Health",
+      "url": "/d/kuma-service-health/kuma-service-health?orgId=1",
+      "type": "link",
+      "icon": "dashboard",
+      "tooltip": "Per-workload RED overview"
+    },
+    {
+      "title": "Workload Debug",
+      "url": "/d/kuma-service-debug/kuma-service-debug?orgId=1",
+      "type": "link",
+      "icon": "dashboard",
+      "tooltip": "Deep-dive workload debug"
+    }
+  ],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Control plane build info",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "noValue": "unknown"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "title": "CP Info",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "cp_info{job=\"kuma-control-plane\"}",
+          "instant": true,
+          "legendFormat": "{{ product }} {{ version }} ({{ zone }})",
+          "refId": "A"
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "1 = this instance is leader. Only one instance should be leader per zone.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "yellow",
+                  "index": 0,
+                  "text": "Follower"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "Leader"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "yellow",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "title": "Leader Status",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "leader{job=\"kuma-control-plane\"}",
+          "instant": true,
+          "legendFormat": "{{ zone }} / {{ instance }}",
+          "refId": "A"
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Number of active xDS streams between CP and data plane proxies",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 18,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Active xDS Streams",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(xds_streams_active{job=\"kuma-control-plane\"})",
+          "legendFormat": "streams",
+          "refId": "A"
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Total number of Dataplane resources — should closely match active xDS streams",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 21,
+        "y": 1
+      },
+      "id": 150,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Dataplane Count",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "max(resources_count{job=\"kuma-control-plane\",resource_type=\"Dataplane\"})",
+          "legendFormat": "dataplanes",
+          "refId": "A"
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 10,
+      "title": "xDS \u2014 Aggregated Discovery Service",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Rate of successful xDS config generations vs errors",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "errors"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "xDS Generation Rate",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(xds_generation_count{job=\"kuma-control-plane\",result=\"changed\"}[5m]))",
+          "legendFormat": "changed",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(xds_generation_count{job=\"kuma-control-plane\",result=\"generated\"}[5m]))",
+          "legendFormat": "generated (no change)",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(xds_generation_count{job=\"kuma-control-plane\",result=\"skip\"}[5m]))",
+          "legendFormat": "skip",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(xds_generation_errors{job=\"kuma-control-plane\"}[5m]))",
+          "legendFormat": "errors",
+          "refId": "B"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "xDS responses sent to proxies and ACK/NACK confirmations received",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "NACKs"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "xDS Message Exchange",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(xds_responses_sent{job=\"kuma-control-plane\"}[5m]))",
+          "legendFormat": "responses sent",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(xds_requests_received{confirmation=\"ACK\",job=\"kuma-control-plane\"}[5m]))",
+          "legendFormat": "ACKs",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(xds_requests_received{confirmation=\"NACK\",job=\"kuma-control-plane\"}[5m]))",
+          "legendFormat": "NACKs",
+          "refId": "C"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "xDS responses sent broken down by resource type (CDS, LDS, EDS, SDS)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "xDS Responses by Resource Type",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (type_url) (rate(xds_responses_sent{job=\"kuma-control-plane\"}[5m]))",
+          "legendFormat": "{{ type_url }}",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "99th percentile latency of xDS config generation per proxy type and result",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "xDS Generation Latency (p99)",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (proxy_type, result, le) (rate(xds_generation_bucket{job=\"kuma-control-plane\"}[5m])))",
+          "legendFormat": "{{ proxy_type }} / {{ result }}",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "99th percentile latency of xDS config delivery to proxies including ACK/NACK",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "xDS Delivery Latency (p99)",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(xds_delivery_bucket{job=\"kuma-control-plane\"}[5m])))",
+          "legendFormat": "p99",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "id": 113,
+      "title": "KDS \u2014 Global Control Plane",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 31
+      },
+      "id": 114,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "KDS Snapshot Generation Rate",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (reason, result) (rate(kds_delta_generation_count[5m]))",
+          "legendFormat": "{{reason}} / {{result}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 31
+      },
+      "id": 115,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "KDS Snapshot Generation Latency (p99)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(kds_delta_generation_bucket[5m])))",
+          "legendFormat": "p99",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 31
+      },
+      "id": 116,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "KDS Generation Errors",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum(rate(kds_delta_generation_errors_total[5m]))",
+          "legendFormat": "errors",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 39
+      },
+      "id": 117,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "KDS Generation by Zone",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (zone_name) (rate(kds_delta_generation_count{result=\"changed\"}[5m]))",
+          "legendFormat": "{{zone_name}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 39
+      },
+      "id": 118,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Zone Watch Interval",
+      "description": "How often the Global CP polls each Zone CP for health/status. High values may indicate connectivity issues between Global and Zone CPs.",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(component_zone_watch_bucket[5m])))",
+          "legendFormat": "p99",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 47
+      },
+      "id": 119,
+      "title": "KDS \u2014 Zone Control Plane",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 48
+      },
+      "id": 120,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "KDS Resource Sync Rate",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum(rate(kds_delta_generation_count{result=\"changed\"}[5m]))",
+          "legendFormat": "changed",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(kds_delta_generation_count{result=\"no_changes\"}[5m]))",
+          "legendFormat": "no changes",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(kds_delta_generation_errors[5m]))",
+          "legendFormat": "errors",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 48
+      },
+      "id": 121,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "KDS Resource Sync Latency (p99)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(kds_delta_delivery_bucket[5m])))",
+          "legendFormat": "p99",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 56
+      },
+      "id": 50,
+      "title": "Resources",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Number of resources tracked by the control plane, by type",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 57
+      },
+      "id": 51,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Resource Count",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "max by (resource_type) (resources_count{job=\"kuma-control-plane\",resource_type=~\"Dataplane|Mesh|MeshService|HostnameGenerator|Zone|ZoneIngress|ZoneEgress\"})",
+          "legendFormat": "{{ resource_type }}",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Number of policy resources tracked by the control plane",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 57
+      },
+      "id": 52,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Policy Count",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "resources_count{job=\"kuma-control-plane\",resource_type=~\"Mesh.*|MeshTrafficPermission|MeshHTTPRoute|MeshTCPRoute\",resource_type!~\"MeshInsight|MeshService\"}",
+          "legendFormat": "{{ resource_type }}",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Number of events dropped in the event bus due to full channels \u2014 non-zero indicates backpressure",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "red",
+            "mode": "fixed"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 65
+      },
+      "id": 53,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Events Dropped",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(events_dropped{job=\"kuma-control-plane\"}[5m]))",
+          "legendFormat": "dropped/s",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 73
+      },
+      "id": 20,
+      "title": "Store",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "99th percentile latency of store operations (get, list, create, update, delete) against the backend",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 74
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Store Operation Latency (p99)",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (operation, le) (rate(store_bucket{job=\"kuma-control-plane\"}[5m])))",
+          "legendFormat": "{{ operation }}",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Rate of store operations by type",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 74
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Store Operations Rate",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (operation) (rate(store_count{job=\"kuma-control-plane\"}[5m]))",
+          "legendFormat": "{{ operation }}",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Store cache hit/miss rate \u2014 hits reduce backend load",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "miss"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 82
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Store Cache Performance",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (result) (rate(store_cache{job=\"kuma-control-plane\"}[5m]))",
+          "legendFormat": "{{ result }}",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 90
+      },
+      "id": 40,
+      "title": "Certificates",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Rate of mTLS certificate generation per mesh",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 91
+      },
+      "id": 41,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "CA Cache Hit Rate",
+      "description": "Ratio of CA cache hits vs misses. High hit rate means fewer expensive cert operations.",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(ca_cache{job=\"kuma-control-plane\",result=\"hit\"}[5m]))",
+          "legendFormat": "hits",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(ca_cache{job=\"kuma-control-plane\",result=\"miss\"}[5m]))",
+          "legendFormat": "misses",
+          "refId": "B"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Minimum days until the first Envoy certificate expires across all dataplanes in the mesh",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "< 1 day (OK)"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "d"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 91
+      },
+      "id": 42,
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "title": "Dataplane Cert Expiry (min days)",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "min by (kuma_workload) (envoy_server_days_until_first_cert_expiring{mesh=\"$mesh\"})",
+          "legendFormat": "{{kuma_workload}}",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Hours until the first certificate expires on each dataplane. Low values indicate upcoming rotations.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd",
+            "fixedColor": "green"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "h",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 2 },
+              { "color": "green", "value": 12 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 99
+      },
+      "id": 122,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "min",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "asc"
+        }
+      },
+      "title": "Dataplane Cert TTL",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "min by (kuma_workload) ((envoy_listener_ssl_certificate_expiration_unix_time_seconds{mesh=\"$mesh\"} - time()) / 3600)",
+          "legendFormat": "{{kuma_workload}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 99
+      },
+      "id": 123,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Certificate Watcher",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum(rate(certwatcher_read_certificate_total[5m]))",
+          "legendFormat": "reads",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(certwatcher_read_certificate_errors_total[5m]))",
+          "legendFormat": "errors",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 107
+      },
+      "id": 90,
+      "title": "Go Runtime",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Number of goroutines \u2014 sustained growth indicates a leak",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "purple",
+            "mode": "fixed"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 108
+      },
+      "id": 91,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Goroutines",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "go_goroutines{job=\"kuma-control-plane\"}",
+          "legendFormat": "{{ instance }}",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Heap memory allocated and RSS (resident set size)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 108
+      },
+      "id": 92,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Memory",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "go_memstats_heap_alloc_bytes{job=\"kuma-control-plane\"}",
+          "legendFormat": "{{ instance }} alloc",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "process_resident_memory_bytes{job=\"kuma-control-plane\"}",
+          "legendFormat": "RSS",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "go_memstats_heap_inuse_bytes{job=\"kuma-control-plane\"}",
+          "legendFormat": "{{ instance }} in-use",
+          "refId": "C"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "CPU usage rate of the control plane process",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "orange",
+            "mode": "fixed"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 108
+      },
+      "id": 93,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "CPU Usage",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(process_cpu_seconds_total{job=\"kuma-control-plane\"}[5m])",
+          "legendFormat": "CPU cores",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "GC pause duration quantiles",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 116
+      },
+      "id": 94,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "GC Duration",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "go_gc_duration_seconds{job=\"kuma-control-plane\",quantile=\"1\"}",
+          "legendFormat": "max",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "go_gc_duration_seconds{job=\"kuma-control-plane\",quantile=\"0.5\"}",
+          "legendFormat": "p50",
+          "refId": "B"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Open file descriptors vs system limit",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "limit"
+            },
+            "properties": [
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "dash",
+                  "dash": [
+                    10,
+                    10
+                  ]
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 116
+      },
+      "id": 95,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "File Descriptors",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "process_open_fds{job=\"kuma-control-plane\"}",
+          "legendFormat": "open",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "process_max_fds{job=\"kuma-control-plane\"}",
+          "legendFormat": "limit",
+          "refId": "B"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Rate of requests from the CP to the Kubernetes API server, by HTTP status code",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 124
+      },
+      "id": 101,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "API Server Requests by Status",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (code) (rate(rest_client_requests_total{job=\"kuma-control-plane\"}[5m]))",
+          "legendFormat": "{{ code }}",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Rate of requests from the CP to the Kubernetes API server, by HTTP method",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 124
+      },
+      "id": 102,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "API Server Requests by Method",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (method) (rate(rest_client_requests_total{job=\"kuma-control-plane\"}[5m]))",
+          "legendFormat": "{{ method }}",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Current depth of K8s controller workqueues \u2014 sustained non-zero indicates backpressure",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 20
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 132
+      },
+      "id": 111,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Workqueue Depth",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "max by (name) (workqueue_depth{job=\"kuma-control-plane\"})",
+          "legendFormat": "{{ name }}",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "99th percentile time to process items from K8s workqueues",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 132
+      },
+      "id": 112,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Workqueue Processing Time (p99)",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (name, le) (rate(workqueue_work_duration_seconds_bucket{job=\"kuma-control-plane\"}[5m])))",
+          "legendFormat": "{{ name }}",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 140
+      },
+      "id": 70,
+      "title": "Kubernetes",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Rate of K8s controller reconciliations by controller and result",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 141
+      },
+      "id": 71,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Reconciliation Rate",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (controller) (rate(controller_runtime_reconcile_total{job=\"kuma-control-plane\",result=\"success\"}[5m]))",
+          "legendFormat": "{{ controller }}",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Rate of reconciliation errors per controller \u2014 non-zero indicates controller issues",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.01
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 141
+      },
+      "id": 72,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Reconciliation Errors",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (controller) (rate(controller_runtime_reconcile_errors_total{job=\"kuma-control-plane\"}[5m]))",
+          "legendFormat": "{{ controller }}",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "99th percentile reconciliation latency per controller",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 149
+      },
+      "id": 73,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Reconciliation Latency (p99)",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (controller, le) (rate(controller_runtime_reconcile_time_seconds_bucket{job=\"kuma-control-plane\"}[5m])))",
+          "legendFormat": "{{ controller }}",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Admission webhook request latency (p99) and request rate",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 149
+      },
+      "id": 74,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Webhook Latency (p99)",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(controller_runtime_webhook_latency_seconds_bucket{job=\"kuma-control-plane\"}[5m])))",
+          "legendFormat": "p99",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 157
+      },
+      "id": 60,
+      "title": "Component Loops",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "99th percentile latency of periodic component loops (hostname generator, status updaters, store counter)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 158
+      },
+      "id": 61,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Component Loop Latency (p99)",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(component_hostname_generator_bucket{job=\"kuma-control-plane\"}[5m])))",
+          "legendFormat": "hostname-generator",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(component_ms_status_updater_bucket{job=\"kuma-control-plane\"}[5m])))",
+          "legendFormat": "meshservice-status",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(component_mzms_status_updater_bucket{job=\"kuma-control-plane\"}[5m])))",
+          "legendFormat": "mzms-status",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(component_workload_status_updater_bucket{job=\"kuma-control-plane\"}[5m])))",
+          "legendFormat": "workload-status",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(component_store_counter_bucket{job=\"kuma-control-plane\"}[5m])))",
+          "legendFormat": "store-counter",
+          "refId": "E"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Insights resyncer event processing time and processor idle time",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 158
+      },
+      "id": 62,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Insights Resyncer (p99)",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(insights_resyncer_event_time_processing_bucket{job=\"kuma-control-plane\"}[5m])))",
+          "legendFormat": "event processing",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(insights_resyncer_processor_idle_time_bucket{job=\"kuma-control-plane\"}[5m])))",
+          "legendFormat": "processor idle",
+          "refId": "B"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 166
+      },
+      "id": 80,
+      "title": "DP Server",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "99th percentile HTTP request latency on the data plane server (SDS, bootstrap, health)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 167
+      },
+      "id": 81,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "DP Server Request Latency (p99)",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (handler, le) (rate(dp_server_http_request_duration_seconds_bucket{job=\"kuma-control-plane\"}[5m])))",
+          "legendFormat": "{{ handler }}",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Number of inflight HTTP requests on the data plane server",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 167
+      },
+      "id": 82,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "DP Server Inflight Requests",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (handler) (dp_server_http_requests_inflight{job=\"kuma-control-plane\"})",
+          "legendFormat": "{{ handler }}",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 175
+      },
+      "id": 30,
+      "title": "gRPC Server",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Rate of gRPC messages sent and received by the CP server (xDS/KDS streams)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 176
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "gRPC Message Exchange",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(grpc_server_msg_received_total{job=\"kuma-control-plane\"}[5m]))",
+          "legendFormat": "received",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(grpc_server_msg_sent_total{job=\"kuma-control-plane\"}[5m]))",
+          "legendFormat": "sent",
+          "refId": "B"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Rate of new gRPC streams started on the CP server",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 176
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "gRPC Streams Started Rate",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (grpc_service) (rate(grpc_server_started_total{job=\"kuma-control-plane\"}[5m]))",
+          "legendFormat": "{{ grpc_service }}",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "kuma",
+    "control-plane"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(envoy_server_live{job=\"kuma-dataplanes\"}, mesh)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Mesh",
+        "multi": false,
+        "name": "mesh",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(envoy_server_live{job=\"kuma-dataplanes\"}, mesh)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Kuma Control Plane",
+  "uid": "kuma-cp-v2",
+  "version": 1
+}

--- a/dashboards/grafana/kuma-control-plane.json
+++ b/dashboards/grafana/kuma-control-plane.json
@@ -233,7 +233,7 @@
           },
           "expr": "leader{job=\"kuma-control-plane\"}",
           "instant": true,
-          "legendFormat": "{{ zone }} / {{ instance }}",
+          "legendFormat": "{{ zone }} / {{ pod }}",
           "refId": "A"
         }
       ],
@@ -304,7 +304,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Total number of Dataplane resources \u2014 should closely match active xDS streams",
+      "description": "Dataplane resource count, falls back to active xDS streams if MeshInsight is unavailable (zone CP).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -352,7 +352,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "max(resources_count{job=\"kuma-control-plane\",resource_type=\"Dataplane\"})",
+          "expr": "max(resources_count{job=\"kuma-control-plane\",resource_type=\"Dataplane\"}) or sum(xds_streams_active{job=\"kuma-control-plane\"})",
           "legendFormat": "dataplanes",
           "refId": "A"
         }
@@ -1330,79 +1330,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "max by (resource_type) (resources_count{job=\"kuma-control-plane\",resource_type=~\"Dataplane|Mesh|MeshService|HostnameGenerator|Zone|ZoneIngress|ZoneEgress\"})",
-          "legendFormat": "{{ resource_type }}",
-          "refId": "A"
-        }
-      ],
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "Number of policy resources tracked by the control plane",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "lineWidth": 1,
-            "pointSize": 5,
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "normal"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 57
-      },
-      "id": 52,
-      "options": {
-        "legend": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "title": "Policy Count",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "resources_count{job=\"kuma-control-plane\",resource_type=~\"Mesh.*|MeshTrafficPermission|MeshHTTPRoute|MeshTCPRoute\",resource_type!~\"MeshInsight|MeshService\"}",
+          "expr": "max by (resource_type) (resources_count{job=\"kuma-control-plane\",resource_type!~\".*Insight|Secret|GlobalSecret|Config\"})",
           "legendFormat": "{{ resource_type }}",
           "refId": "A"
         }
@@ -1450,8 +1378,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 0,
-        "y": 65
+        "x": 12,
+        "y": 57
       },
       "id": 53,
       "options": {
@@ -1870,7 +1798,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "min by (kuma_workload) (envoy_server_days_until_first_cert_expiring{mesh=\"$mesh\"})",
+          "expr": "min(envoy_server_days_until_first_cert_expiring{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"})",
           "legendFormat": "{{kuma_workload}}",
           "refId": "A",
           "instant": true
@@ -1947,7 +1875,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "min by (kuma_workload) ((envoy_listener_ssl_certificate_expiration_unix_time_seconds{mesh=\"$mesh\"} - time()) / 3600)",
+          "expr": "min by (kuma_workload) ((envoy_listener_ssl_certificate_expiration_unix_time_seconds{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",envoy_listener_address=~\"self_inbound_dp_.*\"} - time()) / 3600)",
           "legendFormat": "{{kuma_workload}}",
           "refId": "A"
         }
@@ -2090,7 +2018,7 @@
             "uid": "${datasource}"
           },
           "expr": "go_goroutines{job=\"kuma-control-plane\"}",
-          "legendFormat": "{{ instance }}",
+          "legendFormat": "{{ pod }}",
           "refId": "A"
         }
       ],
@@ -2159,7 +2087,7 @@
             "uid": "${datasource}"
           },
           "expr": "go_memstats_heap_alloc_bytes{job=\"kuma-control-plane\"}",
-          "legendFormat": "{{ instance }} alloc",
+          "legendFormat": "{{ pod }} alloc",
           "refId": "A"
         },
         {
@@ -2168,7 +2096,7 @@
             "uid": "${datasource}"
           },
           "expr": "process_resident_memory_bytes{job=\"kuma-control-plane\"}",
-          "legendFormat": "RSS",
+          "legendFormat": "{{ pod }} RSS",
           "refId": "B"
         },
         {
@@ -2177,7 +2105,7 @@
             "uid": "${datasource}"
           },
           "expr": "go_memstats_heap_inuse_bytes{job=\"kuma-control-plane\"}",
-          "legendFormat": "{{ instance }} in-use",
+          "legendFormat": "{{ pod }} in-use",
           "refId": "C"
         }
       ],
@@ -2247,7 +2175,7 @@
             "uid": "${datasource}"
           },
           "expr": "rate(process_cpu_seconds_total{job=\"kuma-control-plane\"}[5m])",
-          "legendFormat": "CPU cores",
+          "legendFormat": "{{ pod }}",
           "refId": "A"
         }
       ],
@@ -2316,7 +2244,7 @@
             "uid": "${datasource}"
           },
           "expr": "go_gc_duration_seconds{job=\"kuma-control-plane\",quantile=\"1\"}",
-          "legendFormat": "max",
+          "legendFormat": "{{ pod }} max",
           "refId": "A"
         },
         {
@@ -2325,7 +2253,7 @@
             "uid": "${datasource}"
           },
           "expr": "go_gc_duration_seconds{job=\"kuma-control-plane\",quantile=\"0.5\"}",
-          "legendFormat": "p50",
+          "legendFormat": "{{ pod }} p50",
           "refId": "B"
         }
       ],
@@ -2419,7 +2347,7 @@
             "uid": "${datasource}"
           },
           "expr": "process_open_fds{job=\"kuma-control-plane\"}",
-          "legendFormat": "open",
+          "legendFormat": "{{ pod }} open",
           "refId": "A"
         },
         {
@@ -2428,11 +2356,23 @@
             "uid": "${datasource}"
           },
           "expr": "process_max_fds{job=\"kuma-control-plane\"}",
-          "legendFormat": "limit",
+          "legendFormat": "{{ pod }} limit",
           "refId": "B"
         }
       ],
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 124
+      },
+      "id": 100,
+      "title": "API Server & Workqueue",
+      "type": "row"
     },
     {
       "datasource": {
@@ -2471,7 +2411,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 124
+        "y": 125
       },
       "id": 101,
       "options": {
@@ -2540,7 +2480,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 124
+        "y": 125
       },
       "id": 102,
       "options": {
@@ -2617,7 +2557,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 132
+        "y": 133
       },
       "id": 111,
       "options": {
@@ -2686,7 +2626,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 132
+        "y": 133
       },
       "id": 112,
       "options": {
@@ -2724,7 +2664,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 140
+        "y": 141
       },
       "id": 70,
       "title": "Kubernetes",
@@ -2767,7 +2707,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 141
+        "y": 142
       },
       "id": 71,
       "options": {
@@ -2840,7 +2780,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 141
+        "y": 142
       },
       "id": 72,
       "options": {
@@ -2909,7 +2849,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 149
+        "y": 150
       },
       "id": 73,
       "options": {
@@ -2978,7 +2918,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 149
+        "y": 150
       },
       "id": 74,
       "options": {
@@ -3016,7 +2956,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 157
+        "y": 158
       },
       "id": 60,
       "title": "Component Loops",
@@ -3059,7 +2999,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 158
+        "y": 159
       },
       "id": 61,
       "options": {
@@ -3164,7 +3104,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 158
+        "y": 159
       },
       "id": 62,
       "options": {
@@ -3211,7 +3151,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 166
+        "y": 167
       },
       "id": 80,
       "title": "DP Server",
@@ -3254,7 +3194,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 167
+        "y": 168
       },
       "id": 81,
       "options": {
@@ -3323,7 +3263,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 167
+        "y": 168
       },
       "id": 82,
       "options": {
@@ -3361,7 +3301,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 175
+        "y": 176
       },
       "id": 30,
       "title": "gRPC Server",
@@ -3404,7 +3344,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 176
+        "y": 177
       },
       "id": 31,
       "options": {
@@ -3482,7 +3422,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 176
+        "y": 177
       },
       "id": 32,
       "options": {
@@ -3554,6 +3494,30 @@
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_zone)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Zone",
+        "multi": false,
+        "name": "zone",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_zone)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
         "type": "query"
       }
     ]

--- a/dashboards/grafana/kuma-control-plane.json
+++ b/dashboards/grafana/kuma-control-plane.json
@@ -65,21 +65,21 @@
   "links": [
     {
       "title": "Mesh Drilldown",
-      "url": "/d/kuma-mesh/kuma-mesh-drilldown?orgId=1",
+      "url": "/d/kuma-mesh/kuma-mesh-drilldown?var-datasource=${datasource}",
       "type": "link",
       "icon": "dashboard",
       "tooltip": "Fleet-wide mesh overview"
     },
     {
       "title": "Workload Health",
-      "url": "/d/kuma-service-health/kuma-service-health?orgId=1",
+      "url": "/d/kuma-service-health/kuma-service-health?var-datasource=${datasource}",
       "type": "link",
       "icon": "dashboard",
       "tooltip": "Per-workload RED overview"
     },
     {
       "title": "Workload Debug",
-      "url": "/d/kuma-service-debug/kuma-service-debug?orgId=1",
+      "url": "/d/kuma-service-debug/kuma-service-debug?var-datasource=${datasource}",
       "type": "link",
       "icon": "dashboard",
       "tooltip": "Deep-dive workload debug"
@@ -304,7 +304,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Total number of Dataplane resources — should closely match active xDS streams",
+      "description": "Total number of Dataplane resources \u2014 should closely match active xDS streams",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1734,7 +1734,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Rate of mTLS certificate generation per mesh",
+      "description": "Ratio of CA cache hits vs misses. High hit rate means fewer expensive cert operations.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1785,7 +1785,6 @@
         }
       },
       "title": "CA Cache Hit Rate",
-      "description": "Ratio of CA cache hits vs misses. High hit rate means fewer expensive cert operations.",
       "targets": [
         {
           "datasource": {
@@ -1853,7 +1852,9 @@
       "id": 42,
       "options": {
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -1904,9 +1905,18 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "red", "value": null },
-              { "color": "orange", "value": 2 },
-              { "color": "green", "value": 12 }
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 2
+              },
+              {
+                "color": "green",
+                "value": 12
+              }
             ]
           }
         },

--- a/dashboards/grafana/kuma-mesh.json
+++ b/dashboards/grafana/kuma-mesh.json
@@ -1831,7 +1831,7 @@
           "refId": "A"
         },
         {
-          "expr": "clamp_min(1 - (sum by (kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m])) / sum by (kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))), 0)",
+          "expr": "clamp_min(1 - ((sum by (kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m])) or sum by (kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])) * 0) / sum by (kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))), 0)",
           "format": "table",
           "instant": true,
           "refId": "B"

--- a/dashboards/grafana/kuma-mesh.json
+++ b/dashboards/grafana/kuma-mesh.json
@@ -75,7 +75,7 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 4,
+        "w": 3,
         "x": 0,
         "y": 1
       },
@@ -123,8 +123,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 4,
-        "x": 4,
+        "w": 3,
+        "x": 3,
         "y": 1
       },
       "id": 2,
@@ -161,6 +161,60 @@
             "mode": "absolute",
             "steps": [
               {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 6,
+        "y": 1
+      },
+      "id": 40,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Disconnected",
+      "type": "stat",
+      "description": "Dataplanes reporting metrics but not connected to the control plane.",
+      "targets": [
+        {
+          "expr": "count(envoy_server_uptime{mesh=\"$mesh\"}) - sum(envoy_control_plane_connected_state{mesh=\"$mesh\"})",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
                 "color": "blue",
                 "value": null
               }
@@ -171,8 +225,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 4,
-        "x": 8,
+        "w": 3,
+        "x": 9,
         "y": 1
       },
       "id": 3,
@@ -193,54 +247,6 @@
       "targets": [
         {
           "expr": "count(count by (kuma_workload) (envoy_server_uptime{mesh=\"$mesh\"}))",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "purple",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 12,
-        "y": 1
-      },
-      "id": 4,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "title": "Total Policies",
-      "type": "stat",
-      "targets": [
-        {
-          "expr": "sum(resources_count{resource_type=~\"Mesh.*\",resource_type!=\"MeshInsight\"})",
           "legendFormat": "",
           "refId": "A"
         }
@@ -289,7 +295,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "sum(rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum(rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "",
           "refId": "A"
         }
@@ -303,24 +309,25 @@
       "fieldConfig": {
         "defaults": {
           "unit": "percentunit",
-          "decimals": 2,
+          "decimals": 3,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "red",
                 "value": null
               },
               {
                 "color": "yellow",
-                "value": 0.01
+                "value": 0.99
               },
               {
-                "color": "red",
-                "value": 0.05
+                "color": "green",
+                "value": 0.999
               }
             ]
-          }
+          },
+          "noValue": "100%"
         },
         "overrides": []
       },
@@ -343,11 +350,11 @@
         },
         "textMode": "auto"
       },
-      "title": "Mesh 5xx Rate",
+      "title": "Mesh Success Rate",
       "type": "stat",
       "targets": [
         {
-          "expr": "sum(rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m])) / clamp_min(sum(rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])), 1)",
+          "expr": "1 - (sum(rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m])) / clamp_min(sum(rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])), 1))",
           "legendFormat": "",
           "refId": "A"
         }
@@ -408,7 +415,7 @@
             "lastNotNull"
           ],
           "fields": "",
-          "values": true
+          "values": false
         },
         "showUnfilled": true
       },
@@ -417,26 +424,10 @@
       "type": "bargauge",
       "targets": [
         {
-          "expr": "sort(envoy_server_uptime{mesh=\"$mesh\"})",
+          "expr": "sort_desc(envoy_server_uptime{mesh=\"$mesh\"})",
           "legendFormat": "{{pod}}",
           "refId": "A",
-          "instant": true,
-          "range": false,
-          "format": "table"
-        }
-      ],
-      "transformations": [
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "field": "Value",
-                "desc": false
-              }
-            ]
-          }
+          "instant": true
         }
       ]
     },
@@ -492,9 +483,10 @@
       "type": "bargauge",
       "targets": [
         {
-          "expr": "envoy_server_memory_allocated{mesh=\"$mesh\"}",
+          "expr": "sort_desc(envoy_server_memory_allocated{mesh=\"$mesh\"})",
           "legendFormat": "{{pod}}",
-          "refId": "A"
+          "refId": "A",
+          "instant": true
         }
       ]
     },
@@ -1012,7 +1004,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "sum by (kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum by (kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "{{kuma_workload}}",
           "refId": "A"
         }
@@ -1068,7 +1060,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "sum by (kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m]))",
+          "expr": "sum by (kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m]))",
           "legendFormat": "{{kuma_workload}}",
           "refId": "A"
         }
@@ -1124,7 +1116,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum by (le, kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le, kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])))",
           "legendFormat": "{{kuma_workload}}",
           "refId": "A"
         }
@@ -1180,7 +1172,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "sum by (kuma_workload, kuma_io_zone) (envoy_http_downstream_cx_active{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"})",
+          "expr": "sum by (kuma_workload, kuma_io_zone) (envoy_http_downstream_cx_active{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"})",
           "legendFormat": "{{kuma_workload}}",
           "refId": "A"
         }
@@ -1236,12 +1228,12 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "sum by (kuma_workload) (rate(envoy_http_downstream_cx_destroy_local{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum by (kuma_workload) (rate(envoy_http_downstream_cx_destroy_local{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "{{kuma_workload}} local",
           "refId": "A"
         },
         {
-          "expr": "sum by (kuma_workload) (rate(envoy_http_downstream_cx_destroy_remote{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum by (kuma_workload) (rate(envoy_http_downstream_cx_destroy_remote{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "{{kuma_workload}} remote",
           "refId": "B"
         }
@@ -1297,12 +1289,12 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "sum by (kuma_workload) (rate(envoy_http_downstream_cx_rx_bytes_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum by (kuma_workload) (rate(envoy_http_downstream_cx_rx_bytes_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "{{kuma_workload}} rx",
           "refId": "A"
         },
         {
-          "expr": "sum by (kuma_workload) (rate(envoy_http_downstream_cx_tx_bytes_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum by (kuma_workload) (rate(envoy_http_downstream_cx_tx_bytes_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "{{kuma_workload}} tx",
           "refId": "B"
         }
@@ -1476,22 +1468,22 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "sum(rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\",envoy_response_code_class=\"2\"}[5m]))",
+          "expr": "sum(rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\",envoy_response_code_class=\"2\"}[5m]))",
           "legendFormat": "2xx",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\",envoy_response_code_class=\"3\"}[5m]))",
+          "expr": "sum(rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\",envoy_response_code_class=\"3\"}[5m]))",
           "legendFormat": "3xx",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\",envoy_response_code_class=\"4\"}[5m]))",
+          "expr": "sum(rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\",envoy_response_code_class=\"4\"}[5m]))",
           "legendFormat": "4xx",
           "refId": "C"
         },
         {
-          "expr": "sum(rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m]))",
+          "expr": "sum(rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m]))",
           "legendFormat": "5xx",
           "refId": "D"
         }
@@ -1531,7 +1523,7 @@
       "type": "heatmap",
       "targets": [
         {
-          "expr": "sum(increase(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (le)",
+          "expr": "sum(increase(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])) by (le)",
           "format": "heatmap",
           "legendFormat": "{{le}}",
           "refId": "A"
@@ -1654,7 +1646,7 @@
             "properties": [
               {
                 "id": "displayName",
-                "value": "Error Rate"
+                "value": "Success Rate"
               },
               {
                 "id": "unit",
@@ -1662,7 +1654,7 @@
               },
               {
                 "id": "decimals",
-                "value": 2
+                "value": 3
               },
               {
                 "id": "thresholds",
@@ -1670,16 +1662,16 @@
                   "mode": "absolute",
                   "steps": [
                     {
-                      "color": "green",
+                      "color": "red",
                       "value": null
                     },
                     {
                       "color": "yellow",
-                      "value": 0.01
+                      "value": 0.99
                     },
                     {
-                      "color": "red",
-                      "value": 0.05
+                      "color": "green",
+                      "value": 0.999
                     }
                   ]
                 }
@@ -1690,6 +1682,21 @@
                   "mode": "gradient",
                   "type": "color-background"
                 }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "special",
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "N/A",
+                        "color": "text"
+                      }
+                    }
+                  }
+                ]
               }
             ]
           },
@@ -1818,19 +1825,19 @@
       "type": "table",
       "targets": [
         {
-          "expr": "sum by (kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum by (kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
           "format": "table",
           "instant": true,
           "refId": "A"
         },
         {
-          "expr": "sum by (kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m])) / clamp_min(sum by (kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])), 1)",
+          "expr": "clamp_min(1 - (sum by (kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m])) / sum by (kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))), 0)",
           "format": "table",
           "instant": true,
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum by (le, kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le, kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])))",
           "format": "table",
           "instant": true,
           "refId": "C"
@@ -1842,7 +1849,7 @@
           "refId": "D"
         },
         {
-          "expr": "sum by (kuma_workload, kuma_io_zone) (envoy_http_downstream_cx_active{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"})",
+          "expr": "sum by (kuma_workload, kuma_io_zone) (envoy_http_downstream_cx_active{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"})",
           "format": "table",
           "instant": true,
           "refId": "E"

--- a/dashboards/grafana/kuma-mesh.json
+++ b/dashboards/grafana/kuma-mesh.json
@@ -1,0 +1,1909 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [
+    {
+      "title": "Workload Health",
+      "url": "/d/kuma-service-health/kuma-service-health?orgId=1&var-datasource=${datasource}",
+      "type": "link",
+      "icon": "dashboard",
+      "tooltip": "Per-workload RED overview"
+    },
+    {
+      "title": "Workload Debug",
+      "url": "/d/kuma-service-debug/kuma-service-debug?orgId=1&var-datasource=${datasource}",
+      "type": "link",
+      "icon": "dashboard",
+      "tooltip": "Deep-dive workload debug"
+    },
+    {
+      "title": "Control Plane",
+      "url": "/d/kuma-cp-v2/kuma-control-plane?orgId=1",
+      "type": "link",
+      "icon": "dashboard",
+      "tooltip": "CP health and performance"
+    }
+  ],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Active Dataplanes",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "count(envoy_server_uptime{mesh=\"$mesh\"})",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Connected to CP",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "sum(envoy_control_plane_connected_state{mesh=\"$mesh\"})",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Workloads",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "count(count by (kuma_workload) (envoy_server_uptime{mesh=\"$mesh\"}))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "purple",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Total Policies",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "sum(resources_count{resource_type=~\"Mesh.*\",resource_type!=\"MeshInsight\"})",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Mesh Inbound RPS",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "sum(rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.01
+              },
+              {
+                "color": "red",
+                "value": 0.05
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Mesh 5xx Rate",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "sum(rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m])) / sum(rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 101,
+      "title": "Fleet Health",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 3600
+              },
+              {
+                "color": "green",
+                "value": 86400
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 6
+      },
+      "id": 7,
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": true
+        },
+        "showUnfilled": true
+      },
+      "title": "Uptime by Pod",
+      "description": "Recently restarted proxies appear with short bars. Red < 1h, Yellow < 24h, Green > 24h.",
+      "type": "bargauge",
+      "targets": [
+        {
+          "expr": "sort(envoy_server_uptime{mesh=\"$mesh\"})",
+          "legendFormat": "{{pod}}",
+          "refId": "A",
+          "instant": true,
+          "range": false,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Value",
+                "desc": false
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 52428800
+              },
+              {
+                "color": "red",
+                "value": 104857600
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 6
+      },
+      "id": 8,
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "title": "Memory by Pod",
+      "description": "Envoy heap memory per proxy. Green < 50MB, Yellow < 100MB, Red > 100MB.",
+      "type": "bargauge",
+      "targets": [
+        {
+          "expr": "envoy_server_memory_allocated{mesh=\"$mesh\"}",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "ops",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 6
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Cert Rotation Rate",
+      "description": "Rate of SDS certificate updates per second. Active rotation confirms mTLS is healthy.",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (pod) (rate(envoy_listener_server_ssl_socket_factory_ssl_context_update_by_sds{mesh=\"$mesh\"}[5m]))",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 104,
+      "title": "Security",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 15
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "RBAC Denied by Workload",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (kuma_workload) (rate(envoy_rbac_denied{mesh=\"$mesh\"}[5m]))",
+          "legendFormat": "{{kuma_workload}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 15
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Outbound TLS Handshakes by Workload",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (kuma_workload) (rate(envoy_cluster_ssl_handshake{mesh=\"$mesh\",envoy_cluster_name=~\".*_m?svc_.*\"}[5m]))",
+          "legendFormat": "{{kuma_workload}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "d",
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "< 1 day (OK)",
+                  "color": "green"
+                }
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 15
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "min"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "asc"
+        }
+      },
+      "title": "Cert Expiry (days)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "envoy_server_days_until_first_cert_expiring{mesh=\"$mesh\"}",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "description": "Days until mTLS cert expires. 0 is normal for short-lived certs (24h rotation)."
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 107,
+      "title": "Reliability",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 24
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "min"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "asc"
+        }
+      },
+      "title": "Upstream Endpoint Health Ratio",
+      "description": "Healthy/total endpoints per destination. Values below 1.0 indicate degraded backends.",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "min by (envoy_cluster_name) (envoy_cluster_membership_healthy{mesh=\"$mesh\",envoy_cluster_name=~\".*_m?svc_.*\"} / envoy_cluster_membership_total{mesh=\"$mesh\",envoy_cluster_name=~\".*_m?svc_.*\"})",
+          "legendFormat": "{{envoy_cluster_name}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 24
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "min"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "asc"
+        }
+      },
+      "title": "Circuit Breaker \u2014 Remaining RQ Capacity",
+      "description": "Minimum remaining request slots before circuit breaker trips. 0 = CB is actively rejecting.",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "min by (kuma_workload) (envoy_cluster_circuit_breakers_default_remaining_rq{mesh=\"$mesh\",envoy_cluster_name=~\".*_m?svc_.*\"})",
+          "legendFormat": "{{kuma_workload}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 24
+      },
+      "id": 25,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Retry Rate by Workload",
+      "description": "Upstream request retries per workload. High retry rate indicates problematic destinations.",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (kuma_workload) (rate(envoy_cluster_upstream_rq_retry{mesh=\"$mesh\",envoy_cluster_name=~\".*_m?svc_.*\"}[5m]))",
+          "legendFormat": "{{kuma_workload}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Traffic",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "panels": []
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 33
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Inbound Request Rate by Workload",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "legendFormat": "{{kuma_workload}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 33
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Inbound 5xx Rate by Workload",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m]))",
+          "legendFormat": "{{kuma_workload}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 33
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Inbound P99 Latency by Workload",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum by (le, kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])))",
+          "legendFormat": "{{kuma_workload}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 41
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Active Inbound Connections by Workload",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (kuma_workload, kuma_io_zone) (envoy_http_downstream_cx_active{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"})",
+          "legendFormat": "{{kuma_workload}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 41
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Connection Close Rate by Workload",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (kuma_workload) (rate(envoy_http_downstream_cx_destroy_local{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "legendFormat": "{{kuma_workload}} local",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (kuma_workload) (rate(envoy_http_downstream_cx_destroy_remote{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "legendFormat": "{{kuma_workload}} remote",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 49
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Inbound Throughput by Workload",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (kuma_workload) (rate(envoy_http_downstream_cx_rx_bytes_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "legendFormat": "{{kuma_workload}} rx",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (kuma_workload) (rate(envoy_http_downstream_cx_tx_bytes_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "legendFormat": "{{kuma_workload}} tx",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 49
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Outbound Throughput by Workload",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (kuma_workload) (rate(envoy_cluster_upstream_cx_tx_bytes_total{mesh=\"$mesh\",envoy_cluster_name=~\".*_m?svc_.*\"}[5m]))",
+          "legendFormat": "{{kuma_workload}} tx",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (kuma_workload) (rate(envoy_cluster_upstream_cx_rx_bytes_total{mesh=\"$mesh\",envoy_cluster_name=~\".*_m?svc_.*\"}[5m]))",
+          "legendFormat": "{{kuma_workload}} rx",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "lineWidth": 0,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "2xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "3xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "4xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "5xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 57
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Response Code Distribution",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum(rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\",envoy_response_code_class=\"2\"}[5m]))",
+          "legendFormat": "2xx",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\",envoy_response_code_class=\"3\"}[5m]))",
+          "legendFormat": "3xx",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\",envoy_response_code_class=\"4\"}[5m]))",
+          "legendFormat": "4xx",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m]))",
+          "legendFormat": "5xx",
+          "refId": "D"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 57
+      },
+      "id": 32,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "scheme": "Oranges",
+          "steps": 64
+        },
+        "yAxis": {
+          "unit": "ms"
+        }
+      },
+      "title": "Latency Distribution Heatmap",
+      "type": "heatmap",
+      "targets": [
+        {
+          "expr": "sum(increase(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (le)",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 57
+      },
+      "id": 33,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "min"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "asc"
+        }
+      },
+      "title": "Connection Pool \u2014 Remaining Capacity",
+      "description": "Remaining CX, pending, and RQ slots per workload. Near 0 = circuit breaker about to trip.",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "min by (kuma_workload) (envoy_cluster_circuit_breakers_default_remaining_cx{mesh=\"$mesh\",envoy_cluster_name=~\".*_m?svc_.*\"})",
+          "legendFormat": "{{kuma_workload}} cx",
+          "refId": "A"
+        },
+        {
+          "expr": "min by (kuma_workload) (envoy_cluster_circuit_breakers_default_remaining_pending{mesh=\"$mesh\",envoy_cluster_name=~\".*_m?svc_.*\"})",
+          "legendFormat": "{{kuma_workload}} pending",
+          "refId": "B"
+        },
+        {
+          "expr": "min by (kuma_workload) (envoy_cluster_circuit_breakers_default_remaining_rq{mesh=\"$mesh\",envoy_cluster_name=~\".*_m?svc_.*\"})",
+          "legendFormat": "{{kuma_workload}} rq",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 65
+      },
+      "id": 109,
+      "title": "Workload Summary",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #A"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "RPS"
+              },
+              {
+                "id": "unit",
+                "value": "reqps"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #B"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Error Rate"
+              },
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 0.01
+                    },
+                    {
+                      "color": "red",
+                      "value": 0.05
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "color-background"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #C"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "P99 (ms)"
+              },
+              {
+                "id": "unit",
+                "value": "ms"
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #D"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Memory"
+              },
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #E"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Active CX"
+              },
+              {
+                "id": "unit",
+                "value": "short"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "kuma_workload"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Workload"
+              },
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Open Workload Health",
+                    "url": "/d/kuma-service-health/kuma-service-health?orgId=1&var-datasource=${datasource}&var-workload=${__data.fields.kuma_workload}"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "kuma_io_zone"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Zone"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 66
+      },
+      "id": 30,
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "RPS",
+            "desc": true
+          }
+        ],
+        "footer": {
+          "show": false
+        }
+      },
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            }
+          }
+        }
+      ],
+      "title": "Workload Summary Table",
+      "description": "Click a workload name to drill down to Workload Health dashboard.",
+      "type": "table",
+      "targets": [
+        {
+          "expr": "sum by (kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m])) / sum by (kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "format": "table",
+          "instant": true,
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le, kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])))",
+          "format": "table",
+          "instant": true,
+          "refId": "C"
+        },
+        {
+          "expr": "sum by (kuma_workload, kuma_io_zone) (envoy_server_memory_allocated{mesh=\"$mesh\"})",
+          "format": "table",
+          "instant": true,
+          "refId": "D"
+        },
+        {
+          "expr": "sum by (kuma_workload, kuma_io_zone) (envoy_http_downstream_cx_active{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"})",
+          "format": "table",
+          "instant": true,
+          "refId": "E"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": [
+    "kuma",
+    "mesh"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(envoy_server_uptime, mesh)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Mesh",
+        "multi": false,
+        "name": "mesh",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(envoy_server_uptime, mesh)"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Kuma Mesh Drilldown",
+  "uid": "kuma-mesh",
+  "version": 1
+}

--- a/dashboards/grafana/kuma-mesh.json
+++ b/dashboards/grafana/kuma-mesh.json
@@ -21,21 +21,21 @@
   "links": [
     {
       "title": "Workload Health",
-      "url": "/d/kuma-service-health/kuma-service-health?orgId=1&var-datasource=${datasource}",
+      "url": "/d/kuma-service-health/kuma-service-health?var-datasource=${datasource}",
       "type": "link",
       "icon": "dashboard",
       "tooltip": "Per-workload RED overview"
     },
     {
       "title": "Workload Debug",
-      "url": "/d/kuma-service-debug/kuma-service-debug?orgId=1&var-datasource=${datasource}",
+      "url": "/d/kuma-service-debug/kuma-service-debug?var-datasource=${datasource}",
       "type": "link",
       "icon": "dashboard",
       "tooltip": "Deep-dive workload debug"
     },
     {
       "title": "Control Plane",
-      "url": "/d/kuma-cp-v2/kuma-control-plane?orgId=1",
+      "url": "/d/kuma-cp-v2/kuma-control-plane?var-datasource=${datasource}",
       "type": "link",
       "icon": "dashboard",
       "tooltip": "CP health and performance"
@@ -347,7 +347,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "sum(rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m])) / sum(rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum(rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m])) / clamp_min(sum(rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])), 1)",
           "legendFormat": "",
           "refId": "A"
         }
@@ -1760,7 +1760,7 @@
                 "value": [
                   {
                     "title": "Open Workload Health",
-                    "url": "/d/kuma-service-health/kuma-service-health?orgId=1&var-datasource=${datasource}&var-workload=${__data.fields.kuma_workload}"
+                    "url": "/d/kuma-service-health/kuma-service-health?var-datasource=${datasource}&var-mesh=${__data.fields.mesh}&var-zone=${__data.fields.kuma_io_zone}&var-workload=${__data.fields.kuma_workload}"
                   }
                 ]
               }
@@ -1824,7 +1824,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum by (kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m])) / sum by (kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum by (kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m])) / clamp_min(sum by (kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])), 1)",
           "format": "table",
           "instant": true,
           "refId": "B"

--- a/dashboards/grafana/kuma-service-debug.json
+++ b/dashboards/grafana/kuma-service-debug.json
@@ -21,21 +21,21 @@
   "links": [
     {
       "title": "Workload Health",
-      "url": "/d/kuma-service-health/kuma-service-health?orgId=1&var-datasource=${datasource}&var-namespace=${namespace}&var-workload=${workload}",
+      "url": "/d/kuma-service-health/kuma-service-health?var-datasource=${datasource}&var-namespace=${namespace}&var-workload=${workload}",
       "type": "link",
       "icon": "dashboard",
       "tooltip": "RED overview for this workload"
     },
     {
       "title": "Mesh Drilldown",
-      "url": "/d/kuma-mesh/kuma-mesh-drilldown?orgId=1&var-datasource=${datasource}",
+      "url": "/d/kuma-mesh/kuma-mesh-drilldown?var-datasource=${datasource}",
       "type": "link",
       "icon": "dashboard",
       "tooltip": "Fleet-wide mesh overview"
     },
     {
       "title": "Control Plane",
-      "url": "/d/kuma-cp-v2/kuma-control-plane?orgId=1",
+      "url": "/d/kuma-cp-v2/kuma-control-plane?var-datasource=${datasource}",
       "type": "link",
       "icon": "dashboard",
       "tooltip": "CP health and performance"
@@ -110,17 +110,17 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_http_downstream_rq_total{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum(rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "Total",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(envoy_http_downstream_rq_http1_total{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum(rate(envoy_http_downstream_rq_http1_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "HTTP/1.1",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(envoy_http_downstream_rq_http2_total{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum(rate(envoy_http_downstream_rq_http2_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "HTTP/2",
           "refId": "C"
         }
@@ -245,7 +245,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_http_downstream_rq_xx{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (envoy_response_code_class)",
+          "expr": "sum(rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (envoy_response_code_class)",
           "legendFormat": "{{envoy_response_code_class}}xx",
           "refId": "A"
         }
@@ -309,17 +309,17 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(envoy_http_downstream_rq_time_bucket{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (le))",
           "legendFormat": "p99",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(rate(envoy_http_downstream_rq_time_bucket{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (le))",
           "legendFormat": "p95",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.50, sum(rate(envoy_http_downstream_rq_time_bucket{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.50, sum(rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (le))",
           "legendFormat": "p50",
           "refId": "C"
         }
@@ -395,7 +395,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_total{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}}",
           "refId": "A"
         }
@@ -505,7 +505,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_xx{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name, envoy_response_code_class)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_xx{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name, envoy_response_code_class)",
           "legendFormat": "{{envoy_cluster_name}} {{envoy_response_code_class}}xx",
           "refId": "A"
         }
@@ -569,12 +569,12 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_rq_time_bucket{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
+          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_rq_time_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
           "legendFormat": "{{envoy_cluster_name}} p99",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.50, sum(rate(envoy_cluster_upstream_rq_time_bucket{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
+          "expr": "histogram_quantile(0.50, sum(rate(envoy_cluster_upstream_rq_time_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
           "legendFormat": "{{envoy_cluster_name}} p50",
           "refId": "B"
         }
@@ -666,12 +666,12 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_rbac_denied{kuma_workload=\"$workload\"}[5m]))",
+          "expr": "sum(rate(envoy_rbac_denied{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}[5m]))",
           "legendFormat": "Denied/s",
           "refId": "A"
         },
         {
-          "expr": "sum(envoy_rbac_denied{kuma_workload=\"$workload\"})",
+          "expr": "sum(envoy_rbac_denied{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"})",
           "legendFormat": "Denied Total",
           "refId": "B"
         }
@@ -735,12 +735,12 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_cluster_ssl_handshake{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_ssl_handshake{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Outbound",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(envoy_listener_ssl_handshake{kuma_workload=\"$workload\"}[5m]))",
+          "expr": "sum(rate(envoy_listener_ssl_handshake{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}[5m]))",
           "legendFormat": "Inbound",
           "refId": "B"
         }
@@ -805,7 +805,7 @@
       },
       "targets": [
         {
-          "expr": "min(envoy_server_days_until_first_cert_expiring{kuma_workload=\"$workload\"})",
+          "expr": "min(envoy_server_days_until_first_cert_expiring{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"})",
           "legendFormat": "Server Cert",
           "refId": "A"
         }
@@ -914,17 +914,17 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_retry{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_retry{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Retries",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_retry_success{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_retry_success{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Success",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_retry_overflow{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_retry_overflow{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Overflow",
           "refId": "C"
         }
@@ -1004,17 +1004,17 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_cluster_upstream_cx_connect_timeout{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_cx_connect_timeout{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Connect Timeout",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_timeout{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_timeout{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Request Timeout",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_max_duration_reached{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_max_duration_reached{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Max Duration",
           "refId": "C"
         }
@@ -1078,17 +1078,17 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_rx_reset{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_rx_reset{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} RX Reset",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_tx_reset{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_tx_reset{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} TX Reset",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_cancelled{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_cancelled{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Cancelled",
           "refId": "C"
         }
@@ -1196,17 +1196,17 @@
       },
       "targets": [
         {
-          "expr": "sum(envoy_cluster_membership_healthy{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
+          "expr": "sum(envoy_cluster_membership_healthy{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Healthy",
           "refId": "A"
         },
         {
-          "expr": "sum(envoy_cluster_membership_total{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
+          "expr": "sum(envoy_cluster_membership_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Total",
           "refId": "B"
         },
         {
-          "expr": "sum(envoy_cluster_membership_degraded{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
+          "expr": "sum(envoy_cluster_membership_degraded{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Degraded",
           "refId": "C"
         }
@@ -1295,17 +1295,17 @@
       },
       "targets": [
         {
-          "expr": "max(envoy_cluster_circuit_breakers_default_rq_open{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
+          "expr": "max(envoy_cluster_circuit_breakers_default_rq_open{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} RQ",
           "refId": "A"
         },
         {
-          "expr": "max(envoy_cluster_circuit_breakers_default_rq_pending_open{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
+          "expr": "max(envoy_cluster_circuit_breakers_default_rq_pending_open{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Pending",
           "refId": "B"
         },
         {
-          "expr": "max(envoy_cluster_circuit_breakers_default_cx_open{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
+          "expr": "max(envoy_cluster_circuit_breakers_default_cx_open{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} CX",
           "refId": "C"
         }
@@ -1369,22 +1369,22 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_cluster_upstream_cx_overflow{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_cx_overflow{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} CX Overflow",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_pending_overflow{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_pending_overflow{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Pending Overflow",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(envoy_http_no_route{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum(rate(envoy_http_no_route{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "No Route",
           "refId": "C"
         },
         {
-          "expr": "sum(rate(envoy_cluster_lb_healthy_panic{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_lb_healthy_panic{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} LB Panic",
           "refId": "D"
         }
@@ -1459,12 +1459,12 @@
       },
       "targets": [
         {
-          "expr": "sum(envoy_http_downstream_cx_active{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"})",
+          "expr": "sum(envoy_http_downstream_cx_active{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"})",
           "legendFormat": "Inbound",
           "refId": "A"
         },
         {
-          "expr": "sum(envoy_cluster_upstream_cx_active{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
+          "expr": "sum(envoy_cluster_upstream_cx_active{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}}",
           "refId": "B"
         }
@@ -1559,22 +1559,22 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_cluster_upstream_cx_destroy_remote{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m]))",
+          "expr": "sum(rate(envoy_cluster_upstream_cx_destroy_remote{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m]))",
           "legendFormat": "Upstream Remote Close",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(envoy_cluster_upstream_cx_destroy{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) - sum(rate(envoy_cluster_upstream_cx_destroy_remote{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m]))",
+          "expr": "sum(rate(envoy_cluster_upstream_cx_destroy{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) - sum(rate(envoy_cluster_upstream_cx_destroy_remote{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m]))",
           "legendFormat": "Upstream Local Close",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(envoy_http_downstream_cx_destroy_remote{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum(rate(envoy_http_downstream_cx_destroy_remote{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "Inbound Remote Close",
           "refId": "C"
         },
         {
-          "expr": "sum(rate(envoy_http_downstream_cx_destroy_local{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum(rate(envoy_http_downstream_cx_destroy_local{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "Inbound Local Close",
           "refId": "D"
         }
@@ -1638,12 +1638,12 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_cx_connect_ms_bucket{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
+          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_cx_connect_ms_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
           "legendFormat": "{{envoy_cluster_name}} Connect p99",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_cx_length_ms_bucket{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
+          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_cx_length_ms_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
           "legendFormat": "{{envoy_cluster_name}} Lifetime p99",
           "refId": "B"
         }
@@ -1719,22 +1719,22 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_http_downstream_cx_rx_bytes_total{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum(rate(envoy_http_downstream_cx_rx_bytes_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "Inbound RX",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(envoy_http_downstream_cx_tx_bytes_total{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum(rate(envoy_http_downstream_cx_tx_bytes_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "Inbound TX",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(envoy_cluster_upstream_cx_rx_bytes_total{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m]))",
+          "expr": "sum(rate(envoy_cluster_upstream_cx_rx_bytes_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m]))",
           "legendFormat": "Outbound RX",
           "refId": "C"
         },
         {
-          "expr": "sum(rate(envoy_cluster_upstream_cx_tx_bytes_total{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m]))",
+          "expr": "sum(rate(envoy_cluster_upstream_cx_tx_bytes_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m]))",
           "legendFormat": "Outbound TX",
           "refId": "D"
         }
@@ -1798,17 +1798,17 @@
       },
       "targets": [
         {
-          "expr": "sum(envoy_cluster_upstream_rq_pending_active{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
+          "expr": "sum(envoy_cluster_upstream_rq_pending_active{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Pending",
           "refId": "A"
         },
         {
-          "expr": "sum(envoy_cluster_upstream_rq_active{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
+          "expr": "sum(envoy_cluster_upstream_rq_active{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Active",
           "refId": "B"
         },
         {
-          "expr": "sum(envoy_http_downstream_rq_active{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"})",
+          "expr": "sum(envoy_http_downstream_rq_active{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"})",
           "legendFormat": "Inbound Active",
           "refId": "C"
         }
@@ -1871,12 +1871,12 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_rq_per_cx_bucket{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
+          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_rq_per_cx_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
           "legendFormat": "{{envoy_cluster_name}} p99",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.50, sum(rate(envoy_cluster_upstream_rq_per_cx_bucket{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
+          "expr": "histogram_quantile(0.50, sum(rate(envoy_cluster_upstream_rq_per_cx_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
           "legendFormat": "{{envoy_cluster_name}} p50",
           "refId": "B"
         }
@@ -1946,7 +1946,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "envoy_server_memory_allocated{k8s_kuma_io_namespace=\"$namespace\",kuma_workload=\"$workload\"}",
+          "expr": "envoy_server_memory_allocated{k8s_kuma_io_namespace=\"$namespace\",mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}",
           "legendFormat": "{{pod}}",
           "refId": "A"
         }
@@ -1967,9 +1967,18 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "red", "value": null},
-              {"color": "orange", "value": 3600},
-              {"color": "green", "value": 86400}
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 3600
+              },
+              {
+                "color": "green",
+                "value": 86400
+              }
             ]
           }
         },
@@ -1984,7 +1993,9 @@
       "id": 209,
       "options": {
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -1998,7 +2009,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "envoy_server_uptime{k8s_kuma_io_namespace=\"$namespace\",kuma_workload=\"$workload\"}",
+          "expr": "envoy_server_uptime{k8s_kuma_io_namespace=\"$namespace\",mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}",
           "legendFormat": "{{pod}}",
           "refId": "A"
         }
@@ -2054,7 +2065,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(envoy_control_plane_ds_handshake_bucket{k8s_kuma_io_namespace=\"$namespace\",kuma_workload=\"$workload\"}[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(envoy_control_plane_ds_handshake_bucket{k8s_kuma_io_namespace=\"$namespace\",mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}[5m])))",
           "legendFormat": "p99",
           "refId": "A"
         }

--- a/dashboards/grafana/kuma-service-debug.json
+++ b/dashboards/grafana/kuma-service-debug.json
@@ -193,8 +193,8 @@
           },
           {
             "matcher": {
-              "id": "byName",
-              "options": "4xx"
+              "id": "byRegexp",
+              "options": ".*4xx.*"
             },
             "properties": [
               {
@@ -208,8 +208,8 @@
           },
           {
             "matcher": {
-              "id": "byName",
-              "options": "5xx"
+              "id": "byRegexp",
+              "options": ".*5xx.*"
             },
             "properties": [
               {

--- a/dashboards/grafana/kuma-service-debug.json
+++ b/dashboards/grafana/kuma-service-debug.json
@@ -1,0 +1,2195 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [
+    {
+      "title": "Workload Health",
+      "url": "/d/kuma-service-health/kuma-service-health?orgId=1&var-datasource=${datasource}&var-namespace=${namespace}&var-workload=${workload}",
+      "type": "link",
+      "icon": "dashboard",
+      "tooltip": "RED overview for this workload"
+    },
+    {
+      "title": "Mesh Drilldown",
+      "url": "/d/kuma-mesh/kuma-mesh-drilldown?orgId=1&var-datasource=${datasource}",
+      "type": "link",
+      "icon": "dashboard",
+      "tooltip": "Fleet-wide mesh overview"
+    },
+    {
+      "title": "Control Plane",
+      "url": "/d/kuma-cp-v2/kuma-control-plane?orgId=1",
+      "type": "link",
+      "icon": "dashboard",
+      "tooltip": "CP health and performance"
+    }
+  ],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 200,
+      "title": "Inbound Traffic",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "reqps",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(envoy_http_downstream_rq_total{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "legendFormat": "Total",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(envoy_http_downstream_rq_http1_total{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "legendFormat": "HTTP/1.1",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(envoy_http_downstream_rq_http2_total{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "legendFormat": "HTTP/2",
+          "refId": "C"
+        }
+      ],
+      "title": "Request Rate by Protocol",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "reqps",
+          "min": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "2xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "3xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "4xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "5xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(envoy_http_downstream_rq_xx{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (envoy_response_code_class)",
+          "legendFormat": "{{envoy_response_code_class}}xx",
+          "refId": "A"
+        }
+      ],
+      "title": "Response Status Codes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "ms",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(envoy_http_downstream_rq_time_bucket{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(envoy_http_downstream_rq_time_bucket{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(envoy_http_downstream_rq_time_bucket{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "C"
+        }
+      ],
+      "title": "Request Duration",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 201,
+      "title": "Outbound Traffic",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "reqps",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 10
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(envoy_cluster_upstream_rq_total{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "legendFormat": "{{envoy_cluster_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Rate by Destination",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "reqps",
+          "min": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*2xx.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*4xx.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*5xx.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 10
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(envoy_cluster_upstream_rq_xx{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name, envoy_response_code_class)",
+          "legendFormat": "{{envoy_cluster_name}} {{envoy_response_code_class}}xx",
+          "refId": "A"
+        }
+      ],
+      "title": "Status Codes by Destination",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "ms",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 10
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_rq_time_bucket{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
+          "legendFormat": "{{envoy_cluster_name}} p99",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(envoy_cluster_upstream_rq_time_bucket{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
+          "legendFormat": "{{envoy_cluster_name}} p50",
+          "refId": "B"
+        }
+      ],
+      "title": "Duration by Destination",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 206,
+      "title": "Security",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*Denied.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 19
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(envoy_rbac_denied{kuma_workload=\"$workload\"}[5m]))",
+          "legendFormat": "Denied/s",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(envoy_rbac_denied{kuma_workload=\"$workload\"})",
+          "legendFormat": "Denied Total",
+          "refId": "B"
+        }
+      ],
+      "title": "RBAC Denied",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 19
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(envoy_cluster_ssl_handshake{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "legendFormat": "{{envoy_cluster_name}} Outbound",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(envoy_listener_ssl_handshake{kuma_workload=\"$workload\"}[5m]))",
+          "legendFormat": "Inbound",
+          "refId": "B"
+        }
+      ],
+      "title": "TLS Handshakes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "d",
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "< 1 day (OK)",
+                  "color": "green"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 19
+      },
+      "id": 21,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "min(envoy_server_days_until_first_cert_expiring{kuma_workload=\"$workload\"})",
+          "legendFormat": "Server Cert",
+          "refId": "A"
+        }
+      ],
+      "title": "Certificate Expiry",
+      "type": "stat",
+      "description": "0 is normal \u2014 Kuma rotates mTLS certs every 24h"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "id": 205,
+      "title": "Reliability",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Requires MeshRetry policy. Metrics appear on first retry.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "reqps",
+          "min": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*Success.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*Overflow.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 28
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(envoy_cluster_upstream_rq_retry{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "legendFormat": "{{envoy_cluster_name}} Retries",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(envoy_cluster_upstream_rq_retry_success{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "legendFormat": "{{envoy_cluster_name}} Success",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(envoy_cluster_upstream_rq_retry_overflow{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "legendFormat": "{{envoy_cluster_name}} Overflow",
+          "refId": "C"
+        }
+      ],
+      "title": "Retries",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*Timeout.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 28
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(envoy_cluster_upstream_cx_connect_timeout{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "legendFormat": "{{envoy_cluster_name}} Connect Timeout",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(envoy_cluster_upstream_rq_timeout{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "legendFormat": "{{envoy_cluster_name}} Request Timeout",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(envoy_cluster_upstream_rq_max_duration_reached{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "legendFormat": "{{envoy_cluster_name}} Max Duration",
+          "refId": "C"
+        }
+      ],
+      "title": "Timeouts",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 28
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(envoy_cluster_upstream_rq_rx_reset{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "legendFormat": "{{envoy_cluster_name}} RX Reset",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(envoy_cluster_upstream_rq_tx_reset{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "legendFormat": "{{envoy_cluster_name}} TX Reset",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(envoy_cluster_upstream_rq_cancelled{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "legendFormat": "{{envoy_cluster_name}} Cancelled",
+          "refId": "C"
+        }
+      ],
+      "title": "Request Resets & Cancellations",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*Healthy.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*Total.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*Degraded.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 36
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(envoy_cluster_membership_healthy{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
+          "legendFormat": "{{envoy_cluster_name}} Healthy",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(envoy_cluster_membership_total{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
+          "legendFormat": "{{envoy_cluster_name}} Total",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(envoy_cluster_membership_degraded{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
+          "legendFormat": "{{envoy_cluster_name}} Degraded",
+          "refId": "C"
+        }
+      ],
+      "title": "Upstream Endpoint Health",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "max": 1,
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "Closed"
+                },
+                "1": {
+                  "text": "Open"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 36
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "max(envoy_cluster_circuit_breakers_default_rq_open{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
+          "legendFormat": "{{envoy_cluster_name}} RQ",
+          "refId": "A"
+        },
+        {
+          "expr": "max(envoy_cluster_circuit_breakers_default_rq_pending_open{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
+          "legendFormat": "{{envoy_cluster_name}} Pending",
+          "refId": "B"
+        },
+        {
+          "expr": "max(envoy_cluster_circuit_breakers_default_cx_open{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
+          "legendFormat": "{{envoy_cluster_name}} CX",
+          "refId": "C"
+        }
+      ],
+      "title": "Circuit Breaker State",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 36
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(envoy_cluster_upstream_cx_overflow{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "legendFormat": "{{envoy_cluster_name}} CX Overflow",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(envoy_cluster_upstream_rq_pending_overflow{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "legendFormat": "{{envoy_cluster_name}} Pending Overflow",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(envoy_http_no_route{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "legendFormat": "No Route",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(rate(envoy_cluster_lb_healthy_panic{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "legendFormat": "{{envoy_cluster_name}} LB Panic",
+          "refId": "D"
+        }
+      ],
+      "title": "Overflow & Routing Errors",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 44
+      },
+      "id": 203,
+      "title": "Connections",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 45
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(envoy_http_downstream_cx_active{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"})",
+          "legendFormat": "Inbound",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(envoy_cluster_upstream_cx_active{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
+          "legendFormat": "{{envoy_cluster_name}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Active Connections",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "cps",
+          "min": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*Remote.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*Local.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 45
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(envoy_cluster_upstream_cx_destroy_remote{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m]))",
+          "legendFormat": "Upstream Remote Close",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(envoy_cluster_upstream_cx_destroy{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) - sum(rate(envoy_cluster_upstream_cx_destroy_remote{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m]))",
+          "legendFormat": "Upstream Local Close",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(envoy_http_downstream_cx_destroy_remote{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "legendFormat": "Inbound Remote Close",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(rate(envoy_http_downstream_cx_destroy_local{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "legendFormat": "Inbound Local Close",
+          "refId": "D"
+        }
+      ],
+      "title": "Connection Resets",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "ms",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 45
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_cx_connect_ms_bucket{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
+          "legendFormat": "{{envoy_cluster_name}} Connect p99",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_cx_length_ms_bucket{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
+          "legendFormat": "{{envoy_cluster_name}} Lifetime p99",
+          "refId": "B"
+        }
+      ],
+      "title": "Connection Timing (p99)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 53
+      },
+      "id": 204,
+      "title": "Data Transfer",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "Bps",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 54
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(envoy_http_downstream_cx_rx_bytes_total{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "legendFormat": "Inbound RX",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(envoy_http_downstream_cx_tx_bytes_total{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "legendFormat": "Inbound TX",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(envoy_cluster_upstream_cx_rx_bytes_total{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m]))",
+          "legendFormat": "Outbound RX",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(rate(envoy_cluster_upstream_cx_tx_bytes_total{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m]))",
+          "legendFormat": "Outbound TX",
+          "refId": "D"
+        }
+      ],
+      "title": "Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 54
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(envoy_cluster_upstream_rq_pending_active{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
+          "legendFormat": "{{envoy_cluster_name}} Pending",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(envoy_cluster_upstream_rq_active{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
+          "legendFormat": "{{envoy_cluster_name}} Active",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(envoy_http_downstream_rq_active{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"})",
+          "legendFormat": "Inbound Active",
+          "refId": "C"
+        }
+      ],
+      "title": "Inflight Requests",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 54
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_rq_per_cx_bucket{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
+          "legendFormat": "{{envoy_cluster_name}} p99",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(envoy_cluster_upstream_rq_per_cx_bucket{kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
+          "legendFormat": "{{envoy_cluster_name}} p50",
+          "refId": "B"
+        }
+      ],
+      "title": "Requests per Connection",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 62
+      },
+      "id": 207,
+      "title": "Proxy Health",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 63
+      },
+      "id": 208,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Envoy Memory",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "envoy_server_memory_allocated{k8s_kuma_io_namespace=\"$namespace\",kuma_workload=\"$workload\"}",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "green"
+          },
+          "unit": "dtdurations",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": null},
+              {"color": "orange", "value": 3600},
+              {"color": "green", "value": 86400}
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 63
+      },
+      "id": 209,
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "title": "Proxy Uptime",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "envoy_server_uptime{k8s_kuma_io_namespace=\"$namespace\",kuma_workload=\"$workload\"}",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 63
+      },
+      "id": 210,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "xDS Update Latency (p99)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(envoy_control_plane_ds_handshake_bucket{k8s_kuma_io_namespace=\"$namespace\",kuma_workload=\"$workload\"}[5m])))",
+          "legendFormat": "p99",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": [
+    "kuma",
+    "service-mesh",
+    "debug"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(envoy_server_live, mesh)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Mesh",
+        "multi": false,
+        "name": "mesh",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(envoy_server_live, mesh)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_zone)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Zone",
+        "multi": false,
+        "name": "zone",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_zone)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}, k8s_kuma_io_namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}, k8s_kuma_io_namespace)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",k8s_kuma_io_namespace=\"$namespace\"}, kuma_workload)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Workload",
+        "multi": false,
+        "name": "workload",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",k8s_kuma_io_namespace=\"$namespace\"}, kuma_workload)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Kuma Workload Debug",
+  "uid": "kuma-service-debug",
+  "version": 1
+}

--- a/dashboards/grafana/kuma-service-debug.json
+++ b/dashboards/grafana/kuma-service-debug.json
@@ -110,23 +110,24 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
-          "legendFormat": "Total",
+          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
+          "legendFormat": "{{envoy_http_conn_manager_prefix}} total",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(envoy_http_downstream_rq_http1_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
-          "legendFormat": "HTTP/1.1",
+          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_rq_http1_total{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
+          "legendFormat": "{{envoy_http_conn_manager_prefix}} HTTP/1.1",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(envoy_http_downstream_rq_http2_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
-          "legendFormat": "HTTP/2",
+          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_rq_http2_total{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
+          "legendFormat": "{{envoy_http_conn_manager_prefix}} HTTP/2",
           "refId": "C"
         }
       ],
       "title": "Request Rate by Protocol",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "RQ = request. HTTP/1.1 and HTTP/2 breakdown per inbound listener."
     },
     {
       "datasource": {
@@ -245,8 +246,8 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (envoy_response_code_class)",
-          "legendFormat": "{{envoy_response_code_class}}xx",
+          "expr": "sum by (envoy_http_conn_manager_prefix, envoy_response_code_class) (rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
+          "legendFormat": "{{envoy_http_conn_manager_prefix}} {{envoy_response_code_class}}xx",
           "refId": "A"
         }
       ],
@@ -309,18 +310,18 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (le))",
-          "legendFormat": "p99",
+          "expr": "histogram_quantile(0.99, sum by (le, envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])))",
+          "legendFormat": "{{envoy_http_conn_manager_prefix}} p99",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (le))",
-          "legendFormat": "p95",
+          "expr": "histogram_quantile(0.95, sum by (le, envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])))",
+          "legendFormat": "{{envoy_http_conn_manager_prefix}} p95",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.50, sum(rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (le))",
-          "legendFormat": "p50",
+          "expr": "histogram_quantile(0.50, sum by (le, envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])))",
+          "legendFormat": "{{envoy_http_conn_manager_prefix}} p50",
           "refId": "C"
         }
       ],
@@ -395,7 +396,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_total{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}}",
           "refId": "A"
         }
@@ -505,7 +506,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_xx{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name, envoy_response_code_class)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_xx{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name, envoy_response_code_class)",
           "legendFormat": "{{envoy_cluster_name}} {{envoy_response_code_class}}xx",
           "refId": "A"
         }
@@ -569,12 +570,12 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_rq_time_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
+          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_rq_time_bucket{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
           "legendFormat": "{{envoy_cluster_name}} p99",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.50, sum(rate(envoy_cluster_upstream_rq_time_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
+          "expr": "histogram_quantile(0.50, sum(rate(envoy_cluster_upstream_rq_time_bucket{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
           "legendFormat": "{{envoy_cluster_name}} p50",
           "refId": "B"
         }
@@ -666,18 +667,19 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_rbac_denied{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}[5m]))",
-          "legendFormat": "Denied/s",
+          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_rbac_denied{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}[5m]))",
+          "legendFormat": "{{envoy_http_conn_manager_prefix}} denied/s",
           "refId": "A"
         },
         {
-          "expr": "sum(envoy_rbac_denied{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"})",
-          "legendFormat": "Denied Total",
+          "expr": "sum by (envoy_http_conn_manager_prefix) (envoy_rbac_denied{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"})",
+          "legendFormat": "{{envoy_http_conn_manager_prefix}} total",
           "refId": "B"
         }
       ],
       "title": "RBAC Denied",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "Requests denied by Envoy RBAC filter (MeshTrafficPermission). Rate = denied/sec, total = cumulative."
     },
     {
       "datasource": {
@@ -735,18 +737,19 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_cluster_ssl_handshake{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_ssl_handshake{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Outbound",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(envoy_listener_ssl_handshake{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}[5m]))",
-          "legendFormat": "Inbound",
+          "expr": "sum by (envoy_listener_address) (rate(envoy_listener_ssl_handshake{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}[5m]))",
+          "legendFormat": "{{envoy_listener_address}}",
           "refId": "B"
         }
       ],
       "title": "TLS Handshakes",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "SSL/TLS handshake rate. Outbound = per upstream cluster, Inbound = listener-level."
     },
     {
       "datasource": {
@@ -805,7 +808,7 @@
       },
       "targets": [
         {
-          "expr": "min(envoy_server_days_until_first_cert_expiring{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"})",
+          "expr": "min(envoy_server_days_until_first_cert_expiring{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"})",
           "legendFormat": "Server Cert",
           "refId": "A"
         }
@@ -823,7 +826,7 @@
         "y": 27
       },
       "id": 205,
-      "title": "Reliability",
+      "title": "Outbound Reliability",
       "type": "row"
     },
     {
@@ -831,7 +834,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Requires MeshRetry policy. Metrics appear on first retry.",
+      "description": "Requires MeshRetry policy. Retry = attempted, Success = retry succeeded, Overflow = retry budget exhausted.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -914,17 +917,17 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_retry{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_retry{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Retries",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_retry_success{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_retry_success{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Success",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_retry_overflow{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_retry_overflow{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Overflow",
           "refId": "C"
         }
@@ -1004,23 +1007,24 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_cluster_upstream_cx_connect_timeout{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_cx_connect_timeout{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Connect Timeout",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_timeout{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_timeout{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Request Timeout",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_max_duration_reached{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_max_duration_reached{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Max Duration",
           "refId": "C"
         }
       ],
       "title": "Timeouts",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "CX Connect Timeout = TCP connect timed out. RQ Timeout = request-level timeout. Max Duration = stream hit max duration limit."
     },
     {
       "datasource": {
@@ -1078,23 +1082,24 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_rx_reset{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_rx_reset{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} RX Reset",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_tx_reset{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_tx_reset{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} TX Reset",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_cancelled{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_cancelled{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Cancelled",
           "refId": "C"
         }
       ],
       "title": "Request Resets & Cancellations",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "RX Reset = upstream reset the response. TX Reset = local proxy reset the request. Cancelled = client cancelled before completion."
     },
     {
       "datasource": {
@@ -1104,7 +1109,7 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "mode": "thresholds"
           },
           "custom": {
             "axisBorderShow": false,
@@ -1112,7 +1117,7 @@
             "axisLabel": "",
             "drawStyle": "line",
             "fillOpacity": 10,
-            "lineWidth": 1,
+            "lineWidth": 2,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
@@ -1124,59 +1129,47 @@
               "mode": "none"
             }
           },
-          "min": 0
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "1": {
+                  "text": "Healthy",
+                  "color": "green"
+                },
+                "0": {
+                  "text": "Unhealthy",
+                  "color": "red"
+                }
+              }
+            }
+          ],
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byRegexp",
-              "options": ".*Healthy.*"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byRegexp",
-              "options": ".*Total.*"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byRegexp",
-              "options": ".*Degraded.*"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "yellow",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
+        "w": 12,
         "x": 0,
         "y": 36
       },
@@ -1196,23 +1189,14 @@
       },
       "targets": [
         {
-          "expr": "sum(envoy_cluster_membership_healthy{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
-          "legendFormat": "{{envoy_cluster_name}} Healthy",
+          "expr": "sum(envoy_cluster_membership_healthy{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name) / sum(envoy_cluster_membership_total{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
+          "legendFormat": "{{envoy_cluster_name}}",
           "refId": "A"
-        },
-        {
-          "expr": "sum(envoy_cluster_membership_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
-          "legendFormat": "{{envoy_cluster_name}} Total",
-          "refId": "B"
-        },
-        {
-          "expr": "sum(envoy_cluster_membership_degraded{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
-          "legendFormat": "{{envoy_cluster_name}} Degraded",
-          "refId": "C"
         }
       ],
       "title": "Upstream Endpoint Health",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "Health ratio per destination (healthy/total). Green = 100%, yellow = degraded, red = unhealthy."
     },
     {
       "datasource": {
@@ -1275,8 +1259,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
-        "x": 8,
+        "w": 12,
+        "x": 12,
         "y": 36
       },
       "id": 17,
@@ -1295,23 +1279,24 @@
       },
       "targets": [
         {
-          "expr": "max(envoy_cluster_circuit_breakers_default_rq_open{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
+          "expr": "max(envoy_cluster_circuit_breakers_default_rq_open{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} RQ",
           "refId": "A"
         },
         {
-          "expr": "max(envoy_cluster_circuit_breakers_default_rq_pending_open{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
+          "expr": "max(envoy_cluster_circuit_breakers_default_rq_pending_open{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Pending",
           "refId": "B"
         },
         {
-          "expr": "max(envoy_cluster_circuit_breakers_default_cx_open{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
+          "expr": "max(envoy_cluster_circuit_breakers_default_cx_open{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} CX",
           "refId": "C"
         }
       ],
       "title": "Circuit Breaker State",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "RQ Open = request circuit breaker tripped. RQ Pending Open = pending request limit hit. CX Open = connection limit hit."
     },
     {
       "datasource": {
@@ -1348,9 +1333,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 36
+        "w": 12,
+        "x": 0,
+        "y": 44
       },
       "id": 18,
       "options": {
@@ -1369,28 +1354,104 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_cluster_upstream_cx_overflow{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_cx_overflow{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} CX Overflow",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_pending_overflow{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_pending_overflow{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Pending Overflow",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(envoy_http_no_route{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_no_route{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "No Route",
           "refId": "C"
         },
         {
-          "expr": "sum(rate(envoy_cluster_lb_healthy_panic{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_lb_healthy_panic{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} LB Panic",
           "refId": "D"
         }
       ],
       "title": "Overflow & Routing Errors",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "CX Overflow = connection pool full. RQ Pending Overflow = pending queue full. No Route = no matching route found. LB Panic = too few healthy hosts, load balancer in panic mode."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 44
+      },
+      "id": 319,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "asc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "min by (envoy_cluster_name) (envoy_cluster_circuit_breakers_default_remaining_rq{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"})",
+          "legendFormat": "{{envoy_cluster_name}} rq",
+          "refId": "A"
+        },
+        {
+          "expr": "min by (envoy_cluster_name) (envoy_cluster_circuit_breakers_default_remaining_cx{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"})",
+          "legendFormat": "{{envoy_cluster_name}} cx",
+          "refId": "B"
+        },
+        {
+          "expr": "min by (envoy_cluster_name) (envoy_cluster_circuit_breakers_default_remaining_pending{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"})",
+          "legendFormat": "{{envoy_cluster_name}} pending",
+          "refId": "C"
+        }
+      ],
+      "title": "Remaining CB Capacity",
+      "type": "timeseries",
+      "description": "Remaining request (rq), connection (cx), and pending slots before circuit breaker trips. 0 = actively rejecting."
     },
     {
       "collapsed": false,
@@ -1398,10 +1459,187 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 52
       },
-      "id": 203,
-      "title": "Connections",
+      "id": 211,
+      "title": "Inbound Connections",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 53
+      },
+      "id": 300,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (envoy_http_conn_manager_prefix) (envoy_http_downstream_cx_active{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"})",
+          "legendFormat": "{{envoy_http_conn_manager_prefix}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Connections",
+      "type": "timeseries",
+      "description": "CX = connection. Active downstream connections from clients to this workload."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "cps",
+          "min": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*Remote.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*Local.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 53
+      },
+      "id": 302,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_cx_destroy_remote{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
+          "legendFormat": "{{envoy_http_conn_manager_prefix}} Remote Close",
+          "refId": "C"
+        },
+        {
+          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_cx_destroy_local{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
+          "legendFormat": "{{envoy_http_conn_manager_prefix}} Local Close",
+          "refId": "D"
+        }
+      ],
+      "title": "Connection Resets",
+      "type": "timeseries",
+      "description": "Remote Close = client closed the connection. Local Close = Envoy closed the connection."
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 61
+      },
+      "id": 212,
+      "title": "Outbound Connections",
       "type": "row"
     },
     {
@@ -1440,9 +1678,9 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 45
+        "y": 62
       },
-      "id": 10,
+      "id": 301,
       "options": {
         "legend": {
           "calcs": [
@@ -1459,18 +1697,14 @@
       },
       "targets": [
         {
-          "expr": "sum(envoy_http_downstream_cx_active{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"})",
-          "legendFormat": "Inbound",
-          "refId": "A"
-        },
-        {
-          "expr": "sum(envoy_cluster_upstream_cx_active{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
+          "expr": "sum(envoy_cluster_upstream_cx_active{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}}",
           "refId": "B"
         }
       ],
       "title": "Active Connections",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "CX = connection. Active upstream connections to destination services."
     },
     {
       "datasource": {
@@ -1540,9 +1774,9 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 45
+        "y": 62
       },
-      "id": 11,
+      "id": 303,
       "options": {
         "legend": {
           "calcs": [
@@ -1559,28 +1793,19 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_cluster_upstream_cx_destroy_remote{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m]))",
-          "legendFormat": "Upstream Remote Close",
+          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_upstream_cx_destroy_remote{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m]))",
+          "legendFormat": "{{envoy_cluster_name}} Remote Close",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(envoy_cluster_upstream_cx_destroy{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) - sum(rate(envoy_cluster_upstream_cx_destroy_remote{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m]))",
-          "legendFormat": "Upstream Local Close",
+          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_upstream_cx_destroy{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) - sum by (envoy_cluster_name) (rate(envoy_cluster_upstream_cx_destroy_remote{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m]))",
+          "legendFormat": "{{envoy_cluster_name}} Local Close",
           "refId": "B"
-        },
-        {
-          "expr": "sum(rate(envoy_http_downstream_cx_destroy_remote{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
-          "legendFormat": "Inbound Remote Close",
-          "refId": "C"
-        },
-        {
-          "expr": "sum(rate(envoy_http_downstream_cx_destroy_local{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
-          "legendFormat": "Inbound Local Close",
-          "refId": "D"
         }
       ],
       "title": "Connection Resets",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "Remote Close = upstream closed the connection. Local Close = Envoy closed the connection."
     },
     {
       "datasource": {
@@ -1619,7 +1844,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 45
+        "y": 62
       },
       "id": 12,
       "options": {
@@ -1638,18 +1863,19 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_cx_connect_ms_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
+          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_cx_connect_ms_bucket{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
           "legendFormat": "{{envoy_cluster_name}} Connect p99",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_cx_length_ms_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
+          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_cx_length_ms_bucket{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
           "legendFormat": "{{envoy_cluster_name}} Lifetime p99",
           "refId": "B"
         }
       ],
       "title": "Connection Timing (p99)",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "Connect Time = TCP handshake duration. Connection Length = total lifetime of a connection."
     },
     {
       "collapsed": false,
@@ -1657,10 +1883,157 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 53
+        "y": 70
       },
-      "id": 204,
-      "title": "Data Transfer",
+      "id": 213,
+      "title": "Inbound Data Transfer",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "Bps",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 71
+      },
+      "id": 304,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_cx_rx_bytes_total{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
+          "legendFormat": "{{envoy_http_conn_manager_prefix}} RX",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_cx_tx_bytes_total{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
+          "legendFormat": "{{envoy_http_conn_manager_prefix}} TX",
+          "refId": "B"
+        }
+      ],
+      "title": "Throughput",
+      "type": "timeseries",
+      "description": "RX = bytes received from clients, TX = bytes transmitted to clients."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 71
+      },
+      "id": 306,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (envoy_http_conn_manager_prefix) (envoy_http_downstream_rq_active{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"})",
+          "legendFormat": "{{envoy_http_conn_manager_prefix}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Inflight Requests",
+      "type": "timeseries",
+      "description": "Active downstream requests currently being processed by this workload."
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 79
+      },
+      "id": 214,
+      "title": "Outbound Data Transfer",
       "type": "row"
     },
     {
@@ -1700,9 +2073,9 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 54
+        "y": 80
       },
-      "id": 13,
+      "id": 305,
       "options": {
         "legend": {
           "calcs": [
@@ -1719,28 +2092,19 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_http_downstream_cx_rx_bytes_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
-          "legendFormat": "Inbound RX",
-          "refId": "A"
-        },
-        {
-          "expr": "sum(rate(envoy_http_downstream_cx_tx_bytes_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
-          "legendFormat": "Inbound TX",
-          "refId": "B"
-        },
-        {
-          "expr": "sum(rate(envoy_cluster_upstream_cx_rx_bytes_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m]))",
-          "legendFormat": "Outbound RX",
+          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_upstream_cx_rx_bytes_total{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m]))",
+          "legendFormat": "{{envoy_cluster_name}} RX",
           "refId": "C"
         },
         {
-          "expr": "sum(rate(envoy_cluster_upstream_cx_tx_bytes_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m]))",
-          "legendFormat": "Outbound TX",
+          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_upstream_cx_tx_bytes_total{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m]))",
+          "legendFormat": "{{envoy_cluster_name}} TX",
           "refId": "D"
         }
       ],
       "title": "Throughput",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "RX = bytes received from upstream, TX = bytes transmitted to upstream services."
     },
     {
       "datasource": {
@@ -1779,9 +2143,9 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 54
+        "y": 80
       },
-      "id": 14,
+      "id": 307,
       "options": {
         "legend": {
           "calcs": [
@@ -1798,23 +2162,19 @@
       },
       "targets": [
         {
-          "expr": "sum(envoy_cluster_upstream_rq_pending_active{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
+          "expr": "sum(envoy_cluster_upstream_rq_pending_active{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Pending",
           "refId": "A"
         },
         {
-          "expr": "sum(envoy_cluster_upstream_rq_active{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
+          "expr": "sum(envoy_cluster_upstream_rq_active{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Active",
           "refId": "B"
-        },
-        {
-          "expr": "sum(envoy_http_downstream_rq_active{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"})",
-          "legendFormat": "Inbound Active",
-          "refId": "C"
         }
       ],
       "title": "Inflight Requests",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "RQ Pending = waiting for a connection from the pool. RQ Active = currently being processed by upstream."
     },
     {
       "datasource": {
@@ -1852,7 +2212,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 54
+        "y": 80
       },
       "id": 15,
       "options": {
@@ -1871,18 +2231,19 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_rq_per_cx_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
+          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_rq_per_cx_bucket{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
           "legendFormat": "{{envoy_cluster_name}} p99",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.50, sum(rate(envoy_cluster_upstream_rq_per_cx_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
+          "expr": "histogram_quantile(0.50, sum(rate(envoy_cluster_upstream_rq_per_cx_bucket{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
           "legendFormat": "{{envoy_cluster_name}} p50",
           "refId": "B"
         }
       ],
       "title": "Requests per Connection",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "RQ per CX = how many requests are multiplexed over each connection. Higher values indicate good connection reuse (HTTP/2)."
     },
     {
       "collapsed": false,
@@ -1890,7 +2251,184 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 62
+        "y": 88
+      },
+      "id": 215,
+      "title": "DNS",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 89
+      },
+      "id": 316,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(kuma_dp_dns_request_duration_seconds_count{mesh=\"$mesh\"}[5m]) * on(pod) group_left() envoy_server_live{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"})",
+          "legendFormat": "total",
+          "refId": "A"
+        }
+      ],
+      "title": "DNS Request Rate",
+      "type": "timeseries",
+      "description": "Rate of DNS queries handled by the Kuma DNS server in the sidecar."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 89
+      },
+      "id": 317,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(kuma_dp_dns_request_duration_seconds_bucket{mesh=\"$mesh\"}[5m]) * on(pod) group_left() envoy_server_live{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}) by (le))",
+          "legendFormat": "local p99",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(kuma_dp_dns_upstream_request_duration_seconds_bucket{mesh=\"$mesh\"}[5m]) * on(pod) group_left() envoy_server_live{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}) by (le))",
+          "legendFormat": "upstream p99",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(kuma_dp_dns_request_duration_seconds_bucket{mesh=\"$mesh\"}[5m]) * on(pod) group_left() envoy_server_live{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}) by (le))",
+          "legendFormat": "local p50",
+          "refId": "C"
+        },
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(kuma_dp_dns_upstream_request_duration_seconds_bucket{mesh=\"$mesh\"}[5m]) * on(pod) group_left() envoy_server_live{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}) by (le))",
+          "legendFormat": "upstream p50",
+          "refId": "D"
+        }
+      ],
+      "title": "DNS Latency",
+      "type": "timeseries",
+      "description": "Local = Kuma DNS resolution time. Upstream = time to forward queries to the upstream resolver (e.g. CoreDNS)."
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 97
       },
       "id": 207,
       "title": "Proxy Health",
@@ -1925,7 +2463,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 63
+        "y": 98
       },
       "id": 208,
       "options": {
@@ -1946,7 +2484,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "envoy_server_memory_allocated{k8s_kuma_io_namespace=~\"$namespace\",mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}",
+          "expr": "envoy_server_memory_allocated{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}",
           "legendFormat": "{{pod}}",
           "refId": "A"
         }
@@ -1988,7 +2526,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 63
+        "y": 98
       },
       "id": 209,
       "options": {
@@ -2009,7 +2547,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "envoy_server_uptime{k8s_kuma_io_namespace=~\"$namespace\",mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}",
+          "expr": "envoy_server_uptime{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}",
           "legendFormat": "{{pod}}",
           "refId": "A"
         }
@@ -2044,7 +2582,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 63
+        "y": 98
       },
       "id": 210,
       "options": {
@@ -2065,7 +2603,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(envoy_control_plane_ds_handshake_bucket{k8s_kuma_io_namespace=~\"$namespace\",mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(envoy_control_plane_ds_handshake_bucket{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}[5m])))",
           "legendFormat": "p99",
           "refId": "A"
         }
@@ -2150,7 +2688,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}, k8s_kuma_io_namespace)",
+        "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}, namespace)",
         "hide": 0,
         "includeAll": true,
         "allValue": ".*",
@@ -2160,7 +2698,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}, k8s_kuma_io_namespace)",
+          "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}, namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -2175,7 +2713,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",k8s_kuma_io_namespace=~\"$namespace\"}, kuma_workload)",
+        "definition": "label_values(envoy_server_live{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\"}, kuma_workload)",
         "hide": 0,
         "includeAll": false,
         "label": "Workload",
@@ -2184,7 +2722,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",k8s_kuma_io_namespace=~\"$namespace\"}, kuma_workload)",
+          "query": "label_values(envoy_server_live{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\"}, kuma_workload)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/dashboards/grafana/kuma-service-debug.json
+++ b/dashboards/grafana/kuma-service-debug.json
@@ -1946,7 +1946,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "envoy_server_memory_allocated{k8s_kuma_io_namespace=\"$namespace\",mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}",
+          "expr": "envoy_server_memory_allocated{k8s_kuma_io_namespace=~\"$namespace\",mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}",
           "legendFormat": "{{pod}}",
           "refId": "A"
         }
@@ -2009,7 +2009,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "envoy_server_uptime{k8s_kuma_io_namespace=\"$namespace\",mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}",
+          "expr": "envoy_server_uptime{k8s_kuma_io_namespace=~\"$namespace\",mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}",
           "legendFormat": "{{pod}}",
           "refId": "A"
         }
@@ -2065,7 +2065,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(envoy_control_plane_ds_handshake_bucket{k8s_kuma_io_namespace=\"$namespace\",mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(envoy_control_plane_ds_handshake_bucket{k8s_kuma_io_namespace=~\"$namespace\",mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}[5m])))",
           "legendFormat": "p99",
           "refId": "A"
         }
@@ -2152,7 +2152,8 @@
         },
         "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}, k8s_kuma_io_namespace)",
         "hide": 0,
-        "includeAll": false,
+        "includeAll": true,
+        "allValue": ".*",
         "label": "Namespace",
         "multi": false,
         "name": "namespace",
@@ -2174,7 +2175,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",k8s_kuma_io_namespace=\"$namespace\"}, kuma_workload)",
+        "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",k8s_kuma_io_namespace=~\"$namespace\"}, kuma_workload)",
         "hide": 0,
         "includeAll": false,
         "label": "Workload",
@@ -2183,7 +2184,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",k8s_kuma_io_namespace=\"$namespace\"}, kuma_workload)",
+          "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",k8s_kuma_io_namespace=~\"$namespace\"}, kuma_workload)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/dashboards/grafana/kuma-service-health.json
+++ b/dashboards/grafana/kuma-service-health.json
@@ -178,7 +178,7 @@
       },
       "targets": [
         {
-          "expr": "100 * clamp_min(1 - sum(rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m])) / sum(rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])), 0)",
+          "expr": "100 * clamp_min(1 - (sum(rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m])) or vector(0)) / sum(rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])), 0)",
           "legendFormat": "Success Rate",
           "refId": "A"
         }

--- a/dashboards/grafana/kuma-service-health.json
+++ b/dashboards/grafana/kuma-service-health.json
@@ -102,12 +102,12 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
-          "legendFormat": "",
+          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
+          "legendFormat": "{{envoy_http_conn_manager_prefix}}",
           "refId": "A"
         }
       ],
-      "title": "Inbound Request Rate",
+      "title": "Inbound HTTP Request Rate",
       "type": "stat"
     },
     {
@@ -125,8 +125,8 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "0%",
-                  "color": "green"
+                  "text": "N/A",
+                  "color": "text"
                 }
               },
               "type": "special"
@@ -136,21 +136,22 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "red",
                 "value": null
               },
               {
                 "color": "yellow",
-                "value": 1
+                "value": 99
               },
               {
-                "color": "red",
-                "value": 5
+                "color": "green",
+                "value": 99.9
               }
             ]
           },
           "unit": "percent",
-          "noValue": "0%"
+          "min": 0,
+          "max": 100
         },
         "overrides": []
       },
@@ -177,12 +178,12 @@
       },
       "targets": [
         {
-          "expr": "100 * sum(rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m])) / clamp_min(sum(rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])), 1)",
-          "legendFormat": "",
+          "expr": "100 * clamp_min(1 - sum(rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m])) / sum(rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])), 0)",
+          "legendFormat": "Success Rate",
           "refId": "A"
         }
       ],
-      "title": "Inbound Error Rate (5xx)",
+      "title": "Inbound HTTP Success Rate (SLO)",
       "type": "stat"
     },
     {
@@ -241,12 +242,12 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (le))",
-          "legendFormat": "",
+          "expr": "histogram_quantile(0.99, sum by (le, envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])))",
+          "legendFormat": "{{envoy_http_conn_manager_prefix}}",
           "refId": "A"
         }
       ],
-      "title": "Inbound p99 Latency",
+      "title": "Inbound HTTP p99 Latency",
       "type": "stat"
     },
     {
@@ -296,7 +297,7 @@
       },
       "targets": [
         {
-          "expr": "count(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"})",
+          "expr": "count(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\"})",
           "legendFormat": "",
           "refId": "A"
         }
@@ -313,7 +314,7 @@
         "y": 5
       },
       "id": 101,
-      "title": "Inbound Traffic",
+      "title": "Inbound HTTP",
       "type": "row"
     },
     {
@@ -382,8 +383,8 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
-          "legendFormat": "Total",
+          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
+          "legendFormat": "{{envoy_http_conn_manager_prefix}}",
           "refId": "A"
         }
       ],
@@ -517,7 +518,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (envoy_response_code_class)",
+          "expr": "sum(rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])) by (envoy_response_code_class)",
           "legendFormat": "{{envoy_response_code_class}}xx",
           "refId": "A"
         }
@@ -591,12 +592,12 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])) by (le))",
           "legendFormat": "p99",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.50, sum(rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.50, sum(rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])) by (le))",
           "legendFormat": "p50",
           "refId": "B"
         }
@@ -612,8 +613,188 @@
         "x": 0,
         "y": 14
       },
+      "id": 108,
+      "title": "Inbound TCP",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
+      "id": 109,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (envoy_listener_address) (envoy_listener_downstream_cx_active{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_listener_address=~\"self_inbound_dp_.*\"})",
+          "legendFormat": "{{envoy_listener_address}} active",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (envoy_listener_address) (rate(envoy_listener_downstream_cx_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_listener_address=~\"self_inbound_dp_.*\"}[5m]))",
+          "legendFormat": "{{envoy_listener_address}} new/s",
+          "refId": "B"
+        }
+      ],
+      "title": "Inbound Active Connections",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
+      "id": 110,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_cx_rx_bytes_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
+          "legendFormat": "{{envoy_http_conn_manager_prefix}} rx",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_cx_tx_bytes_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
+          "legendFormat": "{{envoy_http_conn_manager_prefix}} tx",
+          "refId": "B"
+        },
+        {
+          "expr": "sum by (envoy_tcp_prefix) (rate(envoy_tcp_downstream_cx_rx_bytes_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_tcp_prefix=~\"self_inbound_dp_.*\"}[5m]))",
+          "legendFormat": "{{envoy_tcp_prefix}} rx (tcp)",
+          "refId": "C"
+        },
+        {
+          "expr": "sum by (envoy_tcp_prefix) (rate(envoy_tcp_downstream_cx_tx_bytes_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_tcp_prefix=~\"self_inbound_dp_.*\"}[5m]))",
+          "legendFormat": "{{envoy_tcp_prefix}} tx (tcp)",
+          "refId": "D"
+        }
+      ],
+      "title": "Inbound Throughput",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
       "id": 102,
-      "title": "Outbound Traffic",
+      "title": "Outbound HTTP",
       "type": "row"
     },
     {
@@ -663,7 +844,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 15
+        "y": 24
       },
       "id": 8,
       "options": {
@@ -682,7 +863,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}}",
           "refId": "A"
         }
@@ -798,7 +979,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 15
+        "y": 24
       },
       "id": 9,
       "options": {
@@ -817,7 +998,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_xx{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m])) by (envoy_cluster_name, envoy_response_code_class)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_xx{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m])) by (envoy_cluster_name, envoy_response_code_class)",
           "legendFormat": "{{envoy_cluster_name}} {{envoy_response_code_class}}xx",
           "refId": "A"
         }
@@ -872,7 +1053,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 15
+        "y": 24
       },
       "id": 10,
       "options": {
@@ -891,7 +1072,7 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_rq_time_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m])) by (le, envoy_cluster_name))",
+          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_rq_time_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m])) by (le, envoy_cluster_name))",
           "legendFormat": "{{envoy_cluster_name}} p99",
           "refId": "A"
         }
@@ -905,331 +1086,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 23
-      },
-      "id": 104,
-      "title": "Security",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "lineWidth": 2,
-            "pointSize": 5,
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "mode": "none"
-            }
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 0,
-        "y": 24
-      },
-      "id": 105,
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "mean",
-            "max"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "title": "RBAC Denied",
-      "type": "timeseries",
-      "targets": [
-        {
-          "expr": "sum(rate(envoy_rbac_denied{k8s_kuma_io_namespace=~\"$namespace\",mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}[5m]))",
-          "legendFormat": "denied",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "lineWidth": 2,
-            "pointSize": 5,
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "mode": "none"
-            }
-          },
-          "unit": "ops"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 8,
-        "y": 24
-      },
-      "id": 106,
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "mean",
-            "max"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "title": "Outbound TLS Handshakes",
-      "type": "timeseries",
-      "targets": [
-        {
-          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_ssl_handshake{k8s_kuma_io_namespace=~\"$namespace\",mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name=~\".*_m?svc_.*\"}[5m]))",
-          "legendFormat": "{{envoy_cluster_name}}",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "lineWidth": 2,
-            "pointSize": 5,
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "mode": "none"
-            }
-          },
-          "unit": "ops",
-          "min": 0
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 24
-      },
-      "id": 107,
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "min"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "asc"
-        }
-      },
-      "title": "Cert Rotation Rate",
-      "type": "timeseries",
-      "targets": [
-        {
-          "expr": "sum by (pod) (rate(envoy_listener_server_ssl_socket_factory_ssl_context_update_by_sds{k8s_kuma_io_namespace=~\"$namespace\",mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}[5m]))",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "description": "Rate of SDS certificate updates. Active rotation = healthy mTLS."
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
         "y": 32
       },
-      "id": 103,
-      "title": "Health",
+      "id": 111,
+      "title": "Outbound TCP",
       "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "options": {
-                "0": {
-                  "text": "Disconnected",
-                  "color": "red"
-                },
-                "1": {
-                  "text": "Connected",
-                  "color": "green"
-                }
-              },
-              "type": "value"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "green",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 0,
-        "y": 33
-      },
-      "id": 11,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "expr": "min(envoy_control_plane_connected_state{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"})",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Control Plane",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "d",
-          "mappings": [
-            {
-              "type": "value",
-              "options": {
-                "0": {
-                  "text": "< 1 day (OK)",
-                  "color": "green"
-                }
-              }
-            }
-          ]
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 6,
-        "y": 33
-      },
-      "id": 12,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "expr": "min(envoy_server_days_until_first_cert_expiring{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"})",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "mTLS Cert Expiry",
-      "type": "stat",
-      "description": "0 is normal \u2014 Kuma rotates mTLS certs every 24h"
     },
     {
       "datasource": {
@@ -1269,36 +1130,386 @@
               }
             ]
           },
+          "unit": "cps",
           "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
+      "id": 112,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_upstream_cx_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m]))",
+          "legendFormat": "{{envoy_cluster_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "TCP Connection Rate by Destination",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "id": 113,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_upstream_cx_rx_bytes_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m]))",
+          "legendFormat": "{{envoy_cluster_name}} rx",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_upstream_cx_tx_bytes_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m]))",
+          "legendFormat": "{{envoy_cluster_name}} tx",
+          "refId": "B"
+        }
+      ],
+      "title": "TCP Throughput by Destination",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 41
+      },
+      "id": 104,
+      "title": "Security",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 42
+      },
+      "id": 105,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "RBAC Denied",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_rbac_denied{namespace=~\"$namespace\",mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}[5m]))",
+          "legendFormat": "{{envoy_http_conn_manager_prefix}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 42
+      },
+      "id": 106,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Outbound TLS Handshakes",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_ssl_handshake{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m]))",
+          "legendFormat": "{{envoy_cluster_name}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "ops",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 42
+      },
+      "id": 107,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "min"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "asc"
+        }
+      },
+      "title": "Cert Rotation Rate",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (pod) (rate(envoy_listener_server_ssl_socket_factory_ssl_context_update_by_sds{namespace=~\"$namespace\",mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}[5m]))",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "description": "Rate of SDS certificate updates. Active rotation = healthy mTLS."
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 50
+      },
+      "id": 103,
+      "title": "Health",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "color-text"
+            },
+            "inspect": false
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
         },
         "overrides": [
           {
             "matcher": {
-              "id": "byRegexp",
-              "options": ".*Healthy.*"
+              "id": "byName",
+              "options": "Status"
             },
             "properties": [
               {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "text": "Disconnected",
+                        "color": "red"
+                      },
+                      "1": {
+                        "text": "Connected",
+                        "color": "green"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              },
+              {
+                "id": "custom.width",
+                "value": 120
               }
             ]
           },
           {
             "matcher": {
-              "id": "byRegexp",
-              "options": ".*Total.*"
+              "id": "byName",
+              "options": "Uptime"
             },
             "properties": [
               {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
+                "id": "unit",
+                "value": "s"
+              },
+              {
+                "id": "custom.width",
+                "value": 120
               }
             ]
           }
@@ -1307,8 +1518,225 @@
       "gridPos": {
         "h": 8,
         "w": 12,
+        "x": 0,
+        "y": 51
+      },
+      "id": 11,
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "Status",
+            "desc": false
+          }
+        ],
+        "footer": {
+          "show": false
+        }
+      },
+      "targets": [
+        {
+          "expr": "envoy_control_plane_connected_state{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\"}",
+          "legendFormat": "",
+          "refId": "A",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "expr": "envoy_server_uptime{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\"}",
+          "legendFormat": "",
+          "refId": "B",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "title": "Control Plane Connection",
+      "type": "table",
+      "transformations": [
+        {
+          "id": "seriesToColumns",
+          "options": {
+            "byField": "pod"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Time 1": true,
+              "Time 2": true,
+              "__name__": true,
+              "__name__ 1": true,
+              "__name__ 2": true,
+              "instance": true,
+              "instance 1": true,
+              "instance 2": true,
+              "job": true,
+              "job 1": true,
+              "job 2": true,
+              "mesh": true,
+              "mesh 1": true,
+              "mesh 2": true,
+              "kuma_io_zone": true,
+              "kuma_io_zone 1": true,
+              "kuma_io_zone 2": true,
+              "kuma_workload": true,
+              "kuma_workload 1": true,
+              "kuma_workload 2": true,
+              "namespace": true,
+              "namespace 1": true,
+              "namespace 2": true,
+              "app": true,
+              "app 1": true,
+              "app 2": true
+            },
+            "renameByName": {
+              "pod": "Dataplane",
+              "Value #A": "Status",
+              "Value #B": "Uptime"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "d",
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "< 1 day (OK)",
+                  "color": "green"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 0,
+        "y": 67
+      },
+      "id": 12,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "min(envoy_server_days_until_first_cert_expiring{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\"})",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "mTLS Cert Expiry",
+      "type": "stat",
+      "description": "0 is normal \u2014 Kuma rotates mTLS certs every 24h"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "1": {
+                  "text": "Healthy",
+                  "color": "green"
+                },
+                "0": {
+                  "text": "Unhealthy",
+                  "color": "red"
+                }
+              }
+            }
+          ],
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
         "x": 12,
-        "y": 33
+        "y": 51
       },
       "id": 13,
       "options": {
@@ -1326,18 +1754,184 @@
       },
       "targets": [
         {
-          "expr": "sum(envoy_cluster_membership_healthy{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}) by (envoy_cluster_name)",
-          "legendFormat": "{{envoy_cluster_name}} Healthy",
+          "expr": "sum(envoy_cluster_membership_healthy{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}) by (envoy_cluster_name) / sum(envoy_cluster_membership_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}) by (envoy_cluster_name)",
+          "legendFormat": "{{envoy_cluster_name}}",
           "refId": "A"
-        },
-        {
-          "expr": "sum(envoy_cluster_membership_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}) by (envoy_cluster_name)",
-          "legendFormat": "{{envoy_cluster_name}} Total",
-          "refId": "B"
         }
       ],
       "title": "Upstream Endpoint Health",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "Health ratio per destination (healthy/total). Green = 100%, yellow = degraded, red = unhealthy."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "OK",
+                  "color": "green"
+                },
+                "1": {
+                  "text": "Open",
+                  "color": "red"
+                }
+              }
+            }
+          ],
+          "unit": "short",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 59
+      },
+      "id": 320,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "clamp_max(max(envoy_cluster_circuit_breakers_default_rq_open{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"} + envoy_cluster_circuit_breakers_default_cx_open{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"} + envoy_cluster_circuit_breakers_default_rq_pending_open{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}) by (envoy_cluster_name), 1)",
+          "legendFormat": "{{envoy_cluster_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Circuit Breaker State",
+      "type": "timeseries",
+      "description": "Any circuit breaker open per destination. Green = all closed (OK), red = at least one CB open (rq, cx, or pending)."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.001
+              }
+            ]
+          },
+          "unit": "ops",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 59
+      },
+      "id": 321,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(envoy_cluster_lb_healthy_panic{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m])) by (envoy_cluster_name)",
+          "legendFormat": "{{envoy_cluster_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "LB Panic Mode Rate",
+      "type": "timeseries",
+      "description": "Rate of load balancer panic mode events per destination. Panic mode activates when too few healthy hosts are available, routing traffic to unhealthy hosts to avoid complete failure."
     }
   ],
   "refresh": "10s",
@@ -1417,7 +2011,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}, k8s_kuma_io_namespace)",
+        "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\"}, namespace)",
         "hide": 0,
         "includeAll": true,
         "allValue": ".*",
@@ -1427,7 +2021,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}, k8s_kuma_io_namespace)",
+          "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\"}, namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -1442,7 +2036,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",k8s_kuma_io_namespace=~\"$namespace\"}, kuma_workload)",
+        "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\"}, kuma_workload)",
         "hide": 0,
         "includeAll": false,
         "label": "Workload",
@@ -1451,7 +2045,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",k8s_kuma_io_namespace=~\"$namespace\"}, kuma_workload)",
+          "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\"}, kuma_workload)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -1466,7 +2060,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(envoy_cluster_membership_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name=~\".*_m?svc_.*\"}, envoy_cluster_name)",
+        "definition": "label_values(envoy_cluster_membership_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\".*_m?svc_.*\"}, envoy_cluster_name)",
         "hide": 0,
         "includeAll": true,
         "label": "Destination",
@@ -1475,14 +2069,15 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(envoy_cluster_membership_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name=~\".*_m?svc_.*\"}, envoy_cluster_name)",
+          "query": "label_values(envoy_cluster_membership_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\".*_m?svc_.*\"}, envoy_cluster_name)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
-        "type": "query"
+        "type": "query",
+        "allValue": ".*"
       }
     ]
   },

--- a/dashboards/grafana/kuma-service-health.json
+++ b/dashboards/grafana/kuma-service-health.json
@@ -961,7 +961,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "sum(rate(envoy_rbac_denied{k8s_kuma_io_namespace=\"$namespace\",mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}[5m]))",
+          "expr": "sum(rate(envoy_rbac_denied{k8s_kuma_io_namespace=~\"$namespace\",mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}[5m]))",
           "legendFormat": "denied",
           "refId": "A"
         }
@@ -1017,7 +1017,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_ssl_handshake{k8s_kuma_io_namespace=\"$namespace\",mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name=~\".*_m?svc_.*\"}[5m]))",
+          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_ssl_handshake{k8s_kuma_io_namespace=~\"$namespace\",mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name=~\".*_m?svc_.*\"}[5m]))",
           "legendFormat": "{{envoy_cluster_name}}",
           "refId": "A"
         }
@@ -1074,7 +1074,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "sum by (pod) (rate(envoy_listener_server_ssl_socket_factory_ssl_context_update_by_sds{k8s_kuma_io_namespace=\"$namespace\",mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}[5m]))",
+          "expr": "sum by (pod) (rate(envoy_listener_server_ssl_socket_factory_ssl_context_update_by_sds{k8s_kuma_io_namespace=~\"$namespace\",mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}[5m]))",
           "legendFormat": "{{pod}}",
           "refId": "A"
         }
@@ -1419,7 +1419,8 @@
         },
         "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}, k8s_kuma_io_namespace)",
         "hide": 0,
-        "includeAll": false,
+        "includeAll": true,
+        "allValue": ".*",
         "label": "Namespace",
         "multi": false,
         "name": "namespace",
@@ -1441,7 +1442,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",k8s_kuma_io_namespace=\"$namespace\"}, kuma_workload)",
+        "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",k8s_kuma_io_namespace=~\"$namespace\"}, kuma_workload)",
         "hide": 0,
         "includeAll": false,
         "label": "Workload",
@@ -1450,7 +1451,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",k8s_kuma_io_namespace=\"$namespace\"}, kuma_workload)",
+          "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",k8s_kuma_io_namespace=~\"$namespace\"}, kuma_workload)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/dashboards/grafana/kuma-service-health.json
+++ b/dashboards/grafana/kuma-service-health.json
@@ -21,21 +21,21 @@
   "links": [
     {
       "title": "Workload Debug",
-      "url": "/d/kuma-service-debug/kuma-service-debug?orgId=1&var-datasource=${datasource}&var-namespace=${namespace}&var-workload=${workload}",
+      "url": "/d/kuma-service-debug/kuma-service-debug?var-datasource=${datasource}&var-namespace=${namespace}&var-workload=${workload}",
       "type": "link",
       "icon": "dashboard",
       "tooltip": "Deep-dive debug for this workload"
     },
     {
       "title": "Mesh Drilldown",
-      "url": "/d/kuma-mesh/kuma-mesh-drilldown?orgId=1&var-datasource=${datasource}",
+      "url": "/d/kuma-mesh/kuma-mesh-drilldown?var-datasource=${datasource}",
       "type": "link",
       "icon": "dashboard",
       "tooltip": "Fleet-wide mesh overview"
     },
     {
       "title": "Control Plane",
-      "url": "/d/kuma-cp-v2/kuma-control-plane?orgId=1",
+      "url": "/d/kuma-cp-v2/kuma-control-plane?var-datasource=${datasource}",
       "type": "link",
       "icon": "dashboard",
       "tooltip": "CP health and performance"
@@ -102,7 +102,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_http_downstream_rq_total{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum(rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "",
           "refId": "A"
         }
@@ -177,7 +177,7 @@
       },
       "targets": [
         {
-          "expr": "100 * sum(rate(envoy_http_downstream_rq_xx{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m])) / sum(rate(envoy_http_downstream_rq_total{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "expr": "100 * sum(rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m])) / clamp_min(sum(rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])), 1)",
           "legendFormat": "",
           "refId": "A"
         }
@@ -241,7 +241,7 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(envoy_http_downstream_rq_time_bucket{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (le))",
           "legendFormat": "",
           "refId": "A"
         }
@@ -296,7 +296,7 @@
       },
       "targets": [
         {
-          "expr": "count(envoy_server_live{kuma_workload=\"$workload\"})",
+          "expr": "count(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"})",
           "legendFormat": "",
           "refId": "A"
         }
@@ -382,7 +382,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_http_downstream_rq_total{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum(rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "Total",
           "refId": "A"
         }
@@ -517,7 +517,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_http_downstream_rq_xx{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (envoy_response_code_class)",
+          "expr": "sum(rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (envoy_response_code_class)",
           "legendFormat": "{{envoy_response_code_class}}xx",
           "refId": "A"
         }
@@ -591,12 +591,12 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(envoy_http_downstream_rq_time_bucket{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (le))",
           "legendFormat": "p99",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.50, sum(rate(envoy_http_downstream_rq_time_bucket{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.50, sum(rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (le))",
           "legendFormat": "p50",
           "refId": "B"
         }
@@ -682,7 +682,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_total{kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}}",
           "refId": "A"
         }
@@ -817,7 +817,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_xx{kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m])) by (envoy_cluster_name, envoy_response_code_class)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_xx{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m])) by (envoy_cluster_name, envoy_response_code_class)",
           "legendFormat": "{{envoy_cluster_name}} {{envoy_response_code_class}}xx",
           "refId": "A"
         }
@@ -891,7 +891,7 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_rq_time_bucket{kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m])) by (le, envoy_cluster_name))",
+          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_rq_time_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m])) by (le, envoy_cluster_name))",
           "legendFormat": "{{envoy_cluster_name}} p99",
           "refId": "A"
         }
@@ -961,7 +961,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "sum(rate(envoy_rbac_denied{k8s_kuma_io_namespace=\"$namespace\",kuma_workload=\"$workload\"}[5m]))",
+          "expr": "sum(rate(envoy_rbac_denied{k8s_kuma_io_namespace=\"$namespace\",mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}[5m]))",
           "legendFormat": "denied",
           "refId": "A"
         }
@@ -1017,7 +1017,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_ssl_handshake{k8s_kuma_io_namespace=\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\".*_m?svc_.*\"}[5m]))",
+          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_ssl_handshake{k8s_kuma_io_namespace=\"$namespace\",mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name=~\".*_m?svc_.*\"}[5m]))",
           "legendFormat": "{{envoy_cluster_name}}",
           "refId": "A"
         }
@@ -1074,7 +1074,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "sum by (pod) (rate(envoy_listener_server_ssl_socket_factory_ssl_context_update_by_sds{k8s_kuma_io_namespace=\"$namespace\",kuma_workload=\"$workload\"}[5m]))",
+          "expr": "sum by (pod) (rate(envoy_listener_server_ssl_socket_factory_ssl_context_update_by_sds{k8s_kuma_io_namespace=\"$namespace\",mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}[5m]))",
           "legendFormat": "{{pod}}",
           "refId": "A"
         }
@@ -1157,7 +1157,7 @@
       },
       "targets": [
         {
-          "expr": "min(envoy_control_plane_connected_state{kuma_workload=\"$workload\"})",
+          "expr": "min(envoy_control_plane_connected_state{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"})",
           "legendFormat": "",
           "refId": "A"
         }
@@ -1222,7 +1222,7 @@
       },
       "targets": [
         {
-          "expr": "min(envoy_server_days_until_first_cert_expiring{kuma_workload=\"$workload\"})",
+          "expr": "min(envoy_server_days_until_first_cert_expiring{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"})",
           "legendFormat": "",
           "refId": "A"
         }
@@ -1326,12 +1326,12 @@
       },
       "targets": [
         {
-          "expr": "sum(envoy_cluster_membership_healthy{kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}) by (envoy_cluster_name)",
+          "expr": "sum(envoy_cluster_membership_healthy{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Healthy",
           "refId": "A"
         },
         {
-          "expr": "sum(envoy_cluster_membership_total{kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}) by (envoy_cluster_name)",
+          "expr": "sum(envoy_cluster_membership_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Total",
           "refId": "B"
         }
@@ -1465,7 +1465,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(envoy_cluster_membership_total{kuma_workload=\"$workload\",envoy_cluster_name=~\".*_m?svc_.*\"}, envoy_cluster_name)",
+        "definition": "label_values(envoy_cluster_membership_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name=~\".*_m?svc_.*\"}, envoy_cluster_name)",
         "hide": 0,
         "includeAll": true,
         "label": "Destination",
@@ -1474,7 +1474,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(envoy_cluster_membership_total{kuma_workload=\"$workload\",envoy_cluster_name=~\".*_m?svc_.*\"}, envoy_cluster_name)",
+          "query": "label_values(envoy_cluster_membership_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name=~\".*_m?svc_.*\"}, envoy_cluster_name)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/dashboards/grafana/kuma-service-health.json
+++ b/dashboards/grafana/kuma-service-health.json
@@ -1,0 +1,1497 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [
+    {
+      "title": "Workload Debug",
+      "url": "/d/kuma-service-debug/kuma-service-debug?orgId=1&var-datasource=${datasource}&var-namespace=${namespace}&var-workload=${workload}",
+      "type": "link",
+      "icon": "dashboard",
+      "tooltip": "Deep-dive debug for this workload"
+    },
+    {
+      "title": "Mesh Drilldown",
+      "url": "/d/kuma-mesh/kuma-mesh-drilldown?orgId=1&var-datasource=${datasource}",
+      "type": "link",
+      "icon": "dashboard",
+      "tooltip": "Fleet-wide mesh overview"
+    },
+    {
+      "title": "Control Plane",
+      "url": "/d/kuma-cp-v2/kuma-control-plane?orgId=1",
+      "type": "link",
+      "icon": "dashboard",
+      "tooltip": "CP health and performance"
+    }
+  ],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "green",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(envoy_http_downstream_rq_total{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Inbound Request Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "0%",
+                  "color": "green"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "percent",
+          "noValue": "0%"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "100 * sum(rate(envoy_http_downstream_rq_xx{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m])) / sum(rate(envoy_http_downstream_rq_total{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Inbound Error Rate (5xx)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 100
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
+          },
+          "unit": "ms",
+          "noValue": "N/A"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(envoy_http_downstream_rq_time_bucket{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (le))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Inbound p99 Latency",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "blue",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "count(envoy_server_live{kuma_workload=\"$workload\"})",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Dataplanes",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 101,
+      "title": "Inbound Traffic",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 6
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(envoy_http_downstream_rq_total{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m]))",
+          "legendFormat": "Total",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps",
+          "min": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "2xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "3xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "4xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "5xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 6
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(envoy_http_downstream_rq_xx{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (envoy_response_code_class)",
+          "legendFormat": "{{envoy_response_code_class}}xx",
+          "refId": "A"
+        }
+      ],
+      "title": "Response Status Codes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ms",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 6
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(envoy_http_downstream_rq_time_bucket{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(envoy_http_downstream_rq_time_bucket{kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"localhost_.*|self_inbound_dp_.*\"}[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "B"
+        }
+      ],
+      "title": "Request Duration",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 102,
+      "title": "Outbound Traffic",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 15
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(envoy_cluster_upstream_rq_total{kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m])) by (envoy_cluster_name)",
+          "legendFormat": "{{envoy_cluster_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Rate by Destination",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps",
+          "min": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*2xx.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*3xx.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*4xx.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*5xx.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 15
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(envoy_cluster_upstream_rq_xx{kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m])) by (envoy_cluster_name, envoy_response_code_class)",
+          "legendFormat": "{{envoy_cluster_name}} {{envoy_response_code_class}}xx",
+          "refId": "A"
+        }
+      ],
+      "title": "Response Status Codes by Destination",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ms",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 15
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_rq_time_bucket{kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m])) by (le, envoy_cluster_name))",
+          "legendFormat": "{{envoy_cluster_name}} p99",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Duration by Destination (p99)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 104,
+      "title": "Security",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 24
+      },
+      "id": 105,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "RBAC Denied",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum(rate(envoy_rbac_denied{k8s_kuma_io_namespace=\"$namespace\",kuma_workload=\"$workload\"}[5m]))",
+          "legendFormat": "denied",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 24
+      },
+      "id": 106,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Outbound TLS Handshakes",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_ssl_handshake{k8s_kuma_io_namespace=\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\".*_m?svc_.*\"}[5m]))",
+          "legendFormat": "{{envoy_cluster_name}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "ops",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 24
+      },
+      "id": 107,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "min"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "asc"
+        }
+      },
+      "title": "Cert Rotation Rate",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (pod) (rate(envoy_listener_server_ssl_socket_factory_ssl_context_update_by_sds{k8s_kuma_io_namespace=\"$namespace\",kuma_workload=\"$workload\"}[5m]))",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "description": "Rate of SDS certificate updates. Active rotation = healthy mTLS."
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "id": 103,
+      "title": "Health",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "Disconnected",
+                  "color": "red"
+                },
+                "1": {
+                  "text": "Connected",
+                  "color": "green"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 33
+      },
+      "id": 11,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "min(envoy_control_plane_connected_state{kuma_workload=\"$workload\"})",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Control Plane",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "d",
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "< 1 day (OK)",
+                  "color": "green"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 33
+      },
+      "id": 12,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "min(envoy_server_days_until_first_cert_expiring{kuma_workload=\"$workload\"})",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "mTLS Cert Expiry",
+      "type": "stat",
+      "description": "0 is normal \u2014 Kuma rotates mTLS certs every 24h"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "min": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*Healthy.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*Total.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(envoy_cluster_membership_healthy{kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}) by (envoy_cluster_name)",
+          "legendFormat": "{{envoy_cluster_name}} Healthy",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(envoy_cluster_membership_total{kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}) by (envoy_cluster_name)",
+          "legendFormat": "{{envoy_cluster_name}} Total",
+          "refId": "B"
+        }
+      ],
+      "title": "Upstream Endpoint Health",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": [
+    "kuma",
+    "service-mesh"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(envoy_server_live, mesh)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Mesh",
+        "multi": false,
+        "name": "mesh",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(envoy_server_live, mesh)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_zone)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Zone",
+        "multi": false,
+        "name": "zone",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_zone)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}, k8s_kuma_io_namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}, k8s_kuma_io_namespace)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",k8s_kuma_io_namespace=\"$namespace\"}, kuma_workload)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Workload",
+        "multi": false,
+        "name": "workload",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",k8s_kuma_io_namespace=\"$namespace\"}, kuma_workload)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(envoy_cluster_membership_total{kuma_workload=\"$workload\",envoy_cluster_name=~\".*_m?svc_.*\"}, envoy_cluster_name)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Destination",
+        "multi": false,
+        "name": "destination",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(envoy_cluster_membership_total{kuma_workload=\"$workload\",envoy_cluster_name=~\".*_m?svc_.*\"}, envoy_cluster_name)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Kuma Workload Health",
+  "uid": "kuma-service-health",
+  "version": 1
+}

--- a/mise.toml
+++ b/mise.toml
@@ -29,6 +29,7 @@ node = "24"
 "go:github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen" = "v2.6.0"
 "go:sigs.k8s.io/controller-tools/cmd/controller-gen" = "v0.20.1"
 "go:sigs.k8s.io/controller-runtime/tools/setup-envtest" = "v0.0.0-20260318145839-6c9615a2a166"
+"go:github.com/grafana/dashboard-linter" = "v0.0.0-20250428211052-5e22d6dc65a1"
 # === tools excluded from GitHub Actions installs ===
 # ⚠️ If you change any tool name below, update `MISE_DISABLE_TOOLS` in:
 #     .github/workflows/_build_publish.yaml

--- a/mk/check.mk
+++ b/mk/check.mk
@@ -70,8 +70,15 @@ else
 	$(ACTIONLINT) -color
 endif
 
+.PHONY: grafana-lint
+grafana-lint:
+	@for f in dashboards/grafana/*.json; do \
+		echo "Linting $$f..."; \
+		$(DASHBOARD_LINTER) lint -c dashboards/grafana/.lint "$$f" || exit 1; \
+	done
+
 .PHONY: lint
-lint: helm-lint golangci-lint shellcheck kube-lint hadolint ginkgo/lint actionlint
+lint: helm-lint golangci-lint shellcheck kube-lint hadolint ginkgo/lint actionlint grafana-lint
 
 
 .PHONY: check

--- a/mk/dev.mk
+++ b/mk/dev.mk
@@ -79,6 +79,7 @@ GOLANGCI_LINT=$(shell $(MISE) which golangci-lint)
 HELM_DOCS=$(shell $(MISE) which helm-docs)
 KUBE_LINTER=$(shell $(MISE) which kube-linter)
 HADOLINT=$(shell $(MISE) which hadolint)
+DASHBOARD_LINTER=$(shell $(MISE) which dashboard-linter)
 # oapi-codegen: mise go: backend installs to CI_TOOLS_BIN_DIR, mise which doesn't find it
 OAPI_CODEGEN=$(shell test -f $(CI_TOOLS_BIN_DIR)/oapi-codegen && echo $(CI_TOOLS_BIN_DIR)/oapi-codegen || command -v oapi-codegen)
 

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -14,7 +14,8 @@ build:
       runtimeType: go
       custom:
         buildCommand: |
-          platform=$(echo $PLATFORMS | cut -d'/' -f2)
+          platform=${PLATFORMS:+$(echo $PLATFORMS | cut -d'/' -f2)}
+          platform=${platform:-$(go env GOARCH)}
           GOTRACEBACK=all DEBUG=true EXTRA_GOFLAGS='-gcflags="all=-N -l"' make image/kuma-cp/$platform docker/tag/kuma-cp
         dependencies:
           paths:
@@ -23,7 +24,8 @@ build:
     - image: kumahq/kuma-dp
       custom:
         buildCommand: |
-          platform=$(echo $PLATFORMS | cut -d'/' -f2)
+          platform=${PLATFORMS:+$(echo $PLATFORMS | cut -d'/' -f2)}
+          platform=${platform:-$(go env GOARCH)}
           make image/kuma-dp/$platform docker/tag/kuma-dp
         dependencies:
           paths:
@@ -32,7 +34,8 @@ build:
     - image: kumahq/kumactl
       custom:
         buildCommand: |
-          platform=$(echo $PLATFORMS | cut -d'/' -f2)
+          platform=${PLATFORMS:+$(echo $PLATFORMS | cut -d'/' -f2)}
+          platform=${platform:-$(go env GOARCH)}
           make image/kumactl/$platform docker/tag/kumactl
         dependencies:
           paths:
@@ -41,7 +44,8 @@ build:
     - image: kumahq/kuma-init
       custom:
         buildCommand: |
-          platform=$(echo $PLATFORMS | cut -d'/' -f2)
+          platform=${PLATFORMS:+$(echo $PLATFORMS | cut -d'/' -f2)}
+          platform=${platform:-$(go env GOARCH)}
           make image/kuma-init/$platform docker/tag/kuma-init
         dependencies:
           paths:


### PR DESCRIPTION
## Motivation

Kuma ships without ready-to-use Grafana dashboards. Users have to build their own from scratch, which requires deep knowledge of Envoy and CP metric names.

## Implementation information

Add 4 Grafana dashboards under `dashboards/grafana/`:

- **Control Plane** (`kuma-cp-v2`): leader status, xDS generation/delivery rates split by result, KDS sync metrics (delta prefix), cert TTL, CA cache, resource counts, Go runtime, workqueue depth, gRPC stats
- **Mesh Drilldown** (`kuma-mesh`): fleet-wide inbound request rate and error rate, per-workload summary table with zone column and drill-down links
- **Workload Health** (`kuma-service-health`): per-workload RED metrics (request rate, error rate, latency), destination breakdown
- **Workload Debug** (`kuma-service-debug`): detailed Envoy stats — connections, circuit breakers, retries, timeouts, resets, bytes, active requests, proxy uptime

Key design decisions:
- All dashboards use `kuma_workload` label instead of `app` for universal (non-K8s) compatibility
- Support both legacy (`localhost_*`) and unified (`self_inbound_dp_*`) Envoy naming patterns
- Cascading variables: datasource → mesh → zone → namespace → workload
- Outbound queries exclude internal clusters (`self_*`, `system_*`, `kuma_*`, `localhost_*`)
- CP metrics aggregated with `max by` / `sum` to deduplicate across multiple CP instances

> Changelog: feat(kuma-cp): improve control-plane observability with dashboards, histograms, and operational metrics
