### PR TITLE
feat(helm): add runtime divisor values

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -787,11 +787,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -12375,11 +12375,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -218,6 +218,15 @@ controlPlane:
     limits:
        memory: 256Mi
 
+  # -- Go runtime settings for the control plane
+  runtime:
+    # -- Divisor for GOMAXPROCS (resourceFieldRef divisor for limits.cpu)
+    goMaxProcs:
+      divisor: "1"
+    # -- Divisor for GOMEMLIMIT (resourceFieldRef divisor for limits.memory)
+    goMemLimit:
+      divisor: "1"
+
   # -- Pod lifecycle settings (useful for adding a preStop hook, when
   # using AWS ALB or NLB)
   lifecycle: {}

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -12375,11 +12375,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-control-plane.global-universal-on-k8s.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.global-universal-on-k8s.golden.yaml
@@ -227,11 +227,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
@@ -578,11 +578,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
@@ -562,11 +562,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
@@ -574,11 +574,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
@@ -562,11 +562,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-control-plane.tproxy-ebpf-experimental-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.tproxy-ebpf-experimental-enabled.golden.yaml
@@ -572,11 +572,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
@@ -593,11 +593,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -12441,11 +12441,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
@@ -562,11 +562,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -597,11 +597,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone-universal-on-k8s.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone-universal-on-k8s.golden.yaml
@@ -219,11 +219,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
@@ -566,11 +566,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/certManagerCustomIssuer.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/certManagerCustomIssuer.golden.yaml
@@ -562,11 +562,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/certManagerEnabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/certManagerEnabled.golden.yaml
@@ -562,11 +562,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/controlPlaneOnlySkipRBAC.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/controlPlaneOnlySkipRBAC.golden.yaml
@@ -285,11 +285,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/dnsConfigOption.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/dnsConfigOption.golden.yaml
@@ -631,11 +631,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/doNotChangeTlsChecksum.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/doNotChangeTlsChecksum.golden.yaml
@@ -561,11 +561,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
@@ -562,11 +562,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/envVarsDownwardApi.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/envVarsDownwardApi.golden.yaml
@@ -566,11 +566,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix12847.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix12847.golden.yaml
@@ -789,11 +789,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix13029.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix13029.golden.yaml
@@ -807,11 +807,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
@@ -587,11 +587,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
@@ -610,11 +610,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
@@ -863,11 +863,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix5978.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix5978.golden.yaml
@@ -628,11 +628,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix7724.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix7724.golden.yaml
@@ -565,11 +565,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix7824.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix7824.golden.yaml
@@ -643,11 +643,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/ingressLbService.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/ingressLbService.golden.yaml
@@ -597,11 +597,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/minReadySeconds.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/minReadySeconds.golden.yaml
@@ -562,11 +562,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/roleBindingInNamespaces.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/roleBindingInNamespaces.golden.yaml
@@ -581,11 +581,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/securityContext.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/securityContext.golden.yaml
@@ -563,11 +563,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/skipRBAC.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/skipRBAC.golden.yaml
@@ -193,11 +193,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: "1"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: "1"
           args:
             - run
             - --log-level=info

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -71,6 +71,9 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.defaults.skipMeshCreation | bool | `false` | Whether to skip creating the default Mesh |
 | controlPlane.automountServiceAccountToken | bool | `true` | Whether to automountServiceAccountToken for cp. Optionally set to false |
 | controlPlane.resources | object | `{"limits":{"memory":"256Mi"},"requests":{"cpu":"500m","memory":"256Mi"}}` | Optionally override the resource spec |
+| controlPlane.runtime | object | `{"goMaxProcs":{"divisor":"1"},"goMemLimit":{"divisor":"1"}}` | Go runtime settings for the control plane |
+| controlPlane.runtime.goMaxProcs | object | `{"divisor":"1"}` | Divisor for GOMAXPROCS (resourceFieldRef divisor for limits.cpu) |
+| controlPlane.runtime.goMemLimit | object | `{"divisor":"1"}` | Divisor for GOMEMLIMIT (resourceFieldRef divisor for limits.memory) |
 | controlPlane.lifecycle | object | `{}` | Pod lifecycle settings (useful for adding a preStop hook, when using AWS ALB or NLB) |
 | controlPlane.terminationGracePeriodSeconds | int | `30` | Number of seconds to wait before force killing the pod. Make sure to update this if you add a preStop hook. |
 | controlPlane.tls.general.secretName | string | `""` | Secret that contains tls.crt, tls.key [and ca.crt when no controlPlane.tls.general.caSecretName specified] for protecting Kuma in-cluster communication |

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -195,11 +195,13 @@ spec:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.memory
+                  divisor: {{ .Values.controlPlane.runtime.goMemLimit.divisor | quote }}
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   containerName: control-plane
                   resource: limits.cpu
+                  divisor: {{ .Values.controlPlane.runtime.goMaxProcs.divisor | quote }}
           args:
             - run
             - --log-level={{ .Values.controlPlane.logLevel }}

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -218,6 +218,15 @@ controlPlane:
     limits:
        memory: 256Mi
 
+  # -- Go runtime settings for the control plane
+  runtime:
+    # -- Divisor for GOMAXPROCS (resourceFieldRef divisor for limits.cpu)
+    goMaxProcs:
+      divisor: "1"
+    # -- Divisor for GOMEMLIMIT (resourceFieldRef divisor for limits.memory)
+    goMemLimit:
+      divisor: "1"
+
   # -- Pod lifecycle settings (useful for adding a preStop hook, when
   # using AWS ALB or NLB)
   lifecycle: {}

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -218,6 +218,15 @@ controlPlane:
     limits:
        memory: 256Mi
 
+  # -- Go runtime settings for the control plane
+  runtime:
+    # -- Divisor for GOMAXPROCS (resourceFieldRef divisor for limits.cpu)
+    goMaxProcs:
+      divisor: "1"
+    # -- Divisor for GOMEMLIMIT (resourceFieldRef divisor for limits.memory)
+    goMemLimit:
+      divisor: "1"
+
   # -- Pod lifecycle settings (useful for adding a preStop hook, when
   # using AWS ALB or NLB)
   lifecycle: {}


### PR DESCRIPTION
## Motivation

Closes #11991. The CP deployment hardcodes `GOMAXPROCS` and `GOMEMLIMIT` env vars via `resourceFieldRef` without a `divisor` field. Users need to configure the divisor (e.g., to reserve memory headroom for sidecar containers or set CPU fractions).

## Implementation information

- Added `controlPlane.runtime.goMaxProcs.divisor` and `controlPlane.runtime.goMemLimit.divisor` values (default `"1"`, preserving current behavior)
- Template references these values in `resourceFieldRef.divisor`
- Updated all golden files

> Changelog: feat(helm): expose divisor for GOMAXPROCS/GOMEMLIMIT env vars