### PR TITLE
feat(motb): add xDS and OTel helpers

### DIFF
--- a/pkg/core/xds/metadata.go
+++ b/pkg/core/xds/metadata.go
@@ -39,6 +39,8 @@ const (
 	FieldTransparentProxy              = "transparentProxy"
 	FieldIPv6Enabled                   = "ipv6Enabled"
 	FieldSpireSocketPath               = "spireAgent.socketPath"
+	FieldDynamicHostIP                 = "HOST_IP"
+	FieldOtelEnvInventory              = "otelEnvInventory"
 )
 
 // DataplaneMetadata represents environment-specific part of a dataplane configuration.
@@ -73,6 +75,7 @@ type DataplaneMetadata struct {
 	TransparentProxy     *tproxy_dp.DataplaneConfig
 	IPv6Enabled          bool
 	SpireSocketPath      string
+	OtelEnvInventory     *OtelBootstrapInventory
 }
 
 // GetDataplaneResource returns the underlying DataplaneResource, if present.
@@ -188,6 +191,13 @@ func (m *DataplaneMetadata) GetIPv6Enabled() bool {
 	return m.IPv6Enabled
 }
 
+func (m *DataplaneMetadata) GetOtelEnvInventory() *OtelBootstrapInventory {
+	if m == nil {
+		return nil
+	}
+	return m.OtelEnvInventory
+}
+
 func (m *DataplaneMetadata) HasFeature(feature string) bool {
 	if m == nil || m.Features == nil {
 		return false
@@ -270,6 +280,15 @@ func DataplaneMetadataFromXdsMetadata(xdsMetadata *structpb.Struct) *DataplaneMe
 	} else {
 		// For backward compatibility as previously this was always enabled
 		metadata.IPv6Enabled = true
+	}
+
+	if value := xdsMetadata.Fields[FieldOtelEnvInventory]; value.GetStructValue() != nil {
+		inventory, err := util_proto.FromMapOfAny[*OtelBootstrapInventory](value.GetStructValue())
+		if err != nil {
+			metadataLog.Error(err, "invalid value in dataplane metadata", "field", FieldOtelEnvInventory, "value", value)
+		} else {
+			metadata.OtelEnvInventory = inventory
+		}
 	}
 
 	if value := xdsMetadata.Fields[FieldDynamicMetadata]; value != nil {

--- a/pkg/core/xds/metadata_test.go
+++ b/pkg/core/xds/metadata_test.go
@@ -93,6 +93,35 @@ var _ = Describe("DataplaneMetadataFromXdsMetadata", func() {
 				IPv6Enabled:     true,
 			},
 		}),
+		Entry("should parse OTEL env inventory", testCase{
+			node: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"otelEnvInventory": {
+						Kind: &structpb.Value_StructValue{
+							StructValue: util_proto.MustStructToProtoStruct(&xds.OtelBootstrapInventory{
+								PipeEnabled: true,
+								Shared: &xds.OtelSignalEnvInventory{
+									EndpointPresent:   true,
+									EffectiveProtocol: xds.OtelProtocolHTTPProtobuf,
+								},
+							}),
+						},
+					},
+				},
+			},
+			expected: xds.DataplaneMetadata{
+				IPv6Enabled: true,
+				OtelEnvInventory: &xds.OtelBootstrapInventory{
+					PipeEnabled: true,
+					Shared: &xds.OtelSignalEnvInventory{
+						EndpointPresent:   true,
+						EffectiveProtocol: xds.OtelProtocolHTTPProtobuf,
+						OverrideKinds:     []string{},
+					},
+					ValidationErrors: []string{},
+				},
+			},
+		}),
 	)
 
 	It("should parse version", func() { // this has to be separate test because Equal does not work on proto

--- a/pkg/core/xds/otel_env.go
+++ b/pkg/core/xds/otel_env.go
@@ -1,0 +1,86 @@
+package xds
+
+type OtelSignal string
+
+const (
+	OtelSignalTraces  OtelSignal = "traces"
+	OtelSignalLogs    OtelSignal = "logs"
+	OtelSignalMetrics OtelSignal = "metrics"
+)
+
+type OtelProtocol string
+
+const (
+	OtelProtocolUnknown      OtelProtocol = "unknown"
+	OtelProtocolGRPC         OtelProtocol = "grpc"
+	OtelProtocolHTTPProtobuf OtelProtocol = "http/protobuf"
+)
+
+type OtelAuthMode string
+
+const (
+	OtelAuthModeNone    OtelAuthMode = "none"
+	OtelAuthModeHeaders OtelAuthMode = "headers"
+	OtelAuthModeTLS     OtelAuthMode = "tls"
+	OtelAuthModeMTLS    OtelAuthMode = "mtls"
+)
+
+type OtelBootstrapInventory struct {
+	PipeEnabled      bool                    `json:"pipeEnabled,omitempty"`
+	Shared           *OtelSignalEnvInventory `json:"shared,omitempty"`
+	Traces           *OtelSignalEnvInventory `json:"traces,omitempty"`
+	Logs             *OtelSignalEnvInventory `json:"logs,omitempty"`
+	Metrics          *OtelSignalEnvInventory `json:"metrics,omitempty"`
+	ValidationErrors []string                `json:"validationErrors,omitempty"`
+}
+
+type OtelSignalEnvInventory struct {
+	EndpointPresent          bool         `json:"endpointPresent,omitempty"`
+	EndpointParsedAsURL      bool         `json:"endpointParsedAsURL,omitempty"`
+	EndpointHasPath          bool         `json:"endpointHasPath,omitempty"`
+	ProtocolPresent          bool         `json:"protocolPresent,omitempty"`
+	HeadersPresent           bool         `json:"headersPresent,omitempty"`
+	TimeoutPresent           bool         `json:"timeoutPresent,omitempty"`
+	CompressionPresent       bool         `json:"compressionPresent,omitempty"`
+	InsecurePresent          bool         `json:"insecurePresent,omitempty"`
+	CertificatePresent       bool         `json:"certificatePresent,omitempty"`
+	ClientCertificatePresent bool         `json:"clientCertificatePresent,omitempty"`
+	ClientKeyPresent         bool         `json:"clientKeyPresent,omitempty"`
+	EffectiveProtocol        OtelProtocol `json:"effectiveProtocol,omitempty"`
+	EffectiveAuthMode        OtelAuthMode `json:"effectiveAuthMode,omitempty"`
+	OverrideKinds            []string     `json:"overrideKinds,omitempty"`
+}
+
+func (i *OtelBootstrapInventory) GetSignal(signal OtelSignal) *OtelSignalEnvInventory {
+	if i == nil {
+		return nil
+	}
+
+	switch signal {
+	case OtelSignalTraces:
+		return i.Traces
+	case OtelSignalLogs:
+		return i.Logs
+	case OtelSignalMetrics:
+		return i.Metrics
+	default:
+		return nil
+	}
+}
+
+func (i *OtelSignalEnvInventory) HasAnyInput() bool {
+	if i == nil {
+		return false
+	}
+
+	return i.EndpointPresent ||
+		i.ProtocolPresent ||
+		i.HeadersPresent ||
+		i.TimeoutPresent ||
+		i.CompressionPresent ||
+		i.InsecurePresent ||
+		i.CertificatePresent ||
+		i.ClientCertificatePresent ||
+		i.ClientKeyPresent ||
+		len(i.OverrideKinds) > 0
+}

--- a/pkg/core/xds/otel_pipe.go
+++ b/pkg/core/xds/otel_pipe.go
@@ -1,0 +1,196 @@
+package xds
+
+import (
+	"slices"
+
+	motb_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshopentelemetrybackend/api/v1alpha1"
+	util_maps "github.com/kumahq/kuma/v2/pkg/util/maps"
+)
+
+const OtelDynconfPath = "/otel"
+
+const (
+	OtelBlockedReasonEnvDisabledByPolicy    = "EnvDisabledByPolicy"
+	OtelBlockedReasonRequiredEnvMissing     = "RequiredEnvMissing"
+	OtelBlockedReasonSignalOverridesBlocked = "SignalOverridesDisallowed"
+	OtelBlockedReasonMultipleBackends       = "MultipleBackendsForSignal"
+)
+
+type OtelResolvedEnvPolicy struct {
+	Mode                 motb_api.EnvMode       `json:"mode,omitempty"`
+	Precedence           motb_api.EnvPrecedence `json:"precedence,omitempty"`
+	AllowSignalOverrides bool                   `json:"allowSignalOverrides,omitempty"`
+}
+
+type OtelSignalRuntimePlan struct {
+	Enabled         bool     `json:"enabled,omitempty"`
+	EnvInputPresent bool     `json:"envInputPresent,omitempty"`
+	OverrideKinds   []string `json:"overrideKinds,omitempty"`
+	MissingFields   []string `json:"missingFields,omitempty"`
+	BlockedReasons  []string `json:"blockedReasons,omitempty"`
+	RefreshInterval string   `json:"refreshInterval,omitempty"`
+}
+
+// OtelPipeBackend represents one MOTB backend for the unified /otel dynconf route.
+// All signals sharing this backend use the same SocketPath.
+type OtelPipeBackend struct {
+	Name       string                 `json:"name,omitempty"`
+	SocketPath string                 `json:"socketPath"`
+	Endpoint   string                 `json:"endpoint"`
+	UseHTTP    bool                   `json:"useHTTP"`
+	UseHTTPS   bool                   `json:"useHTTPS,omitempty"`
+	Path       string                 `json:"path,omitempty"`
+	EnvPolicy  *OtelResolvedEnvPolicy `json:"envPolicy,omitempty"`
+	Traces     *OtelSignalRuntimePlan `json:"traces,omitempty"`
+	Logs       *OtelSignalRuntimePlan `json:"logs,omitempty"`
+	Metrics    *OtelSignalRuntimePlan `json:"metrics,omitempty"`
+}
+
+// OtelDpConfig is sent from CP to DP via the /otel dynconf route.
+type OtelDpConfig struct {
+	Backends []OtelPipeBackend `json:"backends"`
+}
+
+// OtelPipeBackends accumulates backends from policy plugins during xDS generation.
+// Deduplicates by backend name - all signals for the same MOTB share one socket.
+type OtelPipeBackends struct {
+	backends       map[string]*OtelPipeBackend        // key: backendName
+	signalBackends map[OtelSignal]map[string]struct{} // key: signal -> backend names
+}
+
+func (a *OtelPipeBackends) AddSignal(
+	name string,
+	b OtelPipeBackend,
+	signal OtelSignal,
+	plan OtelSignalRuntimePlan,
+) {
+	backend := a.mergeBase(name, b)
+	backend.setSignalPlan(signal, cloneSignalPlan(plan))
+
+	if a.signalBackends == nil {
+		a.signalBackends = map[OtelSignal]map[string]struct{}{}
+	}
+	if a.signalBackends[signal] == nil {
+		a.signalBackends[signal] = map[string]struct{}{}
+	}
+	a.signalBackends[signal][name] = struct{}{}
+}
+
+func (a *OtelPipeBackends) All() []OtelPipeBackend {
+	if len(a.backends) == 0 {
+		return nil
+	}
+	var result []OtelPipeBackend
+	for _, name := range util_maps.SortedKeys(a.backends) {
+		backend := cloneBackend(*a.backends[name])
+		a.finalizeBackend(&backend)
+		result = append(result, backend)
+	}
+	return result
+}
+
+func (a *OtelPipeBackends) Empty() bool {
+	return len(a.backends) == 0
+}
+
+func (a *OtelPipeBackends) mergeBase(name string, b OtelPipeBackend) *OtelPipeBackend {
+	if a.backends == nil {
+		a.backends = map[string]*OtelPipeBackend{}
+	}
+
+	backend, ok := a.backends[name]
+	if !ok {
+		base := b
+		base.Name = name
+		backend = &base
+		a.backends[name] = backend
+		return backend
+	}
+
+	backend.Name = name
+	backend.SocketPath = b.SocketPath
+	backend.Endpoint = b.Endpoint
+	backend.UseHTTP = b.UseHTTP
+	backend.UseHTTPS = b.UseHTTPS
+	backend.Path = b.Path
+	backend.EnvPolicy = b.EnvPolicy
+	return backend
+}
+
+func (a *OtelPipeBackends) finalizeBackend(backend *OtelPipeBackend) {
+	if backend == nil {
+		return
+	}
+
+	for _, signal := range []OtelSignal{OtelSignalTraces, OtelSignalLogs, OtelSignalMetrics} {
+		plan := backend.getSignalPlan(signal)
+		if plan == nil {
+			continue
+		}
+		if len(a.signalBackends[signal]) > 1 &&
+			plan.EnvInputPresent &&
+			(backend.EnvPolicy == nil || backend.EnvPolicy.Mode != motb_api.EnvModeDisabled) &&
+			!slices.Contains(plan.BlockedReasons, OtelBlockedReasonEnvDisabledByPolicy) {
+			plan.BlockedReasons = appendUnique(plan.BlockedReasons, OtelBlockedReasonMultipleBackends)
+		}
+	}
+}
+
+func (b *OtelPipeBackend) getSignalPlan(signal OtelSignal) *OtelSignalRuntimePlan {
+	switch signal {
+	case OtelSignalTraces:
+		return b.Traces
+	case OtelSignalLogs:
+		return b.Logs
+	case OtelSignalMetrics:
+		return b.Metrics
+	default:
+		return nil
+	}
+}
+
+func (b *OtelPipeBackend) setSignalPlan(signal OtelSignal, plan OtelSignalRuntimePlan) {
+	switch signal {
+	case OtelSignalTraces:
+		b.Traces = &plan
+	case OtelSignalLogs:
+		b.Logs = &plan
+	case OtelSignalMetrics:
+		b.Metrics = &plan
+	}
+}
+
+func cloneBackend(in OtelPipeBackend) OtelPipeBackend {
+	out := in
+	if in.Traces != nil {
+		traces := cloneSignalPlan(*in.Traces)
+		out.Traces = &traces
+	}
+	if in.Logs != nil {
+		logs := cloneSignalPlan(*in.Logs)
+		out.Logs = &logs
+	}
+	if in.Metrics != nil {
+		metrics := cloneSignalPlan(*in.Metrics)
+		out.Metrics = &metrics
+	}
+	return out
+}
+
+func cloneSignalPlan(in OtelSignalRuntimePlan) OtelSignalRuntimePlan {
+	return OtelSignalRuntimePlan{
+		Enabled:         in.Enabled,
+		EnvInputPresent: in.EnvInputPresent,
+		OverrideKinds:   slices.Clone(in.OverrideKinds),
+		MissingFields:   slices.Clone(in.MissingFields),
+		BlockedReasons:  slices.Clone(in.BlockedReasons),
+		RefreshInterval: in.RefreshInterval,
+	}
+}
+
+func appendUnique(values []string, value string) []string {
+	if slices.Contains(values, value) {
+		return values
+	}
+	return append(values, value)
+}

--- a/pkg/core/xds/otel_pipe_test.go
+++ b/pkg/core/xds/otel_pipe_test.go
@@ -1,0 +1,64 @@
+package xds_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	motb_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshopentelemetrybackend/api/v1alpha1"
+	core_xds "github.com/kumahq/kuma/v2/pkg/core/xds"
+)
+
+var _ = Describe("OtelPipeBackends", func() {
+	baseBackend := func(name string) core_xds.OtelPipeBackend {
+		return core_xds.OtelPipeBackend{
+			Name:       name,
+			SocketPath: "/tmp/" + name + ".sock",
+			Endpoint:   name + ":4317",
+			EnvPolicy: &core_xds.OtelResolvedEnvPolicy{
+				Mode:                 motb_api.EnvModeOptional,
+				Precedence:           motb_api.EnvPrecedenceEnvFirst,
+				AllowSignalOverrides: true,
+			},
+		}
+	}
+
+	It("should keep both plans when multiple signals share one backend", func() {
+		backends := &core_xds.OtelPipeBackends{}
+		backend := baseBackend("collector")
+
+		backends.AddSignal("collector", backend, core_xds.OtelSignalTraces, core_xds.OtelSignalRuntimePlan{
+			Enabled:         true,
+			EnvInputPresent: true,
+			OverrideKinds:   []string{"endpoint"},
+		})
+		backends.AddSignal("collector", backend, core_xds.OtelSignalLogs, core_xds.OtelSignalRuntimePlan{
+			Enabled:         true,
+			EnvInputPresent: true,
+		})
+
+		all := backends.All()
+		Expect(all).To(HaveLen(1))
+		Expect(all[0].Traces).ToNot(BeNil())
+		Expect(all[0].Logs).ToNot(BeNil())
+	})
+
+	It("should mark ambiguity when one signal uses env on multiple backends", func() {
+		backends := &core_xds.OtelPipeBackends{}
+		backendA := baseBackend("collector-a")
+		backendB := baseBackend("collector-b")
+
+		backends.AddSignal("collector-a", backendA, core_xds.OtelSignalTraces, core_xds.OtelSignalRuntimePlan{
+			Enabled:         true,
+			EnvInputPresent: true,
+		})
+		backends.AddSignal("collector-b", backendB, core_xds.OtelSignalTraces, core_xds.OtelSignalRuntimePlan{
+			Enabled:         true,
+			EnvInputPresent: true,
+		})
+
+		all := backends.All()
+		Expect(all).To(HaveLen(2))
+		Expect(all[0].Traces.BlockedReasons).To(ContainElement(core_xds.OtelBlockedReasonMultipleBackends))
+		Expect(all[1].Traces.BlockedReasons).To(ContainElement(core_xds.OtelBlockedReasonMultipleBackends))
+	})
+})

--- a/pkg/core/xds/types.go
+++ b/pkg/core/xds/types.go
@@ -204,6 +204,9 @@ type Proxy struct {
 	Zone string
 	// InternalAddresses is a set of address prefixes that are considered internal to the mesh, it will be configured to in Envoy HCM config
 	InternalAddresses []InternalAddress
+	// OtelPipeBackends accumulates unified OTel backends across policy plugins.
+	// Populated during xDS generation, consumed by the generator to write /otel dynconf.
+	OtelPipeBackends *OtelPipeBackends
 }
 
 func (p *Proxy) GetTransparentProxy() *tproxy_dp.DataplaneConfig {

--- a/pkg/core/xds/types/features.go
+++ b/pkg/core/xds/types/features.go
@@ -44,3 +44,8 @@ const FeatureReadinessUnixSocket = "feature-readiness-unix-socket"
 
 // FeatureStrictInboundPorts indicates whether the sidecar should reject any inbound traffic on ports other than those explicitly defined.
 const FeatureStrictInboundPorts = "feature-strict-inbound-ports"
+
+// FeatureOtelViaKumaDp indicates that kuma-dp can act as a gRPC proxy for OTel
+// traces and access logs. When present, the CP routes the OTel cluster to a Unix
+// socket instead of connecting directly to the collector.
+const FeatureOtelViaKumaDp = "feature-otel-via-kuma-dp"

--- a/pkg/plugins/policies/core/generator/generator.go
+++ b/pkg/plugins/policies/core/generator/generator.go
@@ -2,13 +2,18 @@ package generator
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/pkg/errors"
 
+	unified_naming "github.com/kumahq/kuma/v2/pkg/core/naming/unified-naming"
 	"github.com/kumahq/kuma/v2/pkg/core/plugins"
+	core_system_names "github.com/kumahq/kuma/v2/pkg/core/system_names"
 	"github.com/kumahq/kuma/v2/pkg/core/xds"
+	xds_types "github.com/kumahq/kuma/v2/pkg/core/xds/types"
 	"github.com/kumahq/kuma/v2/pkg/plugins/policies/core/ordered"
 	xds_context "github.com/kumahq/kuma/v2/pkg/xds/context"
+	"github.com/kumahq/kuma/v2/pkg/xds/dynconf"
 	generator_core "github.com/kumahq/kuma/v2/pkg/xds/generator/core"
 )
 
@@ -19,10 +24,48 @@ func NewGenerator() generator_core.ResourceGenerator {
 type generator struct{}
 
 func (g generator) Generate(ctx context.Context, rs *xds.ResourceSet, xdsCtx xds_context.Context, proxy *xds.Proxy) (*xds.ResourceSet, error) {
+	proxy.OtelPipeBackends = &xds.OtelPipeBackends{}
+
 	for _, policy := range plugins.Plugins().PolicyPlugins(ordered.Policies) {
 		if err := policy.Plugin.Apply(rs, xdsCtx, proxy); err != nil {
 			return nil, errors.Wrapf(err, "could not apply policy plugin %s", policy.Name)
 		}
 	}
+
+	if err := writeUnifiedOtelRoute(rs, xdsCtx, proxy); err != nil {
+		return nil, err
+	}
+
 	return rs, nil
+}
+
+func writeUnifiedOtelRoute(rs *xds.ResourceSet, xdsCtx xds_context.Context, proxy *xds.Proxy) error {
+	if proxy.OtelPipeBackends.Empty() {
+		return nil
+	}
+
+	if !proxy.Metadata.HasFeature(xds_types.FeatureOtelViaKumaDp) {
+		return nil
+	}
+
+	dpConfig := xds.OtelDpConfig{
+		Backends: proxy.OtelPipeBackends.All(),
+	}
+
+	data, err := json.Marshal(dpConfig)
+	if err != nil {
+		return errors.Wrap(err, "marshaling otel dp config")
+	}
+
+	unifiedNamingEnabled := unified_naming.Enabled(proxy.Metadata, xdsCtx.Mesh.Resource)
+	getNameOrDefault := core_system_names.GetNameOrDefault(unifiedNamingEnabled)
+
+	return dynconf.AddConfigRoute(
+		proxy,
+		rs,
+		unifiedNamingEnabled,
+		getNameOrDefault("otel", xds.OtelDynconfPath),
+		xds.OtelDynconfPath,
+		data,
+	)
 }

--- a/pkg/plugins/policies/core/xds/otel.go
+++ b/pkg/plugins/policies/core/xds/otel.go
@@ -1,0 +1,367 @@
+package xds
+
+import (
+	"net"
+	"net/url"
+	"path"
+	"slices"
+	"strconv"
+	"strings"
+
+	common_api "github.com/kumahq/kuma/v2/api/common/v1alpha1"
+	"github.com/kumahq/kuma/v2/pkg/core"
+	motb_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshopentelemetrybackend/api/v1alpha1"
+	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
+	core_xds "github.com/kumahq/kuma/v2/pkg/core/xds"
+	"github.com/kumahq/kuma/v2/pkg/util/pointer"
+	xds_context "github.com/kumahq/kuma/v2/pkg/xds/context"
+)
+
+// OTLP/HTTP signal path suffixes per the OpenTelemetry Protocol specification.
+const (
+	OtelTracesPathSuffix  = "v1/traces"
+	OtelMetricsPathSuffix = "v1/metrics"
+	OtelLogsPathSuffix    = "v1/logs"
+
+	defaultOtelGrpcPort = 4317
+)
+
+var otelLog = core.Log.WithName("otel-backend-resolution")
+
+// ResolvedOtelBackend holds the resolved endpoint info from either a
+// MeshOpenTelemetryBackend resource (via backendRef) or an inline endpoint.
+type ResolvedOtelBackend struct {
+	Endpoint  *core_xds.Endpoint
+	Protocol  motb_api.Protocol
+	EnvPolicy *motb_api.EnvPolicy
+	// UseHTTPS is true when OTLP/HTTP should use HTTPS transport.
+	// Current heuristic: protocol=http with collector port 443.
+	UseHTTPS bool
+	// Path is the base path from MeshOpenTelemetryBackend (nil for inline endpoints and gRPC).
+	Path *string
+	// Name is used for naming clusters/listeners. For backendRef it's the resource name,
+	// for inline endpoint it's derived from the endpoint string.
+	Name string
+}
+
+// FullPath joins the base path from MeshOpenTelemetryBackend with the given
+// OTLP signal suffix (e.g. OtelTracesPathSuffix). Returns "/" + suffix when
+// no base path is set.
+func (r *ResolvedOtelBackend) FullPath(signalSuffix string) string {
+	base := "/"
+	if r.Path != nil {
+		base = *r.Path
+	}
+	return path.Join(base, signalSuffix)
+}
+
+// ResolveOtelBackend resolves a backendRef to a MeshOpenTelemetryBackend resource,
+// falling back to the inline endpoint if backendRef is nil.
+// Returns nil when the backendRef is dangling (resource not found) or no config exists.
+func ResolveOtelBackend(
+	backendRef *common_api.BackendResourceRef,
+	inlineEndpoint string,
+	inlineEndpointParser func(string) *core_xds.Endpoint,
+	inlineNameDeriver func(string) string,
+	resources xds_context.Resources,
+) *ResolvedOtelBackend {
+	switch {
+	case backendRef != nil:
+		return resolveFromBackendRef(backendRef, resources)
+	case inlineEndpoint != "":
+		return &ResolvedOtelBackend{
+			Endpoint: inlineEndpointParser(inlineEndpoint),
+			Protocol: motb_api.ProtocolGRPC,
+			Name:     inlineNameDeriver(inlineEndpoint),
+		}
+	default:
+		return nil
+	}
+}
+
+func resolveFromBackendRef(ref *common_api.BackendResourceRef, resources xds_context.Resources) *ResolvedOtelBackend {
+	var backend *motb_api.MeshOpenTelemetryBackendResource
+	switch {
+	case ref.Name != "":
+		backend = resolveBackendResourceByName(resources, ref.Name)
+	case len(ref.Labels) > 0:
+		backend = resolveBackendResourceByLabels(resources, ref.Labels)
+	}
+
+	if backend == nil {
+		otelLog.Info(
+			"MeshOpenTelemetryBackend not found, skipping backend",
+			"name", ref.Name,
+			"labels", ref.Labels,
+		)
+		return nil
+	}
+
+	return resolvedFromSpec(backend)
+}
+
+func resolvedFromSpec(backend *motb_api.MeshOpenTelemetryBackendResource) *ResolvedOtelBackend {
+	spec := backend.Spec
+	protocol := pointer.DerefOr(spec.Protocol, motb_api.ProtocolGRPC)
+
+	var addr string
+	port := uint32(defaultOtelGrpcPort)
+	var basePath *string
+	if ep := spec.Endpoint; ep != nil {
+		addr = pointer.Deref(ep.Address)
+		if ep.Port != nil {
+			port = uint32(*ep.Port)
+		}
+		basePath = ep.Path
+	}
+
+	return &ResolvedOtelBackend{
+		Endpoint:  &core_xds.Endpoint{Target: addr, Port: port},
+		Protocol:  protocol,
+		EnvPolicy: spec.Env,
+		UseHTTPS:  protocol == motb_api.ProtocolHTTP && port == 443,
+		Path:      basePath,
+		Name:      core_model.GetDisplayName(backend.GetMeta()),
+	}
+}
+
+// resolveBackendResourceByName looks up by display name (the user-facing name
+// without the namespace suffix that Kubernetes adds internally).
+func resolveBackendResourceByName(
+	resources xds_context.Resources,
+	name string,
+) *motb_api.MeshOpenTelemetryBackendResource {
+	for _, backend := range resources.MeshOpenTelemetryBackends().Items {
+		if core_model.GetDisplayName(backend.GetMeta()) == name {
+			return backend
+		}
+	}
+	return nil
+}
+
+// resolveBackendResourceByLabels matches all labels and picks the oldest on collision.
+// Same strategy as DestinationIndex.resolveResourceIdentifier.
+func resolveBackendResourceByLabels(
+	resources xds_context.Resources,
+	labels map[string]string,
+) *motb_api.MeshOpenTelemetryBackendResource {
+	selector := common_api.LabelSelector{MatchLabels: &labels}
+	var matches []*motb_api.MeshOpenTelemetryBackendResource
+	for _, backend := range resources.MeshOpenTelemetryBackends().Items {
+		if selector.Matches(backend.GetMeta().GetLabels()) {
+			matches = append(matches, backend)
+		}
+	}
+
+	if len(matches) == 0 {
+		return nil
+	}
+
+	oldest := matches[0]
+	for _, b := range matches[1:] {
+		if b.GetMeta().GetCreationTime().Before(oldest.GetMeta().GetCreationTime()) {
+			oldest = b
+		}
+	}
+
+	return oldest
+}
+
+type AddResolvedBackendOptions struct {
+	RefreshInterval string
+}
+
+func BuildResolvedPipeBackend(workDir string, resolved *ResolvedOtelBackend) core_xds.OtelPipeBackend {
+	return core_xds.OtelPipeBackend{
+		Name:       resolved.Name,
+		SocketPath: core_xds.OpenTelemetrySocketName(workDir, resolved.Name),
+		Endpoint:   CollectorEndpointString(resolved.Endpoint),
+		UseHTTP:    resolved.Protocol == motb_api.ProtocolHTTP,
+		UseHTTPS:   resolved.UseHTTPS,
+		Path:       pointer.Deref(resolved.Path),
+		EnvPolicy:  ResolveEnvPolicy(resolved.EnvPolicy),
+	}
+}
+
+func ResolveEnvPolicy(policy *motb_api.EnvPolicy) *core_xds.OtelResolvedEnvPolicy {
+	return &core_xds.OtelResolvedEnvPolicy{
+		Mode:                 policy.EffectiveMode(),
+		Precedence:           policy.EffectivePrecedence(),
+		AllowSignalOverrides: policy.EffectiveAllowSignalOverrides(),
+	}
+}
+
+func BuildSignalRuntimePlan(
+	inventory *core_xds.OtelBootstrapInventory,
+	envPolicy *core_xds.OtelResolvedEnvPolicy,
+	signal core_xds.OtelSignal,
+	options AddResolvedBackendOptions,
+) core_xds.OtelSignalRuntimePlan {
+	mode := motb_api.EnvModeOptional
+	allowOverrides := false
+	if envPolicy != nil {
+		mode = envPolicy.Mode
+		allowOverrides = envPolicy.AllowSignalOverrides
+	}
+
+	plan := core_xds.OtelSignalRuntimePlan{
+		Enabled:         true,
+		RefreshInterval: options.RefreshInterval,
+	}
+
+	// Collect env input state from the bootstrap inventory.
+	if inventory != nil {
+		signalInv := inventory.GetSignal(signal)
+
+		sharedHasInput := inventory.Shared != nil && inventory.Shared.HasAnyInput()
+		signalHasInput := signalInv != nil && signalInv.HasAnyInput()
+		plan.EnvInputPresent = sharedHasInput || signalHasInput
+
+		if signalInv != nil {
+			plan.OverrideKinds = slices.Clone(signalInv.OverrideKinds)
+		}
+
+		if mode == motb_api.EnvModeRequired {
+			plan.MissingFields = validationMissingFields(inventory, signal)
+		}
+	}
+
+	// Determine blocked reasons based on mode vs actual env state.
+	plan.BlockedReasons = blockedReasons(mode, allowOverrides, plan)
+
+	return plan
+}
+
+func blockedReasons(
+	mode motb_api.EnvMode,
+	allowOverrides bool,
+	plan core_xds.OtelSignalRuntimePlan,
+) []string {
+	var reasons []string
+
+	switch mode {
+	case motb_api.EnvModeDisabled:
+		if plan.EnvInputPresent {
+			reasons = append(reasons, core_xds.OtelBlockedReasonEnvDisabledByPolicy)
+		}
+	case motb_api.EnvModeRequired:
+		if !plan.EnvInputPresent || len(plan.MissingFields) > 0 {
+			reasons = append(reasons, core_xds.OtelBlockedReasonRequiredEnvMissing)
+		}
+	}
+
+	if len(plan.OverrideKinds) > 0 && !allowOverrides {
+		reasons = append(reasons, core_xds.OtelBlockedReasonSignalOverridesBlocked)
+	}
+
+	return reasons
+}
+
+func validationMissingFields(
+	inventory *core_xds.OtelBootstrapInventory,
+	signal core_xds.OtelSignal,
+) []string {
+	if inventory == nil {
+		return nil
+	}
+
+	var missing []string
+	for _, validationError := range inventory.ValidationErrors {
+		scope, field, ok := strings.Cut(validationError, ".")
+		if !ok {
+			continue
+		}
+
+		if scope != "shared" && scope != string(signal) {
+			continue
+		}
+
+		switch field {
+		case "mtls":
+			missing = appendUnique(missing, "client_certificate")
+			missing = appendUnique(missing, "client_key")
+		default:
+			normalized := strings.ReplaceAll(strings.ReplaceAll(strings.TrimSpace(field), "-", "_"), " ", "_")
+			missing = appendUnique(missing, normalized)
+		}
+	}
+
+	return missing
+}
+
+func appendUnique(values []string, value string) []string {
+	if value == "" || slices.Contains(values, value) {
+		return values
+	}
+	return append(values, value)
+}
+
+// ResolveAddressForDirectExport fills in the target address when the MOTB spec
+// left it empty (node-local default). Uses nodeHostIP from the proxy metadata,
+// falling back to 127.0.0.1 for Universal mode.
+func ResolveAddressForDirectExport(target, nodeHostIP string) string {
+	switch {
+	case target != "":
+		return target
+	case nodeHostIP != "":
+		return nodeHostIP
+	default:
+		return "127.0.0.1"
+	}
+}
+
+// EndpointForDirectOtelExport returns a copy of resolved endpoint adjusted for
+// direct Envoy->collector transport. nodeHostIP fills in the address when the
+// MOTB spec left it empty.
+func EndpointForDirectOtelExport(resolved *ResolvedOtelBackend, nodeHostIP string) *core_xds.Endpoint {
+	if resolved == nil || resolved.Endpoint == nil {
+		return nil
+	}
+
+	ep := *resolved.Endpoint
+	ep.Target = ResolveAddressForDirectExport(ep.Target, nodeHostIP)
+	if resolved.UseHTTPS {
+		if ep.ExternalService == nil {
+			ep.ExternalService = &core_xds.ExternalService{}
+		}
+		ep.ExternalService.TLSEnabled = true
+		ep.ExternalService.FallbackToSystemCa = true
+	}
+
+	return &ep
+}
+
+// CollectorEndpointString formats an Endpoint as a "host:port" string suitable
+// for dialing. IPv6 addresses are bracketed by net.JoinHostPort.
+func CollectorEndpointString(endpoint *core_xds.Endpoint) string {
+	if endpoint.Port == 0 {
+		return endpoint.Target
+	}
+
+	return net.JoinHostPort(
+		endpoint.Target,
+		strconv.FormatUint(uint64(endpoint.Port), 10),
+	)
+}
+
+// ParseOtelEndpoint parses a "host:port" endpoint string into an Endpoint.
+// Prepends a synthetic scheme so url.Parse handles IPv6 and port parsing.
+// Defaults to gRPC port 4317 when no port is specified.
+func ParseOtelEndpoint(endpoint string) *core_xds.Endpoint {
+	u, err := url.Parse("otel://" + endpoint)
+	if err != nil || u.Hostname() == "" {
+		return &core_xds.Endpoint{Target: endpoint, Port: defaultOtelGrpcPort}
+	}
+
+	port := uint32(defaultOtelGrpcPort)
+	if p := u.Port(); p != "" {
+		if val, err := strconv.ParseUint(p, 10, 16); err == nil && val > 0 {
+			port = uint32(val)
+		}
+	}
+
+	return &core_xds.Endpoint{
+		Target: u.Hostname(),
+		Port:   port,
+	}
+}

--- a/pkg/plugins/policies/core/xds/otel_test.go
+++ b/pkg/plugins/policies/core/xds/otel_test.go
@@ -1,0 +1,543 @@
+package xds_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	common_api "github.com/kumahq/kuma/v2/api/common/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
+	motb_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshopentelemetrybackend/api/v1alpha1"
+	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
+	core_xds "github.com/kumahq/kuma/v2/pkg/core/xds"
+	policies_xds "github.com/kumahq/kuma/v2/pkg/plugins/policies/core/xds"
+	test_model "github.com/kumahq/kuma/v2/pkg/test/resources/model"
+	xds_context "github.com/kumahq/kuma/v2/pkg/xds/context"
+)
+
+var _ = Describe("FullPath", func() {
+	DescribeTable("should build correct path",
+		func(basePath *string, suffix string, expected string) {
+			r := &policies_xds.ResolvedOtelBackend{Path: basePath}
+			Expect(r.FullPath(suffix)).To(Equal(expected))
+		},
+		Entry("nil base path", nil, policies_xds.OtelTracesPathSuffix, "/v1/traces"),
+		Entry("root base path", new("/"), policies_xds.OtelTracesPathSuffix, "/v1/traces"),
+		Entry("custom base path", new("/custom"), policies_xds.OtelTracesPathSuffix, "/custom/v1/traces"),
+		Entry("trailing slash base path", new("/custom/"), policies_xds.OtelMetricsPathSuffix, "/custom/v1/metrics"),
+		Entry("logs suffix", new("/otel"), policies_xds.OtelLogsPathSuffix, "/otel/v1/logs"),
+	)
+})
+
+var _ = Describe("ResolveOtelBackend", func() {
+	dummyParser := func(ep string) *core_xds.Endpoint {
+		return &core_xds.Endpoint{Target: ep, Port: 4317}
+	}
+	dummyNamer := func(ep string) string { return ep }
+	emptyResources := xds_context.Resources{}
+
+	It("should return nil when no config sources exist", func() {
+		result := policies_xds.ResolveOtelBackend(
+			nil, "", dummyParser, dummyNamer, emptyResources,
+		)
+		Expect(result).To(BeNil())
+	})
+
+	Describe("priority order", func() {
+		backendRef := &common_api.BackendResourceRef{
+			Kind: common_api.BackendResourceMeshOpenTelemetryBackend,
+			Name: "my-backend",
+		}
+		motbList := &motb_api.MeshOpenTelemetryBackendResourceList{}
+
+		It("should prefer backendRef over inline endpoint", func() {
+			// backendRef will be dangling (no MOTBs in resources), but it should
+			// NOT fall through to inline endpoint
+			resources := xds_context.Resources{
+				MeshLocalResources: map[core_model.ResourceType]core_model.ResourceList{
+					motb_api.MeshOpenTelemetryBackendType: motbList,
+				},
+			}
+			result := policies_xds.ResolveOtelBackend(
+				backendRef, "inline-collector:4317", dummyParser, dummyNamer, resources,
+			)
+			// Dangling backendRef returns nil, does NOT fall through
+			Expect(result).To(BeNil())
+		})
+
+		It("should resolve inline endpoint when no backendRef", func() {
+			result := policies_xds.ResolveOtelBackend(
+				nil, "inline-collector:4317", dummyParser, dummyNamer, emptyResources,
+			)
+			Expect(result).ToNot(BeNil())
+			Expect(result.Endpoint.Target).To(Equal("inline-collector:4317"))
+			Expect(result.Protocol).To(Equal(motb_api.ProtocolGRPC))
+		})
+	})
+
+	Describe("inline endpoint uses ParseOtelEndpoint", func() {
+		It("should resolve via ParseOtelEndpoint when no backendRef", func() {
+			result := policies_xds.ResolveOtelBackend(
+				nil, "collector:4317", policies_xds.ParseOtelEndpoint, func(ep string) string { return ep }, emptyResources,
+			)
+			Expect(result).ToNot(BeNil())
+			Expect(result.Endpoint.Target).To(Equal("collector"))
+			Expect(result.Endpoint.Port).To(Equal(uint32(4317)))
+		})
+	})
+
+	Describe("optional endpoint fields", func() {
+		makeResources := func(backend *motb_api.MeshOpenTelemetryBackendResource) xds_context.Resources {
+			list := &motb_api.MeshOpenTelemetryBackendResourceList{Items: []*motb_api.MeshOpenTelemetryBackendResource{backend}}
+			return xds_context.Resources{
+				MeshLocalResources: map[core_model.ResourceType]core_model.ResourceList{
+					motb_api.MeshOpenTelemetryBackendType: list,
+				},
+			}
+		}
+		backendRef := &common_api.BackendResourceRef{
+			Kind: common_api.BackendResourceMeshOpenTelemetryBackend,
+			Name: "collector",
+		}
+
+		It("should default to port 4317 and empty address when endpoint is nil", func() {
+			backend := motb_api.NewMeshOpenTelemetryBackendResource()
+			backend.SetMeta(&test_model.ResourceMeta{Name: "collector", Mesh: "default"})
+			backend.Spec.Protocol = new(motb_api.ProtocolGRPC)
+
+			result := policies_xds.ResolveOtelBackend(
+				backendRef, "", dummyParser, dummyNamer, makeResources(backend),
+			)
+			Expect(result).ToNot(BeNil())
+			Expect(result.Endpoint.Target).To(BeEmpty())
+			Expect(result.Endpoint.Port).To(Equal(uint32(4317)))
+		})
+
+		It("should default to port 4317 when only address is set", func() {
+			backend := motb_api.NewMeshOpenTelemetryBackendResource()
+			backend.SetMeta(&test_model.ResourceMeta{Name: "collector", Mesh: "default"})
+			backend.Spec.Endpoint = &motb_api.Endpoint{Address: new("collector.example")}
+			backend.Spec.Protocol = new(motb_api.ProtocolGRPC)
+
+			result := policies_xds.ResolveOtelBackend(
+				backendRef, "", dummyParser, dummyNamer, makeResources(backend),
+			)
+			Expect(result).ToNot(BeNil())
+			Expect(result.Endpoint.Target).To(Equal("collector.example"))
+			Expect(result.Endpoint.Port).To(Equal(uint32(4317)))
+		})
+
+		It("should use empty address when only port is set", func() {
+			backend := motb_api.NewMeshOpenTelemetryBackendResource()
+			backend.SetMeta(&test_model.ResourceMeta{Name: "collector", Mesh: "default"})
+			backend.Spec.Endpoint = &motb_api.Endpoint{Port: new(int32(4318))}
+			backend.Spec.Protocol = new(motb_api.ProtocolGRPC)
+
+			result := policies_xds.ResolveOtelBackend(
+				backendRef, "", dummyParser, dummyNamer, makeResources(backend),
+			)
+			Expect(result).ToNot(BeNil())
+			Expect(result.Endpoint.Target).To(BeEmpty())
+			Expect(result.Endpoint.Port).To(Equal(uint32(4318)))
+		})
+	})
+
+	Describe("HTTP backend transport", func() {
+		makeResources := func(backends ...*motb_api.MeshOpenTelemetryBackendResource) xds_context.Resources {
+			list := &motb_api.MeshOpenTelemetryBackendResourceList{Items: backends}
+			return xds_context.Resources{
+				MeshLocalResources: map[core_model.ResourceType]core_model.ResourceList{
+					motb_api.MeshOpenTelemetryBackendType: list,
+				},
+			}
+		}
+
+		It("should enable HTTPS for HTTP protocol on port 443", func() {
+			backend := motb_api.NewMeshOpenTelemetryBackendResource()
+			backend.SetMeta(&test_model.ResourceMeta{Name: "https-collector", Mesh: "default"})
+			backend.Spec.Endpoint = &motb_api.Endpoint{Address: new("collector.example"), Port: new(int32(443))}
+			backend.Spec.Protocol = new(motb_api.ProtocolHTTP)
+
+			result := policies_xds.ResolveOtelBackend(
+				&common_api.BackendResourceRef{
+					Kind: common_api.BackendResourceMeshOpenTelemetryBackend,
+					Name: "https-collector",
+				},
+				"",
+				dummyParser,
+				dummyNamer,
+				makeResources(backend),
+			)
+			Expect(result).ToNot(BeNil())
+			Expect(result.UseHTTPS).To(BeTrue())
+		})
+
+		It("should not enable HTTPS for HTTP protocol on non-443 port", func() {
+			backend := motb_api.NewMeshOpenTelemetryBackendResource()
+			backend.SetMeta(&test_model.ResourceMeta{Name: "http-collector", Mesh: "default"})
+			backend.Spec.Endpoint = &motb_api.Endpoint{Address: new("collector.example"), Port: new(int32(4318))}
+			backend.Spec.Protocol = new(motb_api.ProtocolHTTP)
+
+			result := policies_xds.ResolveOtelBackend(
+				&common_api.BackendResourceRef{
+					Kind: common_api.BackendResourceMeshOpenTelemetryBackend,
+					Name: "http-collector",
+				},
+				"",
+				dummyParser,
+				dummyNamer,
+				makeResources(backend),
+			)
+			Expect(result).ToNot(BeNil())
+			Expect(result.UseHTTPS).To(BeFalse())
+		})
+
+		It("should resolve by labels and pick oldest on collision", func() {
+			now := time.Now()
+
+			backendA := motb_api.NewMeshOpenTelemetryBackendResource()
+			backendA.SetMeta(&test_model.ResourceMeta{
+				Name:         "collector-a.kuma-system",
+				Mesh:         "default",
+				CreationTime: now.Add(-2 * time.Hour),
+				Labels: map[string]string{
+					mesh_proto.DisplayName: "collector",
+				},
+			})
+			backendA.Spec.Endpoint = &motb_api.Endpoint{Address: new("collector-a"), Port: new(int32(4317))}
+
+			backendB := motb_api.NewMeshOpenTelemetryBackendResource()
+			backendB.SetMeta(&test_model.ResourceMeta{
+				Name:         "collector-b.kuma-system",
+				Mesh:         "default",
+				CreationTime: now.Add(-1 * time.Hour),
+				Labels: map[string]string{
+					mesh_proto.DisplayName: "collector",
+				},
+			})
+			backendB.Spec.Endpoint = &motb_api.Endpoint{Address: new("collector-b"), Port: new(int32(4317))}
+
+			result := policies_xds.ResolveOtelBackend(
+				&common_api.BackendResourceRef{
+					Kind: common_api.BackendResourceMeshOpenTelemetryBackend,
+					Labels: map[string]string{
+						mesh_proto.DisplayName: "collector",
+					},
+				},
+				"",
+				dummyParser,
+				dummyNamer,
+				makeResources(backendA, backendB),
+			)
+			Expect(result).ToNot(BeNil())
+			Expect(result.Endpoint.Target).To(Equal("collector-a"))
+		})
+	})
+})
+
+var _ = Describe("CollectorEndpointString", func() {
+	DescribeTable("should format endpoint correctly",
+		func(endpoint *core_xds.Endpoint, expected string) {
+			Expect(policies_xds.CollectorEndpointString(endpoint)).To(Equal(expected))
+		},
+		Entry("ipv4 host and port", &core_xds.Endpoint{Target: "10.0.0.1", Port: 4317}, "10.0.0.1:4317"),
+		Entry("ipv6 host and port", &core_xds.Endpoint{Target: "2001:db8::1", Port: 4318}, "[2001:db8::1]:4318"),
+		Entry("host without port", &core_xds.Endpoint{Target: "collector.mesh"}, "collector.mesh"),
+	)
+})
+
+var _ = Describe("ParseOtelEndpoint", func() {
+	DescribeTable("should parse endpoint correctly",
+		func(input string, expectedTarget string, expectedPort uint32) {
+			ep := policies_xds.ParseOtelEndpoint(input)
+			Expect(ep.Target).To(Equal(expectedTarget))
+			Expect(ep.Port).To(Equal(expectedPort))
+		},
+		Entry("host:port", "collector:4317", "collector", uint32(4317)),
+		Entry("host only", "collector", "collector", uint32(4317)),
+		Entry("ipv4:port", "10.0.0.1:4318", "10.0.0.1", uint32(4318)),
+		Entry("bracketed ipv6:port", "[2001:db8::1]:4317", "2001:db8::1", uint32(4317)),
+		Entry("bare ipv6", "[2001:db8::1]", "2001:db8::1", uint32(4317)),
+		Entry("bare ipv6 no brackets", "2001:db8::1", "2001:db8::1", uint32(4317)),
+	)
+})
+
+var _ = Describe("EndpointForDirectOtelExport", func() {
+	It("should enable TLS transport for HTTPS-resolved HTTP backend", func() {
+		resolved := &policies_xds.ResolvedOtelBackend{
+			Endpoint: &core_xds.Endpoint{
+				Target: "collector.example",
+				Port:   443,
+			},
+			UseHTTPS: true,
+		}
+
+		ep := policies_xds.EndpointForDirectOtelExport(resolved, "")
+		Expect(ep).ToNot(BeNil())
+		Expect(ep.ExternalService).ToNot(BeNil())
+		Expect(ep.ExternalService.TLSEnabled).To(BeTrue())
+		Expect(ep.ExternalService.FallbackToSystemCa).To(BeTrue())
+	})
+
+	It("should fill in nodeHostIP when target is empty", func() {
+		resolved := &policies_xds.ResolvedOtelBackend{
+			Endpoint: &core_xds.Endpoint{
+				Target: "",
+				Port:   4317,
+			},
+		}
+
+		ep := policies_xds.EndpointForDirectOtelExport(resolved, "192.168.1.5")
+		Expect(ep).ToNot(BeNil())
+		Expect(ep.Target).To(Equal("192.168.1.5"))
+		Expect(ep.Port).To(Equal(uint32(4317)))
+	})
+
+	It("should fall back to 127.0.0.1 when target and nodeHostIP are both empty", func() {
+		resolved := &policies_xds.ResolvedOtelBackend{
+			Endpoint: &core_xds.Endpoint{
+				Target: "",
+				Port:   4317,
+			},
+		}
+
+		ep := policies_xds.EndpointForDirectOtelExport(resolved, "")
+		Expect(ep).ToNot(BeNil())
+		Expect(ep.Target).To(Equal("127.0.0.1"))
+	})
+
+	It("should not override existing target", func() {
+		resolved := &policies_xds.ResolvedOtelBackend{
+			Endpoint: &core_xds.Endpoint{
+				Target: "collector.example",
+				Port:   4317,
+			},
+		}
+
+		ep := policies_xds.EndpointForDirectOtelExport(resolved, "192.168.1.5")
+		Expect(ep).ToNot(BeNil())
+		Expect(ep.Target).To(Equal("collector.example"))
+	})
+})
+
+var _ = Describe("BuildSignalRuntimePlan", func() {
+	It("should mark signal overrides as blocked when policy disallows them", func() {
+		plan := policies_xds.BuildSignalRuntimePlan(
+			&core_xds.OtelBootstrapInventory{
+				Shared: &core_xds.OtelSignalEnvInventory{
+					EndpointPresent: true,
+				},
+				Traces: &core_xds.OtelSignalEnvInventory{
+					OverrideKinds: []string{"endpoint"},
+				},
+			},
+			&core_xds.OtelResolvedEnvPolicy{
+				Mode:                 motb_api.EnvModeOptional,
+				Precedence:           motb_api.EnvPrecedenceEnvFirst,
+				AllowSignalOverrides: false,
+			},
+			core_xds.OtelSignalTraces,
+			policies_xds.AddResolvedBackendOptions{},
+		)
+
+		Expect(plan.Enabled).To(BeTrue())
+		Expect(plan.EnvInputPresent).To(BeTrue())
+		Expect(plan.OverrideKinds).To(ConsistOf("endpoint"))
+		Expect(plan.BlockedReasons).To(ContainElement(core_xds.OtelBlockedReasonSignalOverridesBlocked))
+	})
+
+	It("should mark required env as missing when inventory is absent", func() {
+		plan := policies_xds.BuildSignalRuntimePlan(
+			nil,
+			&core_xds.OtelResolvedEnvPolicy{
+				Mode:                 motb_api.EnvModeRequired,
+				Precedence:           motb_api.EnvPrecedenceEnvFirst,
+				AllowSignalOverrides: true,
+			},
+			core_xds.OtelSignalLogs,
+			policies_xds.AddResolvedBackendOptions{},
+		)
+
+		Expect(plan.Enabled).To(BeTrue())
+		Expect(plan.EnvInputPresent).To(BeFalse())
+		Expect(plan.BlockedReasons).To(ContainElement(core_xds.OtelBlockedReasonRequiredEnvMissing))
+	})
+
+	It("should mark invalid required shared env fields as missing", func() {
+		plan := policies_xds.BuildSignalRuntimePlan(
+			&core_xds.OtelBootstrapInventory{
+				Shared: &core_xds.OtelSignalEnvInventory{
+					ProtocolPresent:   true,
+					EffectiveProtocol: core_xds.OtelProtocolUnknown,
+				},
+				ValidationErrors: []string{"shared.protocol"},
+			},
+			&core_xds.OtelResolvedEnvPolicy{
+				Mode:                 motb_api.EnvModeRequired,
+				Precedence:           motb_api.EnvPrecedenceEnvFirst,
+				AllowSignalOverrides: true,
+			},
+			core_xds.OtelSignalMetrics,
+			policies_xds.AddResolvedBackendOptions{},
+		)
+
+		Expect(plan.EnvInputPresent).To(BeTrue())
+		Expect(plan.MissingFields).To(ConsistOf("protocol"))
+		Expect(plan.BlockedReasons).To(ContainElement(core_xds.OtelBlockedReasonRequiredEnvMissing))
+	})
+
+	It("should mark invalid required timeout and compression as missing", func() {
+		plan := policies_xds.BuildSignalRuntimePlan(
+			&core_xds.OtelBootstrapInventory{
+				Shared: &core_xds.OtelSignalEnvInventory{
+					TimeoutPresent:     true,
+					CompressionPresent: true,
+				},
+				ValidationErrors: []string{"shared.timeout", "shared.compression"},
+			},
+			&core_xds.OtelResolvedEnvPolicy{
+				Mode:                 motb_api.EnvModeRequired,
+				Precedence:           motb_api.EnvPrecedenceEnvFirst,
+				AllowSignalOverrides: true,
+			},
+			core_xds.OtelSignalMetrics,
+			policies_xds.AddResolvedBackendOptions{},
+		)
+
+		Expect(plan.EnvInputPresent).To(BeTrue())
+		Expect(plan.MissingFields).To(ConsistOf("timeout", "compression"))
+		Expect(plan.BlockedReasons).To(ContainElement(core_xds.OtelBlockedReasonRequiredEnvMissing))
+	})
+
+	It("should mark invalid required signal mTLS input as missing", func() {
+		plan := policies_xds.BuildSignalRuntimePlan(
+			&core_xds.OtelBootstrapInventory{
+				Traces: &core_xds.OtelSignalEnvInventory{
+					ClientCertificatePresent: true,
+				},
+				ValidationErrors: []string{"traces.mtls"},
+			},
+			&core_xds.OtelResolvedEnvPolicy{
+				Mode:                 motb_api.EnvModeRequired,
+				Precedence:           motb_api.EnvPrecedenceEnvFirst,
+				AllowSignalOverrides: true,
+			},
+			core_xds.OtelSignalTraces,
+			policies_xds.AddResolvedBackendOptions{},
+		)
+
+		Expect(plan.EnvInputPresent).To(BeTrue())
+		Expect(plan.MissingFields).To(ConsistOf("client_certificate", "client_key"))
+		Expect(plan.BlockedReasons).To(ContainElement(core_xds.OtelBlockedReasonRequiredEnvMissing))
+	})
+
+	It("should ignore invalid optional env fields in the runtime plan", func() {
+		plan := policies_xds.BuildSignalRuntimePlan(
+			&core_xds.OtelBootstrapInventory{
+				Shared: &core_xds.OtelSignalEnvInventory{
+					ProtocolPresent:   true,
+					EffectiveProtocol: core_xds.OtelProtocolUnknown,
+				},
+				ValidationErrors: []string{"shared.protocol"},
+			},
+			&core_xds.OtelResolvedEnvPolicy{
+				Mode:                 motb_api.EnvModeOptional,
+				Precedence:           motb_api.EnvPrecedenceEnvFirst,
+				AllowSignalOverrides: true,
+			},
+			core_xds.OtelSignalLogs,
+			policies_xds.AddResolvedBackendOptions{},
+		)
+
+		Expect(plan.EnvInputPresent).To(BeTrue())
+		Expect(plan.MissingFields).To(BeEmpty())
+		Expect(plan.BlockedReasons).To(BeEmpty())
+	})
+
+	It("should mark disabled env mode with env input as blocked by policy", func() {
+		plan := policies_xds.BuildSignalRuntimePlan(
+			&core_xds.OtelBootstrapInventory{
+				Shared: &core_xds.OtelSignalEnvInventory{
+					EndpointPresent:   true,
+					ProtocolPresent:   true,
+					EffectiveProtocol: core_xds.OtelProtocolGRPC,
+				},
+			},
+			&core_xds.OtelResolvedEnvPolicy{
+				Mode:                 motb_api.EnvModeDisabled,
+				Precedence:           motb_api.EnvPrecedenceEnvFirst,
+				AllowSignalOverrides: true,
+			},
+			core_xds.OtelSignalTraces,
+			policies_xds.AddResolvedBackendOptions{},
+		)
+
+		Expect(plan.EnvInputPresent).To(BeTrue())
+		Expect(plan.BlockedReasons).To(ContainElement(core_xds.OtelBlockedReasonEnvDisabledByPolicy))
+	})
+
+	It("should flag ambiguity when multiple backends reuse env input for one signal", func() {
+		backends := core_xds.OtelPipeBackends{}
+		base := core_xds.OtelPipeBackend{
+			Name:       "collector",
+			Endpoint:   "collector:4317",
+			SocketPath: "/tmp/collector.sock",
+			EnvPolicy: &core_xds.OtelResolvedEnvPolicy{
+				Mode:                 motb_api.EnvModeOptional,
+				Precedence:           motb_api.EnvPrecedenceEnvFirst,
+				AllowSignalOverrides: true,
+			},
+		}
+
+		backends.AddSignal("collector", base, core_xds.OtelSignalTraces, core_xds.OtelSignalRuntimePlan{
+			Enabled:         true,
+			EnvInputPresent: true,
+		})
+		backends.AddSignal("second", core_xds.OtelPipeBackend{
+			Name:       "second",
+			Endpoint:   "second:4317",
+			SocketPath: "/tmp/second.sock",
+			EnvPolicy:  base.EnvPolicy,
+		}, core_xds.OtelSignalTraces, core_xds.OtelSignalRuntimePlan{
+			Enabled:         true,
+			EnvInputPresent: true,
+		})
+
+		all := backends.All()
+		Expect(all).To(HaveLen(2))
+		Expect(all[0].Traces.BlockedReasons).To(ContainElement(core_xds.OtelBlockedReasonMultipleBackends))
+		Expect(all[1].Traces.BlockedReasons).To(ContainElement(core_xds.OtelBlockedReasonMultipleBackends))
+	})
+
+	It("should merge signal plans when two plugins add the same backend", func() {
+		backends := core_xds.OtelPipeBackends{}
+		base := core_xds.OtelPipeBackend{
+			Name:       "collector",
+			Endpoint:   "collector:4317",
+			SocketPath: "/tmp/collector.sock",
+			EnvPolicy: &core_xds.OtelResolvedEnvPolicy{
+				Mode:                 motb_api.EnvModeOptional,
+				Precedence:           motb_api.EnvPrecedenceEnvFirst,
+				AllowSignalOverrides: true,
+			},
+		}
+
+		backends.AddSignal("collector", base, core_xds.OtelSignalTraces, core_xds.OtelSignalRuntimePlan{
+			Enabled:         true,
+			EnvInputPresent: true,
+		})
+		backends.AddSignal("collector", base, core_xds.OtelSignalMetrics, core_xds.OtelSignalRuntimePlan{
+			Enabled:         true,
+			EnvInputPresent: true,
+		})
+
+		all := backends.All()
+		Expect(all).To(HaveLen(1))
+		Expect(all[0].Name).To(Equal("collector"))
+		Expect(all[0].Traces).ToNot(BeNil())
+		Expect(all[0].Traces.Enabled).To(BeTrue())
+		Expect(all[0].Metrics).ToNot(BeNil())
+		Expect(all[0].Metrics.Enabled).To(BeTrue())
+	})
+})

--- a/pkg/plugins/policies/core/xds/suite_test.go
+++ b/pkg/plugins/policies/core/xds/suite_test.go
@@ -1,0 +1,11 @@
+package xds_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/v2/pkg/test"
+)
+
+func TestOtel(t *testing.T) {
+	test.RunSpecs(t, "Otel Backend Resolution")
+}

