### PR TITLE
ci(e2e): scope MISE_DISABLE_TOOLS to workflow

### DIFF
--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -17,6 +17,7 @@ env:
   E2E_PARAM_SIDECAR_CONTAINERS: ${{ fromJSON(inputs.matrix).sidecarContainers }}
   E2E_PARAM_TARGET: ${{ fromJSON(inputs.matrix).target }}
   E2E_PARAM_PARALLELISM: ${{ fromJSON(inputs.matrix).parallelism }}
+  MISE_DISABLE_TOOLS: "golangci-lint,skaffold"
 jobs:
   e2e:
     timeout-minutes: 60
@@ -40,7 +41,6 @@ jobs:
       - uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          MISE_DISABLE_TOOLS: "golangci-lint,skaffold"
       - run: |
           make build
       - run: |

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -14,6 +14,7 @@ env:
   # This is automatically managed by CI
   K8S_MIN_VERSION: v1.31.12-k3s1
   K8S_MAX_VERSION: v1.34.1-k3s1
+  MISE_DISABLE_TOOLS: "golangci-lint,skaffold"
 jobs:
   test_unit:
     timeout-minutes: 25
@@ -26,7 +27,6 @@ jobs:
       - uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          MISE_DISABLE_TOOLS: "golangci-lint,skaffold"
       - run: |
           make test
   gen_e2e_matrix:

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -16,6 +16,7 @@ env:
   CI_TOOLS_DIR: "/home/runner/work/kuma/.ci_tools"
   # renovate: datasource=github-tags depName=golangci-lint packageName=golangci/golangci-lint versioning=semver
   GOLANGCI_LINT_VERSION: "v2.11.3"
+  MISE_DISABLE_TOOLS: "golangci-lint,skaffold"
 concurrency:
   group: ${{ format('{0}-{1}-{2}', github.workflow, github.event_name, github.event_name == 'push' && github.sha || github.event_name == 'pull_request' && github.event.pull_request.number || github.event_name == 'workflow_dispatch' && github.ref_name) }}
   cancel-in-progress: ${{ github.event_name == 'push' && false || true }}
@@ -100,7 +101,6 @@ jobs:
       - uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          MISE_DISABLE_TOOLS: "golangci-lint,skaffold"
       - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         if: steps.changes.outputs.code == 'true'
         env:

--- a/.github/workflows/merge-release-to-master.yaml
+++ b/.github/workflows/merge-release-to-master.yaml
@@ -14,6 +14,8 @@ on:
         default: ""
 permissions:
   contents: read
+env:
+  MISE_DISABLE_TOOLS: "golangci-lint,skaffold"
 jobs:
   release:
     runs-on: ubuntu-24.04
@@ -33,7 +35,6 @@ jobs:
       - uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          MISE_DISABLE_TOOLS: "golangci-lint,skaffold"
       - run: |
           git config --global user.email "110050114+kumahq[bot]@users.noreply.github.com"
           git config --global user.name "kumahq[bot]"

--- a/.github/workflows/pr-comments.yaml
+++ b/.github/workflows/pr-comments.yaml
@@ -5,6 +5,7 @@ on:
 env:
   GH_USER: "github-actions[bot]"
   GH_EMAIL: "<41898282+github-actions[bot]@users.noreply.github.com>"
+  MISE_DISABLE_TOOLS: "golangci-lint,skaffold"
 permissions:
   contents: read
 jobs:
@@ -48,7 +49,6 @@ jobs:
       - uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          MISE_DISABLE_TOOLS: "golangci-lint,skaffold"
       # Automatically update code formatting if /format is in the comment
       - name: "Auto-format code"
         if: contains(github.event.comment.body, '/format')

--- a/.github/workflows/transparentproxy-tests.yaml
+++ b/.github/workflows/transparentproxy-tests.yaml
@@ -6,6 +6,7 @@ on:
 env:
   CI_TOOLS_DIR: "/home/runner/work/kuma/kuma/.ci_tools"
   IPV6: "true"
+  MISE_DISABLE_TOOLS: "golangci-lint,skaffold"
 permissions:
   contents: read
 jobs:
@@ -19,7 +20,6 @@ jobs:
       - uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          MISE_DISABLE_TOOLS: "golangci-lint,skaffold"
       - name: "Enable IPv6 for Docker and enable necessary kernel modules for ip6tables"
         run: |
           cat <<'EOF' | sudo tee /etc/docker/daemon.json

--- a/.github/workflows/update-insecure-dependencies.yaml
+++ b/.github/workflows/update-insecure-dependencies.yaml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron: 0 3 * * *
 permissions: read-all
+env:
+  MISE_DISABLE_TOOLS: "golangci-lint,skaffold"
 jobs:
   active-branches:
     uses: ./.github/workflows/_get-active-branches.yaml
@@ -28,7 +30,6 @@ jobs:
       - uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          MISE_DISABLE_TOOLS: "golangci-lint,skaffold"
       - name: "Install tools"
         run: |
           go install github.com/google/osv-scanner/cmd/osv-scanner@b13f37e1a1e4cb98556c1d34cd3256a876929be1 # v1.9.1


### PR DESCRIPTION
## Motivation

The kong-mesh e2e CI job fails with:
```
mise ERROR failed to rebuild runtime symlinks
mise ERROR failed to ln -sf ./2.11.3 /home/ubuntu/.local/share/mise/installs/golangci-lint/2.11
mise ERROR File exists (os error 17)
```

There is at least 3 runs that failed like that: 
<img width="829" height="101" alt="image" src="https://github.com/user-attachments/assets/4fae925a-c41b-4edb-8d87-c4b49bf8f24f" />
<img width="775" height="88" alt="image" src="https://github.com/user-attachments/assets/e523bb55-83b9-4548-a7f2-7cabc9b7a37a" />

`MISE_DISABLE_TOOLS` is set only on the `jdx/mise-action` step, not as a workflow-level env var.
When the e2e test step later runs `make -j2`, two parallel k3d cluster starts both trigger mise via shims.
Since `MISE_DISABLE_TOOLS` is not in scope for those steps, both processes install golangci-lint simultaneously.
After installation, both try to create the symlink `2.11 -> ./2.11.3` - the second one fails with EEXIST.

## Implementation information

Move `MISE_DISABLE_TOOLS: "golangci-lint,skaffold"` from the `jdx/mise-action` step `env:` to the workflow-level `env:` block in all workflow files that had it scoped to the step.

This is safe because:
- `golangci-lint` make target is guarded by `ifndef CI` - in CI it prints "skipping"
- CI linting uses the dedicated `golangci/golangci-lint-action`, not mise
- `skaffold` is not used in any Makefile target

## Supporting documentation

- https://github.com/kumahq/kuma/actions/runs/23249787080/job/67620726437#step:11:385

<!-- Is there a MADR? An Issue? A related PR? -->

> Changelog: skip