--- a/pkg/util/proto/types.go
+++ b/pkg/util/proto/types.go
@@ -2,7 +2,9 @@ package proto
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -101,6 +103,9 @@ func StructToMapOfAny(value any) map[string]any {
 	}
 
 	if v.Kind() == reflect.Pointer {
+		if v.IsNil() {
+			return nil
+		}
 		v = v.Elem()
 	}
 
@@ -120,28 +125,59 @@ func StructToMapOfAny(value any) map[string]any {
 		case "":
 			key = field.Name
 		default:
-			key = k
+			key, _, _ = strings.Cut(k, ",")
 		}
 
-		val := v.Field(i)
-
-		switch val.Kind() {
-		case reflect.Struct:
-			out[key] = StructToMapOfAny(val)
-		case reflect.Bool:
-			out[key] = val.Bool()
-		case reflect.String:
-			out[key] = val.String()
-		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			out[key] = float64(val.Uint())
-		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-			out[key] = float64(val.Int())
-		default:
-			out[key] = val.Interface()
-		}
+		out[key] = structFieldValueToAny(v.Field(i))
 	}
 
 	return out
+}
+
+func structFieldValueToAny(value reflect.Value) any {
+	if !value.IsValid() {
+		return nil
+	}
+
+	switch value.Kind() {
+	case reflect.Pointer, reflect.Interface:
+		if value.IsNil() {
+			return nil
+		}
+		return structFieldValueToAny(value.Elem())
+	case reflect.Struct:
+		return StructToMapOfAny(value)
+	case reflect.Slice, reflect.Array:
+		out := make([]any, value.Len())
+		for i := range value.Len() {
+			out[i] = structFieldValueToAny(value.Index(i))
+		}
+		return out
+	case reflect.Map:
+		if value.IsNil() {
+			return nil
+		}
+		out := map[string]any{}
+		for _, key := range value.MapKeys() {
+			if key.Kind() != reflect.String {
+				continue
+			}
+			out[key.String()] = structFieldValueToAny(value.MapIndex(key))
+		}
+		return out
+	case reflect.Bool:
+		return value.Bool()
+	case reflect.String:
+		return value.String()
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return float64(value.Uint())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return float64(value.Int())
+	case reflect.Float32, reflect.Float64:
+		return value.Float()
+	default:
+		return value.Interface()
+	}
 }
 
 func StructToProtoStruct(in any) (*structpb.Struct, error) {
@@ -157,7 +193,10 @@ func MustStructToProtoStruct(in any) *structpb.Struct {
 }
 
 func MustFromMapOfAny[T any, U map[string]any | *structpb.Struct](in U) T {
-	out, _ := FromMapOfAny[T](in)
+	out, err := FromMapOfAny[T](in)
+	if err != nil {
+		panic(fmt.Sprintf("FromMapOfAny: %v", err))
+	}
 	return out
 }
 

--- a/pkg/util/proto/types_test.go
+++ b/pkg/util/proto/types_test.go
@@ -16,6 +16,12 @@ type sampleStruct struct {
 	} `json:"nested"`
 }
 
+type sampleStructWithOmitEmpty struct {
+	Name   string   `json:"name,omitempty"`
+	Active bool     `json:"active,omitempty"`
+	Labels []string `json:"labels,omitempty"`
+}
+
 var _ = Describe("Proto helpers", func() {
 	obj := sampleStruct{
 		Name:   "Alice",
@@ -36,6 +42,20 @@ var _ = Describe("Proto helpers", func() {
 	It("StructToMapOfAny should convert struct to map", func() {
 		out := util_proto.StructToMapOfAny(obj)
 		Expect(out).To(Equal(expected))
+	})
+
+	It("StructToMapOfAny should ignore json tag options", func() {
+		out := util_proto.StructToMapOfAny(sampleStructWithOmitEmpty{
+			Name:   "Alice",
+			Active: true,
+			Labels: []string{"one", "two"},
+		})
+
+		Expect(out).To(Equal(map[string]any{
+			"name":   "Alice",
+			"active": true,
+			"labels": []any{"one", "two"},
+		}))
 	})
 
 	It("StructToProtoStruct should convert struct to *structpb.Struct", func() {

--- a/pkg/xds/context/resources.go
+++ b/pkg/xds/context/resources.go
@@ -9,6 +9,7 @@ import (
 	meshextsvc "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
 	meshidentity_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshidentity/api/v1alpha1"
 	meshmzservice_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1"
+	motb_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshopentelemetrybackend/api/v1alpha1"
 	meshsvc "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	meshtrust_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshtrust/api/v1alpha1"
 	"github.com/kumahq/kuma/v2/pkg/core/resources/apis/system"
@@ -227,6 +228,18 @@ func (r Resources) MeshIdentities() *meshidentity_api.MeshIdentityResourceList {
 		}
 	}
 	return list.(*meshidentity_api.MeshIdentityResourceList)
+}
+
+func (r Resources) MeshOpenTelemetryBackends() *motb_api.MeshOpenTelemetryBackendResourceList {
+	list, ok := r.MeshLocalResources[motb_api.MeshOpenTelemetryBackendType]
+	if !ok {
+		var err error
+		list, err = registry.Global().NewList(motb_api.MeshOpenTelemetryBackendType)
+		if err != nil {
+			return &motb_api.MeshOpenTelemetryBackendResourceList{}
+		}
+	}
+	return list.(*motb_api.MeshOpenTelemetryBackendResourceList)
 }
 
 func (r Resources) MeshTrusts() *meshtrust_api.MeshTrustResourceList {


### PR DESCRIPTION
## Motivation

PR #15865 added `backendRef` to observability policies and the status updater. Policy plugins now need helpers to resolve those references into endpoints and build the xDS config that routes OTel traffic through kuma-dp.

## Implementation information

Adds core xDS types for OTel pipe mode: signal/protocol enums, bootstrap inventory types, pipe backend accumulator with dedup, and the unified `/otel` dynconf route written after all policy plugins run.

`pkg/plugins/policies/core/xds/otel.go` converts a `backendRef` (by name or labels, oldest-wins) into a `ResolvedOtelBackend` with endpoint, protocol, env policy, and TLS info. Inline endpoint parsing stays for backward compat.

`StructToMapOfAny` now handles pointer, slice, and map fields so `OtelBootstrapInventory` can round-trip through Envoy node metadata.

`OtelPipeBackends` on `Proxy` accumulates backends from each policy plugin. After the plugin loop the generator serializes them as the `/otel` dynconf payload, gated on `FeatureOtelViaKumaDp`.

## Supporting documentation

MADR 095: #15677
Depends on: #15865

> Changelog: feat(kuma-cp): add MeshOpenTelemetryBackend for shared policy-based OpenTelemetry backends
